### PR TITLE
Faster plot image

### DIFF
--- a/scippy/__init__.py
+++ b/scippy/__init__.py
@@ -1,8 +1,8 @@
 from .scippy import *
 from .table import table
 try:
-    from .plot import plot, plot_1d, plot_image, plot_sliceviewer, plot_waterfall
+    from .plot import plot
 except ImportError:
-    print("Warning: the plotting module for Dataset was not imported. Check "
-          "that plotly is installed on your system. You can still use Dataset "
+    print("Warning: the plotting module for Scippy was not imported. Check that"
+          "plotly is installed on your system. You can still use Scippy "
           "without its plotting functionality enabled.")

--- a/scippy/plot.py
+++ b/scippy/plot.py
@@ -15,7 +15,10 @@ from ipywidgets import VBox, HBox, IntSlider, Label
 
 # Some global configuration
 default = {
-    "cb" : { "name" : "Viridis", "log" : False, "min" : None, "max" : None }
+    # The colorbar properties
+    "cb" : { "name" : "Viridis", "log" : False, "min" : None, "max" : None },
+    # The default image height (in pixels)
+    "height" : 600
 }
 
 #===============================================================================
@@ -246,6 +249,7 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None,
         yaxis = dict(),
         showlegend = True,
         legend = dict(x=0.0, y=1.15, orientation="h"),
+        height = default["height"]
         )
     if histogram:
         layout["barmode"] = "overlay"
@@ -315,7 +319,8 @@ def plot_image(input_data, axes=None, contours=False, cb=None, plot=True,
 
         layout = dict(
             xaxis = dict(title = axis_label(xcoord)),
-            yaxis = dict(title = axis_label(ycoord))
+            yaxis = dict(title = axis_label(ycoord)),
+            height = default["height"]
             )
 
         if plot:
@@ -595,7 +600,8 @@ def plot_waterfall(input_data, dim=None, axes=None, plot=True):
                     aspectmode='manual',
                     aspectratio=adict
                     ),
-                showlegend = False
+                showlegend = False,
+                height = default["height"]
                 )
             return display(FigureWidget(data=data, layout=layout))
         else:

--- a/scippy/requirements.txt
+++ b/scippy/requirements.txt
@@ -3,4 +3,5 @@ pandas==0.24.2
 xarray==0.11.3
 matplotlib==3.0.3
 nose
+ipywidgets==7.4.2
 plotly==3.6.1

--- a/scippy/test/test_plotting.py
+++ b/scippy/test/test_plotting.py
@@ -2,10 +2,10 @@ import unittest
 
 from scippy import *
 import numpy as np
-import hashlib
+# import hashlib
 import io
 from contextlib import redirect_stdout
-import re
+# import re
 
 # TODO: For now we are just checking that the plot does not throw any errors.
 # In the future it would be nice to check the output by either comparing


### PR DESCRIPTION
Speeding up the `plot_image` function for large arrays by only displaying a low-resolution version of the data, and recovering the full resolution as we zoom in.

You can now easily plot arrays of any size. Example:
```Python
N = 2000
M = 1000
# xx and yy are the edges of the pixels in the full image
xx = np.arange(N+1, dtype=np.float64)
yy = np.arange(M+1, dtype=np.float64)
x, y = np.meshgrid(xx, yy)
b = N/40.0
c = M/2.0
r = np.sqrt(((x[:-1]-c)/b)**2 + ((y[:-1]-c)/b)**2)
# zz is the heatmap values
zz = np.sin(r)
d = Dataset()
d[Coord.X] = ([Dim.X], xx)
d[Coord.Y] = ([Dim.Y], yy)
d[Data.Value, "sample"] = ([Dim.Y, Dim.X], zz)
plot(d)
```

You can control the resolution of the displayed image by doing `plot(d, resolution=128)` to plot images of 128x128 pixels (`128` is the default).

Fixes #131

TODO: use the same machinery for the `sliceviewer`