### PR TITLE
Sanitizers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "range-v3"]
 	path = range-v3
 	url = https://github.com/ericniebler/range-v3.git
+[submodule "CMake/sanitizers-cmake"]
+	path = CMake/sanitizers-cmake
+	url = git://github.com/arsenm/sanitizers-cmake.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ script:
   - cd build
   - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make -j2 install
-  - ./units/test/scipp_units_test
-  - ./core/test/scipp_core_test
+  - ./units/test/scipp-units-test
+  - ./core/test/scipp-core-test
   - python3 -m pip install -r ../scippy/requirements.txt
   - export PYTHONPATH=$PYTHONPATH:../install
   - cd ../scippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - mkdir -p build
   - mkdir -p install
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
+  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSANITIZE_ADDRESS=On -DSANITIZE_MEMORY=On -DSANITIZE_THREAD=On -DSANITIZE_UNDEFINED=On -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make -j2 install
   - ./units/test/scipp-units-test
   - ./core/test/scipp-core-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - mkdir -p build
   - mkdir -p install
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSANITIZE_ADDRESS=On -DSANITIZE_MEMORY=On -DSANITIZE_THREAD=On -DSANITIZE_UNDEFINED=On -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
+  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSANITIZE_ADDRESS=On -DSANITIZE_UNDEFINED=On -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make -j2 install
   - ./units/test/scipp-units-test
   - ./core/test/scipp-core-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install: 
   # C++17
-  - sudo apt-get install -qq g++-7 libasan4
+  - sudo apt-get install -qq g++-7
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
   - sudo add-apt-repository -y ppa:mhier/libboost-latest
   - sudo apt update
@@ -31,7 +31,7 @@ script:
   - mkdir -p build
   - mkdir -p install
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSANITIZE_ADDRESS=On -DSANITIZE_UNDEFINED=On -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
+  - cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make -j2 install
   - ./units/test/scipp-units-test
   - ./core/test/scipp-core-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install: 
   # C++17
-  - sudo apt-get install -qq g++-7
+  - sudo apt-get install -qq g++-7 libasan4
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
   - sudo add-apt-repository -y ppa:mhier/libboost-latest
   - sudo apt update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,11 @@ if(NOT CMAKE_BUILD_TYPE)
     FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake")
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake" "${CMAKE_SOURCE_DIR}/CMake/sanitizers-cmake/cmake")
 
 find_package(OpenMP 3.1 REQUIRED)
 find_package(Boost 1.67 REQUIRED)
+find_package(Sanitizers REQUIRED)
 
 include(Eigen)
 include(pybind11)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE.txt)
 [![Build Status](https://www.travis-ci.org/scipp/scipp.svg?branch=master)](https://www.travis-ci.org/scipp/scipp)
 [![Documentation Status](https://readthedocs.org/projects/scipp/badge/?version=latest)](https://scipp.readthedocs.io/en/latest/?badge=latest)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Scipp
 
-See https://scipp.readthedocs.io for documentation of **scipp*.
+See https://scipp.readthedocs.io for documentation of **scipp**.
 
 Scipp mainly provides the `Dataset` container, which is inspired by `xarray.Dataset`.
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,27 +3,27 @@
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
 add_executable(variable_benchmark variable_benchmark.cpp)
-target_link_libraries(variable_benchmark LINK_PRIVATE ScippCore benchmark)
+target_link_libraries(variable_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(dataset_benchmark dataset_benchmark.cpp)
-target_link_libraries(dataset_benchmark LINK_PRIVATE ScippCore benchmark)
+target_link_libraries(dataset_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(md_zip_view_benchmark md_zip_view_benchmark.cpp)
-target_link_libraries(md_zip_view_benchmark LINK_PRIVATE ScippCore benchmark)
+target_link_libraries(md_zip_view_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(legacy_histogram_benchmark legacy_histogram_benchmark.cpp)
 target_link_libraries(legacy_histogram_benchmark
                       LINK_PRIVATE
-                      ScippCore
+                      scipp-core
                       benchmark)
 
 add_executable(multi_index_benchmark multi_index_benchmark.cpp)
-target_link_libraries(multi_index_benchmark LINK_PRIVATE ScippCore benchmark)
+target_link_libraries(multi_index_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(event_list_proxy_benchmark event_list_proxy_benchmark.cpp)
 target_link_libraries(event_list_proxy_benchmark
                       LINK_PRIVATE
-                      ScippCore
+                      scipp-core
                       benchmark)
 target_include_directories(event_list_proxy_benchmark SYSTEM
                            PRIVATE "../range-v3/include")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,16 +34,16 @@ set(SRC_FILES
     md_zip_view.cpp
     variable.cpp)
 
-add_library(ScippCore STATIC ${INC_FILES} ${SRC_FILES})
-target_link_libraries(ScippCore
-                      PUBLIC ScippUnits Boost::boost OpenMP::OpenMP_CXX)
+add_library(scipp-core STATIC ${INC_FILES} ${SRC_FILES})
+target_link_libraries(scipp-core
+                      PUBLIC scipp-units Boost::boost OpenMP::OpenMP_CXX)
 target_include_directories(
-  ScippCore
+  scipp-core
   PUBLIC $<INSTALL_INTERFACE:.> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/.>
   )
-target_include_directories(ScippCore SYSTEM
+target_include_directories(scipp-core SYSTEM
                            PUBLIC ${CMAKE_BINARY_DIR}/Eigen-src
                            PRIVATE "../range-v3/include")
-set_target_properties(ScippCore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+set_target_properties(scipp-core PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 add_subdirectory(test)

--- a/core/dataset_index.h
+++ b/core/dataset_index.h
@@ -19,7 +19,7 @@ public:
     scipp::index current = 0;
     for (auto item : axis)
       m_index[item] = current++;
-    if (axis.size() != m_index.size())
+    if (scipp::size(axis) != scipp::size(m_index))
       throw std::runtime_error("Axis contains duplicate labels. Cannot use it "
                                "to index into the data.");
   }

--- a/core/event_list_proxy.h
+++ b/core/event_list_proxy.h
@@ -33,8 +33,7 @@ public:
   // want to support read-only access if only a subset of all fields is
   // requested, e.g., for reading only TOF, without need to know whether also
   // pulse-times or weights are present.
-  template <class... Tags>
-  ZipView<Tags...> getMutable(const Tags... tags) const {
+  template <class... Tags> ZipView<Tags...> getMutable(const Tags...) const {
     return ZipView<Tags...>(*m_dataset);
   }
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # @author Simon Heybrock
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
-add_executable(scipp_core_test
+add_executable(scipp-core-test
                bool_test.cpp
                convert_test.cpp
                dataset_test.cpp
@@ -19,13 +19,14 @@ add_executable(scipp_core_test
                variable_view_test.cpp
                Workspace2D_test.cpp
                zip_view_test.cpp)
-target_link_libraries(scipp_core_test
+add_sanitizers(scipp-core-test)
+target_link_libraries(scipp-core-test
                       LINK_PRIVATE
-                      ScippCore
+                      scipp-core
                       GTest::Main
                       scipp_test_helpers
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
-target_include_directories(scipp_core_test SYSTEM
+target_include_directories(scipp-core-test SYSTEM
                            PRIVATE "../../range-v3/include")
-gtest_discover_tests(scipp_core_test TEST_PREFIX scipp/core/)
+gtest_discover_tests(scipp-core-test TEST_PREFIX scipp/core/)

--- a/core/zip_view.h
+++ b/core/zip_view.h
@@ -256,11 +256,13 @@ constexpr auto doMakeItemZipProxy(const bool mayResize, const T &item,
                                   std::index_sequence<Is...>) noexcept {
   if constexpr ((std::is_const_v<
                      std::remove_reference_t<decltype(std::get<Is>(item))>> &&
-                 ...))
+                 ...)) {
+    static_cast<void>(mayResize);
     return ConstItemZipProxy(std::get<Is>(item)...);
 
-  else
+  } else {
     return ItemZipProxy(mayResize, std::get<Is>(item)...);
+  }
 }
 
 template <class T, bool Resizable, class... Keys> struct ItemProxy {

--- a/scippy/CMakeLists.txt
+++ b/scippy/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
 pybind11_add_module(scippy SHARED dataset.cpp)
-target_link_libraries(scippy LINK_PRIVATE ScippCore)
+target_link_libraries(scippy LINK_PRIVATE scipp-core)
 target_include_directories(scippy SYSTEM PRIVATE "../range-v3/include")
 
 set(PY_FILES __init__.py table.py xarray_compat.py plot.py)

--- a/scippy/dataset.cpp
+++ b/scippy/dataset.cpp
@@ -53,12 +53,13 @@ Variable makeVariable(Tag tag, const Dimensions &dimensions,
 
   } else {
     // Try to find blocks to copy
-    auto index = strides.size() - 1;
+    auto index = scipp::size(strides) - 1;
     while (strides[index] == varStrides[index])
       --index;
     ++index;
-    auto blockSz =
-        index < strides.size() ? strides[index] * dimensions.size(index) : 1;
+    auto blockSz = index < scipp::size(strides)
+                       ? strides[index] * dimensions.size(index)
+                       : 1;
 
     auto res = makeVariable<underlying_type_t<T>>(tag, dimensions);
     std::vector<scipp::index> dsz(ndims);

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -6,12 +6,12 @@ set(INC_FILES include/scipp/units/unit.h)
 
 set(SRC_FILES unit.cpp)
 
-add_library(ScippUnits STATIC ${INC_FILES} ${SRC_FILES})
-target_link_libraries(ScippUnits PUBLIC Boost::boost)
+add_library(scipp-units STATIC ${INC_FILES} ${SRC_FILES})
+target_link_libraries(scipp-units PUBLIC Boost::boost)
 target_include_directories(
-  ScippUnits
+  scipp-units
   PUBLIC $<INSTALL_INTERFACE:include>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-set_target_properties(ScippUnits PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+set_target_properties(scipp-units PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 add_subdirectory(test)

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -2,12 +2,13 @@
 # @author Simon Heybrock
 # Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
-add_executable(scipp_units_test unit_test.cpp)
-target_link_libraries(scipp_units_test
+add_executable(scipp-units-test unit_test.cpp)
+target_link_libraries(scipp-units-test
                       LINK_PRIVATE
-                      ScippUnits
+                      scipp-units
                       GTest::Main
                       scipp_test_helpers
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
-gtest_discover_tests(scipp_units_test TEST_PREFIX scipp/units/)
+add_sanitizers(scipp-units-test)
+gtest_discover_tests(scipp-units-test TEST_PREFIX scipp/units/)


### PR DESCRIPTION
- Fix compiler warnings.
- Add `sanitizers-cmake` submodule, which provides a convenient way to enable various sanitizers (see https://github.com/arsenm/sanitizers-cmake).
- Enable some sanitizers in Travis.

Note that not all sanitizers can be enabled at the same time. We need to setup separate Travis builds so we can also run thread- and memory-sanitizer.