### PR TITLE
Sparse dimension support

### DIFF
--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -84,7 +84,7 @@ void Dimensions::erase(const Dim label) {
     m_dims[i] = m_dims[i + 1];
   }
   --m_ndim;
-  m_shape[m_ndim] = -2;
+  m_shape[m_ndim] = -1;
   m_dims[m_ndim] = Dim::Invalid;
 }
 
@@ -110,6 +110,10 @@ void Dimensions::add(const Dim label, const scipp::index size) {
 void Dimensions::addInner(const Dim label, const scipp::index size) {
   if (sparse())
     throw except::SparseDimensionError();
+  if (label == Dim::Invalid)
+    throw std::runtime_error("Dim::Invalid is not a valid dimension.");
+  if (size < 0)
+    throw std::runtime_error("Dimension extent cannot be negative.");
   if (contains(label))
     throw std::runtime_error("Duplicate dimension.");
   if (m_ndim == 6)

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -90,9 +90,6 @@ void Dimensions::erase(const Dim label) {
 
 /// Add a new dimension, which will be the outermost dimension.
 void Dimensions::add(const Dim label, const scipp::index size) {
-  if (!empty() && size == Extent::Sparse)
-    throw except::SparseDimensionError();
-
   if (contains(label))
     throw std::runtime_error("Duplicate dimension.");
   if (m_ndim == 6)
@@ -108,8 +105,6 @@ void Dimensions::add(const Dim label, const scipp::index size) {
 
 /// Add a new dimension, which will be the innermost dimension.
 void Dimensions::addInner(const Dim label, const scipp::index size) {
-  if (sparse())
-    throw except::SparseDimensionError();
   if (label == Dim::Invalid)
     throw std::runtime_error("Dim::Invalid is not a valid dimension.");
   if (size < 0)

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -84,12 +84,15 @@ void Dimensions::erase(const Dim label) {
     m_dims[i] = m_dims[i + 1];
   }
   --m_ndim;
-  m_shape[m_ndim] = -1;
+  m_shape[m_ndim] = -2;
   m_dims[m_ndim] = Dim::Invalid;
 }
 
 /// Add a new dimension, which will be the outermost dimension.
 void Dimensions::add(const Dim label, const scipp::index size) {
+  if (!empty() && size == Extent::Sparse)
+    throw except::SparseDimensionError();
+
   if (contains(label))
     throw std::runtime_error("Duplicate dimension.");
   if (m_ndim == 6)
@@ -105,6 +108,8 @@ void Dimensions::add(const Dim label, const scipp::index size) {
 
 /// Add a new dimension, which will be the innermost dimension.
 void Dimensions::addInner(const Dim label, const scipp::index size) {
+  if (sparse())
+    throw except::SparseDimensionError();
   if (contains(label))
     throw std::runtime_error("Duplicate dimension.");
   if (m_ndim == 6)

--- a/core/dimensions.h
+++ b/core/dimensions.h
@@ -75,6 +75,25 @@ public:
     return volume;
   }
 
+  /// Returns the volume, excluding a potentially sparse dimensions.
+  ///
+  /// This is named `area` since it typically covers one dimension less that the
+  /// volume would. Example: Consider data shaped as follows:
+  ///
+  /// xxxxxx
+  /// xxx
+  /// xxxxx
+  ///
+  /// The return value would be 3 in this case.
+  scipp::index nonSparseArea() const noexcept {
+    if (!sparse())
+      return volume();
+    scipp::index volume{1};
+    for (int32_t dim = 0; dim < ndim() - 1; ++dim)
+      volume *= m_shape[dim];
+    return volume;
+  }
+
   scipp::span<const scipp::index> shape() const noexcept {
     return {m_shape, m_shape + m_ndim};
   }

--- a/core/dimensions.h
+++ b/core/dimensions.h
@@ -16,10 +16,6 @@
 
 namespace scipp::core {
 
-enum Extent : scipp::index {
-  Sparse = std::numeric_limits<scipp::index>::max()
-};
-
 /// Dimensions are accessed very frequently, so packing everything into a single
 /// (64 Byte) cacheline should be advantageous.
 /// We should follow the numpy convention: First dimension is outer dimension,
@@ -58,38 +54,14 @@ public:
   }
 
   bool empty() const noexcept { return m_ndim == 0; }
-  bool sparse() const noexcept {
-    return m_ndim == 0 ? false : m_shape[m_ndim - 1] == Extent::Sparse;
-  }
 
   int32_t ndim() const noexcept { return m_ndim; }
   // TODO Remove in favor of the new ndim?
   int32_t count() const noexcept { return m_ndim; }
 
   scipp::index volume() const {
-    if (sparse())
-      throw except::SparseDimensionError();
     scipp::index volume{1};
     for (int32_t dim = 0; dim < ndim(); ++dim)
-      volume *= m_shape[dim];
-    return volume;
-  }
-
-  /// Returns the volume, excluding a potentially sparse dimensions.
-  ///
-  /// This is named `area` since it typically covers one dimension less that the
-  /// volume would. Example: Consider data shaped as follows:
-  ///
-  /// xxxxxx
-  /// xxx
-  /// xxxxx
-  ///
-  /// The return value would be 3 in this case.
-  scipp::index nonSparseArea() const noexcept {
-    if (!sparse())
-      return volume();
-    scipp::index volume{1};
-    for (int32_t dim = 0; dim < ndim() - 1; ++dim)
       volume *= m_shape[dim];
     return volume;
   }

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -199,9 +199,14 @@ std::string make_dims_labels(const Variable &variable,
     return "()";
   std::string diminfo = "(";
   for (const auto dim : dims.labels()) {
-    if (datasetDims.contains(dim) && (datasetDims[dim] + 1 == dims[dim]))
-      diminfo += "Bin-edges: ";
     diminfo += to_string(dim, separator);
+    if (datasetDims.contains(dim) && (datasetDims[dim] + 1 == dims[dim]))
+      diminfo += " [bin-edges]";
+    diminfo += ", ";
+  }
+  if (variable.isSparse()) {
+    diminfo += to_string(variable.sparseDim(), separator);
+    diminfo += " [sparse]";
     diminfo += ", ";
   }
   diminfo.resize(diminfo.size() - 2);

--- a/core/except.h
+++ b/core/except.h
@@ -65,7 +65,8 @@ struct DimensionLengthError : public DimensionError {
 };
 
 struct SparseDimensionError : public DimensionError {
-  SparseDimensionError() : DimensionError("") {}
+  SparseDimensionError()
+      : DimensionError("Unsupported operation for sparse dimensions.") {}
 };
 
 struct DatasetError : public std::runtime_error {

--- a/core/except.h
+++ b/core/except.h
@@ -64,6 +64,10 @@ struct DimensionLengthError : public DimensionError {
                        const scipp::index length);
 };
 
+struct SparseDimensionError : public DimensionError {
+  SparseDimensionError() : DimensionError("") {}
+};
+
 struct DatasetError : public std::runtime_error {
   DatasetError(const Dataset &dataset, const std::string &message);
   DatasetError(const ConstDatasetSlice &dataset, const std::string &message);

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -1899,3 +1899,24 @@ TEST(Dataset, counts_toDensity_fromDensity) {
   EXPECT_EQ(result.unit(), units::counts);
   EXPECT_TRUE(equals(result.get(Data::Value), {12, 12, 12}));
 }
+
+TEST(SparseDataset, different_variables_can_have_different_sparse_dimensions) {
+  Dataset d;
+  d.insert(makeSparseVariable<double>(Coord::X, {Dim::X, 2}, Dim::Y));
+  d.insert(makeSparseVariable<double>(Coord::Y, {Dim::X, 2}, Dim::Z));
+  EXPECT_EQ(d.size(), 2);
+}
+
+TEST(SparseDataset, dimensions_of_dataset_does_not_contain_sparse_dims) {
+  Dataset d;
+  d.insert(makeSparseVariable<double>(Coord::X, {Dim::X, 2}, Dim::Y));
+  EXPECT_EQ(d.dimensions(), Dimensions({Dim::X, 2}));
+}
+
+TEST(SparseDataset, dimension_can_be_dense_in_some_vars_and_sparse_in_others) {
+  Dataset d;
+  d.insert(makeSparseVariable<double>(Coord::X, {Dim::X, 2}, Dim::Y));
+  d.insert(makeVariable<double>(Coord::Y, {Dim::Y, 3}));
+  EXPECT_EQ(d.size(), 2);
+  EXPECT_EQ(d.dimensions(), Dimensions({{Dim::Y, 3}, {Dim::X, 2}}));
+}

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -128,3 +128,24 @@ TEST(Dimensions, isContiguousIn) {
   EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::X, 4}}).isContiguousIn(parent));
   EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::Y, 3}}).isContiguousIn(parent));
 }
+
+TEST(SparseDimensions, sparse) {
+  Dimensions dims;
+  EXPECT_FALSE(dims.sparse());
+}
+
+TEST(SparseDimensions, empty_add) {
+  Dimensions dims;
+  ASSERT_NO_THROW(dims.add(Dim::X, Extent::Sparse));
+  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
+}
+
+TEST(SparseDimensions, sparse_must_be_inner) {
+  Dimensions dims(Dim::X, 2);
+  ASSERT_THROW(dims.add(Dim::Y, Extent::Sparse), except::SparseDimensionError);
+  ASSERT_NO_THROW(dims.addInner(Dim::Y, Extent::Sparse));
+  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
+  ASSERT_THROW(dims.addInner(Dim::Z, 2), except::SparseDimensionError);
+  ASSERT_NO_THROW(dims.add(Dim::Z, 2));
+  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
+}

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -154,6 +154,8 @@ TEST(SparseDimensions, sparse_must_be_inner) {
 
 TEST(SparseDimensions, create_initializer_list) {
   ASSERT_NO_THROW((Dimensions{{Dim::X, 2}, {Dim::Y, Extent::Sparse}}));
+  ASSERT_THROW((Dimensions{{Dim::Y, Extent::Sparse}, {Dim::X, 2}}),
+               except::SparseDimensionError);
 }
 
 TEST(SparseDimensions, nonSparseArea) {

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -128,39 +128,3 @@ TEST(Dimensions, isContiguousIn) {
   EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::X, 4}}).isContiguousIn(parent));
   EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::Y, 3}}).isContiguousIn(parent));
 }
-
-TEST(SparseDimensions, sparse) {
-  Dimensions dims;
-  EXPECT_FALSE(dims.sparse());
-}
-
-TEST(SparseDimensions, empty_add) {
-  Dimensions dims;
-  ASSERT_NO_THROW(dims.add(Dim::X, Extent::Sparse));
-  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
-}
-
-TEST(SparseDimensions, sparse_must_be_inner) {
-  Dimensions dims(Dim::X, 2);
-  ASSERT_THROW(dims.add(Dim::Y, Extent::Sparse), except::SparseDimensionError);
-  ASSERT_NO_THROW(dims.addInner(Dim::Y, Extent::Sparse));
-  EXPECT_TRUE(dims.sparse());
-  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
-  ASSERT_THROW(dims.addInner(Dim::Z, 2), except::SparseDimensionError);
-  ASSERT_NO_THROW(dims.add(Dim::Z, 2));
-  EXPECT_TRUE(dims.sparse());
-  ASSERT_THROW(dims.volume(), except::SparseDimensionError);
-}
-
-TEST(SparseDimensions, create_initializer_list) {
-  ASSERT_NO_THROW((Dimensions{{Dim::X, 2}, {Dim::Y, Extent::Sparse}}));
-  ASSERT_THROW((Dimensions{{Dim::Y, Extent::Sparse}, {Dim::X, 2}}),
-               except::SparseDimensionError);
-}
-
-TEST(SparseDimensions, nonSparseArea) {
-  Dimensions dense{{Dim::X, 2}, {Dim::Y, 3}};
-  EXPECT_EQ(dense.nonSparseArea(), 6);
-  Dimensions sparse{{Dim::X, 2}, {Dim::Y, Extent::Sparse}};
-  EXPECT_EQ(sparse.nonSparseArea(), 2);
-}

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -144,8 +144,21 @@ TEST(SparseDimensions, sparse_must_be_inner) {
   Dimensions dims(Dim::X, 2);
   ASSERT_THROW(dims.add(Dim::Y, Extent::Sparse), except::SparseDimensionError);
   ASSERT_NO_THROW(dims.addInner(Dim::Y, Extent::Sparse));
+  EXPECT_TRUE(dims.sparse());
   ASSERT_THROW(dims.volume(), except::SparseDimensionError);
   ASSERT_THROW(dims.addInner(Dim::Z, 2), except::SparseDimensionError);
   ASSERT_NO_THROW(dims.add(Dim::Z, 2));
+  EXPECT_TRUE(dims.sparse());
   ASSERT_THROW(dims.volume(), except::SparseDimensionError);
+}
+
+TEST(SparseDimensions, create_initializer_list) {
+  ASSERT_NO_THROW((Dimensions{{Dim::X, 2}, {Dim::Y, Extent::Sparse}}));
+}
+
+TEST(SparseDimensions, nonSparseArea) {
+  Dimensions dense{{Dim::X, 2}, {Dim::Y, 3}};
+  EXPECT_EQ(dense.nonSparseArea(), 6);
+  Dimensions sparse{{Dim::X, 2}, {Dim::Y, Extent::Sparse}};
+  EXPECT_EQ(sparse.nonSparseArea(), 2);
 }

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1285,3 +1285,7 @@ TEST(Variable, apply_binary_in_place_view_with_view) {
       [](const auto x, const auto y) { return x + y; }, b(Dim::Y, 1));
   EXPECT_TRUE(equals(a.span<double>(), {1.1, 5.5}));
 }
+
+TEST(SparseVariable, create) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+}

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1288,4 +1288,41 @@ TEST(Variable, apply_binary_in_place_view_with_view) {
 
 TEST(SparseVariable, create) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  EXPECT_TRUE(var.dimensions().sparse());
+  // Should we return the full volume here, i.e., accumulate the extents of all
+  // the sparse subdata?
+  EXPECT_EQ(var.size(), 2);
+}
+
+TEST(SparseVariable, DISABLED_dtype) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  // Should we return double or the nested container type here?
+  EXPECT_EQ(var.dtype(), dtype<double>);
+}
+
+TEST(SparseVariable, non_sparse_access_fail) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  ASSERT_THROW(var.get(Data::Value), except::TypeError);
+  ASSERT_THROW(var.span<double>(), except::TypeError);
+}
+
+TEST(SparseVariable, DISABLED_low_level_access) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  // Need to decide whether we allow this direct access or not.
+  ASSERT_THROW((var.span<sparse_container<double>>()), except::TypeError);
+}
+
+TEST(SparseVariable, access) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  ASSERT_NO_THROW(var.sparseSpan<double>());
+  auto data = var.sparseSpan<double>();
+  ASSERT_EQ(data.size(), 2);
+  EXPECT_TRUE(data[0].empty());
+  EXPECT_TRUE(data[1].empty());
+}
+
+TEST(SparseVariable, resize_sparse) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, Extent::Sparse}});
+  auto data = var.sparseSpan<double>();
+  data[1] = {1, 2, 3};
 }

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1472,3 +1472,16 @@ TEST(SparseVariable, binary_with_dense) {
   EXPECT_TRUE(equals(sparse_[0], {1.5, 3.0, 4.5}));
   EXPECT_TRUE(equals(sparse_[1], {2.0}));
 }
+
+TEST(SparseVariable, operator_plus) {
+  auto sparse = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
+  auto sparse_ = sparse.sparseSpan<double>();
+  sparse_[0] = {1, 2, 3};
+  sparse_[1] = {4};
+  auto dense = makeVariable<double>(Data::Value, {Dim::Y, 2}, {1.5, 0.5});
+
+  sparse += dense;
+
+  EXPECT_TRUE(equals(sparse_[0], {2.5, 3.5, 4.5}));
+  EXPECT_TRUE(equals(sparse_[1], {4.5}));
+}

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1439,6 +1439,25 @@ TEST(SparseVariable, unary) {
   EXPECT_TRUE(equals(a_[1], {2}));
 }
 
+TEST(SparseVariable, DISABLED_unary_on_sparse_container) {
+  auto a = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
+  auto a_ = a.sparseSpan<double>();
+  a_[0] = {1, 4, 9};
+  a_[1] = {4};
+
+  // TODO This is currently broken: The wrong overload of
+  // TransformSparse::operator() is selected, so the lambda here is not applied
+  // to the whole sparse container (clearing it), but instead to each item of
+  // each sparse container. Is there a way to handle this correctly
+  // automatically, or do we need to manually specify whether we want to
+  // transform items of the variable, or items of the sparse containers that are
+  // items of the variable?
+  a.transform_in_place<sparse_container<double>>(
+      [](const auto &x) { return decltype(x){}; });
+  EXPECT_TRUE(a_[0].empty());
+  EXPECT_TRUE(a_[1].empty());
+}
+
 TEST(SparseVariable, binary_with_dense) {
   auto sparse = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
   auto sparse_ = sparse.sparseSpan<double>();

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1337,6 +1337,25 @@ TEST(SparseVariable, concatenate) {
   EXPECT_EQ(var.size(), 5);
 }
 
+TEST(SparseVariable, concatenate_along_sparse_dimension) {
+  auto a = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
+  auto a_ = a.sparseSpan<double>();
+  a_[0] = {1, 2, 3};
+  a_[1] = {1, 2};
+  auto b = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
+  auto b_ = b.sparseSpan<double>();
+  b_[0] = {1, 3};
+  b_[1] = {};
+
+  auto var = concatenate(a, b, Dim::X);
+  EXPECT_TRUE(var.isSparse());
+  EXPECT_EQ(var.sparseDim(), Dim::X);
+  EXPECT_EQ(var.size(), 2);
+  auto data = var.sparseSpan<double>();
+  EXPECT_TRUE(equals(data[0], {1, 2, 3, 1, 3}));
+  EXPECT_TRUE(equals(data[1], {1, 2}));
+}
+
 TEST(SparseVariable, slice) {
   auto var = makeSparseVariable<double>(Data::Value, {Dim::Y, 4}, Dim::X);
   auto data = var.sparseSpan<double>();

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -274,7 +274,10 @@ public:
   DataModel(const Dimensions &dimensions, T model)
       : conceptT_t<typename T::value_type>(std::move(dimensions)),
         m_model(std::move(model)) {
-    if (this->dimensions().volume() != scipp::size(m_model))
+    // For now we assume that sparse data is stored in nested containers, i.e.,
+    // we have a vector of vectors. If we were to support a linearized layout
+    // this check would need to be different.
+    if (this->dimensions().nonSparseArea() != scipp::size(m_model))
       throw std::runtime_error("Creating Variable: data size does not match "
                                "volume given by dimension extents");
   }

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -573,13 +573,10 @@ INSTANTIATE(std::array<double, 4>)
 INSTANTIATE(Eigen::Vector3d)
 
 template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
-  // Compare even before pointer comparison since data may be shared even if
-  // names differ.
   if (a.name() != b.name())
     return false;
   if (a.unit() != b.unit())
     return false;
-  // Deep comparison
   if (a.tag() != b.tag())
     return false;
   if (!(a.dimensions() == b.dimensions()))

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -274,10 +274,7 @@ public:
   DataModel(const Dimensions &dimensions, T model)
       : conceptT_t<typename T::value_type>(std::move(dimensions)),
         m_model(std::move(model)) {
-    // For now we assume that sparse data is stored in nested containers, i.e.,
-    // we have a vector of vectors. If we were to support a linearized layout
-    // this check would need to be different.
-    if (this->dimensions().nonSparseArea() != scipp::size(m_model))
+    if (this->dimensions().volume() != scipp::size(m_model))
       throw std::runtime_error("Creating Variable: data size does not match "
                                "volume given by dimension extents");
   }
@@ -337,7 +334,7 @@ public:
   }
 
   VariableConceptHandle clone(const Dimensions &dims) const override {
-    return std::make_unique<DataModel<T>>(dims, T(dims.nonSparseArea()));
+    return std::make_unique<DataModel<T>>(dims, T(dims.volume()));
   }
 
   bool isContiguous() const override { return true; }
@@ -526,13 +523,11 @@ Variable::Variable(const Tag tag, const units::Unit unit,
                                               std::move(object))) {}
 
 void Variable::setDimensions(const Dimensions &dimensions) {
-  if (!(dimensions.sparse() || m_object->dimensions().sparse())) {
     if (dimensions.volume() == m_object->dimensions().volume()) {
       if (dimensions != m_object->dimensions())
         data().m_dimensions = dimensions;
       return;
     }
-  }
   m_object = m_object->clone(dimensions);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -978,6 +978,16 @@ Variable concatenate(const Variable &a1, const Variable &a2, const Dim dim) {
   if (a1.name() != a2.name())
     throw std::runtime_error(
         "Cannot concatenate Variables: Names do not match.");
+
+  if (a1.sparseDim() == dim && a2.sparseDim() == dim) {
+    return a1.transform<pair_self_t<sparse_container<double>>>(
+        [](auto a, const auto &b) {
+          a.insert(a.end(), b.begin(), b.end());
+          return a;
+        },
+        a2);
+  }
+
   const auto &dims1 = a1.dimensions();
   const auto &dims2 = a2.dimensions();
   // TODO Many things in this function should be refactored and moved in class

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -611,7 +611,8 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
     // Note: This will broadcast/transpose the RHS if required. We do not
     // support changing the dimensions of the LHS though!
     variable.template transform_in_place<
-        pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
+        pair_self_t<double, float, int64_t, Eigen::Vector3d>,
+        pair_custom_t<std::pair<sparse_container<double>, double>>>(
         [](auto &&a, auto &&b) { return a + b; }, other);
   } else {
     if (variable.dimensions() == other.dimensions()) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -523,11 +523,11 @@ Variable::Variable(const Tag tag, const units::Unit unit,
                                               std::move(object))) {}
 
 void Variable::setDimensions(const Dimensions &dimensions) {
-    if (dimensions.volume() == m_object->dimensions().volume()) {
-      if (dimensions != m_object->dimensions())
-        data().m_dimensions = dimensions;
-      return;
-    }
+  if (dimensions.volume() == m_object->dimensions().volume()) {
+    if (dimensions != m_object->dimensions())
+      data().m_dimensions = dimensions;
+    return;
+  }
   m_object = m_object->clone(dimensions);
 }
 

--- a/core/variable.h
+++ b/core/variable.h
@@ -362,6 +362,9 @@ struct default_init<Eigen::Matrix<T, Rows, Cols>> {
 };
 } // namespace detail
 
+template <class T>
+using sparse_container = boost::container::small_vector<T, 8>;
+
 /// Variable is a type-erased handle to any data structure representing a
 /// multi-dimensional array. It has a name, a unit, and a set of named
 /// dimensions.
@@ -379,9 +382,9 @@ public:
     using Type = underlying_type_t<typename TagT::type>;
     if (dimensions.sparse()) {
       if constexpr (std::is_same_v<Type, double>)
-        *this = Variable(tag, TagT::unit, std::move(dimensions),
-                         Vector<boost::container::small_vector<Type, 8>>(
-                             dimensions.nonSparseArea()));
+        *this = Variable(
+            tag, TagT::unit, std::move(dimensions),
+            Vector<sparse_container<Type>>(dimensions.nonSparseArea()));
       else
         throw std::runtime_error(
             "Sparse dimensions for this dtype are not supported.");
@@ -518,6 +521,12 @@ public:
 
   template <class T> auto span() const { return scipp::span(cast<T>()); }
   template <class T> auto span() { return scipp::span(cast<T>()); }
+  template <class T> auto sparseSpan() const {
+    return scipp::span(cast<sparse_container<T>>());
+  }
+  template <class T> auto sparseSpan() {
+    return scipp::span(cast<sparse_container<T>>());
+  }
 
   // ATTENTION: It is really important to delete any function returning a
   // (Const)VariableSlice for rvalue Variable. Otherwise the resulting slice

--- a/core/variable.h
+++ b/core/variable.h
@@ -727,7 +727,7 @@ public:
     return strides;
   }
 
-  DType dtype() const noexcept { return data().dtype(); }
+  DType dtype() const noexcept { return m_variable->dtype(); }
   Tag tag() const { return m_variable->tag(); }
 
   const VariableConcept &data() const && = delete;

--- a/core/variable.h
+++ b/core/variable.h
@@ -196,6 +196,8 @@ template <class Op> struct TransformSparse {
     std::transform(x.begin(), x.end(), x.begin(), op);
     return x;
   }
+  // TODO Would like to use T1 and T2 for a and b, but currently this leads to
+  // selection of the wrong overloads.
   template <class T>
   constexpr auto operator()(sparse_container<T> a, const T b) const {
     std::transform(a.begin(), a.end(), a.begin(),


### PR DESCRIPTION
This depends on #205. See also https://github.com/scipp/scipp/blob/master/doc/design-sparse.md.

Adding more integrated (and general) support for event data: We can now handle this as a sparse dimension.

To minimize the impact on existing and future code, we chose to *not* include the sparse dimension in `class Dimensions`. An early attempt (see the history) did this, requiring changes in the implementation of many functions/methods (in particular those of `VariableConcept`, slicing, ...), adding special case handling. The final approach avoids this. The sparse dimension in now just stored in `Variable` (a potential future change might be to move it into `VariableConcept`, adding `SparseDataModel<T>`, which might be cleaner but does not provide an advantage at this point).

A number of tests and example usage of `transform` for variables shows how to operate with sparse data. More complete support of operations should be added after some cleanup around the transform mechanism.

For example, we can easily define a new operation between sparse and dense data as follows:

```cpp
  sparse.transform_in_place<
      pair_custom_t<std::pair<sparse_container<double>, double>>>(
      [](const double a, const double b) { return a * b; }, dense);
```

The syntax for specifying transform and the allowed types in a transform still requires cleanup.

Another thing that is missing are more overloads of `makeSparseVariable`, or equivalent constructors.

It is furthermore worth considering whether `Variable::sparseSpan()` should provide direct access to `sparse_container<T>`. This breaks encapsulation to some extent, since changing the underlying storage container is directly visible. Maybe this should be wrapped in our own vector-like abstraction?