### PR TITLE
Remove special event handling

### DIFF
--- a/core/apply.h
+++ b/core/apply.h
@@ -14,8 +14,8 @@ namespace scipp::core {
 template <class... Ts, class Op, class Var, class... Vars>
 void apply_in_place(Op op, Var &&var, const Vars &... vars) {
   try {
-    scipp::core::visit_impl<Ts...>::apply(op, var.dataHandle().m_object,
-                                          vars.dataHandle().m_object...);
+    scipp::core::visit_impl<Ts...>::apply(op, var.dataHandle().variant(),
+                                          vars.dataHandle().variant()...);
   } catch (const std::bad_variant_access &) {
     throw except::TypeError("");
   }

--- a/core/apply.h
+++ b/core/apply.h
@@ -6,13 +6,19 @@
 #define APPLY_H
 
 #include "variable.h"
+#include "visit.h"
 
 namespace scipp::core {
 
 /// Apply functor to variables of given arguments.
 template <class... Ts, class Op, class Var, class... Vars>
 void apply_in_place(Op op, Var &&var, const Vars &... vars) {
-  var.dataHandle().template apply_in_place<Ts...>(op, vars.dataHandle()...);
+  try {
+    scipp::core::visit_impl<Ts...>::apply(op, var.dataHandle().m_object,
+                                          vars.dataHandle().m_object...);
+  } catch (const std::bad_variant_access &) {
+    throw except::TypeError("");
+  }
 }
 
 } // namespace scipp::core

--- a/core/apply.h
+++ b/core/apply.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef APPLY_H
+#define APPLY_H
+
+#include "variable.h"
+
+namespace scipp::core {
+
+/// Apply functor to variables of given arguments.
+template <class... Ts, class Op, class Var, class... Vars>
+void apply_in_place(Op op, Var &&var, const Vars &... vars) {
+  var.dataHandle().template apply_in_place<Ts...>(op, vars.dataHandle()...);
+}
+
+} // namespace scipp::core
+
+#endif // APPLY_H

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1409,7 +1409,6 @@ TEST(SparseVariable, concatenate_along_sparse_dimension) {
   EXPECT_EQ(var.sparseDim(), Dim::X);
   EXPECT_EQ(var.size(), 2);
   auto data = var.sparseSpan<double>();
-  EXPECT_EQ(data[0].size(), 5);
   EXPECT_TRUE(equals(data[0], {1, 2, 3, 1, 3}));
   EXPECT_TRUE(equals(data[1], {1, 2}));
 }

--- a/core/transform.h
+++ b/core/transform.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef TRANSFORM_H
+#define TRANSFORM_H
+
+#include "variable.h"
+
+namespace scipp::core {
+
+template <class... Ts, class Var, class Op>
+void transform_in_place(Var &var, Op op) {
+  var.dataHandle().template transform_in_place<Ts...>(op);
+}
+
+template <class... TypePairs, class Var1, class Var, class Op>
+void transform_in_place(const Var1 &other, Var &&var, Op op) {
+  var.dataHandle().template transform_in_place<TypePairs...>(
+      op, other.dataHandle());
+}
+
+template <class... Ts, class Var, class Op>
+Variable transform(const Var &var, Op op) {
+  return Variable(var, var.dataHandle().template transform<Ts...>(op));
+}
+
+} // namespace scipp::core
+
+#endif // TRANSFORM_H

--- a/core/transform.h
+++ b/core/transform.h
@@ -116,7 +116,7 @@ template <class Op> struct Transform {
     auto outData = out->getSpan();
     std::transform(data.begin(), data.end(), outData.begin(), op);
     return {std::move(out)};
-}
+  }
 };
 
 } // namespace detail

--- a/core/transform.h
+++ b/core/transform.h
@@ -45,7 +45,7 @@ template <class Op> struct TransformInPlace {
   }
   template <class A, class B> void operator()(A &&a, B &&b_ptr) const {
     // std::unique_ptr::operator*() is const but returns mutable reference, need
-    // to artificially put const to we call the corect overloads of ViewModel.
+    // to artificially put const to we call the correct overloads of ViewModel.
     const auto &b = *b_ptr;
     const auto &dimsA = a->dimensions();
     const auto &dimsB = b.dimensions();
@@ -136,7 +136,7 @@ void transform_in_place(Var &var, Op op) {
   try {
     scipp::core::visit_impl<Ts...>::apply(
         TransformInPlace{overloaded{op, TransformSparse<Op>{op}}},
-        var.dataHandle().m_object);
+        var.dataHandle().variant());
   } catch (const std::bad_variant_access &) {
     throw std::runtime_error("Operation not implemented for this type.");
   }
@@ -153,7 +153,7 @@ void transform_in_place(const Var1 &other, Var &&var, Op op) {
   try {
     scipp::core::visit(std::tuple_cat(TypePairs{}...))
         .apply(TransformInPlace{overloaded{op, TransformSparse<Op>{op}}},
-               var.dataHandle().m_object, other.dataHandle().m_object);
+               var.dataHandle().variant(), other.dataHandle().variant());
   } catch (const std::bad_variant_access &) {
     throw except::TypeError("Cannot apply operation to item dtypes " +
                             to_string(var.dtype()) + " and " +
@@ -171,7 +171,7 @@ Variable transform(const Var &var, Op op) {
   using namespace detail;
   try {
     return Variable(var, scipp::core::visit_impl<Ts...>::apply(
-                             Transform<Op>{op}, var.dataHandle().m_object));
+                             Transform<Op>{op}, var.dataHandle().variant()));
   } catch (const std::bad_variant_access &) {
     throw std::runtime_error("Operation not implemented for this type.");
   }

--- a/core/transform.h
+++ b/core/transform.h
@@ -6,23 +6,159 @@
 #define TRANSFORM_H
 
 #include "variable.h"
+#include "visit.h"
 
 namespace scipp::core {
 
+namespace detail {
+
+template <class T>
+std::unique_ptr<VariableConceptT<T>>
+makeVariableConceptT(const Dimensions &dims);
+template <class T>
+std::unique_ptr<VariableConceptT<T>>
+makeVariableConceptT(const Dimensions &dims, Vector<T> data);
+
+template <class Op> struct TransformSparse {
+  Op op;
+  // TODO avoid copies... need in place transform (for_each, but with a second
+  // input range).
+  template <class T> constexpr auto operator()(sparse_container<T> x) const {
+    std::transform(x.begin(), x.end(), x.begin(), op);
+    return x;
+  }
+  // TODO Would like to use T1 and T2 for a and b, but currently this leads to
+  // selection of the wrong overloads.
+  template <class T>
+  constexpr auto operator()(sparse_container<T> a, const T b) const {
+    std::transform(a.begin(), a.end(), a.begin(),
+                   [&, b](const T a) { return op(a, b); });
+    return a;
+  }
+};
+
+template <class Op> struct TransformInPlace {
+  Op op;
+  template <class T> void operator()(T &&handle) const {
+    auto data = handle->getSpan();
+    std::transform(data.begin(), data.end(), data.begin(), op);
+  }
+  template <class A, class B> void operator()(A &&a, B &&b_ptr) const {
+    // std::unique_ptr::operator*() is const but returns mutable reference, need
+    // to artificially put const to we call the corect overloads of ViewModel.
+    const auto &b = *b_ptr;
+    const auto &dimsA = a->dimensions();
+    const auto &dimsB = b.dimensions();
+    try {
+      if constexpr (std::is_same_v<decltype(*a), decltype(*b_ptr)>) {
+        if (a->getView(dimsA).overlaps(b.getView(dimsA))) {
+          // If there is an overlap between lhs and rhs we copy the rhs before
+          // applying the operation.
+          const auto &data = b.getView(b.dimensions());
+          using T = typename std::remove_reference_t<decltype(b)>::value_type;
+          const std::unique_ptr<VariableConceptT<T>> copy =
+              detail::makeVariableConceptT<T>(
+                  dimsB, Vector<T>(data.begin(), data.end()));
+          return operator()(a, copy);
+        }
+      }
+
+      if (a->isContiguous() && dimsA.contains(dimsB)) {
+        if (b.isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          auto a_ = a->getSpan();
+          auto b_ = b.getSpan();
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        } else {
+          auto a_ = a->getSpan();
+          auto b_ = b.getView(dimsA);
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        }
+      } else if (dimsA.contains(dimsB)) {
+        if (b.isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          auto a_ = a->getView(dimsA);
+          auto b_ = b.getSpan();
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        } else {
+          auto a_ = a->getView(dimsA);
+          auto b_ = b.getView(dimsA);
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        }
+      } else {
+        // LHS has fewer dimensions than RHS, e.g., for computing sum. Use view.
+        if (b.isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          auto a_ = a->getView(dimsB);
+          auto b_ = b.getSpan();
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        } else {
+          auto a_ = a->getView(dimsB);
+          auto b_ = b.getView(dimsB);
+          std::transform(a_.begin(), a_.end(), b_.begin(), a_.begin(), op);
+        }
+      }
+    } catch (const std::bad_cast &) {
+      throw std::runtime_error("Cannot apply arithmetic operation to "
+                               "Variables: Underlying data types do not "
+                               "match.");
+    }
+  }
+};
+template <class Op> TransformInPlace(Op)->TransformInPlace<Op>;
+
+template <class Op> struct Transform {
+  Op op;
+  template <class T> VariableConceptHandle operator()(T &&handle) const {
+    auto data = handle->getSpan();
+    // TODO Should just make empty container here, without init.
+    auto out = detail::makeVariableConceptT<decltype(op(*data.begin()))>(
+        handle->dimensions());
+    // TODO Typo data->getSpan() also compiles, but const-correctness should
+    // forbid this.
+    auto outData = out->getSpan();
+    std::transform(data.begin(), data.end(), outData.begin(), op);
+    return {std::move(out)};
+}
+};
+
+} // namespace detail
+
+template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
+
 template <class... Ts, class Var, class Op>
 void transform_in_place(Var &var, Op op) {
-  var.dataHandle().template transform_in_place<Ts...>(op);
+  using namespace detail;
+  try {
+    scipp::core::visit_impl<Ts...>::apply(
+        TransformInPlace{overloaded{op, TransformSparse<Op>{op}}},
+        var.dataHandle().m_object);
+  } catch (const std::bad_variant_access &) {
+    throw std::runtime_error("Operation not implemented for this type.");
+  }
 }
 
 template <class... TypePairs, class Var1, class Var, class Op>
 void transform_in_place(const Var1 &other, Var &&var, Op op) {
-  var.dataHandle().template transform_in_place<TypePairs...>(
-      op, other.dataHandle());
+  using namespace detail;
+  try {
+    scipp::core::visit(std::tuple_cat(TypePairs{}...))
+        .apply(TransformInPlace{overloaded{op, TransformSparse<Op>{op}}},
+               var.dataHandle().m_object, other.dataHandle().m_object);
+  } catch (const std::bad_variant_access &) {
+    throw except::TypeError("Cannot apply operation to item dtypes " +
+                            to_string(var.dtype()) + " and " +
+                            to_string(other.dtype()) + '.');
+  }
 }
 
 template <class... Ts, class Var, class Op>
 Variable transform(const Var &var, Op op) {
-  return Variable(var, var.dataHandle().template transform<Ts...>(op));
+  using namespace detail;
+  try {
+    return Variable(var, scipp::core::visit_impl<Ts...>::apply(
+                             Transform<Op>{op}, var.dataHandle().m_object));
+  } catch (const std::bad_variant_access &) {
+    throw std::runtime_error("Operation not implemented for this type.");
+  }
 }
 
 } // namespace scipp::core

--- a/core/transform.h
+++ b/core/transform.h
@@ -124,6 +124,12 @@ template <class Op> struct Transform {
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
 
+/// Transform the data elements of a variable in-place.
+//
+// Note that this is deliberately not named `for_each`: Unlike std::for_each,
+// this function does not promise in-order execution. This overload is
+// equivalent to std::transform with a single input range and an output range
+// identical to the input range, but avoids potentially costly element copies.
 template <class... Ts, class Var, class Op>
 void transform_in_place(Var &var, Op op) {
   using namespace detail;
@@ -136,6 +142,11 @@ void transform_in_place(Var &var, Op op) {
   }
 }
 
+/// Transform the data elements of a variable in-place.
+//
+// This overload is equivalent to std::transform with two input ranges and an
+// output range identical to the secound input range, but avoids potentially
+// costly element copies.
 template <class... TypePairs, class Var1, class Var, class Op>
 void transform_in_place(const Var1 &other, Var &&var, Op op) {
   using namespace detail;
@@ -150,6 +161,11 @@ void transform_in_place(const Var1 &other, Var &&var, Op op) {
   }
 }
 
+/// Transform the data elements of a variable and return a new Variable.
+//
+// This overload is equivalent to std::transform with a single input range, but
+// avoids the need to manually create a new variable for the output and the need
+// for, e.g., std::back_inserter.
 template <class... Ts, class Var, class Op>
 Variable transform(const Var &var, Op op) {
   using namespace detail;

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include <cmath>
 
+#include "apply.h"
 #include "counts.h"
 #include "dataset.h"
 #include "except.h"
@@ -1062,7 +1063,8 @@ Variable rebin(const Variable &var, const Variable &oldCoord,
     dims.resize(dim, newCoord.dimensions()[dim] - 1);
     Variable rebinned(var, dims);
     if (rebinned.dimensions().inner() == dim) {
-      rebinned.apply_in_place<double, float>(do_rebin, var, oldCoord, newCoord);
+      apply_in_place<double, float>(do_rebin, rebinned, var, oldCoord,
+                                    newCoord);
     } else {
       if (newCoord.dimensions().ndim() > 1)
         throw std::runtime_error(

--- a/core/variable.h
+++ b/core/variable.h
@@ -180,6 +180,9 @@ public:
         m_object);
   }
 
+  const auto &variant() const noexcept { return m_object; }
+
+private:
   std::variant<std::unique_ptr<VariableConcept>,
                std::unique_ptr<VariableConceptT<Known>>...>
       m_object;
@@ -307,8 +310,6 @@ public:
 
   const VariableConceptHandle &dataHandle() const && = delete;
   const VariableConceptHandle &dataHandle() const & { return m_object; }
-  VariableConceptHandle &dataHandle() && = delete;
-  VariableConceptHandle &dataHandle() & { return m_object; }
 
   DType dtype() const noexcept { return data().dtype(isSparse()); }
   Tag tag() const { return m_tag; }

--- a/core/variable.h
+++ b/core/variable.h
@@ -533,13 +533,6 @@ public:
   // expects the reshaped view to be still valid).
   Variable reshape(const Dimensions &dims) &&;
 
-  template <class... Ts, class Op, class... Vars>
-  Variable &apply_in_place(Op op, const Vars &... vars) {
-    // TODO handle units
-    dataHandle().apply_in_place<Ts...>(op, vars.dataHandle()...);
-    return *this;
-  }
-
   template <class... Tags> friend class ZipView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 

--- a/core/variable.h
+++ b/core/variable.h
@@ -191,7 +191,6 @@ private:
 template <class... Tags> class ZipView;
 class ConstVariableSlice;
 class VariableSlice;
-template <class T1, class T2> T1 &plus_equals(T1 &, const T2 &);
 
 namespace detail {
 template <class T> struct default_init {
@@ -374,7 +373,6 @@ public:
   Variable reshape(const Dimensions &dims) &&;
 
   template <class... Tags> friend class ZipView;
-  template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
 private:
   template <class T> const Vector<underlying_type_t<T>> &cast() const;

--- a/core/variable.h
+++ b/core/variable.h
@@ -533,35 +533,11 @@ public:
   // expects the reshaped view to be still valid).
   Variable reshape(const Dimensions &dims) &&;
 
-  template <class... Ts, class Op> void transform_in_place(Op op) {
-    // TODO handle units
-    m_object.transform_in_place<Ts...>(op);
-  }
-
-  template <class... TypePairs, class Op, class Var>
-  Variable &transform_in_place(Op op, const Var &other) {
-    // TODO handle units
-    dataHandle().transform_in_place<TypePairs...>(op, other.dataHandle());
-    return *this;
-  }
-
-  template <class... TypePairs, class Op, class Var>
-  Variable transform(Op op, const Var &other) const {
-    auto copy(*this);
-    copy.transform_in_place<TypePairs...>(op, other);
-    return copy;
-  }
-
   template <class... Ts, class Op, class... Vars>
   Variable &apply_in_place(Op op, const Vars &... vars) {
     // TODO handle units
     dataHandle().apply_in_place<Ts...>(op, vars.dataHandle()...);
     return *this;
-  }
-
-  template <class... Ts, class Op> Variable transform(Op op) const {
-    // TODO handle units
-    return Variable(*this, m_object.transform<Ts...>(op));
   }
 
   template <class... Tags> friend class ZipView;
@@ -835,13 +811,6 @@ public:
   VariableSlice operator/=(const double value) const;
 
   void setUnit(const units::Unit &unit) const;
-
-  template <class... TypePairs, class Op, class Var>
-  VariableSlice transform_in_place(Op op, const Var &other) const {
-    // TODO handle units
-    dataHandle().transform_in_place<TypePairs...>(op, other.dataHandle());
-    return *this;
-  }
 
 private:
   friend class Variable;

--- a/core/variable_view.h
+++ b/core/variable_view.h
@@ -127,7 +127,7 @@ public:
 private:
   T *m_variable;
   scipp::index m_offset{0};
-  const Dimensions m_targetDimensions;
+  Dimensions m_targetDimensions;
   Dimensions m_dimensions;
 };
 

--- a/core/visit.h
+++ b/core/visit.h
@@ -2,6 +2,9 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#ifndef VISIT_H
+#define VISIT_H
+
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -143,3 +146,5 @@ template <class... Ts> auto visit(const std::tuple<Ts...> &) {
 }
 
 } // namespace scipp::core
+
+#endif // VISIT_H


### PR DESCRIPTION
Addition of `Variable` no longer concatenates nested datasets. Depends on #230.

Fixed concatenate of `Dataset` with sparse dimensions.

This feature was previously introduced for handling event data. Now, sparse dimension support can be used instead, making the design cleaner.

Note that old tags have not been removed yet. We also still have, e.g., Jupyter notebooks from the demo which use the old nested data layout. We should revisit and update the notebookes once we have complete some other related refactoring.