### PR TITLE
Variable without tag and name

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -325,9 +325,9 @@ static void BM_Dataset_Workspace2D_rebin(benchmark::State &state) {
   scipp::index nSpec = state.range(0) * 1024;
   scipp::index nPoint = 1024;
 
-  Variable newCoord(Coord::Tof, {Dim::Tof, nPoint / 2});
+  auto newCoord = makeVariable<double>({Dim::Tof, nPoint / 2});
   double value = 0.0;
-  for (auto &tof : newCoord.get(Coord::Tof)) {
+  for (auto &tof : newCoord.span<double>()) {
     tof = value;
     value += 3.0;
   }

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -9,7 +9,7 @@
 using namespace scipp::core;
 
 static void BM_Variable_copy(benchmark::State &state) {
-  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
 
   for (auto _ : state) {
     Variable copy(var);
@@ -18,7 +18,7 @@ static void BM_Variable_copy(benchmark::State &state) {
 BENCHMARK(BM_Variable_copy);
 
 static void BM_Variable_trivial_slice(benchmark::State &state) {
-  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
 
   for (auto _ : state) {
     ConstVariableSlice view(var);
@@ -30,7 +30,7 @@ BENCHMARK(BM_Variable_trivial_slice);
 // The following two benchmarks "prove" that operator+ with a VariableSlice is
 // not unintentionally converting the second argument to a temporary Variable.
 static void BM_Variable_binary_with_Variable(benchmark::State &state) {
-  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
   Variable a = var(Dim::Z, 0, 8);
 
   for (auto _ : state) {
@@ -39,7 +39,7 @@ static void BM_Variable_binary_with_Variable(benchmark::State &state) {
   }
 }
 static void BM_Variable_binary_with_VariableSlice(benchmark::State &state) {
-  Variable b(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  auto b = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
   Variable a = b(Dim::Z, 0, 8);
 
   for (auto _ : state) {

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(INC_FILES
     aligned_allocator.h
-    convert.h
     dataset.h
     dataset_index.h
     dimensions.h
@@ -23,7 +22,6 @@ set(INC_FILES
     vector.h)
 
 set(SRC_FILES
-    convert.cpp
     counts.cpp
     dataset.cpp
     dimensions.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(INC_FILES
     aligned_allocator.h
+    convert.h
     dataset.h
     dataset_index.h
     dimensions.h
@@ -22,6 +23,7 @@ set(INC_FILES
     vector.h)
 
 set(SRC_FILES
+    convert.cpp
     counts.cpp
     dataset.cpp
     dimensions.cpp

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -744,12 +744,12 @@ DatasetSlice DatasetSlice::operator/=(const ConstDatasetSlice &other) const {
   return op_equals(*this, other, &aligned::divide, &aligned::divide);
 }
 DatasetSlice DatasetSlice::operator/=(const Variable &other) const {
-    for (const auto[name, tag, var] : *this)
-      if (tag == Data::Value)
-        var /= other;
-      else if (tag == Data::Variance)
-        var /= other * other;
-    return *this;
+  for (const auto[name, tag, var] : *this)
+    if (tag == Data::Value)
+      var /= other;
+    else if (tag == Data::Variance)
+      var /= other * other;
+  return *this;
 }
 DatasetSlice DatasetSlice::operator/=(const double value) const {
   for (const auto[name, tag, var] : *this)

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -169,8 +169,8 @@ public:
   template <class Tag, class T>
   void insert(const Tag tag, const std::string &name,
               const Dimensions &dimensions, std::initializer_list<T> values) {
-    Variable a(std::move(dimensions), values);
-    insert(tag, name, std::move(a));
+    insert(tag, name,
+           makeVariable<typename Tag::type>(std::move(dimensions), values));
   }
 
   // Insert variants with custom type

--- a/core/events.cpp
+++ b/core/events.cpp
@@ -15,9 +15,9 @@ namespace scipp::core {
 namespace events {
 
 void sortByTof(Dataset &dataset) {
-  for (const auto &var : dataset) {
-    if (var.tag() == Data::Events) {
-      for (auto &el : var.get(Data::Events)) {
+  for (const auto & [ name, tag, var ] : dataset) {
+    if (tag == Data::Events) {
+      for (auto &el : var.span<Dataset>()) {
         if (el.size() == 1) {
           const auto tofs = el.get(Data::Tof);
           std::sort(tofs.begin(), tofs.end());
@@ -32,7 +32,7 @@ void sortByTof(Dataset &dataset) {
               "Sorting for this event type is not implemented yet.");
         }
       }
-    } else if (var.tag() == Data::EventTofs) {
+    } else if (tag == Data::EventTofs) {
       throw std::runtime_error(
           "Sorting for this event-storage mode is not implemented yet.");
     }

--- a/core/except.h
+++ b/core/except.h
@@ -36,6 +36,12 @@ std::string to_string(const Variable &variable,
                       const std::string &separator = "::");
 std::string to_string(const ConstVariableSlice &variable,
                       const std::string &separator = "::");
+std::string to_string(const std::string &name, const Tag tag,
+                      const Variable &variable,
+                      const std::string &separator = "::");
+std::string to_string(const std::string &name, const Tag tag,
+                      const ConstVariableSlice &variable,
+                      const std::string &separator = "::");
 std::string to_string(const Dataset &dataset,
                       const std::string &separator = "::");
 std::string to_string(const ConstDatasetSlice &dataset,

--- a/core/tags.h
+++ b/core/tags.h
@@ -85,6 +85,10 @@ public:
     return m_value >= value;
   }
 
+  bool isCoord() const;
+  bool isAttr() const;
+  bool isData() const;
+
 private:
   uint16_t m_value;
 };
@@ -580,6 +584,15 @@ struct element_return_type<D, MDZipViewImpl<D, Tags...>> {
 
 template <class D, class Tag>
 using element_return_type_t = typename element_return_type<D, Tag>::type;
+
+inline bool Tag::isCoord() const {
+  return m_value < std::tuple_size<detail::CoordDef::tags>::value;
+}
+inline bool Tag::isAttr() const {
+  return m_value >= std::tuple_size<detail::CoordDef::tags>::value +
+                        std::tuple_size<detail::DataDef::tags>::value;
+}
+inline bool Tag::isData() const { return !isCoord() && !isAttr(); }
 
 } // namespace scipp::core
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 add_executable(scipp-core-test
                bool_test.cpp
-               convert_test.cpp
                dataset_test.cpp
                dimensions_test.cpp
                EventWorkspace_test.cpp

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 add_executable(scipp-core-test
                bool_test.cpp
+               convert_test.cpp
                dataset_test.cpp
                dimensions_test.cpp
                EventWorkspace_test.cpp

--- a/core/test/EventWorkspace_test.cpp
+++ b/core/test/EventWorkspace_test.cpp
@@ -122,13 +122,13 @@ TEST(EventWorkspace, plus) {
   // Note that unlike the tests above this is now using sparse dimensions.
   // Addition for nested Dataset as event list is not supported anymore.
   Dataset d;
-  d.insert(
-      makeSparseVariable<double>(Coord::Tof, {Dim::Spectrum, 2}, Dim::Tof));
+  d.insert(Coord::Tof,
+           makeSparseVariable<double>({Dim::Spectrum, 2}, Dim::Tof));
   auto tofs = d(Coord::Tof).sparseSpan<double>();
   tofs[0].resize(10);
   tofs[1].resize(20);
-  d.insert(
-      makeSparseVariable<double>(Data::Value, {Dim::Spectrum, 2}, Dim::Tof));
+  d.insert(Data::Value,
+           makeSparseVariable<double>({Dim::Spectrum, 2}, Dim::Tof));
   auto weights = d(Data::Value).sparseSpan<double>();
   weights[0].resize(10);
   weights[1].resize(20);

--- a/core/test/Run_test.cpp
+++ b/core/test/Run_test.cpp
@@ -15,7 +15,8 @@ Dataset makeRun() {
   run.insert(Coord::Polarization, {}, {"Spin-Up"});
   run.insert(Coord::FuzzyTemperature, {}, {ValueWithDelta<double>(4.2, 0.1)});
   Dataset comment;
-  comment.insert(Data::DeprecatedString, "", {Dim::Row, 1}, {"first run"});
+  comment.insert(Data::DeprecatedString, "",
+                 makeVariable<std::string>({Dim::Row, 1}, {"first run"}));
   run.insert<Dataset>(Data::Value, "comment", {}, {comment});
   Dataset timeSeriesLog;
   timeSeriesLog.insert(Coord::Time, {Dim::Time, 3}, {0, 1000, 1500});
@@ -48,8 +49,11 @@ TEST(Run, DISABLED_meta_data_propagation) {
       "second run";
   run2.span<Dataset>(Data::Value, "generic_log")[0]
       .span<Dataset>(Data::Value, "root")[0]
-      .insert(Data::DeprecatedString, "user comment", {},
-              {"Spider walked through beam, verify data before publishing."});
+      .insert(
+          Data::DeprecatedString, "user comment",
+          makeVariable<std::string>(
+              {},
+              {"Spider walked through beam, verify data before publishing."}));
 
   Dataset d2;
   d2.insert(Attr::ExperimentLog, "sample_log", {}, {run2});

--- a/core/test/Run_test.cpp
+++ b/core/test/Run_test.cpp
@@ -111,7 +111,7 @@ TEST(Run, DISABLED_meta_data_propagation) {
       generic_log.span<Dataset>(Data::Value, "root")[1];
   // 1 entry from run 2.
   EXPECT_EQ(generic_log_run2.size(), 1);
-  EXPECT_EQ(generic_log_run2[0].name(), "user comment");
+  EXPECT_NO_THROW(generic_log_run2(Data::DeprecatedString, "user comment"));
   // Again there was no automatic merging, can be done by hand if required.
 }
 

--- a/core/test/TableWorkspace_test.cpp
+++ b/core/test/TableWorkspace_test.cpp
@@ -35,10 +35,11 @@ TEST(TableWorkspace, basics) {
       item.get(Data::DeprecatedString) = "why is this negative?";
 
   // Get string representation of arbitrary table, e.g., for visualization.
-  EXPECT_EQ(asStrings(table[0]), std::vector<std::string>({"a", "b", "c"}));
-  EXPECT_EQ(asStrings(table[1]),
+  EXPECT_EQ(asStrings(table(Coord::Row)),
+            std::vector<std::string>({"a", "b", "c"}));
+  EXPECT_EQ(asStrings(table(Data::Value, "")),
             std::vector<std::string>({"1.000000", "-2.000000", "3.000000"}));
-  EXPECT_EQ(asStrings(table[2]),
+  EXPECT_EQ(asStrings(table(Data::DeprecatedString, "")),
             std::vector<std::string>({"", "why is this negative?", ""}));
 
   // Standard shape operations provide basic things required for tables:
@@ -55,11 +56,11 @@ TEST(TableWorkspace, basics) {
 
   // Can sort by arbitrary column.
   auto sortedTable = sort(table, Data::Value);
-  EXPECT_EQ(asStrings(sortedTable[0]),
+  EXPECT_EQ(asStrings(sortedTable(Coord::Row)),
             std::vector<std::string>({"b", "a", "c"}));
-  EXPECT_EQ(asStrings(sortedTable[1]),
+  EXPECT_EQ(asStrings(sortedTable(Data::Value, "")),
             std::vector<std::string>({"-2.000000", "1.000000", "3.000000"}));
-  EXPECT_EQ(asStrings(sortedTable[2]),
+  EXPECT_EQ(asStrings(sortedTable(Data::DeprecatedString, "")),
             std::vector<std::string>({"why is this negative?", "", ""}));
 
   // Split (opposite of concatenate).
@@ -71,7 +72,7 @@ TEST(TableWorkspace, basics) {
   // Remove rows from the middle of a table.
   auto recombined = concatenate(mergedTable(Dim::Row, 0, 2),
                                 mergedTable(Dim::Row, 4, 6), Dim::Row);
-  EXPECT_EQ(asStrings(recombined[0]),
+  EXPECT_EQ(asStrings(recombined(Coord::Row)),
             std::vector<std::string>({"a", "b", "b", "c"}));
 
   // Other basics (to be implemented): cut/truncate/chop/extract (naming

--- a/core/test/TableWorkspace_test.cpp
+++ b/core/test/TableWorkspace_test.cpp
@@ -63,12 +63,6 @@ TEST(TableWorkspace, basics) {
   EXPECT_EQ(asStrings(sortedTable(Data::DeprecatedString, "")),
             std::vector<std::string>({"why is this negative?", "", ""}));
 
-  // Split (opposite of concatenate).
-  auto parts = split(mergedTable, Dim::Row, {3});
-  ASSERT_EQ(parts.size(), 2ul);
-  EXPECT_EQ(parts[0], table);
-  EXPECT_EQ(parts[1], table);
-
   // Remove rows from the middle of a table.
   auto recombined = concatenate(mergedTable(Dim::Row, 0, 2),
                                 mergedTable(Dim::Row, 4, 6), Dim::Row);

--- a/core/test/convert_test.cpp
+++ b/core/test/convert_test.cpp
@@ -251,7 +251,8 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei_to_QxQyQz) {
   qCoords.insert(Coord::Qz,
                  makeVariable<double>({Dim::Qz, 4}, units::meV / units::c,
                                       {8, 9, 10, 11}));
-  qCoords.insert(Coord::DeltaE, makeVariable<double>({Dim::DeltaE, 3}, units::meV , {9, 10, 11}));
+  qCoords.insert(Coord::DeltaE, makeVariable<double>({Dim::DeltaE, 3},
+                                                     units::meV, {9, 10, 11}));
 
   EXPECT_NO_THROW(convert(energy, {Dim::DeltaE, Dim::Position}, qCoords));
 }

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -228,7 +228,7 @@ TEST(Variable, operator_plus_equal_custom_type) {
 }
 
 TEST(Variable, operator_times_equal) {
-  auto a = makeVariable<double>({Dim::X, 2}, {2.0, 3.0});
+  auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a *= a);
@@ -238,7 +238,7 @@ TEST(Variable, operator_times_equal) {
 }
 
 TEST(Variable, operator_times_equal_scalar) {
-  auto a = makeVariable<double>({Dim::X, 2}, {2.0, 3.0});
+  auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a *= 2.0);
@@ -269,7 +269,7 @@ TEST(Variable, operator_divide_equal) {
 }
 
 TEST(Variable, operator_divide_equal_self) {
-  auto a = makeVariable<double>({Dim::X, 2}, {2.0, 3.0});
+  auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a /= a);
@@ -279,7 +279,7 @@ TEST(Variable, operator_divide_equal_self) {
 }
 
 TEST(Variable, operator_divide_equal_scalar) {
-  auto a = makeVariable<double>({Dim::X, 2}, {2.0, 4.0});
+  auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 4.0});
 
   EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a /= 2.0);
@@ -289,7 +289,7 @@ TEST(Variable, operator_divide_equal_scalar) {
 }
 
 TEST(Variable, operator_divide_scalar_double) {
-  const auto a = makeVariable<double>({Dim::X, 2}, {2.0, 4.0});
+  const auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 4.0});
   const auto result = 1.111 / a;
   EXPECT_EQ(result.span<double>()[0], 1.111 / 2.0);
   EXPECT_EQ(result.span<double>()[1], 1.111 / 4.0);
@@ -297,7 +297,7 @@ TEST(Variable, operator_divide_scalar_double) {
 }
 
 TEST(Variable, operator_divide_scalar_float) {
-  const auto a = makeVariable<float>({Dim::X, 2}, {2.0, 4.0});
+  const auto a = makeVariable<float>({Dim::X, 2}, units::m, {2.0, 4.0});
   const auto result = 1.111 / a;
   EXPECT_EQ(result.span<float>()[0], 1.111f / 2.0f);
   EXPECT_EQ(result.span<float>()[1], 1.111f / 4.0f);
@@ -510,7 +510,7 @@ TEST(Variable, concatenate_fail) {
   Dimensions dims(Dim::Tof, 1);
   auto a = makeVariable<double>(dims, {1.0});
   auto b = makeVariable<double>(dims, {2.0});
-  auto c = makeVariable<double>(dims, {2.0});
+  auto c = makeVariable<float>(dims, {2.0});
   EXPECT_THROW_MSG(concatenate(a, c, Dim::Tof), std::runtime_error,
                    "Cannot concatenate Variables: Data types do not match.");
   auto aa = concatenate(a, a, Dim::Tof);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -17,7 +17,7 @@ TEST(Variable, construct) {
   ASSERT_NO_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 2)));
   ASSERT_NO_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 2), 2));
   const Variable a(Data::Value, Dimensions(Dim::Tof, 2));
-  const auto &data = a.get(Data::Value);
+  const auto &data = a.span<double>();
   EXPECT_EQ(data.size(), 2);
 }
 
@@ -40,9 +40,9 @@ TEST(Variable, makeVariable_custom_type) {
   auto doubles = makeVariable<double>(Data::Value, {});
   auto floats = makeVariable<float>(Data::Value, {});
 
-  ASSERT_NO_THROW(doubles.get(Data::Value));
+  ASSERT_NO_THROW(doubles.span<double>());
   // Data::Value defaults to double, so this throws.
-  ASSERT_ANY_THROW(floats.get(Data::Value));
+  ASSERT_ANY_THROW(floats.span<double>());
 
   ASSERT_NO_THROW(doubles.span<double>());
   ASSERT_NO_THROW(floats.span<float>());
@@ -80,14 +80,14 @@ TEST(Variable, dtype) {
 
 TEST(Variable, span_references_Variable) {
   Variable a(Data::Value, Dimensions(Dim::Tof, 2));
-  auto observer = a.get(Data::Value);
+  auto observer = a.span<double>();
   // This line does not compile, const-correctness works:
   // observer[0] = 1.0;
 
   // Note: This also has the "usual" problem of copy-on-write: This non-const
   // call can invalidate the references stored in observer if the underlying
   // data was shared.
-  auto span = a.get(Data::Value);
+  auto span = a.span<double>();
 
   EXPECT_EQ(span.size(), 2);
   span[0] = 1.0;
@@ -96,13 +96,13 @@ TEST(Variable, span_references_Variable) {
 
 TEST(Variable, copy) {
   const Variable a1(Data::Value, {Dim::Tof, 2}, {1.1, 2.2});
-  const auto &data1 = a1.get(Data::Value);
+  const auto &data1 = a1.span<double>();
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_NE(&a1.get(Data::Value)[0], &a2.get(Data::Value)[0]);
-  EXPECT_NE(&a1.get(Data::Value)[0], &a2.get(Data::Value)[0]);
-  const auto &data2 = a2.get(Data::Value);
+  EXPECT_NE(&a1.span<double>()[0], &a2.span<double>()[0]);
+  EXPECT_NE(&a1.span<double>()[0], &a2.span<double>()[0]);
+  const auto &data2 = a2.span<double>();
   EXPECT_EQ(data2[0], 1.1);
   EXPECT_EQ(data2[1], 2.2);
 }
@@ -136,26 +136,26 @@ TEST(Variable, operator_equals_mismatching_dtype) {
 TEST(Variable, operator_unary_minus) {
   const Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a;
-  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value)[1], 2.2);
-  EXPECT_EQ(b.get(Data::Value)[0], -1.1);
-  EXPECT_EQ(b.get(Data::Value)[1], -2.2);
+  EXPECT_EQ(a.span<double>()[0], 1.1);
+  EXPECT_EQ(a.span<double>()[1], 2.2);
+  EXPECT_EQ(b.span<double>()[0], -1.1);
+  EXPECT_EQ(b.span<double>()[1], -2.2);
 }
 
 TEST(VariableSlice, unary_minus) {
   const Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a(Dim::X, 1);
-  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value)[1], 2.2);
-  EXPECT_EQ(b.get(Data::Value)[0], -2.2);
+  EXPECT_EQ(a.span<double>()[0], 1.1);
+  EXPECT_EQ(a.span<double>()[1], 2.2);
+  EXPECT_EQ(b.span<double>()[0], -2.2);
 }
 
 TEST(Variable, operator_plus_equal) {
   Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   ASSERT_NO_THROW(a += a);
-  EXPECT_EQ(a.get(Data::Value)[0], 2.2);
-  EXPECT_EQ(a.get(Data::Value)[1], 4.4);
+  EXPECT_EQ(a.span<double>()[0], 2.2);
+  EXPECT_EQ(a.span<double>()[1], 4.4);
 
   auto different_name(a);
   different_name.setName("test");
@@ -168,8 +168,8 @@ TEST(Variable, operator_plus_equal_automatic_broadcast_of_rhs) {
   Variable fewer_dimensions(Data::Value, {}, {1.0});
 
   ASSERT_NO_THROW(a += fewer_dimensions);
-  EXPECT_EQ(a.get(Data::Value)[0], 2.1);
-  EXPECT_EQ(a.get(Data::Value)[1], 3.2);
+  EXPECT_EQ(a.span<double>()[0], 2.1);
+  EXPECT_EQ(a.span<double>()[1], 3.2);
 }
 
 TEST(Variable, operator_plus_equal_transpose) {
@@ -179,12 +179,12 @@ TEST(Variable, operator_plus_equal_transpose) {
                      {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
   EXPECT_NO_THROW(a += transpose);
-  EXPECT_EQ(a.get(Data::Value)[0], 2.0);
-  EXPECT_EQ(a.get(Data::Value)[1], 4.0);
-  EXPECT_EQ(a.get(Data::Value)[2], 6.0);
-  EXPECT_EQ(a.get(Data::Value)[3], 8.0);
-  EXPECT_EQ(a.get(Data::Value)[4], 10.0);
-  EXPECT_EQ(a.get(Data::Value)[5], 12.0);
+  EXPECT_EQ(a.span<double>()[0], 2.0);
+  EXPECT_EQ(a.span<double>()[1], 4.0);
+  EXPECT_EQ(a.span<double>()[2], 6.0);
+  EXPECT_EQ(a.span<double>()[3], 8.0);
+  EXPECT_EQ(a.span<double>()[4], 10.0);
+  EXPECT_EQ(a.span<double>()[5], 12.0);
 }
 
 TEST(Variable, operator_plus_equal_different_dimensions) {
@@ -220,15 +220,15 @@ TEST(Variable, operator_plus_equal_different_variables_same_element_type) {
   Variable a(Data::Value, {Dim::X, 1}, {1.0});
   Variable b(Data::Variance, {Dim::X, 1}, {2.0});
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get(Data::Value)[0], 3.0);
+  EXPECT_EQ(a.span<double>()[0], 3.0);
 }
 
 TEST(Variable, operator_plus_equal_scalar) {
   Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   EXPECT_NO_THROW(a += 1.0);
-  EXPECT_EQ(a.get(Data::Value)[0], 2.1);
-  EXPECT_EQ(a.get(Data::Value)[1], 3.2);
+  EXPECT_EQ(a.span<double>()[0], 2.1);
+  EXPECT_EQ(a.span<double>()[1], 3.2);
 }
 
 TEST(Variable, operator_plus_equal_custom_type) {
@@ -279,8 +279,8 @@ TEST(Variable, operator_divide_equal) {
   b.setUnit(units::m);
 
   EXPECT_NO_THROW(a /= b);
-  EXPECT_EQ(a.get(Data::Value)[0], 1.0);
-  EXPECT_EQ(a.get(Data::Value)[1], 1.5);
+  EXPECT_EQ(a.span<double>()[0], 1.0);
+  EXPECT_EQ(a.span<double>()[1], 1.5);
   EXPECT_EQ(a.unit(), units::dimensionless / units::m);
 }
 
@@ -359,18 +359,18 @@ TEST(Variable, slice) {
     Variable sliceX = parent(Dim::X, index);
     ASSERT_EQ(sliceX.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::Y, 2}}));
     auto base = static_cast<double>(index);
-    EXPECT_EQ(sliceX.get(Data::Value)[0], base + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[1], base + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[2], base + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[3], base + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[4], base + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[5], base + 21.0);
+    EXPECT_EQ(sliceX.span<double>()[0], base + 1.0);
+    EXPECT_EQ(sliceX.span<double>()[1], base + 5.0);
+    EXPECT_EQ(sliceX.span<double>()[2], base + 9.0);
+    EXPECT_EQ(sliceX.span<double>()[3], base + 13.0);
+    EXPECT_EQ(sliceX.span<double>()[4], base + 17.0);
+    EXPECT_EQ(sliceX.span<double>()[5], base + 21.0);
   }
 
   for (const scipp::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index);
     ASSERT_EQ(sliceY.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::X, 4}}));
-    const auto &data = sliceY.get(Data::Value);
+    const auto &data = sliceY.span<double>();
     auto base = static_cast<double>(index);
     for (const scipp::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * base + 8 * static_cast<double>(z) + 1.0);
@@ -383,7 +383,7 @@ TEST(Variable, slice) {
   for (const scipp::index index : {0, 1, 2}) {
     Variable sliceZ = parent(Dim::Z, index);
     ASSERT_EQ(sliceZ.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value);
+    const auto &data = sliceZ.span<double>();
     for (scipp::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -400,37 +400,37 @@ TEST(Variable, slice_range) {
     Variable sliceX = parent(Dim::X, index, index + 1);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
-    EXPECT_EQ(sliceX.get(Data::Value)[0], index + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[1], index + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[2], index + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[3], index + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[4], index + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[5], index + 21.0);
+    EXPECT_EQ(sliceX.span<double>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.span<double>()[1], index + 5.0);
+    EXPECT_EQ(sliceX.span<double>()[2], index + 9.0);
+    EXPECT_EQ(sliceX.span<double>()[3], index + 13.0);
+    EXPECT_EQ(sliceX.span<double>()[4], index + 17.0);
+    EXPECT_EQ(sliceX.span<double>()[5], index + 21.0);
   }
 
   for (const scipp::index index : {0, 1, 2}) {
     Variable sliceX = parent(Dim::X, index, index + 2);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
-    EXPECT_EQ(sliceX.get(Data::Value)[0], index + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[1], index + 2.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[2], index + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[3], index + 6.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[4], index + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[5], index + 10.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[6], index + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[7], index + 14.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[8], index + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[9], index + 18.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[10], index + 21.0);
-    EXPECT_EQ(sliceX.get(Data::Value)[11], index + 22.0);
+    EXPECT_EQ(sliceX.span<double>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.span<double>()[1], index + 2.0);
+    EXPECT_EQ(sliceX.span<double>()[2], index + 5.0);
+    EXPECT_EQ(sliceX.span<double>()[3], index + 6.0);
+    EXPECT_EQ(sliceX.span<double>()[4], index + 9.0);
+    EXPECT_EQ(sliceX.span<double>()[5], index + 10.0);
+    EXPECT_EQ(sliceX.span<double>()[6], index + 13.0);
+    EXPECT_EQ(sliceX.span<double>()[7], index + 14.0);
+    EXPECT_EQ(sliceX.span<double>()[8], index + 17.0);
+    EXPECT_EQ(sliceX.span<double>()[9], index + 18.0);
+    EXPECT_EQ(sliceX.span<double>()[10], index + 21.0);
+    EXPECT_EQ(sliceX.span<double>()[11], index + 22.0);
   }
 
   for (const scipp::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index, index + 1);
     ASSERT_EQ(sliceY.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
-    const auto &data = sliceY.get(Data::Value);
+    const auto &data = sliceY.span<double>();
     for (const scipp::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * index + 8 * z + 1.0);
       EXPECT_EQ(data[4 * z + 1], 4 * index + 8 * z + 2.0);
@@ -448,7 +448,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 1);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value);
+    const auto &data = sliceZ.span<double>();
     for (scipp::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -457,7 +457,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 2);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value);
+    const auto &data = sliceZ.span<double>();
     for (scipp::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
     for (scipp::index xy = 0; xy < 8; ++xy)
@@ -474,21 +474,21 @@ TEST(Variable, concatenate) {
   auto ab = concatenate(a, b, Dim::Tof);
   ASSERT_EQ(ab.size(), 2);
   EXPECT_EQ(ab.unit(), units::Unit(units::m));
-  const auto &data = ab.get(Data::Value);
+  const auto &data = ab.span<double>();
   EXPECT_EQ(data[0], 1.0);
   EXPECT_EQ(data[1], 2.0);
   auto ba = concatenate(b, a, Dim::Tof);
   const auto abba = concatenate(ab, ba, Dim::Q);
   ASSERT_EQ(abba.size(), 4);
   EXPECT_EQ(abba.dimensions().count(), 2);
-  const auto &data2 = abba.get(Data::Value);
+  const auto &data2 = abba.span<double>();
   EXPECT_EQ(data2[0], 1.0);
   EXPECT_EQ(data2[1], 2.0);
   EXPECT_EQ(data2[2], 2.0);
   EXPECT_EQ(data2[3], 1.0);
   const auto ababbaba = concatenate(abba, abba, Dim::Tof);
   ASSERT_EQ(ababbaba.size(), 8);
-  const auto &data3 = ababbaba.get(Data::Value);
+  const auto &data3 = ababbaba.span<double>();
   EXPECT_EQ(data3[0], 1.0);
   EXPECT_EQ(data3[1], 2.0);
   EXPECT_EQ(data3[2], 1.0);
@@ -499,7 +499,7 @@ TEST(Variable, concatenate) {
   EXPECT_EQ(data3[7], 1.0);
   const auto abbaabba = concatenate(abba, abba, Dim::Q);
   ASSERT_EQ(abbaabba.size(), 8);
-  const auto &data4 = abbaabba.get(Data::Value);
+  const auto &data4 = abbaabba.span<double>();
   EXPECT_EQ(data4[0], 1.0);
   EXPECT_EQ(data4[1], 2.0);
   EXPECT_EQ(data4[2], 2.0);
@@ -559,28 +559,28 @@ TEST(Variable, rebin) {
   auto rebinned = rebin(var, oldEdge, newEdge);
   ASSERT_EQ(rebinned.dimensions().count(), 1);
   ASSERT_EQ(rebinned.dimensions().volume(), 1);
-  ASSERT_EQ(rebinned.get(Data::Value).size(), 1);
-  EXPECT_EQ(rebinned.get(Data::Value)[0], 3.0);
+  ASSERT_EQ(rebinned.span<double>().size(), 1);
+  EXPECT_EQ(rebinned.span<double>()[0], 3.0);
 }
 
 TEST(Variable, sum) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto sumX = sum(var, Dim::X);
   ASSERT_EQ(sumX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(sumX.get(Data::Value), {3.0, 7.0}));
+  EXPECT_TRUE(equals(sumX.span<double>(), {3.0, 7.0}));
   auto sumY = sum(var, Dim::Y);
   ASSERT_EQ(sumY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(sumY.get(Data::Value), {4.0, 6.0}));
+  EXPECT_TRUE(equals(sumY.span<double>(), {4.0, 6.0}));
 }
 
 TEST(Variable, mean) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto meanX = mean(var, Dim::X);
   ASSERT_EQ(meanX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(meanX.get(Data::Value), {1.5, 3.5}));
+  EXPECT_TRUE(equals(meanX.span<double>(), {1.5, 3.5}));
   auto meanY = mean(var, Dim::Y);
   ASSERT_EQ(meanY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(meanY.get(Data::Value), {2.0, 3.0}));
+  EXPECT_TRUE(equals(meanY.span<double>(), {2.0, 3.0}));
 }
 
 TEST(Variable, abs_of_scalar) {
@@ -643,14 +643,14 @@ TEST(Variable, broadcast_fail) {
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X, {{Dim::X, 3}});
   ConstVariableSlice view(var);
-  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
+  EXPECT_EQ(var.span<double>().data(), view.span<double>().data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
   Variable var(Coord::X, {{Dim::X, 3}});
   VariableSlice view(var);
-  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
-  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
+  EXPECT_EQ(var.span<double>().data(), view.span<double>().data());
+  EXPECT_EQ(var.span<double>().data(), view.span<double>().data());
 }
 
 TEST(VariableSlice, strides) {
@@ -678,7 +678,7 @@ TEST(VariableSlice, strides) {
 
 TEST(VariableSlice, get) {
   const Variable var(Data::Value, {Dim::X, 3}, {1, 2, 3});
-  EXPECT_EQ(var(Dim::X, 1, 2).get(Data::Value)[0], 2.0);
+  EXPECT_EQ(var(Dim::X, 1, 2).span<double>()[0], 2.0);
 }
 
 TEST(VariableSlice, slicing_does_not_transpose) {
@@ -700,7 +700,7 @@ TEST(VariableSlice, self_overlapping_view_operation) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var -= var(Dim::Y, 0);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   // This is the critical part: After subtracting for y=0 the view points to
@@ -715,7 +715,7 @@ TEST(VariableSlice, minus_equals_slice_const_outer) {
   const auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -732,7 +732,7 @@ TEST(VariableSlice, minus_equals_slice_outer) {
   auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -749,7 +749,7 @@ TEST(VariableSlice, minus_equals_slice_inner) {
   auto copy(var);
 
   var -= copy(Dim::X, 0);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 1.0);
   EXPECT_EQ(data[2], 0.0);
@@ -766,7 +766,7 @@ TEST(VariableSlice, minus_equals_slice_of_slice) {
   auto copy(var);
 
   var -= copy(Dim::X, 1)(Dim::Y, 1);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -779,7 +779,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 0, 2);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], -21.0);
@@ -788,7 +788,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 0, 2);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -12.0);
     EXPECT_EQ(data[1], -13.0);
     EXPECT_EQ(data[2], -22.0);
@@ -797,7 +797,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -21.0);
     EXPECT_EQ(data[1], -22.0);
     EXPECT_EQ(data[2], -31.0);
@@ -806,7 +806,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -22.0);
     EXPECT_EQ(data[1], -23.0);
     EXPECT_EQ(data[2], -32.0);
@@ -818,7 +818,7 @@ TEST(VariableSlice, slice_inner_minus_equals) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::X, 0) -= var(Dim::X, 1);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], -1.0);
   EXPECT_EQ(data[1], 2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -829,7 +829,7 @@ TEST(VariableSlice, slice_outer_minus_equals) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::Y, 0) -= var(Dim::Y, 1);
-  const auto data = var.get(Data::Value);
+  const auto data = var.span<double>();
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], 3.0);
@@ -842,7 +842,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -858,7 +858,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -874,7 +874,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -890,7 +890,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -909,7 +909,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -925,7 +925,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -941,7 +941,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -957,7 +957,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value);
+    const auto data = target.span<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -978,7 +978,7 @@ TEST(VariableSlice, slice_minus_lower_dimensional) {
 
   target(Dim::Y, 1, 2) -= source;
 
-  const auto data = target.get(Data::Value);
+  const auto data = target.span<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], -1.0);
@@ -991,19 +991,19 @@ TEST(VariableSlice, variable_copy_from_slice) {
 
   Variable target1(source(Dim::X, 0, 2)(Dim::Y, 0, 2));
   EXPECT_EQ(target1.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target1.get(Data::Value), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target1.span<double>(), {11, 12, 21, 22}));
 
   Variable target2(source(Dim::X, 1, 3)(Dim::Y, 0, 2));
   EXPECT_EQ(target2.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target2.get(Data::Value), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target2.span<double>(), {12, 13, 22, 23}));
 
   Variable target3(source(Dim::X, 0, 2)(Dim::Y, 1, 3));
   EXPECT_EQ(target3.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target3.get(Data::Value), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target3.span<double>(), {21, 22, 31, 32}));
 
   Variable target4(source(Dim::X, 1, 3)(Dim::Y, 1, 3));
   EXPECT_EQ(target4.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target4.get(Data::Value), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target4.span<double>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_assign_from_slice) {
@@ -1013,19 +1013,19 @@ TEST(VariableSlice, variable_assign_from_slice) {
 
   target = source(Dim::X, 0, 2)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target.span<double>(), {11, 12, 21, 22}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target.span<double>(), {12, 13, 22, 23}));
 
   target = source(Dim::X, 0, 2)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target.span<double>(), {21, 22, 31, 32}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.span<double>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_self_assign_via_slice) {
@@ -1036,7 +1036,7 @@ TEST(VariableSlice, variable_self_assign_via_slice) {
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.span<double>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, slice_assign_from_variable) {
@@ -1049,29 +1049,25 @@ TEST(VariableSlice, slice_assign_from_variable) {
     Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(
-        equals(target.get(Data::Value), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
+    EXPECT_TRUE(equals(target.span<double>(), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
   }
   {
     Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(
-        equals(target.get(Data::Value), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
+    EXPECT_TRUE(equals(target.span<double>(), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
   }
   {
     Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(
-        equals(target.get(Data::Value), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
+    EXPECT_TRUE(equals(target.span<double>(), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
   }
   {
     Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(
-        equals(target.get(Data::Value), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
+    EXPECT_TRUE(equals(target.span<double>(), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
   }
 }
 
@@ -1085,10 +1081,10 @@ TEST(VariableSlice, slice_binary_operations) {
   auto difference = v(Dim::X, 0) - v(Dim::X, 1);
   auto product = v(Dim::X, 0) * v(Dim::X, 1);
   auto ratio = v(Dim::X, 0) / v(Dim::X, 1);
-  EXPECT_TRUE(equals(sum.get(Data::Value), {3, 7}));
-  EXPECT_TRUE(equals(difference.get(Data::Value), {-1, -1}));
-  EXPECT_TRUE(equals(product.get(Data::Value), {2, 12}));
-  EXPECT_TRUE(equals(ratio.get(Data::Value), {1.0 / 2.0, 3.0 / 4.0}));
+  EXPECT_TRUE(equals(sum.span<double>(), {3, 7}));
+  EXPECT_TRUE(equals(difference.span<double>(), {-1, -1}));
+  EXPECT_TRUE(equals(product.span<double>(), {2, 12}));
+  EXPECT_TRUE(equals(ratio.span<double>(), {1.0 / 2.0, 3.0 / 4.0}));
 }
 
 TEST(Variable, reshape) {
@@ -1097,12 +1093,12 @@ TEST(Variable, reshape) {
   auto view = var.reshape({Dim::Row, 6});
   ASSERT_EQ(view.size(), 6);
   ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
-  EXPECT_TRUE(equals(view.get(Data::Value), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.span<double>(), {1, 2, 3, 4, 5, 6}));
 
   auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
   ASSERT_EQ(view2.size(), 6);
   ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(view2.get(Data::Value), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view2.span<double>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, reshape_temporary) {
@@ -1111,7 +1107,7 @@ TEST(Variable, reshape_temporary) {
   auto reshaped = sum(var, Dim::X).reshape({{Dim::Y, 2}, {Dim::Z, 2}});
   ASSERT_EQ(reshaped.size(), 4);
   ASSERT_EQ(reshaped.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(reshaped.get(Data::Value), {6, 8, 10, 12}));
+  EXPECT_TRUE(equals(reshaped.span<double>(), {6, 8, 10, 12}));
 
   // This is not a temporary, we get a view into `var`.
   EXPECT_EQ(typeid(decltype(std::move(var).reshape({}))),
@@ -1130,7 +1126,7 @@ TEST(Variable, reshape_and_slice) {
 
   auto slice =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
-  EXPECT_TRUE(equals(slice.get(Data::Value), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(slice.span<double>(), {6, 7, 10, 11}));
 
   Variable center =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
@@ -1138,7 +1134,7 @@ TEST(Variable, reshape_and_slice) {
 
   ASSERT_EQ(center.size(), 4);
   ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
-  EXPECT_TRUE(equals(center.get(Data::Value), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(center.span<double>(), {6, 7, 10, 11}));
 }
 
 TEST(Variable, reshape_mutable) {
@@ -1146,11 +1142,11 @@ TEST(Variable, reshape_mutable) {
   const auto copy(var);
 
   auto view = var.reshape({Dim::Row, 6});
-  view.get(Data::Value)[3] = 0;
+  view.span<double>()[3] = 0;
 
-  EXPECT_TRUE(equals(view.get(Data::Value), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(var.get(Data::Value), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(copy.get(Data::Value), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.span<double>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(var.span<double>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(copy.span<double>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, reverse) {
@@ -1204,24 +1200,24 @@ TEST(Variable, non_in_place_scalar_operations) {
   Variable var(Data::Value, {{Dim::X, 2}}, {1, 2});
 
   auto sum = var + 1;
-  EXPECT_TRUE(equals(sum.get(Data::Value), {2, 3}));
+  EXPECT_TRUE(equals(sum.span<double>(), {2, 3}));
   sum = 2 + var;
-  EXPECT_TRUE(equals(sum.get(Data::Value), {3, 4}));
+  EXPECT_TRUE(equals(sum.span<double>(), {3, 4}));
 
   auto diff = var - 1;
-  EXPECT_TRUE(equals(diff.get(Data::Value), {0, 1}));
+  EXPECT_TRUE(equals(diff.span<double>(), {0, 1}));
   diff = 2 - var;
-  EXPECT_TRUE(equals(diff.get(Data::Value), {1, 0}));
+  EXPECT_TRUE(equals(diff.span<double>(), {1, 0}));
 
   auto prod = var * 2;
-  EXPECT_TRUE(equals(prod.get(Data::Value), {2, 4}));
+  EXPECT_TRUE(equals(prod.span<double>(), {2, 4}));
   prod = 3 * var;
-  EXPECT_TRUE(equals(prod.get(Data::Value), {3, 6}));
+  EXPECT_TRUE(equals(prod.span<double>(), {3, 6}));
 
   auto ratio = var / 2;
-  EXPECT_TRUE(equals(ratio.get(Data::Value), {1.0 / 2.0, 1.0}));
+  EXPECT_TRUE(equals(ratio.span<double>(), {1.0 / 2.0, 1.0}));
   ratio = 3 / var;
-  EXPECT_TRUE(equals(ratio.get(Data::Value), {3.0, 1.5}));
+  EXPECT_TRUE(equals(ratio.span<double>(), {3.0, 1.5}));
 }
 
 TEST(VariableSlice, scalar_operations) {
@@ -1229,17 +1225,17 @@ TEST(VariableSlice, scalar_operations) {
                {11, 12, 13, 21, 22, 23});
 
   var(Dim::X, 0) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 13, 22, 22, 23}));
+  EXPECT_TRUE(equals(var.span<double>(), {12, 12, 13, 22, 22, 23}));
   var(Dim::Y, 1) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 13, 23, 23, 24}));
+  EXPECT_TRUE(equals(var.span<double>(), {12, 12, 13, 23, 23, 24}));
   var(Dim::X, 1, 3) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value), {12, 13, 14, 23, 24, 25}));
+  EXPECT_TRUE(equals(var.span<double>(), {12, 13, 14, 23, 24, 25}));
   var(Dim::X, 1) -= 1;
-  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 14, 23, 23, 25}));
+  EXPECT_TRUE(equals(var.span<double>(), {12, 12, 14, 23, 23, 25}));
   var(Dim::X, 2) *= 0;
-  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.span<double>(), {12, 12, 0, 23, 23, 0}));
   var(Dim::Y, 0) /= 2;
-  EXPECT_TRUE(equals(var.get(Data::Value), {6, 6, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.span<double>(), {6, 6, 0, 23, 23, 0}));
 }
 
 TEST(Variable, apply_unary_in_place) {
@@ -1317,7 +1313,7 @@ TEST(SparseVariable, dtype) {
 
 TEST(SparseVariable, non_sparse_access_fail) {
   const auto var = makeSparseVariable<double>(Data::Value, {Dim::Y, 2}, Dim::X);
-  ASSERT_THROW(var.get(Data::Value), except::TypeError);
+  ASSERT_THROW(var.span<double>(), except::TypeError);
   ASSERT_THROW(var.span<double>(), except::TypeError);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -496,7 +496,7 @@ public:
 Variable::Variable(const ConstVariableSlice &slice)
     : Variable(*slice.m_variable) {
   if (slice.m_view) {
-    m_tag = slice.tag();
+    m_tag = slice.m_variable->tag();
     m_name = slice.m_variable->m_name;
     setUnit(slice.unit());
     setDimensions(slice.dimensions());
@@ -508,9 +508,8 @@ Variable::Variable(const Variable &parent, const Dimensions &dims)
       m_object(parent.m_object->clone(dims)) {}
 
 Variable::Variable(const ConstVariableSlice &parent, const Dimensions &dims)
-    : m_tag(parent.tag()), m_unit(parent.unit()),
+    : m_tag(Data::NoTag), m_unit(parent.unit()),
       m_object(parent.data().clone(dims)) {
-  setName(parent.name());
 }
 
 Variable::Variable(const Variable &parent, VariableConceptHandle data)
@@ -575,11 +574,7 @@ INSTANTIATE(std::array<double, 4>)
 INSTANTIATE(Eigen::Vector3d)
 
 template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
-  if (a.name() != b.name())
-    return false;
   if (a.unit() != b.unit())
-    return false;
-  if (a.tag() != b.tag())
     return false;
   if (!(a.dimensions() == b.dimensions()))
     return false;
@@ -703,10 +698,6 @@ Variable &Variable::operator/=(const double value) & {
 }
 
 template <class T> VariableSlice VariableSlice::assign(const T &other) const {
-  // TODO Should mismatching tags be allowed, as long as the type matches?
-  if (tag() != other.tag())
-    throw std::runtime_error("Cannot assign to slice: Type mismatch.");
-  // Name mismatch ok, but do not assign it.
   if (unit() != other.unit())
     throw std::runtime_error("Cannot assign to slice: Unit mismatch.");
   if (dimensions() != other.dimensions())

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -1035,19 +1035,19 @@ Variable rebin(const Variable &var, const Variable &oldCoord,
     // TODO This will currently fail if the data is a multi-dimensional density.
     // Would need a conversion that converts only the rebinned dimension.
     // TODO This could be done more efficiently without a temporary Dataset.
-    throw std::runtime_error("Temporarily disabled for refactor");
     /*
-    Dataset density;
-    density.insert(oldCoord);
-    density.insert(var);
-    auto cnts = counts::fromDensity(std::move(density), dim)
-                    .erase(var.tag(), var.name());
-    Dataset rebinnedCounts;
-    rebinnedCounts.insert(newCoord);
-    rebinnedCounts.insert(rebin(cnts, oldCoord, newCoord));
-    return counts::toDensity(std::move(rebinnedCounts), dim)
-        .erase(var.tag(), var.name());
+    throw std::runtime_error("Temporarily disabled for refactor");
     */
+    Dataset density;
+    density.insert(dimensionCoord(dim), oldCoord);
+    density.insert(Data::Value, var);
+    auto cnts = counts::fromDensity(std::move(density), dim).erase(Data::Value);
+    Dataset rebinnedCounts;
+    rebinnedCounts.insert(dimensionCoord(dim), newCoord);
+    rebinnedCounts.insert(Data::Value,
+                          rebin(std::get<Variable>(cnts), oldCoord, newCoord));
+    return std::get<Variable>(
+        counts::toDensity(std::move(rebinnedCounts), dim).erase(Data::Value));
   }
 }
 

--- a/core/variable.h
+++ b/core/variable.h
@@ -460,10 +460,6 @@ public:
   // slice in general so we must return a copy of the data.
   Variable reshape(const Dimensions &dims) const;
 
-  const std::string &name() const { return m_variable->name(); }
-  void setName(const std::string &) {
-    throw std::runtime_error("Cannot rename Variable via slice view.");
-  }
   units::Unit unit() const { return m_variable->unit(); }
   scipp::index size() const {
     if (m_view)
@@ -491,7 +487,6 @@ public:
   }
 
   DType dtype() const noexcept { return m_variable->dtype(); }
-  Tag tag() const { return m_variable->tag(); }
 
   const VariableConcept &data() const && = delete;
   const VariableConcept &data() const & {
@@ -509,10 +504,6 @@ public:
       return m_variable->dataHandle();
   }
 
-  bool isCoord() const { return m_variable->isCoord(); }
-  bool isAttr() const { return m_variable->isAttr(); }
-  bool isData() const { return m_variable->isData(); }
-
   bool isSparse() const noexcept { return m_variable->isSparse(); }
   Dim sparseDim() const { return m_variable->sparseDim(); }
 
@@ -521,12 +512,6 @@ public:
   // temporaries and we do not need to delete the rvalue overload, unlike for
   // many other methods. The data is owned by the underlying variable so it
   // will not be deleted even if *this is a temporary and gets deleted.
-  template <class TagT> auto get(const TagT t) const {
-    if (t != tag())
-      throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return this->template cast<typename TagT::type>();
-  }
-
   template <class T> auto span() const { return cast<T>(); }
   template <class T> auto sparseSpan() const {
     return cast<sparse_container<T>>();
@@ -540,7 +525,6 @@ public:
 
 protected:
   friend class Variable;
-  template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
   template <class T>
   const VariableView<const underlying_type_t<T>> cast() const;
@@ -580,12 +564,7 @@ public:
     return VariableSlice(*this, dim, begin, end);
   }
 
-  void setName(const std::string &) {
-    throw std::runtime_error("Cannot rename Variable via slice view.");
-  }
-
   using ConstVariableSlice::data;
-  using ConstVariableSlice::get;
 
   VariableConcept &data() const && = delete;
   VariableConcept &data() const & {
@@ -602,12 +581,6 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class TagT> auto get(const TagT t) const {
-    if (t != tag())
-      throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return this->template cast<typename TagT::type>();
-  }
-
   template <class T> auto span() const { return cast<T>(); }
   template <class T> auto sparseSpan() const {
     return cast<sparse_container<T>>();
@@ -646,7 +619,6 @@ public:
 private:
   friend class Variable;
   template <class... Tags> friend class ZipView;
-  template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
   template <class T> VariableView<underlying_type_t<T>> cast() const;
 

--- a/core/variable.h
+++ b/core/variable.h
@@ -329,10 +329,8 @@ private:
   VariableConceptHandle m_object;
 };
 
-template <class T>
-Variable makeVariable(const Dimensions &dimensions,
-                      const units::Unit unit = units::dimensionless) {
-  return Variable(unit, std::move(dimensions),
+template <class T> Variable makeVariable(const Dimensions &dimensions) {
+  return Variable(units::dimensionless, std::move(dimensions),
                   Vector<underlying_type_t<T>>(
                       dimensions.volume(),
                       detail::default_init<underlying_type_t<T>>::value()));
@@ -375,6 +373,12 @@ Variable makeVariable(const Dimensions &dimensions, Args &&... args) {
     // Copies to aligned memory.
     return Variable(units::dimensionless, std::move(dimensions),
                     Vector<underlying_type_t<T>>(args.begin(), args.end())...);
+  } else if constexpr (sizeof...(Args) == 1 &&
+                       (std::is_convertible_v<Args, units::Unit> && ...)) {
+    return Variable(args..., std::move(dimensions),
+                    Vector<underlying_type_t<T>>(
+                        dimensions.volume(),
+                        detail::default_init<underlying_type_t<T>>::value()));
   } else {
     return Variable(units::dimensionless, std::move(dimensions),
                     Vector<underlying_type_t<T>>(std::forward<Args>(args)...));

--- a/core/variable.h
+++ b/core/variable.h
@@ -5,7 +5,6 @@
 #ifndef VARIABLE_H
 #define VARIABLE_H
 
-#include <exception>
 #include <type_traits>
 #include <variant>
 
@@ -330,8 +329,10 @@ private:
   VariableConceptHandle m_object;
 };
 
-template <class T> Variable makeVariable(const Dimensions &dimensions) {
-  return Variable(units::dimensionless, std::move(dimensions),
+template <class T>
+Variable makeVariable(const Dimensions &dimensions,
+                      const units::Unit unit = units::dimensionless) {
+  return Variable(unit, std::move(dimensions),
                   Vector<underlying_type_t<T>>(
                       dimensions.volume(),
                       detail::default_init<underlying_type_t<T>>::value()));
@@ -349,6 +350,13 @@ template <class T, class T2 = T>
 Variable makeVariable(const Dimensions &dimensions,
                       std::initializer_list<T2> values) {
   return Variable(units::dimensionless, std::move(dimensions),
+                  Vector<underlying_type_t<T>>(values.begin(), values.end()));
+}
+
+template <class T, class T2 = T>
+Variable makeVariable(const Dimensions &dimensions, const units::Unit unit,
+                      std::initializer_list<T2> values) {
+  return Variable(unit, std::move(dimensions),
                   Vector<underlying_type_t<T>>(values.begin(), values.end()));
 }
 

--- a/core/zip_view.h
+++ b/core/zip_view.h
@@ -61,7 +61,7 @@ public:
     // TODO Probably we can also support 0-dimensional variables that are not
     // touched?
     for (const auto &var : dataset)
-      if (var.dimensions().count() != 1)
+      if (std::get<VariableSlice>(var).dimensions().count() != 1)
         throw std::runtime_error("ZipView supports only datasets where "
                                  "all variables are 1-dimensional.");
     if (dataset.dimensions().count() != 1)
@@ -306,8 +306,8 @@ public:
           ++count;
       }
       scipp::index requiredCount = 0;
-      for (const auto &var : dataset) {
-        if (var.isData() && name == var.name())
+      for (const auto & [ n, t, var ] : dataset) {
+        if (t.isData() && name == n)
           ++requiredCount;
       }
       m_mayResizeItems &= (count == requiredCount);

--- a/scippy/test/test_dataset.py
+++ b/scippy/test/test_dataset.py
@@ -427,7 +427,7 @@ class TestDataset(unittest.TestCase):
         c = a * b
         # Variables "a" and "b" multiplied despite different names
         self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
-                        data * data))
+                                       data * data))
         self.assertTrue(np.array_equal(
             c[sp.Data.Variance, "i"].numpy, variance * (data * data) * 2))
 
@@ -576,7 +576,7 @@ class TestDataset(unittest.TestCase):
         self.dataset[sp.Data.Value, 'data2'][sp.Dim.Y, 1:3] = np.exp(
             self.dataset[sp.Data.Value, 'data1'][sp.Dim.Y, 0:2])
         np.testing.assert_array_equal(self.dataset[sp.Data.Value,
-                                      "data2"].numpy[:, 1:3, :],
+                                                   "data2"].numpy[:, 1:3, :],
                                       np.exp(self.reference_data1[:, 0:2, :]))
 
         # Restore original value.

--- a/scippy/test/test_dataset.py
+++ b/scippy/test/test_dataset.py
@@ -892,7 +892,8 @@ class TestDatasetExamples(unittest.TestCase):
             [sp.Dim.Energy], np.random.exponential(size=8))
         d[sp.Coord.Monitor, "transmission"] = ([], ())
 
-    @unittest.skip("Tag-derived dtype not available anymore, need to implement way of specifying list type for events.")
+    @unittest.skip("Tag-derived dtype not available anymore, need to implement \
+                   way of specifying list type for events.")
     def test_zip(self):
         d = sp.Dataset()
         d[sp.Coord.SpectrumNumber] = ([sp.Dim.Position], np.arange(1, 6))

--- a/scippy/test/test_datasetslice.py
+++ b/scippy/test/test_datasetslice.py
@@ -26,9 +26,11 @@ class TestDatasetSlice(unittest.TestCase):
         ds_slice = self._d.subset["a"]
         self.assertEqual(type(ds_slice), sp.DatasetSlice)
         # We should have just one data variable
-        self.assertEqual(1, len([var for name, tag, var in ds_slice if tag.is_data]))
+        self.assertEqual(
+            1, len([var for name, tag, var in ds_slice if tag.is_data]))
         # We should have just one coord variable
-        self.assertEqual(1, len([var for name, tag, var in ds_slice if tag.is_coord]))
+        self.assertEqual(
+            1, len([var for name, tag, var in ds_slice if tag.is_coord]))
         self.assertEqual(2, len(ds_slice))
 
     def test_slice_back_ommit_range(self):

--- a/scippy/test/test_datasetslice.py
+++ b/scippy/test/test_datasetslice.py
@@ -26,9 +26,9 @@ class TestDatasetSlice(unittest.TestCase):
         ds_slice = self._d.subset["a"]
         self.assertEqual(type(ds_slice), sp.DatasetSlice)
         # We should have just one data variable
-        self.assertEqual(1, len([var for var in ds_slice if var.is_data]))
+        self.assertEqual(1, len([var for name, tag, var in ds_slice if tag.is_data]))
         # We should have just one coord variable
-        self.assertEqual(1, len([var for var in ds_slice if var.is_coord]))
+        self.assertEqual(1, len([var for name, tag, var in ds_slice if tag.is_coord]))
         self.assertEqual(2, len(ds_slice))
 
     def test_slice_back_ommit_range(self):
@@ -164,7 +164,7 @@ class TestDatasetSlice(unittest.TestCase):
         d[sp.Data.Value, "a"] = ([sp.Dim.X], data)
         d[sp.Data.Variance, "a"] = ([sp.Dim.X], data)
         a = d.subset[sp.Data.Value, "a"]
-        b_var = sp.Variable(sp.Data.Value, [sp.Dim.X], data)
+        b_var = sp.Variable([sp.Dim.X], data)
 
         c = a + b_var
         self.assertTrue(np.array_equal(

--- a/scippy/test/test_dtypes.py
+++ b/scippy/test/test_dtypes.py
@@ -8,6 +8,7 @@ import scippy as sp
 
 
 class TestDTypes(unittest.TestCase):
+    @unittest.skip("Tag-derived dtype not available anymore, need to implement way of specifying Eigen types.")    
     def test_Eigen_Vector3d(self):
         d = sp.Dataset()
         d[sp.Coord.Position] = ([sp.Dim.Position], (4,))

--- a/scippy/test/test_dtypes.py
+++ b/scippy/test/test_dtypes.py
@@ -8,7 +8,8 @@ import scippy as sp
 
 
 class TestDTypes(unittest.TestCase):
-    @unittest.skip("Tag-derived dtype not available anymore, need to implement way of specifying Eigen types.")
+    @unittest.skip("Tag-derived dtype not available anymore, need to implement \
+                   way of specifying Eigen types.")
     def test_Eigen_Vector3d(self):
         d = sp.Dataset()
         d[sp.Coord.Position] = ([sp.Dim.Position], (4,))

--- a/scippy/test/test_dtypes.py
+++ b/scippy/test/test_dtypes.py
@@ -8,7 +8,7 @@ import scippy as sp
 
 
 class TestDTypes(unittest.TestCase):
-    @unittest.skip("Tag-derived dtype not available anymore, need to implement way of specifying Eigen types.")    
+    @unittest.skip("Tag-derived dtype not available anymore, need to implement way of specifying Eigen types.")
     def test_Eigen_Vector3d(self):
         d = sp.Dataset()
         d[sp.Coord.Position] = ([sp.Dim.Position], (4,))

--- a/scippy/test/test_units.py
+++ b/scippy/test/test_units.py
@@ -15,7 +15,6 @@ class TestUnits(unittest.TestCase):
 
     def test_variable_unit_repr(self):
         var1 = sp.Variable([sp.Dim.X], np.arange(4))
-        var2 = sp.Variable([sp.Dim.X], np.arange(4))
         u = sp.units.angstrom
         var1.unit = u
         self.assertEqual(repr(var1.unit), "\u212B")

--- a/scippy/test/test_units.py
+++ b/scippy/test/test_units.py
@@ -13,19 +13,9 @@ class TestUnits(unittest.TestCase):
         u = sp.units.angstrom
         self.assertEqual(repr(u), "\u212B")
 
-    def test_variable_unit(self):
-        var1 = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(4))
-        var2 = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4))
-        self.assertEqual(var1.unit, sp.units.dimensionless)
-        self.assertEqual(var2.unit, sp.units.m)
-        self.assertNotEqual(var2.unit, sp.units.counts)
-        self.assertTrue(var2.unit != sp.units.counts)
-
     def test_variable_unit_repr(self):
-        var1 = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(4))
-        var2 = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4))
-        self.assertEqual(repr(var1.unit), "dimensionless")
-        self.assertEqual(repr(var2.unit), "m")
+        var1 = sp.Variable([sp.Dim.X], np.arange(4))
+        var2 = sp.Variable([sp.Dim.X], np.arange(4))
         u = sp.units.angstrom
         var1.unit = u
         self.assertEqual(repr(var1.unit), "\u212B")

--- a/scippy/test/test_variable.py
+++ b/scippy/test/test_variable.py
@@ -10,8 +10,8 @@ import numpy as np
 
 def make_variables():
     data = np.arange(1, 4, dtype=float)
-    a = sp.Variable(sp.Data.Value, [sp.Dim.X], data)
-    b = sp.Variable(sp.Data.Value, [sp.Dim.X], data)
+    a = sp.Variable([sp.Dim.X], data)
+    b = sp.Variable([sp.Dim.X], data)
     a_slice = a[sp.Dim.X, :]
     b_slice = b[sp.Dim.X, :]
     return a, b, a_slice, b_slice, data
@@ -21,37 +21,32 @@ class TestVariable(unittest.TestCase):
 
     def test_builtins(self):
         # Test builtin support
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4.0))
+        var = sp.Variable([sp.Dim.X], np.arange(4.0))
         self.assertEqual(len(var), 4)
 
     def test_create_coord(self):
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4.0))
-        self.assertEqual(var.name, "")
+        var = sp.Variable([sp.Dim.X], np.arange(4.0))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_coord_different_default_dtype(self):
-        var = sp.Variable(sp.Coord.Mask, [sp.Dim.X], np.array(
+        var = sp.Variable([sp.Dim.X], np.array(
             [True, False, True, False]))
-        self.assertEqual(var.name, "")
         self.assertEqual(var.numpy.dtype, np.dtype(np.bool))
         np.testing.assert_array_equal(
             var.numpy, np.array([True, False, True, False]))
 
     def test_create_data(self):
-        var = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(4.0))
-        self.assertEqual(var.name, "")
+        var = sp.Variable([sp.Dim.X], np.arange(4.0))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_default_init(self):
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,))
-        self.assertEqual(var.name, "")
+        var = sp.Variable([sp.Dim.X], (4,))
 
     def test_create_scalar(self):
         var = sp.Variable(1.2)
         self.assertEqual(var.scalar, 1.2)
-        self.assertEqual(var.name, '')
         self.assertEqual(var.dimensions, sp.Dimensions())
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         self.assertEqual(var.unit, sp.units.dimensionless)
@@ -59,76 +54,48 @@ class TestVariable(unittest.TestCase):
     def test_create_scalar_quantity(self):
         var = sp.Variable(1.2, unit=sp.units.m)
         self.assertEqual(var.scalar, 1.2)
-        self.assertEqual(var.name, '')
         self.assertEqual(var.dimensions, sp.Dimensions())
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         self.assertEqual(var.unit, sp.units.m)
 
     def test_operation_with_scalar_quantity(self):
-        reference = sp.Variable(sp.Data.Value, [sp.Dim.X],
+        reference = sp.Variable([sp.Dim.X],
                                 np.arange(4.0) * 1.5)
         reference.unit = sp.units.kg
 
-        var = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(4.0))
+        var = sp.Variable([sp.Dim.X], np.arange(4.0))
         var *= sp.Variable(1.5, unit=sp.units.kg)
         self.assertEqual(var, reference)
 
     def test_0D_scalar_access(self):
-        var = sp.Variable(sp.Coord.X, [], ())
+        var = sp.Variable([], ())
         self.assertEqual(var.scalar, 0.0)
         var.scalar = 1.2
         self.assertEqual(var.scalar, 1.2)
         self.assertEqual(var.data[0], 1.2)
 
     def test_1D_scalar_access_fail(self):
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (1,))
+        var = sp.Variable([sp.Dim.X], (1,))
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions {}, "
                                     "got {{Dim::X, 1}}."):
             var.scalar = 1.2
 
-    def test_variable_type(self):
-        var_coord = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,))
-        var_data = sp.Variable(sp.Data.Value, [sp.Dim.X], (4,))
-
-        self.assertTrue(var_coord.is_coord)
-        self.assertTrue(var_data.is_data)
-
     def test_create_dtype(self):
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X],
-                          np.arange(4).astype(np.int32))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X],
-                          np.arange(4).astype(np.float64))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X],
-                          np.arange(4).astype(np.float32))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,),
-                          dtype=np.dtype(np.float64))
+        var = sp.Variable([sp.Dim.X], np.arange(4))
+        var = sp.Variable([sp.Dim.X], np.arange(4).astype(np.int32))
+        var = sp.Variable([sp.Dim.X], np.arange(4).astype(np.float64))
+        var = sp.Variable([sp.Dim.X], np.arange(4).astype(np.float32))
+        var = sp.Variable([sp.Dim.X], (4,), dtype=np.dtype(np.float64))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,),
-                          dtype=np.dtype(np.float32))
+        var = sp.Variable([sp.Dim.X], (4,), dtype=np.dtype(np.float32))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float32))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,),
-                          dtype=np.dtype(np.int64))
+        var = sp.Variable([sp.Dim.X], (4,), dtype=np.dtype(np.int64))
         self.assertEqual(var.numpy.dtype, np.dtype(np.int64))
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], (4,),
-                          dtype=np.dtype(np.int32))
+        var = sp.Variable([sp.Dim.X], (4,), dtype=np.dtype(np.int32))
         self.assertEqual(var.numpy.dtype, np.dtype(np.int32))
 
-    def test_coord_set_name(self):
-        var = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(4))
-        # We can set a name for coordinates, but not that operations will
-        # typically not look for a named coordinate. In particular it will not
-        # be considered a "dimension coordinate".
-        var.name = "x"
-        self.assertEqual(var.name, "x")
-
-    def test_set_name(self):
-        var = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(4))
-        var.name = "data"
-        self.assertEqual(var.name, "data")
-
     def test_slicing(self):
-        var = sp.Variable(sp.Data.Value, [sp.Dim.X], np.arange(0, 3))
+        var = sp.Variable([sp.Dim.X], np.arange(0, 3))
         var_slice = var[(sp.Dim.X, slice(0, 2))]
         self.assertTrue(isinstance(var_slice, sp.VariableSlice))
         self.assertEqual(len(var_slice), 2)

--- a/scippy/test/test_variable.py
+++ b/scippy/test/test_variable.py
@@ -42,7 +42,7 @@ class TestVariable(unittest.TestCase):
         np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_default_init(self):
-        var = sp.Variable([sp.Dim.X], (4,))
+        sp.Variable([sp.Dim.X], (4,))
 
     def test_create_scalar(self):
         var = sp.Variable(1.2)

--- a/scippy/test/test_variableslice.py
+++ b/scippy/test/test_variableslice.py
@@ -12,23 +12,16 @@ import operator
 class TestVariableSlice(unittest.TestCase):
 
     def setUp(self):
-        self._a = sp.Variable(
-            sp.Data.Value, [
-                sp.Dim.X], np.arange(
-                1, 10, dtype=float))
-        self._b = sp.Variable(
-            sp.Data.Value, [
-                sp.Dim.X], np.arange(
-                1, 10, dtype=float))
+        self._a = sp.Variable([sp.Dim.X], np.arange(1, 10, dtype=float))
+        self._b = sp.Variable([sp.Dim.X], np.arange(1, 10, dtype=float))
 
     def test_type(self):
         variable_slice = self._a[sp.Dim.X, :]
         self.assertEqual(type(variable_slice), sp.VariableSlice)
 
     def test_variable_type(self):
-        coord_var = sp.Variable(sp.Coord.X, [sp.Dim.X], np.arange(10))
+        coord_var = sp.Variable([sp.Dim.X], np.arange(10))
         coord_slice = coord_var[sp.Dim.X, :]
-        self.assertTrue(coord_slice.is_coord)
 
     def _apply_test_op(self, op, a, b, data):
         op(a, b)
@@ -85,7 +78,7 @@ class TestVariableSlice(unittest.TestCase):
 
     def test_correct_temporaries(self):
         v = sp.Variable(
-            sp.Data.Value, [
+            [
                 sp.Dim.X], np.arange(100).astype(
                 np.float32))
         b = sp.sqrt(v)[sp.Dim.X, 0:10]

--- a/scippy/test/test_variableslice.py
+++ b/scippy/test/test_variableslice.py
@@ -19,10 +19,6 @@ class TestVariableSlice(unittest.TestCase):
         variable_slice = self._a[sp.Dim.X, :]
         self.assertEqual(type(variable_slice), sp.VariableSlice)
 
-    def test_variable_type(self):
-        coord_var = sp.Variable([sp.Dim.X], np.arange(10))
-        coord_slice = coord_var[sp.Dim.X, :]
-
     def _apply_test_op(self, op, a, b, data):
         op(a, b)
         # Assume numpy operations are correct as comparitor


### PR DESCRIPTION
Fixes #232.

A lot of clean up is left to do. However I am postponing this until we have decided on a way forward with #234. The current changes are useful regardless of the chosen strategy, but follow-up clean up may be done differently.