### PR TITLE
In-place transform for sparse data with variances

### DIFF
--- a/core/except.h
+++ b/core/except.h
@@ -115,6 +115,10 @@ struct UnitError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+struct SizeError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 struct UnitMismatchError : public UnitError {
   UnitMismatchError(const units::Unit &a, const units::Unit &b);
 };
@@ -136,6 +140,12 @@ template <class A, class B> void variablesMatch(const A &a, const B &b) {
 }
 void dimensionMatches(const Dimensions &dims, const Dim dim,
                       const scipp::index length);
+
+template <class T, class... Ts>
+void sizeMatches(const T &range, const Ts &... other) {
+  if (((scipp::size(range) != scipp::size(other)) || ...))
+    throw except::SizeError("Expected matching sizes.");
+}
 void equals(const units::Unit &a, const units::Unit &b);
 void equals(const Dimensions &a, const Dimensions &b);
 

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -19,16 +19,16 @@ TEST(TransformTest, apply_unary_in_place) {
 }
 
 TEST(TransformTest, apply_unary_in_place_with_variances) {
-  auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {3.3, 4.4});
-  transform_in_place<double>(var, [](const auto x) { return -x; });
-  EXPECT_TRUE(equals(var.values<double>(), {-1.1, -2.2}));
-  EXPECT_TRUE(equals(var.variances<double>(), {-3.3, -4.4}));
+  auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {1.1, 3.0});
+  transform_in_place<double>(var, [](const auto x) { return 2.0 * x; });
+  EXPECT_TRUE(equals(var.values<double>(), {2.2, 4.4}));
+  EXPECT_TRUE(equals(var.variances<double>(), {4.4, 12.0}));
 }
 
 TEST(TransformTest, apply_unary_implicit_conversion) {
   const auto var = makeVariable<float>({Dim::X, 2}, {1.1, 2.2});
   // The functor returns double, so the output type is also double.
-  auto out = transform<double, float>(var, [](const auto x) { return -x; });
+  auto out = transform<double, float>(var, [](const double x) { return -x; });
   EXPECT_TRUE(equals(out.values<double>(), {-1.1f, -2.2f}));
 }
 

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -14,13 +14,13 @@ using namespace scipp::core;
 
 TEST(TransformTest, apply_unary_in_place) {
   auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
-  transform_in_place<double>(var, [](const auto x) { return -x; });
+  transform_in_place<double>(var, [](auto &x) { x = -x; });
   EXPECT_TRUE(equals(var.values<double>(), {-1.1, -2.2}));
 }
 
 TEST(TransformTest, apply_unary_in_place_with_variances) {
   auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {1.1, 3.0});
-  transform_in_place<double>(var, [](const auto x) { return 2.0 * x; });
+  transform_in_place<double>(var, [](auto &x) { x *= 2.0; });
   EXPECT_TRUE(equals(var.values<double>(), {2.2, 4.4}));
   EXPECT_TRUE(equals(var.variances<double>(), {4.4, 12.0}));
 }
@@ -89,7 +89,7 @@ TEST(TransformTest, unary_on_elements_of_sparse) {
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
-  transform_in_place<double>(a, [](const auto x) { return sqrt(x); });
+  transform_in_place<double>(a, [](auto &x) { x = sqrt(x); });
   EXPECT_TRUE(equals(a_[0], {1, 2, 3}));
   EXPECT_TRUE(equals(a_[1], {2}));
 }
@@ -106,7 +106,7 @@ TEST(TransformTest, unary_on_elements_of_sparse_with_variance) {
   vars[0] = {1.5, 4.5, 9.5};
   vars[1] = {4.5};
 
-  transform_in_place<double>(a, [](const auto x) { return x + 1.0; });
+  transform_in_place<double>(a, [](auto &x) { x += 1.0; });
   EXPECT_TRUE(equals(vals[0], {2, 5, 10}));
   EXPECT_TRUE(equals(vals[1], {5}));
   EXPECT_TRUE(equals(vars[0], {2.5, 5.5, 10.5}));
@@ -119,8 +119,7 @@ TEST(TransformTest, unary_on_sparse_container) {
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
-  transform_in_place<sparse_container<double>>(
-      a, [](const auto &x) { return decltype(x){}; });
+  transform_in_place<sparse_container<double>>(a, [](auto &x) { x.clear(); });
   EXPECT_TRUE(a_[0].empty());
   EXPECT_TRUE(a_[1].empty());
 }

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -12,20 +12,20 @@
 using namespace scipp;
 using namespace scipp::core;
 
-TEST(Variable, apply_unary_in_place) {
+TEST(TransformTest, apply_unary_in_place) {
   auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   transform_in_place<double>(var, [](const double x) { return -x; });
   EXPECT_TRUE(equals(var.values<double>(), {-1.1, -2.2}));
 }
 
-TEST(Variable, apply_unary_implicit_conversion) {
+TEST(TransformTest, apply_unary_implicit_conversion) {
   const auto var = makeVariable<float>({Dim::X, 2}, {1.1, 2.2});
   // The functor returns double, so the output type is also double.
   auto out = transform<double, float>(var, [](const double x) { return -x; });
   EXPECT_TRUE(equals(out.values<double>(), {-1.1f, -2.2f}));
 }
 
-TEST(Variable, apply_unary) {
+TEST(TransformTest, apply_unary) {
   const auto varD = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto varF = makeVariable<float>({Dim::X, 2}, {1.1, 2.2});
   auto outD = transform<double, float>(varD, [](const auto x) { return -x; });
@@ -34,7 +34,7 @@ TEST(Variable, apply_unary) {
   EXPECT_TRUE(equals(outF.values<float>(), {-1.1f, -2.2f}));
 }
 
-TEST(Variable, apply_binary_in_place) {
+TEST(TransformTest, apply_binary_in_place) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
@@ -42,7 +42,7 @@ TEST(Variable, apply_binary_in_place) {
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
-TEST(Variable, apply_binary_in_place_var_with_view) {
+TEST(TransformTest, apply_binary_in_place_var_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
@@ -50,7 +50,7 @@ TEST(Variable, apply_binary_in_place_var_with_view) {
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
-TEST(Variable, apply_binary_in_place_view_with_var) {
+TEST(TransformTest, apply_binary_in_place_view_with_var) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
@@ -58,7 +58,7 @@ TEST(Variable, apply_binary_in_place_view_with_var) {
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
-TEST(Variable, apply_binary_in_place_view_with_view) {
+TEST(TransformTest, apply_binary_in_place_view_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
@@ -67,7 +67,7 @@ TEST(Variable, apply_binary_in_place_view_with_view) {
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
-TEST(VariableTest, transform_combines_uncertainty_propgation) {
+TEST(TransformTest, transform_combines_uncertainty_propgation) {
   auto a = makeVariable<double>({Dim::X, 1}, {2.0}, {0.1});
   const auto b = makeVariable<double>(3.0, 0.2);
   transform_in_place<pair_self_t<double>>(
@@ -76,19 +76,18 @@ TEST(VariableTest, transform_combines_uncertainty_propgation) {
   EXPECT_TRUE(equals(a.variances<double>(), {0.1 * 3 * 3 + 0.2 * 2 * 2 + 0.2}));
 }
 
-TEST(SparseVariable, unary) {
+TEST(TransformTest, unary) {
   auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
   auto a_ = a.sparseSpan<double>();
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
-  transform_in_place<sparse_container<double>>(
-      a, [](const double x) { return sqrt(x); });
+  transform_in_place<double>(a, [](const double x) { return sqrt(x); });
   EXPECT_TRUE(equals(a_[0], {1, 2, 3}));
   EXPECT_TRUE(equals(a_[1], {2}));
 }
 
-TEST(SparseVariable, DISABLED_unary_on_sparse_container) {
+TEST(TransformTest, unary_on_sparse_container) {
   auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
   auto a_ = a.sparseSpan<double>();
   a_[0] = {1, 4, 9};
@@ -107,7 +106,7 @@ TEST(SparseVariable, DISABLED_unary_on_sparse_container) {
   EXPECT_TRUE(a_[1].empty());
 }
 
-TEST(SparseVariable, binary_with_dense) {
+TEST(TransformTest, binary_with_dense) {
   auto sparse = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
   auto sparse_ = sparse.sparseSpan<double>();
   sparse_[0] = {1, 2, 3};

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -197,37 +197,48 @@ protected:
   Variable a = makeVariable<double>(
       dims, {sparse_container<double>(2), sparse_container<double>(2)},
       {sparse_container<double>(2), sparse_container<double>(2)});
-  Variable b = a;
+  Variable val_var = a;
+  Variable val = makeVariable<double>(
+      dims, {sparse_container<double>(2), sparse_container<double>(2)});
   static constexpr auto op = [](auto &a, const auto b) { a *= b; };
 };
 
 TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
        baseline) {
-  ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, b, op));
+  ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op));
+  ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, val, op));
 };
 
 TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
        a_values_size_bad) {
   a.sparseValues<double>()[1].resize(1);
-  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, b, op));
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op));
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val, op));
 };
 
 TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
        a_variances_size_bad) {
   a.sparseVariances<double>()[1].resize(1);
-  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, b, op));
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op));
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val, op));
 };
 
 TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
-       b_values_size_bad) {
-  b.sparseValues<double>()[1].resize(1);
-  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, b, op));
+       val_var_values_size_bad) {
+  val_var.sparseValues<double>()[1].resize(1);
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op));
 };
 
 TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
-       b_variances_size_bad) {
-  b.sparseVariances<double>()[1].resize(1);
-  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, b, op));
+       val_var_variances_size_bad) {
+  val_var.sparseVariances<double>()[1].resize(1);
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op));
+};
+
+TEST_F(TransformInPlaceTest_sparse_binary_values_variances_size_fail,
+       val_values_size_bad) {
+  val.sparseValues<double>()[1].resize(1);
+  ASSERT_ANY_THROW(transform_in_place<pair_self_t<double>>(a, val, op));
 };
 
 auto make_sparse_variable_with_variance() {

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -99,17 +99,17 @@ TEST(TransformTest, unary_on_elements_of_sparse_with_variance) {
       dims, {sparse_container<double>(), sparse_container<double>()},
       {sparse_container<double>(), sparse_container<double>()});
   auto vals = a.sparseValues<double>();
-  vals[0] = {1, 4, 9};
+  vals[0] = {1, 2, 3};
   vals[1] = {4};
   auto vars = a.sparseVariances<double>();
-  vars[0] = {1.5, 4.5, 9.5};
-  vars[1] = {4.5};
+  vars[0] = {1.1, 2.2, 3.3};
+  vars[1] = {4.4};
 
-  transform_in_place<double>(a, [](auto &x) { x += 1.0; });
-  EXPECT_TRUE(equals(vals[0], {2, 5, 10}));
-  EXPECT_TRUE(equals(vals[1], {5}));
-  EXPECT_TRUE(equals(vars[0], {2.5, 5.5, 10.5}));
-  EXPECT_TRUE(equals(vars[1], {5.5}));
+  transform_in_place<double>(a, [](auto &x) { x *= 2.0; });
+  EXPECT_TRUE(equals(vals[0], {2, 4, 6}));
+  EXPECT_TRUE(equals(vals[1], {8}));
+  EXPECT_TRUE(equals(vars[0], {4.4, 8.8, 13.2}));
+  EXPECT_TRUE(equals(vars[1], {17.6}));
 }
 
 TEST(TransformTest, unary_on_sparse_container) {
@@ -118,9 +118,28 @@ TEST(TransformTest, unary_on_sparse_container) {
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
-  transform_in_place<sparse_container<double>>(a, [](auto &x) { x.clear(); });
+  transform_in_place<sparse_container<double>>(a, [](auto &&x) { x.clear(); });
   EXPECT_TRUE(a_[0].empty());
   EXPECT_TRUE(a_[1].empty());
+}
+
+TEST(TransformTest, unary_on_sparse_container_with_variance) {
+  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a = makeVariable<double>(
+      dims, {sparse_container<double>(), sparse_container<double>()},
+      {sparse_container<double>(), sparse_container<double>()});
+  auto vals = a.sparseValues<double>();
+  vals[0] = {1, 2, 3};
+  vals[1] = {4};
+  auto vars = a.sparseVariances<double>();
+  vars[0] = {1.1, 2.2, 3.3};
+  vars[1] = {4.4};
+
+  transform_in_place<sparse_container<double>>(a, [](auto &&x) { x.clear(); });
+  EXPECT_TRUE(vals[0].empty());
+  EXPECT_TRUE(vals[1].empty());
+  EXPECT_TRUE(vars[0].empty());
+  EXPECT_TRUE(vars[1].empty());
 }
 
 TEST(TransformTest, binary_with_dense) {

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -38,7 +38,7 @@ TEST(TransformTest, apply_binary_in_place) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
-      b, a, [](const auto x, const auto y) { return x + y; });
+      a, b, [](const auto x, const auto y) { return x + y; });
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
@@ -46,7 +46,7 @@ TEST(TransformTest, apply_binary_in_place_var_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      b(Dim::Y, 1), a, [](const auto x, const auto y) { return x + y; });
+      a, b(Dim::Y, 1), [](const auto x, const auto y) { return x + y; });
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
@@ -54,7 +54,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_var) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
-      b, a(Dim::X, 1), [](const auto x, const auto y) { return x + y; });
+      a(Dim::X, 1), b, [](const auto x, const auto y) { return x + y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
@@ -62,7 +62,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      b(Dim::Y, 1), a(Dim::X, 1),
+      a(Dim::X, 1), b(Dim::Y, 1),
       [](const auto x, const auto y) { return x + y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
@@ -71,7 +71,7 @@ TEST(TransformTest, transform_combines_uncertainty_propgation) {
   auto a = makeVariable<double>({Dim::X, 1}, {2.0}, {0.1});
   const auto b = makeVariable<double>(3.0, 0.2);
   transform_in_place<pair_self_t<double>>(
-      b, a, [](const auto x, const auto y) { return x * y + y; });
+      a, b, [](const auto x, const auto y) { return x * y + y; });
   EXPECT_TRUE(equals(a.values<double>(), {2.0 * 3.0 + 3.0}));
   EXPECT_TRUE(equals(a.variances<double>(), {0.1 * 3 * 3 + 0.2 * 2 * 2 + 0.2}));
 }
@@ -107,7 +107,7 @@ TEST(TransformTest, binary_with_dense) {
   auto dense = makeVariable<double>({Dim::Y, 2}, {1.5, 0.5});
 
   transform_in_place<pair_self_t<double>>(
-      dense, sparse, [](const auto a, const auto b) { return a * b; });
+      sparse, dense, [](const auto a, const auto b) { return a * b; });
 
   EXPECT_TRUE(equals(sparse_[0], {1.5, 3.0, 4.5}));
   EXPECT_TRUE(equals(sparse_[1], {2.0}));

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -73,7 +73,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_view) {
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
-TEST(TransformTest, transform_combines_uncertainty_propgation) {
+TEST(TransformTest, transform_combines_uncertainty_propagation) {
   auto a = makeVariable<double>({Dim::X, 1}, {2.0}, {0.1});
   const auto b = makeVariable<double>(3.0, 0.2);
   transform_in_place<pair_self_t<double>>(

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -45,7 +45,7 @@ TEST(TransformTest, apply_binary_in_place) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
-      a, b, [](const auto x, const auto y) { return x + y; });
+      a, b, [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
@@ -53,7 +53,7 @@ TEST(TransformTest, apply_binary_in_place_var_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      a, b(Dim::Y, 1), [](const auto x, const auto y) { return x + y; });
+      a, b(Dim::Y, 1), [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
@@ -61,7 +61,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_var) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
-      a(Dim::X, 1), b, [](const auto x, const auto y) { return x + y; });
+      a(Dim::X, 1), b, [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
@@ -69,8 +69,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      a(Dim::X, 1), b(Dim::Y, 1),
-      [](const auto x, const auto y) { return x + y; });
+      a(Dim::X, 1), b(Dim::Y, 1), [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
@@ -78,7 +77,7 @@ TEST(TransformTest, transform_combines_uncertainty_propgation) {
   auto a = makeVariable<double>({Dim::X, 1}, {2.0}, {0.1});
   const auto b = makeVariable<double>(3.0, 0.2);
   transform_in_place<pair_self_t<double>>(
-      a, b, [](const auto x, const auto y) { return x * y + y; });
+      a, b, [](auto &x, const auto y) { x = x * y + y; });
   EXPECT_TRUE(equals(a.values<double>(), {2.0 * 3.0 + 3.0}));
   EXPECT_TRUE(equals(a.variances<double>(), {0.1 * 3 * 3 + 0.2 * 2 * 2 + 0.2}));
 }
@@ -132,7 +131,7 @@ TEST(TransformTest, binary_with_dense) {
   auto dense = makeVariable<double>({Dim::Y, 2}, {1.5, 0.5});
 
   transform_in_place<pair_self_t<double>>(
-      sparse, dense, [](const auto a, const auto b) { return a * b; });
+      sparse, dense, [](auto &a, const auto b) { a *= b; });
 
   EXPECT_TRUE(equals(sparse_[0], {1.5, 3.0, 4.5}));
   EXPECT_TRUE(equals(sparse_[1], {2.0}));

--- a/core/transform.h
+++ b/core/transform.h
@@ -146,10 +146,14 @@ inline constexpr bool is_values_and_variances_v =
 template <class T>
 constexpr auto value_and_maybe_variance(const T &range,
                                         const scipp::index i) noexcept {
-  if constexpr (is_values_and_variances_v<T>)
-    return ValueAndVariance{range.values[i], range.variances[i]};
-  else
+  if constexpr (is_values_and_variances_v<T>) {
+    if constexpr (is_sparse_v<decltype(range.values[0])>)
+      return ValuesAndVariances{range.values[i], range.variances[i]};
+    else
+      return ValueAndVariance{range.values[i], range.variances[i]};
+  } else {
     return range[i];
+  }
 }
 
 template <class T> struct is_eigen_type : std::false_type {};
@@ -167,25 +171,8 @@ void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
   auto & [ vals, vars ] = arg;
   for (scipp::index i = 0; i < scipp::size(vals); ++i) {
     if constexpr (is_sparse_v<decltype(vals[0])>) {
-      if constexpr ((is_values_and_variances_v<Ts> && ...)) {
-        if constexpr ((is_sparse_v<decltype(other.values[0])> && ...)) {
-          op(ValuesAndVariances{vals[i], vars[i]},
-             ValuesAndVariances{other.values[i], other.variances[i]}...);
-        } else {
-          op(ValuesAndVariances{vals[i], vars[i]},
-             value_and_maybe_variance(other, i)...);
-        }
-      } else {
-        if constexpr ((is_sparse_v<decltype(other[0])> && ...)) {
-          static_cast<void>(op);
-          throw std::runtime_error("Transforming sparse data requires "
-                                   "variances on both or neither of the sparse "
-                                   "input arguments.");
-        } else {
-          op(ValuesAndVariances{vals[i], vars[i]},
-             value_and_maybe_variance(other, i)...);
-        }
-      }
+      op(ValuesAndVariances{vals[i], vars[i]},
+         value_and_maybe_variance(other, i)...);
     } else {
       ValueAndVariance _{vals[i], vars[i]};
       op(_, value_and_maybe_variance(other, i)...);
@@ -240,6 +227,13 @@ template <class Op> struct TransformSparse {
     if (scipp::size(a) != scipp::size(b))
       throw std::runtime_error("Mismatch in extent of sparse dimension.");
     transform_in_place_impl(op, a, b);
+  }
+  template <class T1, class T2>
+  constexpr void operator()(ValuesAndVariances<T1> a,
+                            const sparse_container<T2> b) const {
+    if (scipp::size(a) != scipp::size(b))
+      throw std::runtime_error("Mismatch in extent of sparse dimension.");
+    transform_in_place_with_variance_impl(op, a, b);
   }
   template <class T1, class T2>
   constexpr void operator()(ValuesAndVariances<T1> a,

--- a/core/transform.h
+++ b/core/transform.h
@@ -127,8 +127,12 @@ constexpr auto operator/(const T1 a, const ValueAndVariance<T2> b) noexcept {
                                            (b.value * b.value)};
 }
 
-template <class T>
-ValueAndVariance(const T &val, const T &var)->ValueAndVariance<T>;
+/// Deduction guide for class ValueAndVariances. Using decltype to deal with
+/// potential mixed-type val and var arguments arising in binary operations
+/// between, e.g., double and float.
+template <class T1, class T2>
+ValueAndVariance(const T1 &val, const T2 &var)
+    ->ValueAndVariance<decltype(T1() + T2())>;
 
 /// A values/variances pair based on references to sparse data containers.
 ///

--- a/core/transform.h
+++ b/core/transform.h
@@ -67,6 +67,10 @@ constexpr auto operator*(const ValueAndVariance<T1> a, const T2 b) noexcept {
   return ValueAndVariance{a.value * b, a.variance * b * b};
 }
 template <class T1, class T2>
+constexpr auto operator*(const T1 a, const ValueAndVariance<T2> b) noexcept {
+  return ValueAndVariance{a * b.value, a * a * b.variance};
+}
+template <class T1, class T2>
 constexpr auto operator/(const ValueAndVariance<T1> a, const T2 b) noexcept {
   return ValueAndVariance{a.value / b, a.variance / (b * b)};
 }

--- a/core/transform.h
+++ b/core/transform.h
@@ -137,8 +137,7 @@ ValueAndVariance(const T &val, const T &var)->ValueAndVariance<T>;
 /// call to an iteration function.
 template <class T> struct ValuesAndVariances {
   ValuesAndVariances(T &val, T &var) : values(val), variances(var) {
-    if (values.size() != variances.size())
-      throw std::runtime_error("Size mismatch between values and variances.");
+    expect::sizeMatches(values, variances);
   }
   T &values;
   T &variances;
@@ -270,22 +269,19 @@ template <class Op> struct TransformSparse {
   template <class T1, class T2>
   constexpr void operator()(sparse_container<T1> &a,
                             const sparse_container<T2> &b) const {
-    if (scipp::size(a) != scipp::size(b))
-      throw std::runtime_error("Mismatch in extent of sparse dimension.");
+    expect::sizeMatches(a, b);
     transform_in_place_impl(op, a, b);
   }
   template <class T1, class T2>
   constexpr void operator()(ValuesAndVariances<T1> a,
                             const sparse_container<T2> b) const {
-    if (scipp::size(a) != scipp::size(b))
-      throw std::runtime_error("Mismatch in extent of sparse dimension.");
+    expect::sizeMatches(a, b);
     transform_in_place_with_variance_impl(op, a, b);
   }
   template <class T1, class T2>
   constexpr void operator()(ValuesAndVariances<T1> a,
                             const ValuesAndVariances<T2> b) const {
-    if (scipp::size(a) != scipp::size(b))
-      throw std::runtime_error("Mismatch in extent of sparse dimension.");
+    expect::sizeMatches(a, b);
     transform_in_place_with_variance_impl(op, a, b);
   }
 };

--- a/core/transform.h
+++ b/core/transform.h
@@ -136,6 +136,10 @@ ValueAndVariance(const T &val, const T &var)->ValueAndVariance<T>;
 /// `clear`, and for descending into the sparse container itself, using a nested
 /// call to an iteration function.
 template <class T> struct ValuesAndVariances {
+  ValuesAndVariances(T &val, T &var) : values(val), variances(var) {
+    if (values.size() != variances.size())
+      throw std::runtime_error("Size mismatch between values and variances.");
+  }
   T &values;
   T &variances;
 
@@ -165,14 +169,8 @@ template <class T> struct ValuesAndVariances {
         "`end` not implemented for sparse data with variances.");
   }
 
-  auto size() const {
-    if (values.size() != variances.size())
-      throw std::runtime_error("Size mismatch between values and variances.");
-    return values.size();
-  }
+  constexpr auto size() const noexcept { return values.size(); }
 };
-
-template <class T> ValuesAndVariances(T &val, T &var)->ValuesAndVariances<T>;
 
 template <class T> struct is_values_and_variances : std::false_type {};
 template <class T>
@@ -184,8 +182,7 @@ inline constexpr bool is_values_and_variances_v =
 /// Helper for the transform implementation to unify iteration of data with and
 /// without variances as well as sparse are dense container.
 template <class T>
-constexpr auto value_and_maybe_variance(const T &range,
-                                        const scipp::index i) noexcept {
+constexpr auto value_and_maybe_variance(const T &range, const scipp::index i) {
   if constexpr (is_values_and_variances_v<T>) {
     if constexpr (is_sparse_v<decltype(range.values[0])>)
       return ValuesAndVariances{range.values[i], range.variances[i]};

--- a/core/transform.h
+++ b/core/transform.h
@@ -155,6 +155,9 @@ constexpr auto value_and_maybe_variance(const T &range,
 template <class T> struct is_eigen_type : std::false_type {};
 template <class T, int Rows, int Cols>
 struct is_eigen_type<Eigen::Matrix<T, Rows, Cols>> : std::true_type {};
+template <class T, int Rows, int Cols>
+struct is_eigen_type<sparse_container<Eigen::Matrix<T, Rows, Cols>>>
+    : std::true_type {};
 template <class T>
 inline constexpr bool is_eigen_type_v = is_eigen_type<T>::value;
 
@@ -164,10 +167,7 @@ void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
   auto & [ vals, vars ] = arg;
   for (scipp::index i = 0; i < scipp::size(vals); ++i) {
     if constexpr (is_sparse_v<decltype(vals[0])>) {
-      if constexpr (is_eigen_type_v<typename T::value_type::value_type>) {
-        static_cast<void>(op);
-        throw std::runtime_error("This dtype cannot have a variance.");
-      } else if constexpr ((is_values_and_variances_v<Ts> && ...)) {
+      if constexpr ((is_values_and_variances_v<Ts> && ...)) {
         if constexpr ((is_sparse_v<decltype(other.values[0])> && ...)) {
           op(ValuesAndVariances{vals[i], vars[i]},
              ValuesAndVariances{other.values[i], other.variances[i]}...);

--- a/core/transform.h
+++ b/core/transform.h
@@ -144,6 +144,13 @@ template <class T> struct ValuesAndVariances {
     variances.clear();
   }
 
+  // TODO Note that methods like insert, begin, and end are required as long as
+  // we support sparse data via a plain container such as std::vector, e.g., for
+  // concatenation using a.insert(a.end(), b.begin(), b.end()). Instead of
+  // adding these methods here (essentially making ValuesAndVariances support a
+  // proxy iterator) it might be easier to wrap the sparse container and give it
+  // some functionality like concatenate. Then we simply need to support this
+  // method here, which is much simpler than having proxy iterators.
   template <class... Ts> void insert(Ts &&...) {
     throw std::runtime_error(
         "`insert` not implemented for sparse data with variances.");

--- a/core/transform.h
+++ b/core/transform.h
@@ -281,8 +281,8 @@ void transform_in_place(Var &var, Op op) {
 // This overload is equivalent to std::transform with two input ranges and an
 // output range identical to the secound input range, but avoids potentially
 // costly element copies.
-template <class... Ts, class Var1, class Var, class Op>
-void do_transform_in_place(std::tuple<Ts...> &&, const Var1 &other, Var &&var,
+template <class... Ts, class Var, class Var1, class Op>
+void do_transform_in_place(std::tuple<Ts...> &&, Var &&var, const Var1 &other,
                            Op op) {
   using namespace detail;
   try {
@@ -311,9 +311,10 @@ void do_transform_in_place(std::tuple<Ts...> &&, const Var1 &other, Var &&var,
   }
 }
 
-template <class... TypePairs, class Var1, class Var, class Op>
-void transform_in_place(const Var1 &other, Var &&var, Op op) {
-  do_transform_in_place(std::tuple_cat(TypePairs{}...), other, var, op);
+template <class... TypePairs, class Var, class Var1, class Op>
+void transform_in_place(Var &&var, const Var1 &other, Op op) {
+  do_transform_in_place(std::tuple_cat(TypePairs{}...), std::forward<Var>(var),
+                        other, op);
 }
 
 /// Transform the data elements of a variable and return a new Variable.

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -1143,10 +1143,9 @@ Variable operator-(const double a, Variable b) { return -(b -= a); }
 Variable operator*(const double a, Variable b) { return std::move(b *= a); }
 Variable operator/(const double a, Variable b) {
   b.setUnit(units::Unit(units::dimensionless) / b.unit());
-  transform_in_place<double, float>(
-      b, overloaded{[a](const double b) { return a / b; },
-                    [a](const float b) { return a / b; },
-                    [a](const auto b) { return a / b; }});
+  transform_in_place<double, float>(b, overloaded{[a](double &b) { b = a / b; },
+                                                  [a](float &b) { b = a / b; },
+                                                  [a](auto &b) { b = a / b; }});
   return std::move(b);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -470,10 +470,15 @@ template std::unique_ptr<VariableConceptT<double>>
 makeVariableConceptT<double>(const Dimensions &);
 template std::unique_ptr<VariableConceptT<float>>
 makeVariableConceptT<float>(const Dimensions &);
+template std::unique_ptr<VariableConceptT<sparse_container<double>>>
+makeVariableConceptT<sparse_container<double>>(const Dimensions &);
 template std::unique_ptr<VariableConceptT<double>>
 makeVariableConceptT<double>(const Dimensions &, Vector<double>);
 template std::unique_ptr<VariableConceptT<float>>
 makeVariableConceptT<float>(const Dimensions &, Vector<float>);
+template std::unique_ptr<VariableConceptT<sparse_container<double>>>
+makeVariableConceptT<sparse_container<double>>(
+    const Dimensions &, Vector<sparse_container<double>>);
 } // namespace detail
 
 /// Implementation of VariableConcept that represents a view onto data.
@@ -772,7 +777,6 @@ INSTANTIATE(scipp::index)
 INSTANTIATE(std::pair<scipp::index, scipp::index>)
 #endif
 INSTANTIATE(boost::container::small_vector<scipp::index, 1>)
-INSTANTIATE(boost::container::small_vector<double, 8>)
 INSTANTIATE(std::vector<double>)
 INSTANTIATE(std::vector<std::string>)
 INSTANTIATE(std::vector<scipp::index>)
@@ -780,6 +784,10 @@ INSTANTIATE(Dataset)
 INSTANTIATE(std::array<double, 3>)
 INSTANTIATE(std::array<double, 4>)
 INSTANTIATE(Eigen::Vector3d)
+INSTANTIATE(sparse_container<double>)
+INSTANTIATE(sparse_container<float>)
+INSTANTIATE(sparse_container<int64_t>)
+INSTANTIATE(sparse_container<Eigen::Vector3d>)
 
 template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
   if (!a || !b)
@@ -813,9 +821,7 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   expect::contains(variable.dims(), other.dims());
   // Note: This will broadcast/transpose the RHS if required. We do not support
   // changing the dimensions of the LHS though!
-  transform_in_place<
-      pair_self_t<double, float, int64_t, Eigen::Vector3d>,
-      pair_custom_t<std::pair<sparse_container<double>, double>>>(
+  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
       other, variable, [](auto &&a, auto &&b) { return a + b; });
   return variable;
 }

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -1177,7 +1177,7 @@ Variable concatenate(const Variable &a1, const Variable &a2, const Dim dim) {
     // is more reasonable.
     transform_in_place<pair_self_t<sparse_container<double>>>(
         out, a2,
-        [](auto &a, const auto &b) { a.insert(a.end(), b.begin(), b.end()); });
+        [](auto &&a, auto &&b) { a.insert(a.end(), b.begin(), b.end()); });
     return out;
   }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -822,7 +822,7 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   // Note: This will broadcast/transpose the RHS if required. We do not support
   // changing the dimensions of the LHS though!
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      other, variable, [](auto &&a, auto &&b) { return a + b; });
+      variable, other, [](auto &&a, auto &&b) { return a + b; });
   return variable;
 }
 
@@ -851,7 +851,7 @@ template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
   expect::equals(variable.unit(), other.unit());
   expect::contains(variable.dims(), other.dims());
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      other, variable, [](auto &&a, auto &&b) { return a - b; });
+      variable, other, [](auto &&a, auto &&b) { return a - b; });
   return variable;
 }
 
@@ -871,7 +871,7 @@ template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   variable.setUnit(variable.unit() * other.unit());
   transform_in_place<pair_self_t<double, float, int64_t>,
                      pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      other, variable, [](auto &&a, auto &&b) { return a * b; });
+      variable, other, [](auto &&a, auto &&b) { return a * b; });
   return variable;
 }
 
@@ -893,7 +893,7 @@ template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
   variable.setUnit(variable.unit() / other.unit());
   transform_in_place<pair_self_t<double, float, int64_t>,
                      pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      other, variable, [](auto &&a, auto &&b) { return a / b; });
+      variable, other, [](auto &&a, auto &&b) { return a / b; });
   return variable;
 }
 
@@ -1175,7 +1175,7 @@ Variable concatenate(const Variable &a1, const Variable &a2, const Dim dim) {
     // TODO Sanitize transform_in_place implementation so the functor signature
     // is more reasonable.
     transform_in_place<pair_self_t<sparse_container<double>>>(
-        a2, out, [](auto a, const auto &b) {
+        out, a2, [](auto a, const auto &b) {
           a.insert(a.end(), b.begin(), b.end());
           return a;
         });
@@ -1359,7 +1359,7 @@ Variable sum(const Variable &var, const Dim dim) {
   // setDims zeros the data
   summed.setDims(dims);
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      var, summed, [](auto &&a, auto &&b) { return a + b; });
+      summed, var, [](auto &&a, auto &&b) { return a + b; });
   return summed;
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -769,20 +769,11 @@ INSTANTIATE(double)
 INSTANTIATE(float)
 INSTANTIATE(int64_t)
 INSTANTIATE(int32_t)
-INSTANTIATE(char)
 INSTANTIATE(bool)
-INSTANTIATE(std::pair<int64_t, int64_t>)
 #if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 INSTANTIATE(scipp::index)
-INSTANTIATE(std::pair<scipp::index, scipp::index>)
 #endif
-INSTANTIATE(boost::container::small_vector<scipp::index, 1>)
-INSTANTIATE(std::vector<double>)
-INSTANTIATE(std::vector<std::string>)
-INSTANTIATE(std::vector<scipp::index>)
 INSTANTIATE(Dataset)
-INSTANTIATE(std::array<double, 3>)
-INSTANTIATE(std::array<double, 4>)
 INSTANTIATE(Eigen::Vector3d)
 INSTANTIATE(sparse_container<double>)
 INSTANTIATE(sparse_container<float>)
@@ -1047,7 +1038,6 @@ INSTANTIATE_SLICEVIEW(double);
 INSTANTIATE_SLICEVIEW(float);
 INSTANTIATE_SLICEVIEW(int64_t);
 INSTANTIATE_SLICEVIEW(int32_t);
-INSTANTIATE_SLICEVIEW(char);
 INSTANTIATE_SLICEVIEW(bool);
 INSTANTIATE_SLICEVIEW(std::string);
 INSTANTIATE_SLICEVIEW(boost::container::small_vector<double, 8>);

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -472,6 +472,8 @@ template std::unique_ptr<VariableConceptT<float>>
 makeVariableConceptT<float>(const Dimensions &);
 template std::unique_ptr<VariableConceptT<sparse_container<double>>>
 makeVariableConceptT<sparse_container<double>>(const Dimensions &);
+template std::unique_ptr<VariableConceptT<sparse_container<float>>>
+makeVariableConceptT<sparse_container<float>>(const Dimensions &);
 template std::unique_ptr<VariableConceptT<double>>
 makeVariableConceptT<double>(const Dimensions &, Vector<double>);
 template std::unique_ptr<VariableConceptT<float>>
@@ -479,6 +481,9 @@ makeVariableConceptT<float>(const Dimensions &, Vector<float>);
 template std::unique_ptr<VariableConceptT<sparse_container<double>>>
 makeVariableConceptT<sparse_container<double>>(
     const Dimensions &, Vector<sparse_container<double>>);
+template std::unique_ptr<VariableConceptT<sparse_container<float>>>
+makeVariableConceptT<sparse_container<float>>(const Dimensions &,
+                                              Vector<sparse_container<float>>);
 } // namespace detail
 
 /// Implementation of VariableConcept that represents a view onto data.

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -787,6 +787,7 @@ INSTANTIATE(Eigen::Vector3d)
 INSTANTIATE(sparse_container<double>)
 INSTANTIATE(sparse_container<float>)
 INSTANTIATE(sparse_container<int64_t>)
+INSTANTIATE(sparse_container<int32_t>)
 INSTANTIATE(sparse_container<Eigen::Vector3d>)
 
 template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
@@ -1144,7 +1145,8 @@ Variable operator/(const double a, Variable b) {
   b.setUnit(units::Unit(units::dimensionless) / b.unit());
   transform_in_place<double, float>(
       b, overloaded{[a](const double b) { return a / b; },
-                    [a](const float b) { return a / b; }});
+                    [a](const float b) { return a / b; },
+                    [a](const auto b) { return a / b; }});
   return std::move(b);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -823,7 +823,7 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   // Note: This will broadcast/transpose the RHS if required. We do not support
   // changing the dimensions of the LHS though!
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { return a + b; });
+      variable, other, [](auto &&a, auto &&b) { a += b; });
   return variable;
 }
 
@@ -852,7 +852,7 @@ template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
   expect::equals(variable.unit(), other.unit());
   expect::contains(variable.dims(), other.dims());
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { return a - b; });
+      variable, other, [](auto &&a, auto &&b) { a -= b; });
   return variable;
 }
 
@@ -872,7 +872,7 @@ template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   variable.setUnit(variable.unit() * other.unit());
   transform_in_place<pair_self_t<double, float, int64_t>,
                      pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { return a * b; });
+      variable, other, [](auto &&a, auto &&b) { a *= b; });
   return variable;
 }
 
@@ -894,7 +894,7 @@ template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
   variable.setUnit(variable.unit() / other.unit());
   transform_in_place<pair_self_t<double, float, int64_t>,
                      pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { return a / b; });
+      variable, other, [](auto &&a, auto &&b) { a /= b; });
   return variable;
 }
 
@@ -1176,10 +1176,8 @@ Variable concatenate(const Variable &a1, const Variable &a2, const Dim dim) {
     // TODO Sanitize transform_in_place implementation so the functor signature
     // is more reasonable.
     transform_in_place<pair_self_t<sparse_container<double>>>(
-        out, a2, [](auto a, const auto &b) {
-          a.insert(a.end(), b.begin(), b.end());
-          return a;
-        });
+        out, a2,
+        [](auto &a, const auto &b) { a.insert(a.end(), b.begin(), b.end()); });
     return out;
   }
 
@@ -1360,7 +1358,7 @@ Variable sum(const Variable &var, const Dim dim) {
   // setDims zeros the data
   summed.setDims(dims);
   transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      summed, var, [](auto &&a, auto &&b) { return a + b; });
+      summed, var, [](auto &&a, auto &&b) { a += b; });
   return summed;
 }
 

--- a/core/variable.h
+++ b/core/variable.h
@@ -54,8 +54,7 @@ template <class... Known> class VariableConceptHandle_impl;
 // `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
 using VariableConceptHandle = VariableConceptHandle_impl<
     double, float, int64_t, Eigen::Vector3d, sparse_container<double>,
-    sparse_container<float>, sparse_container<int64_t>,
-    sparse_container<Eigen::Vector3d>>;
+    sparse_container<float>, sparse_container<int64_t>>;
 
 /// Abstract base class for any data that can be held by Variable. Also used to
 /// hold views to data by (Const)VariableProxy. This is using so-called

--- a/core/variable.h
+++ b/core/variable.h
@@ -47,7 +47,8 @@ template <class... Known> class VariableConceptHandle_impl;
 // `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
 using VariableConceptHandle =
     VariableConceptHandle_impl<double, float, int64_t, Eigen::Vector3d,
-                               sparse_container<double>>;
+                               sparse_container<double>,
+                               sparse_container<float>>;
 
 /// Abstract base class for any data that can be held by Variable. Also used to
 /// hold views to data by (Const)VariableProxy. This is using so-called

--- a/core/variable.h
+++ b/core/variable.h
@@ -38,6 +38,8 @@ struct is_sparse_container<sparse_container<T>> : std::true_type {};
 template <class T> struct is_sparse : std::false_type {};
 template <class T> struct is_sparse<sparse_container<T>> : std::true_type {};
 template <class T> struct is_sparse<sparse_container<T> &> : std::true_type {};
+template <class T>
+struct is_sparse<const sparse_container<T> &> : std::true_type {};
 template <class T> inline constexpr bool is_sparse_v = is_sparse<T>::value;
 
 // std::vector<bool> may have a packed non-thread-safe implementation which we

--- a/core/variable.h
+++ b/core/variable.h
@@ -45,10 +45,10 @@ class Variable;
 template <class... Known> class VariableConceptHandle_impl;
 // Any item type that is listed here explicitly can be used with the templated
 // `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
-using VariableConceptHandle =
-    VariableConceptHandle_impl<double, float, int64_t, Eigen::Vector3d,
-                               sparse_container<double>,
-                               sparse_container<float>>;
+using VariableConceptHandle = VariableConceptHandle_impl<
+    double, float, int64_t, Eigen::Vector3d, sparse_container<double>,
+    sparse_container<float>, sparse_container<int64_t>,
+    sparse_container<Eigen::Vector3d>>;
 
 /// Abstract base class for any data that can be held by Variable. Also used to
 /// hold views to data by (Const)VariableProxy. This is using so-called

--- a/core/variable.h
+++ b/core/variable.h
@@ -407,8 +407,14 @@ Variable makeVariable(const std::initializer_list<Dim> &dims,
 template <class T, class T2 = T>
 Variable makeVariable(const Dimensions &dimensions,
                       std::initializer_list<T2> values) {
-  return Variable(units::dimensionless, std::move(dimensions),
-                  Vector<underlying_type_t<T>>(values.begin(), values.end()));
+  if constexpr (is_sparse_v<T2>) {
+    return Variable(units::dimensionless, std::move(dimensions),
+                    Vector<sparse_container<underlying_type_t<T>>>(
+                        values.begin(), values.end()));
+  } else {
+    return Variable(units::dimensionless, std::move(dimensions),
+                    Vector<underlying_type_t<T>>(values.begin(), values.end()));
+  }
 }
 
 // This overload is required to avoid wrongly selecting the single-value

--- a/core/variable.h
+++ b/core/variable.h
@@ -37,6 +37,7 @@ struct is_sparse_container<sparse_container<T>> : std::true_type {};
 
 template <class T> struct is_sparse : std::false_type {};
 template <class T> struct is_sparse<sparse_container<T>> : std::true_type {};
+template <class T> struct is_sparse<sparse_container<T> &> : std::true_type {};
 template <class T> inline constexpr bool is_sparse_v = is_sparse<T>::value;
 
 // std::vector<bool> may have a packed non-thread-safe implementation which we

--- a/core/visit.h
+++ b/core/visit.h
@@ -62,8 +62,6 @@ decltype(auto) invoke_active(F &&f, V1 &&v1, V2 &&v2, const std::tuple<T1...> &,
 
   if constexpr (!std::is_same_v<void, Ret>) {
     Ret ret;
-    // For now we only support same type in both variants. Eventually this will
-    // be generalized.
     if (!((std::holds_alternative<T1>(v1) && std::holds_alternative<T2>(v2)
                ? (ret = std::invoke(std::forward<F>(f),
                                     std::get<T1>(std::forward<V1>(v1)),

--- a/test/test_macros.h
+++ b/test/test_macros.h
@@ -37,5 +37,8 @@ template <class T1, class T2>
 bool equals(const T1 &a, const std::initializer_list<T2> &b) {
   return std::equal(a.begin(), a.end(), b.begin(), b.end());
 }
+template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
+  return std::equal(a.begin(), a.end(), b.begin(), b.end());
+}
 
 #endif // TEST_MACROS_H


### PR DESCRIPTION
This is a major iteration of the `tranform` (or more specifically `transfom_in_place`) functions. Depends on #271.

Major changes:
- Support propagation of uncertainties for sparse data.
- Cleaner syntax for functors and `transform_in_place` parameter order (in-place variant is not relying on return value any more). This also avoid expensive copies in the case of sparse data.
- Specifying things like `sparse_container<double>` when calling `transform_in_place` is not necessary any more. Code for handling both sparse and dense data is not generated automatically.
- Some code documentation.

Fixes #264 and fixes #216 (mostly, at least).

There will definitely be a couple of follow-ups to this PR:
- Testing is very incomplete and needs major refactor and additions.
- Some operations for sparse data with variances not supported yet, such as appending (using `insert` and `begin` and `end` of a proxy iterator (essentially what `ValuesAndVariances` is).