### PR TITLE
Non-in-place transform and binary operations

### DIFF
--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -188,4 +188,30 @@ int32_t Dimensions::index(const Dim dim) const {
   throw except::DimensionNotFoundError(*this, dim);
 }
 
+/// Return the direct sum, i.e., the combination of dimensions in a and b.
+///
+/// Throws if there is a mismatching dimension extent.
+Dimensions merge(const Dimensions &a, const Dimensions &b) {
+  auto out(b);
+  if (a.sparse() && b.sparse() && (a.sparseDim() != b.sparseDim()))
+    throw except::DimensionError(
+        "Cannot merge subspaces with mismatching sparse dimension.");
+  if (a.sparse() && !b.sparse())
+    return merge(b, a);
+  for (const auto dim : a.labels()) {
+    if (b.contains(dim)) {
+      if ((dim != b.sparseDim()) && a[dim] != b[dim])
+        throw except::DimensionError(
+            "Cannot merge subspaces with mismatching extent");
+      else if (dim == b.sparseDim() && dim != a.sparseDim())
+        throw except::DimensionError("Cannot merge subspaces with dimension "
+                                     "that is sparse in one argument but dense "
+                                     "in another.");
+    } else {
+      out.add(dim, a[dim]);
+    }
+  }
+  return out;
+}
+
 } // namespace scipp::core

--- a/core/dimensions.h
+++ b/core/dimensions.h
@@ -145,6 +145,8 @@ private:
                 Dim::Invalid, Dim::Invalid, Dim::Invalid};
 };
 
+Dimensions merge(const Dimensions &a, const Dimensions &b);
+
 } // namespace scipp::core
 
 #endif // DIMENSIONS_H

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -273,3 +273,57 @@ TEST(DimensionsTest, erase_sparse) {
   dims.erase(Dim::Z);
   ASSERT_EQ(dims, expected);
 }
+
+TEST(DimensionsTest, merge_self) {
+  Dimensions dims({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse});
+  EXPECT_EQ(merge(dims, dims), dims);
+}
+
+TEST(DimensionsTest, merge_dense) {
+  Dimensions a({Dim::X}, {2});
+  Dimensions b({Dim::Y, Dim::Z}, {3, 4});
+  EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}));
+}
+
+TEST(DimensionsTest, merge_dense_overlapping) {
+  Dimensions a({Dim::X, Dim::Y}, {2, 3});
+  Dimensions b({Dim::Y, Dim::Z}, {3, 4});
+  EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}));
+}
+
+TEST(DimensionsTest, merge_dense_different_order) {
+  // The current implementation "favors" the order of the last argument, but
+  // this is not necessarily a promise. Should there be different variants?
+  Dimensions a({Dim::Y, Dim::X}, {3, 2});
+  Dimensions b({Dim::X, Dim::Y}, {2, 3});
+  EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y}, {2, 3}));
+}
+
+TEST(DimensionsTest, merge_size_fail) {
+  Dimensions a({Dim::X}, {2});
+  Dimensions b({Dim::Y, Dim::X}, {3, 4});
+  EXPECT_THROW(merge(a, b), except::DimensionError);
+}
+
+TEST(DimensionsTest, merge_sparse_dense_fail) {
+  Dimensions a({Dim::X}, {2});
+  Dimensions b({Dim::Y, Dim::X}, {3, Dimensions::Sparse});
+  EXPECT_THROW(merge(a, b), except::DimensionError);
+}
+
+TEST(DimensionsTest, merge_different_sparse_fail) {
+  Dimensions a({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  Dimensions b({Dim::X, Dim::Z}, {3, Dimensions::Sparse});
+  EXPECT_THROW(merge(a, b), except::DimensionError);
+}
+
+TEST(DimensionsTest, merge_sparse) {
+  Dimensions a({Dim::X}, {2});
+  Dimensions b({Dim::Y, Dim::Z}, {3, Dimensions::Sparse});
+  EXPECT_EQ(merge(a, b),
+            Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));
+  // Merging in reverse order also works. Again the current implementation
+  // "favors" putting the dimensions of the argument with sparse dimension last.
+  EXPECT_EQ(merge(b, a),
+            Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));
+}

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -288,15 +288,16 @@ TEST(DimensionsTest, merge_dense) {
 TEST(DimensionsTest, merge_dense_overlapping) {
   Dimensions a({Dim::X, Dim::Y}, {2, 3});
   Dimensions b({Dim::Y, Dim::Z}, {3, 4});
-  EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}));
+  EXPECT_EQ(merge(a, b), Dimensions({Dim::Z, Dim::X, Dim::Y}, {4, 2, 3}));
 }
 
 TEST(DimensionsTest, merge_dense_different_order) {
-  // The current implementation "favors" the order of the last argument, but
-  // this is not necessarily a promise. Should there be different variants?
+  // The current implementation "favors" the order of the first argument if both
+  // inputs have the same number of dimension, but this is not necessarily a
+  // promise. Should there be different variants?
   Dimensions a({Dim::Y, Dim::X}, {3, 2});
   Dimensions b({Dim::X, Dim::Y}, {2, 3});
-  EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y}, {2, 3}));
+  EXPECT_EQ(merge(a, b), Dimensions({Dim::Y, Dim::X}, {3, 2}));
 }
 
 TEST(DimensionsTest, merge_size_fail) {
@@ -322,8 +323,6 @@ TEST(DimensionsTest, merge_sparse) {
   Dimensions b({Dim::Y, Dim::Z}, {3, Dimensions::Sparse});
   EXPECT_EQ(merge(a, b),
             Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));
-  // Merging in reverse order also works. Again the current implementation
-  // "favors" putting the dimensions of the argument with sparse dimension last.
   EXPECT_EQ(merge(b, a),
             Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));
 }

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -55,6 +55,14 @@ TEST(TransformTest, apply_binary_in_place) {
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
+TEST(TransformTest, apply_binary) {
+  const auto a = makeVariable<double>({Dim::X, 2}, {1.0, 2.0});
+  const auto b = makeVariable<float>(3.3);
+  const auto out = transform<pair_custom_t<std::pair<double, float>>>(
+      a, b, [](auto x, const auto y) { return x * y; });
+  EXPECT_EQ(out, makeVariable<double>({Dim::X, 2}, {1.0 * 3.3f, 2.0 * 3.3f}));
+}
+
 TEST(TransformTest, apply_binary_in_place_var_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -28,8 +28,14 @@ TEST(TransformTest, apply_unary_in_place_with_variances) {
 TEST(TransformTest, apply_unary_implicit_conversion) {
   const auto var = makeVariable<float>({Dim::X, 2}, {1.1, 2.2});
   // The functor returns double, so the output type is also double.
-  auto out = transform<double, float>(var, [](const double x) { return -x; });
+  auto out = transform<float>(var, [](const auto x) { return -1.0 * x; });
   EXPECT_TRUE(equals(out.values<double>(), {-1.1f, -2.2f}));
+}
+
+TEST(TransformTest, apply_unary_with_variances) {
+  const auto var = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {3.3, 4.4});
+  auto out = transform<double>(var, [](const auto x) { return x + 1; });
+  EXPECT_EQ(out, makeVariable<double>({Dim::X, 2}, {2.1, 3.2}, {3.3, 4.4}));
 }
 
 TEST(TransformTest, apply_unary) {

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -137,6 +137,12 @@ TEST(Variable, operator_plus) {
   EXPECT_EQ(sum, expected);
 }
 
+TEST(Variable, operator_plus_eigen_type) {
+  auto a = makeVariable<Eigen::Vector3d>({Dim::X, 1});
+  auto sum = a + a;
+  EXPECT_EQ(sum.dtype(), dtype<Eigen::Vector3d>);
+}
+
 TEST(Variable, operator_times_equal) {
   auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
 

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -114,13 +114,27 @@ TEST(Variable, operator_plus_equal_custom_type) {
 }
 
 TEST(Variable, operator_plus) {
-  auto a = makeVariable<double>({Dim::X, 2}, {1.0, 2.0});
-  auto b = makeVariable<float>({Dim::Y, 2}, {0.1, 0.2});
+  auto a = makeVariable<double>({Dim::X, 2}, {1.0, 2.0}, {3.0, 4.0});
+  auto b = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto b_ = b.sparseValues<float>();
+  b_[0] = {0.1, 0.2};
+  b_[1] = {0.3};
 
   auto sum = a + b;
-  EXPECT_EQ(sum, makeVariable<double>(
-                     {{Dim::X, 2}, {Dim::Y, 2}},
-                     {1.0 + 0.1f, 1.0 + 0.2f, 2.0 + 0.1f, 2.0 + 0.2f}));
+
+  auto expected = makeVariableWithVariances<double>(
+      {{Dim::X, 2}, {Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto vals = expected.sparseValues<double>();
+  vals[0] = {1.0 + 0.1f, 1.0 + 0.2f};
+  vals[1] = {1.0 + 0.3f};
+  vals[2] = {2.0 + 0.1f, 2.0 + 0.2f};
+  vals[3] = {2.0 + 0.3f};
+  auto vars = expected.sparseVariances<double>();
+  vars[0] = {3.0, 3.0};
+  vars[1] = {3.0};
+  vars[2] = {4.0, 4.0};
+  vars[3] = {4.0};
+  EXPECT_EQ(sum, expected);
 }
 
 TEST(Variable, operator_times_equal) {

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -113,6 +113,16 @@ TEST(Variable, operator_plus_equal_custom_type) {
   EXPECT_EQ(a.values<float>()[1], 4.4f);
 }
 
+TEST(Variable, operator_plus) {
+  auto a = makeVariable<double>({Dim::X, 2}, {1.0, 2.0});
+  auto b = makeVariable<float>({Dim::Y, 2}, {0.1, 0.2});
+
+  auto sum = a + b;
+  EXPECT_EQ(sum, makeVariable<double>(
+                     {{Dim::X, 2}, {Dim::Y, 2}},
+                     {1.0 + 0.1f, 1.0 + 0.2f, 2.0 + 0.1f, 2.0 + 0.2f}));
+}
+
 TEST(Variable, operator_times_equal) {
   auto a = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
 

--- a/core/transform.h
+++ b/core/transform.h
@@ -381,12 +381,7 @@ template <class Op> struct TransformInPlace {
       if (a->valuesView(dimsA).overlaps(b.valuesView(dimsA))) {
         // If there is an overlap between lhs and rhs we copy the rhs before
         // applying the operation.
-        const auto &data = b.valuesView(b.dims());
-        using T = typename std::remove_reference_t<decltype(b)>::value_type;
-        const std::unique_ptr<VariableConceptT<T>> copy =
-            detail::makeVariableConceptT<T>(
-                dimsB, Vector<T>(data.begin(), data.end()));
-        return operator()(a, copy);
+        return operator()(a, b.copyT());
       }
     }
 

--- a/core/transform.h
+++ b/core/transform.h
@@ -367,6 +367,7 @@ template <class Op> struct TransformInPlace {
   template <class A, class B> void operator()(A &&a, B &&b_ptr) const {
     // std::unique_ptr::operator*() is const but returns mutable reference, need
     // to artificially put const to we call the correct overloads of ViewModel.
+    // See #278.
     const auto &b = *b_ptr;
     const auto &dimsA = a->dims();
     const auto &dimsB = b.dims();
@@ -413,8 +414,6 @@ template <class Op> struct Transform {
     auto data = handle->values();
     // TODO Should just make empty container here, without init.
     Variable out = makeVariable<decltype(op(*data.begin()))>(handle->dims());
-    // TODO Typo data->values() also compiles, but const-correctness should
-    // forbid this.
     auto outData = out.values<decltype(op(*data.begin()))>();
     std::transform(data.begin(), data.end(), outData.begin(), op);
     return out;

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -1351,7 +1351,8 @@ Variable mean(const Variable &var, const Dim dim) {
 }
 
 Variable abs(const Variable &var) {
-  return transform<double, float>(var, [](const auto x) { return ::abs(x); });
+  using std::abs;
+  return transform<double, float>(var, [](const auto x) { return abs(x); });
 }
 
 Variable norm(const Variable &var) {
@@ -1359,8 +1360,9 @@ Variable norm(const Variable &var) {
 }
 
 Variable sqrt(const Variable &var) {
+  using std::sqrt;
   Variable result =
-      transform<double, float>(var, [](const auto x) { return std::sqrt(x); });
+      transform<double, float>(var, [](const auto x) { return sqrt(x); });
   result.setUnit(sqrt(var.unit()));
   return result;
 }

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -318,13 +318,14 @@ void VariableConceptT<T>::copy(const VariableConcept &other, const Dim dim,
 }
 
 /// Implementation of VariableConcept that holds data.
-template <class T> class DataModel : public conceptT_t<typename T::value_type> {
+template <class T>
+class DataModel : public VariableConceptT<typename T::value_type> {
 public:
   using value_type = std::remove_const_t<typename T::value_type>;
 
   DataModel(const Dimensions &dimensions, T model,
             std::optional<T> variances = std::nullopt)
-      : conceptT_t<typename T::value_type>(std::move(dimensions)),
+      : VariableConceptT<typename T::value_type>(std::move(dimensions)),
         m_values(std::move(model)), m_variances(std::move(variances)) {
     if (this->dims().volume() != scipp::size(m_values))
       throw std::runtime_error("Creating Variable: data size does not match "
@@ -489,7 +490,7 @@ makeVariableConceptT<sparse_container<float>>(const Dimensions &,
 /// Implementation of VariableConcept that represents a view onto data.
 template <class T>
 class ViewModel
-    : public conceptT_t<std::remove_const_t<typename T::element_type>> {
+    : public VariableConceptT<std::remove_const_t<typename T::element_type>> {
   void requireMutable() const {
     if (isConstView())
       throw std::runtime_error(
@@ -506,7 +507,7 @@ public:
 
   ViewModel(const Dimensions &dimensions, T model,
             std::optional<T> variances = std::nullopt)
-      : conceptT_t<value_type>(std::move(dimensions)),
+      : VariableConceptT<value_type>(std::move(dimensions)),
         m_values(std::move(model)), m_variances(std::move(variances)) {
     if (this->dims().volume() != m_values.size())
       throw std::runtime_error("Creating Variable: data size does not match "

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -431,6 +431,11 @@ public:
     return makeVariableView(m_variances->data(), 0, dims, dims);
   }
 
+  std::unique_ptr<VariableConceptT<typename T::value_type>>
+  copyT() const override {
+    return std::make_unique<DataModel<T>>(*this);
+  }
+
   VariableConceptHandle clone() const override {
     return std::make_unique<DataModel<T>>(this->dims(), m_values, m_variances);
   }
@@ -667,6 +672,18 @@ public:
     } else {
       return {*m_variances, dims};
     }
+  }
+
+  std::unique_ptr<
+      VariableConceptT<std::remove_const_t<typename T::element_type>>>
+  copyT() const override {
+    using DataT = Vector<std::remove_const_t<typename T::element_type>>;
+    DataT values(m_values.begin(), m_values.end());
+    std::optional<DataT> variances;
+    if (hasVariances())
+      variances = DataT(m_variances->begin(), m_variances->end());
+    return std::make_unique<DataModel<DataT>>(this->dims(), std::move(values),
+                                              std::move(variances));
   }
 
   VariableConceptHandle clone() const override {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -810,15 +810,13 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   return variable;
 }
 
-using arithmetic_and_matrix_type_pairs =
-    std::tuple<std::pair<double, double>, std::pair<float, float>,
-               std::pair<int64_t, int64_t>,
-               std::pair<Eigen::Vector3d, Eigen::Vector3d>,
-               std::pair<double, float>, std::pair<float, double>>;
 using arithmetic_type_pairs =
     std::tuple<std::pair<double, double>, std::pair<float, float>,
                std::pair<int64_t, int64_t>, std::pair<double, float>,
                std::pair<float, double>>;
+using arithmetic_and_matrix_type_pairs = decltype(
+    std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                   std::tuple<std::pair<Eigen::Vector3d, Eigen::Vector3d>>()));
 
 template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
   expect::equals(a.unit(), b.unit());

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -461,37 +461,6 @@ public:
   std::optional<T> m_variances;
 };
 
-namespace detail {
-template <class T>
-std::unique_ptr<VariableConceptT<T>>
-makeVariableConceptT(const Dimensions &dims) {
-  return std::make_unique<DataModel<Vector<T>>>(dims, Vector<T>(dims.volume()));
-}
-template <class T>
-std::unique_ptr<VariableConceptT<T>>
-makeVariableConceptT(const Dimensions &dims, Vector<T> data) {
-  return std::make_unique<DataModel<Vector<T>>>(dims, std::move(data));
-}
-template std::unique_ptr<VariableConceptT<double>>
-makeVariableConceptT<double>(const Dimensions &);
-template std::unique_ptr<VariableConceptT<float>>
-makeVariableConceptT<float>(const Dimensions &);
-template std::unique_ptr<VariableConceptT<sparse_container<double>>>
-makeVariableConceptT<sparse_container<double>>(const Dimensions &);
-template std::unique_ptr<VariableConceptT<sparse_container<float>>>
-makeVariableConceptT<sparse_container<float>>(const Dimensions &);
-template std::unique_ptr<VariableConceptT<double>>
-makeVariableConceptT<double>(const Dimensions &, Vector<double>);
-template std::unique_ptr<VariableConceptT<float>>
-makeVariableConceptT<float>(const Dimensions &, Vector<float>);
-template std::unique_ptr<VariableConceptT<sparse_container<double>>>
-makeVariableConceptT<sparse_container<double>>(
-    const Dimensions &, Vector<sparse_container<double>>);
-template std::unique_ptr<VariableConceptT<sparse_container<float>>>
-makeVariableConceptT<sparse_container<float>>(const Dimensions &,
-                                              Vector<sparse_container<float>>);
-} // namespace detail
-
 /// Implementation of VariableConcept that represents a view onto data.
 template <class T>
 class ViewModel

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -813,7 +813,7 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
 template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
   expect::equals(a.unit(), b.unit());
   return transform<
-      pair_self_t<double, float, int64_t>,
+      pair_self_t<double, float, int64_t, Eigen::Vector3d>,
       pair_custom_t<std::pair<double, float>, std::pair<float, double>>>(
       a, b, [](const auto &a, const auto &b) { return a + b; });
 }

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -810,6 +810,14 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   return variable;
 }
 
+template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
+  expect::equals(a.unit(), b.unit());
+  return transform<
+      pair_self_t<double, float, int64_t>,
+      pair_custom_t<std::pair<double, float>, std::pair<float, double>>>(
+      a, b, [](const auto &a, const auto &b) { return a + b; });
+}
+
 Variable Variable::operator-() const {
   // TODO This implementation only works for variables containing doubles and
   // will throw, e.g., for ints.
@@ -1084,10 +1092,7 @@ Variable VariableConstProxy::reshape(const Dimensions &dims) const {
 
 // Note: The std::move here is necessary because RVO does not work for variables
 // that are function parameters.
-Variable operator+(Variable a, const Variable &b) {
-  auto result = broadcast(std::move(a), b.dims());
-  return result += b;
-}
+Variable operator+(const Variable &a, const Variable &b) { return plus(a, b); }
 Variable operator-(Variable a, const Variable &b) {
   auto result = broadcast(std::move(a), b.dims());
   return result -= b;

--- a/core/variable.h
+++ b/core/variable.h
@@ -103,26 +103,17 @@ private:
   Dimensions m_dimensions;
 };
 
-template <class T> class VariableConceptT;
-
-template <class T, typename Enable = void> struct concept {
-  using type = VariableConcept;
-  using typeT = VariableConceptT<T>;
-};
-
-template <class T> using concept_t = typename concept<T>::type;
-template <class T> using conceptT_t = typename concept<T>::typeT;
-
 /// Partially typed implementation of VariableConcept. This is a common base
 /// class for DataModel<T> and ViewModel<T>. The former holds data in a
 /// contiguous array, whereas the latter is a (potentially non-contiguous) view
 /// into the former. This base class implements functionality that is common to
 /// both, for a specific T.
-template <class T> class VariableConceptT : public concept_t<T> {
+template <class T> class VariableConceptT : public VariableConcept {
 public:
   using value_type = T;
 
-  VariableConceptT(const Dimensions &dimensions) : concept_t<T>(dimensions) {}
+  VariableConceptT(const Dimensions &dimensions)
+      : VariableConcept(dimensions) {}
 
   DType dtype(bool sparse = false) const noexcept override {
     if (!sparse)

--- a/core/variable.h
+++ b/core/variable.h
@@ -392,6 +392,23 @@ template <class T> Variable makeVariable(const Dimensions &dimensions) {
 }
 
 template <class T>
+Variable makeVariableWithVariances(const Dimensions &dimensions) {
+  if (dimensions.sparse())
+    return Variable(
+        units::dimensionless, std::move(dimensions),
+        Vector<sparse_container<underlying_type_t<T>>>(dimensions.volume()),
+        Vector<sparse_container<underlying_type_t<T>>>(dimensions.volume()));
+  else
+    return Variable(units::dimensionless, std::move(dimensions),
+                    Vector<underlying_type_t<T>>(
+                        dimensions.volume(),
+                        detail::default_init<underlying_type_t<T>>::value()),
+                    Vector<underlying_type_t<T>>(
+                        dimensions.volume(),
+                        detail::default_init<underlying_type_t<T>>::value()));
+}
+
+template <class T>
 Variable makeVariable(const std::initializer_list<Dim> &dims,
                       const std::initializer_list<scipp::index> &shape) {
   return makeVariable<T>(Dimensions(dims, shape));

--- a/core/variable.h
+++ b/core/variable.h
@@ -703,7 +703,7 @@ private:
 // Note: If the left-hand-side in an addition is a VariableProxy this simply
 // implicitly converts it to a Variable. A copy for the return value is required
 // anyway so this is a convenient way to avoid defining more overloads.
-Variable operator+(Variable a, const Variable &b);
+Variable operator+(const Variable &a, const Variable &b);
 Variable operator-(Variable a, const Variable &b);
 Variable operator*(Variable a, const Variable &b);
 Variable operator/(Variable a, const Variable &b);

--- a/core/variable.h
+++ b/core/variable.h
@@ -717,17 +717,25 @@ private:
   Variable *m_mutableVariable;
 };
 
+Variable operator+(const Variable &a, const Variable &b);
+Variable operator-(const Variable &a, const Variable &b);
+Variable operator*(const Variable &a, const Variable &b);
+Variable operator/(const Variable &a, const Variable &b);
+Variable operator+(const Variable &a, const VariableConstProxy &b);
+Variable operator-(const Variable &a, const VariableConstProxy &b);
+Variable operator*(const Variable &a, const VariableConstProxy &b);
+Variable operator/(const Variable &a, const VariableConstProxy &b);
+Variable operator+(const VariableConstProxy &a, const Variable &b);
+Variable operator-(const VariableConstProxy &a, const Variable &b);
+Variable operator*(const VariableConstProxy &a, const Variable &b);
+Variable operator/(const VariableConstProxy &a, const Variable &b);
+Variable operator+(const VariableConstProxy &a, const VariableConstProxy &b);
+Variable operator-(const VariableConstProxy &a, const VariableConstProxy &b);
+Variable operator*(const VariableConstProxy &a, const VariableConstProxy &b);
+Variable operator/(const VariableConstProxy &a, const VariableConstProxy &b);
 // Note: If the left-hand-side in an addition is a VariableProxy this simply
 // implicitly converts it to a Variable. A copy for the return value is required
 // anyway so this is a convenient way to avoid defining more overloads.
-Variable operator+(const Variable &a, const Variable &b);
-Variable operator-(Variable a, const Variable &b);
-Variable operator*(Variable a, const Variable &b);
-Variable operator/(Variable a, const Variable &b);
-Variable operator+(Variable a, const VariableConstProxy &b);
-Variable operator-(Variable a, const VariableConstProxy &b);
-Variable operator*(Variable a, const VariableConstProxy &b);
-Variable operator/(Variable a, const VariableConstProxy &b);
 Variable operator+(Variable a, const double b);
 Variable operator-(Variable a, const double b);
 Variable operator*(Variable a, const double b);

--- a/core/variable.h
+++ b/core/variable.h
@@ -158,6 +158,8 @@ public:
   variancesReshaped(const Dimensions &dims) const = 0;
   virtual VariableView<T> variancesReshaped(const Dimensions &dims) = 0;
 
+  virtual std::unique_ptr<VariableConceptT> copyT() const = 0;
+
   VariableConceptHandle makeView() const override;
 
   VariableConceptHandle makeView() override;


### PR DESCRIPTION
Following up with things that were left incomplete in #275.

- `transform` with 1 and 2 inputs support "all" features now (variances, sparse data, mixed precision). Fixes #272.
- `+-*/` for `Variable` is using these now, giving us mixed precision operations, etc. Fixes #213.

As before, testing is very incomplete. See #276.