### PR TITLE
VariableView tests and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(
     CMAKE_BUILD_TYPE "Release"
@@ -16,7 +22,8 @@ if(NOT CMAKE_BUILD_TYPE)
     FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake" "${CMAKE_SOURCE_DIR}/CMake/sanitizers-cmake/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake"
+    "${CMAKE_SOURCE_DIR}/CMake/sanitizers-cmake/cmake")
 
 find_package(OpenMP 3.1 REQUIRED)
 find_package(Sanitizers REQUIRED)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,7 +28,8 @@ set(SRC_FILES
     #events.cpp
     except.cpp
     #md_zip_view.cpp
-    variable.cpp)
+    variable.cpp
+    view_index.cpp)
 
 add_library(scipp-core STATIC ${INC_FILES} ${SRC_FILES})
 target_link_libraries(scipp-core

--- a/core/test/variable_view_test.cpp
+++ b/core/test/variable_view_test.cpp
@@ -230,3 +230,113 @@ TEST(VariableViewTest, collapse_all) {
   Dimensions target;
   EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims), {0}));
 }
+
+// Note the result of slicing with extent 1 is equivalent to that of collapsing.
+TEST(VariableViewTest, slice_inner) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 3, 1});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 4, 8, 12, 16, 20}));
+  // This is a typical use for the offset parameter.
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 3, target, dims),
+                     {3, 7, 11, 15, 19, 23}));
+}
+
+TEST(VariableViewTest, slice_interior) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 1, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 12, 13, 14, 15}));
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 4, target, dims),
+                     {4, 5, 6, 7, 16, 17, 18, 19}));
+}
+
+TEST(VariableViewTest, slice_outer) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {1, 3, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(VariableViewTest, slice_inner_and_outer) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {1, 3, 1});
+  EXPECT_TRUE(
+      equals(VariableView(range(24).data(), 0, target, dims), {0, 4, 8}));
+}
+
+TEST(VariableViewTest, slice_inner_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 1, 1});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims), {0, 12}));
+}
+
+TEST(VariableViewTest, slice_outer_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {1, 1, 4});
+  EXPECT_TRUE(
+      equals(VariableView(range(24).data(), 0, target, dims), {0, 1, 2, 3}));
+}
+
+TEST(VariableViewTest, slice_all) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target{{Dim::X, Dim::Y, Dim::Z}, {1, 1, 1}};
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims), {0}));
+}
+
+TEST(VariableViewTest, slice_range_inner) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 3, 2});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21}));
+}
+
+TEST(VariableViewTest, slice_range_interior) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 2, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17, 18, 19}));
+}
+
+TEST(VariableViewTest, slice_range_inner_and_outer) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 3, 2});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21}));
+}
+
+TEST(VariableViewTest, slice_range_inner_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 2, 2});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 4, 5, 12, 13, 16, 17}));
+}
+
+TEST(VariableViewTest, slice_range_outer_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {1, 2, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 4, 5, 6, 7}));
+}
+
+TEST(VariableViewTest, slice_range_all) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target{{Dim::X, Dim::Y, Dim::Z}, {1, 2, 2}};
+  EXPECT_TRUE(
+      equals(VariableView(range(24).data(), 0, target, dims), {0, 1, 4, 5}));
+}
+
+TEST(VariableViewTest, broadcast_transpose_slice_3d) {
+  Dimensions dims{{Dim::X, Dim::Y}, {2, 3}};
+  Dimensions target{{Dim::Y, Dim::X, Dim::Z}, {2, 2, 4}};
+  EXPECT_TRUE(equals(VariableView(range(6).data(), 0, target, dims),
+                     {0, 0, 0, 0, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 4}));
+}
+
+TEST(VariableViewTest, broadcast_transpose_slice_4d) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target{{Dim::Z, Dim::Y, Dim::Time, Dim::X}, {2, 3, 2, 2}};
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 12, 0, 12, 4, 16, 4, 16, 8, 20, 8, 20,
+                      1, 13, 1, 13, 5, 17, 5, 17, 9, 21, 9, 21}));
+}

--- a/core/test/variable_view_test.cpp
+++ b/core/test/variable_view_test.cpp
@@ -3,6 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <numeric>
+#include <vector>
+
+#include "test_macros.h"
 
 #include "variable_view.h"
 
@@ -101,4 +104,129 @@ TEST(VariableView, subview) {
   EXPECT_EQ(*it++, 2.0);
   EXPECT_EQ(*it++, 4.0);
   EXPECT_EQ(*it++, 4.0);
+}
+
+auto range(const scipp::index end) {
+  std::vector<int32_t> data(end);
+  std::iota(data.begin(), data.end(), 0);
+  return data;
+}
+
+TEST(VariableViewTest, broadcast_inner) {
+  Dimensions dims{Dim::X, 2};
+  Dimensions target({Dim::X, Dim::Y}, {2, 3});
+  EXPECT_TRUE(equals(VariableView(range(2).data(), 0, target, dims),
+                     {0, 0, 0, 1, 1, 1}));
+}
+
+TEST(VariableViewTest, broadcast_outer) {
+  Dimensions dims{Dim::X, 2};
+  Dimensions target({Dim::Y, Dim::X}, {3, 2});
+  EXPECT_TRUE(equals(VariableView(range(2).data(), 0, target, dims),
+                     {0, 1, 0, 1, 0, 1}));
+}
+
+TEST(VariableViewTest, broadcast_interior) {
+  Dimensions dims{{Dim::X, Dim::Z}, {2, 2}};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 3, 2});
+  EXPECT_TRUE(equals(VariableView(range(4).data(), 0, target, dims),
+                     {0, 1, 0, 1, 0, 1, 2, 3, 2, 3, 2, 3}));
+}
+
+TEST(VariableViewTest, broadcast_inner_and_outer) {
+  Dimensions dims{Dim::Y, 2};
+  Dimensions target({Dim::X, Dim::Y, Dim::Z}, {2, 2, 3});
+  EXPECT_TRUE(equals(VariableView(range(2).data(), 0, target, dims),
+                     {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}));
+}
+
+TEST(VariableViewTest, transpose_2d) {
+  Dimensions dims{{Dim::X, Dim::Y}, {2, 3}};
+  Dimensions target({Dim::Y, Dim::X}, {3, 2});
+  EXPECT_TRUE(equals(VariableView(range(6).data(), 0, target, dims),
+                     {0, 3, 1, 4, 2, 5}));
+}
+
+TEST(VariableViewTest, transpose_3d_yx) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Y, Dim::X, Dim::Z}, {3, 2, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0,  1,  2,  3,  12, 13, 14, 15, 4,  5,  6,  7,
+                      16, 17, 18, 19, 8,  9,  10, 11, 20, 21, 22, 23}));
+}
+
+TEST(VariableViewTest, transpose_3d_zy) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Z, Dim::Y}, {2, 4, 3});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0,  4,  8,  1,  5,  9,  2,  6,  10, 3,  7,  11,
+                      12, 16, 20, 13, 17, 21, 14, 18, 22, 15, 19, 23}));
+}
+
+TEST(VariableViewTest, transpose_3d_zx) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Z, Dim::Y, Dim::X}, {4, 3, 2});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 12, 4, 16, 8,  20, 1, 13, 5, 17, 9,  21,
+                      2, 14, 6, 18, 10, 22, 3, 15, 7, 19, 11, 23}));
+}
+
+TEST(VariableViewTest, transpose_3d_zxy) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Z, Dim::X, Dim::Y}, {4, 2, 3});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 4, 8,  12, 16, 20, 1, 5, 9,  13, 17, 21,
+                      2, 6, 10, 14, 18, 22, 3, 7, 11, 15, 19, 23}));
+}
+
+TEST(VariableViewTest, collapse_inner) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Y}, {2, 3});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 4, 8, 12, 16, 20}));
+  // This is a typical use for the offset parameter.
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 3, target, dims),
+                     {3, 7, 11, 15, 19, 23}));
+}
+
+TEST(VariableViewTest, collapse_interior) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X, Dim::Z}, {2, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 12, 13, 14, 15}));
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 4, target, dims),
+                     {4, 5, 6, 7, 16, 17, 18, 19}));
+}
+
+TEST(VariableViewTest, collapse_outer) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Y, Dim::Z}, {3, 4});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims),
+                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(VariableViewTest, collapse_inner_and_outer) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Y}, {3});
+  EXPECT_TRUE(
+      equals(VariableView(range(24).data(), 0, target, dims), {0, 4, 8}));
+}
+
+TEST(VariableViewTest, collapse_inner_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::X}, {2});
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims), {0, 12}));
+}
+
+TEST(VariableViewTest, collapse_outer_two) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target({Dim::Z}, {4});
+  EXPECT_TRUE(
+      equals(VariableView(range(24).data(), 0, target, dims), {0, 1, 2, 3}));
+}
+
+TEST(VariableViewTest, collapse_all) {
+  Dimensions dims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions target;
+  EXPECT_TRUE(equals(VariableView(range(24).data(), 0, target, dims), {0}));
 }

--- a/core/test/variable_view_test.cpp
+++ b/core/test/variable_view_test.cpp
@@ -363,3 +363,34 @@ TEST(VariableViewTest, view_of_view_collapse_and_broadcast) {
                      {0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,
                       12, 13, 14, 15, 12, 13, 14, 15, 12, 13, 14, 15}));
 }
+
+TEST(VariableViewTest, view_of_view_bad_broadcast) {
+  Dimensions dims{{Dim::X, Dim::Y}, {2, 3}};
+  Dimensions target{{Dim::X, Dim::Y}, {2, 2}};
+  const auto data = range(6);
+  // Base view with sliced Y
+  VariableView base(data.data(), 0, target, dims);
+  EXPECT_THROW(VariableView<const int32_t>(base, dims), except::DimensionError);
+}
+
+TEST(VariableViewTest, slicing_view_of_view_collapse_and_broadcast) {
+  Dimensions dataDims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions baseDims{{Dim::X, Dim::Z}, {2, 4}};
+  Dimensions target{{Dim::X, Dim::Y}, {2, 2}};
+  const auto data = range(24);
+  VariableView base(data.data(), 0, baseDims, dataDims);
+  // Slice Z and broadcast Y.
+  EXPECT_TRUE(equals(VariableView<const int32_t>(base, target, Dim::Z, 1),
+                     {1, 1, 13, 13}));
+}
+
+TEST(VariableViewTest, slicing_view_of_view_bad_broadcast) {
+  Dimensions dataDims{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+  Dimensions baseDims{{Dim::X, Dim::Y, Dim::Z}, {2, 1, 4}};
+  Dimensions target{{Dim::X, Dim::Y}, {2, 2}};
+  const auto data = range(24);
+  // Base view with sliced Y
+  VariableView base(data.data(), 0, baseDims, dataDims);
+  EXPECT_THROW(VariableView<const int32_t>(base, target, Dim::Z, 1),
+               except::DimensionError);
+}

--- a/core/variable_view.h
+++ b/core/variable_view.h
@@ -22,11 +22,28 @@ public:
   using element_type = T;
   using value_type = std::remove_cv_t<T>;
 
+  /// Construct a VariableView.
+  ///
+  /// @param variable Pointer to data array.
+  /// @param offset Start offset from beginning of data array.
+  /// @param targetDimensions Dimensions of the constructed VariableView.
+  /// @param dimensions Dimensions of the data array.
+  ///
+  /// The parameter `targetDimensions` can be used to remove, slice, broadcast,
+  /// or transpose dimensions of the input data array.
   VariableView(T *variable, const scipp::index offset,
                const Dimensions &targetDimensions, const Dimensions &dimensions)
       : m_variable(variable), m_offset(offset),
-        m_targetDimensions(targetDimensions), m_dimensions(dimensions) {}
+        m_targetDimensions(targetDimensions), m_dimensions(dimensions) {
+    expectCompatibleTarget();
+  }
 
+  /// Construct a VariableView from another VariableView, with different target
+  /// dimensions.
+  ///
+  /// A good way to think of this is of a non-contiguous underlying data array,
+  /// e.g., since the other view may represent a slice. This also supports
+  /// broadcasting the slice.
   template <class Other>
   VariableView(const Other &other, const Dimensions &targetDimensions)
       : m_variable(other.m_variable), m_offset(other.m_offset),
@@ -35,8 +52,15 @@ public:
     for (const auto label : m_dimensions.labels())
       if (!other.m_targetDimensions.denseContains(label))
         m_dimensions.relabel(m_dimensions.index(label), Dim::Invalid);
+    expectCompatibleTarget();
   }
 
+  /// Construct a VariableView from another VariableView, with different target
+  /// dimensions and offset derived from `dim` and `begin`.
+  ///
+  /// This is essentially performing a slice of a VariableView, creating a new
+  /// view which may at the same time also perform other manipulations such as
+  /// broadcasting and transposing.
   template <class Other>
   VariableView(const Other &other, const Dimensions &targetDimensions,
                const Dim dim, const scipp::index begin)
@@ -48,6 +72,7 @@ public:
     for (const auto label : m_dimensions.labels())
       if (!other.m_targetDimensions.denseContains(label))
         m_dimensions.relabel(m_dimensions.index(label), Dim::Invalid);
+    expectCompatibleTarget();
   }
 
   VariableView<std::remove_const_t<T>>
@@ -127,6 +152,15 @@ private:
   scipp::index m_offset{0};
   Dimensions m_targetDimensions;
   Dimensions m_dimensions;
+
+  void expectCompatibleTarget() const {
+    for (const auto dim : m_targetDimensions.denseLabels())
+      if (m_dimensions.denseContains(dim) &&
+          (m_dimensions[dim] < m_targetDimensions[dim]))
+        throw except::DimensionError("Cannot broadcast/slice dimension since "
+                                     "data has mismatching but smaller "
+                                     "dimension extent.");
+  }
 };
 
 template <class T>

--- a/core/view_index.cpp
+++ b/core/view_index.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Neil Vaytet
+#include "view_index.h"
+
+namespace scipp::core {
+ViewIndex::ViewIndex(const Dimensions &targetDimensions,
+                     const Dimensions &dataDimensions) {
+  m_dims = targetDimensions.shape().size();
+  for (scipp::index d = 0; d < m_dims; ++d)
+    m_extent[d] = targetDimensions.size(m_dims - 1 - d);
+  scipp::index factor{1};
+  for (scipp::index i = dataDimensions.shape().size() - 1; i >= 0; --i) {
+    // Note the hidden behavior here: VariableView may be relabeling certain
+    // dimensions to Dim::Invalid. Dimensions::contains then returns false,
+    // effectively slicing out this dimensions from the data.
+    const auto dimension = dataDimensions.label(i);
+    if (targetDimensions.contains(dimension)) {
+      m_offsets[m_subdims] = m_dims - 1 - targetDimensions.index(dimension);
+      m_factors[m_subdims] = factor;
+      ++m_subdims;
+    }
+    factor *= dataDimensions.size(i);
+  }
+  scipp::index offset{1};
+  for (scipp::index d = 0; d < m_dims; ++d) {
+    setIndex(offset);
+    m_delta[d] = m_index;
+    if (d > 0) {
+      setIndex(offset - 1);
+      m_delta[d] -= m_index;
+      for (scipp::index d2 = 0; d2 < d; ++d2)
+        m_delta[d] -= m_delta[d2];
+    }
+    offset *= m_extent[d];
+  }
+  setIndex(0);
+}
+} // namespace scipp::core

--- a/core/view_index.h
+++ b/core/view_index.h
@@ -11,20 +11,20 @@ namespace scipp::core {
 
 class ViewIndex {
 public:
-  ViewIndex(const Dimensions &parentDimensions,
-            const Dimensions &subdimensions) {
-    m_dims = parentDimensions.shape().size();
+  ViewIndex(const Dimensions &targetDimensions,
+            const Dimensions &dataDimensions) {
+    m_dims = targetDimensions.shape().size();
     for (scipp::index d = 0; d < m_dims; ++d)
-      m_extent[d] = parentDimensions.size(m_dims - 1 - d);
+      m_extent[d] = targetDimensions.size(m_dims - 1 - d);
     scipp::index factor{1};
-    for (scipp::index i = subdimensions.shape().size() - 1; i >= 0; --i) {
-      const auto dimension = subdimensions.label(i);
-      if (parentDimensions.contains(dimension)) {
-        m_offsets[m_subdims] = m_dims - 1 - parentDimensions.index(dimension);
+    for (scipp::index i = dataDimensions.shape().size() - 1; i >= 0; --i) {
+      const auto dimension = dataDimensions.label(i);
+      if (targetDimensions.contains(dimension)) {
+        m_offsets[m_subdims] = m_dims - 1 - targetDimensions.index(dimension);
         m_factors[m_subdims] = factor;
         ++m_subdims;
       }
-      factor *= subdimensions.size(i);
+      factor *= dataDimensions.size(i);
     }
     scipp::index offset{1};
     for (scipp::index d = 0; d < m_dims; ++d) {

--- a/core/view_index.h
+++ b/core/view_index.h
@@ -12,34 +12,7 @@ namespace scipp::core {
 class ViewIndex {
 public:
   ViewIndex(const Dimensions &targetDimensions,
-            const Dimensions &dataDimensions) {
-    m_dims = targetDimensions.shape().size();
-    for (scipp::index d = 0; d < m_dims; ++d)
-      m_extent[d] = targetDimensions.size(m_dims - 1 - d);
-    scipp::index factor{1};
-    for (scipp::index i = dataDimensions.shape().size() - 1; i >= 0; --i) {
-      const auto dimension = dataDimensions.label(i);
-      if (targetDimensions.contains(dimension)) {
-        m_offsets[m_subdims] = m_dims - 1 - targetDimensions.index(dimension);
-        m_factors[m_subdims] = factor;
-        ++m_subdims;
-      }
-      factor *= dataDimensions.size(i);
-    }
-    scipp::index offset{1};
-    for (scipp::index d = 0; d < m_dims; ++d) {
-      setIndex(offset);
-      m_delta[d] = m_index;
-      if (d > 0) {
-        setIndex(offset - 1);
-        m_delta[d] -= m_index;
-        for (scipp::index d2 = 0; d2 < d; ++d2)
-          m_delta[d] -= m_delta[d2];
-      }
-      offset *= m_extent[d];
-    }
-    setIndex(0);
-  }
+            const Dimensions &dataDimensions);
 
   void increment() {
     m_index += m_delta[0];


### PR DESCRIPTION
- Add more systematic tests for `VariableView`.
- Add checks that catch bad broadcasts. I am not sure this was an actual problem in practice since the surrounding code in `Variable` and `transform` may have avoided the bug, but it is better to have the checks in place here.

Also:
- `ccache` auto-detected.