### PR TITLE
Variable test cleanup

### DIFF
--- a/core/counts.cpp
+++ b/core/counts.cpp
@@ -17,8 +17,8 @@ auto getBinWidths(const Dataset &d, const std::vector<Dim> &dims) {
     if (coord.unit() == units::dimensionless)
       throw std::runtime_error("Dimensionless axis cannot be used for "
                                "conversion from or to density");
-    binWidths.emplace_back(coord(dim, 1, coord.dims()[dim]) -
-                           coord(dim, 0, coord.dims()[dim] - 1));
+    binWidths.emplace_back(coord.slice({dim, 1, coord.dims()[dim]}) -
+                           coord.slice({dim, 0, coord.dims()[dim] - 1}));
   }
   return binWidths;
 }

--- a/core/dataset.h
+++ b/core/dataset.h
@@ -62,7 +62,7 @@ auto makeSlice(Var &var,
   for (const auto[params, extent] : slices) {
     const auto[dim, begin, end] = params;
     if (slice.dims().contains(dim))
-      slice = slice(dim, begin, end + slice.dims()[dim] - extent);
+      slice = slice.slice(Slice{dim, begin, end + slice.dims()[dim] - extent});
   }
   return slice;
 }

--- a/core/except.h
+++ b/core/except.h
@@ -131,6 +131,10 @@ struct CoordMismatchError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+struct VariancesError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 } // namespace except
 
 namespace expect {

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -120,7 +120,7 @@ TEST(TransformTest, transform_combines_uncertainty_propagation) {
 
 TEST(TransformTest, unary_on_elements_of_sparse) {
   auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto a_ = a.sparseSpan<double>();
+  auto a_ = a.sparseValues<double>();
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
@@ -150,7 +150,7 @@ TEST(TransformTest, unary_on_elements_of_sparse_with_variance) {
 
 TEST(TransformTest, unary_on_sparse_container) {
   auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto a_ = a.sparseSpan<double>();
+  auto a_ = a.sparseValues<double>();
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
@@ -180,7 +180,7 @@ TEST(TransformTest, unary_on_sparse_container_with_variance) {
 
 TEST(TransformTest, binary_with_dense) {
   auto sparse = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto sparse_ = sparse.sparseSpan<double>();
+  auto sparse_ = sparse.sparseValues<double>();
   sparse_[0] = {1, 2, 3};
   sparse_[1] = {4};
   auto dense = makeVariable<double>({Dim::Y, 2}, {1.5, 0.5});

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -67,28 +67,28 @@ TEST(TransformTest, apply_binary_in_place_var_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      a, b(Dim::Y, 1), [](auto &x, const auto y) { x += y; });
+      a, b.slice({Dim::Y, 1}), [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {4.4, 5.5}));
 }
 
 TEST(TransformTest, apply_binary_in_place_self_overlap_without_variance) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
-  Variable slice_copy = a(Dim::X, 1);
+  Variable slice_copy = a.slice({Dim::X, 1});
   auto reference = a + slice_copy;
   transform_in_place<pair_self_t<double>>(
-      a, a(Dim::X, 1), [](auto &x, const auto y) { x += y; });
+      a, a.slice({Dim::X, 1}), [](auto &x, const auto y) { x += y; });
   ASSERT_EQ(a, reference);
 }
 
 TEST(TransformTest, apply_binary_in_place_self_overlap_with_variance) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {1.0, 2.0});
-  Variable slice_copy = a(Dim::X, 1);
+  Variable slice_copy = a.slice({Dim::X, 1});
   auto reference = a + slice_copy;
   // With self-overlap the implementation needs to make a copy of the rhs. This
   // is a regression test: An initial implementation was unintentionally
   // dropping the variances when making that copy.
   transform_in_place<pair_self_t<double>>(
-      a, a(Dim::X, 1), [](auto &x, const auto y) { x += y; });
+      a, a.slice({Dim::X, 1}), [](auto &x, const auto y) { x += y; });
   ASSERT_EQ(a, reference);
 }
 
@@ -96,7 +96,7 @@ TEST(TransformTest, apply_binary_in_place_view_with_var) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>(3.3);
   transform_in_place<pair_self_t<double>>(
-      a(Dim::X, 1), b, [](auto &x, const auto y) { x += y; });
+      a.slice({Dim::X, 1}), b, [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 
@@ -104,7 +104,8 @@ TEST(TransformTest, apply_binary_in_place_view_with_view) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
   const auto b = makeVariable<double>({Dim::Y, 2}, {0.1, 3.3});
   transform_in_place<pair_self_t<double>>(
-      a(Dim::X, 1), b(Dim::Y, 1), [](auto &x, const auto y) { x += y; });
+      a.slice({Dim::X, 1}), b.slice({Dim::Y, 1}),
+      [](auto &x, const auto y) { x += y; });
   EXPECT_TRUE(equals(a.values<double>(), {1.1, 5.5}));
 }
 

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -23,7 +23,7 @@ TEST(Variable, operator_unary_minus) {
 
 TEST(VariableProxy, unary_minus) {
   const auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
-  auto b = -a(Dim::X, 1);
+  auto b = -a.slice({Dim::X, 1});
   EXPECT_EQ(a.values<double>()[0], 1.1);
   EXPECT_EQ(a.values<double>()[1], 2.2);
   EXPECT_EQ(b.values<double>()[0], -2.2);
@@ -377,7 +377,7 @@ TEST(VariableProxy, minus_equals_failures) {
   auto var =
       makeVariable<double>({{Dim::X, 2}, {Dim::Y, 2}}, {1.0, 2.0, 3.0, 4.0});
 
-  EXPECT_THROW_MSG(var -= var(Dim::X, 0, 1), std::runtime_error,
+  EXPECT_THROW_MSG(var -= var.slice({Dim::X, 0, 1}), std::runtime_error,
                    "Expected {{Dim::X, 2}, {Dim::Y, 2}} to contain {{Dim::X, "
                    "1}, {Dim::Y, 2}}.");
 }
@@ -386,7 +386,7 @@ TEST(VariableProxy, self_overlapping_view_operation) {
   auto var =
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
-  var -= var(Dim::Y, 0);
+  var -= var.slice({Dim::Y, 0});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
@@ -402,13 +402,13 @@ TEST(VariableProxy, minus_equals_slice_const_outer) {
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   const auto copy(var);
 
-  var -= copy(Dim::Y, 0);
+  var -= copy.slice({Dim::Y, 0});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
   EXPECT_EQ(data[3], 2.0);
-  var -= copy(Dim::Y, 1);
+  var -= copy.slice({Dim::Y, 1});
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -4.0);
   EXPECT_EQ(data[2], -1.0);
@@ -420,13 +420,13 @@ TEST(VariableProxy, minus_equals_slice_outer) {
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
-  var -= copy(Dim::Y, 0);
+  var -= copy.slice({Dim::Y, 0});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
   EXPECT_EQ(data[3], 2.0);
-  var -= copy(Dim::Y, 1);
+  var -= copy.slice({Dim::Y, 1});
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -4.0);
   EXPECT_EQ(data[2], -1.0);
@@ -438,13 +438,13 @@ TEST(VariableProxy, minus_equals_slice_inner) {
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
-  var -= copy(Dim::X, 0);
+  var -= copy.slice({Dim::X, 0});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 1.0);
   EXPECT_EQ(data[2], 0.0);
   EXPECT_EQ(data[3], 1.0);
-  var -= copy(Dim::X, 1);
+  var -= copy.slice({Dim::X, 1});
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -1.0);
   EXPECT_EQ(data[2], -4.0);
@@ -456,7 +456,7 @@ TEST(VariableProxy, minus_equals_slice_of_slice) {
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
-  var -= copy(Dim::X, 1)(Dim::Y, 1);
+  var -= copy.slice({Dim::X, 1}).slice({Dim::Y, 1});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -2.0);
@@ -470,7 +470,7 @@ TEST(VariableProxy, minus_equals_nontrivial_slices) {
       {11.0, 12.0, 13.0, 21.0, 22.0, 23.0, 31.0, 32.0, 33.0});
   {
     auto target = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}});
-    target -= source(Dim::X, 0, 2)(Dim::Y, 0, 2);
+    target -= source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
@@ -479,7 +479,7 @@ TEST(VariableProxy, minus_equals_nontrivial_slices) {
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}});
-    target -= source(Dim::X, 1, 3)(Dim::Y, 0, 2);
+    target -= source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -12.0);
     EXPECT_EQ(data[1], -13.0);
@@ -488,7 +488,7 @@ TEST(VariableProxy, minus_equals_nontrivial_slices) {
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}});
-    target -= source(Dim::X, 0, 2)(Dim::Y, 1, 3);
+    target -= source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -21.0);
     EXPECT_EQ(data[1], -22.0);
@@ -497,7 +497,7 @@ TEST(VariableProxy, minus_equals_nontrivial_slices) {
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}});
-    target -= source(Dim::X, 1, 3)(Dim::Y, 1, 3);
+    target -= source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -22.0);
     EXPECT_EQ(data[1], -23.0);
@@ -510,7 +510,7 @@ TEST(VariableProxy, slice_inner_minus_equals) {
   auto var =
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
-  var(Dim::X, 0) -= var(Dim::X, 1);
+  var.slice({Dim::X, 0}) -= var.slice({Dim::X, 1});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], -1.0);
   EXPECT_EQ(data[1], 2.0);
@@ -522,7 +522,7 @@ TEST(VariableProxy, slice_outer_minus_equals) {
   auto var =
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
-  var(Dim::Y, 0) -= var(Dim::Y, 1);
+  var.slice({Dim::Y, 0}) -= var.slice({Dim::Y, 1});
   const auto data = var.values<double>();
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -2.0);
@@ -535,7 +535,7 @@ TEST(VariableProxy, nontrivial_slice_minus_equals) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}},
                                        {11.0, 12.0, 21.0, 22.0});
-    target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source;
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}) -= source;
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
@@ -551,7 +551,7 @@ TEST(VariableProxy, nontrivial_slice_minus_equals) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}},
                                        {11.0, 12.0, 21.0, 22.0});
-    target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source;
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}) -= source;
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
@@ -567,7 +567,7 @@ TEST(VariableProxy, nontrivial_slice_minus_equals) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}},
                                        {11.0, 12.0, 21.0, 22.0});
-    target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source;
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}) -= source;
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
@@ -583,7 +583,7 @@ TEST(VariableProxy, nontrivial_slice_minus_equals) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}},
                                        {11.0, 12.0, 21.0, 22.0});
-    target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source;
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}) -= source;
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
@@ -602,7 +602,8 @@ TEST(VariableProxy, nontrivial_slice_minus_equals_slice) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}},
                                        {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
-    target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}) -=
+        source.slice({Dim::X, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
@@ -618,7 +619,8 @@ TEST(VariableProxy, nontrivial_slice_minus_equals_slice) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}},
                                        {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
-    target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}) -=
+        source.slice({Dim::X, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
@@ -634,7 +636,8 @@ TEST(VariableProxy, nontrivial_slice_minus_equals_slice) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}},
                                        {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
-    target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}) -=
+        source.slice({Dim::X, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
@@ -650,7 +653,8 @@ TEST(VariableProxy, nontrivial_slice_minus_equals_slice) {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
     auto source = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}},
                                        {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
-    target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}) -=
+        source.slice({Dim::X, 1, 3});
     const auto data = target.values<double>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
@@ -667,10 +671,10 @@ TEST(VariableProxy, nontrivial_slice_minus_equals_slice) {
 TEST(VariableProxy, slice_minus_lower_dimensional) {
   auto target = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}});
   auto source = makeVariable<double>({Dim::X, 2}, {1.0, 2.0});
-  EXPECT_EQ(target(Dim::Y, 1, 2).dims(),
+  EXPECT_EQ(target.slice({Dim::Y, 1, 2}).dims(),
             (Dimensions{{Dim::Y, 1}, {Dim::X, 2}}));
 
-  target(Dim::Y, 1, 2) -= source;
+  target.slice({Dim::Y, 1, 2}) -= source;
 
   const auto data = target.values<double>();
   EXPECT_EQ(data[0], 0.0);
@@ -685,10 +689,10 @@ TEST(VariableProxy, slice_binary_operations) {
   // operators that convert the second argument to Variable (it should not), or
   // keep it as a view. See variable_benchmark.cpp for an attempt to verify
   // this.
-  auto sum = v(Dim::X, 0) + v(Dim::X, 1);
-  auto difference = v(Dim::X, 0) - v(Dim::X, 1);
-  auto product = v(Dim::X, 0) * v(Dim::X, 1);
-  auto ratio = v(Dim::X, 0) / v(Dim::X, 1);
+  auto sum = v.slice({Dim::X, 0}) + v.slice({Dim::X, 1});
+  auto difference = v.slice({Dim::X, 0}) - v.slice({Dim::X, 1});
+  auto product = v.slice({Dim::X, 0}) * v.slice({Dim::X, 1});
+  auto ratio = v.slice({Dim::X, 0}) / v.slice({Dim::X, 1});
   EXPECT_TRUE(equals(sum.values<double>(), {3, 7}));
   EXPECT_TRUE(equals(difference.values<double>(), {-1, -1}));
   EXPECT_TRUE(equals(product.values<double>(), {2, 12}));
@@ -735,17 +739,17 @@ TEST(VariableProxy, scalar_operations) {
   auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}},
                                   {11, 12, 13, 21, 22, 23});
 
-  var(Dim::X, 0) += 1;
+  var.slice({Dim::X, 0}) += 1;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 13, 22, 22, 23}));
-  var(Dim::Y, 1) += 1;
+  var.slice({Dim::Y, 1}) += 1;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 13, 23, 23, 24}));
-  var(Dim::X, 1, 3) += 1;
+  var.slice({Dim::X, 1, 3}) += 1;
   EXPECT_TRUE(equals(var.values<double>(), {12, 13, 14, 23, 24, 25}));
-  var(Dim::X, 1) -= 1;
+  var.slice({Dim::X, 1}) -= 1;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 14, 23, 23, 25}));
-  var(Dim::X, 2) *= 0;
+  var.slice({Dim::X, 2}) *= 0;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 0, 23, 23, 0}));
-  var(Dim::Y, 0) /= 2;
+  var.slice({Dim::Y, 0}) /= 2;
   EXPECT_TRUE(equals(var.values<double>(), {6, 6, 0, 23, 23, 0}));
 }
 

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -229,19 +229,19 @@ TEST(Variable, setSlice) {
   auto d(empty);
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1, 2, 3})
-    d(Dim::X, index).assign(parent(Dim::X, index));
+    d.slice({Dim::X, index}).assign(parent.slice({Dim::X, index}));
   EXPECT_EQ(parent, d);
 
   d = empty;
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1})
-    d(Dim::Y, index).assign(parent(Dim::Y, index));
+    d.slice({Dim::Y, index}).assign(parent.slice({Dim::Y, index}));
   EXPECT_EQ(parent, d);
 
   d = empty;
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1, 2})
-    d(Dim::Z, index).assign(parent(Dim::Z, index));
+    d.slice({Dim::Z, index}).assign(parent.slice({Dim::Z, index}));
   EXPECT_EQ(parent, d);
 }
 
@@ -253,7 +253,7 @@ TEST(Variable, slice) {
        13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
   for (const scipp::index index : {0, 1, 2, 3}) {
-    Variable sliceX = parent(Dim::X, index);
+    Variable sliceX = parent.slice({Dim::X, index});
     ASSERT_EQ(sliceX.dims(), Dimensions({{Dim::Z, 3}, {Dim::Y, 2}}));
     auto base = static_cast<double>(index);
     EXPECT_EQ(sliceX.values<double>()[0], base + 1.0);
@@ -265,7 +265,7 @@ TEST(Variable, slice) {
   }
 
   for (const scipp::index index : {0, 1}) {
-    Variable sliceY = parent(Dim::Y, index);
+    Variable sliceY = parent.slice({Dim::Y, index});
     ASSERT_EQ(sliceY.dims(), Dimensions({{Dim::Z, 3}, {Dim::X, 4}}));
     const auto &data = sliceY.values<double>();
     auto base = static_cast<double>(index);
@@ -278,7 +278,7 @@ TEST(Variable, slice) {
   }
 
   for (const scipp::index index : {0, 1, 2}) {
-    Variable sliceZ = parent(Dim::Z, index);
+    Variable sliceZ = parent.slice({Dim::Z, index});
     ASSERT_EQ(sliceZ.dims(), Dimensions({{Dim::Y, 2}, {Dim::X, 4}}));
     const auto &data = sliceZ.values<double>();
     for (scipp::index xy = 0; xy < 8; ++xy)
@@ -294,7 +294,7 @@ TEST(Variable, slice_range) {
        13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
   for (const scipp::index index : {0, 1, 2, 3}) {
-    Variable sliceX = parent(Dim::X, index, index + 1);
+    Variable sliceX = parent.slice({Dim::X, index, index + 1});
     ASSERT_EQ(sliceX.dims(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
     EXPECT_EQ(sliceX.values<double>()[0], index + 1.0);
@@ -306,7 +306,7 @@ TEST(Variable, slice_range) {
   }
 
   for (const scipp::index index : {0, 1, 2}) {
-    Variable sliceX = parent(Dim::X, index, index + 2);
+    Variable sliceX = parent.slice({Dim::X, index, index + 2});
     ASSERT_EQ(sliceX.dims(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
     EXPECT_EQ(sliceX.values<double>()[0], index + 1.0);
@@ -324,7 +324,7 @@ TEST(Variable, slice_range) {
   }
 
   for (const scipp::index index : {0, 1}) {
-    Variable sliceY = parent(Dim::Y, index, index + 1);
+    Variable sliceY = parent.slice({Dim::Y, index, index + 1});
     ASSERT_EQ(sliceY.dims(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
     const auto &data = sliceY.values<double>();
@@ -337,12 +337,12 @@ TEST(Variable, slice_range) {
   }
 
   for (const scipp::index index : {0}) {
-    Variable sliceY = parent(Dim::Y, index, index + 2);
+    Variable sliceY = parent.slice({Dim::Y, index, index + 2});
     EXPECT_EQ(sliceY, parent);
   }
 
   for (const scipp::index index : {0, 1, 2}) {
-    Variable sliceZ = parent(Dim::Z, index, index + 1);
+    Variable sliceZ = parent.slice({Dim::Z, index, index + 1});
     ASSERT_EQ(sliceZ.dims(),
               Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
     const auto &data = sliceZ.values<double>();
@@ -351,7 +351,7 @@ TEST(Variable, slice_range) {
   }
 
   for (const scipp::index index : {0, 1}) {
-    Variable sliceZ = parent(Dim::Z, index, index + 2);
+    Variable sliceZ = parent.slice({Dim::Z, index, index + 2});
     ASSERT_EQ(sliceZ.dims(),
               Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
     const auto &data = sliceZ.values<double>();
@@ -401,56 +401,64 @@ TEST(VariableProxy, full_mutable_view) {
 
 TEST(VariableProxy, strides) {
   auto var = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
-  EXPECT_EQ(var(Dim::X, 0).strides(), (std::vector<scipp::index>{3}));
-  EXPECT_EQ(var(Dim::X, 1).strides(), (std::vector<scipp::index>{3}));
-  EXPECT_EQ(var(Dim::Y, 0).strides(), (std::vector<scipp::index>{1}));
-  EXPECT_EQ(var(Dim::Y, 1).strides(), (std::vector<scipp::index>{1}));
-  EXPECT_EQ(var(Dim::X, 0, 1).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::X, 1, 2).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::Y, 0, 1).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::Y, 1, 2).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::X, 0, 2).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::X, 1, 3).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::Y, 0, 2).strides(), (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var(Dim::Y, 1, 3).strides(), (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::X, 0}).strides(), (std::vector<scipp::index>{3}));
+  EXPECT_EQ(var.slice({Dim::X, 1}).strides(), (std::vector<scipp::index>{3}));
+  EXPECT_EQ(var.slice({Dim::Y, 0}).strides(), (std::vector<scipp::index>{1}));
+  EXPECT_EQ(var.slice({Dim::Y, 1}).strides(), (std::vector<scipp::index>{1}));
+  EXPECT_EQ(var.slice({Dim::X, 0, 1}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::X, 1, 2}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::Y, 0, 1}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::Y, 1, 2}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::X, 0, 2}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::X, 1, 3}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::Y, 0, 2}).strides(),
+            (std::vector<scipp::index>{3, 1}));
+  EXPECT_EQ(var.slice({Dim::Y, 1, 3}).strides(),
+            (std::vector<scipp::index>{3, 1}));
 
-  EXPECT_EQ(var(Dim::X, 0, 1)(Dim::Y, 0, 1).strides(),
+  EXPECT_EQ(var.slice({Dim::X, 0, 1}).slice({Dim::Y, 0, 1}).strides(),
             (std::vector<scipp::index>{3, 1}));
 
   auto var3D = makeVariable<double>({{Dim::Z, 4}, {Dim::Y, 3}, {Dim::X, 2}});
-  EXPECT_EQ(var3D(Dim::X, 0, 1)(Dim::Z, 0, 1).strides(),
+  EXPECT_EQ(var3D.slice({Dim::X, 0, 1}).slice({Dim::Z, 0, 1}).strides(),
             (std::vector<scipp::index>{6, 2, 1}));
 }
 
 TEST(VariableProxy, get) {
   const auto var = makeVariable<double>({Dim::X, 3}, {1, 2, 3});
-  EXPECT_EQ(var(Dim::X, 1, 2).values<double>()[0], 2.0);
+  EXPECT_EQ(var.slice({Dim::X, 1, 2}).values<double>()[0], 2.0);
 }
 
 TEST(VariableProxy, slicing_does_not_transpose) {
   auto var = makeVariable<double>({{Dim::X, 3}, {Dim::Y, 3}});
   Dimensions expected{{Dim::X, 1}, {Dim::Y, 1}};
-  EXPECT_EQ(var(Dim::X, 1, 2)(Dim::Y, 1, 2).dims(), expected);
-  EXPECT_EQ(var(Dim::Y, 1, 2)(Dim::X, 1, 2).dims(), expected);
+  EXPECT_EQ(var.slice({Dim::X, 1, 2}).slice({Dim::Y, 1, 2}).dims(), expected);
+  EXPECT_EQ(var.slice({Dim::Y, 1, 2}).slice({Dim::X, 1, 2}).dims(), expected);
 }
 
 TEST(VariableProxy, variable_copy_from_slice) {
   const auto source = makeVariable<double>(
       {{Dim::Y, 3}, {Dim::X, 3}}, {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
-  Variable target1(source(Dim::X, 0, 2)(Dim::Y, 0, 2));
+  Variable target1(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}));
   EXPECT_EQ(target1.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target1.values<double>(), {11, 12, 21, 22}));
 
-  Variable target2(source(Dim::X, 1, 3)(Dim::Y, 0, 2));
+  Variable target2(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}));
   EXPECT_EQ(target2.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target2.values<double>(), {12, 13, 22, 23}));
 
-  Variable target3(source(Dim::X, 0, 2)(Dim::Y, 1, 3));
+  Variable target3(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}));
   EXPECT_EQ(target3.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target3.values<double>(), {21, 22, 31, 32}));
 
-  Variable target4(source(Dim::X, 1, 3)(Dim::Y, 1, 3));
+  Variable target4(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}));
   EXPECT_EQ(target4.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target4.values<double>(), {22, 23, 32, 33}));
 }
@@ -460,19 +468,19 @@ TEST(VariableProxy, variable_assign_from_slice) {
   const auto source = makeVariable<double>(
       {{Dim::Y, 3}, {Dim::X, 3}}, {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
-  target = source(Dim::X, 0, 2)(Dim::Y, 0, 2);
+  target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2});
   EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target.values<double>(), {11, 12, 21, 22}));
 
-  target = source(Dim::X, 1, 3)(Dim::Y, 0, 2);
+  target = source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2});
   EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target.values<double>(), {12, 13, 22, 23}));
 
-  target = source(Dim::X, 0, 2)(Dim::Y, 1, 3);
+  target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3});
   EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target.values<double>(), {21, 22, 31, 32}));
 
-  target = source(Dim::X, 1, 3)(Dim::Y, 1, 3);
+  target = source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3});
   EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
   EXPECT_TRUE(equals(target.values<double>(), {22, 23, 32, 33}));
 }
@@ -481,7 +489,7 @@ TEST(VariableProxy, variable_self_assign_via_slice) {
   auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}},
                                      {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
-  target = target(Dim::X, 1, 3)(Dim::Y, 1, 3);
+  target = target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3});
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
@@ -496,28 +504,28 @@ TEST(VariableProxy, slice_assign_from_variable) {
   // should!?) assign the view contents, not the data.
   {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
-    target(Dim::X, 0, 2)(Dim::Y, 0, 2).assign(source);
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}).assign(source);
     EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
         equals(target.values<double>(), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
-    target(Dim::X, 1, 3)(Dim::Y, 0, 2).assign(source);
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}).assign(source);
     EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
         equals(target.values<double>(), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
-    target(Dim::X, 0, 2)(Dim::Y, 1, 3).assign(source);
+    target.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}).assign(source);
     EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
         equals(target.values<double>(), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
   }
   {
     auto target = makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}});
-    target(Dim::X, 1, 3)(Dim::Y, 1, 3).assign(source);
+    target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}).assign(source);
     EXPECT_EQ(target.dims(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
         equals(target.values<double>(), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
@@ -571,14 +579,16 @@ TEST(VariableTest, reshape_and_slice) {
       makeVariable<double>({Dim::Spectrum, 16}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
                                                  11, 12, 13, 14, 15, 16});
 
-  auto slice =
-      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
+  auto slice = var.reshape({{Dim::X, 4}, {Dim::Y, 4}})
+                   .slice({Dim::X, 1, 3})
+                   .slice({Dim::Y, 1, 3});
   ASSERT_EQ(slice,
             makeVariable<double>({{Dim::X, 2}, {Dim::Y, 2}}, {6, 7, 10, 11}));
 
-  Variable center =
-      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
-          .reshape({Dim::Spectrum, 4});
+  Variable center = var.reshape({{Dim::X, 4}, {Dim::Y, 4}})
+                        .slice({Dim::X, 1, 3})
+                        .slice({Dim::Y, 1, 3})
+                        .reshape({Dim::Spectrum, 4});
 
   ASSERT_EQ(center, makeVariable<double>({Dim::Spectrum, 4}, {6, 7, 10, 11}));
 }
@@ -766,7 +776,7 @@ TEST(SparseVariable, slice) {
   data[1] = {1, 2};
   data[2] = {1};
   data[3] = {};
-  auto slice = var(Dim::Y, 1, 3);
+  auto slice = var.slice({Dim::Y, 1, 3});
   EXPECT_TRUE(slice.dims().sparse());
   EXPECT_EQ(slice.dims().sparseDim(), Dim::X);
   EXPECT_EQ(slice.dims().volume(), 2);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -13,31 +13,28 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(Variable, construct_default) {
-  ASSERT_NO_THROW(Variable());
+  ASSERT_NO_THROW(Variable{});
   Variable var;
   ASSERT_FALSE(var);
 }
 
 TEST(Variable, construct) {
-  ASSERT_NO_THROW(makeVariable<double>(Dimensions(Dim::Tof, 2)));
-  ASSERT_NO_THROW(makeVariable<double>(Dimensions(Dim::Tof, 2), 2));
-  const auto a = makeVariable<double>(Dimensions(Dim::Tof, 2));
+  ASSERT_NO_THROW(makeVariable<double>({Dim::X, 2}));
+  ASSERT_NO_THROW(makeVariable<double>({Dim::X, 2}, 2));
+  const auto a = makeVariable<double>({Dim::X, 2});
   const auto &data = a.values<double>();
   EXPECT_EQ(data.size(), 2);
 }
 
 TEST(Variable, construct_fail) {
   ASSERT_ANY_THROW(makeVariable<double>(Dimensions(), 2));
-  ASSERT_ANY_THROW(makeVariable<double>(Dimensions(Dim::Tof, 1), 2));
-  ASSERT_ANY_THROW(makeVariable<double>(Dimensions(Dim::Tof, 3), 2));
+  ASSERT_ANY_THROW(makeVariable<double>({Dim::X, 1}, 2));
+  ASSERT_ANY_THROW(makeVariable<double>({Dim::X, 3}, 2));
 }
 
 TEST(Variable, move) {
   auto var = makeVariable<double>({Dim::X, 2});
   Variable moved(std::move(var));
-  // We need to define the behavior on move. Currently most methods will just
-  // segfault, and we have no way of telling whether a Variable is in this
-  // state.
   EXPECT_FALSE(var);
   EXPECT_NE(moved, var);
 }

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -78,7 +78,7 @@ TEST(Variable, dtype) {
 }
 
 TEST(Variable, span_references_Variable) {
-  auto a = makeVariable<double>(Dimensions(Dim::Tof, 2));
+  auto a = makeVariable<double>(Dimensions(Dim::X, 2));
   auto observer = a.values<double>();
   // This line does not compile, const-correctness works:
   // observer[0] = 1.0;
@@ -215,7 +215,6 @@ TEST(VariableTest, copy_and_move) {
 }
 
 TEST(Variable, setSlice) {
-  Dimensions dims(Dim::Tof, 1);
   const auto parent = makeVariable<double>(
       Dimensions({{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
@@ -243,7 +242,6 @@ TEST(Variable, setSlice) {
 }
 
 TEST(Variable, slice) {
-  Dimensions dims(Dim::Tof, 1);
   const auto parent = makeVariable<double>(
       Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
@@ -284,7 +282,6 @@ TEST(Variable, slice) {
 }
 
 TEST(Variable, slice_range) {
-  Dimensions dims(Dim::Tof, 1);
   const auto parent = makeVariable<double>(
       Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -267,128 +267,130 @@ TEST(Variable, assign_slice_variance_checks) {
                except::VariancesError);
 }
 
-TEST(Variable, slice) {
-  const auto parent =
+class VariableTest_3d : public ::testing::Test {
+protected:
+  const Variable parent{
       makeVariable<double>({{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}, units::m,
                            {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                             13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
                            {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
-                            37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48});
+                            37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48})};
+  const std::vector<double> vals_x0{1, 2, 3, 4, 5, 6};
+  const std::vector<double> vals_x1{7, 8, 9, 10, 11, 12};
+  const std::vector<double> vals_x2{13, 14, 15, 16, 17, 18};
+  const std::vector<double> vals_x3{19, 20, 21, 22, 23, 24};
+  const std::vector<double> vars_x0{25, 26, 27, 28, 29, 30};
+  const std::vector<double> vars_x1{31, 32, 33, 34, 35, 36};
+  const std::vector<double> vars_x2{37, 38, 39, 40, 41, 42};
+  const std::vector<double> vars_x3{43, 44, 45, 46, 47, 48};
 
+  const std::vector<double> vals_x02{
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+  };
+  const std::vector<double> vals_x13{7,  8,  9,  10, 11, 12,
+                                     13, 14, 15, 16, 17, 18};
+  const std::vector<double> vals_x24{13, 14, 15, 16, 17, 18,
+                                     19, 20, 21, 22, 23, 24};
+  const std::vector<double> vars_x02{25, 26, 27, 28, 29, 30,
+                                     31, 32, 33, 34, 35, 36};
+  const std::vector<double> vars_x13{31, 32, 33, 34, 35, 36,
+                                     37, 38, 39, 40, 41, 42};
+  const std::vector<double> vars_x24{37, 38, 39, 40, 41, 42,
+                                     43, 44, 45, 46, 47, 48};
+
+  const std::vector<double> vals_y0{1, 2, 3, 7, 8, 9, 13, 14, 15, 19, 20, 21};
+  const std::vector<double> vals_y1{4,  5,  6,  10, 11, 12,
+                                    16, 17, 18, 22, 23, 24};
+  const std::vector<double> vars_y0{25, 26, 27, 31, 32, 33,
+                                    37, 38, 39, 43, 44, 45};
+  const std::vector<double> vars_y1{28, 29, 30, 34, 35, 36,
+                                    40, 41, 42, 46, 47, 48};
+
+  const std::vector<double> vals_z0{1, 4, 7, 10, 13, 16, 19, 22};
+  const std::vector<double> vals_z1{2, 5, 8, 11, 14, 17, 20, 23};
+  const std::vector<double> vals_z2{3, 6, 9, 12, 15, 18, 21, 24};
+  const std::vector<double> vars_z0{25, 28, 31, 34, 37, 40, 43, 46};
+  const std::vector<double> vars_z1{26, 29, 32, 35, 38, 41, 44, 47};
+  const std::vector<double> vars_z2{27, 30, 33, 36, 39, 42, 45, 48};
+
+  const std::vector<double> vals_z02{1,  2,  4,  5,  7,  8,  10, 11,
+                                     13, 14, 16, 17, 19, 20, 22, 23};
+  const std::vector<double> vals_z13{2,  3,  5,  6,  8,  9,  11, 12,
+                                     14, 15, 17, 18, 20, 21, 23, 24};
+  const std::vector<double> vars_z02{25, 26, 28, 29, 31, 32, 34, 35,
+                                     37, 38, 40, 41, 43, 44, 46, 47};
+  const std::vector<double> vars_z13{26, 27, 29, 30, 32, 33, 35, 36,
+                                     38, 39, 41, 42, 44, 45, 47, 48};
+};
+
+TEST_F(VariableTest_3d, slice_single) {
+  Dimensions dims_no_x{{Dim::Y, 2}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::X, 0}),
-            makeVariable<double>({{Dim::Y, 2}, {Dim::Z, 3}}, units::m,
-                                 {1, 2, 3, 4, 5, 6}, {25, 26, 27, 28, 29, 30}));
+            makeVariable<double>(dims_no_x, units::m, vals_x0, vars_x0));
   EXPECT_EQ(parent.slice({Dim::X, 1}),
-            makeVariable<double>({{Dim::Y, 2}, {Dim::Z, 3}}, units::m,
-                                 {7, 8, 9, 10, 11, 12},
-                                 {31, 32, 33, 34, 35, 36}));
+            makeVariable<double>(dims_no_x, units::m, vals_x1, vars_x1));
   EXPECT_EQ(parent.slice({Dim::X, 2}),
-            makeVariable<double>({{Dim::Y, 2}, {Dim::Z, 3}}, units::m,
-                                 {13, 14, 15, 16, 17, 18},
-                                 {37, 38, 39, 40, 41, 42}));
+            makeVariable<double>(dims_no_x, units::m, vals_x2, vars_x2));
   EXPECT_EQ(parent.slice({Dim::X, 3}),
-            makeVariable<double>({{Dim::Y, 2}, {Dim::Z, 3}}, units::m,
-                                 {19, 20, 21, 22, 23, 24},
-                                 {43, 44, 45, 46, 47, 48}));
+            makeVariable<double>(dims_no_x, units::m, vals_x3, vars_x3));
 
-  EXPECT_EQ(
-      parent.slice({Dim::Y, 0}),
-      makeVariable<double>({{Dim::X, 4}, {Dim::Z, 3}}, units::m,
-                           {1, 2, 3, 7, 8, 9, 13, 14, 15, 19, 20, 21},
-                           {25, 26, 27, 31, 32, 33, 37, 38, 39, 43, 44, 45}));
-  EXPECT_EQ(
-      parent.slice({Dim::Y, 1}),
-      makeVariable<double>({{Dim::X, 4}, {Dim::Z, 3}}, units::m,
-                           {4, 5, 6, 10, 11, 12, 16, 17, 18, 22, 23, 24},
-                           {28, 29, 30, 34, 35, 36, 40, 41, 42, 46, 47, 48}));
+  Dimensions dims_no_y{{Dim::X, 4}, {Dim::Z, 3}};
+  EXPECT_EQ(parent.slice({Dim::Y, 0}),
+            makeVariable<double>(dims_no_y, units::m, vals_y0, vars_y0));
+  EXPECT_EQ(parent.slice({Dim::Y, 1}),
+            makeVariable<double>(dims_no_y, units::m, vals_y1, vars_y1));
 
+  Dimensions dims_no_z{{Dim::X, 4}, {Dim::Y, 2}};
   EXPECT_EQ(parent.slice({Dim::Z, 0}),
-            makeVariable<double>({{Dim::X, 4}, {Dim::Y, 2}}, units::m,
-                                 {1, 4, 7, 10, 13, 16, 19, 22},
-                                 {25, 28, 31, 34, 37, 40, 43, 46}));
+            makeVariable<double>(dims_no_z, units::m, vals_z0, vars_z0));
   EXPECT_EQ(parent.slice({Dim::Z, 1}),
-            makeVariable<double>({{Dim::X, 4}, {Dim::Y, 2}}, units::m,
-                                 {2, 5, 8, 11, 14, 17, 20, 23},
-                                 {26, 29, 32, 35, 38, 41, 44, 47}));
+            makeVariable<double>(dims_no_z, units::m, vals_z1, vars_z1));
   EXPECT_EQ(parent.slice({Dim::Z, 2}),
-            makeVariable<double>({{Dim::X, 4}, {Dim::Y, 2}}, units::m,
-                                 {3, 6, 9, 12, 15, 18, 21, 24},
-                                 {27, 30, 33, 36, 39, 42, 45, 48}));
+            makeVariable<double>(dims_no_z, units::m, vals_z2, vars_z2));
 }
 
-TEST(Variable, slice_range) {
-  const auto parent = makeVariable<double>(
-      Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
-      {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
-       13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
+TEST_F(VariableTest_3d, slice_range) {
+  // Length 1 slice
+  Dimensions dims_x1{{Dim::X, 1}, {Dim::Y, 2}, {Dim::Z, 3}};
+  EXPECT_EQ(parent.slice({Dim::X, 0, 1}),
+            makeVariable<double>(dims_x1, units::m, vals_x0, vars_x0));
+  EXPECT_EQ(parent.slice({Dim::X, 1, 2}),
+            makeVariable<double>(dims_x1, units::m, vals_x1, vars_x1));
+  EXPECT_EQ(parent.slice({Dim::X, 2, 3}),
+            makeVariable<double>(dims_x1, units::m, vals_x2, vars_x2));
+  EXPECT_EQ(parent.slice({Dim::X, 3, 4}),
+            makeVariable<double>(dims_x1, units::m, vals_x3, vars_x3));
 
-  for (const scipp::index index : {0, 1, 2, 3}) {
-    Variable sliceX = parent.slice({Dim::X, index, index + 1});
-    ASSERT_EQ(sliceX.dims(),
-              Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
-    EXPECT_EQ(sliceX.values<double>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.values<double>()[1], index + 5.0);
-    EXPECT_EQ(sliceX.values<double>()[2], index + 9.0);
-    EXPECT_EQ(sliceX.values<double>()[3], index + 13.0);
-    EXPECT_EQ(sliceX.values<double>()[4], index + 17.0);
-    EXPECT_EQ(sliceX.values<double>()[5], index + 21.0);
-  }
+  Dimensions dims_y1{{Dim::X, 4}, {Dim::Y, 1}, {Dim::Z, 3}};
+  EXPECT_EQ(parent.slice({Dim::Y, 0, 1}),
+            makeVariable<double>(dims_y1, units::m, vals_y0, vars_y0));
+  EXPECT_EQ(parent.slice({Dim::Y, 1, 2}),
+            makeVariable<double>(dims_y1, units::m, vals_y1, vars_y1));
 
-  for (const scipp::index index : {0, 1, 2}) {
-    Variable sliceX = parent.slice({Dim::X, index, index + 2});
-    ASSERT_EQ(sliceX.dims(),
-              Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
-    EXPECT_EQ(sliceX.values<double>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.values<double>()[1], index + 2.0);
-    EXPECT_EQ(sliceX.values<double>()[2], index + 5.0);
-    EXPECT_EQ(sliceX.values<double>()[3], index + 6.0);
-    EXPECT_EQ(sliceX.values<double>()[4], index + 9.0);
-    EXPECT_EQ(sliceX.values<double>()[5], index + 10.0);
-    EXPECT_EQ(sliceX.values<double>()[6], index + 13.0);
-    EXPECT_EQ(sliceX.values<double>()[7], index + 14.0);
-    EXPECT_EQ(sliceX.values<double>()[8], index + 17.0);
-    EXPECT_EQ(sliceX.values<double>()[9], index + 18.0);
-    EXPECT_EQ(sliceX.values<double>()[10], index + 21.0);
-    EXPECT_EQ(sliceX.values<double>()[11], index + 22.0);
-  }
+  Dimensions dims_z1{{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 1}};
+  EXPECT_EQ(parent.slice({Dim::Z, 0, 1}),
+            makeVariable<double>(dims_z1, units::m, vals_z0, vars_z0));
+  EXPECT_EQ(parent.slice({Dim::Z, 1, 2}),
+            makeVariable<double>(dims_z1, units::m, vals_z1, vars_z1));
+  EXPECT_EQ(parent.slice({Dim::Z, 2, 3}),
+            makeVariable<double>(dims_z1, units::m, vals_z2, vars_z2));
 
-  for (const scipp::index index : {0, 1}) {
-    Variable sliceY = parent.slice({Dim::Y, index, index + 1});
-    ASSERT_EQ(sliceY.dims(),
-              Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
-    const auto &data = sliceY.values<double>();
-    for (const scipp::index z : {0, 1, 2}) {
-      EXPECT_EQ(data[4 * z + 0], 4 * index + 8 * z + 1.0);
-      EXPECT_EQ(data[4 * z + 1], 4 * index + 8 * z + 2.0);
-      EXPECT_EQ(data[4 * z + 2], 4 * index + 8 * z + 3.0);
-      EXPECT_EQ(data[4 * z + 3], 4 * index + 8 * z + 4.0);
-    }
-  }
+  // Length 2 slice
+  Dimensions dims_x2{{Dim::X, 2}, {Dim::Y, 2}, {Dim::Z, 3}};
+  EXPECT_EQ(parent.slice({Dim::X, 0, 2}),
+            makeVariable<double>(dims_x2, units::m, vals_x02, vars_x02));
+  EXPECT_EQ(parent.slice({Dim::X, 1, 3}),
+            makeVariable<double>(dims_x2, units::m, vals_x13, vars_x13));
+  EXPECT_EQ(parent.slice({Dim::X, 2, 4}),
+            makeVariable<double>(dims_x2, units::m, vals_x24, vars_x24));
 
-  for (const scipp::index index : {0}) {
-    Variable sliceY = parent.slice({Dim::Y, index, index + 2});
-    EXPECT_EQ(sliceY, parent);
-  }
+  EXPECT_EQ(parent.slice({Dim::Y, 0, 2}), parent);
 
-  for (const scipp::index index : {0, 1, 2}) {
-    Variable sliceZ = parent.slice({Dim::Z, index, index + 1});
-    ASSERT_EQ(sliceZ.dims(),
-              Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.values<double>();
-    for (scipp::index xy = 0; xy < 8; ++xy)
-      EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
-  }
-
-  for (const scipp::index index : {0, 1}) {
-    Variable sliceZ = parent.slice({Dim::Z, index, index + 2});
-    ASSERT_EQ(sliceZ.dims(),
-              Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.values<double>();
-    for (scipp::index xy = 0; xy < 8; ++xy)
-      EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
-    for (scipp::index xy = 0; xy < 8; ++xy)
-      EXPECT_EQ(data[8 + xy], 1.0 + 8 + xy + 8 * index);
-  }
+  Dimensions dims_z2{{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 2}};
+  EXPECT_EQ(parent.slice({Dim::Z, 0, 2}),
+            makeVariable<double>(dims_z2, units::m, vals_z02, vars_z02));
+  EXPECT_EQ(parent.slice({Dim::Z, 1, 3}),
+            makeVariable<double>(dims_z2, units::m, vals_z13, vars_z13));
 }
 
 TEST(Variable, broadcast) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -934,7 +934,7 @@ Variable &Variable::operator/=(const double value) & {
 
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
   if (unit() != other.unit())
-    throw std::runtime_error("Cannot assign to slice: Unit mismatch.");
+    throw except::UnitError("Cannot assign to slice: Unit mismatch.");
   if (dims() != other.dims())
     throw except::DimensionMismatchError(dims(), other.dims());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);
@@ -1010,8 +1010,8 @@ void VariableProxy::setUnit(const units::Unit &unit) const {
   // particular since views onto subsets of dataset do not imply slicing of
   // variables but return slice views.
   if ((this->unit() != unit) && (dims() != m_mutableVariable->dims()))
-    throw std::runtime_error("Partial view on data of variable cannot be used "
-                             "to change the unit.\n");
+    throw except::UnitError("Partial view on data of variable cannot be used "
+                            "to change the unit.");
   m_mutableVariable->setUnit(unit);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -114,7 +114,7 @@ template <typename T> struct RebinGeneralHelper {
         delta -= xo_low > xn_low ? xo_low : xn_low;
 
         auto owidth = xo_high - xo_low;
-        newT(dim, inew) += oldT(dim, iold) * delta / owidth;
+        newT.slice({dim, inew}) += oldT.slice({dim, iold}) * delta / owidth;
         if (xn_high > xo_high) {
           iold++;
         } else {
@@ -1087,16 +1087,6 @@ VariableProxy Variable::slice(const Slice slice) & {
 
 Variable Variable::slice(const Slice slice) && { return {this->slice(slice)}; }
 
-VariableConstProxy Variable::operator()(const Dim dim, const scipp::index begin,
-                                        const scipp::index end) const & {
-  return slice({dim, begin, end});
-}
-
-VariableProxy Variable::operator()(const Dim dim, const scipp::index begin,
-                                   const scipp::index end) & {
-  return slice({dim, begin, end});
-}
-
 VariableConstProxy Variable::reshape(const Dimensions &dims) const & {
   return {*this, dims};
 }
@@ -1185,10 +1175,10 @@ std::vector<Variable> split(const Variable &var, const Dim dim,
   if (indices.empty())
     return {var};
   std::vector<Variable> vars;
-  vars.emplace_back(var(dim, 0, indices.front()));
+  vars.emplace_back(var.slice({dim, 0, indices.front()}));
   for (scipp::index i = 0; i < scipp::size(indices) - 1; ++i)
-    vars.emplace_back(var(dim, indices[i], indices[i + 1]));
-  vars.emplace_back(var(dim, indices.back(), var.dims()[dim]));
+    vars.emplace_back(var.slice({dim, indices[i], indices[i + 1]}));
+  vars.emplace_back(var.slice({dim, indices.back(), var.dims()[dim]}));
   return vars;
 }
 
@@ -1435,9 +1425,9 @@ Variable broadcast(Variable var, const Dimensions &dims) {
 
 void swap(Variable &var, const Dim dim, const scipp::index a,
           const scipp::index b) {
-  const Variable tmp = var(dim, a);
-  var(dim, a).assign(var(dim, b));
-  var(dim, b).assign(tmp);
+  const Variable tmp = var.slice({dim, a});
+  var.slice({dim, a}).assign(var.slice({dim, b}));
+  var.slice({dim, b}).assign(tmp);
 }
 
 Variable reverse(Variable var, const Dim dim) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -709,8 +709,12 @@ template <class T>
 Variable::Variable(const units::Unit unit, const Dimensions &dimensions,
                    T values, T variances)
     : m_unit{unit},
-      m_object(std::make_unique<DataModel<T>>(
-          std::move(dimensions), std::move(values), std::move(variances))) {}
+      m_object(variances.empty()
+                   ? std::make_unique<DataModel<T>>(std::move(dimensions),
+                                                    std::move(values))
+                   : std::make_unique<DataModel<T>>(std::move(dimensions),
+                                                    std::move(values),
+                                                    std::move(variances))) {}
 
 void Variable::setDims(const Dimensions &dimensions) {
   if (dimensions.volume() == m_object->dims().volume()) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -936,8 +936,7 @@ Variable &Variable::operator/=(const double value) & {
 }
 
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
-  if (unit() != other.unit())
-    throw except::UnitError("Cannot assign to slice: Unit mismatch.");
+  setUnit(other.unit());
   if (dims() != other.dims())
     throw except::DimensionMismatchError(dims(), other.dims());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);
@@ -1009,9 +1008,6 @@ Variable VariableConstProxy::operator-() const {
 }
 
 void VariableProxy::setUnit(const units::Unit &unit) const {
-  // TODO Should we forbid setting the unit altogether? I think it is useful in
-  // particular since views onto subsets of dataset do not imply slicing of
-  // variables but return slice views.
   if ((this->unit() != unit) && (dims() != m_mutableVariable->dims()))
     throw except::UnitError("Partial view on data of variable cannot be used "
                             "to change the unit.");

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -268,6 +268,9 @@ void VariableConceptT<T>::copy(const VariableConcept &other, const Dim dim,
                                const scipp::index offset,
                                const scipp::index otherBegin,
                                const scipp::index otherEnd) {
+  if (this->hasVariances() != other.hasVariances())
+    throw except::VariancesError(
+        "Either both or neither of the operands must have a variances.");
   auto iterDims = this->dims();
   const scipp::index delta = otherEnd - otherBegin;
   if (iterDims.contains(dim))

--- a/core/variable.h
+++ b/core/variable.h
@@ -307,16 +307,6 @@ public:
   VariableProxy slice(const Slice slice) &;
   Variable slice(const Slice slice) &&;
 
-  VariableConstProxy operator()(const Dim dim, const scipp::index begin,
-                                const scipp::index end = -1) const &;
-  VariableConstProxy operator()(const Dim dim, const scipp::index begin,
-                                const scipp::index end = -1) const && = delete;
-
-  VariableProxy operator()(const Dim dim, const scipp::index begin,
-                           const scipp::index end = -1) &;
-  VariableProxy operator()(const Dim dim, const scipp::index begin,
-                           const scipp::index end = -1) && = delete;
-
   VariableConstProxy reshape(const Dimensions &dims) const &;
   VariableProxy reshape(const Dimensions &dims) &;
   // Note: Do we have to delete the `const &&` version? Consider
@@ -541,11 +531,6 @@ public:
     return VariableConstProxy(*this, slice.dim, slice.begin, slice.end);
   }
 
-  VariableConstProxy operator()(const Dim dim, const scipp::index begin,
-                                const scipp::index end = -1) const {
-    return slice({dim, begin, end});
-  }
-
   // Note the return type. Reshaping a non-contiguous slice cannot return a
   // slice in general so we must return a copy of the data.
   Variable reshape(const Dimensions &dims) const;
@@ -647,11 +632,6 @@ public:
 
   VariableProxy slice(const Slice slice) const {
     return VariableProxy(*this, slice.dim, slice.begin, slice.end);
-  }
-
-  VariableProxy operator()(const Dim dim, const scipp::index begin,
-                           const scipp::index end = -1) const {
-    return slice({dim, begin, end});
   }
 
   using VariableConstProxy::data;

--- a/core/variable.h
+++ b/core/variable.h
@@ -299,7 +299,7 @@ public:
   template <class T> auto sparseSpan() const { return sparseValues<T>(); }
   template <class T> auto sparseSpan() { return sparseValues<T>(); }
 
-  // ATTENTION: It is really important to delete any function returning a
+  // ATTENTION: It is really important to avoid any function returning a
   // (Const)VariableProxy for rvalue Variable. Otherwise the resulting slice
   // will point to free'ed memory.
   VariableConstProxy slice(const Slice slice) const &;
@@ -404,26 +404,6 @@ Variable makeVariable(const std::initializer_list<Dim> &dims,
   return makeVariable<T>(Dimensions(dims, shape));
 }
 
-template <class T, class T2 = T>
-Variable makeVariable(const Dimensions &dimensions,
-                      std::initializer_list<T2> values) {
-  if constexpr (is_sparse_v<T2>) {
-    return Variable(units::dimensionless, std::move(dimensions),
-                    Vector<sparse_container<underlying_type_t<T>>>(
-                        values.begin(), values.end()));
-  } else {
-    return Variable(units::dimensionless, std::move(dimensions),
-                    Vector<underlying_type_t<T>>(values.begin(), values.end()));
-  }
-}
-
-// This overload is required to avoid wrongly selecting the single-value
-// overload with two template arguments.
-// template <class T>
-// Variable makeVariable(const std::pair<Dim, scipp::index> &dims_init) {
-//  return makeVariable<T>(Dimensions(dims_init.first, dims_init.second));
-//}
-
 template <class T> Variable makeVariable(T value) {
   return Variable(units::dimensionless, Dimensions{},
                   Vector<underlying_type_t<T>>(1, value));
@@ -438,7 +418,7 @@ template <class T> Variable makeVariable(T value, T variance) {
 template <class T, class T2 = T>
 Variable makeVariable(const Dimensions &dimensions,
                       std::initializer_list<T2> values,
-                      std::initializer_list<T2> variances) {
+                      std::initializer_list<T2> variances = {}) {
   if constexpr (is_sparse_v<T2>) {
     return Variable(units::dimensionless, std::move(dimensions),
                     Vector<sparse_container<underlying_type_t<T>>>(
@@ -455,7 +435,7 @@ Variable makeVariable(const Dimensions &dimensions,
 
 template <class T, class T2 = T>
 Variable makeVariable(const Dimensions &dimensions, std::vector<T2> values,
-                      std::vector<T2> variances) {
+                      std::vector<T2> variances = {}) {
   return Variable(
       units::dimensionless, std::move(dimensions),
       Vector<underlying_type_t<T>>(values.begin(), values.end()),
@@ -464,15 +444,8 @@ Variable makeVariable(const Dimensions &dimensions, std::vector<T2> values,
 
 template <class T, class T2 = T>
 Variable makeVariable(const Dimensions &dimensions, const units::Unit unit,
-                      std::initializer_list<T2> values) {
-  return Variable(unit, std::move(dimensions),
-                  Vector<underlying_type_t<T>>(values.begin(), values.end()));
-}
-
-template <class T, class T2 = T>
-Variable makeVariable(const Dimensions &dimensions, const units::Unit unit,
                       std::initializer_list<T2> values,
-                      std::initializer_list<T2> variances) {
+                      std::initializer_list<T2> variances = {}) {
   return Variable(
       unit, std::move(dimensions),
       Vector<underlying_type_t<T>>(values.begin(), values.end()),

--- a/core/variable.h
+++ b/core/variable.h
@@ -296,8 +296,6 @@ public:
   template <class T> auto sparseVariances() {
     return scipp::span(cast<sparse_container<T>>(true));
   }
-  template <class T> auto sparseSpan() const { return sparseValues<T>(); }
-  template <class T> auto sparseSpan() { return sparseValues<T>(); }
 
   // ATTENTION: It is really important to avoid any function returning a
   // (Const)VariableProxy for rvalue Variable. Otherwise the resulting slice
@@ -587,8 +585,11 @@ public:
   // will not be deleted even if *this is a temporary and gets deleted.
   template <class T> auto values() const { return cast<T>(); }
   template <class T> auto variances() const { return castVariances<T>(); }
-  template <class T> auto sparseSpan() const {
+  template <class T> auto sparseValues() const {
     return cast<sparse_container<T>>();
+  }
+  template <class T> auto sparseVariances() const {
+    return castVariances<sparse_container<T>>();
   }
 
   bool operator==(const Variable &other) const;
@@ -658,8 +659,11 @@ public:
   // Note: No need to delete rvalue overloads here, see VariableConstProxy.
   template <class T> auto values() const { return cast<T>(); }
   template <class T> auto variances() const { return castVariances<T>(); }
-  template <class T> auto sparseSpan() const {
+  template <class T> auto sparseValues() const {
     return cast<sparse_container<T>>();
+  }
+  template <class T> auto sparseVariances() const {
+    return castVariances<sparse_container<T>>();
   }
 
   // Note: We want to support things like `var(Dim::X, 0) += var2`, i.e., when


### PR DESCRIPTION
Fixes #228, but testing code related to operations left to be handled in #276.

- Mainly this adds unit and variance checks to more tests.
- Also remove/rename some outdated method of `Variable`.