### PR TITLE
Transform tests and small cleanup

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRC_FILES
     #events.cpp
     except.cpp
     variable.cpp
+    variable_binary_ops.cpp
     view_index.cpp)
 
 add_library(scipp-core STATIC ${INC_FILES} ${SRC_FILES})

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -738,7 +738,7 @@ void transform_in_place(Var &&var, const Var1 &other, Op op) {
 /// avoids the need to manually create a new variable for the output and the
 /// need for, e.g., std::back_inserter.
 template <class... Ts, class Var, class Op>
-Variable transform(const Var &var, Op op) {
+[[nodiscard]] Variable transform(const Var &var, Op op) {
   using namespace detail;
   try {
     if constexpr ((is_sparse_v<Ts> || ...)) {
@@ -789,7 +789,7 @@ Variable transform(std::tuple<Ts...> &&, const Var1 &var1, const Var2 &var2,
 /// avoids the need to manually create a new variable for the output and the
 /// need for, e.g., std::back_inserter.
 template <class... TypePairs, class Var1, class Var2, class Op>
-Variable transform(const Var1 &var1, const Var2 &var2, Op op) {
+[[nodiscard]] Variable transform(const Var1 &var1, const Var2 &var2, Op op) {
   // Wrapped implementation to convert multiple tuples into a parameter pack.
   return detail::transform(std::tuple_cat(TypePairs{}...), var1, var2, op);
 }

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -209,7 +209,8 @@ inline constexpr bool has_variances_v = has_variances<T>::value;
 /// Helper for the transform implementation to unify iteration of data with and
 /// without variances as well as sparse are dense container.
 template <class T>
-constexpr auto value_and_maybe_variance(const T &range, const scipp::index i) {
+constexpr const auto value_and_maybe_variance(const T &range,
+                                              const scipp::index i) {
   if constexpr (has_variances_v<T>) {
     if constexpr (is_sparse_v<decltype(range.values[0])>)
       return ValuesAndVariances{range.values[i], range.variances[i]};

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -208,6 +208,11 @@ inline constexpr bool has_variances_v = has_variances<T>::value;
 
 /// Helper for the transform implementation to unify iteration of data with and
 /// without variances as well as sparse are dense container.
+///
+/// The `const` in the return type is important. It guarantees that when
+/// transform is called with a functor accepting a parameter by `auto &` the
+/// deduced type for `auto` is const. Without this the injected sparse overload
+/// would match, leading to a cryptic error message.
 template <class T>
 constexpr const auto value_and_maybe_variance(const T &range,
                                               const scipp::index i) {

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -223,6 +223,8 @@ template <class Op, class T, class... Ts>
 void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
                                            Ts &&... other) {
   auto & [ vals, vars ] = arg;
+  // WARNING: Do not parallelize this loop in all cases! The output may have a
+  // dimension with stride zero so parallelization must be done with care.
   for (scipp::index i = 0; i < scipp::size(vals); ++i) {
     // Two cases are distinguished here:
     // 1. In the case of sparse data we create ValuesAndVariances, which hold
@@ -264,6 +266,8 @@ void transform_elements_with_variance(Op op, ValuesAndVariances<Out> out,
 
 template <class Op, class T, class... Ts>
 void transform_in_place_impl(Op op, T &&vals, Ts &&... other) {
+  // WARNING: Do not parallelize this loop in all cases! The output may have a
+  // dimension with stride zero so parallelization must be done with care.
   for (scipp::index i = 0; i < scipp::size(vals); ++i)
     op(vals[i], other[i]...);
 }

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -180,7 +180,15 @@ template <class T> struct ValuesAndVariances {
     throw std::runtime_error(
         "`begin` not implemented for sparse data with variances.");
   }
+  void *begin() const {
+    throw std::runtime_error(
+        "`begin` not implemented for sparse data with variances.");
+  }
   void *end() {
+    throw std::runtime_error(
+        "`end` not implemented for sparse data with variances.");
+  }
+  void *end() const {
     throw std::runtime_error(
         "`end` not implemented for sparse data with variances.");
   }
@@ -193,6 +201,8 @@ template <class T>
 struct has_variances<ValueAndVariance<T>> : std::true_type {};
 template <class T>
 struct has_variances<ValuesAndVariances<T>> : std::true_type {};
+template <class T>
+struct has_variances<ValuesAndVariances<T> &> : std::true_type {};
 template <class T>
 inline constexpr bool has_variances_v = has_variances<T>::value;
 
@@ -236,8 +246,8 @@ void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
     // This then falls into case 2 and thus the recursion terminates with the
     // second level.
     if constexpr (is_sparse_v<decltype(vals[0])>) {
-      op(ValuesAndVariances{vals[i], vars[i]},
-         value_and_maybe_variance(other, i)...);
+      ValuesAndVariances _{vals[i], vars[i]};
+      op(_, value_and_maybe_variance(other, i)...);
     } else {
       ValueAndVariance _{vals[i], vars[i]};
       op(_, value_and_maybe_variance(other, i)...);
@@ -293,6 +303,8 @@ struct element_type<ValuesAndVariances<const sparse_container<T>>> {
   using type = T;
 };
 template <class T> using element_type_t = typename element_type<T>::type;
+template <class T>
+using const_element_type_t = const typename element_type<T>::type;
 
 namespace transform_detail {
 template <class T> struct is_sparse : std::false_type {};

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -208,14 +208,8 @@ inline constexpr bool has_variances_v = has_variances<T>::value;
 
 /// Helper for the transform implementation to unify iteration of data with and
 /// without variances as well as sparse are dense container.
-///
-/// The `const` in the return type is important. It guarantees that when
-/// transform is called with a functor accepting a parameter by `auto &` the
-/// deduced type for `auto` is const. Without this the injected sparse overload
-/// would match, leading to a cryptic error message.
 template <class T>
-constexpr const auto value_and_maybe_variance(const T &range,
-                                              const scipp::index i) {
+constexpr auto value_and_maybe_variance(const T &range, const scipp::index i) {
   if constexpr (has_variances_v<T>) {
     if constexpr (is_sparse_v<decltype(range.values[0])>)
       return ValuesAndVariances{range.values[i], range.variances[i]};

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -15,7 +15,7 @@ using namespace scipp::core;
 class TransformUnaryTest : public ::testing::Test {
 protected:
   static constexpr auto op_in_place{[](auto &x) { x *= 2.0; }};
-  static constexpr auto op{[](const auto &x) { return x * 2.0; }};
+  static constexpr auto op{[](const auto x) { return x * 2.0; }};
 };
 
 TEST_F(TransformUnaryTest, dense) {
@@ -72,6 +72,19 @@ TEST_F(TransformUnaryTest, elements_of_sparse_with_variance) {
   EXPECT_TRUE(equals(vars[0], {4.4, 8.8, 13.2}));
   EXPECT_TRUE(equals(vars[1], {17.6}));
   EXPECT_EQ(result, var);
+}
+
+TEST_F(TransformUnaryTest, sparse_values_variances_size_fail) {
+  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a = makeVariable<double>(
+      dims, {sparse_container<double>(2), sparse_container<double>(1)},
+      {sparse_container<double>(2), sparse_container<double>(2)});
+
+  ASSERT_THROW(transform<double>(a, op), except::SizeError);
+  ASSERT_THROW(transform_in_place<double>(a, op_in_place), except::SizeError);
+  a.sparseVariances<double>()[1].resize(1);
+  ASSERT_NO_THROW(transform<double>(a, op));
+  ASSERT_NO_THROW(transform_in_place<double>(a, op_in_place));
 }
 
 TEST(TransformTest, apply_unary_implicit_conversion) {
@@ -191,6 +204,25 @@ TEST_F(TransformBinaryTest, dense_sparse) {
   EXPECT_EQ(ba, sparse);
 }
 
+TEST_F(TransformBinaryTest, sparse_size_fail) {
+  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a = makeVariable<double>(
+      dims, {sparse_container<double>(2), sparse_container<double>(1)});
+  auto b = makeVariable<double>(
+      dims, {sparse_container<double>(2), sparse_container<double>()});
+
+  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
+  ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
+               except::SizeError);
+  b.sparseValues<double>()[1].resize(1);
+  ASSERT_NO_THROW(transform<pair_self_t<double>>(a, b, op));
+  ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place));
+  b.sparseValues<double>()[1].resize(2);
+  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
+  ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
+               except::SizeError);
+}
+
 TEST(TransformTest, mixed_precision) {
   auto d = makeVariable<double>(1e-12);
   auto f = makeVariable<float>(1e-12);
@@ -235,7 +267,7 @@ TEST(TransformTest, mixed_precision_in_place) {
 
 TEST(TransformTest, combined_uncertainty_propagation) {
   auto a = makeVariable<double>({Dim::X, 1}, {2.0}, {0.1});
-  const auto a2(a);
+  const auto a_2_step(a);
   const auto b = makeVariable<double>(3.0, 0.2);
 
   const auto abb = transform<pair_self_t<double>>(
@@ -243,14 +275,14 @@ TEST(TransformTest, combined_uncertainty_propagation) {
   transform_in_place<pair_self_t<double>>(
       a, b, [](auto &x, const auto y) { x = x * y + y; });
   transform_in_place<pair_self_t<double>>(
-      a2, b, [](auto &x, const auto y) { x = x * y; });
+      a_2_step, b, [](auto &x, const auto y) { x = x * y; });
   transform_in_place<pair_self_t<double>>(
-      a2, b, [](auto &x, const auto y) { x = x + y; });
+      a_2_step, b, [](auto &x, const auto y) { x = x + y; });
 
   EXPECT_TRUE(equals(a.values<double>(), {2.0 * 3.0 + 3.0}));
   EXPECT_TRUE(equals(a.variances<double>(), {0.1 * 3 * 3 + 0.2 * 2 * 2 + 0.2}));
   EXPECT_EQ(abb, a);
-  EXPECT_EQ(abb, a2);
+  EXPECT_EQ(abb, a_2_step);
 }
 
 TEST(TransformTest, unary_on_sparse_container) {
@@ -259,7 +291,7 @@ TEST(TransformTest, unary_on_sparse_container) {
   a_[0] = {1, 4, 9};
   a_[1] = {4};
 
-  transform_in_place<sparse_container<double>>(a, [](auto &&x) { x.clear(); });
+  transform_in_place<sparse_container<double>>(a, [](auto &x) { x.clear(); });
   EXPECT_TRUE(a_[0].empty());
   EXPECT_TRUE(a_[1].empty());
 }
@@ -276,47 +308,11 @@ TEST(TransformTest, unary_on_sparse_container_with_variance) {
   vars[0] = {1.1, 2.2, 3.3};
   vars[1] = {4.4};
 
-  transform_in_place<sparse_container<double>>(a, [](auto &&x) { x.clear(); });
+  transform_in_place<sparse_container<double>>(a, [](auto &x) { x.clear(); });
   EXPECT_TRUE(vals[0].empty());
   EXPECT_TRUE(vals[1].empty());
   EXPECT_TRUE(vars[0].empty());
   EXPECT_TRUE(vars[1].empty());
-}
-
-TEST(TransformTest, sparse_unary_values_variances_size_fail) {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto a = makeVariable<double>(
-      dims, {sparse_container<double>(2), sparse_container<double>(1)},
-      {sparse_container<double>(2), sparse_container<double>(2)});
-  auto op = [](const auto a) { return a * 2.0; };
-  auto op_in_place = [](auto &a) { a *= 2.0; };
-
-  ASSERT_THROW(transform<double>(a, op), except::SizeError);
-  ASSERT_THROW(transform_in_place<double>(a, op_in_place), except::SizeError);
-  a.sparseVariances<double>()[1].resize(1);
-  ASSERT_NO_THROW(transform<double>(a, op));
-  ASSERT_NO_THROW(transform_in_place<double>(a, op_in_place));
-}
-
-TEST(TransformTest, sparse_binary_size_fail) {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto a = makeVariable<double>(
-      dims, {sparse_container<double>(2), sparse_container<double>(1)});
-  auto b = makeVariable<double>(
-      dims, {sparse_container<double>(2), sparse_container<double>()});
-  auto op = [](const auto a, const auto b) { return a * b; };
-  auto op_in_place = [](auto &a, const auto b) { a *= b; };
-
-  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
-  ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
-               except::SizeError);
-  b.sparseValues<double>()[1].resize(1);
-  ASSERT_NO_THROW(transform<pair_self_t<double>>(a, b, op));
-  ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place));
-  b.sparseValues<double>()[1].resize(2);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
-  ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
-               except::SizeError);
 }
 
 class TransformTest_sparse_binary_values_variances_size_fail

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -810,137 +810,6 @@ bool Variable::operator!=(const VariableConstProxy &other) const {
   return !(*this == other);
 }
 
-template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
-  // Addition with different Variable type is supported, mismatch of underlying
-  // element types is handled in DataModel::operator+=.
-  // Different name is ok for addition.
-  expect::equals(variable.unit(), other.unit());
-  expect::contains(variable.dims(), other.dims());
-  // Note: This will broadcast/transpose the RHS if required. We do not support
-  // changing the dimensions of the LHS though!
-  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { a += b; });
-  return variable;
-}
-
-using arithmetic_type_pairs =
-    std::tuple<std::pair<double, double>, std::pair<float, float>,
-               std::pair<int64_t, int64_t>, std::pair<double, float>,
-               std::pair<float, double>>;
-using arithmetic_and_matrix_type_pairs = decltype(
-    std::tuple_cat(std::declval<arithmetic_type_pairs>(),
-                   std::tuple<std::pair<Eigen::Vector3d, Eigen::Vector3d>>()));
-
-template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
-  expect::equals(a.unit(), b.unit());
-  auto result = transform<arithmetic_and_matrix_type_pairs>(
-      a, b, [](const auto a, const auto b) { return a + b; });
-  result.setUnit(a.unit());
-  return result;
-}
-
-Variable Variable::operator-() const {
-  auto result = transform<double, float, int64_t, Eigen::Vector3d>(
-      *this, [](const auto a) { return -a; });
-  result.setUnit(unit());
-  return result;
-}
-
-Variable &Variable::operator+=(const Variable &other) & {
-  return plus_equals(*this, other);
-}
-Variable &Variable::operator+=(const VariableConstProxy &other) & {
-  return plus_equals(*this, other);
-}
-Variable &Variable::operator+=(const double value) & {
-  // TODO By not setting a unit here this operator is only usable if the
-  // variable is dimensionless. Should we ignore the unit for scalar operations,
-  // i.e., set the same unit as *this.unit()?
-  return plus_equals(*this, makeVariable<double>(value));
-}
-
-template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
-  expect::equals(variable.unit(), other.unit());
-  expect::contains(variable.dims(), other.dims());
-  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { a -= b; });
-  return variable;
-}
-
-template <class T1, class T2> Variable minus(const T1 &a, const T2 &b) {
-  expect::equals(a.unit(), b.unit());
-  auto result = transform<arithmetic_and_matrix_type_pairs>(
-      a, b, [](const auto a, const auto b) { return a - b; });
-  result.setUnit(a.unit());
-  return result;
-}
-
-Variable &Variable::operator-=(const Variable &other) & {
-  return minus_equals(*this, other);
-}
-Variable &Variable::operator-=(const VariableConstProxy &other) & {
-  return minus_equals(*this, other);
-}
-Variable &Variable::operator-=(const double value) & {
-  return minus_equals(*this, makeVariable<double>(value));
-}
-
-template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
-  expect::contains(variable.dims(), other.dims());
-  // setUnit is catching bad cases of changing units (if `variable` is a slice).
-  variable.setUnit(variable.unit() * other.unit());
-  transform_in_place<pair_self_t<double, float, int64_t>,
-                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { a *= b; });
-  return variable;
-}
-
-template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
-  auto result = transform<arithmetic_type_pairs>(
-      a, b, [](const auto a, const auto b) { return a * b; });
-  result.setUnit(a.unit() * b.unit());
-  return result;
-}
-
-Variable &Variable::operator*=(const Variable &other) & {
-  return times_equals(*this, other);
-}
-Variable &Variable::operator*=(const VariableConstProxy &other) & {
-  return times_equals(*this, other);
-}
-Variable &Variable::operator*=(const double value) & {
-  auto other = makeVariable<double>(value);
-  other.setUnit(units::dimensionless);
-  return times_equals(*this, other);
-}
-
-template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
-  expect::contains(variable.dims(), other.dims());
-  // setUnit is catching bad cases of changing units (if `variable` is a slice).
-  variable.setUnit(variable.unit() / other.unit());
-  transform_in_place<pair_self_t<double, float, int64_t>,
-                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { a /= b; });
-  return variable;
-}
-
-template <class T1, class T2> Variable divide(const T1 &a, const T2 &b) {
-  auto result = transform<arithmetic_type_pairs>(
-      a, b, [](const auto a, const auto b) { return a / b; });
-  result.setUnit(a.unit() / b.unit());
-  return result;
-}
-
-Variable &Variable::operator/=(const Variable &other) & {
-  return divide_equals(*this, other);
-}
-Variable &Variable::operator/=(const VariableConstProxy &other) & {
-  return divide_equals(*this, other);
-}
-Variable &Variable::operator/=(const double value) & {
-  return divide_equals(*this, makeVariable<double>(value));
-}
-
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
   setUnit(other.unit());
   if (dims() != other.dims())
@@ -951,46 +820,6 @@ template <class T> VariableProxy VariableProxy::assign(const T &other) const {
 
 template VariableProxy VariableProxy::assign(const Variable &) const;
 template VariableProxy VariableProxy::assign(const VariableConstProxy &) const;
-
-VariableProxy VariableProxy::operator+=(const Variable &other) const {
-  return plus_equals(*this, other);
-}
-VariableProxy VariableProxy::operator+=(const VariableConstProxy &other) const {
-  return plus_equals(*this, other);
-}
-VariableProxy VariableProxy::operator+=(const double value) const {
-  return plus_equals(*this, makeVariable<double>(value));
-}
-
-VariableProxy VariableProxy::operator-=(const Variable &other) const {
-  return minus_equals(*this, other);
-}
-VariableProxy VariableProxy::operator-=(const VariableConstProxy &other) const {
-  return minus_equals(*this, other);
-}
-VariableProxy VariableProxy::operator-=(const double value) const {
-  return minus_equals(*this, makeVariable<double>(value));
-}
-
-VariableProxy VariableProxy::operator*=(const Variable &other) const {
-  return times_equals(*this, other);
-}
-VariableProxy VariableProxy::operator*=(const VariableConstProxy &other) const {
-  return times_equals(*this, other);
-}
-VariableProxy VariableProxy::operator*=(const double value) const {
-  return times_equals(*this, makeVariable<double>(value));
-}
-
-VariableProxy VariableProxy::operator/=(const Variable &other) const {
-  return divide_equals(*this, other);
-}
-VariableProxy VariableProxy::operator/=(const VariableConstProxy &other) const {
-  return divide_equals(*this, other);
-}
-VariableProxy VariableProxy::operator/=(const double value) const {
-  return divide_equals(*this, makeVariable<double>(value));
-}
 
 bool VariableConstProxy::operator==(const Variable &other) const {
   // Always use deep comparison (pointer comparison does not make sense since we
@@ -1006,11 +835,6 @@ bool VariableConstProxy::operator!=(const Variable &other) const {
 }
 bool VariableConstProxy::operator!=(const VariableConstProxy &other) const {
   return !(*this == other);
-}
-
-Variable VariableConstProxy::operator-() const {
-  Variable copy(*this);
-  return -copy;
 }
 
 void VariableProxy::setUnit(const units::Unit &unit) const {
@@ -1116,65 +940,6 @@ Variable VariableConstProxy::reshape(const Dimensions &dims) const {
   Variable reshaped(*this);
   reshaped.setDims(dims);
   return reshaped;
-}
-
-Variable operator+(const Variable &a, const Variable &b) { return plus(a, b); }
-Variable operator-(const Variable &a, const Variable &b) { return minus(a, b); }
-Variable operator*(const Variable &a, const Variable &b) { return times(a, b); }
-Variable operator/(const Variable &a, const Variable &b) {
-  return divide(a, b);
-}
-Variable operator+(const Variable &a, const VariableConstProxy &b) {
-  return plus(a, b);
-}
-Variable operator-(const Variable &a, const VariableConstProxy &b) {
-  return minus(a, b);
-}
-Variable operator*(const Variable &a, const VariableConstProxy &b) {
-  return times(a, b);
-}
-Variable operator/(const Variable &a, const VariableConstProxy &b) {
-  return divide(a, b);
-}
-Variable operator+(const VariableConstProxy &a, const Variable &b) {
-  return plus(a, b);
-}
-Variable operator-(const VariableConstProxy &a, const Variable &b) {
-  return minus(a, b);
-}
-Variable operator*(const VariableConstProxy &a, const Variable &b) {
-  return times(a, b);
-}
-Variable operator/(const VariableConstProxy &a, const Variable &b) {
-  return divide(a, b);
-}
-Variable operator+(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return plus(a, b);
-}
-Variable operator-(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return minus(a, b);
-}
-Variable operator*(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return times(a, b);
-}
-Variable operator/(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return divide(a, b);
-}
-// Note: The std::move here is necessary because RVO does not work for variables
-// that are function parameters.
-Variable operator+(Variable a, const double b) { return std::move(a += b); }
-Variable operator-(Variable a, const double b) { return std::move(a -= b); }
-Variable operator*(Variable a, const double b) { return std::move(a *= b); }
-Variable operator/(Variable a, const double b) { return std::move(a /= b); }
-Variable operator+(const double a, Variable b) { return std::move(b += a); }
-Variable operator-(const double a, Variable b) { return -(b -= a); }
-Variable operator*(const double a, Variable b) { return std::move(b *= a); }
-Variable operator/(const double a, Variable b) {
-  b.setUnit(units::Unit(units::dimensionless) / b.unit());
-  transform_in_place<double, float>(b, overloaded{[a](double &b) { b = a / b; },
-                                                  [a](float &b) { b = a / b; },
-                                                  [a](auto &b) { b = a / b; }});
-  return std::move(b);
 }
 
 // Example of a "derived" operation: Implementation does not require adding a

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -1201,11 +1201,9 @@ Variable concatenate(const Variable &a1, const Variable &a2, const Dim dim) {
 
   if (a1.dims().sparseDim() == dim && a2.dims().sparseDim() == dim) {
     Variable out(a1);
-    // TODO Sanitize transform_in_place implementation so the functor signature
-    // is more reasonable.
     transform_in_place<pair_self_t<sparse_container<double>>>(
         out, a2,
-        [](auto &&a, auto &&b) { a.insert(a.end(), b.begin(), b.end()); });
+        [](auto &a, const auto &b) { a.insert(a.end(), b.begin(), b.end()); });
     return out;
   }
 

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <cmath>
+
+#include "scipp/core/except.h"
+#include "scipp/core/transform.h"
+#include "scipp/core/variable.h"
+
+namespace scipp::core {
+
+template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
+  // Addition with different Variable type is supported, mismatch of underlying
+  // element types is handled in DataModel::operator+=.
+  // Different name is ok for addition.
+  expect::equals(variable.unit(), other.unit());
+  expect::contains(variable.dims(), other.dims());
+  // Note: This will broadcast/transpose the RHS if required. We do not support
+  // changing the dimensions of the LHS though!
+  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
+      variable, other, [](auto &&a, auto &&b) { a += b; });
+  return variable;
+}
+
+using arithmetic_type_pairs =
+    std::tuple<std::pair<double, double>, std::pair<float, float>,
+               std::pair<int64_t, int64_t>, std::pair<double, float>,
+               std::pair<float, double>>;
+using arithmetic_and_matrix_type_pairs = decltype(
+    std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                   std::tuple<std::pair<Eigen::Vector3d, Eigen::Vector3d>>()));
+
+template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
+  expect::equals(a.unit(), b.unit());
+  auto result = transform<arithmetic_and_matrix_type_pairs>(
+      a, b, [](const auto a, const auto b) { return a + b; });
+  result.setUnit(a.unit());
+  return result;
+}
+
+Variable Variable::operator-() const {
+  auto result = transform<double, float, int64_t, Eigen::Vector3d>(
+      *this, [](const auto a) { return -a; });
+  result.setUnit(unit());
+  return result;
+}
+
+Variable &Variable::operator+=(const Variable &other) & {
+  return plus_equals(*this, other);
+}
+Variable &Variable::operator+=(const VariableConstProxy &other) & {
+  return plus_equals(*this, other);
+}
+Variable &Variable::operator+=(const double value) & {
+  // TODO By not setting a unit here this operator is only usable if the
+  // variable is dimensionless. Should we ignore the unit for scalar operations,
+  // i.e., set the same unit as *this.unit()?
+  return plus_equals(*this, makeVariable<double>(value));
+}
+
+template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
+  expect::equals(variable.unit(), other.unit());
+  expect::contains(variable.dims(), other.dims());
+  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
+      variable, other, [](auto &&a, auto &&b) { a -= b; });
+  return variable;
+}
+
+template <class T1, class T2> Variable minus(const T1 &a, const T2 &b) {
+  expect::equals(a.unit(), b.unit());
+  auto result = transform<arithmetic_and_matrix_type_pairs>(
+      a, b, [](const auto a, const auto b) { return a - b; });
+  result.setUnit(a.unit());
+  return result;
+}
+
+Variable &Variable::operator-=(const Variable &other) & {
+  return minus_equals(*this, other);
+}
+Variable &Variable::operator-=(const VariableConstProxy &other) & {
+  return minus_equals(*this, other);
+}
+Variable &Variable::operator-=(const double value) & {
+  return minus_equals(*this, makeVariable<double>(value));
+}
+
+template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
+  expect::contains(variable.dims(), other.dims());
+  // setUnit is catching bad cases of changing units (if `variable` is a slice).
+  variable.setUnit(variable.unit() * other.unit());
+  transform_in_place<pair_self_t<double, float, int64_t>,
+                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
+      variable, other, [](auto &&a, auto &&b) { a *= b; });
+  return variable;
+}
+
+template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
+  auto result = transform<arithmetic_type_pairs>(
+      a, b, [](const auto a, const auto b) { return a * b; });
+  result.setUnit(a.unit() * b.unit());
+  return result;
+}
+
+Variable &Variable::operator*=(const Variable &other) & {
+  return times_equals(*this, other);
+}
+Variable &Variable::operator*=(const VariableConstProxy &other) & {
+  return times_equals(*this, other);
+}
+Variable &Variable::operator*=(const double value) & {
+  auto other = makeVariable<double>(value);
+  other.setUnit(units::dimensionless);
+  return times_equals(*this, other);
+}
+
+template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
+  expect::contains(variable.dims(), other.dims());
+  // setUnit is catching bad cases of changing units (if `variable` is a slice).
+  variable.setUnit(variable.unit() / other.unit());
+  transform_in_place<pair_self_t<double, float, int64_t>,
+                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
+      variable, other, [](auto &&a, auto &&b) { a /= b; });
+  return variable;
+}
+
+template <class T1, class T2> Variable divide(const T1 &a, const T2 &b) {
+  auto result = transform<arithmetic_type_pairs>(
+      a, b, [](const auto a, const auto b) { return a / b; });
+  result.setUnit(a.unit() / b.unit());
+  return result;
+}
+
+Variable &Variable::operator/=(const Variable &other) & {
+  return divide_equals(*this, other);
+}
+Variable &Variable::operator/=(const VariableConstProxy &other) & {
+  return divide_equals(*this, other);
+}
+Variable &Variable::operator/=(const double value) & {
+  return divide_equals(*this, makeVariable<double>(value));
+}
+
+VariableProxy VariableProxy::operator+=(const Variable &other) const {
+  return plus_equals(*this, other);
+}
+VariableProxy VariableProxy::operator+=(const VariableConstProxy &other) const {
+  return plus_equals(*this, other);
+}
+VariableProxy VariableProxy::operator+=(const double value) const {
+  return plus_equals(*this, makeVariable<double>(value));
+}
+
+VariableProxy VariableProxy::operator-=(const Variable &other) const {
+  return minus_equals(*this, other);
+}
+VariableProxy VariableProxy::operator-=(const VariableConstProxy &other) const {
+  return minus_equals(*this, other);
+}
+VariableProxy VariableProxy::operator-=(const double value) const {
+  return minus_equals(*this, makeVariable<double>(value));
+}
+
+VariableProxy VariableProxy::operator*=(const Variable &other) const {
+  return times_equals(*this, other);
+}
+VariableProxy VariableProxy::operator*=(const VariableConstProxy &other) const {
+  return times_equals(*this, other);
+}
+VariableProxy VariableProxy::operator*=(const double value) const {
+  return times_equals(*this, makeVariable<double>(value));
+}
+
+VariableProxy VariableProxy::operator/=(const Variable &other) const {
+  return divide_equals(*this, other);
+}
+VariableProxy VariableProxy::operator/=(const VariableConstProxy &other) const {
+  return divide_equals(*this, other);
+}
+VariableProxy VariableProxy::operator/=(const double value) const {
+  return divide_equals(*this, makeVariable<double>(value));
+}
+
+Variable VariableConstProxy::operator-() const {
+  Variable copy(*this);
+  return -copy;
+}
+
+Variable operator+(const Variable &a, const Variable &b) { return plus(a, b); }
+Variable operator-(const Variable &a, const Variable &b) { return minus(a, b); }
+Variable operator*(const Variable &a, const Variable &b) { return times(a, b); }
+Variable operator/(const Variable &a, const Variable &b) {
+  return divide(a, b);
+}
+Variable operator+(const Variable &a, const VariableConstProxy &b) {
+  return plus(a, b);
+}
+Variable operator-(const Variable &a, const VariableConstProxy &b) {
+  return minus(a, b);
+}
+Variable operator*(const Variable &a, const VariableConstProxy &b) {
+  return times(a, b);
+}
+Variable operator/(const Variable &a, const VariableConstProxy &b) {
+  return divide(a, b);
+}
+Variable operator+(const VariableConstProxy &a, const Variable &b) {
+  return plus(a, b);
+}
+Variable operator-(const VariableConstProxy &a, const Variable &b) {
+  return minus(a, b);
+}
+Variable operator*(const VariableConstProxy &a, const Variable &b) {
+  return times(a, b);
+}
+Variable operator/(const VariableConstProxy &a, const Variable &b) {
+  return divide(a, b);
+}
+Variable operator+(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return plus(a, b);
+}
+Variable operator-(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return minus(a, b);
+}
+Variable operator*(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return times(a, b);
+}
+Variable operator/(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return divide(a, b);
+}
+// Note: The std::move here is necessary because RVO does not work for variables
+// that are function parameters.
+Variable operator+(Variable a, const double b) { return std::move(a += b); }
+Variable operator-(Variable a, const double b) { return std::move(a -= b); }
+Variable operator*(Variable a, const double b) { return std::move(a *= b); }
+Variable operator/(Variable a, const double b) { return std::move(a /= b); }
+Variable operator+(const double a, Variable b) { return std::move(b += a); }
+Variable operator-(const double a, Variable b) { return -(b -= a); }
+Variable operator*(const double a, Variable b) { return std::move(b *= a); }
+Variable operator/(const double a, Variable b) {
+  b.setUnit(units::Unit(units::dimensionless) / b.unit());
+  transform_in_place<double, float>(b, overloaded{[a](double &b) { b = a / b; },
+                                                  [a](float &b) { b = a / b; },
+                                                  [a](auto &b) { b = a / b; }});
+  return std::move(b);
+}
+
+} // namespace scipp::core


### PR DESCRIPTION
Some cleanup and additions to the tests for `transform` and `transform_in_place`.

Is there anything else that could be tested in a more exhaustive manner? This is not really as exhaustive or automatic as I had in mind, but I am not sure how it could be done better. Ideas welcome!

Fixes #276.