### PR TITLE
Expose values and variances properties as numpy.ndarray-like objects

### DIFF
--- a/scippy/bind_slice_methods.h
+++ b/scippy/bind_slice_methods.h
@@ -129,8 +129,8 @@ template <class T> struct slicer {
 
 template <class T, class... Ignored>
 void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
-  c.def("__getitem__", &slicer<T>::get);
-  c.def("__getitem__", &slicer<T>::get_range);
+  c.def("__getitem__", &slicer<T>::get, py::keep_alive<0, 1>());
+  c.def("__getitem__", &slicer<T>::get_range, py::keep_alive<0, 1>());
   if constexpr (!std::is_same_v<T, Dataset> &&
                 !std::is_same_v<T, DatasetProxy>) {
     c.def("__setitem__", &slicer<T>::set_from_numpy);

--- a/scippy/tests/test_variable.py
+++ b/scippy/tests/test_variable.py
@@ -51,13 +51,13 @@ def test_create_with_variances():
 def test_create_from_numpy_1d():
     var = sp.Variable([sp.Dim.X], np.arange(4.0))
     assert var.dtype == sp.dtype.double
-    np.testing.assert_array_equal(var.numpy, np.arange(4))
+    np.testing.assert_array_equal(var.values, np.arange(4))
 
 
 def test_create_from_numpy_1d_bool():
     var = sp.Variable(labels=[sp.Dim.X], values=np.array([True, False, True]))
     assert var.dtype == sp.dtype.bool
-    np.testing.assert_array_equal(var.numpy, np.array([True, False, True]))
+    np.testing.assert_array_equal(var.values, np.array([True, False, True]))
 
 
 def test_create_with_variances_from_numpy_1d():
@@ -172,69 +172,69 @@ def test_slicing():
     var_slice = var[(sp.Dim.X, slice(0, 2))]
     assert isinstance(var_slice, sp.VariableProxy)
     assert len(var_slice.values) == 2
-    assert np.array_equal(var_slice.numpy, np.array([0, 1]))
+    assert np.array_equal(var_slice.values, np.array([0, 1]))
 
 
 def test_binary_plus():
     a, b, a_slice, b_slice, data = make_variables()
     c = a + b
-    assert np.array_equal(c.numpy, data + data)
+    assert np.array_equal(c.values, data + data)
     c = a + 2.0
-    assert np.array_equal(c.numpy, data + 2.0)
+    assert np.array_equal(c.values, data + 2.0)
     c = a + b_slice
-    assert np.array_equal(c.numpy, data + data)
+    assert np.array_equal(c.values, data + data)
     c += b
-    assert np.array_equal(c.numpy, data + data + data)
+    assert np.array_equal(c.values, data + data + data)
     c += b_slice
-    assert np.array_equal(c.numpy, data + data + data + data)
+    assert np.array_equal(c.values, data + data + data + data)
     c = 3.5 + c
-    assert np.array_equal(c.numpy, data + data + data + data + 3.5)
+    assert np.array_equal(c.values, data + data + data + data + 3.5)
 
 
 def test_binary_minus():
     a, b, a_slice, b_slice, data = make_variables()
     c = a - b
-    assert np.array_equal(c.numpy, data - data)
+    assert np.array_equal(c.values, data - data)
     c = a - 2.0
-    assert np.array_equal(c.numpy, data - 2.0)
+    assert np.array_equal(c.values, data - 2.0)
     c = a - b_slice
-    assert np.array_equal(c.numpy, data - data)
+    assert np.array_equal(c.values, data - data)
     c -= b
-    assert np.array_equal(c.numpy, data - data - data)
+    assert np.array_equal(c.values, data - data - data)
     c -= b_slice
-    assert np.array_equal(c.numpy, data - data - data - data)
+    assert np.array_equal(c.values, data - data - data - data)
     c = 3.5 - c
-    assert np.array_equal(c.numpy, 3.5 - data + data + data + data)
+    assert np.array_equal(c.values, 3.5 - data + data + data + data)
 
 
 def test_binary_multiply():
     a, b, a_slice, b_slice, data = make_variables()
     c = a * b
-    assert np.array_equal(c.numpy, data * data)
+    assert np.array_equal(c.values, data * data)
     c = a * 2.0
-    assert np.array_equal(c.numpy, data * 2.0)
+    assert np.array_equal(c.values, data * 2.0)
     c = a * b_slice
-    assert np.array_equal(c.numpy, data * data)
+    assert np.array_equal(c.values, data * data)
     c *= b
-    assert np.array_equal(c.numpy, data * data * data)
+    assert np.array_equal(c.values, data * data * data)
     c *= b_slice
-    assert np.array_equal(c.numpy, data * data * data * data)
+    assert np.array_equal(c.values, data * data * data * data)
     c = 3.5 * c
-    assert np.array_equal(c.numpy, data * data * data * data * 3.5)
+    assert np.array_equal(c.values, data * data * data * data * 3.5)
 
 
 def test_binary_divide():
     a, b, a_slice, b_slice, data = make_variables()
     c = a / b
-    assert np.array_equal(c.numpy, data / data)
+    assert np.array_equal(c.values, data / data)
     c = a / 2.0
-    assert np.array_equal(c.numpy, data / 2.0)
+    assert np.array_equal(c.values, data / 2.0)
     c = a / b_slice
-    assert np.array_equal(c.numpy, data / data)
+    assert np.array_equal(c.values, data / data)
     c /= b
-    assert np.array_equal(c.numpy, data / data / data)
+    assert np.array_equal(c.values, data / data / data)
     c /= b_slice
-    assert np.array_equal(c.numpy, data / data / data / data)
+    assert np.array_equal(c.values, data / data / data / data)
 
 
 def test_binary_equal():

--- a/scippy/tests/test_variable.py
+++ b/scippy/tests/test_variable.py
@@ -99,15 +99,46 @@ def test_0D_scalar_access():
     assert var.value == 0.0
     var.value = 1.2
     assert var.value == 1.2
-    assert var.values[0] == 1.2
+    assert var.values.shape == ()
+    assert var.values == 1.2
 
 
 def test_1D_scalar_access_fail():
-    var = sp.Variable([sp.Dim.X], (1,))
+    var = sp.Variable([Dim.X], (1,))
     with pytest.raises(RuntimeError):
         assert var.value == 0.0
     with pytest.raises(RuntimeError):
         var.value = 1.2
+
+
+def test_1D_access():
+    var = sp.Variable([Dim.X], (2,))
+    assert len(var.values) == 2
+    assert var.values.shape == (2,)
+    var.values[1] = 1.2
+    assert var.values[1] == 1.2
+
+
+def test_2D_access():
+    var = sp.Variable([Dim.X, Dim.Y], (2,3))
+    assert var.values.shape == (2,3)
+    assert len(var.values) == 2
+    assert len(var.values[0]) == 3
+    var.values[1] = 1.2 # numpy assigns to all elements in "slice"
+    var.values[1][2] = 2.2
+    assert var.values[1][0] == 1.2
+    assert var.values[1][1] == 1.2
+    assert var.values[1][2] == 2.2
+
+
+def test_2D_access_variances():
+    var = sp.Variable([Dim.X, Dim.Y], (2,3), variances=True)
+    assert var.values.shape == (2,3)
+    assert var.variances.shape == (2,3)
+    var.values[1] = 1.2
+    assert np.array_equal(var.variances, np.zeros(shape=(2,3)))
+    var.variances = np.ones(shape=(2,3))
+    assert np.array_equal(var.variances, np.ones(shape=(2,3)))
 
 
 def test_create_dtype():

--- a/scippy/tests/test_variable.py
+++ b/scippy/tests/test_variable.py
@@ -120,11 +120,11 @@ def test_1D_access():
 
 
 def test_2D_access():
-    var = sp.Variable([Dim.X, Dim.Y], (2,3))
-    assert var.values.shape == (2,3)
+    var = sp.Variable([Dim.X, Dim.Y], (2, 3))
+    assert var.values.shape == (2, 3)
     assert len(var.values) == 2
     assert len(var.values[0]) == 3
-    var.values[1] = 1.2 # numpy assigns to all elements in "slice"
+    var.values[1] = 1.2  # numpy assigns to all elements in "slice"
     var.values[1][2] = 2.2
     assert var.values[1][0] == 1.2
     assert var.values[1][1] == 1.2
@@ -132,13 +132,13 @@ def test_2D_access():
 
 
 def test_2D_access_variances():
-    var = sp.Variable([Dim.X, Dim.Y], (2,3), variances=True)
-    assert var.values.shape == (2,3)
-    assert var.variances.shape == (2,3)
+    var = sp.Variable([Dim.X, Dim.Y], (2, 3), variances=True)
+    assert var.values.shape == (2, 3)
+    assert var.variances.shape == (2, 3)
     var.values[1] = 1.2
-    assert np.array_equal(var.variances, np.zeros(shape=(2,3)))
-    var.variances = np.ones(shape=(2,3))
-    assert np.array_equal(var.variances, np.ones(shape=(2,3)))
+    assert np.array_equal(var.variances, np.zeros(shape=(2, 3)))
+    var.variances = np.ones(shape=(2, 3))
+    assert np.array_equal(var.variances, np.ones(shape=(2, 3)))
 
 
 def test_create_dtype():

--- a/scippy/tests/test_variable_proxy.py
+++ b/scippy/tests/test_variable_proxy.py
@@ -17,8 +17,8 @@ def test_type():
 def apply_test_op(op, a, b, data):
     op(a, b)
     # Assume numpy operations are correct as comparitor
-    op(data, b.numpy)
-    assert np.array_equal(a.numpy, data)
+    op(data, b.values)
+    assert np.array_equal(a.values, data)
 
 
 def test_binary_operations():
@@ -27,16 +27,16 @@ def test_binary_operations():
     a = _a[Dim.X, :]
     b = _b[Dim.X, :]
 
-    data = np.copy(a.numpy)
+    data = np.copy(a.values)
     c = a + b
     assert type(c) == sp.Variable
-    assert np.array_equal(c.numpy, data + data)
+    assert np.array_equal(c.values, data + data)
     c = a - b
-    assert np.array_equal(c.numpy, data - data)
+    assert np.array_equal(c.values, data - data)
     c = a * b
-    assert np.array_equal(c.numpy, data * data)
+    assert np.array_equal(c.values, data * data)
     c = a / b
-    assert np.array_equal(c.numpy, data / data)
+    assert np.array_equal(c.values, data / data)
 
     apply_test_op(operator.iadd, a, b, data)
     apply_test_op(operator.isub, a, b, data)
@@ -47,21 +47,21 @@ def test_binary_operations():
 def test_binary_float_operations():
     _a = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
     a = _a[Dim.X, :]
-    data = np.copy(a.numpy)
+    data = np.copy(a.values)
     c = a + 2.0
-    assert np.array_equal(c.numpy, data + 2.0)
+    assert np.array_equal(c.values, data + 2.0)
     c = a - 2.0
-    assert np.array_equal(c.numpy, data - 2.0)
+    assert np.array_equal(c.values, data - 2.0)
     c = a * 2.0
-    assert np.array_equal(c.numpy, data * 2.0)
+    assert np.array_equal(c.values, data * 2.0)
     c = a / 2.0
-    assert np.array_equal(c.numpy, data / 2.0)
+    assert np.array_equal(c.values, data / 2.0)
     c = 2.0 + a
-    assert np.array_equal(c.numpy, data + 2.0)
+    assert np.array_equal(c.values, data + 2.0)
     c = 2.0 - a
-    assert np.array_equal(c.numpy, 2.0 - data)
+    assert np.array_equal(c.values, 2.0 - data)
     c = 2.0 * a
-    assert np.array_equal(c.numpy, data * 2.0)
+    assert np.array_equal(c.values, data * 2.0)
 
 
 def test_equal_not_equal():

--- a/scippy/variable.cpp
+++ b/scippy/variable.cpp
@@ -57,8 +57,6 @@ template <class T> struct MakeVariableDefaultInit {
 };
 
 namespace scippy {
-using dtype = std::variant<py::dtype, scipp::core::DType>;
-
 scipp::core::DType scipp_dtype(const py::dtype &type) {
   if (type.is(py::dtype::of<double>()))
     return scipp::core::dtype<double>;

--- a/scippy/variable.cpp
+++ b/scippy/variable.cpp
@@ -155,11 +155,6 @@ void init_variable(py::module &m) {
       .def("__deepcopy__",
            [](Variable &self, py::dict) { return Variable(self); })
       .def_property_readonly("dtype", &Variable::dtype)
-      .def_property_readonly(
-          "numpy",
-          &as_py_array_t<get_values, Variable, double, float, int64_t, int32_t,
-                         bool>,
-          "Returns a read-only numpy array containing the Variable's values.")
       .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + double(), py::call_guard<py::gil_scoped_release>())
@@ -215,12 +210,6 @@ void init_variable(py::module &m) {
       .def("__copy__", [](VariableProxy &self) { return Variable(self); })
       .def("__deepcopy__",
            [](VariableProxy &self, py::dict) { return Variable(self); })
-      .def_property_readonly(
-          "numpy",
-          &as_py_array_t<get_values, VariableProxy, double, float, int64_t,
-                         int32_t, bool>,
-          "Returns a read-only numpy array containing the VariableProxy's "
-          "values.")
       .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self /= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())

--- a/scippy/variable.cpp
+++ b/scippy/variable.cpp
@@ -157,7 +157,8 @@ void init_variable(py::module &m) {
       .def_property_readonly("dtype", &Variable::dtype)
       .def_property_readonly(
           "numpy",
-          &as_py_array_t<Variable, double, float, int64_t, int32_t, bool>,
+          &as_py_array_t<get_values, Variable, double, float, int64_t, int32_t,
+                         bool>,
           "Returns a read-only numpy array containing the Variable's values.")
       .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
@@ -216,7 +217,8 @@ void init_variable(py::module &m) {
            [](VariableProxy &self, py::dict) { return Variable(self); })
       .def_property_readonly(
           "numpy",
-          &as_py_array_t<VariableProxy, double, float, int64_t, int32_t, bool>,
+          &as_py_array_t<get_values, VariableProxy, double, float, int64_t,
+                         int32_t, bool>,
           "Returns a read-only numpy array containing the VariableProxy's "
           "values.")
       .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())


### PR DESCRIPTION
This implements most of the Python-facing part of #289. I feel that this is a definite improvement, in particular since it will be less confusing for someone familiar with `numpy` or `xarray`. Furthermore it decreases the API differences, so we are a step closer to interoperability.

I opened #290 to solve some follow-up tasks.