### PR TITLE
Remaining binary operations

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -750,8 +750,28 @@ Dataset operator+(const Dataset &lhs, const Dataset &rhs) {
   return res;
 }
 
+Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs);
+  apply(plus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(plus_equals, res, rhs);
+  return res;
+}
+
 Dataset operator+(Dataset &&lhs, const Dataset &rhs) {
   return apply(plus_equals, lhs, rhs);
+}
+
+Dataset operator+(Dataset &&lhs, const DatasetConstProxy &rhs) {
+  return apply(plus_equals, lhs, rhs);
+}
+
+Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs) {
+  return apply_with_delay(plus_equals, lhs, rhs);
 }
 
 Dataset operator+(const Dataset &lhs, Dataset &&rhs) {
@@ -760,54 +780,6 @@ Dataset operator+(const Dataset &lhs, Dataset &&rhs) {
 
 Dataset operator+(Dataset &&lhs, Dataset &&rhs) {
   return apply(plus_equals, lhs, rhs);
-}
-
-Dataset operator-(const Dataset &lhs, const Dataset &rhs) {
-  Dataset res(lhs);
-  apply(minus_equals, res, rhs);
-  return res;
-}
-
-Dataset operator-(Dataset &&lhs, const Dataset &rhs) {
-  return apply(minus_equals, lhs, rhs);
-}
-
-Dataset operator-(Dataset &&lhs, Dataset &&rhs) {
-  return apply(minus_equals, lhs, rhs);
-}
-
-Dataset operator*(const Dataset &lhs, const Dataset &rhs) {
-  Dataset res(lhs);
-  apply(times_equals, res, rhs);
-  return res;
-}
-
-Dataset operator*(Dataset &&lhs, const Dataset &rhs) {
-  return apply(times_equals, lhs, rhs);
-}
-
-Dataset operator*(Dataset &&lhs, Dataset &&rhs) {
-  return apply(times_equals, lhs, rhs);
-}
-
-Dataset operator/(const Dataset &lhs, const Dataset &rhs) {
-  Dataset res(lhs);
-  apply(divide_equals, res, rhs);
-  return res;
-}
-
-Dataset operator/(Dataset &&lhs, const Dataset &rhs) {
-  return apply(divide_equals, lhs, rhs);
-}
-
-Dataset operator/(Dataset &&lhs, Dataset &&rhs) {
-  return apply(divide_equals, lhs, rhs);
-}
-
-Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs) {
-  Dataset res(lhs);
-  apply(plus_equals, res, rhs);
-  return res;
 }
 
 Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -822,10 +794,38 @@ Dataset operator+(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
   return res;
 }
 
+Dataset operator-(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(minus_equals, res, rhs);
+  return res;
+}
+
 Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs);
   apply(minus_equals, res, rhs);
   return res;
+}
+
+Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(Dataset &&lhs, const Dataset &rhs) {
+  return apply(minus_equals, lhs, rhs);
+}
+
+Dataset operator-(Dataset &&lhs, const DatasetConstProxy &rhs) {
+  return apply(minus_equals, lhs, rhs);
+}
+
+Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs) {
+  return apply_with_delay(minus_equals, lhs, rhs);
+}
+
+Dataset operator-(Dataset &&lhs, Dataset &&rhs) {
+  return apply(minus_equals, lhs, rhs);
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -840,10 +840,38 @@ Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
   return res;
 }
 
+Dataset operator*(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(times_equals, res, rhs);
+  return res;
+}
+
 Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs);
   apply(times_equals, res, rhs);
   return res;
+}
+
+Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(times_equals, res, rhs);
+  return res;
+}
+
+Dataset operator*(Dataset &&lhs, const Dataset &rhs) {
+  return apply(times_equals, lhs, rhs);
+}
+
+Dataset operator*(Dataset &&lhs, const DatasetConstProxy &rhs) {
+  return apply(times_equals, lhs, rhs);
+}
+
+Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs) {
+  return apply_with_delay(times_equals, lhs, rhs);
+}
+
+Dataset operator*(Dataset &&lhs, Dataset &&rhs) {
+  return apply(times_equals, lhs, rhs);
 }
 
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -858,10 +886,38 @@ Dataset operator*(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
   return res;
 }
 
+Dataset operator/(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(divide_equals, res, rhs);
+  return res;
+}
+
 Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs);
   apply(divide_equals, res, rhs);
   return res;
+}
+
+Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(divide_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(Dataset &&lhs, const Dataset &rhs) {
+  return apply(divide_equals, lhs, rhs);
+}
+
+Dataset operator/(Dataset &&lhs, const DatasetConstProxy &rhs) {
+  return apply(divide_equals, lhs, rhs);
+}
+
+Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs) {
+  return apply_with_delay(divide_equals, lhs, rhs);
+}
+
+Dataset operator/(Dataset &&lhs, Dataset &&rhs) {
+  return apply(divide_equals, lhs, rhs);
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -873,30 +929,6 @@ Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {
 Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs.dataset());
   apply(divide_equals, res, rhs);
-  return res;
-}
-
-Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(plus_equals, res, rhs);
-  return res;
-}
-
-Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(minus_equals, res, rhs);
-  return res;
-}
-
-Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(times_equals, res, rhs);
-  return res;
-}
-
-Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(divide_equals, res, rhs);
   return res;
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -388,6 +388,13 @@ DataProxy DataProxy::operator+=(const DataConstProxy &other) const {
   return *this;
 }
 
+DataProxy DataProxy::operator-=(const DataConstProxy &other) const {
+  expect::coordsAndLabelsAreSuperset(*this, other);
+  if (hasData())
+    data() -= other.data();
+  return *this;
+}
+
 DataProxy DataProxy::operator*=(const DataConstProxy &other) const {
   expect::coordsAndLabelsAreSuperset(*this, other);
   if (hasData())
@@ -549,6 +556,7 @@ bool DatasetConstProxy::operator!=(const DatasetConstProxy &other) const {
 }
 
 constexpr static auto plus_equals = [](auto &&a, auto &b) { return a += b; };
+constexpr static auto minus_equals = [](auto &&a, auto &b) { return a -= b; };
 constexpr static auto times_equals = [](auto &&a, auto &b) { return a *= b; };
 
 template <class Op, class A, class B>
@@ -581,12 +589,20 @@ Dataset &Dataset::operator+=(const DataConstProxy &other) {
   return apply_with_delay(plus_equals, *this, other);
 }
 
+Dataset &Dataset::operator-=(const DataConstProxy &other) {
+  return apply_with_delay(minus_equals, *this, other);
+}
+
 Dataset &Dataset::operator*=(const DataConstProxy &other) {
   return apply_with_delay(times_equals, *this, other);
 }
 
 Dataset &Dataset::operator+=(const DatasetConstProxy &other) {
   return apply(plus_equals, *this, other);
+}
+
+Dataset &Dataset::operator-=(const DatasetConstProxy &other) {
+  return apply(minus_equals, *this, other);
 }
 
 Dataset &Dataset::operator*=(const DatasetConstProxy &other) {
@@ -597,12 +613,20 @@ Dataset &Dataset::operator+=(const Dataset &other) {
   return apply(plus_equals, *this, other);
 }
 
+Dataset &Dataset::operator-=(const Dataset &other) {
+  return apply(minus_equals, *this, other);
+}
+
 Dataset &Dataset::operator*=(const Dataset &other) {
   return apply(times_equals, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator+=(const DataConstProxy &other) const {
   return apply_with_delay(plus_equals, *this, other);
+}
+
+DatasetProxy DatasetProxy::operator-=(const DataConstProxy &other) const {
+  return apply_with_delay(minus_equals, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator*=(const DataConstProxy &other) const {
@@ -613,12 +637,20 @@ DatasetProxy DatasetProxy::operator+=(const DatasetConstProxy &other) const {
   return apply(plus_equals, *this, other);
 }
 
+DatasetProxy DatasetProxy::operator-=(const DatasetConstProxy &other) const {
+  return apply(minus_equals, *this, other);
+}
+
 DatasetProxy DatasetProxy::operator*=(const DatasetConstProxy &other) const {
   return apply(times_equals, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator+=(const Dataset &other) const {
   return apply(plus_equals, *this, other);
+}
+
+DatasetProxy DatasetProxy::operator-=(const Dataset &other) const {
+  return apply(minus_equals, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator*=(const Dataset &other) const {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -402,6 +402,13 @@ DataProxy DataProxy::operator*=(const DataConstProxy &other) const {
   return *this;
 }
 
+DataProxy DataProxy::operator/=(const DataConstProxy &other) const {
+  expect::coordsAndLabelsAreSuperset(*this, other);
+  if (hasData())
+    data() /= other.data();
+  return *this;
+}
+
 DataProxy DataProxy::operator*=(const Variable &other) const {
   if (hasData())
     data() *= other;
@@ -558,6 +565,7 @@ bool DatasetConstProxy::operator!=(const DatasetConstProxy &other) const {
 constexpr static auto plus_equals = [](auto &&a, auto &b) { return a += b; };
 constexpr static auto minus_equals = [](auto &&a, auto &b) { return a -= b; };
 constexpr static auto times_equals = [](auto &&a, auto &b) { return a *= b; };
+constexpr static auto divide_equals = [](auto &&a, auto &b) { return a /= b; };
 
 template <class Op, class A, class B>
 auto &apply(const Op &op, A &a, const B &b) {
@@ -597,6 +605,10 @@ Dataset &Dataset::operator*=(const DataConstProxy &other) {
   return apply_with_delay(times_equals, *this, other);
 }
 
+Dataset &Dataset::operator/=(const DataConstProxy &other) {
+  return apply_with_delay(divide_equals, *this, other);
+}
+
 Dataset &Dataset::operator+=(const DatasetConstProxy &other) {
   return apply(plus_equals, *this, other);
 }
@@ -607,6 +619,10 @@ Dataset &Dataset::operator-=(const DatasetConstProxy &other) {
 
 Dataset &Dataset::operator*=(const DatasetConstProxy &other) {
   return apply(times_equals, *this, other);
+}
+
+Dataset &Dataset::operator/=(const DatasetConstProxy &other) {
+  return apply(divide_equals, *this, other);
 }
 
 Dataset &Dataset::operator+=(const Dataset &other) {
@@ -621,6 +637,10 @@ Dataset &Dataset::operator*=(const Dataset &other) {
   return apply(times_equals, *this, other);
 }
 
+Dataset &Dataset::operator/=(const Dataset &other) {
+  return apply(divide_equals, *this, other);
+}
+
 DatasetProxy DatasetProxy::operator+=(const DataConstProxy &other) const {
   return apply_with_delay(plus_equals, *this, other);
 }
@@ -631,6 +651,10 @@ DatasetProxy DatasetProxy::operator-=(const DataConstProxy &other) const {
 
 DatasetProxy DatasetProxy::operator*=(const DataConstProxy &other) const {
   return apply_with_delay(times_equals, *this, other);
+}
+
+DatasetProxy DatasetProxy::operator/=(const DataConstProxy &other) const {
+  return apply_with_delay(divide_equals, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator+=(const DatasetConstProxy &other) const {
@@ -645,6 +669,10 @@ DatasetProxy DatasetProxy::operator*=(const DatasetConstProxy &other) const {
   return apply(times_equals, *this, other);
 }
 
+DatasetProxy DatasetProxy::operator/=(const DatasetConstProxy &other) const {
+  return apply(divide_equals, *this, other);
+}
+
 DatasetProxy DatasetProxy::operator+=(const Dataset &other) const {
   return apply(plus_equals, *this, other);
 }
@@ -655,6 +683,10 @@ DatasetProxy DatasetProxy::operator-=(const Dataset &other) const {
 
 DatasetProxy DatasetProxy::operator*=(const Dataset &other) const {
   return apply(times_equals, *this, other);
+}
+
+DatasetProxy DatasetProxy::operator/=(const Dataset &other) const {
+  return apply(divide_equals, *this, other);
 }
 
 std::ostream &operator<<(std::ostream &os, const DataConstProxy &data) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -810,8 +810,32 @@ Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs) {
   return res;
 }
 
+Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs) {
+  Dataset res(lhs.dataset());
+  apply(plus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator+(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs.dataset());
+  apply(plus_equals, res, rhs);
+  return res;
+}
+
 Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs);
+  apply(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
+  Dataset res(lhs.dataset());
+  apply(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs.dataset());
   apply(minus_equals, res, rhs);
   return res;
 }
@@ -822,8 +846,32 @@ Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs) {
   return res;
 }
 
+Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
+  Dataset res(lhs.dataset());
+  apply(times_equals, res, rhs);
+  return res;
+}
+
+Dataset operator*(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs.dataset());
+  apply(times_equals, res, rhs);
+  return res;
+}
+
 Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs) {
   Dataset res(lhs);
+  apply(divide_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {
+  Dataset res(lhs.dataset());
+  apply(divide_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs.dataset());
   apply(divide_equals, res, rhs);
   return res;
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -562,10 +562,21 @@ bool DatasetConstProxy::operator!=(const DatasetConstProxy &other) const {
   return !dataset_equals(*this, other);
 }
 
-constexpr static auto plus_equals = [](auto &&a, auto &b) { return a += b; };
-constexpr static auto minus_equals = [](auto &&a, auto &b) { return a -= b; };
-constexpr static auto times_equals = [](auto &&a, auto &b) { return a *= b; };
-constexpr static auto divide_equals = [](auto &&a, auto &b) { return a /= b; };
+constexpr static auto plus_equals = [](auto &&a, const auto &b) {
+  return a += b;
+};
+
+constexpr static auto minus_equals = [](auto &&a, const auto &b) {
+  return a -= b;
+};
+
+constexpr static auto times_equals = [](auto &&a, const auto &b) {
+  return a *= b;
+};
+
+constexpr static auto divide_equals = [](auto &&a, const auto &b) {
+  return a /= b;
+};
 
 template <class Op, class A, class B>
 auto &apply(const Op &op, A &a, const B &b) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -744,4 +744,112 @@ std::ostream &operator<<(std::ostream &os, const Dim dim) {
   return os << to_string(dim);
 }
 
+Dataset operator+(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(plus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator+(Dataset &&lhs, const Dataset &rhs) {
+  return apply(plus_equals, lhs, rhs);
+}
+
+Dataset operator+(const Dataset &lhs, Dataset &&rhs) {
+  return apply(plus_equals, rhs, lhs);
+}
+
+Dataset operator+(Dataset &&lhs, Dataset &&rhs) {
+  return apply(plus_equals, lhs, rhs);
+}
+
+Dataset operator-(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(Dataset &&lhs, const Dataset &rhs) {
+  return apply(minus_equals, lhs, rhs);
+}
+
+Dataset operator-(Dataset &&lhs, Dataset &&rhs) {
+  return apply(minus_equals, lhs, rhs);
+}
+
+Dataset operator*(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(times_equals, res, rhs);
+  return res;
+}
+
+Dataset operator*(Dataset &&lhs, const Dataset &rhs) {
+  return apply(times_equals, lhs, rhs);
+}
+
+Dataset operator*(Dataset &&lhs, Dataset &&rhs) {
+  return apply(times_equals, lhs, rhs);
+}
+
+Dataset operator/(const Dataset &lhs, const Dataset &rhs) {
+  Dataset res(lhs);
+  apply(divide_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(Dataset &&lhs, const Dataset &rhs) {
+  return apply(divide_equals, lhs, rhs);
+}
+
+Dataset operator/(Dataset &&lhs, Dataset &&rhs) {
+  return apply(divide_equals, lhs, rhs);
+}
+
+Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs);
+  apply(plus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs);
+  apply(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs);
+  apply(times_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs) {
+  Dataset res(lhs);
+  apply(divide_equals, res, rhs);
+  return res;
+}
+
+Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(plus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(minus_equals, res, rhs);
+  return res;
+}
+
+Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(times_equals, res, rhs);
+  return res;
+}
+
+Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
+  Dataset res(lhs);
+  apply_with_delay(divide_equals, res, rhs);
+  return res;
+}
+
 } // namespace scipp::core

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -185,6 +185,7 @@ public:
   DataProxy operator+=(const DataConstProxy &other) const;
   DataProxy operator-=(const DataConstProxy &other) const;
   DataProxy operator*=(const DataConstProxy &other) const;
+  DataProxy operator/=(const DataConstProxy &other) const;
   DataProxy operator*=(const Variable &other) const;
   DataProxy operator/=(const Variable &other) const;
 
@@ -296,12 +297,15 @@ public:
   Dataset &operator+=(const DataConstProxy &other);
   Dataset &operator-=(const DataConstProxy &other);
   Dataset &operator*=(const DataConstProxy &other);
+  Dataset &operator/=(const DataConstProxy &other);
   Dataset &operator+=(const DatasetConstProxy &other);
   Dataset &operator-=(const DatasetConstProxy &other);
   Dataset &operator*=(const DatasetConstProxy &other);
+  Dataset &operator/=(const DatasetConstProxy &other);
   Dataset &operator+=(const Dataset &other);
   Dataset &operator-=(const Dataset &other);
   Dataset &operator*=(const Dataset &other);
+  Dataset &operator/=(const Dataset &other);
 
 private:
   friend class DatasetConstProxy;
@@ -598,12 +602,15 @@ public:
   DatasetProxy operator+=(const DataConstProxy &other) const;
   DatasetProxy operator-=(const DataConstProxy &other) const;
   DatasetProxy operator*=(const DataConstProxy &other) const;
+  DatasetProxy operator/=(const DataConstProxy &other) const;
   DatasetProxy operator+=(const DatasetConstProxy &other) const;
   DatasetProxy operator-=(const DatasetConstProxy &other) const;
   DatasetProxy operator*=(const DatasetConstProxy &other) const;
+  DatasetProxy operator/=(const DatasetConstProxy &other) const;
   DatasetProxy operator+=(const Dataset &other) const;
   DatasetProxy operator-=(const Dataset &other) const;
   DatasetProxy operator*=(const Dataset &other) const;
+  DatasetProxy operator/=(const Dataset &other) const;
 
 private:
   Dataset *m_mutableDataset;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -183,6 +183,7 @@ public:
   DataProxy assign(const Variable &other) const;
   DataProxy assign(const VariableConstProxy &other) const;
   DataProxy operator+=(const DataConstProxy &other) const;
+  DataProxy operator-=(const DataConstProxy &other) const;
   DataProxy operator*=(const DataConstProxy &other) const;
   DataProxy operator*=(const Variable &other) const;
   DataProxy operator/=(const Variable &other) const;
@@ -293,10 +294,13 @@ public:
   bool operator!=(const DatasetConstProxy &other) const;
 
   Dataset &operator+=(const DataConstProxy &other);
+  Dataset &operator-=(const DataConstProxy &other);
   Dataset &operator*=(const DataConstProxy &other);
   Dataset &operator+=(const DatasetConstProxy &other);
+  Dataset &operator-=(const DatasetConstProxy &other);
   Dataset &operator*=(const DatasetConstProxy &other);
   Dataset &operator+=(const Dataset &other);
+  Dataset &operator-=(const Dataset &other);
   Dataset &operator*=(const Dataset &other);
 
 private:
@@ -592,10 +596,13 @@ public:
   }
 
   DatasetProxy operator+=(const DataConstProxy &other) const;
+  DatasetProxy operator-=(const DataConstProxy &other) const;
   DatasetProxy operator*=(const DataConstProxy &other) const;
   DatasetProxy operator+=(const DatasetConstProxy &other) const;
+  DatasetProxy operator-=(const DatasetConstProxy &other) const;
   DatasetProxy operator*=(const DatasetConstProxy &other) const;
   DatasetProxy operator+=(const Dataset &other) const;
+  DatasetProxy operator-=(const Dataset &other) const;
   DatasetProxy operator*=(const Dataset &other) const;
 
 private:

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -626,6 +626,33 @@ std::ostream &operator<<(std::ostream &os, const VariableProxy &variable);
 std::ostream &operator<<(std::ostream &os, const Variable &variable);
 std::ostream &operator<<(std::ostream &os, const Dim dim);
 
+Dataset operator+(const Dataset &lhs, const Dataset &rhs);
+Dataset operator+(Dataset &&lhs, const Dataset &rhs);
+Dataset operator+(const Dataset &lhs, Dataset &&rhs);
+Dataset operator+(Dataset &&lhs, Dataset &&rhs);
+
+Dataset operator-(const Dataset &lhs, const Dataset &rhs);
+Dataset operator-(Dataset &&lhs, const Dataset &rhs);
+Dataset operator-(Dataset &&lhs, Dataset &&rhs);
+
+Dataset operator*(const Dataset &lhs, const Dataset &rhs);
+Dataset operator*(Dataset &&lhs, const Dataset &rhs);
+Dataset operator*(Dataset &&lhs, Dataset &&rhs);
+
+Dataset operator/(const Dataset &lhs, const Dataset &rhs);
+Dataset operator/(Dataset &&lhs, const Dataset &rhs);
+Dataset operator/(Dataset &&lhs, Dataset &&rhs);
+
+Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs);
+
+Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs);
+
 } // namespace scipp::core
 
 #endif // DATASET_NEXT_H

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -544,6 +544,7 @@ public:
   }
 
   const auto &slices() const noexcept { return m_slices; }
+  const auto &dataset() const noexcept { return *m_dataset; }
 
   bool operator==(const Dataset &other) const;
   bool operator==(const DatasetConstProxy &other) const;
@@ -644,9 +645,20 @@ Dataset operator/(Dataset &&lhs, const Dataset &rhs);
 Dataset operator/(Dataset &&lhs, Dataset &&rhs);
 
 Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs);
+Dataset operator+(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
+
 Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs);
+Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
+
 Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs);
+Dataset operator*(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
+
 Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs);
+Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
 
 Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs);
 Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -628,42 +628,45 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable);
 std::ostream &operator<<(std::ostream &os, const Dim dim);
 
 Dataset operator+(const Dataset &lhs, const Dataset &rhs);
+Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs);
 Dataset operator+(Dataset &&lhs, const Dataset &rhs);
+Dataset operator+(Dataset &&lhs, const DatasetConstProxy &rhs);
+Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs);
 Dataset operator+(const Dataset &lhs, Dataset &&rhs);
 Dataset operator+(Dataset &&lhs, Dataset &&rhs);
-
-Dataset operator-(const Dataset &lhs, const Dataset &rhs);
-Dataset operator-(Dataset &&lhs, const Dataset &rhs);
-Dataset operator-(Dataset &&lhs, Dataset &&rhs);
-
-Dataset operator*(const Dataset &lhs, const Dataset &rhs);
-Dataset operator*(Dataset &&lhs, const Dataset &rhs);
-Dataset operator*(Dataset &&lhs, Dataset &&rhs);
-
-Dataset operator/(const Dataset &lhs, const Dataset &rhs);
-Dataset operator/(Dataset &&lhs, const Dataset &rhs);
-Dataset operator/(Dataset &&lhs, Dataset &&rhs);
-
-Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs);
 Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs);
 Dataset operator+(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
 
+Dataset operator-(const Dataset &lhs, const Dataset &rhs);
 Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator-(Dataset &&lhs, const Dataset &rhs);
+Dataset operator-(Dataset &&lhs, const DatasetConstProxy &rhs);
+Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs);
+Dataset operator-(Dataset &&lhs, Dataset &&rhs);
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs);
 Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
 
+Dataset operator*(const Dataset &lhs, const Dataset &rhs);
 Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator*(Dataset &&lhs, const Dataset &rhs);
+Dataset operator*(Dataset &&lhs, const DatasetConstProxy &rhs);
+Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs);
+Dataset operator*(Dataset &&lhs, Dataset &&rhs);
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs);
 Dataset operator*(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
 
 Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs);
+Dataset operator/(const Dataset &lhs, const Dataset &rhs);
+Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs);
+Dataset operator/(Dataset &&lhs, const Dataset &rhs);
+Dataset operator/(Dataset &&lhs, const DatasetConstProxy &rhs);
+Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs);
+Dataset operator/(Dataset &&lhs, Dataset &&rhs);
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs);
 Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs);
-
-Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs);
-Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs);
-Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs);
-Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs);
 
 } // namespace scipp::core
 

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -529,8 +529,8 @@ TYPED_TEST(DatasetBinaryOpTest2,
            dataset_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
-  DatasetConstProxy dataset_b_proxy(dataset_b);
 
+  DatasetConstProxy dataset_b_proxy(dataset_b);
   const auto res = TestFixture::op(dataset_a, dataset_b_proxy);
 
   for (const auto & [ name, item ] : res) {
@@ -544,8 +544,8 @@ TYPED_TEST(DatasetBinaryOpTest2,
            datasetconstproxy_const_lvalue_lhs_dataset_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
-  DatasetConstProxy dataset_a_proxy(dataset_a);
 
+  DatasetConstProxy dataset_a_proxy(dataset_a);
   const auto res = TestFixture::op(dataset_a_proxy, dataset_b);
 
   for (const auto & [ name, item ] : res) {
@@ -560,14 +560,60 @@ TYPED_TEST(
     datasetconstproxy_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
+
   DatasetConstProxy dataset_a_proxy(dataset_a);
   DatasetConstProxy dataset_b_proxy(dataset_b);
-
   const auto res = TestFixture::op(dataset_a_proxy, dataset_b_proxy);
 
   for (const auto & [ name, item ] : res) {
     const auto reference =
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}
+
+TYPED_TEST(DatasetBinaryOpTest2,
+           dataset_rvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
+  const auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+
+  auto dataset_a_copy(dataset_a);
+  DatasetConstProxy dataset_b_proxy(dataset_b);
+  const auto res = TestFixture::op(std::move(dataset_a_copy), dataset_b_proxy);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference =
+        TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}
+
+TYPED_TEST(DatasetBinaryOpTest2,
+           dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
+  const auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+
+  auto dataset_a_copy(dataset_a);
+  const auto res =
+      TestFixture::op(std::move(dataset_a_copy), dataset_b["data_scalar"]);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference = TestFixture::op(dataset_a[name].data(),
+                                           dataset_b["data_scalar"].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}
+
+TYPED_TEST(DatasetBinaryOpTest2,
+           dataset_const_lvalue_lhs_dataproxy_const_lvalue_rhs) {
+  auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+
+  const auto res = TestFixture::op(dataset_a, dataset_b["data_scalar"]);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference = TestFixture::op(dataset_a[name].data(),
+                                           dataset_b["data_scalar"].data());
     EXPECT_EQ(reference, item.data());
   }
 }

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -60,6 +60,30 @@ TEST_P(DataProxyBinaryOpEqualsTest, plus_lhs_without_variance) {
   }
 }
 
+TEST_P(DataProxyBinaryOpEqualsTest, minus_lhs_with_variance) {
+  const auto &item = GetParam().second;
+  auto dataset = datasetFactory.make();
+  const auto target = dataset["data_zyx"];
+  auto reference = target.data() - item.data();
+
+  ASSERT_NO_THROW(target -= item);
+  EXPECT_EQ(target.data(), reference);
+}
+
+TEST_P(DataProxyBinaryOpEqualsTest, minus_lhs_without_variance) {
+  const auto &item = GetParam().second;
+  auto dataset = datasetFactory.make();
+  const auto target = dataset["data_xyz"];
+  if (item.hasVariances()) {
+    ASSERT_ANY_THROW(target -= item);
+  } else {
+    auto reference = target.data() - item.data();
+    ASSERT_NO_THROW(target -= item);
+    EXPECT_EQ(target.data(), reference);
+    EXPECT_FALSE(target.hasVariances());
+  }
+}
+
 TEST_P(DataProxyBinaryOpEqualsTest, times_lhs_with_variance) {
   const auto &item = GetParam().second;
   auto dataset = datasetFactory.make();

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -108,6 +108,30 @@ TEST_P(DataProxyBinaryOpEqualsTest, times_lhs_without_variance) {
   }
 }
 
+TEST_P(DataProxyBinaryOpEqualsTest, divide_lhs_with_variance) {
+  const auto &item = GetParam().second;
+  auto dataset = datasetFactory.make();
+  const auto target = dataset["data_zyx"];
+  auto reference = target.data() / item.data();
+
+  ASSERT_NO_THROW(target /= item);
+  EXPECT_EQ(target.data(), reference);
+}
+
+TEST_P(DataProxyBinaryOpEqualsTest, divide_lhs_without_variance) {
+  const auto &item = GetParam().second;
+  auto dataset = datasetFactory.make();
+  const auto target = dataset["data_xyz"];
+  if (item.hasVariances()) {
+    ASSERT_ANY_THROW(target /= item);
+  } else {
+    auto reference = target.data() / item.data();
+    ASSERT_NO_THROW(target /= item);
+    EXPECT_EQ(target.data(), reference);
+    EXPECT_FALSE(target.hasVariances());
+  }
+}
+
 TEST_P(DataProxyBinaryOpEqualsTest, plus_slice_lhs_with_variance) {
   const auto &item = GetParam().second;
   auto dataset = datasetFactory.make();

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -65,31 +65,32 @@ using BinaryEquals =
     ::testing::Types<plus_equals, minus_equals, times_equals, divide_equals>;
 
 template <class Op>
-class DataProxyBinaryOpTest : public ::testing::Test,
-                              public ::testing::WithParamInterface<Op> {
+class DataProxyBinaryEqualsOpTest : public ::testing::Test,
+                                    public ::testing::WithParamInterface<Op> {
 protected:
   Op op;
 };
 
 template <class Op>
-class DatasetBinaryOpTest : public ::testing::Test,
-                            public ::testing::WithParamInterface<Op> {
+class DatasetBinaryEqualsOpTest : public ::testing::Test,
+                                  public ::testing::WithParamInterface<Op> {
 protected:
   Op op;
 };
 
 template <class Op>
-class DatasetProxyBinaryOpTest : public ::testing::Test,
-                                 public ::testing::WithParamInterface<Op> {
+class DatasetProxyBinaryEqualsOpTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<Op> {
 protected:
   Op op;
 };
 
-TYPED_TEST_SUITE(DataProxyBinaryOpTest, BinaryEquals);
-TYPED_TEST_SUITE(DatasetBinaryOpTest, BinaryEquals);
-TYPED_TEST_SUITE(DatasetProxyBinaryOpTest, BinaryEquals);
+TYPED_TEST_SUITE(DataProxyBinaryEqualsOpTest, BinaryEquals);
+TYPED_TEST_SUITE(DatasetBinaryEqualsOpTest, BinaryEquals);
+TYPED_TEST_SUITE(DatasetProxyBinaryEqualsOpTest, BinaryEquals);
 
-TYPED_TEST(DataProxyBinaryOpTest, other_data_unchanged) {
+TYPED_TEST(DataProxyBinaryEqualsOpTest, other_data_unchanged) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
@@ -107,7 +108,7 @@ TYPED_TEST(DataProxyBinaryOpTest, other_data_unchanged) {
   }
 }
 
-TYPED_TEST(DataProxyBinaryOpTest, lhs_with_variance) {
+TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_with_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
@@ -122,7 +123,7 @@ TYPED_TEST(DataProxyBinaryOpTest, lhs_with_variance) {
   }
 }
 
-TYPED_TEST(DataProxyBinaryOpTest, lhs_without_variance) {
+TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_without_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
@@ -142,7 +143,7 @@ TYPED_TEST(DataProxyBinaryOpTest, lhs_without_variance) {
   }
 }
 
-TYPED_TEST(DataProxyBinaryOpTest, slice_lhs_with_variance) {
+TYPED_TEST(DataProxyBinaryEqualsOpTest, slice_lhs_with_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
@@ -181,9 +182,9 @@ TYPED_TEST(DataProxyBinaryOpTest, slice_lhs_with_variance) {
   }
 }
 
-// DataProxyBinaryOpTest ensures correctness of operations between
+// DataProxyBinaryEqualsOpTest ensures correctness of operations between
 // DataProxy with itself, so we can rely on that for building the reference.
-TYPED_TEST(DatasetBinaryOpTest, return_value) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, return_value) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
 
@@ -203,7 +204,7 @@ TYPED_TEST(DatasetBinaryOpTest, return_value) {
   ASSERT_EQ(&result3, &a);
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_DataProxy_self_overlap) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_DataProxy_self_overlap) {
   auto dataset = datasetFactory.make();
   auto original(dataset);
   auto reference(dataset);
@@ -214,7 +215,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_DataProxy_self_overlap) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_DataProxy_self_overlap_slice) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_DataProxy_self_overlap_slice) {
   auto dataset = datasetFactory.make();
   auto original(dataset);
   auto reference(dataset);
@@ -227,7 +228,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_DataProxy_self_overlap_slice) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
   auto reference(a);
@@ -238,7 +239,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_coord_mismatch) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_coord_mismatch) {
   auto a = datasetFactory.make();
   DatasetFactory3D otherCoordsFactory;
   auto b = otherCoordsFactory.make();
@@ -246,7 +247,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_coord_mismatch) {
   ASSERT_THROW(TestFixture::op(a, b), except::CoordMismatchError);
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_with_missing_items) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
   auto a = datasetFactory.make();
   a.setData("extra", makeVariable<double>({}));
   auto b = datasetFactory.make();
@@ -262,7 +263,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_with_missing_items) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_with_extra_items) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_with_extra_items) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
   b.setData("extra", makeVariable<double>({}));
@@ -270,7 +271,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_Dataset_with_extra_items) {
   ASSERT_ANY_THROW(TestFixture::op(a, b));
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_DatasetProxy_self_overlap) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_DatasetProxy_self_overlap) {
   auto dataset = datasetFactory.make();
   const auto slice = dataset.slice({Dim::Z, 3});
   auto reference(dataset);
@@ -287,7 +288,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_DatasetProxy_self_overlap) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest, rhs_DatasetProxy_coord_mismatch) {
+TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_DatasetProxy_coord_mismatch) {
   auto dataset = datasetFactory.make();
 
   // Non-range sliced throws for X and Y due to multi-dimensional coords.
@@ -304,7 +305,7 @@ TYPED_TEST(DatasetBinaryOpTest, rhs_DatasetProxy_coord_mismatch) {
                except::CoordMismatchError);
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, return_value) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, return_value) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
   DatasetProxy proxy(a);
@@ -330,7 +331,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, return_value) {
             &a["data_scalar"].template values<double>()[0]);
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DataProxy_self_overlap) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_DataProxy_self_overlap) {
   auto dataset = datasetFactory.make();
   auto reference(dataset);
   TestFixture::op(reference, dataset["data_scalar"]);
@@ -349,7 +350,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DataProxy_self_overlap) {
     }
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DataProxy_self_overlap_slice) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_DataProxy_self_overlap_slice) {
   auto dataset = datasetFactory.make();
   auto reference(dataset);
   TestFixture::op(reference, dataset["values_x"].slice({Dim::X, 1}));
@@ -368,7 +369,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DataProxy_self_overlap_slice) {
     }
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_coord_mismatch) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_coord_mismatch) {
   DatasetFactory3D otherCoordsFactory;
   auto a = otherCoordsFactory.make();
   auto b = datasetFactory.make();
@@ -376,7 +377,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_coord_mismatch) {
   ASSERT_THROW(TestFixture::op(DatasetProxy(a), b), except::CoordMismatchError);
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_with_missing_items) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
   auto a = datasetFactory.make();
   a.setData("extra", makeVariable<double>({}));
   auto b = datasetFactory.make();
@@ -392,7 +393,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_with_missing_items) {
   }
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_with_extra_items) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_with_extra_items) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
   b.setData("extra", makeVariable<double>({}));
@@ -400,7 +401,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_Dataset_with_extra_items) {
   ASSERT_ANY_THROW(TestFixture::op(DatasetProxy(a), b));
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DatasetProxy_self_overlap) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_DatasetProxy_self_overlap) {
   auto dataset = datasetFactory.make();
   const auto slice = dataset.slice({Dim::Z, 3});
   auto reference(dataset);
@@ -418,7 +419,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DatasetProxy_self_overlap) {
   }
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest,
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest,
            rhs_DatasetProxy_self_overlap_undetectable) {
   auto dataset = datasetFactory.make();
   const auto slice = dataset.slice({Dim::Z, 3});
@@ -440,7 +441,7 @@ TYPED_TEST(DatasetProxyBinaryOpTest,
   }
 }
 
-TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DatasetProxy_coord_mismatch) {
+TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_DatasetProxy_coord_mismatch) {
   auto dataset = datasetFactory.make();
   const DatasetProxy proxy(dataset);
 
@@ -459,15 +460,15 @@ TYPED_TEST(DatasetProxyBinaryOpTest, rhs_DatasetProxy_coord_mismatch) {
 }
 
 template <class Op>
-class DatasetBinaryOpTest2 : public ::testing::Test,
-                             public ::testing::WithParamInterface<Op> {
+class DatasetBinaryOpTest : public ::testing::Test,
+                            public ::testing::WithParamInterface<Op> {
 protected:
   Op op;
 };
 
-TYPED_TEST_SUITE(DatasetBinaryOpTest2, Binary);
+TYPED_TEST_SUITE(DatasetBinaryOpTest, Binary);
 
-TYPED_TEST(DatasetBinaryOpTest2,
+TYPED_TEST(DatasetBinaryOpTest,
            dataset_const_lvalue_lhs_dataset_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
@@ -481,7 +482,7 @@ TYPED_TEST(DatasetBinaryOpTest2,
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2, dataset_rvalue_lhs_dataset_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataset_const_lvalue_rhs) {
   const auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
 
@@ -495,7 +496,7 @@ TYPED_TEST(DatasetBinaryOpTest2, dataset_rvalue_lhs_dataset_const_lvalue_rhs) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2, dataset_const_lvalue_lhs_dataset_rvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_const_lvalue_lhs_dataset_rvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   const auto dataset_b = datasetFactory.make();
 
@@ -509,7 +510,7 @@ TYPED_TEST(DatasetBinaryOpTest2, dataset_const_lvalue_lhs_dataset_rvalue_rhs) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2, dataset_rvalue_lhs_dataset_rvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataset_rvalue_rhs) {
   const auto dataset_a = datasetFactory.make();
   const auto dataset_b = datasetFactory.make();
 
@@ -525,7 +526,7 @@ TYPED_TEST(DatasetBinaryOpTest2, dataset_rvalue_lhs_dataset_rvalue_rhs) {
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2,
+TYPED_TEST(DatasetBinaryOpTest,
            dataset_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
@@ -540,7 +541,7 @@ TYPED_TEST(DatasetBinaryOpTest2,
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2,
+TYPED_TEST(DatasetBinaryOpTest,
            datasetconstproxy_const_lvalue_lhs_dataset_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
@@ -556,7 +557,7 @@ TYPED_TEST(DatasetBinaryOpTest2,
 }
 
 TYPED_TEST(
-    DatasetBinaryOpTest2,
+    DatasetBinaryOpTest,
     datasetconstproxy_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
@@ -572,7 +573,7 @@ TYPED_TEST(
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2,
+TYPED_TEST(DatasetBinaryOpTest,
            dataset_rvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   const auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
@@ -588,8 +589,7 @@ TYPED_TEST(DatasetBinaryOpTest2,
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2,
-           dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
   const auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
 
@@ -604,7 +604,7 @@ TYPED_TEST(DatasetBinaryOpTest2,
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest2,
+TYPED_TEST(DatasetBinaryOpTest,
            dataset_const_lvalue_lhs_dataproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -524,3 +524,50 @@ TYPED_TEST(DatasetBinaryOpTest2, dataset_rvalue_lhs_dataset_rvalue_rhs) {
     EXPECT_EQ(reference, item.data());
   }
 }
+
+TYPED_TEST(DatasetBinaryOpTest2,
+           dataset_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
+  auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+  DatasetConstProxy dataset_b_proxy(dataset_b);
+
+  const auto res = TestFixture::op(dataset_a, dataset_b_proxy);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference =
+        TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}
+
+TYPED_TEST(DatasetBinaryOpTest2,
+           datasetconstproxy_const_lvalue_lhs_dataset_const_lvalue_rhs) {
+  auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+  DatasetConstProxy dataset_a_proxy(dataset_a);
+
+  const auto res = TestFixture::op(dataset_a_proxy, dataset_b);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference =
+        TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}
+
+TYPED_TEST(
+    DatasetBinaryOpTest2,
+    datasetconstproxy_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
+  auto dataset_a = datasetFactory.make();
+  auto dataset_b = datasetFactory.make();
+  DatasetConstProxy dataset_a_proxy(dataset_a);
+  DatasetConstProxy dataset_b_proxy(dataset_b);
+
+  const auto res = TestFixture::op(dataset_a_proxy, dataset_b_proxy);
+
+  for (const auto & [ name, item ] : res) {
+    const auto reference =
+        TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
+    EXPECT_EQ(reference, item.data());
+  }
+}


### PR DESCRIPTION
Adds `-=` and `/=` operators for `Dataset`, `DataProxy`, and `DatasetProxy`.

Fixes partially #246.