### PR TITLE
Cleanup cmake config and add helper scripts for running sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,17 +46,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   endif()
 endif()
 
-option(WITH_ASAN "Enable address sanitizer" OFF)
-if(WITH_ASAN)
-  message(STATUS "Enabling address sanitizer")
-  add_compile_options(-fno-omit-frame-pointer -fno-common -fsanitize=address)
-  set(CMAKE_MODULE_LINKER_FLAGS
-      "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address -lasan -static-libasan")
-  set(CMAKE_EXE_LINKER_FLAGS
-      "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address -lasan -static-libasan")
-  set(CMAKE_SHARED_LINKER_FLAGS
-      "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address -lasan -static-libasan")
-endif()
+option(WITH_CTEST "Enable ctest integration of tests" ON)
 
 add_compile_options(-Wall
                     -Wextra

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -15,7 +15,6 @@ add_executable(scipp-core-test
                view_index_test.cpp
                #zip_view_test.cpp
                )
-add_sanitizers(scipp-core-test)
 target_link_libraries(scipp-core-test
                       LINK_PRIVATE
                       scipp-core
@@ -25,4 +24,7 @@ target_link_libraries(scipp-core-test
                       ${GMOCK_LIBRARIES})
 target_include_directories(scipp-core-test SYSTEM
                            PRIVATE "../../range-v3/include")
-gtest_discover_tests(scipp-core-test TEST_PREFIX scipp/core/)
+add_sanitizers(scipp-core-test)
+if(${WITH_CTEST})
+  gtest_discover_tests(scipp-core-test TEST_PREFIX scipp/core/)
+endif()

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -16,4 +16,6 @@ target_link_libraries(scipp-neutron-test
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
 add_sanitizers(scipp-neutron-test)
-gtest_discover_tests(scipp-neutron-test TEST_PREFIX scipp/neutron/)
+if(${WITH_CTEST})
+  gtest_discover_tests(scipp-neutron-test TEST_PREFIX scipp/neutron/)
+endif()

--- a/scippy/CMakeLists.txt
+++ b/scippy/CMakeLists.txt
@@ -16,6 +16,8 @@ target_include_directories(scipp SYSTEM PRIVATE "../range-v3/include")
 # Set symbol visibility to hidden to reduce binary size, as recommended in pybind11 FAQ.
 set_target_properties(scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
+add_sanitizers(scipp)
+
 set(PY_FILES __init__.py table.py plot.py)
 
 install(DIRECTORY "src/scippy" DESTINATION ".")

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,8 @@
+# Scipp Tools
+
+This directory contains a number of helper scripts for the scipp development process.
+
+1. `run_asan.sh` builds all tests and runs them with Address Sanitizer enabled.
+1. `run_ubsan.sh` builds all tests and runs them with Undefined-Behavior Sanitizer enabled.
+
+`run_sanitizer.sh` is a helper script and not intended for direct use.

--- a/tools/run_asan.sh
+++ b/tools/run_asan.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$(dirname $BASH_SOURCE)/run_sanitizer.sh ADDRESS "$@"

--- a/tools/run_sanitizer.sh
+++ b/tools/run_sanitizer.sh
@@ -16,6 +16,8 @@ cd $WORKING_DIR
 mkdir $BUILD
 mkdir $INSTALL
 cd $BUILD
+# We need to disable ctest integration of gtest-based tests since gtest_discover_tests
+# fails due to missing (asan) preload.
 cmake -DWITH_CTEST=Off -DSANITIZE_$SANITIZER=On -DCMAKE_INSTALL_PREFIX=$INSTALL $SOURCE
 make -j12 install
 export ASan_WRAPPER=$SOURCE/CMake/sanitizers-cmake/cmake/asan-wrapper

--- a/tools/run_sanitizer.sh
+++ b/tools/run_sanitizer.sh
@@ -19,7 +19,7 @@ cd $BUILD
 # We need to disable ctest integration of gtest-based tests since gtest_discover_tests
 # fails due to missing (asan) preload.
 cmake -DWITH_CTEST=Off -DSANITIZE_$SANITIZER=On -DCMAKE_INSTALL_PREFIX=$INSTALL $SOURCE
-make -j12 install
+make -j install
 export ASan_WRAPPER=$SOURCE/CMake/sanitizers-cmake/cmake/asan-wrapper
 ${ASan_WRAPPER} ./units/test/scipp-units-test || { exit 1; }
 ${ASan_WRAPPER} ./core/test/scipp-core-test || { exit 1; }

--- a/tools/run_sanitizer.sh
+++ b/tools/run_sanitizer.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SANITIZER=$1
+
+if [ "$#" -eq 2 ]; then
+  SOURCE=$2
+else
+  SOURCE=$(cd $(dirname $BASH_SOURCE); pwd)/..
+fi
+
+WORKING_DIR=$PWD
+BUILD=$WORKING_DIR/build-sanitizer
+INSTALL=$WORKING_DIR/install-sanitizer
+
+cd $WORKING_DIR
+mkdir $BUILD
+mkdir $INSTALL
+cd $BUILD
+cmake -DWITH_CTEST=Off -DSANITIZE_$SANITIZER=On -DCMAKE_INSTALL_PREFIX=$INSTALL $SOURCE
+make -j12 install
+export ASan_WRAPPER=$SOURCE/CMake/sanitizers-cmake/cmake/asan-wrapper
+${ASan_WRAPPER} ./units/test/scipp-units-test || { exit 1; }
+${ASan_WRAPPER} ./core/test/scipp-core-test || { exit 1; }
+cd $SOURCE/scippy
+export PYTHONPATH=$PYTHONPATH:$INSTALL
+python3 -m pytest || { exit 1; }
+
+cd $WORKING_DIR
+rm -rf $BUILD $INSTALL

--- a/tools/run_ubsan.sh
+++ b/tools/run_ubsan.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$(dirname $BASH_SOURCE)/run_sanitizer.sh UNDEFINED "$@"

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(scipp-units-test
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
 add_sanitizers(scipp-units-test)
-gtest_discover_tests(scipp-units-test TEST_PREFIX scipp/units/)
+if(${WITH_CTEST})
+  gtest_discover_tests(scipp-units-test TEST_PREFIX scipp/units/)
+endif()


### PR DESCRIPTION
Add scripts for automatically building and running with some sanitizers. This is by no means perfect and complete, e.g., scripts are gcc-only for now.

This does *not* solve https://github.com/scipp/scipp/issues/202, but at least it is now straight-forward to run some tests locally.