### PR TITLE
Fix has_variances python method

### DIFF
--- a/scippy/bind_data_access.h
+++ b/scippy/bind_data_access.h
@@ -229,7 +229,12 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
                  &as_VariableView::set_variance<T>,
                  "The only variance for 0-dimensional data. Raises an "
                  "exception if the data is not 0-dimensional.");
-  c.def_property_readonly("has_variances", &T::hasVariances);
+  c.def_property_readonly(
+      "has_variances",
+      [](T &v) {
+        return v.hasVariances();
+      }); // Cannot bind to member directly, see
+          // https://github.com/pybind/pybind11/issues/580#issuecomment-269836784
 }
 
 #endif // SCIPPY_BIND_DATA_ACCESS_H


### PR DESCRIPTION
Fixes #301

General [pybind11 issue](https://github.com/pybind/pybind11/issues/580#issuecomment-269836784), but chosen to fix via lambda rather than exposing base class.

`hasVariances` defined on base `VariableConstProxy` not `VariableProxy`, pointer to data member in base undefined.