### PR TITLE
Changing python version requirements from == to >=

### DIFF
--- a/scippy/requirements.txt
+++ b/scippy/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.14.6
-pandas==0.24.2
-xarray==0.11.3
-matplotlib==3.0.3
+numpy>=1.14.6
+pandas>=0.24.2
+xarray>=0.11.3
+matplotlib>=3.0.3
 nose
-ipywidgets==7.4.2
-plotly==3.6.1
+ipywidgets>=7.4.2
+plotly>=3.6.1
 pytest


### PR DESCRIPTION
In the Python `requirements.txt` file, I changed version requirements to `>=` instead of the more restrictive `==`.
