### PR TITLE
Binary operator followup

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -869,10 +869,6 @@ Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs) {
   return apply_with_delay(minus_equals, lhs, rhs);
 }
 
-Dataset operator-(Dataset &&lhs, Dataset &&rhs) {
-  return apply(minus_equals, lhs, rhs);
-}
-
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
   Dataset res(lhs);
   apply(minus_equals, res, rhs);
@@ -921,10 +917,6 @@ Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs) {
   return apply_with_delay(times_equals, lhs, rhs);
 }
 
-Dataset operator*(Dataset &&lhs, Dataset &&rhs) {
-  return apply(times_equals, lhs, rhs);
-}
-
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
   Dataset res(lhs);
   apply(times_equals, res, rhs);
@@ -971,10 +963,6 @@ Dataset operator/(Dataset &&lhs, const DatasetConstProxy &rhs) {
 
 Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs) {
   return apply_with_delay(divide_equals, lhs, rhs);
-}
-
-Dataset operator/(Dataset &&lhs, Dataset &&rhs) {
-  return apply(divide_equals, lhs, rhs);
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -633,6 +633,13 @@ auto &apply(const Op &op, A &a, const B &b) {
 }
 
 template <class Op, class A, class B>
+auto apply(const Op &op, A &&a, const B &b) {
+  for (const auto & [ name, item ] : b)
+    op(a[name], item);
+  return std::move(a);
+}
+
+template <class Op, class A, class B>
 decltype(auto) apply_with_delay(const Op &op, A &&a, const B &b) {
   // For `b` referencing data in `a` we delay operation. The alternative would
   // be to make a deep copy of `other` before starting the iteration over items.
@@ -802,23 +809,23 @@ Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
 }
 
 Dataset operator+(Dataset &&lhs, const Dataset &rhs) {
-  return apply(plus_equals, lhs, rhs);
+  return apply(plus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator+(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(plus_equals, lhs, rhs);
+  return apply(plus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(plus_equals, lhs, rhs);
+  return apply_with_delay(plus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator+(const Dataset &lhs, Dataset &&rhs) {
-  return apply(plus_equals, rhs, lhs);
+  return apply(plus_equals, std::move(rhs), lhs);
 }
 
 Dataset operator+(Dataset &&lhs, Dataset &&rhs) {
-  return apply(plus_equals, lhs, rhs);
+  return apply(plus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -858,15 +865,15 @@ Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
 }
 
 Dataset operator-(Dataset &&lhs, const Dataset &rhs) {
-  return apply(minus_equals, lhs, rhs);
+  return apply(minus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator-(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(minus_equals, lhs, rhs);
+  return apply(minus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(minus_equals, lhs, rhs);
+  return apply_with_delay(minus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -906,15 +913,15 @@ Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
 }
 
 Dataset operator*(Dataset &&lhs, const Dataset &rhs) {
-  return apply(times_equals, lhs, rhs);
+  return apply(times_equals, std::move(lhs), rhs);
 }
 
 Dataset operator*(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(times_equals, lhs, rhs);
+  return apply(times_equals, std::move(lhs), rhs);
 }
 
 Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(times_equals, lhs, rhs);
+  return apply_with_delay(times_equals, std::move(lhs), rhs);
 }
 
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -954,15 +961,15 @@ Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
 }
 
 Dataset operator/(Dataset &&lhs, const Dataset &rhs) {
-  return apply(divide_equals, lhs, rhs);
+  return apply(divide_equals, std::move(lhs), rhs);
 }
 
 Dataset operator/(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(divide_equals, lhs, rhs);
+  return apply(divide_equals, std::move(lhs), rhs);
 }
 
 Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(divide_equals, lhs, rhs);
+  return apply_with_delay(divide_equals, std::move(lhs), rhs);
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -659,18 +659,31 @@ auto apply_with_broadcast(const Op &op, A &a, const B &b) {
 
   /* Copy labels to result dataset */
   for (const auto & [ name, value ] : a.labels()) {
-    res.setLabels(static_cast<std::string>(name), value);
+    res.setLabels(std::string(name), value);
   }
 
   /* Copy attributes to result dataset */
   for (const auto & [ name, value ] : a.attrs()) {
-    res.setAttr(static_cast<std::string>(name), value);
+    res.setAttr(std::string(name), value);
   }
 
   for (const auto & [ name, item ] : b) {
     if (a.contains(name)) {
       res.setData(static_cast<std::string>(name),
                   op(a[name].data(), item.data()));
+
+      for (const auto &coord : a[name].coords()) {
+        if (coord.second.dims().sparse()) {
+          res.setSparseCoord(std::string(name), coord.second);
+        }
+      }
+
+      for (const auto & [ label_name, labels ] : a[name].labels()) {
+        if (labels.dims().sparse()) {
+          res.setSparseLabels(std::string(name), std::string(label_name),
+                              labels);
+        }
+      }
     }
   }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -647,13 +647,6 @@ auto &apply(const Op &op, A &a, const B &b) {
 }
 
 template <class Op, class A, class B>
-auto apply(const Op &op, A &&a, const B &b) {
-  for (const auto & [ name, item ] : b)
-    op(a[name], item);
-  return std::move(a);
-}
-
-template <class Op, class A, class B>
 auto apply_with_broadcast(const Op &op, A &a, const B &b) {
   expect::coordsAndLabelsMatch(a, b);
 
@@ -851,14 +844,6 @@ Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
   return res;
 }
 
-Dataset operator+(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(plus_equals, std::move(lhs), rhs);
-}
-
-Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(plus_equals, std::move(lhs), rhs);
-}
-
 Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs) {
   Dataset res(lhs);
   apply(plus_equals, res, rhs);
@@ -891,14 +876,6 @@ Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
   Dataset res(lhs);
   apply_with_delay(minus_equals, res, rhs);
   return res;
-}
-
-Dataset operator-(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(minus_equals, std::move(lhs), rhs);
-}
-
-Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(minus_equals, std::move(lhs), rhs);
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -935,14 +912,6 @@ Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
   return res;
 }
 
-Dataset operator*(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(times_equals, std::move(lhs), rhs);
-}
-
-Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(times_equals, std::move(lhs), rhs);
-}
-
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
   Dataset res(lhs);
   apply(times_equals, res, rhs);
@@ -975,14 +944,6 @@ Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
   Dataset res(lhs);
   apply_with_delay(divide_equals, res, rhs);
   return res;
-}
-
-Dataset operator/(Dataset &&lhs, const DatasetConstProxy &rhs) {
-  return apply(divide_equals, std::move(lhs), rhs);
-}
-
-Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs) {
-  return apply_with_delay(divide_equals, std::move(lhs), rhs);
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -716,6 +716,19 @@ auto apply_with_broadcast(const Op &op, const A &a, const B &b) {
   return res;
 }
 
+template <class Op, class A>
+auto apply_with_broadcast(const Op &op, const A &a, const DataConstProxy &b) {
+  Dataset res;
+  copy_metadata(res, a);
+
+  for (const auto & [ name, item ] : a) {
+    res.setData(std::string(name), op(item.data(), b.data()));
+    copy_metadata(res, std::string(name), a[name]);
+  }
+
+  return res;
+}
+
 Dataset &Dataset::operator+=(const DataConstProxy &other) {
   return apply_with_delay(plus_equals, *this, other);
 }
@@ -857,9 +870,7 @@ Dataset operator+(const Dataset &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator+(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(plus_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(plus, lhs, rhs);
 }
 
 Dataset operator+(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -871,9 +882,7 @@ Dataset operator+(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator+(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(plus_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(plus, lhs, rhs);
 }
 
 Dataset operator-(const Dataset &lhs, const Dataset &rhs) {
@@ -885,9 +894,7 @@ Dataset operator-(const Dataset &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator-(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(minus_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(minus, lhs, rhs);
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -899,9 +906,7 @@ Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(minus_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(minus, lhs, rhs);
 }
 
 Dataset operator*(const Dataset &lhs, const Dataset &rhs) {
@@ -913,9 +918,7 @@ Dataset operator*(const Dataset &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator*(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(times_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(times, lhs, rhs);
 }
 
 Dataset operator*(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -927,9 +930,7 @@ Dataset operator*(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator*(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(times_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(times, lhs, rhs);
 }
 
 Dataset operator/(const Dataset &lhs, const Dataset &rhs) {
@@ -941,9 +942,7 @@ Dataset operator/(const Dataset &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator/(const Dataset &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(divide_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(divide, lhs, rhs);
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const Dataset &rhs) {
@@ -955,9 +954,7 @@ Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
-  Dataset res(lhs);
-  apply_with_delay(divide_equals, res, rhs);
-  return res;
+  return apply_with_broadcast(divide, lhs, rhs);
 }
 
 } // namespace scipp::core

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -288,11 +288,6 @@ void validSlice(const Dimensions &dims, const Slice &slice) {
                              to_string(dims) + ".");
 }
 
-void coordsAndLabelsMatch(const DataConstProxy &a, const DataConstProxy &b) {
-  if (a.coords() != b.coords() || a.labels() != b.labels())
-    throw except::CoordMismatchError("Expected coords and labels to match.");
-}
-
 void coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                 const DataConstProxy &b) {
   for (const auto & [ dim, coord ] : b.coords())

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -288,6 +288,33 @@ void validSlice(const Dimensions &dims, const Slice &slice) {
                              to_string(dims) + ".");
 }
 
+void sparseCoordsAndLabelsMatch(const DataConstProxy &a,
+                                const DataConstProxy &b) {
+  if (b.dims().sparse()) {
+    const auto sparseDim = b.dims().sparseDim();
+
+    /* Fail if: */
+    /* - presence of a sparse dimension is not identical in both items */
+    /* - both items have a sparse dimension but it's coordinates differ */
+    if ((a.coords().contains(sparseDim) != b.coords().contains(sparseDim)) ||
+        (a.coords().contains(sparseDim) &&
+         a.coords()[sparseDim] != b.coords()[sparseDim])) {
+      throw except::CoordMismatchError("Expected sparse coords to match.");
+    }
+
+    /* Check that a and b have identical sparse labels */
+    for (const auto & [ name, label ] : b.labels()) {
+      if (!a.labels().contains(name)) {
+        throw except::CoordMismatchError("Expected sparse labels to match.");
+      }
+
+      if (a.labels()[name] != label) {
+        throw except::CoordMismatchError("Expected sparse labels to match.");
+      }
+    }
+  }
+}
+
 void coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                 const DataConstProxy &b) {
   for (const auto & [ dim, coord ] : b.coords())

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -669,7 +669,6 @@ SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, Dataset &&rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
@@ -686,7 +685,6 @@ SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, Dataset &&rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
@@ -703,7 +701,6 @@ SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, Dataset &&rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -378,6 +378,11 @@ public:
   /// Return true if there are 0 coordinates in the proxy.
   [[nodiscard]] bool empty() const noexcept { return size() == 0; }
 
+  /// Returns whether a given key is present in the proxy.
+  bool contains(const Key &k) const {
+    return m_items.find(k) != m_items.cend();
+  }
+
   /// Return a const proxy to the coordinate for given dimension.
   VariableConstProxy operator[](const Key key) const {
     return detail::makeSlice(*m_items.at(key).first, m_slices);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -647,12 +647,9 @@ SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs, Dataset &&rhs);
-SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs, Dataset &&rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
@@ -665,7 +662,6 @@ SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs);
@@ -681,7 +677,6 @@ SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs);
@@ -697,7 +692,6 @@ SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs,
 SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -647,9 +647,6 @@ SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs,
-                                    const DatasetConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator+(Dataset &&lhs, const DataConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
@@ -662,9 +659,6 @@ SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs,
-                                    const DatasetConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator-(Dataset &&lhs, const DataConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
@@ -677,9 +671,6 @@ SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs,
-                                    const DatasetConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator*(Dataset &&lhs, const DataConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
@@ -692,9 +683,6 @@ SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs,
 SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs,
                                     const DataConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs,
-                                    const DatasetConstProxy &rhs);
-SCIPP_CORE_EXPORT Dataset operator/(Dataset &&lhs, const DataConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,
                                     const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -170,7 +170,8 @@ template <class T> void countsOrCountsDensity(const T &object) {
 
 void SCIPP_CORE_EXPORT validSlice(const Dimensions &dims, const Slice &slice);
 
-template <typename T> void coordsAndLabelsMatch(const T &a, const T &b) {
+template <typename A, typename B>
+void coordsAndLabelsMatch(const A &a, const B &b) {
   if (a.coords() != b.coords() || a.labels() != b.labels())
     throw except::CoordMismatchError("Expected coords and labels to match.");
 

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -169,8 +169,12 @@ template <class T> void countsOrCountsDensity(const T &object) {
 }
 
 void SCIPP_CORE_EXPORT validSlice(const Dimensions &dims, const Slice &slice);
-void SCIPP_CORE_EXPORT coordsAndLabelsMatch(const DataConstProxy &a,
-                                            const DataConstProxy &b);
+
+template <typename T> void coordsAndLabelsMatch(const T &a, const T &b) {
+  if (a.coords() != b.coords() || a.labels() != b.labels())
+    throw except::CoordMismatchError("Expected coords and labels to match.");
+}
+
 void SCIPP_CORE_EXPORT coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                                   const DataConstProxy &b);
 void SCIPP_CORE_EXPORT notSparse(const Dimensions &dims);

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -170,6 +170,9 @@ template <class T> void countsOrCountsDensity(const T &object) {
 
 void SCIPP_CORE_EXPORT validSlice(const Dimensions &dims, const Slice &slice);
 
+void SCIPP_CORE_EXPORT sparseCoordsAndLabelsMatch(const DataConstProxy &a,
+                                                  const DataConstProxy &b);
+
 template <typename A, typename B>
 void coordsAndLabelsMatch(const A &a, const B &b) {
   if (a.coords() != b.coords() || a.labels() != b.labels())
@@ -177,35 +180,7 @@ void coordsAndLabelsMatch(const A &a, const B &b) {
 
   for (const auto & [ name, item ] : b) {
     if (a.contains(name)) {
-      if (item.dims().sparse()) {
-        const auto sparseDim = item.dims().sparseDim();
-
-        const auto coords_a = a[name].coords();
-        const auto coords_b = item.coords();
-
-        /* Fail if: */
-        /* - presence of a sparse dimension is not identical in both items */
-        /* - both items have a sparse dimension but it's coordinates differ */
-        if ((coords_a.contains(sparseDim) != coords_b.contains(sparseDim)) ||
-            (coords_a.contains(sparseDim) &&
-             coords_a[sparseDim] != coords_b[sparseDim])) {
-          throw except::CoordMismatchError("Expected sparse coords to match.");
-        }
-
-        /* Check that a and b have identical sparse labels */
-        const auto labels_a = a[name].labels();
-        for (const auto & [ label_name, label_b ] : item.labels()) {
-          if (!labels_a.contains(label_name)) {
-            throw except::CoordMismatchError(
-                "Expected sparse labels to match.");
-          }
-
-          if (labels_a[label_name] != label_b) {
-            throw except::CoordMismatchError(
-                "Expected sparse labels to match.");
-          }
-        }
-      }
+      sparseCoordsAndLabelsMatch(a[name], item);
     }
   }
 }

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -507,6 +507,14 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataset_const_lvalue_rhs) {
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
     EXPECT_EQ(reference, item.data());
   }
+
+  /* Ensure that the original operand was moved (in which case it sould be
+   * empty) */
+  EXPECT_TRUE(dataset_a_copy.empty());
+}
+
+template <typename A, typename B> inline bool is_same_type(const B) {
+  return std::is_same<A, B>::value;
 }
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_const_lvalue_lhs_dataset_rvalue_rhs) {
@@ -520,6 +528,13 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_const_lvalue_lhs_dataset_rvalue_rhs) {
     const auto reference =
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
     EXPECT_EQ(reference, item.data());
+  }
+
+  /* Ensure that the original operand was moved (in which case it sould be
+   * empty) */
+  /* Only available for plus when RHS is rvalue */
+  if (is_same_type<plus>(TestFixture::op)) {
+    EXPECT_TRUE(dataset_b_copy.empty());
   }
 }
 
@@ -537,6 +552,10 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataset_rvalue_rhs) {
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
     EXPECT_EQ(reference, item.data());
   }
+
+  /* Ensure that the original operand was moved (in which case it sould be
+   * empty) */
+  EXPECT_TRUE(dataset_a_copy.empty());
 }
 
 TYPED_TEST(DatasetBinaryOpTest,
@@ -598,6 +617,10 @@ TYPED_TEST(DatasetBinaryOpTest,
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
     EXPECT_EQ(reference, item.data());
   }
+
+  /* Ensure that the original operand was moved (in which case it sould be
+   * empty) */
+  EXPECT_TRUE(dataset_a_copy.empty());
 }
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
@@ -613,6 +636,10 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
                                            dataset_b["data_scalar"].data());
     EXPECT_EQ(reference, item.data());
   }
+
+  /* Ensure that the original operand was moved (in which case it sould be
+   * empty) */
+  EXPECT_TRUE(dataset_a_copy.empty());
 }
 
 TYPED_TEST(DatasetBinaryOpTest,

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -538,6 +538,25 @@ TYPED_TEST(DatasetBinaryOpTest,
 }
 
 TYPED_TEST(DatasetBinaryOpTest,
+           dataset_sparse_const_lvalue_lhs_dataset_sparse_const_lvalue_rhs) {
+  const auto dataset_a = make_simple_sparse({1.1, 2.2});
+  const auto dataset_b = make_simple_sparse({3.3, 4.4});
+
+  const auto res = TestFixture::op(dataset_a, dataset_b);
+
+  /* Only one variable should be present in result as only one common name
+   * existed between input datasets. */
+  EXPECT_EQ(1, res.size());
+
+  /* Test that the dataset contains the equivalent of operating on the Variable
+   * directly. */
+  /* Correctness of results is tested via Variable tests. */
+  const auto reference =
+      TestFixture::op(dataset_a["sparse"].data(), dataset_b["sparse"].data());
+  EXPECT_EQ(reference, res["sparse"].data());
+}
+
+TYPED_TEST(DatasetBinaryOpTest,
            dataset_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -542,8 +542,7 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
   return std::make_tuple(a, b);
 }
 
-TYPED_TEST(DatasetBinaryOpTest,
-           dataset_const_lvalue_lhs_dataset_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_dataset_rhs) {
   const auto[dataset_a, dataset_b] = generateBinaryOpTestCase();
 
   const auto res = TestFixture::op(dataset_a, dataset_b);
@@ -564,8 +563,7 @@ TYPED_TEST(DatasetBinaryOpTest,
   EXPECT_EQ(res.labels(), dataset_a.labels());
 }
 
-TYPED_TEST(DatasetBinaryOpTest,
-           dataset_sparse_const_lvalue_lhs_dataset_sparse_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataset_sparse_rhs) {
   const auto dataset_a =
       make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});
   const auto dataset_b =
@@ -587,9 +585,8 @@ TYPED_TEST(DatasetBinaryOpTest,
   EXPECT_EQ(dataset_a["sparse"].coords(), res["sparse"].coords());
 }
 
-TYPED_TEST(
-    DatasetBinaryOpTest,
-    dataset_sparse_const_lvalue_lhs_dataset_sparse_const_lvalue_rhs_fail_when_coords_mismatch) {
+TYPED_TEST(DatasetBinaryOpTest,
+           dataset_sparse_lhs_dataset_sparse_rhs_fail_when_coords_mismatch) {
   auto dataset_a = make_simple_sparse({1.1, 2.2});
   auto dataset_b = make_simple_sparse({3.3, 4.4});
 
@@ -609,9 +606,8 @@ TYPED_TEST(
                except::CoordMismatchError);
 }
 
-TYPED_TEST(
-    DatasetBinaryOpTest,
-    dataset_sparse_const_lvalue_lhs_dataset_sparse_const_lvalue_rhs_fail_when_labels_mismatch) {
+TYPED_TEST(DatasetBinaryOpTest,
+           dataset_sparse_lhs_dataset_sparse_rhs_fail_when_labels_mismatch) {
   auto dataset_a = make_simple_sparse({1.1, 2.2});
   auto dataset_b = make_simple_sparse({3.3, 4.4});
 
@@ -631,8 +627,7 @@ TYPED_TEST(
                except::CoordMismatchError);
 }
 
-TYPED_TEST(DatasetBinaryOpTest,
-           dataset_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_datasetconstproxy_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
 
@@ -646,8 +641,7 @@ TYPED_TEST(DatasetBinaryOpTest,
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest,
-           datasetconstproxy_const_lvalue_lhs_dataset_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, datasetconstproxy_lhs_dataset_rhs) {
   const auto dataset_a = datasetFactory.make();
   const auto dataset_b = datasetFactory.make().slice({Dim::X, 1});
 
@@ -659,9 +653,7 @@ TYPED_TEST(DatasetBinaryOpTest,
   EXPECT_EQ(res, reference);
 }
 
-TYPED_TEST(
-    DatasetBinaryOpTest,
-    datasetconstproxy_const_lvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, datasetconstproxy_lhs_datasetconstproxy_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
 
@@ -676,39 +668,7 @@ TYPED_TEST(
   }
 }
 
-TYPED_TEST(DatasetBinaryOpTest,
-           dataset_rvalue_lhs_datasetconstproxy_const_lvalue_rhs) {
-  const auto dataset_a = datasetFactory.make();
-  auto dataset_b = datasetFactory.make();
-
-  auto dataset_a_copy(dataset_a);
-  DatasetConstProxy dataset_b_proxy(dataset_b);
-  const auto res = TestFixture::op(std::move(dataset_a_copy), dataset_b_proxy);
-
-  for (const auto & [ name, item ] : res) {
-    const auto reference =
-        TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
-    EXPECT_EQ(reference, item.data());
-  }
-}
-
-TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
-  const auto dataset_a = datasetFactory.make();
-  auto dataset_b = datasetFactory.make();
-
-  auto dataset_a_copy(dataset_a);
-  const auto res =
-      TestFixture::op(std::move(dataset_a_copy), dataset_b["data_scalar"]);
-
-  for (const auto & [ name, item ] : res) {
-    const auto reference = TestFixture::op(dataset_a[name].data(),
-                                           dataset_b["data_scalar"].data());
-    EXPECT_EQ(reference, item.data());
-  }
-}
-
-TYPED_TEST(DatasetBinaryOpTest,
-           dataset_const_lvalue_lhs_dataproxy_const_lvalue_rhs) {
+TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_dataproxy_rhs) {
   auto dataset_a = datasetFactory.make();
   auto dataset_b = datasetFactory.make();
 

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -615,10 +615,6 @@ TYPED_TEST(DatasetBinaryOpTest,
         TestFixture::op(dataset_a[name].data(), dataset_b[name].data());
     EXPECT_EQ(reference, item.data());
   }
-
-  /* Ensure that the original operand was moved (in which case it sould be
-   * empty) */
-  EXPECT_TRUE(dataset_a_copy.empty());
 }
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
@@ -634,10 +630,6 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_rvalue_lhs_dataproxy_const_lvalue_rhs) {
                                            dataset_b["data_scalar"].data());
     EXPECT_EQ(reference, item.data());
   }
-
-  /* Ensure that the original operand was moved (in which case it sould be
-   * empty) */
-  EXPECT_TRUE(dataset_a_copy.empty());
 }
 
 TYPED_TEST(DatasetBinaryOpTest,


### PR DESCRIPTION
Addresses comments left on #294 after merging.

- Operator overloads taking two rvalues are removed when they are not needed.
- Operators taking an rvalue now correctly handle the rvalue