### PR TITLE
Improve exception safety guarantees for operations with Variables

### DIFF
--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -270,12 +270,14 @@ void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
   // For sparse data we can fail for any subitem if the sizes to not match. To
   // avoid partially modifying (and thus corrupting) data in an in-place
   // operation we need to do the checks before any modification happens.
-  if constexpr (is_sparse_v<decltype(vals[0])> &&
-                std::is_base_of_v<SparseFlag, Op>) {
+  if constexpr (is_sparse_v<decltype(vals[0])>) {
     for (scipp::index i = 0; i < scipp::size(vals); ++i) {
       ValuesAndVariances _{vals[i], vars[i]};
-      static_cast<void>(
-          check_and_get_size(_, value_and_maybe_variance(other, i)...));
+      if constexpr (std::is_base_of_v<SparseFlag, Op>)
+        static_cast<void>(
+            check_and_get_size(_, value_and_maybe_variance(other, i)...));
+      else
+        static_cast<void>((value_and_maybe_variance(other, i), ...));
     }
   }
   // WARNING: Do not parallelize this loop in all cases! The output may have a

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -235,10 +235,46 @@ struct is_eigen_type<sparse_container<Eigen::Matrix<T, Rows, Cols>>>
 template <class T>
 inline constexpr bool is_eigen_type_v = is_eigen_type<T>::value;
 
+namespace transform_detail {
+template <class T> struct is_sparse : std::false_type {};
+template <class T> struct is_sparse<sparse_container<T>> : std::true_type {};
+template <class T>
+struct is_sparse<ValuesAndVariances<sparse_container<T>>> : std::true_type {};
+template <class T>
+struct is_sparse<ValuesAndVariances<const sparse_container<T>>>
+    : std::true_type {};
+template <class T> inline constexpr bool is_sparse_v = is_sparse<T>::value;
+} // namespace transform_detail
+
+template <class T> auto check_and_get_size(const T &a) {
+  return scipp::size(a);
+}
+
+template <class T1, class T2>
+auto check_and_get_size(const T1 &a, const T2 &b) {
+  if constexpr (transform_detail::is_sparse_v<T1>) {
+    if constexpr (transform_detail::is_sparse_v<T2>)
+      expect::sizeMatches(a, b);
+    return scipp::size(a);
+  } else {
+    return scipp::size(b);
+  }
+}
+
 template <class Op, class T, class... Ts>
 void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
                                            Ts &&... other) {
   auto & [ vals, vars ] = arg;
+  // For sparse data we can fail for any subitem if the sizes to not match. To
+  // avoid partially modifying (and thus corrupting) data in an in-place
+  // operation we need to do the checks before any modification happens.
+  if constexpr (is_sparse_v<decltype(vals[0])>) {
+    for (scipp::index i = 0; i < scipp::size(vals); ++i) {
+      ValuesAndVariances _{vals[i], vars[i]};
+      static_cast<void>(
+          check_and_get_size(_, value_and_maybe_variance(other, i)...));
+    }
+  }
   // WARNING: Do not parallelize this loop in all cases! The output may have a
   // dimension with stride zero so parallelization must be done with care.
   for (scipp::index i = 0; i < scipp::size(vals); ++i) {
@@ -282,6 +318,12 @@ void transform_elements_with_variance(Op op, ValuesAndVariances<Out> out,
 
 template <class Op, class T, class... Ts>
 void transform_in_place_impl(Op op, T &&vals, Ts &&... other) {
+  // For sparse data we can fail for any subitem if the sizes to not match. To
+  // avoid partially modifying (and thus corrupting) data in an in-place
+  // operation we need to do the checks before any modification happens.
+  if constexpr (is_sparse_v<decltype(vals[0])>)
+    for (scipp::index i = 0; i < scipp::size(vals); ++i)
+      static_cast<void>(check_and_get_size(vals[i], other[i]...));
   // WARNING: Do not parallelize this loop in all cases! The output may have a
   // dimension with stride zero so parallelization must be done with care.
   for (scipp::index i = 0; i < scipp::size(vals); ++i)
@@ -312,17 +354,6 @@ template <class T> using element_type_t = typename element_type<T>::type;
 template <class T>
 using const_element_type_t = const typename element_type<T>::type;
 
-namespace transform_detail {
-template <class T> struct is_sparse : std::false_type {};
-template <class T> struct is_sparse<sparse_container<T>> : std::true_type {};
-template <class T>
-struct is_sparse<ValuesAndVariances<sparse_container<T>>> : std::true_type {};
-template <class T>
-struct is_sparse<ValuesAndVariances<const sparse_container<T>>>
-    : std::true_type {};
-template <class T> inline constexpr bool is_sparse_v = is_sparse<T>::value;
-} // namespace transform_detail
-
 /// Broadcast a constant to arbitrary size. Helper for TransformSparse.
 ///
 /// This helper allows the use of a common transform implementation when mixing
@@ -339,21 +370,6 @@ template <class T> decltype(auto) maybe_broadcast(T &&value) {
     return std::forward<T>(value);
   else
     return broadcast{value};
-}
-
-template <class T> auto check_and_get_size(const T &a) {
-  return scipp::size(a);
-}
-
-template <class T1, class T2>
-auto check_and_get_size(const T1 &a, const T2 &b) {
-  if constexpr (transform_detail::is_sparse_v<T1>) {
-    if constexpr (transform_detail::is_sparse_v<T2>)
-      expect::sizeMatches(a, b);
-    return scipp::size(a);
-  } else {
-    return scipp::size(b);
-  }
 }
 
 template <class T>

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -270,6 +270,7 @@ public:
 
   units::Unit unit() const { return m_unit; }
   void setUnit(const units::Unit &unit) { m_unit = unit; }
+  constexpr void expectCanSetUnit(const units::Unit &) const noexcept {}
 
   Dimensions dims() const && { return m_object->dims(); }
   const Dimensions &dims() const & { return m_object->dims(); }
@@ -696,6 +697,7 @@ public:
   VariableProxy operator/=(const double value) const;
 
   void setUnit(const units::Unit &unit) const;
+  void expectCanSetUnit(const units::Unit &unit) const;
 
 private:
   friend class Variable;

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -176,6 +176,41 @@ TEST(Variable, operator_times_equal_scalar) {
   EXPECT_EQ(a.unit(), units::m);
 }
 
+TEST(Variable, operator_times_equal_unit_fail_integrity) {
+  auto a = makeVariable<double>({Dim::X, 2}, units::m * units::m, {2.0, 3.0});
+  const auto expected(a);
+
+  // This test relies on m^4 being an unsupported unit.
+  ASSERT_THROW(a *= a, std::runtime_error);
+  EXPECT_EQ(a, expected);
+}
+
+TEST(Variable, operator_times_equal_data_fail_unit_integrity) {
+  auto a = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto a_ = a.sparseValues<float>();
+  auto b(a);
+  a_[0] = {0.1, 0.2};
+  a_[1] = {0.3};
+  b.setUnit(units::m);
+  auto expected(a);
+
+  ASSERT_THROW(a *= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+}
+
+TEST(Variable, operator_times_equal_slice_unit_fail_integrity) {
+  auto a = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto a_ = a.sparseValues<float>();
+  a_[0] = {0.1, 0.2};
+  a_[1] = {0.3};
+  auto b(a);
+  b.setUnit(units::m);
+  auto expected(a);
+
+  ASSERT_THROW(a.slice({Dim::Y, 0}) *= b.slice({Dim::Y, 0}), except::UnitError);
+  EXPECT_EQ(a, expected);
+}
+
 TEST(Variable, operator_times_can_broadcast) {
   auto a = makeVariable<double>({Dim::X, 2}, {0.5, 1.5});
   auto b = makeVariable<double>({Dim::Y, 2}, {2.0, 3.0});

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -200,6 +200,52 @@ TEST(Variable, operator_binary_equal_data_fail_unit_integrity) {
   EXPECT_EQ(a, expected);
 }
 
+TEST(Variable, operator_binary_equal_data_fail_data_integrity) {
+  auto a = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto a_ = a.sparseValues<float>();
+  a_[0] = {0.1, 0.2};
+  auto b(a);
+  a_[1] = {0.3};
+  b.setUnit(units::m);
+  auto expected(a);
+
+  ASSERT_THROW(a *= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+  ASSERT_THROW(a /= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+}
+
+TEST(Variable, operator_binary_equal_with_variances_data_fail_data_integrity) {
+  auto a = makeVariableWithVariances<float>(
+      {{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
+  auto a_ = a.sparseValues<float>();
+  auto a_vars = a.sparseVariances<float>();
+  a_[0] = {0.1, 0.2};
+  a_vars[0] = {0.1, 0.2};
+  auto b(a);
+  a_[1] = {0.3};
+  a_vars[1] = {0.3};
+  b.setUnit(units::m);
+  auto expected(a);
+
+  // Length mismatch of second sparse item
+  ASSERT_THROW(a *= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+  ASSERT_THROW(a /= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+
+  b = a;
+  b.setUnit(units::m);
+  a_vars[1].clear();
+  expected = a;
+
+  // Length mismatch between values and variances
+  ASSERT_THROW(a *= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+  ASSERT_THROW(a /= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+}
+
 TEST(Variable, operator_times_equal_slice_unit_fail_integrity) {
   auto a = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
   auto a_ = a.sparseValues<float>();

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -185,7 +185,7 @@ TEST(Variable, operator_times_equal_unit_fail_integrity) {
   EXPECT_EQ(a, expected);
 }
 
-TEST(Variable, operator_times_equal_data_fail_unit_integrity) {
+TEST(Variable, operator_binary_equal_data_fail_unit_integrity) {
   auto a = makeVariable<float>({{Dim::Y, 2}, {Dim::Z, Dimensions::Sparse}});
   auto a_ = a.sparseValues<float>();
   auto b(a);
@@ -195,6 +195,8 @@ TEST(Variable, operator_times_equal_data_fail_unit_integrity) {
   auto expected(a);
 
   ASSERT_THROW(a *= b, except::SizeError);
+  EXPECT_EQ(a, expected);
+  ASSERT_THROW(a /= b, except::SizeError);
   EXPECT_EQ(a, expected);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -839,10 +839,14 @@ bool VariableConstProxy::operator!=(const VariableConstProxy &other) const {
 }
 
 void VariableProxy::setUnit(const units::Unit &unit) const {
+  expectCanSetUnit(unit);
+  m_mutableVariable->setUnit(unit);
+}
+
+void VariableProxy::expectCanSetUnit(const units::Unit &unit) const {
   if ((this->unit() != unit) && (dims() != m_mutableVariable->dims()))
     throw except::UnitError("Partial view on data of variable cannot be used "
                             "to change the unit.");
-  m_mutableVariable->setUnit(unit);
 }
 
 template <class T>

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -88,16 +88,11 @@ Variable &Variable::operator-=(const double value) & {
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   expect::contains(variable.dims(), other.dims());
   // setUnit is catching bad cases of changing units (if `variable` is a slice).
-  const auto oldUnit = variable.unit();
+  variable.expectCanSetUnit(variable.unit() * other.unit());
+  transform_in_place<pair_self_t<double, float, int64_t>,
+                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
+      variable, other, [](auto &&a, auto &&b) { a *= b; });
   variable.setUnit(variable.unit() * other.unit());
-  try {
-    transform_in_place<pair_self_t<double, float, int64_t>,
-                       pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-        variable, other, [](auto &&a, auto &&b) { a *= b; });
-  } catch (const std::runtime_error &) {
-    variable.setUnit(oldUnit);
-    throw;
-  }
   return variable;
 }
 

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -88,10 +88,16 @@ Variable &Variable::operator-=(const double value) & {
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   expect::contains(variable.dims(), other.dims());
   // setUnit is catching bad cases of changing units (if `variable` is a slice).
+  const auto oldUnit = variable.unit();
   variable.setUnit(variable.unit() * other.unit());
-  transform_in_place<pair_self_t<double, float, int64_t>,
-                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { a *= b; });
+  try {
+    transform_in_place<pair_self_t<double, float, int64_t>,
+                       pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
+        variable, other, [](auto &&a, auto &&b) { a *= b; });
+  } catch (const std::runtime_error &) {
+    variable.setUnit(oldUnit);
+    throw;
+  }
   return variable;
 }
 

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -118,10 +118,11 @@ Variable &Variable::operator*=(const double value) & {
 template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
   expect::contains(variable.dims(), other.dims());
   // setUnit is catching bad cases of changing units (if `variable` is a slice).
-  variable.setUnit(variable.unit() / other.unit());
+  variable.expectCanSetUnit(variable.unit() / other.unit());
   transform_in_place<pair_self_t<double, float, int64_t>,
                      pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
       variable, other, [](auto &&a, auto &&b) { a /= b; });
+  variable.setUnit(variable.unit() / other.unit());
   return variable;
 }
 

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -142,7 +142,7 @@ using supported_units = decltype(detail::make_unit(
     std::make_tuple(m, dimensionless / m),
     std::make_tuple(dimensionless, counts, s, kg, angstrom, meV, us,
                     dimensionless / us, dimensionless / s, counts / us,
-                    counts / meV, m *m *m *m, meV *us *us / (m * m),
+                    counts / meV, m *m *m, meV *us *us / (m * m),
                     meV *us *us *dimensionless, kg *m / s, m / s, c, c *m,
                     meV / c, dimensionless / c, K, us / angstrom,
                     us / (m * angstrom))));

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -66,9 +66,9 @@ TEST(Unit, multiply) {
   EXPECT_EQ(a * c, c);
   EXPECT_EQ(c * a, c);
   EXPECT_EQ(b * b, c);
-  EXPECT_ANY_THROW(b * c);
-  EXPECT_ANY_THROW(c * b);
-  EXPECT_EQ(c * c, units::m * units::m * units::m * units::m);
+  EXPECT_EQ(b * c, units::m * units::m * units::m);
+  EXPECT_EQ(c * b, units::m * units::m * units::m);
+  EXPECT_ANY_THROW(c * c);
 }
 
 TEST(Unit, multiply_counts) {


### PR DESCRIPTION
This is a step towards #248 but does not yet cover operations with `Dataset`.

- `transform_in_place` is adapted to check all sparse container sizes in advance, before data is modified.
- Some changes in `*=` and `/=` to avoid corruption of the unit if the data operation fails.