### PR TITLE
Extend documentation with code examples

### DIFF
--- a/core/except.cpp
+++ b/core/except.cpp
@@ -81,7 +81,7 @@ std::string make_dims_labels(const Variable &variable,
   if (dims.empty())
     return "()";
   std::string diminfo = "(";
-  for (const auto dim : dims.labels()) {
+  for (const auto dim : dims.denseLabels()) {
     diminfo += to_string_with_sep(dim, separator);
     if (datasetDims.contains(dim) && (datasetDims[dim] + 1 == dims[dim]))
       diminfo += " [bin-edges]";
@@ -146,7 +146,7 @@ void format_line(std::stringstream &s,
 
 std::string to_string(const Variable &variable, const std::string &separator) {
   std::stringstream s;
-  s << "<Variable>";
+  s << "<scipp.Variable>";
   format_line(s, to_string_components(variable, separator));
   return s.str();
 }
@@ -154,7 +154,7 @@ std::string to_string(const Variable &variable, const std::string &separator) {
 std::string to_string(const VariableConstProxy &variable,
                       const std::string &separator) {
   std::stringstream s;
-  s << "<VariableProxy>";
+  s << "<scipp.VariableProxy>";
   format_line(s, to_string_components(variable, separator));
   return s.str();
 }
@@ -194,12 +194,13 @@ template <class T> Dimensions dimensions(const T &dataset) {
 }
 
 std::string to_string(const Dataset &dataset, const std::string &separator) {
-  return do_to_string(dataset, "<Dataset>", dimensions(dataset), separator);
+  return do_to_string(dataset, "<scipp.Dataset>", dimensions(dataset),
+                      separator);
 }
 
 std::string to_string(const DatasetConstProxy &dataset,
                       const std::string &separator) {
-  return do_to_string(dataset, "<DatasetProxy>", dimensions(dataset),
+  return do_to_string(dataset, "<scipp.DatasetProxy>", dimensions(dataset),
                       separator);
 }
 

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -115,7 +115,10 @@ auto to_string_components(const Key &key, const Var &variable,
                           const std::string &separator,
                           const Dimensions &datasetDims = Dimensions()) {
   std::array<std::string, 4> out;
-  out[0] = to_string(key);
+  if constexpr (std::is_same_v<Key, Dim>)
+    out[0] = to_string_with_sep(key, separator);
+  else
+    out[0] = to_string(key);
   out[1] = to_string(variable.dtype());
   out[2] = '[' + variable.unit().name() + ']';
   out[3] = make_dims_labels(variable, separator, datasetDims);
@@ -168,6 +171,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
   s << "Coordinates:\n";
   for (const auto & [ dim, var ] : dataset.coords())
     format_line(s, to_string_components(dim, var, separator, dims));
+  s << "Labels:\n";
   for (const auto & [ name, var ] : dataset.labels())
     format_line(s, to_string_components(name, var, separator, dims));
   s << "Data:\n";

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }
 

--- a/docs/cpp-reference/customizing.rst
+++ b/docs/cpp-reference/customizing.rst
@@ -1,3 +1,5 @@
+.. _customizing:
+
 Customizing Scipp
 =================
 

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -13,7 +13,7 @@ For a more detailed explanation we refer to the :ref:`documentation of Dataset <
 
 Scipp labels dimensions and their associated coordinates using pre-defined dimension labels such as ``Dim.X``, ``Dim.Temperature``, or ``Dim.Wavelength``.
 
-Operations with dataset "align" data items based on their names, dimension labels, and coordinate values.
+Operations with datasets "align" data items based on their names, dimension labels, and coordinate values.
 Missing dimensions in the operands are automatically broadcast.
 If names or coordinates do not match, operations fail.
 In general scipp does not support automatic re-alignment of data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Documentation
 
    user-guide/data-structures
    user-guide/slicing
+   user-guide/operations
 
 .. toctree::
    :caption: Python Reference

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Documentation
    user-guide/data-structures
    user-guide/slicing
    user-guide/operations
+   user-guide/sparse-data
 
 .. toctree::
    :caption: Python Reference

--- a/docs/user-guide/data-structures.rst
+++ b/docs/user-guide/data-structures.rst
@@ -3,6 +3,23 @@
 Data Structures
 ===============
 
+Dimension labels
+----------------
+
+Scipp uses hard-coded labels for dimension naming.
+Arbitrary string-based labels are deliberately avoided, for two reasons:
+
+- Matching between coordinates and dimensions based on string-matching is error-prone and could lead to non-obvious bugs and data corruption.
+  For example, an operation between two datasets with a mismatching x-coordinate might erroneously succeed if the coordinates of the respective datasets are named ``"x"`` and ``"X"``.
+- Potential performance issues in the underlying C++ libraries.
+
+Instead, scipp uses labels such as ``Dim.X``, ``Dim.Y``, or ``Dim.Temperature``.
+It is obviously impossible to support an exhaustive list of possible dimension labels.
+The intention is to provide different library builds for different science applications, which typically *do* have a well defined set of relevant dimensions.
+See :ref:`customizing` on how to do this.
+
+To keep this documentation generic we typically use ``Dim.X`` or ``Dim.Y``, but this should *not* be seen as a recommendation to use these labels for anything but actual positions or offsets in space.
+
 Variable
 --------
 
@@ -53,8 +70,10 @@ Instead we create it by specifying a shape:
                       variances=True,
                       unit=sc.units.kg)
     var
-    var.values
-    var.variances
+    var.shape # The sparse dimension is not part of the shape
+    len(var.values[0]) # Initially the extent in the sparse dimension is 0
+
+For more details see :ref:`sparse-data`.
 
 A 0-dimensional variable contains a single value (and an optional variance).
 For convenience, singular versions of the ``values`` and ``variances`` properties are provided:

--- a/docs/user-guide/data-structures.rst
+++ b/docs/user-guide/data-structures.rst
@@ -3,26 +3,70 @@
 Data Structures
 ===============
 
-.. ipython:: python
-
-    import numpy as np
-    import scipp as sc
-    dir(sc)
-
 Variable
 --------
 
 :py:class:`scipp.Variable` is a labeled multi-dimensional array.
-It consists of:
+A :py:class:`~scipp.Variable` can be constructed using:
 
-- ``values``: the values of the array
-- ``variances``: the (optional) variances of the array values
-- ``dims``: the dimension names and sizes of for each axis of the array
-- ``unit``: the physical unit of the values in the array
+- ``values``: a multi-dimensional array of values, e.g., a :py:class:`numpy.ndarray`
+- ``variances``: a (optional) multi-dimensional array of variances for the array values
+- ``dims``: a list of dimension labels for each axis of the array
+- ``unit``: a (optional) physical unit of the values in the array
 
 Note that variables, unlike :py:class:`xarray.DataArray`, do *not* have coordinate arrays.
 
+.. ipython:: python
+
+    import numpy as np
+    import scipp as sc
+    from scipp import Dim
+
+    var = sc.Variable(values=np.random.rand(2, 4), dims=[Dim.X, Dim.Y])
+    var
+    var.unit
+    var.values
+    try:
+      var.variances
+    except RuntimeError:
+      print('No variances specified, so they do not exist.')
+
+Variances must have the same shape as values, and units are specified using the :py:class:`scipp.units` module:
+
+.. ipython:: python
+
+    var = sc.Variable(values=np.random.rand(2, 4),
+                      variances=np.random.rand(2, 4),
+                      dims=[Dim.X, Dim.Y],
+                      unit=sc.units.m/sc.units.s)
+    var
+    var.variances
+
 :py:class:`~scipp.Variable` also supports a single *sparse* dimension.
+In this case it is currently not possible to set data directly in the cosntructor.
+Instead we create it by specifying a shape:
+
+.. ipython:: python
+
+    var = sc.Variable(dims=[Dim.X, Dim.Y],
+                      shape=[4, sc.Dimensions.Sparse],
+                      variances=True,
+                      unit=sc.units.kg)
+    var
+    var.values
+    var.variances
+
+A 0-dimensional variable contains a single value (and an optional variance).
+For convenience, singular versions of the ``values`` and ``variances`` properties are provided:
+
+.. ipython:: python
+
+    var_0d = sc.Variable(variances=True, unit=sc.units.kg)
+    var_0d
+    var_0d.value = 2.3
+    var_0d.variance
+
+An exception is raised from the ``value`` and ``variance`` properties if the variable is not 0-dimensional.
 
 .. _data-structures-dataset:
 
@@ -44,3 +88,25 @@ See also the `xarray documentation <http://xarray.pydata.org/en/stable/data-stru
 
 The key distinction between ``coords``, ``labels``, and ``attrs`` is that the former two are required to match in operations between multiple datasets whereas the latter one is not.
 All three are internally a :py:class:`~scipp.Variable`, i.e., they have a physical unit and optionally variances.
+
+.. ipython:: python
+
+    d = sc.Dataset(
+            {'a': sc.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+             'b': sc.Variable(1.0)},
+             coords={
+                 Dim.X: sc.Variable([Dim.X], values=np.arange(2.0), unit=sc.units.m),
+                 Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)},
+             labels={
+                 'aux': sc.Variable([Dim.Y], values=np.random.rand(3))})
+    d
+    d.coords[Dim.X].values
+    d['a'].values
+
+All variables in a dataset must have consistent dimensions.
+Thanks to labeled dimensions transposed data is supported:
+
+.. ipython:: python
+
+    d['c'] = sc.Variable(dims=[Dim.Y, Dim.X], values=np.random.rand(3, 2))
+    d

--- a/docs/user-guide/operations.rst
+++ b/docs/user-guide/operations.rst
@@ -1,0 +1,68 @@
+.. _operations:
+
+Operations with variables and datasets
+======================================
+
+Operations "align" data items based on their dimension labels:
+
+.. ipython:: python
+
+    import numpy as np
+    import scipp as sc
+    from scipp import Dim
+
+    a = sc.Variable(values=np.random.rand(2, 4),
+                    variances=np.random.rand(2, 4),
+                    dims=[Dim.X, Dim.Y],
+                    unit=sc.units.m)
+    b = sc.Variable(values=np.random.rand(4, 2),
+                    variances=np.random.rand(4, 2),
+                    dims=[Dim.Y, Dim.X],
+                    unit=sc.units.s)
+    a/b
+
+Note how operations with variables correctly propagate uncertainties (variances), in contrast to a naive implementation using numpy:
+
+.. ipython:: python
+
+    result = a/b
+    result.values
+    a.values/np.transpose(b.values)
+    result.variances
+    a.variances/np.transpose(b.variances)
+
+The implementation assumes uncorrelated data and is otherwise based on, e.g., `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae>`_.
+
+Missing dimensions in the operands are automatically broadcast:
+
+.. ipython:: python
+
+    a.values
+    a -= a[Dim.X, 1]
+    a.values
+
+Units are required to be compatible:
+
+.. ipython:: python
+    :okexcept:
+
+    a + b
+
+Operations with datasets or items of datasets pair data items based on their names and compare the coordinate values.
+If names or coordinates do not match, operations fail.
+
+.. ipython:: python
+    :okexcept:
+
+    d = sc.Dataset(
+            {'a': sc.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+             'b': sc.Variable(dims=[Dim.Y, Dim.X], values=np.random.rand(3, 2)),
+             'c': sc.Variable(dims=[Dim.X], values=np.random.rand(2)),
+             'd': sc.Variable(1.0)},
+             coords={
+                 Dim.X: sc.Variable([Dim.X], values=np.arange(2.0), unit=sc.units.m),
+                 Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)})
+    d['a'] -= d['b'] # transposing
+    d['a'] -= d[Dim.X, 1]['b'] # broadcasting
+    d['a'] -= d[Dim.X, 1:2]['b'] # fail due to coordinate mismatch
+

--- a/docs/user-guide/slicing.rst
+++ b/docs/user-guide/slicing.rst
@@ -7,3 +7,43 @@ Data in a :py:class:`~scipp.Variable` or :py:class:`~scipp.Dataset` can be index
 The dimension to be sliced is specified using a dimension label and, in contrast to NumPy, positional dimension lookup is not available.
 Positional indexing with an integer or an integer range is implemented by the ``slice`` method, which is available for variables, datasets, as well as items of a dataset.
 In all cases a *view* is returned, i.e., just like when slicing a :py:class:`numpy.ndarray` no copy is performed.
+
+.. ipython:: python
+
+    import numpy as np
+    import scipp as sc
+    from scipp import Dim
+
+    d = sc.Dataset(
+            {'a': sc.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+             'b': sc.Variable(dims=[Dim.Y, Dim.X], values=np.random.rand(3, 2)),
+             'c': sc.Variable(dims=[Dim.X], values=np.random.rand(2)),
+             'd': sc.Variable(1.0)},
+             coords={
+                 Dim.X: sc.Variable([Dim.X], values=np.arange(2.0), unit=sc.units.m),
+                 Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)})
+
+    d[Dim.X, 1]
+
+As when slicing a :py:class:`numpy.ndarray`, the dimension ``Dim.X`` is removed since no range is specified.
+When slicing a dataset a number of other things happen as well:
+
+- The coordinate for ``Dim.X`` is removed.
+- Any data item that does not depend on ``Dim.X`` (``d`` in this case) is removed.
+
+.. ipython:: python
+
+    d[Dim.X, 1:2]
+
+When slicing with a range:
+
+- The coordinate is *not* removed.
+  As above, this is the same behavior as in numpy.
+- Any data item that does not depend on ``Dim.X`` (``d`` in this case) is removed.
+
+Slicing and item access can be done in arbitrary order with identical results:
+
+.. ipython:: python
+
+    d[Dim.X, 1:2]['a'] == d['a'][Dim.X, 1:2]
+    d[Dim.X, 1:2]['a'].coords[Dim.X] == d.coords[Dim.X][Dim.X, 1:2]

--- a/docs/user-guide/sparse-data.rst
+++ b/docs/user-guide/sparse-data.rst
@@ -1,0 +1,73 @@
+.. _sparse-data:
+
+Sparse data
+===========
+
+Scipp can handle a certain type of sparse data, i.e., data that cannot directly be represented as a multi-dimensional array.
+For applications that rely solely on dense arrays of data this section can safely be ignored.
+
+Scipp supports sparse data in shape of a multi-dimensional array of lists.
+This could, e.g., be used to store data from an array of sensors/detectors that are read out independently, with potentially widely varying frequency.
+
+If data has a sparse dimension it is always the innermost dimension of a variable.
+Since here we are not dealing with a dense array we cannot set values for all ``X`` from a numpy array.
+The recommended approach is to slice out all outer dimensions.
+Then the remaining values (for a particluar "X" in this case) are a dense array with a list-like interface:
+
+.. ipython:: python
+
+    import numpy as np
+    import scipp as sc
+    from scipp import Dim
+
+    var = sc.Variable(dims=[Dim.X, Dim.Y],
+                      shape=[4, sc.Dimensions.Sparse])
+
+    var[Dim.X, 0]
+    var[Dim.X, 0].values = np.arange(3)
+    var[Dim.X, 0].values.append(42)
+    var[Dim.X, 0].values.extend(np.ones(3))
+    var[Dim.X, 1].values = np.ones(6)
+    var[Dim.X, 0].values
+    var[Dim.X, 1].values
+    var[Dim.X, 2].values
+
+Operations such as slicing the sparse dimension are ill-defined and are not supported:
+
+.. ipython:: python
+    :okexcept:
+
+    var[Dim.Y, 0]
+
+Operations between variables or datasets broadcast dense data into sparse dimensions:
+
+.. ipython:: python
+
+    scale = sc.Variable(dims=[Dim.X], values=np.arange(2.0, 6))
+    var *= scale
+    var[Dim.X, 0].values
+    var[Dim.X, 1].values
+    var[Dim.X, 2].values
+
+Sparse data in a dataset can be associated with a corresponding sparse coordinate and sparse labels.
+These are specific for a particular data item.
+The sparse coord shadows the global coordinate when accessed via the ``coords`` property of a data item:
+
+.. ipython:: python
+
+    d = sc.Dataset(
+            {'a': sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse]),
+             'b': sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse])},
+             coords={
+                 Dim.X: sc.Variable([Dim.X], values=np.arange(2.0)),
+                 Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0))})
+    d.set_sparse_coord('a', sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse]))
+    d.coords[Dim.Y]
+    d['a'].coords[Dim.Y]
+    try:
+      d['b'].coords[Dim.Y]
+    except IndexError:
+      print('Dense coord is meaningless for sparse data, so it is also hidden')
+
+The lengths of the sublists between coordinate and values (and variances) must match.
+Scipp does not enforce this when modifying sublists, but *does* verify correctness in operations on variables or dataset.

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -157,7 +157,7 @@ template <class... Ts> struct as_VariableViewImpl {
             // 2. For 1-D sparse data, where the individual item is then a
             //    vector-like object.
             if (dims.shape().size() == 0)
-              return py::cast(data[0]);
+              return py::cast(data[0], py::return_value_policy::reference);
             else
               return py::cast(data);
           },

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -254,9 +254,28 @@ using as_VariableView =
 
 template <class T, class... Ignored>
 void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
-  c.def_property_readonly("dims", [](const T &self) { return self.dims(); },
-                          py::return_value_policy::copy,
-                          "The dimensions of the data (read-only).");
+  c.def_property_readonly("dims",
+                          [](const T &self) {
+                            const auto &dims = self.dims();
+                            return std::vector<Dim>(dims.labels().begin(),
+                                                    dims.labels().end());
+                          },
+                          "Dimension labels of the data (read-only).");
+  c.def_property_readonly("shape",
+                          [](const T &self) {
+                            const auto &dims = self.dims();
+                            return std::vector<scipp::index>(
+                                dims.shape().begin(), dims.shape().end());
+                          },
+                          "Shape of the data (read-only).");
+  c.def_property_readonly("sparse",
+                          [](const T &self) { return self.dims().sparse(); },
+                          "Return True if there is a sparse dimension.");
+  c.def_property_readonly("sparse_dim",
+                          [](const T &self) { return self.dims().sparseDim(); },
+                          "Return the label of a potential sparse dimension, "
+                          "Dim.Invalid otherwise.");
+
   c.def_property("unit", &T::unit, &T::setUnit,
                  "The physical unit of the data (writable).");
 

--- a/python/bind_math_methods.h
+++ b/python/bind_math_methods.h
@@ -11,8 +11,12 @@ namespace py = pybind11;
 
 template <class T, class... Ignored>
 void bind_math_methods(pybind11::class_<T, Ignored...> &c) {
+  c.def(py::self == py::self, py::call_guard<py::gil_scoped_release>());
+  c.def(py::self != py::self, py::call_guard<py::gil_scoped_release>());
   c.def(py::self += py::self, py::call_guard<py::gil_scoped_release>());
+  c.def(py::self -= py::self, py::call_guard<py::gil_scoped_release>());
   c.def(py::self *= py::self, py::call_guard<py::gil_scoped_release>());
+  c.def(py::self /= py::self, py::call_guard<py::gil_scoped_release>());
 }
 
 #endif // SCIPPY_BIND_MATH_METHODS_H

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -48,6 +48,10 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
         [](const T &self, const Dataset &other) { return self == other; });
   c.def("__eq__",
         [](const T &self, const DatasetProxy &other) { return self == other; });
+  c.def("__ne__",
+        [](const T &self, const Dataset &other) { return self == other; });
+  c.def("__ne__",
+        [](const T &self, const DatasetProxy &other) { return self == other; });
 }
 
 void init_dataset(py::module &m) {
@@ -82,6 +86,13 @@ void init_dataset(py::module &m) {
            py::arg("coords") = std::map<Dim, Variable>{},
            py::arg("labels") = std::map<std::string, Variable>{})
       .def("__setitem__", &Dataset::setData)
+      .def("__setitem__",
+           [](Dataset &self, const std::string &name, const DataProxy &data) {
+             if (self.contains(name))
+               self[name].assign(data);
+             else
+               throw std::runtime_error("Not implemented yet");
+           })
       .def("set_coord", &Dataset::setCoord);
 
   bind_dataset_proxy_methods(dataset);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -93,7 +93,11 @@ void init_dataset(py::module &m) {
              else
                throw std::runtime_error("Not implemented yet");
            })
-      .def("set_coord", &Dataset::setCoord);
+      .def("set_sparse_coord", &Dataset::setSparseCoord)
+      .def("set_sparse_labels", &Dataset::setSparseLabels)
+      .def("set_coord", &Dataset::setCoord)
+      .def("set_labels", &Dataset::setLabels)
+      .def("set_attr", &Dataset::setAttr);
 
   bind_dataset_proxy_methods(dataset);
   bind_dataset_proxy_methods(datasetProxy);

--- a/python/src/scipp/plot.py
+++ b/python/src/scipp/plot.py
@@ -745,8 +745,8 @@ class SliceViewer:
         self.xlabs = self.xcoord.dims
         self.ylabs = self.ycoord.dims
 
-        self.labels = self.dims
-        self.shapes = self.shape
+        self.labels = self.input_data.dims
+        self.shapes = dict(zip(self.labels, self.input_data.shape))
 
         # Size of the slider coordinate arrays
         self.slider_nx = []

--- a/python/src/scipp/plot.py
+++ b/python/src/scipp/plot.py
@@ -191,16 +191,18 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
     """
 
     dims = input_data.dims
-    labs = dims.labels
+    shape = input_data.shape
     coords = input_data.coords
 
     # Gather list of dimensions that are to be collapsed
     slice_dims = []
     volume = 1
-    for lab in labs:
-        if lab != dim:
-            slice_dims.append(lab)
-            volume *= dims[lab]
+    slice_shape = dict()
+    for d, size in zip(dims, shape):
+        if d != dim:
+            slice_dims.append(d)
+            slice_shape[d] = size
+            volume *= size
 
     # Create temporary Dataset
     ds = sp.Dataset()
@@ -214,7 +216,7 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
     # [[0, 1, 2, 3, 4], [0, 1, 2]]
     dim_list = []
     for l in slice_dims:
-        dim_list.append(np.arange(dims[l], dtype=np.int32))
+        dim_list.append(np.arange(slice_shape[l], dtype=np.int32))
     # Next create a grid of indices
     # grid will contain
     # [ [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
@@ -707,9 +709,7 @@ def plot_sliceviewer(input_data, axes=None, contours=False, cb=None,
     """
 
     if axes is None:
-        dims = input_data.dims
-        labs = dims.labels
-        axes = [l for l in labs]
+        axes = input_data.dims
 
     # Use the machinery in plot_image to make the layout
     data, layout, xlabs, ylabs, cbar = plot_image(input_data, axes=axes,
@@ -742,15 +742,11 @@ class SliceViewer:
         self.coords = self.input_data.coords
         self.xcoord = self.coords[axes[-1]]
         self.ycoord = self.coords[axes[-2]]
-        self.xdims = self.xcoord.dims
-        self.xlabs = self.xdims.labels
-        self.ydims = self.ycoord.dims
-        self.ylabs = self.ydims.labels
+        self.xlabs = self.xcoord.dims
+        self.ylabs = self.ycoord.dims
 
-        # Need these to avoid things running out of scope
-        self.dims = self.input_data.dims
-        self.labels = self.dims.labels
-        self.shapes = self.dims.shape
+        self.labels = self.dims
+        self.shapes = self.shape
 
         # Size of the slider coordinate arrays
         self.slider_nx = []
@@ -819,8 +815,7 @@ class SliceViewer:
         z = vslice.values
 
         # Check if dimensions of arrays agree, if not, plot the transpose
-        zdims = vslice.dims
-        zlabs = zdims.labels
+        zlabs = vslice.dims
         if (zlabs[0] == self.xlabs[0]) and (zlabs[1] == self.ylabs[0]):
             z = z.T
         # Apply colorbar parameters
@@ -860,9 +855,8 @@ def process_dimensions(input_data, coords, axes):
     Make x and y arrays from dimensions and check for bins edges
     """
     # coords = input_data.coords
-    zdims = input_data.dims
-    zlabs = zdims.labels
-    nz = zdims.shape
+    zlabs = input_data.dims
+    nz = input_data.shape
 
     if axes is None:
         axes = [l for l in zlabs]
@@ -879,12 +873,10 @@ def process_dimensions(input_data, coords, axes):
     # TODO: find a better way to handle edges. Currently, we convert from
     # edges to centers and then back to edges afterwards inside the plotly
     # object. This is not optimal and could lead to precision loss issues.
-    ydims = ycoord.dims
-    ylabs = ydims.labels
-    ny = ydims.shape
-    xdims = xcoord.dims
-    xlabs = xdims.labels
-    nx = xdims.shape
+    ylabs = ycoord.dims
+    ny = ycoord.shape
+    xlabs = xcoord.dims
+    nx = xcoord.shape
     # Find the dimension in z that corresponds to x and y
     ix = iy = None
     for i in range(len(zlabs)):
@@ -896,7 +888,7 @@ def process_dimensions(input_data, coords, axes):
         raise RuntimeError(
             "Dimension of either x ({}) or y ({}) array was not "
             "found in z ({}) array.".format(
-                xdims, ydims, zdims))
+                xlabs, ylabs, zlabs))
     if nx[0] == nz[ix]:
         xe = centers_to_edges(x)
         xc = x

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -55,7 +55,7 @@ def table_ds(dataset):
     for name, var in dataset:
         if len(var.coords) == 1:
             datum1d[name] = var
-            coords1d = var.coords[var.dims.labels[0]]
+            coords1d = var.coords[var.dims[0]]
 
         else:
             datum0d[name] = var
@@ -111,8 +111,7 @@ def table_ds(dataset):
                              attrib=dict({'colspan':
                                          str(1 + val.has_variances)}.items() |
                                          style_border_center.items()))
-            dims = val.dims
-            length = dims.shape[0]
+            length = val.shape[0]
 
         # Check if is histogram
         # TODO: what if the Dataset contains one coordinate with N+1 elements,
@@ -159,10 +158,9 @@ def table_ds(dataset):
 
 def table_var(variable):
     dims = variable.dims
-    labs = dims.labels
-    if len(labs) > 1:
+    if len(dims) > 1:
         raise RuntimeError("Only 1-D variable can be rendered")
-    nx = dims.shape[0]
+    nx = variable.shape[0]
 
     body = et.Element('body')
     headline = et.SubElement(body, 'h3')
@@ -173,7 +171,7 @@ def table_var(variable):
     tab = et.SubElement(body, 'table')
 
     tr = et.SubElement(tab, 'tr')
-    append_with_text(tr, 'th', axis_label(variable, name=str(labs[0])),
+    append_with_text(tr, 'th', axis_label(variable, name=str(dims[0])),
                          attrib=dict({'colspan':
                                      str(1 + variable.has_variances)}.items() |
                                      style_border_center.items()))

--- a/python/src/scipp/tools.py
+++ b/python/src/scipp/tools.py
@@ -29,7 +29,7 @@ def axis_label(var, name=None, log=False):
     if name is not None:
         label = name
     else:
-        label = str(var.dims.labels[0]).replace("Dim.", "")
+        label = str(var.dims[0]).replace("Dim.", "")
 
     if log:
         label = "log\u2081\u2080(" + label + ")"

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -32,20 +32,20 @@ def test_create_default_dtype():
 
 
 def test_create_with_dtype():
-    var = sp.Variable(labels=[Dim.X], shape=[2], dtype=sp.dtype.float)
+    var = sp.Variable(dims=[Dim.X], shape=[2], dtype=sp.dtype.float)
     assert var.dtype == sp.dtype.float
 
 
 def test_create_with_numpy_dtype():
-    var = sp.Variable(labels=[Dim.X], shape=[2], dtype=np.dtype(np.float32))
+    var = sp.Variable(dims=[Dim.X], shape=[2], dtype=np.dtype(np.float32))
     assert var.dtype == sp.dtype.float
 
 
 def test_create_with_variances():
-    assert not sp.Variable(labels=[Dim.X], shape=[2]).has_variances
-    assert not sp.Variable(labels=[Dim.X], shape=[
+    assert not sp.Variable(dims=[Dim.X], shape=[2]).has_variances
+    assert not sp.Variable(dims=[Dim.X], shape=[
                            2], variances=False).has_variances
-    assert sp.Variable(labels=[Dim.X], shape=[2], variances=True).has_variances
+    assert sp.Variable(dims=[Dim.X], shape=[2], variances=True).has_variances
 
 
 def test_create_sparse():
@@ -64,7 +64,7 @@ def test_create_from_numpy_1d():
 
 
 def test_create_from_numpy_1d_bool():
-    var = sp.Variable(labels=[sp.Dim.X], values=np.array([True, False, True]))
+    var = sp.Variable(dims=[sp.Dim.X], values=np.array([True, False, True]))
     assert var.dtype == sp.dtype.bool
     np.testing.assert_array_equal(var.values, np.array([True, False, True]))
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -20,7 +20,7 @@ def make_variables():
 
 def test_create_default():
     var = sp.Variable()
-    assert var.dims == sp.Dimensions()
+    assert var.dims == []
     assert var.dtype == sp.dtype.double
     assert var.unit == sp.units.dimensionless
     assert var.value == 0.0
@@ -51,7 +51,7 @@ def test_create_with_variances():
 def test_create_sparse():
     var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
     assert var.dtype == sp.dtype.double
-    assert var.dims.sparse
+    assert var.sparse
     assert len(var.values) == 4
     for vals in var.values:
         assert len(vals) == 0
@@ -80,7 +80,7 @@ def test_create_with_variances_from_numpy_1d():
 def test_create_scalar():
     var = sp.Variable(1.2)
     assert var.value == 1.2
-    assert var.dims == sp.Dimensions()
+    assert var.dims == []
     assert var.dtype == sp.dtype.double
     assert var.unit == sp.units.dimensionless
 
@@ -88,7 +88,7 @@ def test_create_scalar():
 def test_create_scalar_quantity():
     var = sp.Variable(1.2, unit=sp.units.m)
     assert var.value == 1.2
-    assert var.dims == sp.Dimensions()
+    assert var.dims == []
     assert var.dtype == sp.dtype.double
     assert var.unit == sp.units.m
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -167,7 +167,7 @@ def test_sparse_slice():
     vals0 = var[Dim.X, 0].values
     assert len(vals0) == 0
     vals0.append(1.2)
-    assert len(vals0) == 1
+    assert len(var[Dim.X, 0].values) == 1
 
 
 def test_sparse_setitem():

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -149,7 +149,6 @@ void init_variable(py::module &m) {
       .def("__deepcopy__",
            [](Variable &self, py::dict) { return Variable(self); })
       .def_property_readonly("dtype", &Variable::dtype)
-      .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + double(), py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
@@ -159,13 +158,9 @@ void init_variable(py::module &m) {
       .def(py::self / py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self / double(), py::call_guard<py::gil_scoped_release>())
       .def(py::self += double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self -= double(), py::call_guard<py::gil_scoped_release>())
       .def(py::self *= double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self /= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self /= double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
-      .def(py::self != py::self, py::call_guard<py::gil_scoped_release>())
       .def("__eq__", [](Variable &a, VariableProxy &b) { return a == b; },
            py::is_operator())
       .def("__ne__", [](Variable &a, VariableProxy &b) { return a != b; },
@@ -204,14 +199,10 @@ void init_variable(py::module &m) {
       .def("__copy__", [](VariableProxy &self) { return Variable(self); })
       .def("__deepcopy__",
            [](VariableProxy &self, py::dict) { return Variable(self); })
-      .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
-      .def(py::self /= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self * py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self / py::self, py::call_guard<py::gil_scoped_release>())
-      .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
-      .def(py::self != py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self += double(), py::call_guard<py::gil_scoped_release>())
       .def(py::self -= double(), py::call_guard<py::gil_scoped_release>())
       .def(py::self *= double(), py::call_guard<py::gil_scoped_release>())

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -119,7 +119,7 @@ void init_variable(py::module &m) {
   py::class_<Variable> variable(m, "Variable");
   variable
       .def(py::init(&makeVariableDefaultInit),
-           py::arg("labels") = std::vector<Dim>{},
+           py::arg("dims") = std::vector<Dim>{},
            py::arg("shape") = std::vector<scipp::index>{},
            py::arg("unit") = units::Unit(units::dimensionless),
            py::arg("dtype") = py::dtype::of<double>(),
@@ -138,7 +138,7 @@ void init_variable(py::module &m) {
            py::arg("data"), py::arg("unit") = units::Unit(units::dimensionless))
       // TODO Need to add overload for std::vector<std::string>, etc., see
       // Dataset.__setitem__
-      .def(py::init(&doMakeVariable), py::arg("labels"), py::arg("values"),
+      .def(py::init(&doMakeVariable), py::arg("dims"), py::arg("values"),
            py::arg("variances") = std::nullopt,
            py::arg("unit") = units::Unit(units::dimensionless),
            py::arg("dtype") = py::none())


### PR DESCRIPTION
- The `dims` property now returns only the labels, as in `xarray`. Keyword arguments have also been changed.
- Small fixes around string representation of various objects.
- Add some missing operator bindings.
- Add code examples and extent docs.

Note that when merging this PR the RTD build will fail, since the conda package would need to be updated first.

Fixes #210 (documentation still not complete, but major sections exist now).