### PR TITLE
Use autosummary to include docstrings from Python module.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting'
@@ -41,6 +42,10 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }
+
+# Currently we are using autodoc, autosummary may be more suitable in the long run when the API grows.
+# For a nice example see how xarray handles its API documentation.
+#autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,9 +43,10 @@ intersphinx_mapping = {
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }
 
-# Currently we are using autodoc, autosummary may be more suitable in the long run when the API grows.
+# autodocs includes everything, even irrelevant API internals. autosummary looks
+# more suitable in the long run when the API grows.
 # For a nice example see how xarray handles its API documentation.
-#autosummary_generate = True
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,8 @@ Documentation
    :caption: Python Reference
    :maxdepth: 2
 
+   python-reference/api
+
 .. toctree::
    :caption: C++ Reference
    :maxdepth: 2

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -4,18 +4,27 @@
 API Reference
 #############
 
-.. autoclass:: scipp.Dim
-   :members:
-   :special-members:
+Classes
+=======
 
-.. autoclass:: scipp.Dataset
-   :members:
-   :special-members:
+.. autosummary::
+   :toctree: ../generated
 
-.. autoclass:: scipp.DataProxy
-   :members:
-   :special-members:
+   Dim
+   Variable
+   DataProxy
+   Dataset
 
-.. autoclass:: scipp.Variable
-   :members:
-   :special-members:
+Free functions
+==============
+
+.. autosummary::
+   :toctree: ../generated
+
+   concatenate
+   filter
+   mean
+   norm
+   rebin
+   sqrt
+   sum

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -1,0 +1,21 @@
+.. currentmodule:: scipp
+
+#############
+API Reference
+#############
+
+.. autoclass:: scipp.Dim
+   :members:
+   :special-members:
+
+.. autoclass:: scipp.Dataset
+   :members:
+   :special-members:
+
+.. autoclass:: scipp.DataProxy
+   :members:
+   :special-members:
+
+.. autoclass:: scipp.Variable
+   :members:
+   :special-members:


### PR DESCRIPTION
This adds a new section to the documentation including the auto-generated (from pybind11) docstrings for our exported classes.

- I first tried `autodoc` but this includes a lot of details that should probably not be part of any (user-facing) documentation.

- `autosummary` looks like a better solution, but requires manually maintaining a list of documented methods/functions. What I am adding here is incomplete and only the basic idea. See what xarray does for a nice example: https://github.com/pydata/xarray/blob/stable/doc/api.rst.