### PR TITLE
Fixes to Conda CI step conditionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       script: sh .travis/run_tests.sh
     - stage: "Deploy"
       name: "conda"
+      if: branch = master AND NOT type = pull_request
       git:
         depth: false
       env:

--- a/.travis/conda_build_and_deploy.sh
+++ b/.travis/conda_build_and_deploy.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# Do not perform Conda build and publish unless this is a build of the master branch.
-# Continue regardless if this script is run outside of a Travis-CI environment
-if [[ $TRAVIS == 'true' ]] && [[ ! $TRAVIS_BRANCH == 'master' ]]; then
-  echo 'Not performing conda build and publish for non-master branch job'
-  exit
-fi
-echo 'Performing conda build and publish'
-
 # Show this for debugging only
 git describe --tags
 


### PR DESCRIPTION
Use Travis functionality to restrict Conda build.

Fixes issues in previous logic:
  - test did not correctly prevent building on pull requests
  - test did not guard against installing Miniconda

Things to check:
  - the Conda deploy step did not run (or even show up in the matrix) for this PR
  - the Conda deploy step does run one this PR is merged into `master`