### PR TITLE
Use dev label for documentation

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,7 @@
 name: scipp-docs
 
 channels:
-  - scipp
+  - scipp/label/dev
 
 dependencies:
   - scipp


### PR DESCRIPTION
Installs packages from scipp/labels/dev for the Read The Docs build.

This should fix the failing RTD build.