### PR TITLE
Not using OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,4 +83,3 @@ add_subdirectory(core)
 add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
-#include "scipp/core/variable.tcc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake"
     "${CMAKE_SOURCE_DIR}/CMake/sanitizers-cmake/cmake")
 
-find_package(OpenMP 3.1 REQUIRED)
 find_package(Sanitizers REQUIRED)
 
 include(boost)
@@ -84,3 +83,4 @@ add_subdirectory(core)
 add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
+#include "scipp/core/variable.tcc"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,7 +31,7 @@ set(SRC_FILES
 add_library(scipp-core STATIC ${INC_FILES} ${SRC_FILES})
 generate_export_header(scipp-core)
 target_link_libraries(scipp-core
-                      PUBLIC scipp-units Boost::boost OpenMP::OpenMP_CXX)
+                      PUBLIC scipp-units Boost::boost)
 # Include tcb/span as system header to avoid compiler warnings.
 target_include_directories(
   scipp-core SYSTEM


### PR DESCRIPTION
Requirement removed ahead of improving cross platform and compiler coverage.

OpenMP likely will be a future dependency, but currently it is not.