### PR TITLE
Unit conversion to d-spacing

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -14,8 +14,7 @@ make -j2 install
 ./core/test/scipp-core-test
 
 # Neutron tests
-# There are none so the executable cannot be built
-#./neutron/test/scipp-neutron-test
+./neutron/test/scipp-neutron-test
 
 # Python tests
 python3 -m pip install -r ../python/requirements.txt

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -11,6 +11,17 @@
 
 namespace scipp::core {
 
+void expectUnique(const Dimensions &dims, const Dim label) {
+  if (dims.contains(label))
+    throw except::DimensionError("Duplicate dimension.");
+}
+
+void expectExtendable(const Dimensions &dims) {
+  if (dims.shape().size() == NDIM_MAX)
+    throw except::DimensionError(
+        "Maximum number of allowed dimensions exceeded.");
+}
+
 Dimensions::Dimensions(const std::vector<Dim> &labels,
                        const std::vector<scipp::index> &shape) {
   if (labels.size() != shape.size())
@@ -90,6 +101,12 @@ bool Dimensions::isContiguousIn(const Dimensions &parent) const {
 
 Dim Dimensions::label(const scipp::index i) const { return m_dims[i]; }
 
+void Dimensions::relabel(const scipp::index i, const Dim label) {
+  if (label != Dim::Invalid)
+    expectUnique(*this, label);
+  m_dims[i] = label;
+}
+
 scipp::index Dimensions::size(const scipp::index i) const { return m_shape[i]; }
 
 /// Return the offset of elements along this dimension in a multi-dimensional
@@ -127,17 +144,6 @@ void Dimensions::erase(const Dim label) {
   m_dims[m_ndim] = Dim::Invalid;
   --m_ndim;
   m_shape[m_ndim] = -1;
-}
-
-void expectUnique(const Dimensions &dims, const Dim label) {
-  if (dims.contains(label))
-    throw except::DimensionError("Duplicate dimension.");
-}
-
-void expectExtendable(const Dimensions &dims) {
-  if (dims.shape().size() == NDIM_MAX)
-    throw except::DimensionError(
-        "Maximum number of allowed dimensions exceeded.");
 }
 
 /// Add a new dimension, which will be the outermost dimension.

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -296,6 +296,8 @@ public:
   Dataset slice(const Slice slice1, const Slice slice2,
                 const Slice slice3) const &&;
 
+  void rename(const Dim from, const Dim to);
+
   bool operator==(const Dataset &other) const;
   bool operator==(const DatasetConstProxy &other) const;
   bool operator!=(const Dataset &other) const;

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -121,7 +121,7 @@ public:
   // TODO Some of the following methods are probably legacy and should be
   // considered for removal.
   Dim label(const scipp::index i) const;
-  void relabel(const scipp::index i, const Dim label) { m_dims[i] = label; }
+  void relabel(const scipp::index i, const Dim label);
   scipp::index size(const scipp::index i) const;
   scipp::index offset(const Dim label) const;
   void resize(const Dim label, const scipp::index size);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -763,6 +763,7 @@ SCIPP_CORE_EXPORT Variable mean(const Variable &var, const Dim dim);
 SCIPP_CORE_EXPORT Variable abs(const Variable &var);
 SCIPP_CORE_EXPORT Variable norm(const Variable &var);
 SCIPP_CORE_EXPORT Variable sqrt(const Variable &var);
+SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
 SCIPP_CORE_EXPORT Variable broadcast(Variable var, const Dimensions &dims);
 SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -307,6 +307,7 @@ public:
   // will not go out of scope, so that is ok (unless someone changes var and
   // expects the reshaped view to be still valid).
   Variable reshape(const Dimensions &dims) &&;
+  void rename(const Dim from, const Dim to);
 
   bool operator==(const Variable &other) const;
   bool operator==(const VariableConstProxy &other) const;

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -230,9 +230,7 @@ TEST(TransformTest, Eigen_Vector3d_pass_by_value) {
   const auto expected =
       makeVariable<Eigen::Vector3d>({}, {Eigen::Vector3d{1.0, 2.0, 3.0}});
   // Passing Eigen types by value often causes issues, ensure that it works.
-  auto op = [](const auto x, const auto y) {
-    return x - y;
-  };
+  auto op = [](const auto x, const auto y) { return x - y; };
 
   const auto result = transform<pair_self_t<Eigen::Vector3d>>(
       var.slice({Dim::X, 0}), var.slice({Dim::X, 1}), op);

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -223,6 +223,23 @@ TEST_F(TransformBinaryTest, sparse_size_fail) {
                except::SizeError);
 }
 
+TEST(TransformTest, Eigen_Vector3d_pass_by_value) {
+  const auto var = makeVariable<Eigen::Vector3d>(
+      {Dim::X, 2},
+      {Eigen::Vector3d{1.1, 2.2, 3.3}, Eigen::Vector3d{0.1, 0.2, 0.3}});
+  const auto expected =
+      makeVariable<Eigen::Vector3d>({}, {Eigen::Vector3d{1.0, 2.0, 3.0}});
+  // Passing Eigen types by value often causes issues, ensure that it works.
+  auto op = [](const auto x, const auto y) {
+    return x - y;
+  };
+
+  const auto result = transform<pair_self_t<Eigen::Vector3d>>(
+      var.slice({Dim::X, 0}), var.slice({Dim::X, 1}), op);
+
+  EXPECT_EQ(result, expected);
+}
+
 TEST(TransformTest, mixed_precision) {
   auto d = makeVariable<double>(1e-12);
   auto f = makeVariable<float>(1e-12);
@@ -631,7 +648,7 @@ TEST_F(TransformBinaryTest, DISABLED_broadcast_sparse_val_var_with_val) {
                except::SizeError);
 }
 
-// It is possible to use transform with functors that call non-build-in
+// It is possible to use transform with functors that call non-built-in
 // functions. To do so we have to define that function for the ValueAndVariance
 // helper. If this turns out to be a useful feature we should move
 // ValueAndVariance out of the `detail` namespace and document the mechanism.

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -503,10 +503,11 @@ TEST(Variable, abs_of_scalar) {
 
 TEST(Variable, norm_of_vector) {
   auto reference =
-      makeVariable<double>({Dim::X, 3}, {sqrt(2.0), sqrt(2.0), 2.0});
-  auto var = makeVariable<Eigen::Vector3d>(
-      {Dim::X, 3}, {Eigen::Vector3d{1, 0, -1}, Eigen::Vector3d{1, 1, 0},
-                    Eigen::Vector3d{0, 0, -2}});
+      makeVariable<double>({Dim::X, 3}, units::m, {sqrt(2.0), sqrt(2.0), 2.0});
+  auto var = makeVariable<Eigen::Vector3d>({Dim::X, 3}, units::m,
+                                           {Eigen::Vector3d{1, 0, -1},
+                                            Eigen::Vector3d{1, 1, 0},
+                                            Eigen::Vector3d{0, 0, -2}});
   EXPECT_EQ(norm(var), reference);
 }
 

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -138,9 +138,15 @@ TEST(Variable, operator_plus) {
 }
 
 TEST(Variable, operator_plus_eigen_type) {
-  auto a = makeVariable<Eigen::Vector3d>({Dim::X, 1});
-  auto sum = a + a;
-  EXPECT_EQ(sum.dtype(), dtype<Eigen::Vector3d>);
+  const auto var = makeVariable<Eigen::Vector3d>(
+      {Dim::X, 2},
+      {Eigen::Vector3d{1.0, 2.0, 3.0}, Eigen::Vector3d{0.1, 0.2, 0.3}});
+  const auto expected =
+      makeVariable<Eigen::Vector3d>({}, {Eigen::Vector3d{1.1, 2.2, 3.3}});
+
+  const auto result = var.slice({Dim::X, 0}) + var.slice({Dim::X, 1});
+
+  EXPECT_EQ(result, expected);
 }
 
 TEST(SparseVariable, operator_plus) {

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -751,6 +751,15 @@ TEST(VariableTest, reshape_mutable) {
   ASSERT_EQ(var, modified_original);
 }
 
+TEST(VariableTest, rename) {
+  auto var = makeVariable<double>({{Dim::X, 2}, {Dim::Y, 3}},
+                                  {1, 2, 3, 4, 5, 6}, {7, 8, 9, 10, 11, 12});
+  const Variable expected = var.reshape({{Dim::X, 2}, {Dim::Z, 3}});
+
+  var.rename(Dim::Y, Dim::Z);
+  ASSERT_EQ(var, expected);
+}
+
 TEST(Variable, access_typed_view) {
   auto var =
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}}, {1, 2, 3, 4, 5, 6});

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -177,6 +177,11 @@ Variable VariableConstProxy::reshape(const Dimensions &dims) const {
   return reshaped;
 }
 
+void Variable::rename(const Dim from, const Dim to) {
+  if (dims().contains(from))
+    data().m_dimensions.relabel(dims().index(from), to);
+}
+
 // Example of a "derived" operation: Implementation does not require adding a
 // virtual function to VariableConcept.
 std::vector<Variable> split(const Variable &var, const Dim dim,

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -400,7 +400,10 @@ Variable abs(const Variable &var) {
 }
 
 Variable norm(const Variable &var) {
-  return transform<Eigen::Vector3d>(var, [](auto &&x) { return x.norm(); });
+  Variable result =
+      transform<Eigen::Vector3d>(var, [](auto &&x) { return x.norm(); });
+  result.setUnit(var.unit());
+  return result;
 }
 
 Variable sqrt(const Variable &var) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -414,6 +414,13 @@ Variable sqrt(const Variable &var) {
   return result;
 }
 
+Variable dot(const Variable &a, const Variable &b) {
+  auto result = transform<pair_self_t<Eigen::Vector3d>>(
+      a, b, [](const auto &a_, const auto &b_) { return a_.dot(b_); });
+  result.setUnit(a.unit() * b.unit());
+  return result;
+}
+
 Variable broadcast(Variable var, const Dimensions &dims) {
   if (var.dims().contains(dims))
     return var;

--- a/neutron/CMakeLists.txt
+++ b/neutron/CMakeLists.txt
@@ -16,4 +16,4 @@ target_include_directories(scipp-neutron SYSTEM
                            PRIVATE "../range-v3/include")
 set_target_properties(scipp-neutron PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-#add_subdirectory(test)
+add_subdirectory(test)

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -62,11 +62,9 @@ Dataset tofToDSpacing(Dataset &&d) {
     static_cast<void>(name);
     if (data.coords()[Dim::Tof].dims().sparse()) {
       data.coords()[Dim::Tof] /= conversionFactor;
-    } else {
-      if (data.unit().isCountDensity()) {
-        throw std::runtime_error(
-            "Converting density data to DSpacing not implemented yet.");
-      }
+    } else if (data.unit().isCountDensity()) {
+      // Tof to DSpacing is just a scale factor, so density transform is simple:
+      data *= conversionFactor;
     }
   }
 

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -1,4 +1,3 @@
-/*
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
@@ -7,27 +6,13 @@
 #include <boost/units/systems/si/codata/neutron_constants.hpp>
 #include <boost/units/systems/si/codata/universal_constants.hpp>
 
-#include "counts.h"
-#include "dataset.h"
-#include "md_zip_view.h"
+#include "scipp/core/counts.h"
+#include "scipp/core/dataset.h"
 #include "scipp/neutron/convert.h"
-#include "zip_view.h"
 
-namespace scipp::core {
+using namespace scipp::core;
 
-Variable getSpecPos(const Dataset &d) {
-  // TODO There should be a better way to extract the actual spectrum positions
-  // as a variable.
-  if (d.contains(Coord::Position))
-    return d(Coord::Position);
-  auto specPosView = zipMD(d, MDRead(Coord::Position));
-  auto specPos =
-      makeVariable<double>(d(Coord::DetectorGrouping).dimensions(), units::m);
-  std::transform(specPosView.begin(), specPosView.end(),
-                 specPos.span<Eigen::Vector3d>().begin(),
-                 [](const auto &item) { return item.get(Coord::Position); });
-  return specPos;
-}
+namespace scipp::neutron {
 
 const auto tof_to_s =
     boost::units::quantity<boost::units::si::time>(1.0 * units::us) / units::us;
@@ -46,26 +31,19 @@ const auto tofToDSpacingPhysicalConstants =
     2.0 * boost::units::si::constants::codata::m_n * m_to_angstrom /
     (boost::units::si::constants::codata::h * tof_to_s);
 
-namespace neutron {
-namespace tof {
-Dataset tofToDSpacing(const Dataset &d) {
-  if (d.contains(Coord::Ei) || d.contains(Coord::Ef))
-    throw std::runtime_error(
-        "Dataset contains Coord::Ei or Coord::Ef. "
-        "However, conversion to Dim::DSpacing is currently "
-        "only supported for elastic scattering.");
-
+Dataset tofToDSpacing(Dataset &&d) {
   // 1. Compute conversion factor
-  const auto &compPos = d.get(Coord::ComponentInfo)[0](Coord::Position);
+  // TODO Is this a good way to store component information?
+  const auto &compPos =
+      d.labels()["component_info"].values<Dataset>()[0]["position"].data();
   // TODO Need a better mechanism to identify source and sample.
-  const auto &sourcePos = compPos(Dim::Component, 0);
-  const auto &samplePos = compPos(Dim::Component, 1);
+  const auto &sourcePos = compPos.slice({Dim::Row, 0});
+  const auto &samplePos = compPos.slice({Dim::Row, 1});
 
   auto beam = samplePos - sourcePos;
   const auto l1 = norm(beam);
   beam /= l1;
-  const auto specPos = getSpecPos(d);
-  auto scattered = specPos - samplePos;
+  auto scattered = d.coords()[Dim::Position] - samplePos;
   const auto l2 = norm(scattered);
   scattered /= l2;
 
@@ -73,58 +51,30 @@ Dataset tofToDSpacing(const Dataset &d) {
   auto conversionFactor(l1 + l2);
 
   conversionFactor *= tofToDSpacingPhysicalConstants;
-
-  // sin(scattering_angle)
-  // TODO Need `dot` for `Variable`. The following block should just be
-  // conversionFactor *= sqrt(0.5 * (1.0 - dot(beam, scattered)))
-  std::vector<double> sinThetaData(scattered.size());
-  const auto &beamVec = beam.span<Eigen::Vector3d>()[0];
-  const auto scatteredVec = scattered.span<Eigen::Vector3d>();
-  // Using
-  //   cos(2 theta) = 1 - 2 sin^2(theta)
-  // and
-  //   v1 dot v2 = norm(v1) norm(v2) cos(alpha).
-  std::transform(scatteredVec.begin(), scatteredVec.end(), sinThetaData.begin(),
-                 [&](const Eigen::Vector3d &scattered) {
-                   return std::sqrt(0.5 * (1.0 - beamVec.dot(scattered)));
-                 });
-  const auto sinTheta =
-      makeVariable<double>(scattered.dimensions(), sinThetaData);
-  conversionFactor *= sinTheta;
+  conversionFactor *= sqrt(0.5 * (1.0 - dot(beam, scattered)));
 
   // 2. Transform coordinate
-  Dataset converted;
-  const auto &coord = d(Coord::Tof);
-  auto coordDims = coord.dimensions();
-  coordDims.relabel(coordDims.index(Dim::Tof), Dim::DSpacing);
-  // The reshape is to remap the dimension label.
-  converted.insert(Coord::DSpacing,
-                   coord.reshape(coordDims) / conversionFactor);
+  // Cannot use /= since often a broadcast into Dim::Position is required.
+  d.setCoord(Dim::Tof, d.coords()[Dim::Tof] / conversionFactor);
 
   // 3. Transform variables
-  for (const auto & [ name, tag, var ] : d) {
-    auto varDims = var.dimensions();
-    if (varDims.contains(Dim::Tof))
-      varDims.relabel(varDims.index(Dim::Tof), Dim::DSpacing);
-    if (tag == Coord::Tof) {
-      // Done already.
-    } else if (tag == Data::Events) {
-      throw std::runtime_error(
-          "TODO Converting units of event data not implemented yet.");
+  for (const auto & [ name, data ] : d) {
+    static_cast<void>(name);
+    if (data.coords()[Dim::Tof].dims().sparse()) {
+      data.coords()[Dim::Tof] /= conversionFactor;
     } else {
-      // Changing Dim::Tof to Dim::DSpacing.
-      if (counts::isDensity(var)) {
+      if (data.unit().isCountDensity()) {
         throw std::runtime_error(
-            "TODO Converting density data to DSpacing not implemented yet.");
-      } else {
-        converted.insert(tag, name, var.reshape(varDims));
+            "Converting density data to DSpacing not implemented yet.");
       }
     }
   }
 
-  return converted;
+  d.rename(Dim::Tof, Dim::DSpacing);
+  return std::move(d);
 }
 
+/*
 Dataset tofToEnergy(const Dataset &d) {
   // TODO Could in principle also support inelastic. Note that the conversion in
   // Mantid is wrong since it handles inelastic data as if it were elastic.
@@ -265,126 +215,17 @@ Dataset tofToDeltaE(const Dataset &d) {
   // reversed.
   return reverse(converted, Dim::DeltaE);
 }
+*/
 
-scipp::index continuousToIndex(const double val,
-                               const scipp::span<const double> axis) {
-  const auto lower = std::lower_bound(axis.begin(), axis.end(), val);
-  const auto upper = std::upper_bound(axis.begin(), axis.end(), val);
-  if (upper == axis.end() || upper == axis.begin())
-    return -1;
-  if (upper != lower)
-    return std::distance(axis.begin(), lower);
-  return std::distance(axis.begin(), lower) - 1;
-}
-
-Dataset continuousToIndex(const Variable &values, const Dataset &coords) {
-  expect::equals(values.unit(), coords(Coord::Qx).unit());
-  expect::equals(values.unit(), coords(Coord::Qy).unit());
-  expect::equals(values.unit(), coords(Coord::Qz).unit());
-  const auto &vals = values.span<Eigen::Vector3d>();
-  const auto &qx = coords.get(Coord::Qx);
-  const auto &qy = coords.get(Coord::Qy);
-  const auto &qz = coords.get(Coord::Qz);
-  std::vector<scipp::index> ix;
-  std::vector<scipp::index> iy;
-  std::vector<scipp::index> iz;
-  for (const auto &val : vals) {
-    ix.push_back(continuousToIndex(val[0], qx));
-    iy.push_back(continuousToIndex(val[1], qy));
-    iz.push_back(continuousToIndex(val[2], qz));
-  }
-  Dataset index;
-  index.insert<scipp::index>(Coord::Qx, values.dimensions(), ix);
-  index.insert<scipp::index>(Coord::Qy, values.dimensions(), iy);
-  index.insert<scipp::index>(Coord::Qz, values.dimensions(), iz);
-  return index;
-}
-
-Dataset positionToQ(const Dataset &d, const Dataset &qCoords) {
-  const auto &compPos = d.get(Coord::ComponentInfo)[0](Coord::Position);
-  const auto &sourcePos = compPos(Dim::Component, 0);
-  const auto &samplePos = compPos(Dim::Component, 1);
-  const auto l1 = norm(sourcePos - samplePos);
-  const auto specPos = getSpecPos(d);
-
-  auto ki = samplePos - sourcePos;
-  ki /= norm(ki);
-  ki /= 1.0 * units::c;
-  ki = ki * d(Coord::Ei);
-
-  auto kf = specPos - samplePos;
-  kf /= norm(kf);
-  kf /= 1.0 * units::c;
-  kf = kf * (d(Coord::Ei) + d(Coord::DeltaE)); // TODO sign?
-
-  // Coord::Ei could have Dim::Ei, or Dim::Position, in the former case,
-  // ki has {Dim::Ei},
-  // kf has {Dim::Ei, Dim::DeltaE, Dim::Position},
-  // thus qIndex also has {Dim::Ei, Dim::DeltaE, Dim::Position}.
-  // In the latter case we do not have Dim::Ei, the other dimensions are the
-  // same.
-  const auto Q = kf - ki;
-  const auto qIndex = continuousToIndex(Q, qCoords);
-
-  Dataset converted(qCoords);
-  converted.erase(Coord::DeltaE);
-  for (const auto & [ name, tag, var ] : d) {
-    if (tag == Data::Events || tag == Data::EventTofs) {
-      throw std::runtime_error(
-          "TODO Converting units of event data not implemented yet.");
-    } else if (var.dimensions().contains(Dim::Position) &&
-               var.dimensions().contains(Dim::DeltaE)) {
-      // Position axis is converted into 3 Q axes.
-      auto dims = var.dimensions();
-      // TODO Make sure that Dim::Position is outer, otherwise insert
-      // Q-dimensions correctly elsewhere.
-      dims.erase(Dim::Position);
-      dims.add(Dim::Qx, qCoords.dimensions()[Dim::Qx] - 1);
-      dims.add(Dim::Qy, qCoords.dimensions()[Dim::Qy] - 1);
-      dims.add(Dim::Qz, qCoords.dimensions()[Dim::Qz] - 1);
-
-      Variable tmp(var, dims);
-
-      for (scipp::index deltaE = 0; deltaE < var.dimensions()[Dim::DeltaE];
-           ++deltaE) {
-        const auto in = var(Dim::DeltaE, deltaE);
-        const auto out = tmp(Dim::DeltaE, deltaE);
-        const Dataset indices = qIndex(Dim::DeltaE, deltaE);
-        const auto q = zip(indices, Access::Key<scipp::index>{Coord::Qx},
-                           Access::Key<scipp::index>{Coord::Qy},
-                           Access::Key<scipp::index>{Coord::Qz});
-        if (in.dimensions()[Dim::Position] != q.size())
-          throw std::runtime_error("Broken implementation of convert.");
-        for (scipp::index i = 0; i < q.size(); ++i) {
-          const auto[qx, qy, qz] = q[i];
-          // Drop out-of-range values
-          if (qx < 0 || qy < 0 || qz < 0)
-            continue;
-          // Really inefficient accumulation of volume histogram
-          out(Dim::Qx, qx)(Dim::Qy, qy)(Dim::Qz, qz) += in(Dim::Position, i);
-        }
-      }
-      converted.insert(tag, name, std::move(tmp));
-    } else if (var.dimensions().contains(Dim::Position)) {
-      // TODO Drop?
-    } else {
-      converted.insert(tag, name, var);
-    }
-  }
-
-  return converted;
-}
-
-} // namespace tof
-} // namespace neutron
-
-Dataset convert(const Dataset &d, const Dim from, const Dim to) {
+Dataset convert(Dataset d, const Dim from, const Dim to) {
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
-    return neutron::tof::tofToDSpacing(d);
+    return tofToDSpacing(std::move(d));
+  /*
   if ((from == Dim::Tof) && (to == Dim::Energy))
-    return neutron::tof::tofToEnergy(d);
+   return nofToEnergy(d);
   if ((from == Dim::Tof) && (to == Dim::DeltaE))
-    return neutron::tof::tofToDeltaE(d);
+   return tofToDeltaE(d);
+   */
   throw std::runtime_error(
       "Conversion between requested dimensions not implemented yet.");
   // How to convert? There are several cases:
@@ -410,32 +251,4 @@ Dataset convert(const Dataset &d, const Dim from, const Dim to) {
   // MDZipView<const Coord::TwoTheta>(dataset);
 }
 
-bool contains(const std::vector<Dim> &dims, const Dim dim) {
-  return std::find(dims.begin(), dims.end(), dim) != dims.end();
-}
-
-Dataset convert(const Dataset &d, const std::vector<Dim> &from,
-                const Dataset &toCoords) {
-  if (from.size() == 2 && contains(from, Dim::Position) &&
-      contains(from, Dim::DeltaE)) {
-    // Converting from position space
-    if (toCoords.size() == 4 && toCoords.contains(Coord::DeltaE) &&
-        toCoords.contains(Coord::Qx) && toCoords.contains(Coord::Qy) &&
-        toCoords.contains(Coord::Qz)) {
-      // Converting to momentum transfer
-      if (d(Coord::DeltaE) != toCoords(Coord::DeltaE)) {
-        // TODO Do we lose precision by rebinning before having computed Q?
-        // Should we map to the output DeltaE only in the main conversion step?
-        auto converted = rebin(d, toCoords(Coord::DeltaE));
-        return neutron::tof::positionToQ(converted, toCoords);
-      } else {
-        return neutron::tof::positionToQ(d, toCoords);
-      }
-    }
-  }
-  throw std::runtime_error(
-      "Conversion between requested dimensions not implemented yet.");
-}
-
-} // namespace scipp::core
-*/
+} // namespace scipp::neutron

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -2,21 +2,21 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef CONVERT_H
-#define CONVERT_H
+#ifndef SCIPP_NEUTRON_CONVERT_H
+#define SCIPP_NEUTRON_CONVERT_H
 
 #include <vector>
 
-#include "dimension.h"
+#include "scipp/units/dimension.h"
 
 namespace scipp::core {
-
 class Dataset;
+}
 
-Dataset convert(const Dataset &d, const Dim from, const Dim to);
-Dataset convert(const Dataset &d, const std::vector<Dim> &from,
-                const Dataset &toCoords);
+namespace scipp::neutron {
 
-} // namespace scipp::core
+core::Dataset convert(core::Dataset d, const Dim from, const Dim to);
 
-#endif // CONVERT_H
+} // namespace scipp::neutron
+
+#endif // SCIPP_NEUTRON_CONVERT_H

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-#include "scipp/units/dimension.h"
+#include "scipp/units/unit.h"
 
 namespace scipp::core {
 class Dataset;

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(scipp-neutron-test
                #Run_test.cpp
                #TableWorkspace_test.cpp
                #Workspace2D_test.cpp
-               #convert_test.cpp
+               convert_test.cpp
                )
 target_link_libraries(scipp-neutron-test
                       LINK_PRIVATE

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,12 +6,13 @@ pybind11_add_module(_scipp
                     dataset.cpp
                     dimensions.cpp
                     dtype.cpp
+                    neutron.cpp
                     scipp.cpp
                     sparse_container.cpp
                     units_neutron.cpp
                     variable.cpp
                     variable_view.cpp)
-target_link_libraries(_scipp LINK_PRIVATE scipp-core)
+target_link_libraries(_scipp LINK_PRIVATE scipp-core scipp-neutron)
 target_include_directories(_scipp SYSTEM PRIVATE "../range-v3/include")
 
 # Set symbol visibility to hidden to reduce binary size, as recommended in pybind11 FAQ.

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/dataset.h"
+#include "scipp/neutron/convert.h"
+
+#include "pybind11.h"
+
+using namespace scipp;
+using namespace scipp::neutron;
+
+namespace py = pybind11;
+
+void init_neutron(py::module &m) {
+  auto neutron = m.def_submodule("neutron");
+
+  neutron.def("convert", convert, py::call_guard<py::gil_scoped_release>(),
+              "Convert coordinates from one dimension (unit) to another.");
+}

--- a/python/scipp.cpp
+++ b/python/scipp.cpp
@@ -9,6 +9,7 @@ namespace py = pybind11;
 void init_dataset(py::module &);
 void init_dimensions(py::module &);
 void init_dtype(py::module &);
+void init_neutron(py::module &);
 void init_sparse_container(py::module &);
 void init_units_neutron(py::module &);
 void init_variable(py::module &);
@@ -18,6 +19,7 @@ PYBIND11_MODULE(_scipp, m) {
   init_dataset(m);
   init_dimensions(m);
   init_dtype(m);
+  init_neutron(m);
   init_sparse_container(m);
   init_units_neutron(m);
   init_variable(m);

--- a/python/tests/test_neutron_convert.py
+++ b/python/tests/test_neutron_convert.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+from scipp import Dim
+import numpy as np
+
+
+def test_neutron_convert():
+    d = sc.Dataset(
+            {'a': sc.Variable(
+                [Dim.Position, Dim.Tof],
+                values=np.random.rand(4, 9))},
+            coords={
+                Dim.Tof: sc.Variable(
+                    [Dim.Tof],
+                    values=np.arange(1000.0, 1010.0), unit=sc.units.us),
+                Dim.Position: sc.Variable(
+                    dims=[Dim.Position],
+                    shape=(4,),
+                    dtype=sc.dtype.vector_3_double,
+                    unit=sc.units.m)},
+            labels={'component_info': sc.Variable(dtype=sc.dtype.Dataset)})
+    d.labels['component_info'].value = sc.Dataset({'position': sc.Variable(
+        dims=[Dim.Row], shape=(2,),
+        dtype=sc.dtype.vector_3_double,
+        unit=sc.units.m)})
+
+    dspacing = sc.neutron.convert(d, Dim.Tof, Dim.DSpacing)
+    # Detailed testing done on the C++ side
+    assert dspacing.coords[Dim.DSpacing].unit == sc.units.angstrom

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -142,10 +142,10 @@ using supported_units = decltype(detail::make_unit(
     std::make_tuple(m, dimensionless / m),
     std::make_tuple(dimensionless, counts, s, kg, angstrom, meV, us,
                     dimensionless / us, dimensionless / s, counts / us,
-                    counts / meV, m *m *m, meV *us *us / (m * m),
-                    meV *us *us *dimensionless, kg *m / s, m / s, c, c *m,
-                    meV / c, dimensionless / c, K, us / angstrom,
-                    us / (m * angstrom))));
+                    counts / angstrom, counts / meV, m *m *m,
+                    meV *us *us / (m * m), meV *us *us *dimensionless,
+                    kg *m / s, m / s, c, c *m, meV / c, dimensionless / c, K,
+                    us / angstrom, us / (m * angstrom))));
 
 using counts_unit = decltype(counts);
 using Unit = Unit_impl<supported_units, counts_unit>;


### PR DESCRIPTION
This PR provides the first unit conversion after they were disabled during the `Dataset` rewrite.

- Tof - > d-spacing conversion, as needed for powder reduction. 
- Fix #354, an issue of our `transform` template with `Eigen` types.
- Fix a bad unit in `norm`.
- Re-enable running `scipp-neutron-tests` in Travis, since now they are not empty any more.

Both the core logic as well as the unit tests are right now not generic yet. When we add more conversions as a follow-up we will need to figure out how to avoid duplicating too much code. That being said, the code is already shorter than it used to be due to some more recent improvements in scipp.

Another open point is handling the "component info". I am not happy with the current structure and this should not be considered final, but at least this works for now.