### PR TITLE
Units class refactor

### DIFF
--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -101,7 +101,7 @@ constexpr auto make_times_lut(std::variant<Ts...>) {
 template <class T, class... Ts>
 constexpr auto make_divide_inner(std::variant<Ts...>) {
   using V = std::variant<Ts...>;
-  constexpr auto times_ = [](auto x, auto y) -> int64_t {
+  constexpr auto divide_ = [](auto x, auto y) -> int64_t {
     // It is done here to have the si::dimensionless then the units are
     // the same, but is the si::dimensionless valid for non si types? TODO
     if constexpr (std::is_same_v<decltype(x), decltype(y)>)
@@ -111,7 +111,7 @@ constexpr auto make_divide_inner(std::variant<Ts...>) {
       return V(resultT{}).index();
     return -1;
   };
-  return std::array{times_(T{}, Ts{})...};
+  return std::array{divide_(T{}, Ts{})...};
 }
 
 template <class... Ts>

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -81,56 +81,97 @@ Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a,
                            ".");
 }
 
+template <class... Ts>
+constexpr auto make_lut(std::variant<Ts...>) {
+  using T = std::variant<Ts...>;
+  return std::array{T(Ts{})...};
+}
+
+template <class T, class... Ts>
+constexpr auto make_times_inner(std::variant<Ts...>) {
+  using V = std::variant<Ts...>;
+  constexpr auto times_ = [](auto x, auto y) -> int64_t {
+    using resultT = typename decltype(x*y)::unit_type;
+    if constexpr (isKnownUnit<V>(resultT{}))
+      return V(resultT{}).index();
+    return -1;
+  };
+  return std::array{times_(T{}, Ts{})...};
+}
+
+template <class... Ts>
+constexpr auto make_times_lut(std::variant<Ts...>) {
+  return std::array{make_times_inner<Ts>(std::variant<Ts...>{})...};
+}
+
+template <class T, class... Ts>
+constexpr auto make_divide_inner(std::variant<Ts...>) {
+  using V = std::variant<Ts...>;
+  constexpr auto times_ = [](auto x, auto y) -> int64_t {
+    // It is done here to have the si::dimensionless then the units are
+    // the same, but is the si::dimensionless valid for non si types? TODO
+    if constexpr (std::is_same_v<decltype(x), decltype(y)>)
+      return V(dimensionless).index();
+    using resultT = typename decltype(x/y)::unit_type;
+    if constexpr (isKnownUnit<V>(resultT{}))
+      return V(resultT{}).index();
+    return -1;
+  };
+  return std::array{times_(T{}, Ts{})...};
+}
+
+template <class... Ts>
+constexpr auto make_divide_lut(std::variant<Ts...>) {
+  return std::array{make_divide_inner<Ts>(std::variant<Ts...>{})...};
+}
+
+template <class... Ts>
+constexpr auto make_sqrt_lut(std::variant<Ts...>) {
+  using T = std::variant<Ts...>;
+  constexpr auto sqrt_ = [](auto x) -> int64_t {
+    using resultT = typename decltype(sqrt(1.0 * x))::unit_type;
+    if constexpr (isKnownUnit<T>(resultT{}))
+      return T(resultT{}).index();
+    return -1;
+  };
+  return std::array{sqrt_(Ts{})...};
+}
+
 // Mutliplying two units together using std::visit to run through the contents
 // of the std::variant
 template <class T, class Counts>
 Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
                                const Unit_impl<T, Counts> &b) {
-  return Unit_impl<T, Counts>(std::visit(
-      [](auto x, auto y) -> typename Unit_impl<T, Counts>::unit_t {
-        // Creation of z needed here because putting x*y inside the call to
-        // isKnownUnit(x*y) leads to error: temporary of non-literal type in a
-        // constant expression
-        auto z{x * y};
-        if constexpr (isKnownUnit<T>(z))
-          return z;
-        throw std::runtime_error(
-            "Unsupported unit as result of multiplication: (" +
-            units::to_string(x) + ") * (" + units::to_string(y) + ')');
-      },
-      a(), b()));
+  static constexpr auto lut = make_times_lut(T{});
+  auto resultIndex = lut[a().index()][b().index()];
+  if (resultIndex < 0)
+    throw std::runtime_error("Unsupported unit as result of multiplication: (" +
+                             a.name() + ") * (" + b.name() + ')');
+  static constexpr auto units = make_lut(T{});
+  return Unit_impl<T, Counts>(units[resultIndex]);
 }
 
 template <class T, class Counts>
 Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
                                const Unit_impl<T, Counts> &b) {
-  return Unit_impl<T, Counts>(std::visit(
-      [](auto x, auto y) -> typename Unit_impl<T, Counts>::unit_t {
-        // It is done here to have the si::dimensionless then the units are
-        // the same, but is the si::dimensionless valid for non si types? TODO
-        if constexpr (std::is_same_v<decltype(x), decltype(y)>)
-          return dimensionless;
-        auto z{x / y};
-        if constexpr (isKnownUnit<T>(z))
-          return z;
-        throw std::runtime_error("Unsupported unit as result of division: (" +
-                                 units::to_string(x) + ") / (" +
-                                 units::to_string(y) + ')');
-      },
-      a(), b()));
+  static constexpr auto lut = make_divide_lut(T{});
+  auto resultIndex = lut[a().index()][b().index()];
+  if (resultIndex < 0)
+    throw std::runtime_error("Unsupported unit as result of division: (" +
+                             a.name() + ") / (" + b.name() + ')');
+  static constexpr auto units = make_lut(T{});
+  return Unit_impl<T, Counts>(units[resultIndex]);
 }
 
 template <class T, class Counts>
 Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a) {
-  return Unit_impl<T, Counts>(std::visit(
-      [](auto x) -> typename Unit_impl<T, Counts>::unit_t {
-        typename decltype(sqrt(1.0 * x))::unit_type sqrt_x;
-        if constexpr (isKnownUnit<T>(sqrt_x))
-          return sqrt_x;
-        throw std::runtime_error("Unsupported unit as result of sqrt: sqrt(" +
-                                 units::to_string(x) + ").");
-      },
-      a()));
+  static constexpr auto lut = make_sqrt_lut(T{});
+  auto resultIndex = lut[a().index()];
+  if (resultIndex < 0)
+    throw std::runtime_error("Unsupported unit as result of sqrt: sqrt(" +
+                             a.name() + ").");
+  static constexpr auto units = make_lut(T{});
+  return Unit_impl<T, Counts>(units[resultIndex]);
 }
 
 #define INSTANTIATE(Units, Counts)                                             \

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -81,12 +81,6 @@ Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a,
                            ".");
 }
 
-template <class... Ts>
-constexpr auto make_lut(std::variant<Ts...>) {
-  using T = std::variant<Ts...>;
-  return std::array{T(Ts{})...};
-}
-
 template <class T, class... Ts>
 constexpr auto make_times_inner(std::variant<Ts...>) {
   using V = std::variant<Ts...>;
@@ -147,8 +141,7 @@ Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
   if (resultIndex < 0)
     throw std::runtime_error("Unsupported unit as result of multiplication: (" +
                              a.name() + ") * (" + b.name() + ')');
-  static constexpr auto units = make_lut(T{});
-  return Unit_impl<T, Counts>(units[resultIndex]);
+  return Unit_impl<T, Counts>::fromIndex(resultIndex);
 }
 
 template <class T, class Counts>
@@ -159,8 +152,7 @@ Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
   if (resultIndex < 0)
     throw std::runtime_error("Unsupported unit as result of division: (" +
                              a.name() + ") / (" + b.name() + ')');
-  static constexpr auto units = make_lut(T{});
-  return Unit_impl<T, Counts>(units[resultIndex]);
+  return Unit_impl<T, Counts>::fromIndex(resultIndex);
 }
 
 template <class T, class Counts>
@@ -170,8 +162,7 @@ Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a) {
   if (resultIndex < 0)
     throw std::runtime_error("Unsupported unit as result of sqrt: sqrt(" +
                              a.name() + ").");
-  static constexpr auto units = make_lut(T{});
-  return Unit_impl<T, Counts>(units[resultIndex]);
+  return Unit_impl<T, Counts>::fromIndex(resultIndex);
 }
 
 #define INSTANTIATE(Units, Counts)                                             \

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -20,9 +20,9 @@ template <typename T, typename... ALL_T>
 struct isVariantMember<T, std::variant<ALL_T...>>
     : public std::disjunction<std::is_same<T, ALL_T>...> {};
 // Helper to make checking for allowed units more compact
-template <class Units, class Counts, class T>
+template <class Units, class T>
 constexpr bool isKnownUnit(const T &) {
-  return isVariantMember<T, typename Unit_impl<Units, Counts>::unit_t>::value;
+  return isVariantMember<T, Units>::value;
 }
 
 namespace units {
@@ -92,7 +92,7 @@ Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
         // isKnownUnit(x*y) leads to error: temporary of non-literal type in a
         // constant expression
         auto z{x * y};
-        if constexpr (isKnownUnit<T, Counts>(z))
+        if constexpr (isKnownUnit<T>(z))
           return z;
         throw std::runtime_error(
             "Unsupported unit as result of multiplication: (" +
@@ -111,7 +111,7 @@ Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
         if constexpr (std::is_same_v<decltype(x), decltype(y)>)
           return dimensionless;
         auto z{x / y};
-        if constexpr (isKnownUnit<T, Counts>(z))
+        if constexpr (isKnownUnit<T>(z))
           return z;
         throw std::runtime_error("Unsupported unit as result of division: (" +
                                  units::to_string(x) + ") / (" +
@@ -125,7 +125,7 @@ Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a) {
   return Unit_impl<T, Counts>(std::visit(
       [](auto x) -> typename Unit_impl<T, Counts>::unit_t {
         typename decltype(sqrt(1.0 * x))::unit_type sqrt_x;
-        if constexpr (isKnownUnit<T, Counts>(sqrt_x))
+        if constexpr (isKnownUnit<T>(sqrt_x))
           return sqrt_x;
         throw std::runtime_error("Unsupported unit as result of sqrt: sqrt(" +
                                  units::to_string(x) + ").");

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -20,8 +20,7 @@ template <typename T, typename... ALL_T>
 struct isVariantMember<T, std::variant<ALL_T...>>
     : public std::disjunction<std::is_same<T, ALL_T>...> {};
 // Helper to make checking for allowed units more compact
-template <class Units, class T>
-constexpr bool isKnownUnit(const T &) {
+template <class Units, class T> constexpr bool isKnownUnit(const T &) {
   return isVariantMember<T, Units>::value;
 }
 
@@ -85,7 +84,7 @@ template <class T, class... Ts>
 constexpr auto make_times_inner(std::variant<Ts...>) {
   using V = std::variant<Ts...>;
   constexpr auto times_ = [](auto x, auto y) -> int64_t {
-    using resultT = typename decltype(x*y)::unit_type;
+    using resultT = typename decltype(x * y)::unit_type;
     if constexpr (isKnownUnit<V>(resultT{}))
       return V(resultT{}).index();
     return -1;
@@ -93,8 +92,7 @@ constexpr auto make_times_inner(std::variant<Ts...>) {
   return std::array{times_(T{}, Ts{})...};
 }
 
-template <class... Ts>
-constexpr auto make_times_lut(std::variant<Ts...>) {
+template <class... Ts> constexpr auto make_times_lut(std::variant<Ts...>) {
   return std::array{make_times_inner<Ts>(std::variant<Ts...>{})...};
 }
 
@@ -106,7 +104,7 @@ constexpr auto make_divide_inner(std::variant<Ts...>) {
     // the same, but is the si::dimensionless valid for non si types? TODO
     if constexpr (std::is_same_v<decltype(x), decltype(y)>)
       return V(dimensionless).index();
-    using resultT = typename decltype(x/y)::unit_type;
+    using resultT = typename decltype(x / y)::unit_type;
     if constexpr (isKnownUnit<V>(resultT{}))
       return V(resultT{}).index();
     return -1;
@@ -114,13 +112,11 @@ constexpr auto make_divide_inner(std::variant<Ts...>) {
   return std::array{divide_(T{}, Ts{})...};
 }
 
-template <class... Ts>
-constexpr auto make_divide_lut(std::variant<Ts...>) {
+template <class... Ts> constexpr auto make_divide_lut(std::variant<Ts...>) {
   return std::array{make_divide_inner<Ts>(std::variant<Ts...>{})...};
 }
 
-template <class... Ts>
-constexpr auto make_sqrt_lut(std::variant<Ts...>) {
+template <class... Ts> constexpr auto make_sqrt_lut(std::variant<Ts...>) {
   using T = std::variant<Ts...>;
   constexpr auto sqrt_ = [](auto x) -> int64_t {
     using resultT = typename decltype(sqrt(1.0 * x))::unit_type;

--- a/units/include/scipp/units/unit_impl.h
+++ b/units/include/scipp/units/unit_impl.h
@@ -32,6 +32,11 @@ std::variant<Ts...,
 make_unit(const std::tuple<Ts...> &, const std::tuple<Extra...> &) {
   return {};
 }
+
+template <class... Ts> constexpr auto make_lut(std::variant<Ts...>) {
+  return std::array{std::variant<Ts...>(Ts{})...};
+}
+
 } // namespace detail
 
 template <class T, class Counts> class Unit_impl {
@@ -43,6 +48,9 @@ public:
   template <class Dim, class System, class Enable>
   Unit_impl(boost::units::unit<Dim, System, Enable> unit) : m_unit(unit) {}
   explicit Unit_impl(const unit_t &unit) : m_unit(unit) {}
+  static constexpr Unit_impl fromIndex(const int64_t index) {
+    return Unit_impl(m_lut[index]);
+  }
 
   constexpr const Unit_impl::unit_t &operator()() const noexcept {
     return m_unit;
@@ -58,6 +66,7 @@ public:
 
 private:
   unit_t m_unit{units::dimensionless};
+  static constexpr auto m_lut{detail::make_lut(T{})};
   // TODO need to support scale
 };
 

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -78,6 +78,18 @@ TEST(Unit, multiply_counts) {
   EXPECT_EQ(none * counts, counts);
 }
 
+TEST(Unit, divide) {
+  Unit one{units::dimensionless};
+  Unit l{units::m};
+  Unit t{units::s};
+  Unit v{units::m / units::s};
+  EXPECT_EQ(l / one, l);
+  EXPECT_EQ(t / one, t);
+  EXPECT_EQ(l / l, one);
+  EXPECT_EQ(l / t, v);
+  EXPECT_ANY_THROW(one / v);
+}
+
 TEST(Unit, conversion_factors) {
   boost::units::quantity<detail::tof::wavelength> a(2.0 * angstrom);
   boost::units::quantity<boost::units::si::length> b(3.0 * angstrom);


### PR DESCRIPTION
Fixes #218.

Now using a LUT instead of `std::visit` (apart from some single-argument visit, which is less of an issue). Main improvements are:

- Reduce `scipp-units.a` from 42 MB to less than 4 MB (gcc).
- Reduce link time of, e.g., `scipp-core-test` from 1m50s to 1m30s.

In the future we would be able to completely eliminate the `std::variant` and just store the index. At this point this is not necessary. It is an internal change and therefore not urgent, I recommend to wait for future developments such as adding unit scales before we make a decision.