### PR TITLE
Python improvements

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -85,6 +85,15 @@ def test_create_scalar():
     assert var.unit == sp.units.dimensionless
 
 
+def test_create_scalar_Dataset():
+    dataset = sp.Dataset({'a': sp.Variable([sp.Dim.X], np.arange(4.0))})
+    var = sp.Variable(dataset)
+    assert var.value == dataset
+    assert var.dims == []
+    assert var.dtype == sp.dtype.Dataset
+    assert var.unit == sp.units.dimensionless
+
+
 def test_create_scalar_quantity():
     var = sp.Variable(1.2, unit=sp.units.m)
     assert var.value == 1.2

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -102,6 +102,27 @@ def test_create_scalar_quantity():
     assert var.unit == sp.units.m
 
 
+def test_create_1D_string():
+    var = sp.Variable(dims=[Dim.Row], values=['a', 'bb'], unit=sp.units.m)
+    assert len(var.values) == 2
+    assert var.values[0] == 'a'
+    assert var.values[1] == 'bb'
+    assert var.dims == [Dim.Row]
+    assert var.dtype == sp.dtype.string
+    assert var.unit == sp.units.m
+
+
+def test_create_1D_vector_3_double():
+    var = sp.Variable(dims=[Dim.X], values=[
+                      [1, 2, 3], [4, 5, 6]], unit=sp.units.m)
+    assert len(var.values) == 2
+    np.testing.assert_array_equal(var.values[0], [1, 2, 3])
+    np.testing.assert_array_equal(var.values[1], [4, 5, 6])
+    assert var.dims == [Dim.X]
+    assert var.dtype == sp.dtype.vector_3_double
+    assert var.unit == sp.units.m
+
+
 def test_operation_with_scalar_quantity():
     reference = sp.Variable([sp.Dim.X],
                             np.arange(4.0) * 1.5)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -132,6 +132,24 @@ template <class T> void bind_init_0D(py::class_<Variable> &c) {
         py::arg("unit") = units::Unit(units::dimensionless));
 }
 
+template <class T> void bind_init_1D(py::class_<Variable> &c) {
+  c.def(
+      py::init([](const std::vector<Dim> &labels, const std::vector<T> &values,
+                  const std::optional<std::vector<T>> &variances,
+                  const units::Unit &unit) {
+        Variable var;
+        Dimensions dims(labels, {scipp::size(values)});
+        if (variances)
+          var = makeVariable<T>(dims, values, *variances);
+        else
+          var = makeVariable<T>(dims, values);
+        var.setUnit(unit);
+        return var;
+      }),
+      py::arg("dims"), py::arg("values"), py::arg("variances") = std::nullopt,
+      py::arg("unit") = units::Unit(units::dimensionless));
+}
+
 void init_variable(py::module &m) {
   py::class_<Variable> variable(m, "Variable");
   bind_init_0D<Dataset>(variable);
@@ -140,6 +158,8 @@ void init_variable(py::module &m) {
   bind_init_0D<double>(variable);
   bind_init_0D<float>(variable);
   bind_init_0D<Eigen::Vector3d>(variable);
+  bind_init_1D<std::string>(variable);
+  bind_init_1D<Eigen::Vector3d>(variable);
   variable
       .def(py::init(&makeVariableDefaultInit),
            py::arg("dims") = std::vector<Dim>{},

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -167,8 +167,6 @@ void init_variable(py::module &m) {
            py::arg("unit") = units::Unit(units::dimensionless),
            py::arg("dtype") = py::dtype::of<double>(),
            py::arg("variances") = false)
-      // TODO Need to add overload for std::vector<std::string>, etc., see
-      // Dataset.__setitem__
       .def(py::init(&doMakeVariable), py::arg("dims"), py::arg("values"),
            py::arg("variances") = std::nullopt,
            py::arg("unit") = units::Unit(units::dimensionless),


### PR DESCRIPTION
- Support init of 0D variables in more cases.
- Support init of 1D variables in cases where it cannot be done using `numpy.ndarray`, in particular for `std::string` and `Eigen::Vector3d`. This also fixes #340 -- not supporting creation from numpy array now, but at last this is a good baseline.