### PR TITLE
Fix some clang warnings

### DIFF
--- a/core/counts.cpp
+++ b/core/counts.cpp
@@ -52,7 +52,7 @@ Dataset toDensity(Dataset d, const std::vector<Dim> &dims) {
     static_cast<void>(name);
     toDensity(data, binWidths);
   }
-  return std::move(d);
+  return d;
 }
 
 void fromDensity(const DataProxy data, const std::vector<Variable> &binWidths) {
@@ -74,7 +74,7 @@ Dataset fromDensity(Dataset d, const std::vector<Dim> &dims) {
     static_cast<void>(name);
     fromDensity(data, binWidths);
   }
-  return std::move(d);
+  return d;
 }
 
 } // namespace counts

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -169,9 +169,9 @@ TEST(DimensionsTest, duplicate) {
 }
 
 TEST(DimensionsTest, contains_with_sparse_data) {
-  Dimensions denseX({Dim::X}, {2});
+  Dimensions denseX(Dim::X, 2);
   Dimensions denseXY({Dim::X, Dim::Y}, {2, 3});
-  Dimensions sparseY({Dim::Y}, {Dimensions::Sparse});
+  Dimensions sparseY(Dim::Y, Dimensions::Sparse);
   Dimensions sparseXY({Dim::X, Dim::Y}, {2, Dimensions::Sparse});
   Dimensions sparseXZ({Dim::X, Dim::Z}, {2, Dimensions::Sparse});
 
@@ -217,9 +217,9 @@ TEST_F(DimensionsTest_comparison_operators, dense_0d) {
 
 TEST_F(DimensionsTest_comparison_operators, dense_1d) {
   Dimensions empty;
-  Dimensions x2({Dim::X}, {2});
-  Dimensions x3({Dim::X}, {3});
-  Dimensions y2({Dim::Y}, {2});
+  Dimensions x2(Dim::X, 2);
+  Dimensions x3(Dim::X, 3);
+  Dimensions y2(Dim::Y, 2);
 
   expect_eq(x2, x2);
   expect_ne(x2, empty);
@@ -228,7 +228,7 @@ TEST_F(DimensionsTest_comparison_operators, dense_1d) {
 }
 
 TEST_F(DimensionsTest_comparison_operators, dense_2d) {
-  Dimensions x2({Dim::X}, {2});
+  Dimensions x2(Dim::X, 2);
   Dimensions x2y3({Dim::X, Dim::Y}, {2, 3});
   Dimensions y3x2({Dim::Y, Dim::X}, {3, 2});
   Dimensions x3y2({Dim::X, Dim::Y}, {3, 2});
@@ -280,7 +280,7 @@ TEST(DimensionsTest, merge_self) {
 }
 
 TEST(DimensionsTest, merge_dense) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::Z}, {3, 4});
   EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}));
 }
@@ -301,13 +301,13 @@ TEST(DimensionsTest, merge_dense_different_order) {
 }
 
 TEST(DimensionsTest, merge_size_fail) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::X}, {3, 4});
   EXPECT_THROW(merge(a, b), except::DimensionError);
 }
 
 TEST(DimensionsTest, merge_sparse_dense_fail) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::X}, {3, Dimensions::Sparse});
   EXPECT_THROW(merge(a, b), except::DimensionError);
 }
@@ -319,7 +319,7 @@ TEST(DimensionsTest, merge_different_sparse_fail) {
 }
 
 TEST(DimensionsTest, merge_sparse) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::Z}, {3, Dimensions::Sparse});
   EXPECT_EQ(merge(a, b),
             Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -559,9 +559,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val_var) {
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<double>({1.5}, {1.7});
+  auto b0 = makeVariable<double>(1.5, 1.7);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<double>({1.6}, {1.8});
+  auto b1 = makeVariable<double>(1.6, 1.8);
   auto expected0 = a0 * b0;
   auto expected1 = a1 * b1;
   EXPECT_TRUE(equals(a.sparseValues<double>()[0], expected0.values<double>()));
@@ -584,9 +584,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val) {
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<double>({1.5});
+  auto b0 = makeVariable<double>(1.5);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<double>({1.6});
+  auto b1 = makeVariable<double>(1.6);
   auto expected0 = a0 * b0;
   auto expected1 = a1 * b1;
   EXPECT_TRUE(equals(a.sparseValues<double>()[0], expected0.values<double>()));
@@ -608,9 +608,9 @@ TEST_F(TransformBinaryTest, broadcast_sparse_val_var_with_val) {
   const auto ab = transform<pair_custom_t<std::pair<double, float>>>(a, b, op);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<float>({1.5});
+  auto b0 = makeVariable<float>(1.5);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<float>({1.6});
+  auto b1 = makeVariable<float>(1.6);
   auto expected00 = a0 * b0;
   auto expected01 = a0 * b1;
   auto expected10 = a1 * b0;

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -80,10 +80,10 @@ TEST_F(TransformUnaryTest, sparse_values_variances_size_fail) {
       dims, {sparse_container<double>(2), sparse_container<double>(1)},
       {sparse_container<double>(2), sparse_container<double>(2)});
 
-  ASSERT_THROW(transform<double>(a, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<double>(a, op), except::SizeError);
   ASSERT_THROW(transform_in_place<double>(a, op_in_place), except::SizeError);
   a.sparseVariances<double>()[1].resize(1);
-  ASSERT_NO_THROW(transform<double>(a, op));
+  ASSERT_NO_THROW_NODISCARD(transform<double>(a, op));
   ASSERT_NO_THROW(transform_in_place<double>(a, op_in_place));
 }
 
@@ -211,14 +211,16 @@ TEST_F(TransformBinaryTest, sparse_size_fail) {
   auto b = makeVariable<double>(
       dims, {sparse_container<double>(2), sparse_container<double>()});
 
-  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, b, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
                except::SizeError);
   b.sparseValues<double>()[1].resize(1);
-  ASSERT_NO_THROW(transform<pair_self_t<double>>(a, b, op));
+  ASSERT_NO_THROW_NODISCARD(transform<pair_self_t<double>>(a, b, op));
   ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place));
   b.sparseValues<double>()[1].resize(2);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, b, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, b, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
                except::SizeError);
 }
@@ -411,8 +413,8 @@ protected:
 };
 
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail, baseline) {
-  ASSERT_NO_THROW(transform<pair_self_t<double>>(a, val_var, op));
-  ASSERT_NO_THROW(transform<pair_self_t<double>>(a, val, op));
+  ASSERT_NO_THROW_NODISCARD(transform<pair_self_t<double>>(a, val_var, op));
+  ASSERT_NO_THROW_NODISCARD(transform<pair_self_t<double>>(a, val, op));
   ASSERT_NO_THROW(
       transform_in_place<pair_self_t<double>>(a, val_var, op_in_place));
   ASSERT_NO_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place));
@@ -421,9 +423,10 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail, baseline) {
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
        a_values_size_bad) {
   a.sparseValues<double>()[1].resize(1);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val_var, op),
-               except::SizeError);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val_var, op),
+                         except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op_in_place),
                except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place),
@@ -433,9 +436,10 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
        a_variances_size_bad) {
   a.sparseVariances<double>()[1].resize(1);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val_var, op),
-               except::SizeError);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val_var, op),
+                         except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op_in_place),
                except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place),
@@ -445,8 +449,8 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
        val_var_values_size_bad) {
   val_var.sparseValues<double>()[1].resize(1);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val_var, op),
-               except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val_var, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op_in_place),
                except::SizeError);
 }
@@ -454,8 +458,8 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
        val_var_variances_size_bad) {
   val_var.sparseVariances<double>()[1].resize(1);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val_var, op),
-               except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val_var, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op_in_place),
                except::SizeError);
 }
@@ -463,7 +467,8 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
        val_values_size_bad) {
   val.sparseValues<double>()[1].resize(1);
-  ASSERT_THROW(transform<pair_self_t<double>>(a, val, op), except::SizeError);
+  ASSERT_THROW_NODISCARD(transform<pair_self_t<double>>(a, val, op),
+                         except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place),
                except::SizeError);
 }

--- a/test/test_macros.h
+++ b/test/test_macros.h
@@ -41,4 +41,9 @@ template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
   return std::equal(a.begin(), a.end(), b.begin(), b.end());
 }
 
+/* Helper macros to avoid warnings when testing [[nodiscard]] qualified
+ * functions */
+#define ASSERT_NO_THROW_NODISCARD(expr) ASSERT_NO_THROW((void)expr)
+#define ASSERT_THROW_NODISCARD(expr, type) ASSERT_THROW((void)expr, type)
+
 #endif // TEST_MACROS_H


### PR DESCRIPTION
Fixes unnecessary `std::move` on return and brace initialisation of scalars.