### PR TITLE
Removed braced initializer from scalars

### DIFF
--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -169,9 +169,9 @@ TEST(DimensionsTest, duplicate) {
 }
 
 TEST(DimensionsTest, contains_with_sparse_data) {
-  Dimensions denseX({Dim::X}, {2});
+  Dimensions denseX(Dim::X, 2);
   Dimensions denseXY({Dim::X, Dim::Y}, {2, 3});
-  Dimensions sparseY({Dim::Y}, {Dimensions::Sparse});
+  Dimensions sparseY(Dim::Y, Dimensions::Sparse);
   Dimensions sparseXY({Dim::X, Dim::Y}, {2, Dimensions::Sparse});
   Dimensions sparseXZ({Dim::X, Dim::Z}, {2, Dimensions::Sparse});
 
@@ -217,9 +217,9 @@ TEST_F(DimensionsTest_comparison_operators, dense_0d) {
 
 TEST_F(DimensionsTest_comparison_operators, dense_1d) {
   Dimensions empty;
-  Dimensions x2({Dim::X}, {2});
-  Dimensions x3({Dim::X}, {3});
-  Dimensions y2({Dim::Y}, {2});
+  Dimensions x2(Dim::X, 2);
+  Dimensions x3(Dim::X, 3);
+  Dimensions y2(Dim::Y, 2);
 
   expect_eq(x2, x2);
   expect_ne(x2, empty);
@@ -228,7 +228,7 @@ TEST_F(DimensionsTest_comparison_operators, dense_1d) {
 }
 
 TEST_F(DimensionsTest_comparison_operators, dense_2d) {
-  Dimensions x2({Dim::X}, {2});
+  Dimensions x2(Dim::X, 2);
   Dimensions x2y3({Dim::X, Dim::Y}, {2, 3});
   Dimensions y3x2({Dim::Y, Dim::X}, {3, 2});
   Dimensions x3y2({Dim::X, Dim::Y}, {3, 2});
@@ -280,7 +280,7 @@ TEST(DimensionsTest, merge_self) {
 }
 
 TEST(DimensionsTest, merge_dense) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::Z}, {3, 4});
   EXPECT_EQ(merge(a, b), Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}));
 }
@@ -301,13 +301,13 @@ TEST(DimensionsTest, merge_dense_different_order) {
 }
 
 TEST(DimensionsTest, merge_size_fail) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::X}, {3, 4});
   EXPECT_THROW(merge(a, b), except::DimensionError);
 }
 
 TEST(DimensionsTest, merge_sparse_dense_fail) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::X}, {3, Dimensions::Sparse});
   EXPECT_THROW(merge(a, b), except::DimensionError);
 }
@@ -319,7 +319,7 @@ TEST(DimensionsTest, merge_different_sparse_fail) {
 }
 
 TEST(DimensionsTest, merge_sparse) {
-  Dimensions a({Dim::X}, {2});
+  Dimensions a(Dim::X, 2);
   Dimensions b({Dim::Y, Dim::Z}, {3, Dimensions::Sparse});
   EXPECT_EQ(merge(a, b),
             Dimensions({Dim::X, Dim::Y, Dim::Z}, {2, 3, Dimensions::Sparse}));

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -559,9 +559,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val_var) {
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<double>({1.5}, {1.7});
+  auto b0 = makeVariable<double>(1.5, 1.7);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<double>({1.6}, {1.8});
+  auto b1 = makeVariable<double>(1.6, 1.8);
   auto expected0 = a0 * b0;
   auto expected1 = a1 * b1;
   EXPECT_TRUE(equals(a.sparseValues<double>()[0], expected0.values<double>()));
@@ -584,9 +584,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val) {
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<double>({1.5});
+  auto b0 = makeVariable<double>(1.5);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<double>({1.6});
+  auto b1 = makeVariable<double>(1.6);
   auto expected0 = a0 * b0;
   auto expected1 = a1 * b1;
   EXPECT_TRUE(equals(a.sparseValues<double>()[0], expected0.values<double>()));
@@ -608,9 +608,9 @@ TEST_F(TransformBinaryTest, broadcast_sparse_val_var_with_val) {
   const auto ab = transform<pair_custom_t<std::pair<double, float>>>(a, b, op);
 
   auto a0 = makeVariable<double>({Dim::X, 3}, {1, 2, 3}, {5, 6, 7});
-  auto b0 = makeVariable<float>({1.5});
+  auto b0 = makeVariable<float>(1.5);
   auto a1 = makeVariable<double>({Dim::X, 1}, {4}, {8});
-  auto b1 = makeVariable<float>({1.6});
+  auto b1 = makeVariable<float>(1.6);
   auto expected00 = a0 * b0;
   auto expected01 = a0 * b1;
   auto expected10 = a1 * b0;


### PR DESCRIPTION
`"-Wbraced-scalar-init"` warning triggered on apple clang. 

Note that this is likely a bug, which seems to have been fixed recently [here](https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=269045)would have to wait some time before this gets through to stable compiler releases for apple.

This PR removes the redundant braces in the hope that it gives us better visibility for real warnings that should be treated.

We may wish to revert this in future compiler upgrades