### PR TITLE
Fix shadowing warnings

### DIFF
--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -408,8 +408,8 @@ protected:
   Variable val_var = a;
   Variable val = makeVariable<double>(
       dims, {sparse_container<double>(2), sparse_container<double>(2)});
-  static constexpr auto op = [](const auto a, const auto b) { return a * b; };
-  static constexpr auto op_in_place = [](auto &a, const auto b) { a *= b; };
+  static constexpr auto op = [](const auto i, const auto j) { return i * j; };
+  static constexpr auto op_in_place = [](auto &i, const auto j) { i *= j; };
 };
 
 TEST_F(TransformTest_sparse_binary_values_variances_size_fail, baseline) {

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -16,17 +16,17 @@ namespace scipp::neutron {
 
 const auto tof_to_s =
     boost::units::quantity<boost::units::si::time>(1.0 * units::us) / units::us;
-const auto J_to_meV =
-    units::meV /
-    boost::units::quantity<boost::units::si::energy>(1.0 * units::meV);
+//const auto J_to_meV =
+//    units::meV /
+//    boost::units::quantity<boost::units::si::energy>(1.0 * units::meV); // unused
 const auto m_to_angstrom =
     boost::units::quantity<boost::units::si::length>(1.0 * units::angstrom) /
     units::angstrom;
 // In tof-to-energy conversions we *divide* by time-of-flight (squared), so the
 // tof_to_s factor is in the denominator.
-const auto tofToEnergyPhysicalConstants =
-    0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
-    (tof_to_s * tof_to_s);
+//const auto tofToEnergyPhysicalConstants =
+//    0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
+//    (tof_to_s * tof_to_s); // unused
 const auto tofToDSpacingPhysicalConstants =
     2.0 * boost::units::si::constants::codata::m_n * m_to_angstrom /
     (boost::units::si::constants::codata::h * tof_to_s);

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -12,10 +12,10 @@ using namespace scipp::units;
 
 namespace py = pybind11;
 
-void init_units_neutron(py::module &mod) {
-  bind_enum(mod, "Dim", Dim::Invalid, 4);
+void init_units_neutron(py::module &m) {
+  bind_enum(m, "Dim", Dim::Invalid, 4);
 
-  py::class_<units::Unit>(mod, "Unit")
+  py::class_<units::Unit>(m, "Unit")
       .def(py::init())
       .def("__repr__",
            [](const units::Unit &u) -> std::string { return u.name(); })
@@ -29,7 +29,7 @@ void init_units_neutron(py::module &mod) {
       .def(py::self == py::self)
       .def(py::self != py::self);
 
-  auto units = mod.def_submodule("units");
+  auto units = m.def_submodule("units");
   units.attr("dimensionless") = units::Unit(units::dimensionless);
   units.attr("m") = units::Unit(units::m);
   units.attr("counts") = units::Unit(units::counts);

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -12,10 +12,10 @@ using namespace scipp::units;
 
 namespace py = pybind11;
 
-void init_units_neutron(py::module &m) {
-  bind_enum(m, "Dim", Dim::Invalid, 4);
+void init_units_neutron(py::module &mod) {
+  bind_enum(mod, "Dim", Dim::Invalid, 4);
 
-  py::class_<units::Unit>(m, "Unit")
+  py::class_<units::Unit>(mod, "Unit")
       .def(py::init())
       .def("__repr__",
            [](const units::Unit &u) -> std::string { return u.name(); })
@@ -29,7 +29,7 @@ void init_units_neutron(py::module &m) {
       .def(py::self == py::self)
       .def(py::self != py::self);
 
-  auto units = m.def_submodule("units");
+  auto units = mod.def_submodule("units");
   units.attr("dimensionless") = units::Unit(units::dimensionless);
   units.attr("m") = units::Unit(units::m);
   units.attr("counts") = units::Unit(units::counts);

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -8,8 +8,6 @@
 #include "pybind11.h"
 
 using namespace scipp;
-using namespace scipp::units;
-
 namespace py = pybind11;
 
 void init_units_neutron(py::module &m) {

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -19,7 +19,6 @@
 
 using namespace scipp;
 using namespace scipp::core;
-using namespace scipp::units;
 
 namespace py = pybind11;
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -119,17 +119,17 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
 
 template <class T> void bind_init_0D(py::class_<Variable> &cls) {
   cls.def(py::init([](const T &value, const std::optional<T> &variance,
-                    const units::Unit &unit) {
-          Variable var;
-          if (variance)
-            var = makeVariable<T>(value, *variance);
-          else
-            var = makeVariable<T>(value);
-          var.setUnit(unit);
-          return var;
-        }),
-        py::arg("value"), py::arg("variance") = std::nullopt,
-        py::arg("unit") = units::Unit(units::dimensionless));
+                      const units::Unit &unit) {
+            Variable var;
+            if (variance)
+              var = makeVariable<T>(value, *variance);
+            else
+              var = makeVariable<T>(value);
+            var.setUnit(unit);
+            return var;
+          }),
+          py::arg("value"), py::arg("variance") = std::nullopt,
+          py::arg("unit") = units::Unit(units::dimensionless));
 }
 
 template <class T> void bind_init_1D(py::class_<Variable> &cls) {
@@ -252,37 +252,38 @@ void init_variable(py::module &mod) {
   py::implicitly_convertible<VariableProxy, Variable>();
 
   mod.def("split",
-        py::overload_cast<const Variable &, const Dim,
-                          const std::vector<scipp::index> &>(&split),
-        py::call_guard<py::gil_scoped_release>(),
-        "Split a Variable along a given Dimension.");
+          py::overload_cast<const Variable &, const Dim,
+                            const std::vector<scipp::index> &>(&split),
+          py::call_guard<py::gil_scoped_release>(),
+          "Split a Variable along a given Dimension.");
   mod.def("concatenate",
-        py::overload_cast<const Variable &, const Variable &, const Dim>(
-            &concatenate),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing a concatenation "
-        "of two Variables along a given Dimension.");
-  mod.def("rebin",
-        py::overload_cast<const Variable &, const Variable &, const Variable &>(
-            &rebin),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable whose data is rebinned with new bin edges.");
+          py::overload_cast<const Variable &, const Variable &, const Dim>(
+              &concatenate),
+          py::call_guard<py::gil_scoped_release>(),
+          "Returns a new Variable containing a concatenation "
+          "of two Variables along a given Dimension.");
+  mod.def(
+      "rebin",
+      py::overload_cast<const Variable &, const Variable &, const Variable &>(
+          &rebin),
+      py::call_guard<py::gil_scoped_release>(),
+      "Returns a new Variable whose data is rebinned with new bin edges.");
   mod.def("filter",
-        py::overload_cast<const Variable &, const Variable &>(&filter),
-        py::call_guard<py::gil_scoped_release>());
+          py::overload_cast<const Variable &, const Variable &>(&filter),
+          py::call_guard<py::gil_scoped_release>());
   mod.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the sum of the data along the "
-        "specified dimension.");
+          py::call_guard<py::gil_scoped_release>(),
+          "Returns a new Variable containing the sum of the data along the "
+          "specified dimension.");
   mod.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the mean of the data along the "
-        "specified dimension.");
+          py::call_guard<py::gil_scoped_release>(),
+          "Returns a new Variable containing the mean of the data along the "
+          "specified dimension.");
   mod.def("norm", py::overload_cast<const Variable &>(&norm),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the norm of the data.");
+          py::call_guard<py::gil_scoped_release>(),
+          "Returns a new Variable containing the norm of the data.");
   // find out why py::overload_cast is not working correctly here
   mod.def("sqrt", [](const Variable &self) { return sqrt(self); },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the square root of the data.");
+          py::call_guard<py::gil_scoped_release>(),
+          "Returns a new Variable containing the square root of the data.");
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -117,8 +117,8 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
                                      unit, variances);
 }
 
-template <class T> void bind_init_0D(py::class_<Variable> &c) {
-  c.def(py::init([](const T &value, const std::optional<T> &variance,
+template <class T> void bind_init_0D(py::class_<Variable> &cls) {
+  cls.def(py::init([](const T &value, const std::optional<T> &variance,
                     const units::Unit &unit) {
           Variable var;
           if (variance)
@@ -132,8 +132,8 @@ template <class T> void bind_init_0D(py::class_<Variable> &c) {
         py::arg("unit") = units::Unit(units::dimensionless));
 }
 
-template <class T> void bind_init_1D(py::class_<Variable> &c) {
-  c.def(
+template <class T> void bind_init_1D(py::class_<Variable> &cls) {
+  cls.def(
       py::init([](const std::vector<Dim> &labels, const std::vector<T> &values,
                   const std::optional<std::vector<T>> &variances,
                   const units::Unit &unit) {
@@ -150,8 +150,8 @@ template <class T> void bind_init_1D(py::class_<Variable> &c) {
       py::arg("unit") = units::Unit(units::dimensionless));
 }
 
-void init_variable(py::module &m) {
-  py::class_<Variable> variable(m, "Variable");
+void init_variable(py::module &mod) {
+  py::class_<Variable> variable(mod, "Variable");
   bind_init_0D<Dataset>(variable);
   bind_init_0D<int64_t>(variable);
   bind_init_0D<int32_t>(variable);
@@ -194,7 +194,7 @@ void init_variable(py::module &m) {
            py::is_operator())
       .def("__repr__", [](const Variable &self) { return to_string(self); });
 
-  py::class_<VariableProxy> variableProxy(m, "VariableProxy",
+  py::class_<VariableProxy> variableProxy(mod, "VariableProxy",
                                           py::buffer_protocol());
   variableProxy.def_buffer(&make_py_buffer_info);
   variableProxy
@@ -251,38 +251,38 @@ void init_variable(py::module &m) {
   // operator overload definitions
   py::implicitly_convertible<VariableProxy, Variable>();
 
-  m.def("split",
+  mod.def("split",
         py::overload_cast<const Variable &, const Dim,
                           const std::vector<scipp::index> &>(&split),
         py::call_guard<py::gil_scoped_release>(),
         "Split a Variable along a given Dimension.");
-  m.def("concatenate",
+  mod.def("concatenate",
         py::overload_cast<const Variable &, const Variable &, const Dim>(
             &concatenate),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable containing a concatenation "
         "of two Variables along a given Dimension.");
-  m.def("rebin",
+  mod.def("rebin",
         py::overload_cast<const Variable &, const Variable &, const Variable &>(
             &rebin),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable whose data is rebinned with new bin edges.");
-  m.def("filter",
+  mod.def("filter",
         py::overload_cast<const Variable &, const Variable &>(&filter),
         py::call_guard<py::gil_scoped_release>());
-  m.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
+  mod.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable containing the sum of the data along the "
         "specified dimension.");
-  m.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
+  mod.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable containing the mean of the data along the "
         "specified dimension.");
-  m.def("norm", py::overload_cast<const Variable &>(&norm),
+  mod.def("norm", py::overload_cast<const Variable &>(&norm),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable containing the norm of the data.");
   // find out why py::overload_cast is not working correctly here
-  m.def("sqrt", [](const Variable &self) { return sqrt(self); },
+  mod.def("sqrt", [](const Variable &self) { return sqrt(self); },
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable containing the square root of the data.");
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -117,23 +117,23 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
                                      unit, variances);
 }
 
-template <class T> void bind_init_0D(py::class_<Variable> &cls) {
-  cls.def(py::init([](const T &value, const std::optional<T> &variance,
-                      const units::Unit &unit) {
-            Variable var;
-            if (variance)
-              var = makeVariable<T>(value, *variance);
-            else
-              var = makeVariable<T>(value);
-            var.setUnit(unit);
-            return var;
-          }),
-          py::arg("value"), py::arg("variance") = std::nullopt,
-          py::arg("unit") = units::Unit(units::dimensionless));
+template <class T> void bind_init_0D(py::class_<Variable> &c) {
+  c.def(py::init([](const T &value, const std::optional<T> &variance,
+                    const units::Unit &unit) {
+          Variable var;
+          if (variance)
+            var = makeVariable<T>(value, *variance);
+          else
+            var = makeVariable<T>(value);
+          var.setUnit(unit);
+          return var;
+        }),
+        py::arg("value"), py::arg("variance") = std::nullopt,
+        py::arg("unit") = units::Unit(units::dimensionless));
 }
 
-template <class T> void bind_init_1D(py::class_<Variable> &cls) {
-  cls.def(
+template <class T> void bind_init_1D(py::class_<Variable> &c) {
+  c.def(
       py::init([](const std::vector<Dim> &labels, const std::vector<T> &values,
                   const std::optional<std::vector<T>> &variances,
                   const units::Unit &unit) {
@@ -150,8 +150,8 @@ template <class T> void bind_init_1D(py::class_<Variable> &cls) {
       py::arg("unit") = units::Unit(units::dimensionless));
 }
 
-void init_variable(py::module &mod) {
-  py::class_<Variable> variable(mod, "Variable");
+void init_variable(py::module &m) {
+  py::class_<Variable> variable(m, "Variable");
   bind_init_0D<Dataset>(variable);
   bind_init_0D<int64_t>(variable);
   bind_init_0D<int32_t>(variable);
@@ -194,7 +194,7 @@ void init_variable(py::module &mod) {
            py::is_operator())
       .def("__repr__", [](const Variable &self) { return to_string(self); });
 
-  py::class_<VariableProxy> variableProxy(mod, "VariableProxy",
+  py::class_<VariableProxy> variableProxy(m, "VariableProxy",
                                           py::buffer_protocol());
   variableProxy.def_buffer(&make_py_buffer_info);
   variableProxy
@@ -251,39 +251,38 @@ void init_variable(py::module &mod) {
   // operator overload definitions
   py::implicitly_convertible<VariableProxy, Variable>();
 
-  mod.def("split",
-          py::overload_cast<const Variable &, const Dim,
-                            const std::vector<scipp::index> &>(&split),
-          py::call_guard<py::gil_scoped_release>(),
-          "Split a Variable along a given Dimension.");
-  mod.def("concatenate",
-          py::overload_cast<const Variable &, const Variable &, const Dim>(
-              &concatenate),
-          py::call_guard<py::gil_scoped_release>(),
-          "Returns a new Variable containing a concatenation "
-          "of two Variables along a given Dimension.");
-  mod.def(
-      "rebin",
-      py::overload_cast<const Variable &, const Variable &, const Variable &>(
-          &rebin),
-      py::call_guard<py::gil_scoped_release>(),
-      "Returns a new Variable whose data is rebinned with new bin edges.");
-  mod.def("filter",
-          py::overload_cast<const Variable &, const Variable &>(&filter),
-          py::call_guard<py::gil_scoped_release>());
-  mod.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
-          py::call_guard<py::gil_scoped_release>(),
-          "Returns a new Variable containing the sum of the data along the "
-          "specified dimension.");
-  mod.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
-          py::call_guard<py::gil_scoped_release>(),
-          "Returns a new Variable containing the mean of the data along the "
-          "specified dimension.");
-  mod.def("norm", py::overload_cast<const Variable &>(&norm),
-          py::call_guard<py::gil_scoped_release>(),
-          "Returns a new Variable containing the norm of the data.");
+  m.def("split",
+        py::overload_cast<const Variable &, const Dim,
+                          const std::vector<scipp::index> &>(&split),
+        py::call_guard<py::gil_scoped_release>(),
+        "Split a Variable along a given Dimension.");
+  m.def("concatenate",
+        py::overload_cast<const Variable &, const Variable &, const Dim>(
+            &concatenate),
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable containing a concatenation "
+        "of two Variables along a given Dimension.");
+  m.def("rebin",
+        py::overload_cast<const Variable &, const Variable &, const Variable &>(
+            &rebin),
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable whose data is rebinned with new bin edges.");
+  m.def("filter",
+        py::overload_cast<const Variable &, const Variable &>(&filter),
+        py::call_guard<py::gil_scoped_release>());
+  m.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable containing the sum of the data along the "
+        "specified dimension.");
+  m.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable containing the mean of the data along the "
+        "specified dimension.");
+  m.def("norm", py::overload_cast<const Variable &>(&norm),
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable containing the norm of the data.");
   // find out why py::overload_cast is not working correctly here
-  mod.def("sqrt", [](const Variable &self) { return sqrt(self); },
-          py::call_guard<py::gil_scoped_release>(),
-          "Returns a new Variable containing the square root of the data.");
+  m.def("sqrt", [](const Variable &self) { return sqrt(self); },
+        py::call_guard<py::gil_scoped_release>(),
+        "Returns a new Variable containing the square root of the data.");
 }

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -7,14 +7,14 @@
 #include "scipp/units/unit.h"
 
 using namespace scipp;
-using namespace scipp::units;
+using scipp::units::Unit;
 
 TEST(DummyUnitsTest, basics) {
   // Current neutron::Unit is inlined as Unit, but we can still use others.
-  dummy::Unit m{units::m};
-  dummy::Unit s{units::s};
+  units::dummy::Unit m{units::m};
+  units::dummy::Unit s{units::s};
   ASSERT_NE(m, s);
-  dummy::Unit expected{units::m / units::s};
+  units::dummy::Unit expected{units::m / units::s};
   auto result = m / s;
   EXPECT_EQ(result, expected);
 }
@@ -91,16 +91,18 @@ TEST(Unit, divide) {
 }
 
 TEST(Unit, conversion_factors) {
-  boost::units::quantity<detail::tof::wavelength> a(2.0 * angstrom);
-  boost::units::quantity<boost::units::si::length> b(3.0 * angstrom);
-  boost::units::quantity<detail::tof::wavelength> c(4.0 *
-                                                    boost::units::si::meters);
+  boost::units::quantity<units::detail::tof::wavelength> a(2.0 *
+                                                           units::angstrom);
+  boost::units::quantity<boost::units::si::length> b(3.0 * units::angstrom);
+  boost::units::quantity<units::detail::tof::wavelength> c(
+      4.0 * boost::units::si::meters);
   boost::units::quantity<boost::units::si::area> d(
-      5.0 * boost::units::si::meters * angstrom);
-  boost::units::quantity<detail::tof::energy> e = 6.0 * meV;
-  boost::units::quantity<boost::units::si::energy> f(7.0 * meV);
-  boost::units::quantity<boost::units::si::time> g(8.0 * us);
-  boost::units::quantity<detail::tof::tof> h(9.0 * boost::units::si::seconds);
+      5.0 * boost::units::si::meters * units::angstrom);
+  boost::units::quantity<units::detail::tof::energy> e = 6.0 * units::meV;
+  boost::units::quantity<boost::units::si::energy> f(7.0 * units::meV);
+  boost::units::quantity<boost::units::si::time> g(8.0 * units::us);
+  boost::units::quantity<units::detail::tof::tof> h(9.0 *
+                                                    boost::units::si::seconds);
   EXPECT_DOUBLE_EQ(a.value(), 2.0);
   EXPECT_DOUBLE_EQ(b.value(), 3.0e-10);
   EXPECT_DOUBLE_EQ(c.value(), 4.0e10);
@@ -152,11 +154,12 @@ TEST(Unit, isCountDensity) {
 }
 
 TEST(DummyUnitsTest, isCounts) {
-  EXPECT_TRUE(dummy::Unit(units::dimensionless).isCounts());
-  EXPECT_FALSE(dummy::Unit(units::dimensionless / units::m).isCounts());
+  EXPECT_TRUE(units::dummy::Unit(units::dimensionless).isCounts());
+  EXPECT_FALSE(units::dummy::Unit(units::dimensionless / units::m).isCounts());
 }
 
 TEST(DummyUnitsTest, isCountDensity) {
-  EXPECT_FALSE(dummy::Unit(units::dimensionless).isCountDensity());
-  EXPECT_TRUE(dummy::Unit(units::dimensionless / units::m).isCountDensity());
+  EXPECT_FALSE(units::dummy::Unit(units::dimensionless).isCountDensity());
+  EXPECT_TRUE(
+      units::dummy::Unit(units::dimensionless / units::m).isCountDensity());
 }


### PR DESCRIPTION
Some warnings not addressed in #362 

Note that the gtest `TYPED_TEST` unused variadic argument warnings remain. Those have been addressed in open PR https://github.com/google/googletest/pull/2316