### PR TITLE
Small fixes and documentation improvements

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -752,21 +752,21 @@ Variable operator/(Variable a, const boost::units::quantity<T> &quantity) {
 SCIPP_CORE_EXPORT std::vector<Variable>
 split(const Variable &var, const Dim dim,
       const std::vector<scipp::index> &indices);
+SCIPP_CORE_EXPORT Variable abs(const Variable &var);
+SCIPP_CORE_EXPORT Variable broadcast(Variable var, const Dimensions &dims);
 SCIPP_CORE_EXPORT Variable concatenate(const Variable &a1, const Variable &a2,
                                        const Dim dim);
-SCIPP_CORE_EXPORT Variable rebin(const Variable &var, const Variable &oldCoord,
-                                 const Variable &newCoord);
+SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
+SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
+SCIPP_CORE_EXPORT Variable mean(const Variable &var, const Dim dim);
+SCIPP_CORE_EXPORT Variable norm(const Variable &var);
 SCIPP_CORE_EXPORT Variable permute(const Variable &var, const Dim dim,
                                    const std::vector<scipp::index> &indices);
-SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
-SCIPP_CORE_EXPORT Variable sum(const Variable &var, const Dim dim);
-SCIPP_CORE_EXPORT Variable mean(const Variable &var, const Dim dim);
-SCIPP_CORE_EXPORT Variable abs(const Variable &var);
-SCIPP_CORE_EXPORT Variable norm(const Variable &var);
-SCIPP_CORE_EXPORT Variable sqrt(const Variable &var);
-SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable broadcast(Variable var, const Dimensions &dims);
+SCIPP_CORE_EXPORT Variable rebin(const Variable &var, const Variable &oldCoord,
+                                 const Variable &newCoord);
 SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
+SCIPP_CORE_EXPORT Variable sqrt(const Variable &var);
+SCIPP_CORE_EXPORT Variable sum(const Variable &var, const Dim dim);
 
 template <class T>
 VariableView<const T> getView(const Variable &var, const Dimensions &dims);

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -499,11 +499,11 @@ TEST(Variable, mean) {
   EXPECT_TRUE(equals(meanY.values<double>(), {2.0, 3.0}));
 }
 
-TEST(Variable, abs_of_scalar) {
+TEST(Variable, abs) {
   auto reference =
-      makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
-  auto var =
-      makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {1.0, -2.0, -3.0, 4.0});
+      makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m, {1, 2, 3, 4});
+  auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m,
+                                  {1.0, -2.0, -3.0, 4.0});
   EXPECT_EQ(abs(var), reference);
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -401,7 +401,10 @@ Variable mean(const Variable &var, const Dim dim) {
 
 Variable abs(const Variable &var) {
   using std::abs;
-  return transform<double, float>(var, [](const auto x) { return abs(x); });
+  Variable result =
+      transform<double, float>(var, [](const auto x) { return abs(x); });
+  result.setUnit(var.unit());
+  return result;
 }
 
 Variable norm(const Variable &var) {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.imgmath',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting'
 ]

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -22,6 +22,10 @@ To add scipp to an existing conda environment:
 We are currently recommending the `scipp/label/dev` channel instead of just `scipp` since the latter is not useful until we have had our first proper release.
 Note that these packages from `Anaconda Cloud <https://conda.anaconda.org/scipp>`_ are currently only available on Linux.
 
+After installation the module ``scipp`` can be imported in Python.
+
+To update or remove ``scipp`` use `conda update <https://docs.conda.io/projects/conda/en/latest/commands/update.html>`_ and `conda remove <https://docs.conda.io/projects/conda/en/latest/commands/remove.html>`_.
+
 Docker
 ------
 
@@ -40,4 +44,4 @@ These notebooks provide an introduction and basic usage turorial.
 From source
 -----------
 
-See the `scipp README <See https://github.com/scipp/scipp/blob/master/README.md>`_.
+See the `scipp README <https://github.com/scipp/scipp/blob/master/README.md>`_.

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -38,7 +38,7 @@ Data items in a dataset as well as coordinates support optional variances in add
 The variances are accessed using the ``variances`` property and have the same shape and dtype as the ``values`` array.
 All operations take the variances into account:
 
-- Operations fail if the variances of coordinates do not match.
+- Operations fail if the variances of coordinates are not identical, element by element.
   For the future, we are considering supporting inexact matching based on variances of coordinates but currently this is not implemented.
 - Operations such as addition or multiplication propagate the errors to the output.
   An overview of the method can be found in `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty>`_.
@@ -66,7 +66,7 @@ Scipp handles such sparse data by supporting data-item-specific *sparse coordina
   It represents the time-stamps at which event occurred and is thus essentially an array of lists.
 - If the coordinate is sparse, the corresponding data is also sparse and must have matching list lengths.
 - The values and variances for sparse data correspond to the event weight and its uncertainty.
-  For unweighted events, scipp supports items without a values array.
+  For cases where by definition events all have the *same* weight, scipp supports items without a values array.
   In this case each sparse coordinate entry corresponds to a single event count.
 
 Sparse items in a dataset can be seen as a case of unaligned data, with misalignment not just between different items, but also between slices within an item.

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -28,7 +28,7 @@ All operations take the unit into account:
 
 - Operations fail if the units of coordinates do not match.
 - Operations such as addition fail if the units of the data items do not match.
-- Operations such as multiplication produce an output dataset with a new unit for each data item, e.g., ``m^2`` results from multiplication of two data items with unit ``m``.
+- Operations such as multiplication produce an output dataset with a new unit for each data item, e.g., :math:`m^{2}` results from multiplication of two data items with unit :math:`m`.
 
 
 Variances and propagation of uncertainties

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -21,7 +21,9 @@ Free functions
 .. autosummary::
    :toctree: ../generated
 
+   abs
    concatenate
+   dot
    filter
    mean
    norm

--- a/docs/user-guide/data-structures.rst
+++ b/docs/user-guide/data-structures.rst
@@ -60,7 +60,7 @@ Variances must have the same shape as values, and units are specified using the 
     var.variances
 
 :py:class:`~scipp.Variable` also supports a single *sparse* dimension.
-In this case it is currently not possible to set data directly in the cosntructor.
+In this case it is currently not possible to set data directly in the constructor.
 Instead we create it by specifying a shape:
 
 .. ipython:: python

--- a/docs/user-guide/dtype.rst
+++ b/docs/user-guide/dtype.rst
@@ -16,7 +16,7 @@ In most cases the ``dtype`` is derived from the data, e.g., when passing a :py:c
     var = sc.Variable(dims=[sc.Dim.X], values=np.arange(4))
     var.dtype    
 
-The ``dtype`` may also be scecified using a keyword argument, both :py:class:`numpy.dtype` and :py:class:`scipp.dtype` are supported:
+The ``dtype`` may also be specified using a keyword argument, both :py:class:`numpy.dtype` and :py:class:`scipp.dtype` are supported:
 
 .. ipython:: python
 

--- a/docs/user-guide/error-propagation.rst
+++ b/docs/user-guide/error-propagation.rst
@@ -1,9 +1,12 @@
-.. _units:
+.. _propagation_of_uncertainties:
 
-Error Propagation
-=================
+Propagation of uncertainties
+============================
 
-This table outlines how error is propagated when using operations provided by Scipp.
+If present, scipp propagates uncertainties (errors) as described in `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty>`_.
+The implemented mechanism assumes *uncorrelated data*.
+
+An overview for key operation is:
 
 .. table::
     :widths: 50 50
@@ -15,7 +18,7 @@ This table outlines how error is propagated when using operations provided by Sc
     +-------------------+-------------------------------------------------------------------------+
     |:math:`|a|`        |:math:`\sigma^{2}_{a}`                                                   |
     +-------------------+-------------------------------------------------------------------------+
-    |:math:`\sqrt{a}`   |:math:`\frac{1}{2}^2 \frac{\sigma^{2}_{a}}{a}`                           |
+    |:math:`\sqrt{a}`   |:math:`\frac{1}{4} \frac{\sigma^{2}_{a}}{a}`                             |
     +-------------------+-------------------------------------------------------------------------+
     |:math:`a + b`      |:math:`\sigma^{2}_{a} + \sigma^{2}_{b}`                                  |
     +-------------------+-------------------------------------------------------------------------+
@@ -26,4 +29,4 @@ This table outlines how error is propagated when using operations provided by Sc
     |:math:`a / b`      |:math:`\frac{\sigma^{2}_{a} + \sigma^{2}_{b} \frac{a^{2}}{b^{2}}}{b^{2}}`|
     +-------------------+-------------------------------------------------------------------------+
 
-The expression for division is derived from :math:`(\frac{\sigma_{z}}{z})^{2} = (\frac{\sigma_{a}}{a})^{2} + (\frac{\sigma_{a}}{a})^{2}`.
+The expression for division is derived from :math:`(\frac{\sigma_{a/b}}{a/b})^{2} = (\frac{\sigma_{a}}{a})^{2} + (\frac{\sigma_{b}}{b})^{2}`.

--- a/docs/user-guide/operations.rst
+++ b/docs/user-guide/operations.rst
@@ -21,7 +21,7 @@ Operations "align" data items based on their dimension labels:
                     unit=sc.units.s)
     a/b
 
-Note how operations with variables correctly propagate uncertainties (variances), in contrast to a naive implementation using numpy:
+Note how operations with variables correctly propagate uncertainties (the variances), in contrast to a naive implementation using numpy:
 
 .. ipython:: python
 
@@ -32,6 +32,7 @@ Note how operations with variables correctly propagate uncertainties (variances)
     a.variances/np.transpose(b.variances)
 
 The implementation assumes uncorrelated data and is otherwise based on, e.g., `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae>`_.
+See also :ref:`propagation_of_uncertainties` for the concrete equations used for error propagation.
 
 Missing dimensions in the operands are automatically broadcast:
 

--- a/docs/user-guide/units.rst
+++ b/docs/user-guide/units.rst
@@ -23,7 +23,7 @@ This can be used to create units that do not have a pref-defined identifier:
     speed = length / sc.units.s
     speed
 
-Due to a restriction in scipp's units implementation the set of supported units is unfortunately limited a compile-time of the underlying C++ library:
+Due to a restriction in scipp's units implementation the set of supported units is unfortunately limited at compile-time of the underlying C++ library:
 
 .. ipython:: python
     :okexcept:

--- a/docs/user-guide/units.rst
+++ b/docs/user-guide/units.rst
@@ -23,7 +23,7 @@ This can be used to create units that do not have a pref-defined identifier:
     speed = length / sc.units.s
     speed
 
-Due to a restriction in scipp's units implementation the set of supported units is unfortunately limited:
+Due to a restriction in scipp's units implementation the set of supported units is unfortunately limited a compile-time of the underlying C++ library:
 
 .. ipython:: python
     :okexcept:

--- a/python/tests/test_units_neutron.py
+++ b/python/tests/test_units_neutron.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
-import scipp as sp
+import pytest
+
+import scipp as sc
 from scipp import Dim
 
 
@@ -14,10 +16,21 @@ def test_dims():
 
 
 def test_default_unit():
-    u = sp.Unit()
-    assert u == sp.units.dimensionless
+    u = sc.Unit()
+    assert u == sc.units.dimensionless
 
 
 def test_unit_repr():
-    assert repr(sp.units.angstrom) == "\u212B"
-    assert repr(sp.units.m) == "m"
+    assert repr(sc.units.angstrom) == "\u212B"
+    assert repr(sc.units.m) == "m"
+
+
+def test_pow():
+    assert sc.units.m**0 == sc.units.dimensionless
+    assert sc.units.m**1 == sc.units.m
+    assert sc.units.m**2 == sc.units.m * sc.units.m
+    assert sc.units.m**3 == sc.units.m * sc.units.m * sc.units.m
+    assert sc.units.m**-1 == sc.units.dimensionless / sc.units.m
+    assert sc.units.m**-2 == sc.units.dimensionless / sc.units.m / sc.units.m
+    with pytest.raises(RuntimeError):
+        assert sc.units.m**27

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -123,6 +123,22 @@ def test_create_1D_vector_3_double():
     assert var.unit == sp.units.m
 
 
+def test_create_2D_inner_size_3():
+    var = sp.Variable(
+        dims=[
+            Dim.X,
+            Dim.Y],
+        values=np.arange(6.0).reshape(
+            2,
+            3),
+        unit=sp.units.m)
+    assert var.shape == [2, 3]
+    np.testing.assert_array_equal(var.values[0], [0, 1, 2])
+    np.testing.assert_array_equal(var.values[1], [3, 4, 5])
+    assert var.dims == [Dim.X, Dim.Y]
+    assert var.dtype == sp.dtype.double
+    assert var.unit == sp.units.m
+
 def test_operation_with_scalar_quantity():
     reference = sp.Variable([sp.Dim.X],
                             np.arange(4.0) * 1.5)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -139,6 +139,7 @@ def test_create_2D_inner_size_3():
     assert var.dtype == sp.dtype.double
     assert var.unit == sp.units.m
 
+
 def test_operation_with_scalar_quantity():
     reference = sp.Variable([sp.Dim.X],
                             np.arange(4.0) * 1.5)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -43,8 +43,8 @@ def test_create_with_numpy_dtype():
 
 def test_create_with_variances():
     assert not sp.Variable(dims=[Dim.X], shape=[2]).has_variances
-    assert not sp.Variable(dims=[Dim.X], shape=[
-                           2], variances=False).has_variances
+    assert not sp.Variable(dims=[Dim.X], shape=[2],
+                           variances=False).has_variances
     assert sp.Variable(dims=[Dim.X], shape=[2], variances=True).has_variances
 
 
@@ -70,7 +70,8 @@ def test_create_from_numpy_1d_bool():
 
 
 def test_create_with_variances_from_numpy_1d():
-    var = sp.Variable([sp.Dim.X], values=np.arange(4.0),
+    var = sp.Variable([sp.Dim.X],
+                      values=np.arange(4.0),
                       variances=np.arange(4.0, 8.0))
     assert var.dtype == sp.dtype.double
     np.testing.assert_array_equal(var.values, np.arange(4))
@@ -113,8 +114,9 @@ def test_create_1D_string():
 
 
 def test_create_1D_vector_3_double():
-    var = sp.Variable(dims=[Dim.X], values=[
-                      [1, 2, 3], [4, 5, 6]], unit=sp.units.m)
+    var = sp.Variable(dims=[Dim.X],
+                      values=[[1, 2, 3], [4, 5, 6]],
+                      unit=sp.units.m)
     assert len(var.values) == 2
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
@@ -124,14 +126,9 @@ def test_create_1D_vector_3_double():
 
 
 def test_create_2D_inner_size_3():
-    var = sp.Variable(
-        dims=[
-            Dim.X,
-            Dim.Y],
-        values=np.arange(6.0).reshape(
-            2,
-            3),
-        unit=sp.units.m)
+    var = sp.Variable(dims=[Dim.X, Dim.Y],
+                      values=np.arange(6.0).reshape(2, 3),
+                      unit=sp.units.m)
     assert var.shape == [2, 3]
     np.testing.assert_array_equal(var.values[0], [0, 1, 2])
     np.testing.assert_array_equal(var.values[1], [3, 4, 5])
@@ -141,8 +138,7 @@ def test_create_2D_inner_size_3():
 
 
 def test_operation_with_scalar_quantity():
-    reference = sp.Variable([sp.Dim.X],
-                            np.arange(4.0) * 1.5)
+    reference = sp.Variable([sp.Dim.X], np.arange(4.0) * 1.5)
     reference.unit = sp.units.kg
 
     var = sp.Variable([sp.Dim.X], np.arange(4.0))
@@ -160,7 +156,7 @@ def test_0D_scalar_access():
 
 
 def test_1D_scalar_access_fail():
-    var = sp.Variable([Dim.X], (1,))
+    var = sp.Variable([Dim.X], (1, ))
     with pytest.raises(RuntimeError):
         assert var.value == 0.0
     with pytest.raises(RuntimeError):
@@ -168,15 +164,15 @@ def test_1D_scalar_access_fail():
 
 
 def test_1D_access():
-    var = sp.Variable([Dim.X], (2,))
+    var = sp.Variable([Dim.X], (2, ))
     assert len(var.values) == 2
-    assert var.values.shape == (2,)
+    assert var.values.shape == (2, )
     var.values[1] = 1.2
     assert var.values[1] == 1.2
 
 
 def test_1D_access_bad_shape_fail():
-    var = sp.Variable([Dim.X], (2,))
+    var = sp.Variable([Dim.X], (2, ))
     with pytest.raises(RuntimeError):
         var.values = np.arange(3)
 
@@ -236,15 +232,15 @@ def test_sparse_setitem_shape_fail():
 
 
 def test_sparse_setitem_float():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [
-                      4, sp.Dimensions.Sparse], dtype=sp.dtype.float)
+    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse],
+                      dtype=sp.dtype.float)
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
 
 
 def test_sparse_setitem_int64_t():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [
-                      4, sp.Dimensions.Sparse], dtype=sp.dtype.int64)
+    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse],
+                      dtype=sp.dtype.int64)
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
 
@@ -258,21 +254,21 @@ def test_create_dtype():
     assert var.dtype == sp.dtype.double
     var = sp.Variable([Dim.X], values=np.arange(4).astype(np.float32))
     assert var.dtype == sp.dtype.float
-    var = sp.Variable([Dim.X], (4,), dtype=np.dtype(np.float64))
+    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.float64))
     assert var.dtype == sp.dtype.double
-    var = sp.Variable([Dim.X], (4,), dtype=np.dtype(np.float32))
+    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.float32))
     assert var.dtype == sp.dtype.float
-    var = sp.Variable([Dim.X], (4,), dtype=np.dtype(np.int64))
+    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.int64))
     assert var.dtype == sp.dtype.int64
-    var = sp.Variable([Dim.X], (4,), dtype=np.dtype(np.int32))
+    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.int32))
     assert var.dtype == sp.dtype.int32
 
 
 def test_get_slice():
     var = sp.Variable([Dim.X, Dim.Y], values=np.arange(0, 8).reshape(2, 4))
     var_slice = var[Dim.X, 1:2]
-    assert var_slice == sp.Variable(
-        [Dim.X, Dim.Y], values=np.arange(4, 8).reshape(1, 4))
+    assert var_slice == sp.Variable([Dim.X, Dim.Y],
+                                    values=np.arange(4, 8).reshape(1, 4))
 
 
 def test_slicing():
@@ -362,3 +358,70 @@ def test_binary_not_equal():
     assert a_slice != c
     assert c != a
     assert c != a_slice
+
+
+def test_abs():
+    var = sp.Variable([Dim.X], values=np.array([0.1, -0.2]), unit=sp.units.m)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([0.1, 0.2]),
+                           unit=sp.units.m)
+    assert sp.abs(var) == expected
+
+
+def test_dot():
+    a = sp.Variable(dims=[Dim.X],
+                    values=[[1, 0, 0], [0, 1, 0]],
+                    unit=sp.units.m)
+    b = sp.Variable(dims=[Dim.X],
+                    values=[[1, 0, 0], [1, 0, 0]],
+                    unit=sp.units.m)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([1.0, 0.0]),
+                           unit=sp.units.m**2)
+    assert sp.dot(a, b) == expected
+
+
+def test_concatenate():
+    var = sp.Variable([Dim.X], values=np.array([0.1, 0.2]), unit=sp.units.m)
+    expected = sp.Variable([sp.Dim.X],
+                           values=np.array([0.1, 0.2, 0.1, 0.2]),
+                           unit=sp.units.m)
+    assert sp.concatenate(var, var, Dim.X) == expected
+
+
+def test_mean():
+    var = sp.Variable([Dim.X, Dim.Y],
+                      values=np.array([[0.1, 0.3], [0.2, 0.6]]),
+                      unit=sp.units.m)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([0.2, 0.4]),
+                           unit=sp.units.m)
+    assert sp.mean(var, Dim.Y) == expected
+
+
+def test_norm():
+    var = sp.Variable(dims=[Dim.X],
+                      values=[[1, 0, 0], [3, 4, 0]],
+                      unit=sp.units.m)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([1.0, 5.0]),
+                           unit=sp.units.m)
+    assert sp.norm(var) == expected
+
+
+def test_sqrt():
+    var = sp.Variable([Dim.X], values=np.array([4.0, 9.0]), unit=sp.units.m**2)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([2.0, 3.0]),
+                           unit=sp.units.m)
+    assert sp.sqrt(var) == expected
+
+
+def test_sum():
+    var = sp.Variable([Dim.X, Dim.Y],
+                      values=np.array([[0.1, 0.3], [0.2, 0.6]]),
+                      unit=sp.units.m)
+    expected = sp.Variable([Dim.X],
+                           values=np.array([0.4, 0.8]),
+                           unit=sp.units.m)
+    assert sp.sum(var, Dim.Y) == expected

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -24,6 +24,27 @@ void init_units_neutron(py::module &m) {
       .def(py::self - py::self)
       .def(py::self * py::self)
       .def(py::self / py::self)
+      .def("__pow__",
+           [](const units::Unit &self, int power) -> units::Unit {
+             switch (power) {
+             case 0:
+               return units::dimensionless;
+             case 1:
+               return self;
+             case 2:
+               return self * self;
+             case 3:
+               return self * self * self;
+             case -1:
+               return units::Unit() / (self);
+             case -2:
+               return units::Unit() / (self * self);
+             case -3:
+               return units::Unit() / (self * self * self);
+             default:
+               throw std::runtime_error("Unsupported power of unit.");
+             }
+           })
       .def(py::self == py::self)
       .def(py::self != py::self);
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -133,11 +133,14 @@ template <class T> void bind_init_0D(py::class_<Variable> &c) {
 
 template <class T> void bind_init_1D(py::class_<Variable> &c) {
   c.def(
-      py::init([](const std::vector<Dim> &labels, const std::vector<T> &values,
+      // Using fixed-size-1 array for the labels. This avoids the
+      // `T=Eigen::Vector3d` overload wrongly matching to an 2d (or higher)
+      // array with inner dimension 3 as `values`.
+      py::init([](const std::array<Dim, 1> &label, const std::vector<T> &values,
                   const std::optional<std::vector<T>> &variances,
                   const units::Unit &unit) {
         Variable var;
-        Dimensions dims(labels, {scipp::size(values)});
+        Dimensions dims({label[0]}, {scipp::size(values)});
         if (variances)
           var = makeVariable<T>(dims, values, *variances);
         else

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -253,38 +253,76 @@ void init_variable(py::module &m) {
   // operator overload definitions
   py::implicitly_convertible<VariableProxy, Variable>();
 
-  m.def("split",
-        py::overload_cast<const Variable &, const Dim,
-                          const std::vector<scipp::index> &>(&split),
-        py::call_guard<py::gil_scoped_release>(),
-        "Split a Variable along a given Dimension.");
+  m.def("abs", [](const Variable &self) { return abs(self); },
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise absolute value.
+
+        :raises: If the dtype has no absolute value, e.g., if it is a string
+        :seealso: :py:class:`scipp.norm` for vector-like dtype
+        :return: Copy of the input with values replaced by the absolute values
+        :rtype: Variable)");
+  m.def("dot", py::overload_cast<const Variable &, const Variable &>(&dot),
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise dot-product.
+
+        :raises: If the dtype is not a vector such as :py:class:`scipp.dtype.vector_3_double`
+        :return: New variable with scalar elements based on the two inputs.
+        :rtype: Variable)");
   m.def("concatenate",
         py::overload_cast<const Variable &, const Variable &, const Dim>(
             &concatenate),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing a concatenation "
-        "of two Variables along a given Dimension.");
+        py::call_guard<py::gil_scoped_release>(), R"(
+        Concatenate input variables along the given dimension.
+
+        Concatenation can happen in two ways:
+        - Along an existing dimension, yielding a new dimension extent given by the sum of the input's extents.
+        - Along a new dimension that is not contained in either of the inputs, yielding an output with one extra dimensions.
+
+        :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
+        :return: New variable containing all elements of the input variables.
+        :rtype: Variable)");
+  m.def("filter",
+        py::overload_cast<const Variable &, const Variable &>(&filter),
+        py::call_guard<py::gil_scoped_release>());
+  m.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise mean over the specified dimension.
+
+        :raises: If the dtype cannot be summed, e.g., if it is a string
+        :seealso: :py:class:`scipp.sum`
+        :return: New variable containing the mean.
+        :rtype: Variable)");
+  m.def("norm", py::overload_cast<const Variable &>(&norm),
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise norm.
+
+        :raises: If the dtype does not norm, i.e., if it is not a vector
+        :seealso: :py:class:`scipp.abs` for scalar dtype
+        :return: New variable with scalar elements computed as the norm values if the input elements.
+        :rtype: Variable)");
   m.def("rebin",
         py::overload_cast<const Variable &, const Variable &, const Variable &>(
             &rebin),
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Variable whose data is rebinned with new bin edges.");
-  m.def("filter",
-        py::overload_cast<const Variable &, const Variable &>(&filter),
-        py::call_guard<py::gil_scoped_release>());
-  m.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
+  m.def("split",
+        py::overload_cast<const Variable &, const Dim,
+                          const std::vector<scipp::index> &>(&split),
         py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the sum of the data along the "
-        "specified dimension.");
-  m.def("mean", py::overload_cast<const Variable &, const Dim>(&mean),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the mean of the data along the "
-        "specified dimension.");
-  m.def("norm", py::overload_cast<const Variable &>(&norm),
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the norm of the data.");
-  // find out why py::overload_cast is not working correctly here
+        "Split a Variable along a given Dimension.");
   m.def("sqrt", [](const Variable &self) { return sqrt(self); },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable containing the square root of the data.");
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise square-root.
+
+        :raises: If the dtype has no square-root, e.g., if it is a string
+        :return: Copy of the input with values replaced by the square-root.
+        :rtype: Variable)");
+  m.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
+        py::call_guard<py::gil_scoped_release>(), R"(
+        The element-wise sum over the specified dimension.
+
+        :raises: If the dtype cannot be summed, e.g., if it is a string
+        :seealso: :py:class:`scipp.mean`
+        :return: New variable containing the sum.
+        :rtype: Variable)");
 }


### PR DESCRIPTION
- Fix bug in error propagation of `abs`.
- Fix bug when creating data with inner extent 3.
- Test how we can improve the docstrings in pybind11, yielding better API documentation in Sphinx.
- Enable sphinx math extension. This might not work on RTD though, and we should switch to `jsmath`. Unfortunately I could not find on how to setup the correct Javascript module it needs. Anyone?
- Address (most) comments from doc review.