### PR TITLE
Sparse data subtleties

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -832,6 +832,7 @@ auto apply_with_broadcast(const Op &op, const A &a, const DataConstProxy &b) {
 
   for (const auto & [ name, item ] : a) {
     expect::matchingDataPresence(item, b);
+    expect::coordsAndLabelsAreSuperset(item, b);
     if (item.hasData())
       res.setData(std::string(name), op(item.data(), b.data()));
     copy_metadata(res, std::string(name), item);
@@ -847,6 +848,7 @@ auto apply_with_broadcast(const Op &op, const DataConstProxy &a, const B &b) {
 
   for (const auto & [ name, item ] : b) {
     expect::matchingDataPresence(a, item);
+    expect::coordsAndLabelsAreSuperset(a, item);
     if (item.hasData())
       res.setData(std::string(name), op(a.data(), item.data()));
     copy_metadata(res, std::string(name), item);

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -815,7 +815,9 @@ auto apply_with_broadcast(const Op &op, const A &a, const B &b) {
 
   for (const auto & [ name, item ] : b) {
     if (a.contains(name)) {
-      res.setData(std::string(name), op(a[name].data(), item.data()));
+      expect::matchingDataPresence(a[name], item);
+      if (item.hasData())
+        res.setData(std::string(name), op(a[name].data(), item.data()));
       copy_metadata(res, std::string(name), a[name]);
     }
   }
@@ -829,8 +831,10 @@ auto apply_with_broadcast(const Op &op, const A &a, const DataConstProxy &b) {
   copy_metadata(res, a);
 
   for (const auto & [ name, item ] : a) {
-    res.setData(std::string(name), op(item.data(), b.data()));
-    copy_metadata(res, std::string(name), a[name]);
+    expect::matchingDataPresence(item, b);
+    if (item.hasData())
+      res.setData(std::string(name), op(item.data(), b.data()));
+    copy_metadata(res, std::string(name), item);
   }
 
   return res;

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -840,6 +840,21 @@ auto apply_with_broadcast(const Op &op, const A &a, const DataConstProxy &b) {
   return res;
 }
 
+template <class Op, class B>
+auto apply_with_broadcast(const Op &op, const DataConstProxy &a, const B &b) {
+  Dataset res;
+  copy_metadata(res, b);
+
+  for (const auto & [ name, item ] : b) {
+    expect::matchingDataPresence(a, item);
+    if (item.hasData())
+      res.setData(std::string(name), op(a.data(), item.data()));
+    copy_metadata(res, std::string(name), item);
+  }
+
+  return res;
+}
+
 Dataset &Dataset::operator+=(const DataConstProxy &other) {
   return apply_with_delay(plus_equals, *this, other);
 }
@@ -996,6 +1011,14 @@ Dataset operator+(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
   return apply_with_broadcast(plus, lhs, rhs);
 }
 
+Dataset operator+(const DataConstProxy &lhs, const Dataset &rhs) {
+  return apply_with_broadcast(plus, lhs, rhs);
+}
+
+Dataset operator+(const DataConstProxy &lhs, const DatasetConstProxy &rhs) {
+  return apply_with_broadcast(plus, lhs, rhs);
+}
+
 Dataset operator-(const Dataset &lhs, const Dataset &rhs) {
   return apply_with_broadcast(minus, lhs, rhs);
 }
@@ -1017,6 +1040,14 @@ Dataset operator-(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator-(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
+  return apply_with_broadcast(minus, lhs, rhs);
+}
+
+Dataset operator-(const DataConstProxy &lhs, const Dataset &rhs) {
+  return apply_with_broadcast(minus, lhs, rhs);
+}
+
+Dataset operator-(const DataConstProxy &lhs, const DatasetConstProxy &rhs) {
   return apply_with_broadcast(minus, lhs, rhs);
 }
 
@@ -1044,6 +1075,14 @@ Dataset operator*(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
   return apply_with_broadcast(times, lhs, rhs);
 }
 
+Dataset operator*(const DataConstProxy &lhs, const Dataset &rhs) {
+  return apply_with_broadcast(times, lhs, rhs);
+}
+
+Dataset operator*(const DataConstProxy &lhs, const DatasetConstProxy &rhs) {
+  return apply_with_broadcast(times, lhs, rhs);
+}
+
 Dataset operator/(const Dataset &lhs, const Dataset &rhs) {
   return apply_with_broadcast(divide, lhs, rhs);
 }
@@ -1065,6 +1104,14 @@ Dataset operator/(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
 }
 
 Dataset operator/(const DatasetConstProxy &lhs, const DataConstProxy &rhs) {
+  return apply_with_broadcast(divide, lhs, rhs);
+}
+
+Dataset operator/(const DataConstProxy &lhs, const Dataset &rhs) {
+  return apply_with_broadcast(divide, lhs, rhs);
+}
+
+Dataset operator/(const DataConstProxy &lhs, const DatasetConstProxy &rhs) {
   return apply_with_broadcast(divide, lhs, rhs);
 }
 
@@ -1123,4 +1170,5 @@ Dataset histogram(const Dataset &dataset, const Dim &dim) {
   auto bins = dataset.coords()[dim];
   return histogram(dataset, bins);
 }
+
 } // namespace scipp::core

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -789,8 +789,8 @@ template <class T> void copy_metadata(Dataset &dest, const T &src) {
   }
 }
 
-void copy_metadata(Dataset &dest, const std::string &name,
-                   const DataConstProxy &src) {
+void copy_sparse_metadata(Dataset &dest, const std::string &name,
+                          const DataConstProxy &src) {
   /* Sparse coordinates */
   for (const auto &coord : src.coords()) {
     if (coord.second.dims().sparse()) {
@@ -818,7 +818,10 @@ auto apply_with_broadcast(const Op &op, const A &a, const B &b) {
       expect::matchingDataPresence(a[name], item);
       if (item.hasData())
         res.setData(std::string(name), op(a[name].data(), item.data()));
-      copy_metadata(res, std::string(name), a[name]);
+      if (item.dims().sparse())
+        copy_sparse_metadata(res, std::string(name), item);
+      else
+        copy_sparse_metadata(res, std::string(name), a[name]);
     }
   }
 
@@ -835,7 +838,10 @@ auto apply_with_broadcast(const Op &op, const A &a, const DataConstProxy &b) {
     expect::coordsAndLabelsAreSuperset(item, b);
     if (item.hasData())
       res.setData(std::string(name), op(item.data(), b.data()));
-    copy_metadata(res, std::string(name), item);
+    if (item.dims().sparse())
+      copy_sparse_metadata(res, std::string(name), item);
+    else
+      copy_sparse_metadata(res, std::string(name), b);
   }
 
   return res;
@@ -851,7 +857,10 @@ auto apply_with_broadcast(const Op &op, const DataConstProxy &a, const B &b) {
     expect::coordsAndLabelsAreSuperset(a, item);
     if (item.hasData())
       res.setData(std::string(name), op(a.data(), item.data()));
-    copy_metadata(res, std::string(name), item);
+    if (item.dims().sparse())
+      copy_sparse_metadata(res, std::string(name), item);
+    else
+      copy_sparse_metadata(res, std::string(name), a);
   }
 
   return res;

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -303,15 +303,9 @@ void sparseCoordsAndLabelsMatch(const DataConstProxy &a,
     }
 
     /* Check that a and b have identical sparse labels */
-    for (const auto & [ name, label ] : b.labels()) {
-      if (!a.labels().contains(name)) {
+    for (const auto & [ name, label ] : b.labels())
+      if (!a.labels().contains(name) || a.labels()[name] != label)
         throw except::CoordMismatchError("Expected sparse labels to match.");
-      }
-
-      if (a.labels()[name] != label) {
-        throw except::CoordMismatchError("Expected sparse labels to match.");
-      }
-    }
   }
 }
 

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -325,6 +325,13 @@ void coordsAndLabelsAreSuperset(const DataConstProxy &a,
       throw except::CoordMismatchError("Expected labels to match.");
 }
 
+void matchingDataPresence(const DataConstProxy &a, const DataConstProxy &b) {
+  if (a.hasData() != b.hasData())
+    throw except::SparseDataError(
+        "Either both or neither of the operands in "
+        "a operation with sparse data must have data values.");
+}
+
 void notSparse(const Dimensions &dims) {
   if (dims.sparse())
     throw except::DimensionError("Expected non-sparse dimensions.");

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -290,22 +290,22 @@ void validSlice(const Dimensions &dims, const Slice &slice) {
 
 void sparseCoordsAndLabelsMatch(const DataConstProxy &a,
                                 const DataConstProxy &b) {
-  if (b.dims().sparse()) {
-    const auto sparseDim = b.dims().sparseDim();
-
-    /* Fail if: */
-    /* - presence of a sparse dimension is not identical in both items */
-    /* - both items have a sparse dimension but it's coordinates differ */
-    if ((a.coords().contains(sparseDim) != b.coords().contains(sparseDim)) ||
-        (a.coords().contains(sparseDim) &&
-         a.coords()[sparseDim] != b.coords()[sparseDim])) {
+  if (a.dims().sparse() && b.dims().sparse()) {
+    if (a.dims().sparseDim() != b.dims().sparseDim())
+      throw except::DimensionError(
+          "Sparse dimension of operands expected to match.");
+    const auto sparseDim = a.dims().sparseDim();
+    if (a.coords().contains(sparseDim) && b.coords().contains(sparseDim) &&
+        (a.coords()[sparseDim] != b.coords()[sparseDim]))
       throw except::CoordMismatchError("Expected sparse coords to match.");
-    }
-
-    /* Check that a and b have identical sparse labels */
     for (const auto & [ name, label ] : b.labels())
       if (!a.labels().contains(name) || a.labels()[name] != label)
         throw except::CoordMismatchError("Expected sparse labels to match.");
+  } else if (a.dims().sparse() || b.dims().sparse()) {
+    if (a.coords().contains(b.dims().sparseDim()) ||
+        b.coords().contains(a.dims().sparseDim()))
+      throw except::DimensionError(
+          "Dimension is sparse in one operand but dense in the other operand.");
   }
 }
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -670,6 +670,10 @@ SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const DatasetConstProxy &lhs,
                                     const DataConstProxy &rhs);
+SCIPP_CORE_EXPORT Dataset operator+(const DataConstProxy &lhs,
+                                    const Dataset &rhs);
+SCIPP_CORE_EXPORT Dataset operator+(const DataConstProxy &lhs,
+                                    const DatasetConstProxy &rhs);
 
 SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const Dataset &lhs,
@@ -682,6 +686,10 @@ SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator-(const DatasetConstProxy &lhs,
                                     const DataConstProxy &rhs);
+SCIPP_CORE_EXPORT Dataset operator-(const DataConstProxy &lhs,
+                                    const Dataset &rhs);
+SCIPP_CORE_EXPORT Dataset operator-(const DataConstProxy &lhs,
+                                    const DatasetConstProxy &rhs);
 
 SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const Dataset &lhs,
@@ -694,6 +702,10 @@ SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator*(const DatasetConstProxy &lhs,
                                     const DataConstProxy &rhs);
+SCIPP_CORE_EXPORT Dataset operator*(const DataConstProxy &lhs,
+                                    const Dataset &rhs);
+SCIPP_CORE_EXPORT Dataset operator*(const DataConstProxy &lhs,
+                                    const DatasetConstProxy &rhs);
 
 SCIPP_CORE_EXPORT Dataset operator/(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);
@@ -706,6 +718,10 @@ SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,
                                     const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset operator/(const DatasetConstProxy &lhs,
                                     const DataConstProxy &rhs);
+SCIPP_CORE_EXPORT Dataset operator/(const DataConstProxy &lhs,
+                                    const Dataset &rhs);
+SCIPP_CORE_EXPORT Dataset operator/(const DataConstProxy &lhs,
+                                    const DatasetConstProxy &rhs);
 
 SCIPP_CORE_EXPORT Variable histogram(const DataConstProxy &sparse,
                                      const Variable &binEdges);

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -135,6 +135,10 @@ struct SCIPP_CORE_EXPORT VariancesError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+struct SCIPP_CORE_EXPORT SparseDataError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 } // namespace except
 
 namespace expect {
@@ -187,6 +191,8 @@ void coordsAndLabelsMatch(const A &a, const B &b) {
 
 void SCIPP_CORE_EXPORT coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                                   const DataConstProxy &b);
+void SCIPP_CORE_EXPORT matchingDataPresence(const DataConstProxy &a,
+                                            const DataConstProxy &b);
 void SCIPP_CORE_EXPORT notSparse(const Dimensions &dims);
 void SCIPP_CORE_EXPORT validDim(const Dim dim);
 void SCIPP_CORE_EXPORT validExtent(const scipp::index size);

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -597,6 +597,34 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataconstproxy_sparse_rhs) {
   EXPECT_EQ(res, TestFixture::op(dataset_a, dataset_b));
 }
 
+TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense) {
+  Dataset dense;
+  dense.setData("a", makeVariable<double>(2.0));
+  const auto sparse =
+      make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0}, "a");
+
+  const auto res = TestFixture::op(sparse, dense);
+
+  EXPECT_EQ(res.size(), 1);
+  EXPECT_TRUE(res.contains("a"));
+  EXPECT_EQ(res["a"].data(),
+            TestFixture::op(sparse["a"].data(), dense["a"].data()));
+}
+
+TYPED_TEST(DatasetBinaryOpTest, dense_with_sparse) {
+  Dataset dense;
+  dense.setData("a", makeVariable<double>(2.0));
+  const auto sparse =
+      make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0}, "a");
+
+  const auto res = TestFixture::op(dense, sparse);
+
+  EXPECT_EQ(res.size(), 1);
+  EXPECT_TRUE(res.contains("a"));
+  EXPECT_EQ(res["a"].data(),
+            TestFixture::op(dense["a"].data(), sparse["a"].data()));
+}
+
 TYPED_TEST(DatasetBinaryOpTest, dataconstproxy_sparse_lhs_dataset_sparse_rhs) {
   const auto dataset_a =
       make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -586,6 +586,17 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataset_sparse_rhs) {
   EXPECT_EQ(dataset_a["sparse"].coords(), res["sparse"].coords());
 }
 
+TYPED_TEST(DatasetBinaryOpTest, sparse_data_presense_mismatch) {
+  Dataset a;
+  a.setSparseCoord("sparse",
+                   makeVariable<double>({Dim::X, Dimensions::Sparse}));
+  auto b(a);
+  a.setData("sparse", makeVariable<double>({Dim::X, Dimensions::Sparse}));
+
+  EXPECT_THROW(TestFixture::op(a, b), except::SparseDataError);
+  EXPECT_THROW(TestFixture::op(a, b["sparse"]), except::SparseDataError);
+}
+
 TYPED_TEST(DatasetBinaryOpTest,
            dataset_sparse_lhs_dataset_sparse_rhs_fail_when_coords_mismatch) {
   auto dataset_a = make_simple_sparse({1.1, 2.2});

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -679,8 +679,6 @@ TYPED_TEST(DatasetBinaryOpTest,
 
   EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
                except::CoordMismatchError);
-  EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
-               except::CoordMismatchError);
 }
 
 TYPED_TEST(DatasetBinaryOpTest,

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -608,6 +608,18 @@ TYPED_TEST(DatasetBinaryOpTest, dataconstproxy_sparse_lhs_dataset_sparse_rhs) {
   EXPECT_EQ(res, TestFixture::op(dataset_a, dataset_b));
 }
 
+TYPED_TEST(DatasetBinaryOpTest, sparse_dataconstproxy_coord_mismatch) {
+  const auto dataset_a =
+      make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});
+  const auto dataset_b =
+      make_sparse_with_coords_and_labels({3.3, 4.4}, {1.0, 2.1});
+
+  ASSERT_THROW(TestFixture::op(dataset_a, dataset_b["sparse"]),
+               except::CoordMismatchError);
+  ASSERT_THROW(TestFixture::op(dataset_a["sparse"], dataset_b),
+               except::CoordMismatchError);
+}
+
 TYPED_TEST(DatasetBinaryOpTest, sparse_data_presense_mismatch) {
   Dataset a;
   a.setSparseCoord("sparse",
@@ -617,6 +629,7 @@ TYPED_TEST(DatasetBinaryOpTest, sparse_data_presense_mismatch) {
 
   EXPECT_THROW(TestFixture::op(a, b), except::SparseDataError);
   EXPECT_THROW(TestFixture::op(a, b["sparse"]), except::SparseDataError);
+  EXPECT_THROW(TestFixture::op(a["sparse"], b), except::SparseDataError);
 }
 
 TYPED_TEST(DatasetBinaryOpTest,

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -586,6 +586,28 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataset_sparse_rhs) {
   EXPECT_EQ(dataset_a["sparse"].coords(), res["sparse"].coords());
 }
 
+TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataconstproxy_sparse_rhs) {
+  const auto dataset_a =
+      make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});
+  const auto dataset_b =
+      make_sparse_with_coords_and_labels({3.3, 4.4}, {1.0, 2.0});
+
+  const auto res = TestFixture::op(dataset_a, dataset_b["sparse"]);
+
+  EXPECT_EQ(res, TestFixture::op(dataset_a, dataset_b));
+}
+
+TYPED_TEST(DatasetBinaryOpTest, dataconstproxy_sparse_lhs_dataset_sparse_rhs) {
+  const auto dataset_a =
+      make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});
+  const auto dataset_b =
+      make_sparse_with_coords_and_labels({3.3, 4.4}, {1.0, 2.0});
+
+  const auto res = TestFixture::op(dataset_a["sparse"], dataset_b);
+
+  EXPECT_EQ(res, TestFixture::op(dataset_a, dataset_b));
+}
+
 TYPED_TEST(DatasetBinaryOpTest, sparse_data_presense_mismatch) {
   Dataset a;
   a.setSparseCoord("sparse",
@@ -614,6 +636,8 @@ TYPED_TEST(DatasetBinaryOpTest,
     dataset_b.setSparseCoord("sparse", var);
   }
 
+  EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
+               except::CoordMismatchError);
   EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
                except::CoordMismatchError);
 }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -137,6 +137,8 @@ void init_dataset(py::module &m) {
   bind_binary<Dataset>(datasetProxy);
   bind_binary<DatasetProxy>(datasetProxy);
   bind_binary<DataProxy>(datasetProxy);
+  bind_binary<Dataset>(dataProxy);
+  bind_binary<DatasetProxy>(dataProxy);
 
   bind_data_properties(dataProxy);
 


### PR DESCRIPTION
Fixes #366.

Binary operations like `+`:

- Must handle coord-only sparse data. Currently `DataConstProxy::data()` is accessed without checking for the presence of data.
- We are already supporting `sparse + dense` in the current implementation. However, `dense + sparse` (which should yield the same result) is not working in the current implementation.
- Operations with `DataConstProxy` as the first operand are missing.
- Operations with `DataConstProxy` are not checking coords and labels.