### PR TITLE
Correct labels treatment in setData()

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -295,7 +295,7 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
 
   for (const auto & [ nm, v ] : data.labels()) {
     if (v.dims().sparse()) {
-      setSparseLabels(name, name, v);
+      setSparseLabels(name, std::string(nm), v);
     }
   }
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -232,7 +232,7 @@ void Dataset::setData(const std::string &name, Variable data) {
   m_data[name].data = std::move(data);
 }
 
-// This only checks the coordinates, not labels, not attributes
+// This only checks the coordinates and labels, not attributes
 bool checkCorrespondingDenseCoords(const Dataset &dataset,
                                    const DataConstProxy &other) {
   if (other.dims().sparse())

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -249,6 +249,20 @@ bool checkCorrespondingDenseCoords(const Dataset &dataset,
       }
     }
   }
+
+  const auto dsLabels{dataset.labels()};
+  const auto otLabels{other.labels()};
+  const auto dsLItems{dsLabels.items()};
+  for (const auto & [ nm, v ] : otLabels) {
+    if (auto iter = dsLItems.find(nm); iter == dsLItems.end()) {
+      return false;
+    } else {
+      if (*iter->second.first != v) {
+        return false;
+      }
+    }
+
+  }
   return true;
 }
 
@@ -278,6 +292,12 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
   auto dim = data.dims().sparseDim();
   if (dim != Dim::Invalid) {
     setSparseCoord(name, data.coords()[dim]);
+  }
+
+  for (const auto & [nm, v] : data.labels()) {
+    if(v.dims().sparse()) {
+      setSparseLabels(name, name, v);
+    }
   }
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -261,7 +261,6 @@ bool checkCorrespondingDenseCoords(const Dataset &dataset,
         return false;
       }
     }
-
   }
   return true;
 }
@@ -294,8 +293,8 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
     setSparseCoord(name, data.coords()[dim]);
   }
 
-  for (const auto & [nm, v] : data.labels()) {
-    if(v.dims().sparse()) {
+  for (const auto & [ nm, v ] : data.labels()) {
+    if (v.dims().sparse()) {
       setSparseLabels(name, name, v);
     }
   }

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -743,7 +743,7 @@ TEST(DatasetSetData, sparse_to_dense) {
   auto dense = datasetFactory.make();
   dense.setData("sparse", base["base"]);
   EXPECT_EQ(base["base"].data(), dense["sparse"].data());
-  EXPECT_EQ(base["base"].labels().items().count("l"), 1);
+  EXPECT_EQ(dense["sparse"].labels().items().count("l"), 1);
 }
 
 TEST(DatasetSetData, dense_to_dense) {

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -736,9 +736,14 @@ TEST(DatasetSetData, sparse_to_sparse) {
 
 TEST(DatasetSetData, sparse_to_dense) {
   auto base = non_trivial_2d_sparse("base");
+  auto var = makeVariable<double>({Dim::Y}, {Dimensions::Sparse});
+  var.sparseValues<double>()[0] = {1, 2, 3};
+  base.setSparseLabels("base", "l", var);
+
   auto dense = datasetFactory.make();
   dense.setData("sparse", base["base"]);
   EXPECT_EQ(base["base"].data(), dense["sparse"].data());
+  EXPECT_EQ(base["base"].labels().items().count("l"), 1);
 }
 
 TEST(DatasetSetData, dense_to_dense) {
@@ -756,4 +761,15 @@ TEST(DatasetSetData, dense_to_empty) {
   ds.setData("data_x", dense["data_x"]);
   EXPECT_EQ(dense["data_x"].coords(), ds["data_x"].coords());
   EXPECT_EQ(dense["data_x"].data(), ds["data_x"].data());
+}
+
+TEST(DatasetSetData, labels) {
+  auto dense = datasetFactory.make();
+  dense.setLabels("l", makeVariable<double>({Dim::X}, {dense.coords()[Dim::X].values<double>().size()}));
+  auto d = Dataset(dense.slice({Dim::Y, 0}));
+  dense.setData("data_x_1", dense["data_x"]);
+  EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
+
+  d.setLabels("l1", makeVariable<double>({Dim::X}, {d.coords()[Dim::X].values<double>().size()}));
+  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), std::logic_error);
 }

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -765,11 +765,15 @@ TEST(DatasetSetData, dense_to_empty) {
 
 TEST(DatasetSetData, labels) {
   auto dense = datasetFactory.make();
-  dense.setLabels("l", makeVariable<double>({Dim::X}, {dense.coords()[Dim::X].values<double>().size()}));
+  dense.setLabels(
+      "l", makeVariable<double>(
+               {Dim::X}, {dense.coords()[Dim::X].values<double>().size()}));
   auto d = Dataset(dense.slice({Dim::Y, 0}));
   dense.setData("data_x_1", dense["data_x"]);
   EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
 
-  d.setLabels("l1", makeVariable<double>({Dim::X}, {d.coords()[Dim::X].values<double>().size()}));
+  d.setLabels(
+      "l1", makeVariable<double>({Dim::X},
+                                 {d.coords()[Dim::X].values<double>().size()}));
   EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), std::logic_error);
 }

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -169,7 +169,7 @@ def test_dataset_set_data():
                                unit=sp.units.m),
             Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0),
                                unit=sp.units.m)},
-        labels={'aux': sp.Variable([Dim.Y], values=np.random.rand(3))})
+        labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
 
     d2 = sp.Dataset(
         {'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
@@ -177,9 +177,8 @@ def test_dataset_set_data():
             Dim.X: sp.Variable([Dim.X], values=np.arange(2.0),
                                unit=sp.units.m),
             Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0),
-                               unit=sp.units.m)}, labels={
-            'aux': sp.Variable([Dim.Y], values=np.random.rand(
-                3))})
+                               unit=sp.units.m)},
+        labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
 
     d3 = sp.Dataset()
     d3['b'] = d1['a']


### PR DESCRIPTION
Process the labels the same way as the coordinates.
fixes #383 