### PR TITLE
Disable imgmath extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,11 +40,10 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
-    'nbsphinx',
-    'sphinx.ext.mathjax'
+    'nbsphinx'
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
There is no obvious reason for MathJax not working that I can see.

The JS library is pulled from cdnjs so there is nothing we should have to do to make it work.

This commit disable imgmath in case there is some issue having multiple math rendering extensions configured.