### PR TITLE
Correct file permissions for demos and examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,8 @@ RUN conda install --yes -c scipp/label/dev scipp
 # Add the demo notebooks and Python examples
 ADD 'python/demo/' "/home/$NB_USER/demo"
 ADD 'python/examples/' "/home/$NB_USER/examples"
+USER root
+RUN chown -R "$NB_USER" \
+      "/home/$NB_USER/demo" \
+      "/home/$NB_USER/examples"
+USER $NB_USER


### PR DESCRIPTION
Changes the owner of the demos and example directories to NB_USER inside the image.

This allows users to overwrite then, etc. which was not possible before.