### PR TITLE
Implement find() for Dataset and proxies

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -480,6 +480,12 @@ public:
     return detail::makeSlice(*Base::items().at(key).second, Base::slices());
   }
 
+  template <class T> auto find(const T k) const && = delete;
+  template <class T> auto find(const T k) const &noexcept {
+    return boost::make_transform_iterator(Base::items().find(k),
+                                          make_item{this});
+  }
+
   auto begin() const && = delete;
   /// Return iterator to the beginning of all items.
   auto begin() const &noexcept {

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -247,6 +247,13 @@ public:
 
   bool contains(const std::string_view name) const noexcept;
 
+  auto find() const && = delete;
+  auto find() && = delete;
+  auto find(const std::string_view name) & noexcept {
+    return boost::make_transform_iterator(m_data.find(name),
+                                          detail::make_item{this});
+  }
+
   DataConstProxy operator[](const std::string_view name) const;
   DataProxy operator[](const std::string_view name);
 
@@ -392,6 +399,11 @@ public:
     return detail::makeSlice(*m_items.at(key).first, m_slices);
   }
 
+  auto find(const Key k) const && = delete;
+  auto find(const Key k) const &noexcept {
+    return boost::make_transform_iterator(m_items.find(k), make_item{this});
+  }
+
   auto begin() const && = delete;
   /// Return const iterator to the beginning of all items.
   auto begin() const &noexcept {
@@ -521,6 +533,13 @@ public:
 
   DataConstProxy operator[](const std::string_view name) const;
 
+  auto find(const std::string_view name) const && = delete;
+  auto find(const std::string_view name) const &noexcept {
+    return boost::make_transform_iterator(
+        std::find(std::begin(m_indices), std::end(m_indices), name),
+        detail::make_item{this});
+  }
+
   auto begin() const && = delete;
   auto begin() const &noexcept {
     return boost::make_transform_iterator(m_indices.begin(),
@@ -599,6 +618,13 @@ public:
   AttrsProxy attrs() const noexcept;
 
   DataProxy operator[](const std::string_view name) const;
+
+  auto find(const std::string_view name) const && = delete;
+  auto find(const std::string_view name) const &noexcept {
+    return boost::make_transform_iterator(
+        std::find(std::begin(m_indices), std::end(m_indices), name),
+        detail::make_item{this});
+  }
 
   auto begin() const && = delete;
   auto begin() const &noexcept {

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -264,6 +264,34 @@ TEST(DatasetTest, find) {
   EXPECT_EQ(it, d.find("b"));
 }
 
+TEST(DatasetTest, find_coords_const) {
+  DatasetFactory3D factory;
+  const auto dataset = factory.make();
+  const CoordsConstProxy coords = dataset.coords();
+
+  EXPECT_EQ(coords.end(), coords.find(Dim::Q));
+
+  EXPECT_EQ(coords.begin(), coords.find(Dim::Time));
+
+  auto it = coords.begin();
+  ++it;
+  EXPECT_EQ(it, coords.find(Dim::X));
+}
+
+TEST(DatasetTest, find_coords_mutable) {
+  DatasetFactory3D factory;
+  auto dataset = factory.make();
+  CoordsProxy coords = dataset.coords();
+
+  EXPECT_EQ(coords.end(), coords.find(Dim::Q));
+
+  EXPECT_EQ(coords.begin(), coords.find(Dim::Time));
+
+  auto it = coords.begin();
+  ++it;
+  EXPECT_EQ(it, coords.find(Dim::X));
+}
+
 TEST(DatasetTest, set_dense_data_with_sparse_coord) {
 
   auto sparse_variable =

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -249,6 +249,21 @@ TEST(DatasetTest, const_iterators_return_types) {
   ASSERT_TRUE((std::is_same_v<decltype(d.end()->second), DataConstProxy>));
 }
 
+TEST(DatasetTest, find) {
+  Dataset d;
+  d.setData("a", makeVariable<double>({}));
+  d.setData("b", makeVariable<float>({}));
+  d.setData("c", makeVariable<int64_t>({}));
+
+  EXPECT_EQ(d.end(), d.find("not a thing"));
+
+  EXPECT_EQ(d.begin(), d.find("a"));
+
+  auto it = d.begin();
+  ++it;
+  EXPECT_EQ(it, d.find("b"));
+}
+
 TEST(DatasetTest, set_dense_data_with_sparse_coord) {
 
   auto sparse_variable =
@@ -1693,4 +1708,21 @@ TYPED_TEST(DataProxy3DTest, slice_with_edges) {
       }
     }
   }
+}
+
+TEST(DatasetProxyTest, find) {
+  Dataset d;
+  d.setData("a", makeVariable<double>({}));
+  d.setData("b", makeVariable<float>({}));
+  d.setData("c", makeVariable<int64_t>({}));
+
+  DatasetProxy dp(d);
+
+  EXPECT_EQ(dp.end(), dp.find("not a thing"));
+
+  EXPECT_EQ(dp.begin(), dp.find("a"));
+
+  auto it = dp.begin();
+  ++it;
+  EXPECT_EQ(it, dp.find("b"));
 }

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -1726,3 +1726,46 @@ TEST(DatasetProxyTest, find) {
   ++it;
   EXPECT_EQ(it, dp.find("b"));
 }
+
+TEST(DatasetProxyTest, find_in_slice) {
+  Dataset d;
+  d.setCoord(Dim::X, makeVariable<double>({Dim::X, 2}));
+  d.setCoord(Dim::Y, makeVariable<double>({Dim::Y, 2}));
+  d.setData("a", makeVariable<double>({Dim::X, 2}));
+  d.setData("b", makeVariable<float>({Dim::Y, 2}));
+
+  DatasetProxy slice = d.slice({Dim::X, 1});
+
+  EXPECT_EQ(slice.begin(), slice.find("a"));
+  EXPECT_EQ(slice.end(), slice.find("b"));
+}
+
+TEST(DatasetConstProxyTest, find) {
+  Dataset d;
+  d.setData("a", makeVariable<double>({}));
+  d.setData("b", makeVariable<float>({}));
+  d.setData("c", makeVariable<int64_t>({}));
+
+  DatasetConstProxy dp(d);
+
+  EXPECT_EQ(dp.end(), dp.find("not a thing"));
+
+  EXPECT_EQ(dp.begin(), dp.find("a"));
+
+  auto it = dp.begin();
+  ++it;
+  EXPECT_EQ(it, dp.find("b"));
+}
+
+TEST(DatasetConstProxyTest, find_in_slice) {
+  Dataset d;
+  d.setCoord(Dim::X, makeVariable<double>({Dim::X, 2}));
+  d.setCoord(Dim::Y, makeVariable<double>({Dim::Y, 2}));
+  d.setData("a", makeVariable<double>({Dim::X, 2}));
+  d.setData("b", makeVariable<float>({Dim::Y, 2}));
+
+  const DatasetConstProxy slice = d.slice({Dim::X, 1});
+
+  EXPECT_EQ(slice.begin(), slice.find("a"));
+  EXPECT_EQ(slice.end(), slice.find("b"));
+}


### PR DESCRIPTION
Implements `find()` (as per `std::map`) for `Dataset`, `DatasetProxy` and `DatasetConstProxy`.

Closes #388.