### PR TITLE
Fix Python lifetime issues

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -293,20 +293,28 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property("unit", &T::unit, &T::setUnit,
                  "The physical unit of the data (writable).");
 
-  c.def_property("values", &as_VariableView::values<T>,
-                 &as_VariableView::set_values<T>,
-                 "The array of values of the data (writable).");
-  c.def_property("variances", &as_VariableView::variances<T>,
-                 &as_VariableView::set_variances<T>,
-                 "The array of variances of the data (writable).");
-  c.def_property("value", &as_VariableView::value<T>,
-                 &as_VariableView::set_value<T>,
-                 "The only value for 0-dimensional data. Raises an exception "
-                 "if the data is not 0-dimensional.");
-  c.def_property("variance", &as_VariableView::variance<T>,
-                 &as_VariableView::set_variance<T>,
-                 "The only variance for 0-dimensional data. Raises an "
-                 "exception if the data is not 0-dimensional.");
+  c.def_property(
+      "values",
+      py::cpp_function(&as_VariableView::values<T>, py::keep_alive<0, 1>()),
+      &as_VariableView::set_values<T>,
+      "The array of values of the data (writable).");
+  c.def_property(
+      "variances",
+      py::cpp_function(&as_VariableView::variances<T>, py::keep_alive<0, 1>()),
+      &as_VariableView::set_variances<T>,
+      "The array of variances of the data (writable).");
+  c.def_property(
+      "value",
+      py::cpp_function(&as_VariableView::value<T>, py::keep_alive<0, 1>()),
+      &as_VariableView::set_value<T>,
+      "The only value for 0-dimensional data. Raises an exception if the data "
+      "is not 0-dimensional.");
+  c.def_property(
+      "variance",
+      py::cpp_function(&as_VariableView::variance<T>, py::keep_alive<0, 1>()),
+      &as_VariableView::set_variance<T>,
+      "The only variance for 0-dimensional data. Raises an exception if the "
+      "data is not 0-dimensional.");
   c.def_property_readonly(
       "has_variances", [](T &v) { return v.hasVariances(); },
       py::return_value_policy::

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -233,7 +233,7 @@ template <class... Ts> struct as_VariableViewImpl {
     auto &view = obj.cast<Var &>();
     expect::equals(Dimensions(), view.dims());
     return std::visit(
-        [](const auto &data) {
+        [&obj](const auto &data) {
           // Passing `obj` as parent so py::keep_alive works.
           return py::cast(data[0], py::return_value_policy::reference_internal,
                           obj);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -22,7 +22,8 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
   py::class_<ConstT>(m, (name + "ConstProxy").c_str());
   py::class_<T, ConstT> proxy(m, (name + "Proxy").c_str());
   proxy.def("__len__", &T::size)
-      .def("__getitem__", &T::operator[], py::keep_alive<0, 1>())
+      .def("__getitem__", &T::operator[], py::return_value_policy::move,
+           py::keep_alive<0, 1>())
       .def("__iter__",
            [](T &self) {
              return py::make_iterator(self.begin(), self.end(),
@@ -35,12 +36,20 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
 
 template <class T, class... Ignored>
 void bind_coord_properties(py::class_<T, Ignored...> &c) {
-  c.def_property_readonly("coords", [](T &self) { return self.coords(); },
-                          py::return_value_policy::move);
-  c.def_property_readonly("labels", [](T &self) { return self.labels(); },
-                          py::return_value_policy::move);
-  c.def_property_readonly("attrs", [](T &self) { return self.attrs(); },
-                          py::return_value_policy::move);
+  // For some reason the return value policy and/or keep-alive policy do not
+  // work unless we wrap things in py::cpp_function.
+  c.def_property_readonly(
+      "coords",
+      py::cpp_function([](T &self) { return self.coords(); },
+                       py::return_value_policy::move, py::keep_alive<0, 1>()));
+  c.def_property_readonly(
+      "labels",
+      py::cpp_function([](T &self) { return self.labels(); },
+                       py::return_value_policy::move, py::keep_alive<0, 1>()));
+  c.def_property_readonly("attrs",
+                          py::cpp_function([](T &self) { return self.attrs(); },
+                                           py::return_value_policy::move,
+                                           py::keep_alive<0, 1>()));
 }
 
 template <class T, class... Ignored>
@@ -52,7 +61,7 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
           return py::make_iterator(self.begin(), self.end(),
                                    py::return_value_policy::move);
         },
-        py::keep_alive<0, 1>());
+        py::return_value_policy::move, py::keep_alive<0, 1>());
   c.def("__getitem__",
         [](T &self, const std::string &name) { return self[name]; },
         py::keep_alive<0, 1>());
@@ -76,9 +85,9 @@ void init_dataset(py::module &m) {
 
   py::class_<DataConstProxy>(m, "DataConstProxy");
   py::class_<DataProxy, DataConstProxy> dataProxy(m, "DataProxy");
-  dataProxy.def_property_readonly("data", &DataProxy::data,
-                                  py::return_value_policy::move,
-                                  py::keep_alive<0, 1>());
+  dataProxy.def_property_readonly(
+      "data", py::cpp_function(&DataProxy::data, py::return_value_policy::move,
+                               py::keep_alive<0, 1>()));
   dataProxy.def("__repr__",
                 [](const DataProxy &self) { return to_string(self); });
 

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -289,9 +289,7 @@ def test_lifetime_values_of_item_of_temporary():
 
 def test_lifetime_coords_of_temporary():
     var = sp.Variable(dims=[Dim.X], values=np.arange(10))
-    d = sp.Dataset({'a': var},
-                   coords={Dim.X: var},
-                   labels={'aux': var})
+    d = sp.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
     assert d.coords[Dim.X].values[-1] == 9
     assert d['a'].coords[Dim.X].values[-1] == 9
     assert d[Dim.X, 1:]['a'].coords[Dim.X].values[-1] == 9
@@ -301,17 +299,26 @@ def test_lifetime_coords_of_temporary():
 
 def test_lifetime_iter():
     var = sp.Variable(dims=[Dim.X], values=np.arange(10))
-    d = sp.Dataset({'a': var},
-                   coords={Dim.X: var},
-                   labels={'aux': var})
-    for name, item in d+d:
+    d = sp.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
+    for name, item in d + d:
         assert item.data == var + var
-    for dim, coord in (d+d).coords:
+    for dim, coord in (d + d).coords:
         assert coord == var
     for name, item in d[Dim.X, 1:5]:
         assert item.data == var[Dim.X, 1:5]
     for dim, coord in d[Dim.X, 1:5].coords:
         assert coord == var[Dim.X, 1:5]
+    for name, item in (d + d)[Dim.X, 1:5]:
+        assert item.data == (var + var)[Dim.X, 1:5]
+    for dim, coord in (d + d)[Dim.X, 1:5].coords:
+        assert coord == var[Dim.X, 1:5]
+
+
+def test_lifetime_single_value():
+    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
+    var = sp.Variable(d)
+    assert var.value['a'].values[-1] == 9
+    assert var.copy().values['a'].values[-1] == 9
 
 
 # def test_delitem(self):

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -4,7 +4,6 @@
 # @author Simon Heybrock
 import pytest
 
-import scipp as sc
 import scipp as sp
 from scipp import Dim
 import numpy as np
@@ -260,65 +259,6 @@ def test_dataset_set_data():
                                 variances=np.arange(1.0))
     expected["b"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0, 11.0))
     assert d2 == expected
-
-
-def test_lifetime_values_of_py_array_t_item():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
-    vals = (d + d)['a'].values
-    d2 = d + d  # do something allocating memory to trigger potential segfault
-    assert vals[-1] == 2 * 9
-
-
-def test_lifetime_values_of_py_array_t_item_of_temporary():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
-    assert d['a'].values[-1] == 9
-
-
-def test_lifetime_values_of_item():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=["aa", "bb", "cc"])})
-    assert d['a'].values[2] == "cc"
-
-
-def test_lifetime_values_of_item_of_temporary():
-    d = sp.Dataset(
-        coords={Dim.X: sp.Variable([Dim.X], values=["aa", "bb", "cc"])})
-    vals = (d + d).coords[Dim.X].values
-    d2 = d + d  # do something allocating memory to trigger potential segfault
-    assert vals[2] == "cc"
-
-
-def test_lifetime_coords_of_temporary():
-    var = sp.Variable(dims=[Dim.X], values=np.arange(10))
-    d = sp.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
-    assert d.coords[Dim.X].values[-1] == 9
-    assert d['a'].coords[Dim.X].values[-1] == 9
-    assert d[Dim.X, 1:]['a'].coords[Dim.X].values[-1] == 9
-    assert (d + d).coords[Dim.X].values[-1] == 9
-    assert (d + d).labels['aux'].values[-1] == 9
-
-
-def test_lifetime_iter():
-    var = sp.Variable(dims=[Dim.X], values=np.arange(10))
-    d = sp.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
-    for name, item in d + d:
-        assert item.data == var + var
-    for dim, coord in (d + d).coords:
-        assert coord == var
-    for name, item in d[Dim.X, 1:5]:
-        assert item.data == var[Dim.X, 1:5]
-    for dim, coord in d[Dim.X, 1:5].coords:
-        assert coord == var[Dim.X, 1:5]
-    for name, item in (d + d)[Dim.X, 1:5]:
-        assert item.data == (var + var)[Dim.X, 1:5]
-    for dim, coord in (d + d)[Dim.X, 1:5].coords:
-        assert coord == var[Dim.X, 1:5]
-
-
-def test_lifetime_single_value():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
-    var = sp.Variable(d)
-    assert var.value['a'].values[-1] == 9
-    assert var.copy().values['a'].values[-1] == 9
 
 
 # def test_delitem(self):

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -4,6 +4,7 @@
 # @author Simon Heybrock
 import pytest
 
+import scipp as sc
 import scipp as sp
 from scipp import Dim
 import numpy as np
@@ -85,9 +86,9 @@ def test_slice_item():
     d['a'] = sp.Variable([Dim.X], values=np.arange(4))
     assert d['a'][Dim.X, 2:4].data == sp.Variable([Dim.X],
                                                   values=np.arange(2, 4))
-    assert d['a'][Dim.X, 2:4].coords[Dim.X] == sp.Variable([Dim.X],
-                                                           values=np.arange(6,
-                                                                            8))
+    assert d['a'][Dim.X,
+                  2:4].coords[Dim.X] == sp.Variable([Dim.X],
+                                                    values=np.arange(6, 8))
 
 
 def test_set_item_slice_from_numpy():
@@ -145,9 +146,12 @@ def test_contains():
 
 
 def test_slice():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-                    'b': sp.Variable(1.0)}, coords={
-        Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
+    d = sp.Dataset(
+        {
+            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sp.Variable(1.0)
+        },
+        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
     expected = sp.Dataset({'a': sp.Variable(1.0)})
 
     assert d[Dim.X, 1] == expected
@@ -156,13 +160,19 @@ def test_slice():
 
 
 def test_coords_proxy_comparison_operators():
-    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-                    'b': sp.Variable(1.0)}, coords={
-        Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
+    d = sp.Dataset(
+        {
+            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sp.Variable(1.0)
+        },
+        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
 
-    d1 = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-                     'b': sp.Variable(1.0)}, coords={
-        Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
+    d1 = sp.Dataset(
+        {
+            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sp.Variable(1.0)
+        },
+        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
     assert d1['a'].coords == d['a'].coords
 
 
@@ -174,11 +184,11 @@ def test_variable_histogram():
     var[Dim.X, 1].values = np.ones(6)
     ds = sp.Dataset()
     ds.set_sparse_coord("sparse", var)
-    hist = sp.histogram(ds["sparse"],
-                        sp.Variable(values=np.arange(5, dtype=np.float64),
-                                    dims=[Dim.Y]))
-    assert np.array_equal(hist.values, np.array(
-        [[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
+    hist = sp.histogram(
+        ds["sparse"],
+        sp.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
+    assert np.array_equal(
+        hist.values, np.array([[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
 
 
 def test_dataset_histogram():
@@ -190,31 +200,37 @@ def test_dataset_histogram():
     ds = sp.Dataset()
     ds.set_sparse_coord("s", var)
     ds.set_sparse_coord("s1", var * 5)
-    h = sp.histogram(ds, sp.Variable(values=np.arange(5, dtype=np.float64),
-                                     dims=[Dim.Y]))
-    assert np.array_equal(h["s"].values, np.array(
-        [[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
-    assert np.array_equal(h["s1"].values, np.array(
-        [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]))
+    h = sp.histogram(
+        ds, sp.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
+    assert np.array_equal(
+        h["s"].values, np.array([[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
+    assert np.array_equal(
+        h["s1"].values, np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]))
 
 
 def test_dataset_set_data():
     d1 = sp.Dataset(
-        {'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
-         'b': sp.Variable(1.0)}, coords={
+        {
+            'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+            'b': sp.Variable(1.0)
+        },
+        coords={
             Dim.X: sp.Variable([Dim.X], values=np.arange(2.0),
                                unit=sp.units.m),
-            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0),
-                               unit=sp.units.m)},
+            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0), unit=sp.units.m)
+        },
         labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
 
     d2 = sp.Dataset(
-        {'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
-         'b': sp.Variable(1.0)}, coords={
+        {
+            'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+            'b': sp.Variable(1.0)
+        },
+        coords={
             Dim.X: sp.Variable([Dim.X], values=np.arange(2.0),
                                unit=sp.units.m),
-            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0),
-                               unit=sp.units.m)},
+            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0), unit=sp.units.m)
+        },
         labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
 
     d3 = sp.Dataset()
@@ -228,7 +244,8 @@ def test_dataset_set_data():
 
     d = sp.Dataset()
     d.set_coord(sp.Dim.Row, sp.Variable([sp.Dim.Row], values=np.arange(10.0)))
-    d["a"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0),
+    d["a"] = sp.Variable([sp.Dim.Row],
+                         values=np.arange(10.0),
                          variances=np.arange(10.0))
     d["b"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0, 20.0))
     d1 = d[sp.Dim.Row, 0:1]
@@ -236,12 +253,66 @@ def test_dataset_set_data():
                     coords={sp.Dim.Row: d1["a"].coords[sp.Dim.Row]})
     d2["b"] = d1["b"]
     expected = sp.Dataset()
-    expected.set_coord(sp.Dim.Row, sp.Variable([sp.Dim.Row],
-                                               values=np.arange(1.0)))
-    expected["a"] = sp.Variable([sp.Dim.Row], values=np.arange(1.0),
+    expected.set_coord(sp.Dim.Row,
+                       sp.Variable([sp.Dim.Row], values=np.arange(1.0)))
+    expected["a"] = sp.Variable([sp.Dim.Row],
+                                values=np.arange(1.0),
                                 variances=np.arange(1.0))
     expected["b"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0, 11.0))
     assert d2 == expected
+
+
+def test_lifetime_values_of_py_array_t_item():
+    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
+    vals = (d + d)['a'].values
+    d2 = d + d  # do something allocating memory to trigger potential segfault
+    assert vals[-1] == 2 * 9
+
+
+def test_lifetime_values_of_py_array_t_item_of_temporary():
+    d = sp.Dataset({'a': sp.Variable([Dim.X], values=np.arange(10))})
+    assert d['a'].values[-1] == 9
+
+
+def test_lifetime_values_of_item():
+    d = sp.Dataset({'a': sp.Variable([Dim.X], values=["aa", "bb", "cc"])})
+    assert d['a'].values[2] == "cc"
+
+
+def test_lifetime_values_of_item_of_temporary():
+    d = sp.Dataset(
+        coords={Dim.X: sp.Variable([Dim.X], values=["aa", "bb", "cc"])})
+    vals = (d + d).coords[Dim.X].values
+    d2 = d + d  # do something allocating memory to trigger potential segfault
+    assert vals[2] == "cc"
+
+
+def test_lifetime_coords_of_temporary():
+    var = sp.Variable(dims=[Dim.X], values=np.arange(10))
+    d = sp.Dataset({'a': var},
+                   coords={Dim.X: var},
+                   labels={'aux': var})
+    assert d.coords[Dim.X].values[-1] == 9
+    assert d['a'].coords[Dim.X].values[-1] == 9
+    assert d[Dim.X, 1:]['a'].coords[Dim.X].values[-1] == 9
+    assert (d + d).coords[Dim.X].values[-1] == 9
+    assert (d + d).labels['aux'].values[-1] == 9
+
+
+def test_lifetime_iter():
+    var = sp.Variable(dims=[Dim.X], values=np.arange(10))
+    d = sp.Dataset({'a': var},
+                   coords={Dim.X: var},
+                   labels={'aux': var})
+    for name, item in d+d:
+        assert item.data == var + var
+    for dim, coord in (d+d).coords:
+        assert coord == var
+    for name, item in d[Dim.X, 1:5]:
+        assert item.data == var[Dim.X, 1:5]
+    for dim, coord in d[Dim.X, 1:5].coords:
+        assert coord == var[Dim.X, 1:5]
+
 
 # def test_delitem(self):
 #    dataset = sp.Dataset()

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -65,3 +65,11 @@ def test_lifetime_single_value():
     var = sc.Variable(d)
     assert var.value['a'].values[-1] == 9
     assert var.copy().values['a'].values[-1] == 9
+
+
+def test_lifetime_coord_values():
+    var = sc.Variable([Dim.X], values=np.arange(10))
+    d = sc.Dataset(coords={Dim.X: var})
+    values = d.coords[Dim.X].values
+    d += d
+    assert np.array_equal(values, var.values)

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import numpy as np
+import scipp as sc
+from scipp import Dim
+"""This file contains tests specific to pybind11 lifetime issues, in particular
+py::return_value_policy and py::keep_alive."""
+
+
+def test_lifetime_values_of_py_array_t_item():
+    d = sc.Dataset({'a': sc.Variable([Dim.X], values=np.arange(10))})
+    assert d['a'].values[-1] == 9
+
+
+def test_lifetime_values_of_py_array_t_item_of_temporary():
+    d = sc.Dataset({'a': sc.Variable([Dim.X], values=np.arange(10))})
+    vals = (d + d)['a'].values
+    d + d  # do something allocating memory to trigger potential segfault
+    assert vals[-1] == 2 * 9
+
+
+def test_lifetime_values_of_item():
+    d = sc.Dataset({'a': sc.Variable([Dim.X], values=["aa", "bb", "cc"])})
+    assert d['a'].values[2] == "cc"
+
+
+def test_lifetime_values_of_item_of_temporary():
+    d = sc.Dataset(
+        coords={Dim.X: sc.Variable([Dim.X], values=["aa", "bb", "cc"])})
+    vals = (d + d).coords[Dim.X].values
+    d + d  # do something allocating memory to trigger potential segfault
+    assert vals[2] == "cc"
+
+
+def test_lifetime_coords_of_temporary():
+    var = sc.Variable(dims=[Dim.X], values=np.arange(10))
+    d = sc.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
+    assert d.coords[Dim.X].values[-1] == 9
+    assert d['a'].coords[Dim.X].values[-1] == 9
+    assert d[Dim.X, 1:]['a'].coords[Dim.X].values[-1] == 9
+    assert (d + d).coords[Dim.X].values[-1] == 9
+    assert (d + d).labels['aux'].values[-1] == 9
+
+
+def test_lifetime_iter():
+    var = sc.Variable(dims=[Dim.X], values=np.arange(10))
+    d = sc.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
+    for name, item in d + d:
+        assert item.data == var + var
+    for dim, coord in (d + d).coords:
+        assert coord == var
+    for name, item in d[Dim.X, 1:5]:
+        assert item.data == var[Dim.X, 1:5]
+    for dim, coord in d[Dim.X, 1:5].coords:
+        assert coord == var[Dim.X, 1:5]
+    for name, item in (d + d)[Dim.X, 1:5]:
+        assert item.data == (var + var)[Dim.X, 1:5]
+    for dim, coord in (d + d)[Dim.X, 1:5].coords:
+        assert coord == var[Dim.X, 1:5]
+
+
+def test_lifetime_single_value():
+    d = sc.Dataset({'a': sc.Variable([Dim.X], values=np.arange(10))})
+    var = sc.Variable(d)
+    assert var.value['a'].values[-1] == 9
+    assert var.copy().values['a'].values[-1] == 9


### PR DESCRIPTION
Relating to what was mention in #400, this PR fixes a number of problems relating to return value policies in our PYthon bindings, and applies `py::keep_alive` where necessary.

The properties caused a lot of headaches, since applying the policies directly did not appear to work. In the end we found that wrapping things in `py::cpp_function` does work. It would be worth investigating some more to figure out if this is an upstream issue.