### PR TITLE
DataArray and fixes for Dataset binary operations

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -22,6 +22,7 @@ set(INC_FILES
 
 set(SRC_FILES
     counts.cpp
+    data_array.cpp
     dataset.cpp
     dimensions.cpp
     #events.cpp

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <ostream>
+
+#include "scipp/core/dataset.h"
+#include "scipp/core/except.h"
+
+namespace scipp::core {
+
+DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,
+                     std::map<std::string, Variable> labels) {
+  m_holder.setData("", std::move(data));
+  for (auto & [ dim, c ] : coords)
+    m_holder.setCoord(dim, std::move(c));
+  for (auto & [ name, l ] : labels)
+    m_holder.setLabels(name, std::move(l));
+}
+
+} // namespace scipp::core

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -13,9 +13,15 @@ DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,
                      std::map<std::string, Variable> labels) {
   m_holder.setData("", std::move(data));
   for (auto & [ dim, c ] : coords)
-    m_holder.setCoord(dim, std::move(c));
+    if (c.dims().sparse())
+      m_holder.setSparseCoord("", std::move(c));
+    else
+      m_holder.setCoord(dim, std::move(c));
   for (auto & [ name, l ] : labels)
-    m_holder.setLabels(name, std::move(l));
+    if (l.dims().sparse())
+      m_holder.setSparseLabels("", name, std::move(l));
+    else
+      m_holder.setLabels(name, std::move(l));
 }
 
 } // namespace scipp::core

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -6,6 +6,10 @@
 
 namespace scipp::core {
 
+DataArray::DataArray(const DataConstProxy &proxy) {
+  m_holder.setData("", proxy);
+}
+
 DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,
                      std::map<std::string, Variable> labels) {
   m_holder.setData("", std::move(data));
@@ -20,6 +24,8 @@ DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,
     else
       m_holder.setLabels(name, std::move(l));
 }
+
+DataArray::operator DataConstProxy() const { return get(); }
 
 DataArray operator+(const DataConstProxy &a, const DataConstProxy &b) {
   return DataArray(a.data() + b.data(), union_(a.coords(), b.coords()),

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -2,10 +2,7 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include <ostream>
-
 #include "scipp/core/dataset.h"
-#include "scipp/core/except.h"
 
 namespace scipp::core {
 
@@ -22,6 +19,26 @@ DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,
       m_holder.setSparseLabels("", name, std::move(l));
     else
       m_holder.setLabels(name, std::move(l));
+}
+
+DataArray operator+(const DataConstProxy &a, const DataConstProxy &b) {
+  return DataArray(a.data() + b.data(), union_(a.coords(), b.coords()),
+                   union_(a.labels(), b.labels()));
+}
+
+DataArray operator-(const DataConstProxy &a, const DataConstProxy &b) {
+  return {a.data() - b.data(), union_(a.coords(), b.coords()),
+          union_(a.labels(), b.labels())};
+}
+
+DataArray operator*(const DataConstProxy &a, const DataConstProxy &b) {
+  return {a.data() * b.data(), union_(a.coords(), b.coords()),
+          union_(a.labels(), b.labels())};
+}
+
+DataArray operator/(const DataConstProxy &a, const DataConstProxy &b) {
+  return {a.data() / b.data(), union_(a.coords(), b.coords()),
+          union_(a.labels(), b.labels())};
 }
 
 } // namespace scipp::core

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -257,16 +257,6 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
     setData(name, data.data());
 }
 
-/// Set (insert or replace) data item with given name.
-///
-/// Coordinated and labels of the data array are added to the dataset. Throws if
-/// there are existing but mismatching coords or labels. Throws if the provided
-/// data brings the dataset into an inconsistent state (mismatching dtype, unit,
-/// or dimensions).
-void Dataset::setData(const std::string &name, const DataArray &data) {
-  setData(name, DataConstProxy(data));
-}
-
 /// Set (insert or replace) the sparse coordinate with given name.
 ///
 /// Sparse coordinates can exist even without corresponding data.
@@ -416,9 +406,6 @@ void Dataset::rename(const Dim from, const Dim to) {
       labels.second.rename(from, to);
   }
 }
-
-DataConstProxy::DataConstProxy(const DataArray &dataArray)
-    : DataConstProxy(dataArray.get()) {}
 
 /// Return an ordered mapping of dimension labels to extents, excluding a
 /// potentialy sparse dimensions.
@@ -619,20 +606,24 @@ DataProxy DatasetProxy::operator[](const std::string_view name) const {
 }
 
 /// Return true if the dataset proxies have identical content.
-bool DataConstProxy::operator==(const DataConstProxy &other) const {
-  if (hasData() != other.hasData())
+bool operator==(const DataConstProxy &a, const DataConstProxy &b) {
+  if (a.hasData() != b.hasData())
     return false;
-  if (hasVariances() != other.hasVariances())
+  if (a.hasVariances() != b.hasVariances())
     return false;
-  if (coords() != other.coords())
+  if (a.coords() != b.coords())
     return false;
-  if (labels() != other.labels())
+  if (a.labels() != b.labels())
     return false;
-  if (attrs() != other.attrs())
+  if (a.attrs() != b.attrs())
     return false;
-  if (hasData() && data() != other.data())
+  if (a.hasData() && a.data() != b.data())
     return false;
   return true;
+}
+
+bool operator!=(const DataConstProxy &a, const DataConstProxy &b) {
+  return !operator==(a, b);
 }
 
 template <class A, class B> bool dataset_equals(const A &a, const B &b) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -232,11 +232,11 @@ void Dataset::setData(const std::string &name, Variable data) {
   m_data[name].data = std::move(data);
 }
 
-/// Set (insert or replace) data (values, optional variances, sparse
-/// coordinates) with given name. If the Dataset is empty - coordinates and data
-/// are copied.
+/// Set (insert or replace) data item with given name.
 ///
-/// Throws if the provided values bring the dataset into an inconsistent state
+/// Coordinated, labels, and attributes of the data array are added to the
+/// dataset. Throws if there are existing but mismatching coords or labels.
+/// Throws if the provided data brings the dataset into an inconsistent state
 /// (mismatching dtype, unit, or dimensions).
 void Dataset::setData(const std::string &name, const DataConstProxy &data) {
   for (const auto & [ dim, coord ] : data.coords()) {
@@ -264,7 +264,7 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
     setData(name, data.data());
 }
 
-/// Set (insert or replace) data array with given name.
+/// Set (insert or replace) data item with given name.
 ///
 /// Coordinated, labels, and attributes of the data array are added to the
 /// dataset. Throws if there are existing but mismatching coords or labels.

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -67,15 +67,8 @@ Dataset::Dataset(const DatasetConstProxy &proxy) {
     setLabels(std::string(name), labels);
   for (const auto & [ name, attr ] : proxy.attrs())
     setAttr(std::string(name), attr);
-  for (const auto & [ name, item ] : proxy) {
-    for (const auto &coord : item.coords())
-      if (coord.second.dims().sparse())
-        setSparseCoord(std::string(name), coord.second);
-    for (const auto & [ label_name, labels ] : item.labels())
-      if (labels.dims().sparse())
-        setSparseLabels(std::string(name), std::string(label_name), labels);
-    setData(std::string(name), item.data());
-  }
+  for (const auto & [ name, item ] : proxy)
+    setData(std::string(name), item);
 }
 
 /// Return a const proxy to all coordinates of the dataset.

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -227,10 +227,10 @@ void Dataset::setData(const std::string &name, Variable data) {
 
 /// Set (insert or replace) data item with given name.
 ///
-/// Coordinated, labels, and attributes of the data array are added to the
-/// dataset. Throws if there are existing but mismatching coords or labels.
-/// Throws if the provided data brings the dataset into an inconsistent state
-/// (mismatching dtype, unit, or dimensions).
+/// Coordinated and labels of the data array are added to the dataset. Throws if
+/// there are existing but mismatching coords or labels. Throws if the provided
+/// data brings the dataset into an inconsistent state (mismatching dtype, unit,
+/// or dimensions).
 void Dataset::setData(const std::string &name, const DataConstProxy &data) {
   for (const auto & [ dim, coord ] : data.coords()) {
     if (coord.dims().sparse()) {
@@ -259,10 +259,10 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
 
 /// Set (insert or replace) data item with given name.
 ///
-/// Coordinated, labels, and attributes of the data array are added to the
-/// dataset. Throws if there are existing but mismatching coords or labels.
-/// Throws if the provided data brings the dataset into an inconsistent state
-/// (mismatching dtype, unit, or dimensions).
+/// Coordinated and labels of the data array are added to the dataset. Throws if
+/// there are existing but mismatching coords or labels. Throws if the provided
+/// data brings the dataset into an inconsistent state (mismatching dtype, unit,
+/// or dimensions).
 void Dataset::setData(const std::string &name, const DataArray &data) {
   setData(name, DataConstProxy(data));
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -555,26 +555,6 @@ DataProxy DataProxy::operator/=(const Variable &other) const {
   return *this;
 }
 
-DataArray operator+(const DataConstProxy &a, const DataConstProxy &b) {
-  return DataArray(a.data() + b.data(), union_(a.coords(), b.coords()),
-                   union_(a.labels(), b.labels()));
-}
-
-DataArray operator-(const DataConstProxy &a, const DataConstProxy &b) {
-  return {a.data() - b.data(), union_(a.coords(), b.coords()),
-          union_(a.labels(), b.labels())};
-}
-
-DataArray operator*(const DataConstProxy &a, const DataConstProxy &b) {
-  return {a.data() * b.data(), union_(a.coords(), b.coords()),
-          union_(a.labels(), b.labels())};
-}
-
-DataArray operator/(const DataConstProxy &a, const DataConstProxy &b) {
-  return {a.data() / b.data(), union_(a.coords(), b.coords()),
-          union_(a.labels(), b.labels())};
-}
-
 /// Return a const proxy to all coordinates of the dataset slice.
 ///
 /// This proxy includes only "dimension-coordinates". To access

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -264,6 +264,12 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
     setData(name, data.data());
 }
 
+/// Set (insert or replace) data array with given name.
+///
+/// Coordinated, labels, and attributes of the data array are added to the
+/// dataset. Throws if there are existing but mismatching coords or labels.
+/// Throws if the provided data brings the dataset into an inconsistent state
+/// (mismatching dtype, unit, or dimensions).
 void Dataset::setData(const std::string &name, const DataArray &data) {
   setData(name, DataConstProxy(data));
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -227,10 +227,10 @@ void Dataset::setData(const std::string &name, Variable data) {
 
 /// Set (insert or replace) data item with given name.
 ///
-/// Coordinated and labels of the data array are added to the dataset. Throws if
-/// there are existing but mismatching coords or labels. Throws if the provided
-/// data brings the dataset into an inconsistent state (mismatching dtype, unit,
-/// or dimensions).
+/// Coordinates, labels, and attributes of the data array are added to the
+/// dataset. Throws if there are existing but mismatching coords, labels, or
+/// attributes. Throws if the provided data brings the dataset into an
+/// inconsistent state (mismatching dtype, unit, or dimensions).
 void Dataset::setData(const std::string &name, const DataConstProxy &data) {
   for (const auto & [ dim, coord ] : data.coords()) {
     if (coord.dims().sparse()) {
@@ -251,6 +251,12 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
       else
         setLabels(std::string(nm), labs);
     }
+  }
+  for (const auto & [ nm, attr ] : data.attrs()) {
+    if (const auto it = m_attrs.find(std::string(nm)); it != m_attrs.end())
+      expect::variablesMatch(attr, it->second);
+    else
+      setAttr(std::string(nm), attr);
   }
 
   if (data.hasData())

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -552,41 +552,35 @@ DataProxy DataProxy::assign(const VariableConstProxy &other) const {
 
 DataProxy DataProxy::operator+=(const DataConstProxy &other) const {
   expect::coordsAndLabelsAreSuperset(*this, other);
-  if (hasData())
-    data() += other.data();
+  data() += other.data();
   return *this;
 }
 
 DataProxy DataProxy::operator-=(const DataConstProxy &other) const {
   expect::coordsAndLabelsAreSuperset(*this, other);
-  if (hasData())
-    data() -= other.data();
+  data() -= other.data();
   return *this;
 }
 
 DataProxy DataProxy::operator*=(const DataConstProxy &other) const {
   expect::coordsAndLabelsAreSuperset(*this, other);
-  if (hasData())
-    data() *= other.data();
+  data() *= other.data();
   return *this;
 }
 
 DataProxy DataProxy::operator/=(const DataConstProxy &other) const {
   expect::coordsAndLabelsAreSuperset(*this, other);
-  if (hasData())
-    data() /= other.data();
+  data() /= other.data();
   return *this;
 }
 
 DataProxy DataProxy::operator*=(const Variable &other) const {
-  if (hasData())
-    data() *= other;
+  data() *= other;
   return *this;
 }
 
 DataProxy DataProxy::operator/=(const Variable &other) const {
-  if (hasData())
-    data() /= other;
+  data() /= other;
   return *this;
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -232,39 +232,6 @@ void Dataset::setData(const std::string &name, Variable data) {
   m_data[name].data = std::move(data);
 }
 
-// This only checks the coordinates and labels, not attributes
-bool checkCorrespondingDenseCoords(const Dataset &dataset,
-                                   const DataConstProxy &other) {
-  if (other.dims().sparse())
-    return true;
-  const auto dsCoords{dataset.coords()};
-  const auto otCoords{other.coords()};
-  const auto &dsItems = dsCoords.items();
-  for (const auto & [ d, v ] : otCoords) {
-    if (auto iter = dsItems.find(d); iter == dsItems.end()) {
-      return false;
-    } else {
-      if (*iter->second.first != v) {
-        return false;
-      }
-    }
-  }
-
-  const auto dsLabels{dataset.labels()};
-  const auto otLabels{other.labels()};
-  const auto dsLItems{dsLabels.items()};
-  for (const auto & [ nm, v ] : otLabels) {
-    if (auto iter = dsLItems.find(nm); iter == dsLItems.end()) {
-      return false;
-    } else {
-      if (*iter->second.first != v) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 /// Set (insert or replace) data (values, optional variances, sparse
 /// coordinates) with given name. If the Dataset is empty - coordinates and data
 /// are copied.
@@ -272,32 +239,29 @@ bool checkCorrespondingDenseCoords(const Dataset &dataset,
 /// Throws if the provided values bring the dataset into an inconsistent state
 /// (mismatching dtype, unit, or dimensions).
 void Dataset::setData(const std::string &name, const DataConstProxy &data) {
-  if (empty()) {
-    if (!data.dims().sparse()) {
-      for (const auto & [ d, v ] : data.coords()) {
-        setCoord(d, Variable(v));
-      }
-    }
-  } else {
-    if (!checkCorrespondingDenseCoords(*this, data))
-      throw std::logic_error(
-          "The corresponding dense coordinates should match.");
-  }
-
-  if (data.hasData()) {
-    setData(name, Variable(data.data()));
-  }
-
-  auto dim = data.dims().sparseDim();
-  if (dim != Dim::Invalid) {
-    setSparseCoord(name, data.coords()[dim]);
-  }
-
-  for (const auto & [ nm, v ] : data.labels()) {
-    if (v.dims().sparse()) {
-      setSparseLabels(name, std::string(nm), v);
+  for (const auto & [ dim, coord ] : data.coords()) {
+    if (coord.dims().sparse()) {
+      setSparseCoord(name, coord);
+    } else {
+      if (const auto it = m_coords.find(dim); it != m_coords.end())
+        expect::variablesMatch(coord, it->second);
+      else
+        setCoord(dim, coord);
     }
   }
+  for (const auto & [ nm, labs ] : data.labels()) {
+    if (labs.dims().sparse()) {
+      setSparseLabels(name, std::string(nm), labs);
+    } else {
+      if (const auto it = m_labels.find(std::string(nm)); it != m_labels.end())
+        expect::variablesMatch(labs, it->second);
+      else
+        setLabels(std::string(nm), labs);
+    }
+  }
+
+  if (data.hasData())
+    setData(name, data.data());
 }
 
 void Dataset::setData(const std::string &name, const DataArray &data) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -877,6 +877,10 @@ std::ostream &operator<<(std::ostream &os, const DataProxy &data) {
   return os << DataConstProxy(data);
 }
 
+std::ostream &operator<<(std::ostream &os, const DataArray &data) {
+  return os << DataConstProxy(data);
+}
+
 std::ostream &operator<<(std::ostream &os, const DatasetConstProxy &dataset) {
   return os << to_string(dataset);
 }

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -288,27 +288,6 @@ void validSlice(const Dimensions &dims, const Slice &slice) {
                              to_string(dims) + ".");
 }
 
-void sparseCoordsAndLabelsMatch(const DataConstProxy &a,
-                                const DataConstProxy &b) {
-  if (a.dims().sparse() && b.dims().sparse()) {
-    if (a.dims().sparseDim() != b.dims().sparseDim())
-      throw except::DimensionError(
-          "Sparse dimension of operands expected to match.");
-    const auto sparseDim = a.dims().sparseDim();
-    if (a.coords().contains(sparseDim) && b.coords().contains(sparseDim) &&
-        (a.coords()[sparseDim] != b.coords()[sparseDim]))
-      throw except::CoordMismatchError("Expected sparse coords to match.");
-    for (const auto & [ name, label ] : b.labels())
-      if (!a.labels().contains(name) || a.labels()[name] != label)
-        throw except::CoordMismatchError("Expected sparse labels to match.");
-  } else if (a.dims().sparse() || b.dims().sparse()) {
-    if (a.coords().contains(b.dims().sparseDim()) ||
-        b.coords().contains(a.dims().sparseDim()))
-      throw except::DimensionError(
-          "Dimension is sparse in one operand but dense in the other operand.");
-  }
-}
-
 void coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                 const DataConstProxy &b) {
   for (const auto & [ dim, coord ] : b.coords())
@@ -317,13 +296,6 @@ void coordsAndLabelsAreSuperset(const DataConstProxy &a,
   for (const auto & [ name, labels ] : b.labels())
     if (a.labels()[name] != labels)
       throw except::CoordMismatchError("Expected labels to match.");
-}
-
-void matchingDataPresence(const DataConstProxy &a, const DataConstProxy &b) {
-  if (a.hasData() != b.hasData())
-    throw except::SparseDataError(
-        "Either both or neither of the operands in "
-        "a operation with sparse data must have data values.");
 }
 
 void notSparse(const Dimensions &dims) {

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -779,6 +779,15 @@ SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const Variable &variable);
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os, const Dim dim);
 
+SCIPP_CORE_EXPORT DataArray operator+(const DataConstProxy &a,
+                                      const DataConstProxy &b);
+SCIPP_CORE_EXPORT DataArray operator-(const DataConstProxy &a,
+                                      const DataConstProxy &b);
+SCIPP_CORE_EXPORT DataArray operator*(const DataConstProxy &a,
+                                      const DataConstProxy &b);
+SCIPP_CORE_EXPORT DataArray operator/(const DataConstProxy &a,
+                                      const DataConstProxy &b);
+
 SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs, const Dataset &rhs);
 SCIPP_CORE_EXPORT Dataset operator+(const Dataset &lhs,
                                     const DatasetConstProxy &rhs);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -736,19 +736,16 @@ public:
 
   /// Return untyped const proxy for data (values and optional variances).
   VariableConstProxy data() const { return get().data(); }
-
-  /// Return typed const proxy for data values.
-  template <class T> auto values() const { return get().values<T>(); }
-
-  /// Return typed const proxy for data variances.
-  template <class T> auto variances() const { return get().variances<T>(); }
-
   /// Return untyped proxy for data (values and optional variances).
   VariableProxy data() { return get().data(); }
 
+  /// Return typed const proxy for data values.
+  template <class T> auto values() const { return get().values<T>(); }
   /// Return typed proxy for data values.
   template <class T> auto values() { return get().values<T>(); }
 
+  /// Return typed const proxy for data variances.
+  template <class T> auto variances() const { return get().variances<T>(); }
   /// Return typed proxy for data variances.
   template <class T> auto variances() { return get().variances<T>(); }
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -761,6 +761,8 @@ SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const DataProxy &data);
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
+                                           const DataArray &data);
+SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const DatasetConstProxy &dataset);
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const DatasetProxy &dataset);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -92,7 +92,7 @@ public:
   /// Return untyped const proxy for data (values and optional variances).
   VariableConstProxy data() const {
     if (!hasData())
-      throw std::logic_error("No data available for this object.");
+      throw except::SparseDataError("No data in item.");
     return detail::makeSlice(*m_data->data, slices());
   }
   /// Return typed const proxy for data values.
@@ -156,7 +156,7 @@ public:
   /// Return untyped proxy for data (values and optional variances).
   VariableProxy data() const {
     if (!hasData())
-      throw std::logic_error("No data available for this object.");
+      throw except::SparseDataError("No data in item.");
     return detail::makeSlice(*m_mutableData->data, slices());
   }
   /// Return typed proxy for data values.

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -174,25 +174,8 @@ template <class T> void countsOrCountsDensity(const T &object) {
 
 void SCIPP_CORE_EXPORT validSlice(const Dimensions &dims, const Slice &slice);
 
-void SCIPP_CORE_EXPORT sparseCoordsAndLabelsMatch(const DataConstProxy &a,
-                                                  const DataConstProxy &b);
-
-template <typename A, typename B>
-void coordsAndLabelsMatch(const A &a, const B &b) {
-  if (a.coords() != b.coords() || a.labels() != b.labels())
-    throw except::CoordMismatchError("Expected coords and labels to match.");
-
-  for (const auto & [ name, item ] : b) {
-    if (a.contains(name)) {
-      sparseCoordsAndLabelsMatch(a[name], item);
-    }
-  }
-}
-
 void SCIPP_CORE_EXPORT coordsAndLabelsAreSuperset(const DataConstProxy &a,
                                                   const DataConstProxy &b);
-void SCIPP_CORE_EXPORT matchingDataPresence(const DataConstProxy &a,
-                                            const DataConstProxy &b);
 void SCIPP_CORE_EXPORT notSparse(const Dimensions &dims);
 void SCIPP_CORE_EXPORT validDim(const Dim dim);
 void SCIPP_CORE_EXPORT validExtent(const scipp::index size);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TARGET_NAME "scipp-core-test")
 add_executable(${TARGET_NAME}
                bool_test.cpp
                counts_test.cpp
+               data_array_test.cpp
                dataset_test.cpp
                dataset_test_common.cpp
                dataset_operations_test.cpp

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/dataset.h"
+
+#include "dataset_test_common.h"
+#include "test_macros.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(DataArrayTest, construct) {
+  DatasetFactory3D factory;
+  const auto dataset = factory.make();
+
+  DataArray array(dataset["data_xyz"]);
+  EXPECT_EQ(array, dataset["data_xyz"]);
+}

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -17,3 +17,19 @@ TEST(DataArrayTest, construct) {
   DataArray array(dataset["data_xyz"]);
   EXPECT_EQ(array, dataset["data_xyz"]);
 }
+
+TEST(DataArrayTest, sum_dataset_columns_via_DataArray) {
+  DatasetFactory3D factory;
+  auto dataset = factory.make();
+
+  DataArray array(dataset["data_zyx"]);
+  auto sum = array + dataset["data_xyz"];
+
+  dataset["data_zyx"] += dataset["data_xyz"];
+
+  // Direction compare fails since binary operation do not propagate attributes.
+  EXPECT_NE(sum, dataset["data_zyx"]);
+
+  dataset.setData("sum", sum);
+  EXPECT_EQ(dataset["sum"], dataset["data_zyx"]);
+}

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -849,7 +849,8 @@ TEST(DatasetSetData, dense_to_dense) {
   dense.setData("data_x_1", dense["data_x"]);
   EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
 
-  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), std::logic_error);
+  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]),
+               except::VariableMismatchError);
 }
 
 TEST(DatasetSetData, dense_to_empty) {

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -564,6 +564,22 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_dataset_rhs) {
   EXPECT_EQ(res.labels(), dataset_a.labels());
 }
 
+TYPED_TEST(DatasetBinaryOpTest, broadcast) {
+  const auto x = makeVariable<double>({Dim::X, 3}, {1, 2, 3});
+  const auto y = makeVariable<double>({Dim::Y, 2}, {1, 2});
+  const auto c = makeVariable<double>(2.0);
+  Dataset a;
+  Dataset b;
+  a.setCoord(Dim::X, x);
+  a.setData("data1", x);
+  a.setData("data2", x);
+  b.setData("data1", c);
+  b.setData("data2", c + c);
+  const auto res = TestFixture::op(a, b);
+  EXPECT_EQ(res["data1"].data(), TestFixture::op(x, c));
+  EXPECT_EQ(res["data2"].data(), TestFixture::op(x, c + c));
+}
+
 TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataset_sparse_rhs) {
   const auto dataset_a =
       make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0});

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -666,9 +666,9 @@ TYPED_TEST(DatasetBinaryOpTest, sparse_dataconstproxy_coord_mismatch) {
       make_sparse_with_coords_and_labels({3.3, 4.4}, {1.0, 2.1});
 
   ASSERT_THROW(TestFixture::op(dataset_a, dataset_b["sparse"]),
-               except::CoordMismatchError);
+               except::VariableMismatchError);
   ASSERT_THROW(TestFixture::op(dataset_a["sparse"], dataset_b),
-               except::CoordMismatchError);
+               except::VariableMismatchError);
 }
 
 TYPED_TEST(DatasetBinaryOpTest, sparse_data_presense_mismatch) {
@@ -701,7 +701,7 @@ TYPED_TEST(DatasetBinaryOpTest,
   }
 
   EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
-               except::CoordMismatchError);
+               except::VariableMismatchError);
 }
 
 TYPED_TEST(DatasetBinaryOpTest,
@@ -722,7 +722,7 @@ TYPED_TEST(DatasetBinaryOpTest,
   }
 
   EXPECT_THROW(TestFixture::op(dataset_a, dataset_b),
-               except::CoordMismatchError);
+               except::VariableMismatchError);
 }
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_datasetconstproxy_rhs) {

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -303,6 +303,13 @@ Dataset make_sparse_2d(std::initializer_list<double> values,
   return ds;
 }
 
+TYPED_TEST(DatasetBinaryEqualsOpTest, coord_only_sparse_fails) {
+  auto var = makeVariable<double>({Dim::X, Dim::Y}, {2, Dimensions::Sparse});
+  Dataset d;
+  d.setSparseCoord("a", var);
+  ASSERT_THROW(TestFixture::op(d, d), except::SparseDataError);
+}
+
 TYPED_TEST(DatasetBinaryEqualsOpTest,
            with_single_var_with_single_sparse_dimensions_sized_same) {
   Dataset a = make_simple_sparse({1.1, 2.2});

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -620,6 +620,15 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_sparse_lhs_dataconstproxy_sparse_rhs) {
   EXPECT_EQ(res, TestFixture::op(dataset_a, dataset_b));
 }
 
+TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense_fail) {
+  Dataset dense;
+  dense.setData("a", makeVariable<double>({Dim::X, 2}, {1, 2}));
+  Dataset sparse;
+  sparse.setData("a", makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+
+  ASSERT_THROW(TestFixture::op(sparse, dense), except::DimensionError);
+}
+
 TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense) {
   Dataset dense;
   dense.setData("a", makeVariable<double>(2.0));

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -83,6 +83,7 @@ void init_dataset(py::module &m) {
   bind_mutable_proxy<LabelsProxy, LabelsConstProxy>(m, "Labels");
   bind_mutable_proxy<AttrsProxy, AttrsConstProxy>(m, "Attrs");
 
+  py::class_<DataArray>(m, "DataArray");
   py::class_<DataConstProxy>(m, "DataConstProxy");
   py::class_<DataProxy, DataConstProxy> dataProxy(m, "DataProxy");
   dataProxy.def_property_readonly(
@@ -121,10 +122,11 @@ void init_dataset(py::module &m) {
               const DataConstProxy &data) { self.setData(name, data); })
       .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataProxy &data) {
-             if (self.contains(name))
-               self[name].assign(data);
-             else
-               throw std::runtime_error("Not implemented yet");
+               self.setData(name, data);
+           })
+      .def("__setitem__",
+           [](Dataset &self, const std::string &name, const DataArray &data) {
+             self.setData(name, data);
            })
       .def("set_sparse_coord", &Dataset::setSparseCoord)
       .def("set_sparse_labels", &Dataset::setSparseLabels)
@@ -164,6 +166,7 @@ void init_dataset(py::module &m) {
   bind_binary<DataProxy>(datasetProxy);
   bind_binary<Dataset>(dataProxy);
   bind_binary<DatasetProxy>(dataProxy);
+  bind_binary<DataProxy>(dataProxy);
 
   bind_data_properties(dataProxy);
 

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -121,10 +121,6 @@ void init_dataset(py::module &m) {
            [](Dataset &self, const std::string &name,
               const DataConstProxy &data) { self.setData(name, data); })
       .def("__setitem__",
-           [](Dataset &self, const std::string &name, const DataProxy &data) {
-             self.setData(name, data);
-           })
-      .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataArray &data) {
              self.setData(name, data);
            })
@@ -197,7 +193,6 @@ void init_dataset(py::module &m) {
         },
         py::call_guard<py::gil_scoped_release>(),
         "Returns a new Dataset with histograms for sparse dims");
-  // Implicit conversion DatasetProxy -> Dataset. Reduces need for
-  // excessive operator overload definitions
-  py::implicitly_convertible<DatasetProxy, Dataset>();
+
+  py::implicitly_convertible<DataArray, DataConstProxy>();
 }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -122,7 +122,7 @@ void init_dataset(py::module &m) {
               const DataConstProxy &data) { self.setData(name, data); })
       .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataProxy &data) {
-               self.setData(name, data);
+             self.setData(name, data);
            })
       .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataArray &data) {

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -278,6 +278,16 @@ def test_binary_with_broadcast():
     assert d == d2
 
 
+def test_add_sum_of_columns():
+    d = sc.Dataset({
+        'a': sc.Variable([Dim.X], values=np.arange(10.0)),
+        'b': sc.Variable([Dim.X], values=np.ones(10))
+    })
+    d['sum'] = d['a'] + d['b']
+    d['a'] += d['b']
+    assert d['sum'] == d['a']
+
+
 # def test_delitem(self):
 #    dataset = sc.Dataset()
 #    dataset[sc.Data.Value, "data"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -4,21 +4,21 @@
 # @author Simon Heybrock
 import pytest
 
-import scipp as sp
-from scipp import Dim
 import numpy as np
+import scipp as sc
+from scipp import Dim
 
 
 def test_create_empty():
-    d = sp.Dataset()
+    d = sc.Dataset()
     assert len(d) == 0
 
 
 def test_create():
-    x = sp.Variable([Dim.X], values=np.arange(3))
-    y = sp.Variable([Dim.Y], values=np.arange(4))
-    xy = sp.Variable([Dim.X, Dim.Y], values=np.arange(12).reshape(3, 4))
-    d = sp.Dataset({'xy': xy, 'x': x}, coords={Dim.X: x, Dim.Y: y})
+    x = sc.Variable([Dim.X], values=np.arange(3))
+    y = sc.Variable([Dim.Y], values=np.arange(4))
+    xy = sc.Variable([Dim.X, Dim.Y], values=np.arange(12).reshape(3, 4))
+    d = sc.Dataset({'xy': xy, 'x': x}, coords={Dim.X: x, Dim.Y: y})
     assert len(d) == 2
     assert d.coords[Dim.X] == x
     assert d.coords[Dim.Y] == y
@@ -27,81 +27,81 @@ def test_create():
 
 
 def test_setitem():
-    d = sp.Dataset()
-    d['a'] = sp.Variable(1.0)
+    d = sc.Dataset()
+    d['a'] = sc.Variable(1.0)
     assert len(d) == 1
-    assert d['a'].data == sp.Variable(1.0)
+    assert d['a'].data == sc.Variable(1.0)
     assert len(d.coords) == 0
 
 
 def test_set_coord():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable(1.0))
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable(1.0))
     assert len(d) == 0
     assert len(d.coords) == 1
-    assert d.coords[Dim.X] == sp.Variable(1.0)
+    assert d.coords[Dim.X] == sc.Variable(1.0)
 
 
 def test_contains_coord():
-    d = sp.Dataset()
+    d = sc.Dataset()
     assert Dim.X not in d.coords
-    d.set_coord(Dim.X, sp.Variable(1.0))
+    d.set_coord(Dim.X, sc.Variable(1.0))
     assert Dim.X in d.coords
 
 
 def test_set_labels():
-    d = sp.Dataset()
-    d.set_labels("a", sp.Variable(1.0))
+    d = sc.Dataset()
+    d.set_labels("a", sc.Variable(1.0))
     assert len(d) == 0
     assert len(d.labels) == 1
-    assert d.labels["a"] == sp.Variable(1.0)
+    assert d.labels["a"] == sc.Variable(1.0)
 
 
 def test_contains_labels():
-    d = sp.Dataset()
+    d = sc.Dataset()
     assert "a" not in d.labels
-    d.set_labels("a", sp.Variable(1.0))
+    d.set_labels("a", sc.Variable(1.0))
     assert "a" in d.labels
 
 
 def test_set_attrs():
-    d = sp.Dataset()
-    d.set_attr("b", sp.Variable(1.0))
+    d = sc.Dataset()
+    d.set_attr("b", sc.Variable(1.0))
     assert len(d) == 0
     assert len(d.attrs) == 1
-    assert d.attrs["b"] == sp.Variable(1.0)
+    assert d.attrs["b"] == sc.Variable(1.0)
 
 
 def test_contains_attrs():
-    d = sp.Dataset()
+    d = sc.Dataset()
     assert "b" not in d.attrs
-    d.set_attr("b", sp.Variable(1.0))
+    d.set_attr("b", sc.Variable(1.0))
     assert "b" in d.attrs
 
 
 def test_slice_item():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable([Dim.X], values=np.arange(4, 8)))
-    d['a'] = sp.Variable([Dim.X], values=np.arange(4))
-    assert d['a'][Dim.X, 2:4].data == sp.Variable([Dim.X],
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(4, 8)))
+    d['a'] = sc.Variable([Dim.X], values=np.arange(4))
+    assert d['a'][Dim.X, 2:4].data == sc.Variable([Dim.X],
                                                   values=np.arange(2, 4))
     assert d['a'][Dim.X,
-                  2:4].coords[Dim.X] == sp.Variable([Dim.X],
+                  2:4].coords[Dim.X] == sc.Variable([Dim.X],
                                                     values=np.arange(6, 8))
 
 
 def test_set_item_slice_from_numpy():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable([Dim.X], values=np.arange(4, 8)))
-    d['a'] = sp.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(4, 8)))
+    d['a'] = sc.Variable([Dim.X], values=np.arange(4))
     d['a'][Dim.X, 2:4] = np.arange(2)
-    assert d['a'].data == sp.Variable([Dim.X], values=np.array([0, 1, 0, 1]))
+    assert d['a'].data == sc.Variable([Dim.X], values=np.array([0, 1, 0, 1]))
 
 
 def test_set_item_slice_with_variances_from_numpy():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable([Dim.X], values=np.arange(4, 8)))
-    d['a'] = sp.Variable([Dim.X], values=np.arange(4), variances=np.arange(4))
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(4, 8)))
+    d['a'] = sc.Variable([Dim.X], values=np.arange(4), variances=np.arange(4))
     d['a'][Dim.X, 2:4].values = np.arange(2)
     d['a'][Dim.X, 2:4].variances = np.arange(2, 4)
     assert np.array_equal(d['a'].values, np.array([0.0, 1.0, 0.0, 1.0]))
@@ -109,49 +109,49 @@ def test_set_item_slice_with_variances_from_numpy():
 
 
 def test_sparse_setitem():
-    d = sp.Dataset(
-        {'a': sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])})
+    d = sc.Dataset(
+        {'a': sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])})
     d['a'][Dim.X, 0].values = np.arange(4)
     assert len(d['a'][Dim.X, 0].values) == 4
 
 
 def test_iadd_slice():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable([Dim.X], values=np.arange(4, 8)))
-    d['a'] = sp.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(4, 8)))
+    d['a'] = sc.Variable([Dim.X], values=np.arange(4))
     d['a'][Dim.X, 1] += d['a'][Dim.X, 2]
-    assert d['a'].data == sp.Variable([Dim.X], values=np.array([0, 3, 2, 3]))
+    assert d['a'].data == sc.Variable([Dim.X], values=np.array([0, 3, 2, 3]))
 
 
 def test_iadd_range():
-    d = sp.Dataset()
-    d.set_coord(Dim.X, sp.Variable([Dim.X], values=np.arange(4, 8)))
-    d['a'] = sp.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset()
+    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(4, 8)))
+    d['a'] = sc.Variable([Dim.X], values=np.arange(4))
     with pytest.raises(RuntimeError):
         d['a'][Dim.X, 2:4] += d['a'][Dim.X, 1:3]
     d['a'][Dim.X, 2:4] += d['a'][Dim.X, 2:4]
-    assert d['a'].data == sp.Variable([Dim.X], values=np.array([0, 1, 4, 6]))
+    assert d['a'].data == sc.Variable([Dim.X], values=np.array([0, 1, 4, 6]))
 
 
 def test_contains():
-    d = sp.Dataset()
+    d = sc.Dataset()
     assert 'a' not in d
-    d['a'] = sp.Variable(1.0)
+    d['a'] = sc.Variable(1.0)
     assert 'a' in d
     assert 'b' not in d
-    d['b'] = sp.Variable(1.0)
+    d['b'] = sc.Variable(1.0)
     assert 'a' in d
     assert 'b' in d
 
 
 def test_slice():
-    d = sp.Dataset(
+    d = sc.Dataset(
         {
-            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-            'b': sp.Variable(1.0)
+            'a': sc.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sc.Variable(1.0)
         },
-        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
-    expected = sp.Dataset({'a': sp.Variable(1.0)})
+        coords={Dim.X: sc.Variable([Dim.X], values=np.arange(10.0))})
+    expected = sc.Dataset({'a': sc.Variable(1.0)})
 
     assert d[Dim.X, 1] == expected
     assert 'a' in d[Dim.X, 1]
@@ -159,48 +159,48 @@ def test_slice():
 
 
 def test_coords_proxy_comparison_operators():
-    d = sp.Dataset(
+    d = sc.Dataset(
         {
-            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-            'b': sp.Variable(1.0)
+            'a': sc.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sc.Variable(1.0)
         },
-        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
+        coords={Dim.X: sc.Variable([Dim.X], values=np.arange(10.0))})
 
-    d1 = sp.Dataset(
+    d1 = sc.Dataset(
         {
-            'a': sp.Variable([Dim.X], values=np.arange(10.0)),
-            'b': sp.Variable(1.0)
+            'a': sc.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sc.Variable(1.0)
         },
-        coords={Dim.X: sp.Variable([Dim.X], values=np.arange(10.0))})
+        coords={Dim.X: sc.Variable([Dim.X], values=np.arange(10.0))})
     assert d1['a'].coords == d['a'].coords
 
 
 def test_variable_histogram():
-    var = sp.Variable(dims=[Dim.X, Dim.Y], shape=[2, sp.Dimensions.Sparse])
+    var = sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse])
     var[Dim.X, 0].values = np.arange(3)
     var[Dim.X, 0].values.append(42)
     var[Dim.X, 0].values.extend(np.ones(3))
     var[Dim.X, 1].values = np.ones(6)
-    ds = sp.Dataset()
+    ds = sc.Dataset()
     ds.set_sparse_coord("sparse", var)
-    hist = sp.histogram(
+    hist = sc.histogram(
         ds["sparse"],
-        sp.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
+        sc.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
     assert np.array_equal(
         hist.values, np.array([[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
 
 
 def test_dataset_histogram():
-    var = sp.Variable(dims=[Dim.X, Dim.Y], shape=[2, sp.Dimensions.Sparse])
+    var = sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse])
     var[Dim.X, 0].values = np.arange(3)
     var[Dim.X, 0].values.append(42)
     var[Dim.X, 0].values.extend(np.ones(3))
     var[Dim.X, 1].values = np.ones(6)
-    ds = sp.Dataset()
+    ds = sc.Dataset()
     ds.set_sparse_coord("s", var)
     ds.set_sparse_coord("s1", var * 5)
-    h = sp.histogram(
-        ds, sp.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
+    h = sc.histogram(
+        ds, sc.Variable(values=np.arange(5, dtype=np.float64), dims=[Dim.Y]))
     assert np.array_equal(
         h["s"].values, np.array([[1.0, 4.0, 1.0, 0.0], [0.0, 6.0, 0.0, 0.0]]))
     assert np.array_equal(
@@ -208,31 +208,31 @@ def test_dataset_histogram():
 
 
 def test_dataset_set_data():
-    d1 = sp.Dataset(
+    d1 = sc.Dataset(
         {
-            'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
-            'b': sp.Variable(1.0)
+            'a': sc.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+            'b': sc.Variable(1.0)
         },
         coords={
-            Dim.X: sp.Variable([Dim.X], values=np.arange(2.0),
-                               unit=sp.units.m),
-            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0), unit=sp.units.m)
+            Dim.X: sc.Variable([Dim.X], values=np.arange(2.0),
+                               unit=sc.units.m),
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)
         },
-        labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
+        labels={'aux': sc.Variable([Dim.Y], values=np.arange(3))})
 
-    d2 = sp.Dataset(
+    d2 = sc.Dataset(
         {
-            'a': sp.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
-            'b': sp.Variable(1.0)
+            'a': sc.Variable(dims=[Dim.X, Dim.Y], values=np.random.rand(2, 3)),
+            'b': sc.Variable(1.0)
         },
         coords={
-            Dim.X: sp.Variable([Dim.X], values=np.arange(2.0),
-                               unit=sp.units.m),
-            Dim.Y: sp.Variable([Dim.Y], values=np.arange(3.0), unit=sp.units.m)
+            Dim.X: sc.Variable([Dim.X], values=np.arange(2.0),
+                               unit=sc.units.m),
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)
         },
-        labels={'aux': sp.Variable([Dim.Y], values=np.arange(3))})
+        labels={'aux': sc.Variable([Dim.Y], values=np.arange(3))})
 
-    d3 = sp.Dataset()
+    d3 = sc.Dataset()
     d3['b'] = d1['a']
     assert d3["b"].data == d1['a'].data
     assert d3["b"].coords == d1['a'].coords
@@ -241,346 +241,357 @@ def test_dataset_set_data():
     assert d2['a'].data == d1['a'].data
     assert d2['a'].data == d1['c'].data
 
-    d = sp.Dataset()
-    d.set_coord(sp.Dim.Row, sp.Variable([sp.Dim.Row], values=np.arange(10.0)))
-    d["a"] = sp.Variable([sp.Dim.Row],
+    d = sc.Dataset()
+    d.set_coord(sc.Dim.Row, sc.Variable([sc.Dim.Row], values=np.arange(10.0)))
+    d["a"] = sc.Variable([sc.Dim.Row],
                          values=np.arange(10.0),
                          variances=np.arange(10.0))
-    d["b"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0, 20.0))
-    d1 = d[sp.Dim.Row, 0:1]
-    d2 = sp.Dataset({'a': d1["a"].data},
-                    coords={sp.Dim.Row: d1["a"].coords[sp.Dim.Row]})
+    d["b"] = sc.Variable([sc.Dim.Row], values=np.arange(10.0, 20.0))
+    d1 = d[sc.Dim.Row, 0:1]
+    d2 = sc.Dataset({'a': d1["a"].data},
+                    coords={sc.Dim.Row: d1["a"].coords[sc.Dim.Row]})
     d2["b"] = d1["b"]
-    expected = sp.Dataset()
-    expected.set_coord(sp.Dim.Row,
-                       sp.Variable([sp.Dim.Row], values=np.arange(1.0)))
-    expected["a"] = sp.Variable([sp.Dim.Row],
+    expected = sc.Dataset()
+    expected.set_coord(sc.Dim.Row,
+                       sc.Variable([sc.Dim.Row], values=np.arange(1.0)))
+    expected["a"] = sc.Variable([sc.Dim.Row],
                                 values=np.arange(1.0),
                                 variances=np.arange(1.0))
-    expected["b"] = sp.Variable([sp.Dim.Row], values=np.arange(10.0, 11.0))
+    expected["b"] = sc.Variable([sc.Dim.Row], values=np.arange(10.0, 11.0))
     assert d2 == expected
 
 
 def test_dataset_data_access():
-    var = sp.Variable(dims=[Dim.X, Dim.Y], shape=[2, sp.Dimensions.Sparse])
-    ds = sp.Dataset()
+    var = sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse])
+    ds = sc.Dataset()
     ds.set_sparse_coord("sparse", var)
     assert ds["sparse"].values is None
 
+
+def test_binary_with_broadcast():
+    d = sc.Dataset(
+        {'data': sc.Variable([Dim.X], values=np.arange(10.0))},
+        coords={Dim.X: sc.Variable([Dim.X], values=np.arange(10.0))})
+
+    d2 = d - d[Dim.X, 0]
+    d -= d[Dim.X, 0]
+    assert d == d2
+
+
 # def test_delitem(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
 #                                      (1, 2, 3))
-#    dataset[sp.Data.Value, "aux"] = ([], ())
-#    self.assertTrue((sp.Data.Value, "data") in dataset)
+#    dataset[sc.Data.Value, "aux"] = ([], ())
+#    self.assertTrue((sc.Data.Value, "data") in dataset)
 #    self.assertEqual(len(dataset.dimensions), 3)
-#    del dataset[sp.Data.Value, "data"]
-#    self.assertFalse((sp.Data.Value, "data") in dataset)
+#    del dataset[sc.Data.Value, "data"]
+#    self.assertFalse((sc.Data.Value, "data") in dataset)
 #    self.assertEqual(len(dataset.dimensions), 0)
 #
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
 #                                      (1, 2, 3))
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.arange(3))
-#    del dataset[sp.Data.Value, "data"]
-#    self.assertFalse((sp.Data.Value, "data") in dataset)
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.arange(3))
+#    del dataset[sc.Data.Value, "data"]
+#    self.assertFalse((sc.Data.Value, "data") in dataset)
 #    self.assertEqual(len(dataset.dimensions), 1)
-#    del dataset[sp.Coord.X]
-#    self.assertFalse(sp.Coord.X in dataset)
+#    del dataset[sc.Coord.X]
+#    self.assertFalse(sc.Coord.X in dataset)
 #    self.assertEqual(len(dataset.dimensions), 0)
 #
 # def test_insert_default_init(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = ((sp.Dim.Z, sp.Dim.Y, sp.Dim.X), (4, 3, 2))
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = ((sc.Dim.Z, sc.Dim.Y, sc.Dim.X), (4, 3, 2))
 #    self.assertEqual(len(d), 1)
 #    np.testing.assert_array_equal(
-#        d[sp.Data.Value, "data1"].numpy, np.zeros(shape=(4, 3, 2)))
+#        d[sc.Data.Value, "data1"].numpy, np.zeros(shape=(4, 3, 2)))
 #
 # def test_insert(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.arange(24).reshape(4, 3, 2))
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.arange(24).reshape(4, 3, 2))
 #    self.assertEqual(len(d), 1)
 #    np.testing.assert_array_equal(
-#        d[sp.Data.Value, "data1"].numpy, self.reference_data1)
+#        d[sc.Data.Value, "data1"].numpy, self.reference_data1)
 #
 #    self.assertRaisesRegex(
 #        RuntimeError,
 #        "Cannot insert variable into Dataset: Dimensions do not match.",
 #        d.__setitem__,
-#        (sp.Data.Value,
+#        (sc.Data.Value,
 #         "data2"),
 #        ([
-#            sp.Dim.Z,
-#            sp.Dim.Y,
-#            sp.Dim.X],
+#            sc.Dim.Z,
+#            sc.Dim.Y,
+#            sc.Dim.X],
 #            np.arange(24).reshape(
 #            4,
 #            2,
 #            3)))
 #
 # def test_replace(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.zeros(24).reshape(4, 3, 2))
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.arange(24).reshape(4, 3, 2))
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.zeros(24).reshape(4, 3, 2))
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.arange(24).reshape(4, 3, 2))
 #    self.assertEqual(len(d), 1)
 #    np.testing.assert_array_equal(
-#        d[sp.Data.Value, "data1"].numpy, self.reference_data1)
+#        d[sc.Data.Value, "data1"].numpy, self.reference_data1)
 #
 # def test_insert_Variable(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.arange(24).reshape(4, 3, 2))
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.arange(24).reshape(4, 3, 2))
 #
-#    var = sp.Variable([sp.Dim.X], np.arange(2))
-#    d[sp.Data.Value, "data2"] = var
-#    d[sp.Data.Variance, "data2"] = var
+#    var = sc.Variable([sc.Dim.X], np.arange(2))
+#    d[sc.Data.Value, "data2"] = var
+#    d[sc.Data.Variance, "data2"] = var
 #    self.assertEqual(len(d), 3)
 #
 # def test_insert_variable_slice(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.arange(24).reshape(4, 3, 2))
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.arange(24).reshape(4, 3, 2))
 #
-#    d[sp.Data.Value, "data2"] = d[sp.Data.Value, "data1"]
-#    d[sp.Data.Variance, "data2"] = d[sp.Data.Value, "data1"]
+#    d[sc.Data.Value, "data2"] = d[sc.Data.Value, "data1"]
+#    d[sc.Data.Variance, "data2"] = d[sc.Data.Value, "data1"]
 #    self.assertEqual(len(d), 3)
 #
 # This characterises existing broken behaviour. Will need to be fixed.
 # def test_demo_int_to_float_issue(self):
 #    # Demo bug
-#    d = sp.Dataset()
+#    d = sc.Dataset()
 #    # Variable containing int array data
-#    d[sp.Data.Value, "v1"] = ([sp.Dim.X, sp.Dim.Y], np.ndarray.tolist(
+#    d[sc.Data.Value, "v1"] = ([sc.Dim.X, sc.Dim.Y], np.ndarray.tolist(
 #        np.arange(0, 10).reshape(2, 5)))
 #    # Correct behaviour should be int64
-#    self.assertEqual(d[sp.Data.Value, "v1"].numpy.dtype, 'float64')
+#    self.assertEqual(d[sc.Data.Value, "v1"].numpy.dtype, 'float64')
 #
 #    # Demo working 1D
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "v2"] = ([sp.Dim.X], np.ndarray.tolist(
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "v2"] = ([sc.Dim.X], np.ndarray.tolist(
 #        np.arange(0, 10)))  # Variable containing int array data
-#    self.assertEqual(d[sp.Data.Value, "v2"].numpy.dtype, 'int64')
+#    self.assertEqual(d[sc.Data.Value, "v2"].numpy.dtype, 'int64')
 #
 # def test_set_data(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], np.arange(24).reshape(4, 3, 2))
-#    self.assertEqual(d[sp.Data.Value, "data1"].numpy.dtype, np.int64)
-#    d[sp.Data.Value, "data1"] = np.arange(24).reshape(4, 3, 2)
-#    self.assertEqual(d[sp.Data.Value, "data1"].numpy.dtype, np.int64)
+#    d = sc.Dataset()
+#    d[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], np.arange(24).reshape(4, 3, 2))
+#    self.assertEqual(d[sc.Data.Value, "data1"].numpy.dtype, np.int64)
+#    d[sc.Data.Value, "data1"] = np.arange(24).reshape(4, 3, 2)
+#    self.assertEqual(d[sc.Data.Value, "data1"].numpy.dtype, np.int64)
 #    # For existing items we do *not* change the dtype, but convert.
-#    d[sp.Data.Value, "data1"] = np.arange(24.0).reshape(4, 3, 2)
-#    self.assertEqual(d[sp.Data.Value, "data1"].numpy.dtype, np.int64)
+#    d[sc.Data.Value, "data1"] = np.arange(24.0).reshape(4, 3, 2)
+#    self.assertEqual(d[sc.Data.Value, "data1"].numpy.dtype, np.int64)
 #
 # def test_nested_0D_empty_item(self):
-#    d = sp.Dataset()
-#    d[sp.Data.Events] = ([], sp.Dataset())
-#    self.assertEqual(d[sp.Data.Events].data[0], sp.Dataset())
+#    d = sc.Dataset()
+#    d[sc.Data.Events] = ([], sc.Dataset())
+#    self.assertEqual(d[sc.Data.Events].data[0], sc.Dataset())
 #
 # def test_set_data_nested(self):
-#    d = sp.Dataset()
-#    table = sp.Dataset()
-#    table[sp.Data.Value, "col1"] = ([sp.Dim.Row], [3.0, 2.0, 1.0, 0.0])
-#    table[sp.Data.Value, "col2"] = ([sp.Dim.Row], np.arange(4.0))
-#    d[sp.Data.Value, "data1"] = ([sp.Dim.X], [table, table])
-#    d[sp.Data.Value, "data1"].data[1][sp.Data.Value, "col1"].data[0] = 0.0
-#    self.assertEqual(d[sp.Data.Value, "data1"].data[0], table)
-#    self.assertNotEqual(d[sp.Data.Value, "data1"].data[1], table)
-#    self.assertNotEqual(d[sp.Data.Value, "data1"].data[0],
-#                        d[sp.Data.Value, "data1"].data[1])
+#    d = sc.Dataset()
+#    table = sc.Dataset()
+#    table[sc.Data.Value, "col1"] = ([sc.Dim.Row], [3.0, 2.0, 1.0, 0.0])
+#    table[sc.Data.Value, "col2"] = ([sc.Dim.Row], np.arange(4.0))
+#    d[sc.Data.Value, "data1"] = ([sc.Dim.X], [table, table])
+#    d[sc.Data.Value, "data1"].data[1][sc.Data.Value, "col1"].data[0] = 0.0
+#    self.assertEqual(d[sc.Data.Value, "data1"].data[0], table)
+#    self.assertNotEqual(d[sc.Data.Value, "data1"].data[1], table)
+#    self.assertNotEqual(d[sc.Data.Value, "data1"].data[0],
+#                        d[sc.Data.Value, "data1"].data[1])
 #
 # def test_dimensions(self):
-#    self.assertEqual(self.dataset.dimensions[sp.Dim.X], 2)
-#    self.assertEqual(self.dataset.dimensions[sp.Dim.Y], 3)
-#    self.assertEqual(self.dataset.dimensions[sp.Dim.Z], 4)
+#    self.assertEqual(self.dataset.dimensions[sc.Dim.X], 2)
+#    self.assertEqual(self.dataset.dimensions[sc.Dim.Y], 3)
+#    self.assertEqual(self.dataset.dimensions[sc.Dim.Z], 4)
 #
 # def test_data(self):
-#    self.assertEqual(len(self.dataset[sp.Coord.X].data), 2)
-#    self.assertSequenceEqual(self.dataset[sp.Coord.X].data, [0, 1])
+#    self.assertEqual(len(self.dataset[sc.Coord.X].data), 2)
+#    self.assertSequenceEqual(self.dataset[sc.Coord.X].data, [0, 1])
 #    # `data` property provides a flat view
-#    self.assertEqual(len(self.dataset[sp.Data.Value, "data1"].data), 24)
+#    self.assertEqual(len(self.dataset[sc.Data.Value, "data1"].data), 24)
 #    self.assertSequenceEqual(
-#        self.dataset[sp.Data.Value, "data1"].data, range(24))
+#        self.dataset[sc.Data.Value, "data1"].data, range(24))
 #
 # def test_numpy_data(self):
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Coord.X].numpy, self.reference_x)
+#        self.dataset[sc.Coord.X].numpy, self.reference_x)
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Coord.Y].numpy, self.reference_y)
+#        self.dataset[sc.Coord.Y].numpy, self.reference_y)
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Coord.Z].numpy, self.reference_z)
+#        self.dataset[sc.Coord.Z].numpy, self.reference_z)
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data1"].numpy, self.reference_data1)
+#        self.dataset[sc.Data.Value, "data1"].numpy, self.reference_data1)
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy, self.reference_data2)
+#        self.dataset[sc.Data.Value, "data2"].numpy, self.reference_data2)
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data3"].numpy, self.reference_data3)
+#        self.dataset[sc.Data.Value, "data3"].numpy, self.reference_data3)
 #
 # def test_view_subdata(self):
 #    view = self.dataset.subset["data1"]
 #    # TODO Need consistent dimensions() implementation for Dataset and its
 #    # views.
-#    self.assertEqual(view.dimensions[sp.Dim.X], 2)
-#    self.assertEqual(view.dimensions[sp.Dim.Y], 3)
-#    self.assertEqual(view.dimensions[sp.Dim.Z], 4)
+#    self.assertEqual(view.dimensions[sc.Dim.X], 2)
+#    self.assertEqual(view.dimensions[sc.Dim.Y], 3)
+#    self.assertEqual(view.dimensions[sc.Dim.Z], 4)
 #    self.assertEqual(len(view), 4)
 #
 # def test_insert_subdata(self):
-#    d1 = sp.Dataset()
-#    d1[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10, dtype="double"))
-#    d1[sp.Data.Variance, "a"] = ([sp.Dim.X], np.arange(10, dtype="double"))
+#    d1 = sc.Dataset()
+#    d1[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10, dtype="double"))
+#    d1[sc.Data.Variance, "a"] = ([sc.Dim.X], np.arange(10, dtype="double"))
 #    ds_slice = d1.subset["a"]
 #
-#    d2 = sp.Dataset()
+#    d2 = sc.Dataset()
 #    # Insert from subset
 #    d2.subset["a"] = ds_slice
 #    self.assertEqual(len(d1), len(d2))
 #    self.assertEqual(d1, d2)
 #
-#    d3 = sp.Dataset()
+#    d3 = sc.Dataset()
 #    # Insert from subset
 #    d3.subset["b"] = ds_slice
 #    self.assertEqual(len(d3), 2)
 #    self.assertNotEqual(d1, d3)  # imported names should differ
 #
-#    d4 = sp.Dataset()
+#    d4 = sc.Dataset()
 #    d4.subset["2a"] = ds_slice + ds_slice
 #    self.assertEqual(len(d4), 2)
 #    self.assertNotEqual(d1, d4)
 #    self.assertTrue(np.array_equal(
-#        d4[sp.Data.Value, "2a"].numpy,
-#        ds_slice[sp.Data.Value, "a"].numpy * 2))
+#        d4[sc.Data.Value, "2a"].numpy,
+#        ds_slice[sc.Data.Value, "a"].numpy * 2))
 #
 # def test_insert_subdata_different_variable_types(self):
-#    a = sp.Dataset()
-#    xcoord = sp.Variable([sp.Dim.X], np.arange(4))
-#    a[sp.Data.Value] = ([sp.Dim.X], np.arange(3))
-#    a[sp.Coord.X] = xcoord
-#    a[sp.Attr.ExperimentLog] = ([], sp.Dataset())
+#    a = sc.Dataset()
+#    xcoord = sc.Variable([sc.Dim.X], np.arange(4))
+#    a[sc.Data.Value] = ([sc.Dim.X], np.arange(3))
+#    a[sc.Coord.X] = xcoord
+#    a[sc.Attr.ExperimentLog] = ([], sc.Dataset())
 #
-#    b = sp.Dataset()
+#    b = sc.Dataset()
 #    with self.assertRaises(RuntimeError):
-#        b.subset["b"] = a[sp.Dim.X, :]  # Coordinates dont match
-#    b[sp.Coord.X] = xcoord
-#    b.subset["b"] = a[sp.Dim.X, :]  # Should now work
+#        b.subset["b"] = a[sc.Dim.X, :]  # Coordinates dont match
+#    b[sc.Coord.X] = xcoord
+#    b.subset["b"] = a[sc.Dim.X, :]  # Should now work
 #    self.assertEqual(len(a), len(b))
-#    self.assertTrue((sp.Attr.ExperimentLog, "b") in b)
+#    self.assertTrue((sc.Attr.ExperimentLog, "b") in b)
 #
 # def test_slice_dataset(self):
 #    for x in range(2):
-#        view = self.dataset[sp.Dim.X, x]
+#        view = self.dataset[sc.Dim.X, x]
 #        self.assertRaisesRegex(
 #            RuntimeError,
 #            'could not find variable with tag Coord::X and name ``.',
 #            view.__getitem__,
-#            sp.Coord.X)
+#            sc.Coord.X)
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.Y].numpy, self.reference_y)
+#            view[sc.Coord.Y].numpy, self.reference_y)
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.Z].numpy, self.reference_z)
+#            view[sc.Coord.Z].numpy, self.reference_z)
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data1"].numpy,
+#            view[sc.Data.Value, "data1"].numpy,
 #            self.reference_data1[:, :, x])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data2"].numpy,
+#            view[sc.Data.Value, "data2"].numpy,
 #            self.reference_data2[:, :, x])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data3"].numpy,
+#            view[sc.Data.Value, "data3"].numpy,
 #            self.reference_data3[:, x])
 #    for y in range(3):
-#        view = self.dataset[sp.Dim.Y, y]
+#        view = self.dataset[sc.Dim.Y, y]
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.X].numpy, self.reference_x)
+#            view[sc.Coord.X].numpy, self.reference_x)
 #        self.assertRaisesRegex(
 #            RuntimeError,
 #            'could not find variable with tag Coord::Y and name ``.',
 #            view.__getitem__,
-#            sp.Coord.Y)
+#            sc.Coord.Y)
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.Z].numpy, self.reference_z)
+#            view[sc.Coord.Z].numpy, self.reference_z)
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data1"].numpy,
+#            view[sc.Data.Value, "data1"].numpy,
 #            self.reference_data1[:, y, :])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data2"].numpy,
+#            view[sc.Data.Value, "data2"].numpy,
 #            self.reference_data2[:, y, :])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data3"].numpy,
+#            view[sc.Data.Value, "data3"].numpy,
 #            self.reference_data3)
 #    for z in range(4):
-#        view = self.dataset[sp.Dim.Z, z]
+#        view = self.dataset[sc.Dim.Z, z]
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.X].numpy, self.reference_x)
+#            view[sc.Coord.X].numpy, self.reference_x)
 #        np.testing.assert_array_equal(
-#            view[sp.Coord.Y].numpy, self.reference_y)
+#            view[sc.Coord.Y].numpy, self.reference_y)
 #        self.assertRaisesRegex(
 #            RuntimeError,
 #            'could not find variable with tag Coord::Z and name ``.',
 #            view.__getitem__,
-#            sp.Coord.Z)
+#            sc.Coord.Z)
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data1"].numpy,
+#            view[sc.Data.Value, "data1"].numpy,
 #            self.reference_data1[z, :, :])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data2"].numpy,
+#            view[sc.Data.Value, "data2"].numpy,
 #            self.reference_data2[z, :, :])
 #        np.testing.assert_array_equal(
-#            view[sp.Data.Value, "data3"].numpy, self.reference_data3[z, :])
+#            view[sc.Data.Value, "data3"].numpy, self.reference_data3[z, :])
 #    for x in range(2):
 #        for delta in range(3 - x):
-#            view = self.dataset[sp.Dim.X, x:x + delta]
+#            view = self.dataset[sc.Dim.X, x:x + delta]
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.X].numpy, self.reference_x[x:x + delta])
+#                view[sc.Coord.X].numpy, self.reference_x[x:x + delta])
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Y].numpy, self.reference_y)
+#                view[sc.Coord.Y].numpy, self.reference_y)
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Z].numpy, self.reference_z)
+#                view[sc.Coord.Z].numpy, self.reference_z)
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data1"].numpy,
+#                view[sc.Data.Value, "data1"].numpy,
 #                self.reference_data1[:, :, x:x + delta])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data2"].numpy,
+#                view[sc.Data.Value, "data2"].numpy,
 #                self.reference_data2[:, :, x:x + delta])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data3"].numpy,
+#                view[sc.Data.Value, "data3"].numpy,
 #                self.reference_data3[:, x:x + delta])
 #    for y in range(3):
 #        for delta in range(4 - y):
-#            view = self.dataset[sp.Dim.Y, y:y + delta]
+#            view = self.dataset[sc.Dim.Y, y:y + delta]
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.X].numpy, self.reference_x)
+#                view[sc.Coord.X].numpy, self.reference_x)
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Y].numpy, self.reference_y[y:y + delta])
+#                view[sc.Coord.Y].numpy, self.reference_y[y:y + delta])
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Z].numpy, self.reference_z)
+#                view[sc.Coord.Z].numpy, self.reference_z)
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data1"].numpy,
+#                view[sc.Data.Value, "data1"].numpy,
 #                self.reference_data1[:, y:y + delta, :])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data2"].numpy,
+#                view[sc.Data.Value, "data2"].numpy,
 #                self.reference_data2[:, y:y + delta, :])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data3"].numpy,
+#                view[sc.Data.Value, "data3"].numpy,
 #                self.reference_data3)
 #    for z in range(4):
 #        for delta in range(5 - z):
-#            view = self.dataset[sp.Dim.Z, z:z + delta]
+#            view = self.dataset[sc.Dim.Z, z:z + delta]
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.X].numpy, self.reference_x)
+#                view[sc.Coord.X].numpy, self.reference_x)
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Y].numpy, self.reference_y)
+#                view[sc.Coord.Y].numpy, self.reference_y)
 #            np.testing.assert_array_equal(
-#                view[sp.Coord.Z].numpy, self.reference_z[z:z + delta])
+#                view[sc.Coord.Z].numpy, self.reference_z[z:z + delta])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data1"].numpy,
+#                view[sc.Data.Value, "data1"].numpy,
 #                self.reference_data1[z:z + delta, :, :])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data2"].numpy,
+#                view[sc.Data.Value, "data2"].numpy,
 #                self.reference_data2[z:z + delta, :, :])
 #            np.testing.assert_array_equal(
-#                view[sp.Data.Value, "data3"].numpy,
+#                view[sc.Data.Value, "data3"].numpy,
 #                self.reference_data3[z:z + delta, :])
 #
 # def _apply_test_op_rhs_dataset(
@@ -592,10 +603,10 @@ def test_dataset_data_access():
 #    lh_var_name="i",
 #        rh_var_name="j"):
 #    # Assume numpy operations are correct as comparitor
-#    op(data, b[sp.Data.Value, rh_var_name].numpy)
+#    op(data, b[sc.Data.Value, rh_var_name].numpy)
 #    op(a, b)
 #    # Desired nan comparisons
-#    np.testing.assert_equal(a[sp.Data.Value, lh_var_name].numpy, data)
+#    np.testing.assert_equal(a[sc.Data.Value, lh_var_name].numpy, data)
 #
 # def _apply_test_op_rhs_Variable(
 #    self,
@@ -609,45 +620,45 @@ def test_dataset_data_access():
 #    op(data, b.numpy)
 #    op(a, b)
 #    # Desired nan comparisons
-#    np.testing.assert_equal(a[sp.Data.Value, lh_var_name].numpy, data)
+#    np.testing.assert_equal(a[sc.Data.Value, lh_var_name].numpy, data)
 #
 # def test_binary_dataset_rhs_operations(self):
-#    a = sp.Dataset()
-#    a[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-#    a[sp.Data.Value, "i"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    a[sp.Data.Variance, "i"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    b = sp.Dataset()
-#    b[sp.Data.Value, "j"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    b[sp.Data.Variance, "j"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    data = np.copy(a[sp.Data.Value, "i"].numpy)
-#    variance = np.copy(a[sp.Data.Variance, "i"].numpy)
+#    a = sc.Dataset()
+#    a[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+#    a[sc.Data.Value, "i"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    a[sc.Data.Variance, "i"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    b = sc.Dataset()
+#    b[sc.Data.Value, "j"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    b[sc.Data.Variance, "j"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    data = np.copy(a[sc.Data.Value, "i"].numpy)
+#    variance = np.copy(a[sc.Data.Variance, "i"].numpy)
 #
 #    c = a + b
 #    # Variables "i" and "j" added despite different names
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data + data))
 #    self.assertTrue(np.array_equal(
-#        c[sp.Data.Variance, "i"].numpy, variance + variance))
+#        c[sc.Data.Variance, "i"].numpy, variance + variance))
 #
 #    c = a - b
 #    # Variables "a" and "b" subtracted despite different names
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data - data))
 #    self.assertTrue(np.array_equal(
-#        c[sp.Data.Variance, "i"].numpy, variance + variance))
+#        c[sc.Data.Variance, "i"].numpy, variance + variance))
 #
 #    c = a * b
 #    # Variables "a" and "b" multiplied despite different names
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data * data))
 #    self.assertTrue(np.array_equal(
-#        c[sp.Data.Variance, "i"].numpy, variance * (data * data) * 2))
+#        c[sc.Data.Variance, "i"].numpy, variance * (data * data) * 2))
 #
 #    c = a / b
 #    # Variables "a" and "b" divided despite different names
 #    with np.errstate(invalid="ignore"):
-#        np.testing.assert_equal(c[sp.Data.Value, "i"].numpy, data / data)
-#        np.testing.assert_equal(c[sp.Data.Variance, "i"].numpy,
+#        np.testing.assert_equal(c[sc.Data.Value, "i"].numpy, data / data)
+#        np.testing.assert_equal(c[sc.Data.Variance, "i"].numpy,
 #                                2 * variance / (data * data))
 #
 #    self._apply_test_op_rhs_dataset(operator.iadd, a, b, data)
@@ -659,23 +670,23 @@ def test_dataset_data_access():
 # def test_binary_variable_rhs_operations(self):
 #    data = np.ones(10, dtype='float64')
 #
-#    a = sp.Dataset()
-#    a[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-#    a[sp.Data.Value, "i"] = ([sp.Dim.X], data)
+#    a = sc.Dataset()
+#    a[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+#    a[sc.Data.Value, "i"] = ([sc.Dim.X], data)
 #
-#    b_var = sp.Variable([sp.Dim.X], data)
+#    b_var = sc.Variable([sc.Dim.X], data)
 #
 #    c = a + b_var
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data + data))
 #    c = a - b_var
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data - data))
 #    c = a * b_var
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data * data))
 #    c = a / b_var
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data / data))
 #
 #    self._apply_test_op_rhs_Variable(operator.iadd, a, b_var, data)
@@ -685,50 +696,50 @@ def test_dataset_data_access():
 #        self._apply_test_op_rhs_Variable(operator.itruediv, a, b_var, data)
 #
 # def test_binary_float_operations(self):
-#    a = sp.Dataset()
-#    a[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-#    a[sp.Data.Value, "i"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    b = sp.Dataset()
-#    b[sp.Data.Value, "j"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    data = np.copy(a[sp.Data.Value, "i"].numpy)
+#    a = sc.Dataset()
+#    a[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+#    a[sc.Data.Value, "i"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    b = sc.Dataset()
+#    b[sc.Data.Value, "j"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    data = np.copy(a[sc.Data.Value, "i"].numpy)
 #
 #    c = a + 2.0
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data + 2.0))
 #    c = a - b
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data - data))
 #    c = a - 2.0
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data - 2.0))
 #    c = a * 2.0
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data * 2.0))
 #    c = a / 2.0
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data / 2.0))
 #    c = 2.0 + a
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data + 2.0))
 #    c = 2.0 - a
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   2.0 - data))
 #    c = 2.0 * a
-#    self.assertTrue(np.array_equal(c[sp.Data.Value, "i"].numpy,
+#    self.assertTrue(np.array_equal(c[sc.Data.Value, "i"].numpy,
 #                                   data * 2.0))
 #
 # def test_equal_not_equal(self):
-#    a = sp.Dataset()
-#    a[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-#    a[sp.Data.Value, "i"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    b = sp.Dataset()
-#    b[sp.Data.Value, "j"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
+#    a = sc.Dataset()
+#    a[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+#    a[sc.Data.Value, "i"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    b = sc.Dataset()
+#    b[sc.Data.Value, "j"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
 #    c = a + b
-#    d = sp.Dataset()
-#    d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-#    d[sp.Data.Value, "i"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-#    a_slice = a[sp.Dim.X, :]
-#    d_slice = d[sp.Dim.X, :]
+#    d = sc.Dataset()
+#    d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+#    d[sc.Data.Value, "i"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+#    a_slice = a[sc.Dim.X, :]
+#    d_slice = d[sc.Dim.X, :]
 #    # Equal
 #    self.assertEqual(a, d)
 #    self.assertEqual(a, a_slice)
@@ -744,252 +755,252 @@ def test_dataset_data_access():
 #    self.assertNotEqual(c, a_slice)
 #
 # def test_plus_equals_slice(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data1"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X], self.reference_data1)
-#    a = sp.Dataset(dataset[sp.Dim.X, 0])
-#    b = dataset[sp.Dim.X, 1]
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data1"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X], self.reference_data1)
+#    a = sc.Dataset(dataset[sc.Dim.X, 0])
+#    b = dataset[sc.Dim.X, 1]
 #    a += b
 #
 # def test_numpy_interoperable(self):
 #    # TODO: Need also __setitem__ with view.
-#    # self.dataset[sp.Data.Value, 'data2'] =
-#    #     self.dataset[sp.Data.Value, 'data1']
-#    self.dataset[sp.Data.Value, 'data2'] = np.exp(
-#        self.dataset[sp.Data.Value, 'data1'])
+#    # self.dataset[sc.Data.Value, 'data2'] =
+#    #     self.dataset[sc.Data.Value, 'data1']
+#    self.dataset[sc.Data.Value, 'data2'] = np.exp(
+#        self.dataset[sc.Data.Value, 'data1'])
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy,
+#        self.dataset[sc.Data.Value, "data2"].numpy,
 #        np.exp(self.reference_data1))
 #    # Restore original value.
-#    self.dataset[sp.Data.Value, 'data2'] = self.reference_data2
+#    self.dataset[sc.Data.Value, 'data2'] = self.reference_data2
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy, self.reference_data2)
+#        self.dataset[sc.Data.Value, "data2"].numpy, self.reference_data2)
 #
 # def test_slice_numpy_interoperable(self):
 #    # Dataset subset then view single variable
-#    self.dataset.subset['data2'][sp.Data.Value, 'data2'] = np.exp(
-#        self.dataset[sp.Data.Value, 'data1'])
+#    self.dataset.subset['data2'][sc.Data.Value, 'data2'] = np.exp(
+#        self.dataset[sc.Data.Value, 'data1'])
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy,
+#        self.dataset[sc.Data.Value, "data2"].numpy,
 #        np.exp(self.reference_data1))
 #    # Slice view of dataset then view single variable
-#    self.dataset[sp.Dim.X, 0][sp.Data.Value, 'data2'] = np.exp(
-#        self.dataset[sp.Dim.X, 1][sp.Data.Value, 'data1'])
+#    self.dataset[sc.Dim.X, 0][sc.Data.Value, 'data2'] = np.exp(
+#        self.dataset[sc.Dim.X, 1][sc.Data.Value, 'data1'])
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy[..., 0],
+#        self.dataset[sc.Data.Value, "data2"].numpy[..., 0],
 #        np.exp(self.reference_data1[..., 1]))
 #    # View single variable then slice view
-#    self.dataset[sp.Data.Value, 'data2'][sp.Dim.X, 1] = np.exp(
-#        self.dataset[sp.Data.Value, 'data1'][sp.Dim.X, 0])
+#    self.dataset[sc.Data.Value, 'data2'][sc.Dim.X, 1] = np.exp(
+#        self.dataset[sc.Data.Value, 'data1'][sc.Dim.X, 0])
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy[..., 1],
+#        self.dataset[sc.Data.Value, "data2"].numpy[..., 1],
 #        np.exp(self.reference_data1[..., 0]))
 #    # View single variable then view range of slices
-#    self.dataset[sp.Data.Value, 'data2'][sp.Dim.Y, 1:3] = np.exp(
-#        self.dataset[sp.Data.Value, 'data1'][sp.Dim.Y, 0:2])
-#    np.testing.assert_array_equal(self.dataset[sp.Data.Value,
+#    self.dataset[sc.Data.Value, 'data2'][sc.Dim.Y, 1:3] = np.exp(
+#        self.dataset[sc.Data.Value, 'data1'][sc.Dim.Y, 0:2])
+#    np.testing.assert_array_equal(self.dataset[sc.Data.Value,
 #                                               "data2"].numpy[:, 1:3, :],
 #                                  np.exp(self.reference_data1[:, 0:2, :]))
 #
 #    # Restore original value.
-#    self.dataset[sp.Data.Value, 'data2'] = self.reference_data2
+#    self.dataset[sc.Data.Value, 'data2'] = self.reference_data2
 #    np.testing.assert_array_equal(
-#        self.dataset[sp.Data.Value, "data2"].numpy, self.reference_data2)
+#        self.dataset[sc.Data.Value, "data2"].numpy, self.reference_data2)
 #
 # def test_concatenate(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.X], np.arange(4))
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.array([3, 2, 4, 1]))
-#    dataset = sp.concatenate(dataset, dataset, sp.Dim.X)
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.X], np.arange(4))
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.array([3, 2, 4, 1]))
+#    dataset = sc.concatenate(dataset, dataset, sc.Dim.X)
 #    np.testing.assert_array_equal(
-#        dataset[sp.Coord.X].numpy, np.array([3, 2, 4, 1, 3, 2, 4, 1]))
+#        dataset[sc.Coord.X].numpy, np.array([3, 2, 4, 1, 3, 2, 4, 1]))
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy,
+#        dataset[sc.Data.Value, "data"].numpy,
 #        np.array([0, 1, 2, 3, 0, 1, 2, 3]))
 #
 # def test_concatenate_with_slice(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.X], np.arange(4))
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.array([3, 2, 4, 1]))
-#    dataset = sp.concatenate(dataset, dataset[sp.Dim.X, 0:2], sp.Dim.X)
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.X], np.arange(4))
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.array([3, 2, 4, 1]))
+#    dataset = sc.concatenate(dataset, dataset[sc.Dim.X, 0:2], sc.Dim.X)
 #    np.testing.assert_array_equal(
-#        dataset[sp.Coord.X].numpy, np.array([3, 2, 4, 1, 3, 2]))
+#        dataset[sc.Coord.X].numpy, np.array([3, 2, 4, 1, 3, 2]))
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy, np.array([0, 1, 2, 3, 0, 1]))
+#        dataset[sc.Data.Value, "data"].numpy, np.array([0, 1, 2, 3, 0, 1]))
 #
 # def test_rebin(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.X], np.array(10 * [1.0]))
-#    dataset[sp.Data.Value, "data"].unit = sp.units.counts
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.arange(11.0))
-#    new_coord = sp.Variable([sp.Dim.X], np.arange(0.0, 11, 2))
-#    dataset = sp.rebin(dataset, new_coord)
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.X], np.array(10 * [1.0]))
+#    dataset[sc.Data.Value, "data"].unit = sc.units.counts
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.arange(11.0))
+#    new_coord = sc.Variable([sc.Dim.X], np.arange(0.0, 11, 2))
+#    dataset = sc.rebin(dataset, new_coord)
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy, np.array(5 * [2]))
+#        dataset[sc.Data.Value, "data"].numpy, np.array(5 * [2]))
 #    np.testing.assert_array_equal(
-#        dataset[sp.Coord.X].numpy, np.arange(0, 11, 2))
+#        dataset[sc.Coord.X].numpy, np.arange(0, 11, 2))
 #
 # def test_sort(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.X], np.arange(4))
-#    dataset[sp.Data.Value, "data2"] = ([sp.Dim.X], np.arange(4))
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.array([3, 2, 4, 1]))
-#    dataset = sp.sort(dataset, sp.Coord.X)
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.X], np.arange(4))
+#    dataset[sc.Data.Value, "data2"] = ([sc.Dim.X], np.arange(4))
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.array([3, 2, 4, 1]))
+#    dataset = sc.sort(dataset, sc.Coord.X)
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy, np.array([3, 1, 0, 2]))
+#        dataset[sc.Data.Value, "data"].numpy, np.array([3, 1, 0, 2]))
 #    np.testing.assert_array_equal(
-#        dataset[sp.Coord.X].numpy, np.array([1, 2, 3, 4]))
-#    dataset = sp.sort(dataset, sp.Data.Value, "data")
+#        dataset[sc.Coord.X].numpy, np.array([1, 2, 3, 4]))
+#    dataset = sc.sort(dataset, sc.Data.Value, "data")
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy, np.arange(4))
+#        dataset[sc.Data.Value, "data"].numpy, np.arange(4))
 #    np.testing.assert_array_equal(
-#        dataset[sp.Coord.X].numpy, np.array([3, 2, 4, 1]))
+#        dataset[sc.Coord.X].numpy, np.array([3, 2, 4, 1]))
 #
 # def test_filter(self):
-#    dataset = sp.Dataset()
-#    dataset[sp.Data.Value, "data"] = ([sp.Dim.X], np.arange(4))
-#    dataset[sp.Coord.X] = ([sp.Dim.X], np.array([3, 2, 4, 1]))
-#    select = sp.Variable([sp.Dim.X], np.array([False, True, False, True]))
-#    dataset = sp.filter(dataset, select)
+#    dataset = sc.Dataset()
+#    dataset[sc.Data.Value, "data"] = ([sc.Dim.X], np.arange(4))
+#    dataset[sc.Coord.X] = ([sc.Dim.X], np.array([3, 2, 4, 1]))
+#    select = sc.Variable([sc.Dim.X], np.array([False, True, False, True]))
+#    dataset = sc.filter(dataset, select)
 #    np.testing.assert_array_equal(
-#        dataset[sp.Data.Value, "data"].numpy, np.array([1, 3]))
-#    np.testing.assert_array_equal(dataset[sp.Coord.X].numpy,
+#        dataset[sc.Data.Value, "data"].numpy, np.array([1, 3]))
+#    np.testing.assert_array_equal(dataset[sc.Coord.X].numpy,
 #                                  np.array([2, 1]))
 #
 #
 # s TestDatasetExamples(unittest.TestCase):
 # def test_table_example(self):
-#    table = sp.Dataset()
-#    table[sp.Coord.Row] = ([sp.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
-#    self.assertSequenceEqual(table[sp.Coord.Row].data, [
+#    table = sc.Dataset()
+#    table[sc.Coord.Row] = ([sc.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+#    self.assertSequenceEqual(table[sc.Coord.Row].data, [
 #                             'a', 'bb', 'ccc', 'dddd'])
-#    table[sp.Data.Value, "col1"] = ([sp.Dim.Row], [3.0, 2.0, 1.0, 0.0])
-#    table[sp.Data.Value, "col2"] = ([sp.Dim.Row], np.arange(4.0))
+#    table[sc.Data.Value, "col1"] = ([sc.Dim.Row], [3.0, 2.0, 1.0, 0.0])
+#    table[sc.Data.Value, "col2"] = ([sc.Dim.Row], np.arange(4.0))
 #    self.assertEqual(len(table), 3)
 #
-#    table[sp.Data.Value, "sum"] = ([sp.Dim.Row],
-#                                   (len(table[sp.Coord.Row]),))
+#    table[sc.Data.Value, "sum"] = ([sc.Dim.Row],
+#                                   (len(table[sc.Coord.Row]),))
 #
 #    for name, tag, col in table:
 #        if not tag.is_coord and name != "sum":
-#            table[sp.Data.Value, "sum"] += col
+#            table[sc.Data.Value, "sum"] += col
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col2"].numpy, np.array([0, 1, 2, 3]))
+#        table[sc.Data.Value, "col2"].numpy, np.array([0, 1, 2, 3]))
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "sum"].numpy, np.array([3, 3, 3, 3]))
+#        table[sc.Data.Value, "sum"].numpy, np.array([3, 3, 3, 3]))
 #
-#    table = sp.concatenate(table, table, sp.Dim.Row)
+#    table = sc.concatenate(table, table, sc.Dim.Row)
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col1"].numpy,
+#        table[sc.Data.Value, "col1"].numpy,
 #        np.array([3, 2, 1, 0, 3, 2, 1, 0]))
 #
-#    table = sp.concatenate(table[sp.Dim.Row, 0:2], table[sp.Dim.Row, 5:7],
-#                           sp.Dim.Row)
+#    table = sc.concatenate(table[sc.Dim.Row, 0:2], table[sc.Dim.Row, 5:7],
+#                           sc.Dim.Row)
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col1"].numpy, np.array([3, 2, 2, 1]))
+#        table[sc.Data.Value, "col1"].numpy, np.array([3, 2, 2, 1]))
 #
-#    table = sp.sort(table, sp.Data.Value, "col1")
+#    table = sc.sort(table, sc.Data.Value, "col1")
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col1"].numpy, np.array([1, 2, 2, 3]))
+#        table[sc.Data.Value, "col1"].numpy, np.array([1, 2, 2, 3]))
 #
-#    table = sp.sort(table, sp.Coord.Row)
+#    table = sc.sort(table, sc.Coord.Row)
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col1"].numpy, np.array([3, 2, 2, 1]))
+#        table[sc.Data.Value, "col1"].numpy, np.array([3, 2, 2, 1]))
 #
-#    for i in range(1, len(table[sp.Coord.Row])):
-#        table[sp.Dim.Row, i] += table[sp.Dim.Row, i - 1]
+#    for i in range(1, len(table[sc.Coord.Row])):
+#        table[sc.Dim.Row, i] += table[sc.Dim.Row, i - 1]
 #
 #    np.testing.assert_array_equal(
-#        table[sp.Data.Value, "col1"].numpy, np.array([3, 5, 7, 8]))
+#        table[sc.Data.Value, "col1"].numpy, np.array([3, 5, 7, 8]))
 #
-#    table[sp.Data.Value, "exp1"] = (
-#        [sp.Dim.Row], np.exp(table[sp.Data.Value, "col1"]))
-#    table[sp.Data.Value, "exp1"] -= table[sp.Data.Value, "col1"]
-#    np.testing.assert_array_equal(table[sp.Data.Value, "exp1"].numpy,
+#    table[sc.Data.Value, "exp1"] = (
+#        [sc.Dim.Row], np.exp(table[sc.Data.Value, "col1"]))
+#    table[sc.Data.Value, "exp1"] -= table[sc.Data.Value, "col1"]
+#    np.testing.assert_array_equal(table[sc.Data.Value, "exp1"].numpy,
 #                                  np.exp(np.array([3, 5, 7, 8]))
 #                                  - np.array([3, 5, 7, 8]))
 #
 #    table += table
-#    self.assertSequenceEqual(table[sp.Coord.Row].data, [
+#    self.assertSequenceEqual(table[sc.Coord.Row].data, [
 #                             'a', 'bb', 'bb', 'ccc'])
 #
 # def test_table_example_no_assert(self):
-#    table = sp.Dataset()
+#    table = sc.Dataset()
 #
 #    # Add columns
-#    table[sp.Coord.Row] = ([sp.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
-#    table[sp.Data.Value, "col1"] = ([sp.Dim.Row], [3.0, 2.0, 1.0, 0.0])
-#    table[sp.Data.Value, "col2"] = ([sp.Dim.Row], np.arange(4.0))
-#    table[sp.Data.Value, "sum"] = ([sp.Dim.Row], (4,))
+#    table[sc.Coord.Row] = ([sc.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+#    table[sc.Data.Value, "col1"] = ([sc.Dim.Row], [3.0, 2.0, 1.0, 0.0])
+#    table[sc.Data.Value, "col2"] = ([sc.Dim.Row], np.arange(4.0))
+#    table[sc.Data.Value, "sum"] = ([sc.Dim.Row], (4,))
 #
 #    # Do something for each column (here: sum)
 #    for name, tag, col in table:
 #        if not tag.is_coord and name != "sum":
-#            table[sp.Data.Value, "sum"] += col
+#            table[sc.Data.Value, "sum"] += col
 #
 #    # Append tables (append rows of second table to first)
-#    table = sp.concatenate(table, table, sp.Dim.Row)
+#    table = sc.concatenate(table, table, sc.Dim.Row)
 #
 #    # Append tables sections (e.g., to remove rows from the middle)
-#    table = sp.concatenate(table[sp.Dim.Row, 0:2], table[sp.Dim.Row, 5:7],
-#                           sp.Dim.Row)
+#    table = sc.concatenate(table[sc.Dim.Row, 0:2], table[sc.Dim.Row, 5:7],
+#                           sc.Dim.Row)
 #
 #    # Sort by column
-#    table = sp.sort(table, sp.Data.Value, "col1")
+#    table = sc.sort(table, sc.Data.Value, "col1")
 #    # ... or another one
-#    table = sp.sort(table, sp.Coord.Row)
+#    table = sc.sort(table, sc.Coord.Row)
 #
 #    # Do something for each row (here: cumulative sum)
-#    for i in range(1, len(table[sp.Coord.Row])):
-#        table[sp.Dim.Row, i] += table[sp.Dim.Row, i - 1]
+#    for i in range(1, len(table[sc.Coord.Row])):
+#        table[sc.Dim.Row, i] += table[sc.Dim.Row, i - 1]
 #
 #    # Apply numpy function to column, store result as a new column
-#    table[sp.Data.Value, "exp1"] = (
-#        [sp.Dim.Row], np.exp(table[sp.Data.Value, "col1"]))
+#    table[sc.Data.Value, "exp1"] = (
+#        [sc.Dim.Row], np.exp(table[sc.Data.Value, "col1"]))
 #    # ... or as an existing column
-#    table[sp.Data.Value, "exp1"] = np.sin(table[sp.Data.Value, "exp1"])
+#    table[sc.Data.Value, "exp1"] = np.sin(table[sc.Data.Value, "exp1"])
 #
 #    # Remove column
-#    del table[sp.Data.Value, "exp1"]
+#    del table[sc.Data.Value, "exp1"]
 #
 #    # Arithmetics with tables (here: add two tables)
 #    table += table
 #
 # def test_MDHistoWorkspace_example(self):
 #    L = 30
-#    d = sp.Dataset()
+#    d = sc.Dataset()
 #
 #    # Add bin-edge axis for X
-#    d[sp.Coord.X] = ([sp.Dim.X], np.arange(L + 1).astype(np.float64))
+#    d[sc.Coord.X] = ([sc.Dim.X], np.arange(L + 1).astype(np.float64))
 #    # ... and normal axes for Y and Z
-#    d[sp.Coord.Y] = ([sp.Dim.Y], np.arange(L))
-#    d[sp.Coord.Z] = ([sp.Dim.Z], np.arange(L))
+#    d[sc.Coord.Y] = ([sc.Dim.Y], np.arange(L))
+#    d[sc.Coord.Z] = ([sc.Dim.Z], np.arange(L))
 #
 #    # Add data variables
-#    d[sp.Data.Value, "temperature"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+#    d[sc.Data.Value, "temperature"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
 #        np.random.normal(size=L * L * L).reshape([L, L, L]))
-#    d[sp.Data.Value, "pressure"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+#    d[sc.Data.Value, "pressure"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
 #        np.random.normal(size=L * L * L).reshape([L, L, L]))
 #    # Add uncertainties, matching name implicitly links it to corresponding
 #    # data
-#    d[sp.Data.Variance, "temperature"] = (
-#        [sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
-#        d[sp.Data.Value, "temperature"].numpy)
+#    d[sc.Data.Variance, "temperature"] = (
+#        [sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
+#        d[sc.Data.Value, "temperature"].numpy)
 #
 #    # Uncertainties are propagated using grouping mechanism based on name
 #    square = d * d
 #    np.testing.assert_array_equal(
-#        square[sp.Data.Variance, "temperature"].numpy,
-#        2.0 * (d[sp.Data.Value, "temperature"].numpy**2
-#               * d[sp.Data.Variance, "temperature"].numpy))
+#        square[sc.Data.Variance, "temperature"].numpy,
+#        2.0 * (d[sc.Data.Value, "temperature"].numpy**2
+#               * d[sc.Data.Variance, "temperature"].numpy))
 #
 #    # Add the counts units
-#    d[sp.Data.Value, "temperature"].unit = sp.units.counts
-#    d[sp.Data.Value, "pressure"].unit = sp.units.counts
-#    d[sp.Data.Variance, "temperature"].unit = sp.units.counts \
-#        * sp.units.counts
+#    d[sc.Data.Value, "temperature"].unit = sc.units.counts
+#    d[sc.Data.Value, "pressure"].unit = sc.units.counts
+#    d[sc.Data.Variance, "temperature"].unit = sc.units.counts \
+#        * sc.units.counts
 #    # The square operation is now prevented because the resulting counts
 #    # variance unit (counts^4) is not part of the supported units, i.e. the
 #    # result of that operation makes little physical sense.
@@ -1000,48 +1011,48 @@ def test_dataset_data_access():
 #        d = d * d
 #
 #    # Rebin the X axis
-#    d = sp.rebin(d, sp.Variable(
-#        [sp.Dim.X], np.arange(0, L + 1, 2).astype(np.float64)))
+#    d = sc.rebin(d, sc.Variable(
+#        [sc.Dim.X], np.arange(0, L + 1, 2).astype(np.float64)))
 #    # Rebin to different axis for every y
 #    # Our rebin implementatinon is broken for this case for now
-#    # rebinned = sp.rebin(d, sp.Variable(sp.Coord.X, [sp.Dim.Y, sp.Dim.X],
+#    # rebinned = sc.rebin(d, sc.Variable(sc.Coord.X, [sc.Dim.Y, sc.Dim.X],
 #    #                  np.arange(0,2*L).reshape([L,2]).astype(np.float64)))
 #
 #    # Do something with numpy and insert result
-#    d[sp.Data.Value, "dz(p)"] = ([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
-#                                 np.gradient(d[sp.Data.Value, "pressure"],
-#                                             d[sp.Coord.Z], axis=0))
+#    d[sc.Data.Value, "dz(p)"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
+#                                 np.gradient(d[sc.Data.Value, "pressure"],
+#                                             d[sc.Coord.Z], axis=0))
 #
 #    # Truncate Y and Z axes
-#    d = sp.Dataset(d[sp.Dim.Y, 10:20][sp.Dim.Z, 10:20])
+#    d = sc.Dataset(d[sc.Dim.Y, 10:20][sc.Dim.Z, 10:20])
 #
 #    # Mean along Y axis
-#    meanY = sp.mean(d, sp.Dim.Y)
+#    meanY = sc.mean(d, sc.Dim.Y)
 #    # Subtract from original, making use of automatic broadcasting
 #    d -= meanY
 #
 #    # Extract a Z slice
-#    sliceZ = sp.Dataset(d[sp.Dim.Z, 7])
+#    sliceZ = sc.Dataset(d[sc.Dim.Z, 7])
 #    self.assertEqual(len(sliceZ.dimensions), 2)
 #
 # def test_Workspace2D_example(self):
-#    d = sp.Dataset()
+#    d = sc.Dataset()
 #
-#    d[sp.Coord.SpectrumNumber] = ([sp.Dim.Spectrum], np.arange(1, 101))
+#    d[sc.Coord.SpectrumNumber] = ([sc.Dim.Spectrum], np.arange(1, 101))
 #
 #    # Add a (common) time-of-flight axis
-#    d[sp.Coord.Tof] = ([sp.Dim.Tof], np.arange(1000))
+#    d[sc.Coord.Tof] = ([sc.Dim.Tof], np.arange(1000))
 #
 #    # Add data with uncertainties
-#    d[sp.Data.Value, "sample1"] = (
-#        [sp.Dim.Spectrum, sp.Dim.Tof],
+#    d[sc.Data.Value, "sample1"] = (
+#        [sc.Dim.Spectrum, sc.Dim.Tof],
 #        np.random.exponential(size=100 * 1000).reshape([100, 1000]))
-#    d[sp.Data.Variance, "sample1"] = d[sp.Data.Value, "sample1"]
+#    d[sc.Data.Variance, "sample1"] = d[sc.Data.Value, "sample1"]
 #
 #    # Create a mask and use it to extract some of the spectra
-#    select = sp.Variable([sp.Dim.Spectrum], np.isin(
-#        d[sp.Coord.SpectrumNumber], np.arange(10, 20)))
-#    spectra = sp.filter(d, select)
+#    select = sc.Variable([sc.Dim.Spectrum], np.isin(
+#        d[sc.Coord.SpectrumNumber], np.arange(10, 20)))
+#    spectra = sc.filter(d, select)
 #    self.assertEqual(spectra.dimensions.shape[1], 10)
 #
 #    # Direct representation of a simple instrument (more standard Mantid
@@ -1050,75 +1061,75 @@ def test_dataset_data_access():
 #    steps = np.arange(-0.45, 0.46, 0.1)
 #    x = np.tile(steps, (10,))
 #    y = x.reshape([10, 10]).transpose().flatten()
-#    d[sp.Coord.X] = ([sp.Dim.Spectrum], x)
-#    d[sp.Coord.Y] = ([sp.Dim.Spectrum], y)
-#    d[sp.Coord.Z] = ([], 10.0)
+#    d[sc.Coord.X] = ([sc.Dim.Spectrum], x)
+#    d[sc.Coord.Y] = ([sc.Dim.Spectrum], y)
+#    d[sc.Coord.Z] = ([], 10.0)
 #
 #    # Mask some spectra based on distance from beam center
-#    r = np.sqrt(np.square(d[sp.Coord.X]) + np.square(d[sp.Coord.Y]))
-#    d[sp.Coord.Mask] = ([sp.Dim.Spectrum], np.less(r, 0.2))
+#    r = np.sqrt(np.square(d[sc.Coord.X]) + np.square(d[sc.Coord.Y]))
+#    d[sc.Coord.Mask] = ([sc.Dim.Spectrum], np.less(r, 0.2))
 #
 #    # Do something for each spectrum (here: apply mask)
-#    d[sp.Coord.Mask].data
-#    for i, masked in enumerate(d[sp.Coord.Mask].numpy):
-#        spec = d[sp.Dim.Spectrum, i]
+#    d[sc.Coord.Mask].data
+#    for i, masked in enumerate(d[sc.Coord.Mask].numpy):
+#        spec = d[sc.Dim.Spectrum, i]
 #        if masked:
-#            spec[sp.Data.Value, "sample1"] = np.zeros(1000)
-#            spec[sp.Data.Variance, "sample1"] = np.zeros(1000)
+#            spec[sc.Data.Value, "sample1"] = np.zeros(1000)
+#            spec[sc.Data.Variance, "sample1"] = np.zeros(1000)
 #
 # def test_monitors_example(self):
-#    d = sp.Dataset()
+#    d = sc.Dataset()
 #
-#    d[sp.Coord.SpectrumNumber] = ([sp.Dim.Spectrum], np.arange(1, 101))
+#    d[sc.Coord.SpectrumNumber] = ([sc.Dim.Spectrum], np.arange(1, 101))
 #
 #    # Add a (common) time-of-flight axis
-#    d[sp.Coord.Tof] = ([sp.Dim.Tof], np.arange(9))
+#    d[sc.Coord.Tof] = ([sc.Dim.Tof], np.arange(9))
 #
 #    # Add data with uncertainties
-#    d[sp.Data.Value, "sample1"] = (
-#        [sp.Dim.Spectrum, sp.Dim.Tof],
+#    d[sc.Data.Value, "sample1"] = (
+#        [sc.Dim.Spectrum, sc.Dim.Tof],
 #        np.random.exponential(size=100 * 8).reshape([100, 8]))
-#    d[sp.Data.Variance, "sample1"] = d[sp.Data.Value, "sample1"]
+#    d[sc.Data.Variance, "sample1"] = d[sc.Data.Value, "sample1"]
 #
 #    # Add event-mode beam-status monitor
-#    status = sp.Dataset()
-#    status[sp.Data.Tof] = ([sp.Dim.Event],
+#    status = sc.Dataset()
+#    status[sc.Data.Tof] = ([sc.Dim.Event],
 #                           np.random.exponential(size=1000))
-#    status[sp.Data.PulseTime] = (
-#        [sp.Dim.Event], np.random.exponential(size=1000))
-#    d[sp.Coord.Monitor, "beam-status"] = ([], status)
+#    status[sc.Data.PulseTime] = (
+#        [sc.Dim.Event], np.random.exponential(size=1000))
+#    d[sc.Coord.Monitor, "beam-status"] = ([], status)
 #
 #    # Add position-resolved beam-profile monitor
-#    profile = sp.Dataset()
-#    profile[sp.Coord.X] = ([sp.Dim.X], [-0.02, -0.01, 0.0, 0.01, 0.02])
-#    profile[sp.Coord.Y] = ([sp.Dim.Y], [-0.02, -0.01, 0.0, 0.01, 0.02])
-#    profile[sp.Data.Value] = ([sp.Dim.Y, sp.Dim.X], (4, 4))
+#    profile = sc.Dataset()
+#    profile[sc.Coord.X] = ([sc.Dim.X], [-0.02, -0.01, 0.0, 0.01, 0.02])
+#    profile[sc.Coord.Y] = ([sc.Dim.Y], [-0.02, -0.01, 0.0, 0.01, 0.02])
+#    profile[sc.Data.Value] = ([sc.Dim.Y, sc.Dim.X], (4, 4))
 #    # Monitors can also be attributes, so they are not required to match in
 #    # operations
-#    d[sp.Attr.Monitor, "beam-profile"] = ([], profile)
+#    d[sc.Attr.Monitor, "beam-profile"] = ([], profile)
 #
 #    # Add histogram-mode transmission monitor
-#    transmission = sp.Dataset()
-#    transmission[sp.Coord.Energy] = ([sp.Dim.Energy], np.arange(9))
-#    transmission[sp.Data.Value] = (
-#        [sp.Dim.Energy], np.random.exponential(size=8))
-#    d[sp.Coord.Monitor, "transmission"] = ([], ())
+#    transmission = sc.Dataset()
+#    transmission[sc.Coord.Energy] = ([sc.Dim.Energy], np.arange(9))
+#    transmission[sc.Data.Value] = (
+#        [sc.Dim.Energy], np.random.exponential(size=8))
+#    d[sc.Coord.Monitor, "transmission"] = ([], ())
 #
 # @unittest.skip("Tag-derived dtype not available anymore, need to implement \
 #               way of specifying list type for events.")
 # def test_zip(self):
-#    d = sp.Dataset()
-#    d[sp.Coord.SpectrumNumber] = ([sp.Dim.Position], np.arange(1, 6))
-#    d[sp.Data.EventTofs, ""] = ([sp.Dim.Position], (5,))
-#    d[sp.Data.EventPulseTimes, ""] = ([sp.Dim.Position], (5,))
-#    self.assertEqual(len(d[sp.Data.EventTofs, ""].data), 5)
-#    d[sp.Data.EventTofs, ""].data[0].append(10)
-#    d[sp.Data.EventPulseTimes, ""].data[0].append(1000)
-#    d[sp.Data.EventTofs, ""].data[1].append(10)
-#    d[sp.Data.EventPulseTimes, ""].data[1].append(1000)
+#    d = sc.Dataset()
+#    d[sc.Coord.SpectrumNumber] = ([sc.Dim.Position], np.arange(1, 6))
+#    d[sc.Data.EventTofs, ""] = ([sc.Dim.Position], (5,))
+#    d[sc.Data.EventPulseTimes, ""] = ([sc.Dim.Position], (5,))
+#    self.assertEqual(len(d[sc.Data.EventTofs, ""].data), 5)
+#    d[sc.Data.EventTofs, ""].data[0].append(10)
+#    d[sc.Data.EventPulseTimes, ""].data[0].append(1000)
+#    d[sc.Data.EventTofs, ""].data[1].append(10)
+#    d[sc.Data.EventPulseTimes, ""].data[1].append(1000)
 #    # Don't do this, there are no compatiblity checks:
-#    # for el in zip(d[sp.Data.EventTofs, ""].data,
-#    #     d[sp.Data.EventPulseTimes, ""].data):
+#    # for el in zip(d[sc.Data.EventTofs, ""].data,
+#    #     d[sc.Data.EventPulseTimes, ""].data):
 #    for el, size in zip(d.zip(), [1, 1, 0, 0, 0]):
 #        self.assertEqual(len(el), size)
 #        for e in el:
@@ -1130,70 +1141,70 @@ def test_dataset_data_access():
 # def test_np_array_strides(self):
 #    N = 6
 #    M = 4
-#    d1 = sp.Dataset()
-#    d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-#    d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+#    d1 = sc.Dataset()
+#    d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+#    d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
 #
 #    arr1 = np.arange(N * M).reshape(N, M).astype(np.float64)
 #    arr2 = np.transpose(arr1)
 #    K = 3
 #    arr_buf = np.arange(N * K * M).reshape(N, K, M)
 #    arr3 = arr_buf[:, 1, :]
-#    d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
-#    d1[sp.Data.Value, "B"] = ([sp.Dim.Y, sp.Dim.X], arr2)
-#    d1[sp.Data.Value, "C"] = ([sp.Dim.X, sp.Dim.Y], arr3)
-#    np.testing.assert_array_equal(arr1, d1[sp.Data.Value, "A"].numpy)
-#    np.testing.assert_array_equal(arr2, d1[sp.Data.Value, "B"].numpy)
-#    np.testing.assert_array_equal(arr3, d1[sp.Data.Value, "C"].numpy)
+#    d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
+#    d1[sc.Data.Value, "B"] = ([sc.Dim.Y, sc.Dim.X], arr2)
+#    d1[sc.Data.Value, "C"] = ([sc.Dim.X, sc.Dim.Y], arr3)
+#    np.testing.assert_array_equal(arr1, d1[sc.Data.Value, "A"].numpy)
+#    np.testing.assert_array_equal(arr2, d1[sc.Data.Value, "B"].numpy)
+#    np.testing.assert_array_equal(arr3, d1[sc.Data.Value, "C"].numpy)
 #
 # def test_rebin(self):
 #    N = 6
 #    M = 4
-#    d1 = sp.Dataset()
-#    d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-#    d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+#    d1 = sc.Dataset()
+#    d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+#    d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
 #
 #    arr1 = np.arange(N * M).reshape(N, M).astype(np.float64)
 #    # TODO copy not needed after correct treatment of strides
 #    arr2 = np.transpose(arr1).copy()
 #
-#    d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
-#    d1[sp.Data.Value, "B"] = ([sp.Dim.Y, sp.Dim.X], arr2)
-#    d1[sp.Data.Value, "A"].unit = sp.units.counts
-#    d1[sp.Data.Value, "B"].unit = sp.units.counts
-#    rd1 = sp.rebin(d1, sp.Variable([sp.Dim.X], np.arange(
+#    d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
+#    d1[sc.Data.Value, "B"] = ([sc.Dim.Y, sc.Dim.X], arr2)
+#    d1[sc.Data.Value, "A"].unit = sc.units.counts
+#    d1[sc.Data.Value, "B"].unit = sc.units.counts
+#    rd1 = sc.rebin(d1, sc.Variable([sc.Dim.X], np.arange(
 #        0, N + 1, 1.5).astype(np.float64)))
-#    np.testing.assert_array_equal(rd1[sp.Data.Value, "A"].numpy,
+#    np.testing.assert_array_equal(rd1[sc.Data.Value, "A"].numpy,
 #                                  np.transpose(
-#                                      rd1[sp.Data.Value, "B"].numpy))
+#                                      rd1[sc.Data.Value, "B"].numpy))
 #
 # def test_copy(self):
 #    import copy
 #    N = 6
 #    M = 4
-#    d1 = sp.Dataset()
-#    d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-#    d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+#    d1 = sc.Dataset()
+#    d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+#    d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
 #    arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
-#    d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
+#    d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
 #    d2 = copy.copy(d1)
 #    d3 = copy.deepcopy(d2)
 #    self.assertEqual(d1, d2)
 #    self.assertEqual(d3, d2)
-#    d2[sp.Data.Value, "A"] *= d2[sp.Data.Value, "A"]
+#    d2[sc.Data.Value, "A"] *= d2[sc.Data.Value, "A"]
 #    self.assertNotEqual(d1, d2)
 #    self.assertNotEqual(d3, d2)
 #
 # def test_correct_temporaries(self):
 #    N = 6
 #    M = 4
-#    d1 = sp.Dataset()
-#    d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-#    d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+#    d1 = sc.Dataset()
+#    d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+#    d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
 #    arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
-#    d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
-#    d1 = d1[sp.Dim.X, 1:2]
-#    self.assertEqual(list(d1[sp.Data.Value, "A"].data),
+#    d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
+#    d1 = d1[sc.Dim.X, 1:2]
+#    self.assertEqual(list(d1[sc.Data.Value, "A"].data),
 #                     [5.0, 6.0, 7.0, 8.0])
-#    d1 = d1[sp.Dim.Y, 2:3]
-#    self.assertEqual(list(d1[sp.Data.Value, "A"].data), [7])
+#    d1 = d1[sc.Dim.Y, 2:3]
+#    self.assertEqual(list(d1[sc.Data.Value, "A"].data), [7])

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -27,6 +27,7 @@ def test_lifetime_values_of_item():
 
 def test_lifetime_values_of_item_of_temporary():
     d = sc.Dataset(
+        {'a': sc.Variable([Dim.X], values=np.arange(3))},
         coords={Dim.X: sc.Variable([Dim.X], values=["aa", "bb", "cc"])})
     vals = (d + d).coords[Dim.X].values
     d + d  # do something allocating memory to trigger potential segfault


### PR DESCRIPTION
While attempting to resolve two issues with binary operations, I realized that a lot of complexity that has accumulated recently in `dataset.cpp` and related code can be avoid by adding `DataArray` (see #245) and some other helpers.

- Fixes #418.
- Fixes #417.

The implementation of `DataArray` (and its Python bindings) are deliberately incomplete for now (and direct tests are missing). It is not essential to have more features, and I think we can postpone those changes. My plan is to improve our units tests for dataset operations, it may be that I will do the remaining work for `DataArray` while that is done.

@igudich @DanNixon I am requesting your review, since this refactors parts of the code you wrote recently.

@OwenArnold Please also have a look, since the addition of `DataArray` and some of the applied logic is a central concept.