### PR TITLE
Resolve the build issue with clang on ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,19 +42,6 @@ find_package(Boost 1.67 REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
 
-# See https://github.com/pybind/pybind11/issues/1604
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
-  if(APPLE)
-    add_compile_definitions(_APPLE_CLANG_)
-  endif()
-else()
-  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-
-  # Reduces binary size of, e.g., libscipp-core.so by several MB.
-  set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
-endif()
-
 option(WITH_CTEST "Enable ctest integration of tests" ON)
 option(DYNAMIC_LIB "Build shared libraries" OFF)
 
@@ -68,6 +55,24 @@ else ()
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
   message(WARNING "IPO is not supported: ${output}")
 endif (result)
+
+
+# See https://github.com/pybind/pybind11/issues/1604
+set(INTERPROCEDURAL_OPTIMIZATION_TESTS FALSE)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
+  if(APPLE)
+    add_compile_definitions(_APPLE_CLANG_)
+  else()
+    # For some reason clang6 on ubuntu18 can't link parts
+    # with different INTERPROCEDURAL_OPTIMIZATION flag.
+    set(INTERPROCEDURAL_OPTIMIZATION_TESTS ${CMAKE_INTERPROCEDURAL_OPTIMIZATION})
+  endif()
+else()
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  # Reduces binary size of, e.g., libscipp-core.so by several MB.
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+endif()
 
 add_compile_options(-Wall
                     -Wextra

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(${TARGET_NAME}
                       ${GMOCK_LIBRARIES})
 target_include_directories(${TARGET_NAME} SYSTEM
                            PRIVATE "../../range-v3/include")
-set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ${INTERPROCEDURAL_OPTIMIZATION_TESTS})
 add_sanitizers(${TARGET_NAME})
 if(${WITH_CTEST})
   gtest_discover_tests(${TARGET_NAME} TEST_PREFIX scipp/core/)

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(${TARGET_NAME}
                       scipp_test_helpers
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
-set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ${INTERPROCEDURAL_OPTIMIZATION_TESTS})
 add_sanitizers(${TARGET_NAME})
 if(${WITH_CTEST})
   gtest_discover_tests(${TARGET_NAME} TEST_PREFIX scipp/neutron/)

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(${TARGET_NAME}
                       scipp_test_helpers
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
-set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ${INTERPROCEDURAL_OPTIMIZATION_TESTS})
 add_sanitizers(${TARGET_NAME})
 if(${WITH_CTEST})
   gtest_discover_tests(${TARGET_NAME} TEST_PREFIX scipp/units/)


### PR DESCRIPTION
For some reason, clang6 on ubuntu can't link if tests haven't interprocedural optimization while all other targets have it. Just forbid this behaviour for clang on NON-Apple platforms.

Fixes #414.