### PR TITLE
Add `DataProxy::name`

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -7,7 +7,7 @@
 namespace scipp::core {
 
 DataArray::DataArray(const DataConstProxy &proxy) {
-  m_holder.setData("", proxy);
+  m_holder.setData(proxy.name(), proxy);
 }
 
 DataArray::DataArray(Variable data, std::map<Dim, Variable> coords,

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -416,6 +416,14 @@ void Dataset::rename(const Dim from, const Dim to) {
   }
 }
 
+/// Return the name of the proxy.
+///
+/// The name of the proxy is equal to the name of the item in a Dataset, or the
+/// name of a DataArray. Note that comparison operations igore the name.
+const std::string &DataConstProxy::name() const noexcept {
+  return m_data->first;
+}
+
 /// Return an ordered mapping of dimension labels to extents, excluding a
 /// potentialy sparse dimensions.
 Dimensions DataConstProxy::dims() const noexcept {

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -80,6 +80,8 @@ public:
                  const std::vector<std::pair<Slice, scipp::index>> &slices = {})
       : m_dataset(&dataset), m_data(&data), m_slices(slices) {}
 
+  const std::string &name() const noexcept;
+
   Dimensions dims() const noexcept;
   units::Unit unit() const;
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -56,6 +56,8 @@ struct DatasetData {
   std::unordered_map<std::string, Variable> labels;
 };
 
+using dataset_item_map = std::unordered_map<std::string, DatasetData>;
+
 template <class Var>
 auto makeSlice(Var &var,
                const std::vector<std::pair<Slice, scipp::index>> &slices) {
@@ -73,7 +75,8 @@ auto makeSlice(Var &var,
 /// Const proxy for a data item and related coordinates of Dataset.
 class SCIPP_CORE_EXPORT DataConstProxy {
 public:
-  DataConstProxy(const Dataset &dataset, const detail::DatasetData &data,
+  DataConstProxy(const Dataset &dataset,
+                 const detail::dataset_item_map::value_type &data,
                  const std::vector<std::pair<Slice, scipp::index>> &slices = {})
       : m_dataset(&dataset), m_data(&data), m_slices(slices) {}
 
@@ -85,17 +88,17 @@ public:
   AttrsConstProxy attrs() const noexcept;
 
   /// Return true if the proxy contains data values.
-  bool hasData() const noexcept { return m_data->data.has_value(); }
+  bool hasData() const noexcept { return m_data->second.data.has_value(); }
   /// Return true if the proxy contains data variances.
   bool hasVariances() const noexcept {
-    return hasData() && m_data->data->hasVariances();
+    return hasData() && m_data->second.data->hasVariances();
   }
 
   /// Return untyped const proxy for data (values and optional variances).
   VariableConstProxy data() const {
     if (!hasData())
       throw except::SparseDataError("No data in item.");
-    return detail::makeSlice(*m_data->data, slices());
+    return detail::makeSlice(*m_data->second.data, slices());
   }
   /// Return typed const proxy for data values.
   template <class T> auto values() const { return data().template values<T>(); }
@@ -125,14 +128,14 @@ public:
     return m_slices;
   }
 
-  auto &underlying() const { return *m_data; }
+  auto &underlying() const { return m_data->second; }
 
 private:
   friend class DatasetConstProxy;
   friend class DatasetProxy;
 
   const Dataset *m_dataset;
-  const detail::DatasetData *m_data;
+  const detail::dataset_item_map::value_type *m_data;
   std::vector<std::pair<Slice, scipp::index>> m_slices;
 };
 
@@ -144,7 +147,7 @@ SCIPP_CORE_EXPORT bool operator!=(const DataConstProxy &a,
 /// Proxy for a data item and related coordinates of Dataset.
 class SCIPP_CORE_EXPORT DataProxy : public DataConstProxy {
 public:
-  DataProxy(Dataset &dataset, detail::DatasetData &data,
+  DataProxy(Dataset &dataset, detail::dataset_item_map::value_type &data,
             const std::vector<std::pair<Slice, scipp::index>> &slices = {})
       : DataConstProxy(dataset, data, slices), m_mutableDataset(&dataset),
         m_mutableData(&data) {}
@@ -159,7 +162,7 @@ public:
   VariableProxy data() const {
     if (!hasData())
       throw except::SparseDataError("No data in item.");
-    return detail::makeSlice(*m_mutableData->data, slices());
+    return detail::makeSlice(*m_mutableData->second.data, slices());
   }
   /// Return typed proxy for data values.
   template <class T> auto values() const { return data().template values<T>(); }
@@ -197,7 +200,7 @@ public:
 
 private:
   Dataset *m_mutableDataset;
-  detail::DatasetData *m_mutableData;
+  detail::dataset_item_map::value_type *m_mutableData;
 };
 
 namespace detail {
@@ -214,7 +217,7 @@ template <class D> struct make_item {
   template <class T>
   std::pair<const std::string &, P> operator()(T &item) const {
     if constexpr (std::is_same_v<std::remove_const_t<D>, Dataset>)
-      return {item.first, P(*dataset, item.second)};
+      return {item.first, P(*dataset, item)};
     else
       // TODO Using operator[] is quite inefficient, revert the logic.
       return {item, dataset->operator[](item)};
@@ -352,7 +355,7 @@ private:
   std::unordered_map<Dim, Variable> m_coords;
   std::unordered_map<std::string, Variable> m_labels;
   std::unordered_map<std::string, Variable> m_attrs;
-  std::unordered_map<std::string, detail::DatasetData> m_data;
+  detail::dataset_item_map m_data;
 };
 
 /// Common functionality for other const-proxy classes.

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -16,6 +16,8 @@ TEST(DataArrayTest, construct) {
 
   DataArray array(dataset["data_xyz"]);
   EXPECT_EQ(array, dataset["data_xyz"]);
+  // Comparison ignores the name, so this is tested separately.
+  EXPECT_EQ(array.name(), "data_xyz");
 }
 
 TEST(DataArrayTest, sum_dataset_columns_via_DataArray) {

--- a/core/test/data_proxy_test.cpp
+++ b/core/test/data_proxy_test.cpp
@@ -23,6 +23,15 @@ protected:
 using DataProxyTypes = ::testing::Types<DataProxy, DataConstProxy>;
 TYPED_TEST_SUITE(DataProxyTest, DataProxyTypes);
 
+TYPED_TEST(DataProxyTest, name_ignored_in_comparison) {
+  const auto var = makeVariable<double>(1.0);
+  Dataset d;
+  d.setData("a", var);
+  d.setData("b", var);
+  typename TestFixture::dataset_type &d_ref(d);
+  EXPECT_EQ(d_ref["a"], d_ref["b"]);
+}
+
 TYPED_TEST(DataProxyTest, sparse_sparseDim) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);

--- a/core/test/dataset_proxy_test.cpp
+++ b/core/test/dataset_proxy_test.cpp
@@ -51,6 +51,19 @@ TYPED_TEST(DatasetProxyTest, bad_item_access) {
   ASSERT_ANY_THROW(proxy["abc"]);
 }
 
+TYPED_TEST(DatasetProxyTest, name) {
+  Dataset d;
+  d.setData("a", makeVariable<double>({}));
+  d.setData("b", makeVariable<float>({}));
+  d.setData("c", makeVariable<int64_t>({}));
+  auto &&proxy = TestFixture::access(d);
+
+  for (const auto &name : {"a", "b", "c"})
+    EXPECT_EQ(d[name].name(), name);
+  for (const auto &name : {"a", "b", "c"})
+    EXPECT_EQ(d.find(name)->second.name(), name);
+}
+
 TYPED_TEST(DatasetProxyTest, find_and_contains) {
   Dataset d;
   d.setData("a", makeVariable<double>({}));

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -76,6 +76,11 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
         [](const T &self, const DatasetProxy &other) { return self == other; });
 }
 
+template <class T, class... Ignored>
+void bind_data_array_properties(py::class_<T, Ignored...> &c) {
+  c.def_property_readonly("name", &T::name);
+}
+
 void init_dataset(py::module &m) {
   py::class_<Slice>(m, "Slice");
 
@@ -83,7 +88,7 @@ void init_dataset(py::module &m) {
   bind_mutable_proxy<LabelsProxy, LabelsConstProxy>(m, "Labels");
   bind_mutable_proxy<AttrsProxy, AttrsConstProxy>(m, "Attrs");
 
-  py::class_<DataArray>(m, "DataArray");
+  py::class_<DataArray> dataArray(m, "DataArray");
   py::class_<DataConstProxy>(m, "DataConstProxy");
   py::class_<DataProxy, DataConstProxy> dataProxy(m, "DataProxy");
   dataProxy.def_property_readonly(
@@ -94,6 +99,9 @@ void init_dataset(py::module &m) {
                   py::return_value_policy::move, py::keep_alive<0, 1>()));
   dataProxy.def("__repr__",
                 [](const DataProxy &self) { return to_string(self); });
+
+  bind_data_array_properties(dataArray);
+  bind_data_array_properties(dataProxy);
 
   py::class_<DatasetConstProxy>(m, "DatasetConstProxy");
   py::class_<DatasetProxy, DatasetConstProxy> datasetProxy(m, "DatasetProxy");

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -288,6 +288,21 @@ def test_add_sum_of_columns():
     assert d['sum'] == d['a']
 
 
+def test_name():
+    d = sc.Dataset(
+        {
+            'a': sc.Variable([Dim.X], values=np.arange(10.0)),
+            'b': sc.Variable([Dim.X], values=np.ones(10))
+        },
+        coords={Dim.X: sc.Variable([Dim.X], values=np.arange(10))})
+    assert d['a'].name == 'a'
+    assert d['b'].name == 'b'
+    assert d[Dim.X, 2]['b'].name == 'b'
+    assert d['b'][Dim.X, 2].name == 'b'
+    array = d['a'] + d['b']
+    assert array.name == ''
+
+
 # def test_delitem(self):
 #    dataset = sc.Dataset()
 #    dataset[sc.Data.Value, "data"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],


### PR DESCRIPTION
- Required for better output, in e.g., Python table render.
- Consistent with `xarray.DataArray`.