### PR TITLE
Improve Python API for inserting coords, labels, and attributes

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -96,27 +96,27 @@ CoordsConstProxy Dataset::coords() const noexcept {
 /// This proxy includes only "dimension-coordinates". To access
 /// non-dimension-coordinates" see labels().
 CoordsProxy Dataset::coords() noexcept {
-  return CoordsProxy(makeProxyItems<Dim>(m_coords));
+  return CoordsProxy(this, makeProxyItems<Dim>(m_coords));
 }
 
 /// Return a const proxy to all labels of the dataset.
 LabelsConstProxy Dataset::labels() const noexcept {
-  return LabelsConstProxy(makeProxyItems<std::string_view>(m_labels));
+  return LabelsConstProxy(makeProxyItems<std::string>(m_labels));
 }
 
 /// Return a proxy to all labels of the dataset.
 LabelsProxy Dataset::labels() noexcept {
-  return LabelsProxy(makeProxyItems<std::string_view>(m_labels));
+  return LabelsProxy(this, makeProxyItems<std::string>(m_labels));
 }
 
 /// Return a const proxy to all attributes of the dataset.
 AttrsConstProxy Dataset::attrs() const noexcept {
-  return AttrsConstProxy(makeProxyItems<std::string_view>(m_attrs));
+  return AttrsConstProxy(makeProxyItems<std::string>(m_attrs));
 }
 
 /// Return a proxy to all attributes of the dataset.
 AttrsProxy Dataset::attrs() noexcept {
-  return AttrsProxy(makeProxyItems<std::string_view>(m_attrs));
+  return AttrsProxy(this, makeProxyItems<std::string>(m_attrs));
 }
 
 bool Dataset::contains(const std::string &name) const noexcept {
@@ -502,16 +502,16 @@ CoordsConstProxy DataConstProxy::coords() const noexcept {
 /// If the data has a sparse dimension the returned proxy will not contain any
 /// of the dataset's labels that depends on the sparse dimension.
 LabelsConstProxy DataConstProxy::labels() const noexcept {
-  return LabelsConstProxy(
-      makeProxyItems<std::string_view>(dims(), m_dataset->m_labels,
-                                       &m_data->second.labels),
-      slices());
+  return LabelsConstProxy(makeProxyItems<std::string>(dims(),
+                                                      m_dataset->m_labels,
+                                                      &m_data->second.labels),
+                          slices());
 }
 
 /// Return a const proxy to all attributes of the data proxy.
 AttrsConstProxy DataConstProxy::attrs() const noexcept {
   return AttrsConstProxy(
-      makeProxyItems<std::string_view>(dims(), m_dataset->m_attrs), slices());
+      makeProxyItems<std::string>(dims(), m_dataset->m_attrs), slices());
 }
 
 /// Return a proxy to all coordinates of the data proxy.
@@ -519,7 +519,8 @@ AttrsConstProxy DataConstProxy::attrs() const noexcept {
 /// If the data has a sparse dimension the returned proxy will not contain any
 /// of the dataset's coordinates that depends on the sparse dimension.
 CoordsProxy DataProxy::coords() const noexcept {
-  return CoordsProxy(makeProxyItems<Dim>(dims(), m_mutableDataset->m_coords,
+  return CoordsProxy(m_mutableDataset,
+                     makeProxyItems<Dim>(dims(), m_mutableDataset->m_coords,
                                          m_mutableData->second.coord
                                              ? &*m_mutableData->second.coord
                                              : nullptr),
@@ -531,17 +532,18 @@ CoordsProxy DataProxy::coords() const noexcept {
 /// If the data has a sparse dimension the returned proxy will not contain any
 /// of the dataset's labels that depends on the sparse dimension.
 LabelsProxy DataProxy::labels() const noexcept {
-  return LabelsProxy(
-      makeProxyItems<std::string_view>(dims(), m_mutableDataset->m_labels,
-                                       &m_mutableData->second.labels),
-      slices());
+  return LabelsProxy(m_mutableDataset,
+                     makeProxyItems<std::string>(dims(),
+                                                 m_mutableDataset->m_labels,
+                                                 &m_mutableData->second.labels),
+                     slices());
 }
 
 /// Return a const proxy to all attributes of the data proxy.
 AttrsProxy DataProxy::attrs() const noexcept {
   return AttrsProxy(
-      makeProxyItems<std::string_view>(dims(), m_mutableDataset->m_attrs),
-      slices());
+      m_mutableDataset,
+      makeProxyItems<std::string>(dims(), m_mutableDataset->m_attrs), slices());
 }
 
 DataProxy DataProxy::assign(const DataConstProxy &other) const {
@@ -612,30 +614,33 @@ CoordsConstProxy DatasetConstProxy::coords() const noexcept {
 /// This proxy includes only "dimension-coordinates". To access
 /// non-dimension-coordinates" see labels().
 CoordsProxy DatasetProxy::coords() const noexcept {
-  return CoordsProxy(makeProxyItems<Dim>(m_mutableDataset->m_coords), slices());
+  return CoordsProxy(m_mutableDataset,
+                     makeProxyItems<Dim>(m_mutableDataset->m_coords), slices());
 }
 
 /// Return a const proxy to all labels of the dataset slice.
 LabelsConstProxy DatasetConstProxy::labels() const noexcept {
-  return LabelsConstProxy(makeProxyItems<std::string_view>(m_dataset->m_labels),
+  return LabelsConstProxy(makeProxyItems<std::string>(m_dataset->m_labels),
                           slices());
 }
 
 /// Return a proxy to all labels of the dataset slice.
 LabelsProxy DatasetProxy::labels() const noexcept {
-  return LabelsProxy(
-      makeProxyItems<std::string_view>(m_mutableDataset->m_labels), slices());
+  return LabelsProxy(m_mutableDataset,
+                     makeProxyItems<std::string>(m_mutableDataset->m_labels),
+                     slices());
 }
 
 /// Return a const proxy to all attributes of the dataset slice.
 AttrsConstProxy DatasetConstProxy::attrs() const noexcept {
-  return AttrsConstProxy(makeProxyItems<std::string_view>(m_dataset->m_attrs),
+  return AttrsConstProxy(makeProxyItems<std::string>(m_dataset->m_attrs),
                          slices());
 }
 
 /// Return a proxy to all attributes of the dataset slice.
 AttrsProxy DatasetProxy::attrs() const noexcept {
-  return AttrsProxy(makeProxyItems<std::string_view>(m_mutableDataset->m_attrs),
+  return AttrsProxy(m_mutableDataset,
+                    makeProxyItems<std::string>(m_mutableDataset->m_attrs),
                     slices());
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -96,7 +96,7 @@ CoordsConstProxy Dataset::coords() const noexcept {
 /// This proxy includes only "dimension-coordinates". To access
 /// non-dimension-coordinates" see labels().
 CoordsProxy Dataset::coords() noexcept {
-  return CoordsProxy(this, makeProxyItems<Dim>(m_coords));
+  return CoordsProxy(this, nullptr, makeProxyItems<Dim>(m_coords));
 }
 
 /// Return a const proxy to all labels of the dataset.
@@ -106,7 +106,7 @@ LabelsConstProxy Dataset::labels() const noexcept {
 
 /// Return a proxy to all labels of the dataset.
 LabelsProxy Dataset::labels() noexcept {
-  return LabelsProxy(this, makeProxyItems<std::string>(m_labels));
+  return LabelsProxy(this, nullptr, makeProxyItems<std::string>(m_labels));
 }
 
 /// Return a const proxy to all attributes of the dataset.
@@ -116,7 +116,7 @@ AttrsConstProxy Dataset::attrs() const noexcept {
 
 /// Return a proxy to all attributes of the dataset.
 AttrsProxy Dataset::attrs() noexcept {
-  return AttrsProxy(this, makeProxyItems<std::string>(m_attrs));
+  return AttrsProxy(this, nullptr, makeProxyItems<std::string>(m_attrs));
 }
 
 bool Dataset::contains(const std::string &name) const noexcept {
@@ -519,7 +519,7 @@ AttrsConstProxy DataConstProxy::attrs() const noexcept {
 /// If the data has a sparse dimension the returned proxy will not contain any
 /// of the dataset's coordinates that depends on the sparse dimension.
 CoordsProxy DataProxy::coords() const noexcept {
-  return CoordsProxy(m_mutableDataset,
+  return CoordsProxy(m_mutableDataset, &name(),
                      makeProxyItems<Dim>(dims(), m_mutableDataset->m_coords,
                                          m_mutableData->second.coord
                                              ? &*m_mutableData->second.coord
@@ -532,7 +532,7 @@ CoordsProxy DataProxy::coords() const noexcept {
 /// If the data has a sparse dimension the returned proxy will not contain any
 /// of the dataset's labels that depends on the sparse dimension.
 LabelsProxy DataProxy::labels() const noexcept {
-  return LabelsProxy(m_mutableDataset,
+  return LabelsProxy(m_mutableDataset, &name(),
                      makeProxyItems<std::string>(dims(),
                                                  m_mutableDataset->m_labels,
                                                  &m_mutableData->second.labels),
@@ -542,7 +542,7 @@ LabelsProxy DataProxy::labels() const noexcept {
 /// Return a const proxy to all attributes of the data proxy.
 AttrsProxy DataProxy::attrs() const noexcept {
   return AttrsProxy(
-      m_mutableDataset,
+      m_mutableDataset, &name(),
       makeProxyItems<std::string>(dims(), m_mutableDataset->m_attrs), slices());
 }
 
@@ -614,7 +614,8 @@ CoordsConstProxy DatasetConstProxy::coords() const noexcept {
 /// This proxy includes only "dimension-coordinates". To access
 /// non-dimension-coordinates" see labels().
 CoordsProxy DatasetProxy::coords() const noexcept {
-  return CoordsProxy(m_mutableDataset,
+  auto *parent = slices().empty() ? m_mutableDataset : nullptr;
+  return CoordsProxy(parent, nullptr,
                      makeProxyItems<Dim>(m_mutableDataset->m_coords), slices());
 }
 
@@ -626,7 +627,8 @@ LabelsConstProxy DatasetConstProxy::labels() const noexcept {
 
 /// Return a proxy to all labels of the dataset slice.
 LabelsProxy DatasetProxy::labels() const noexcept {
-  return LabelsProxy(m_mutableDataset,
+  auto *parent = slices().empty() ? m_mutableDataset : nullptr;
+  return LabelsProxy(parent, nullptr,
                      makeProxyItems<std::string>(m_mutableDataset->m_labels),
                      slices());
 }
@@ -639,7 +641,8 @@ AttrsConstProxy DatasetConstProxy::attrs() const noexcept {
 
 /// Return a proxy to all attributes of the dataset slice.
 AttrsProxy DatasetProxy::attrs() const noexcept {
-  return AttrsProxy(m_mutableDataset,
+  auto *parent = slices().empty() ? m_mutableDataset : nullptr;
+  return AttrsProxy(parent, nullptr,
                     makeProxyItems<std::string>(m_mutableDataset->m_attrs),
                     slices());
 }

--- a/core/test/dataset_proxy_test.cpp
+++ b/core/test/dataset_proxy_test.cpp
@@ -59,9 +59,9 @@ TYPED_TEST(DatasetProxyTest, name) {
   auto &&proxy = TestFixture::access(d);
 
   for (const auto &name : {"a", "b", "c"})
-    EXPECT_EQ(d[name].name(), name);
+    EXPECT_EQ(proxy[name].name(), name);
   for (const auto &name : {"a", "b", "c"})
-    EXPECT_EQ(d.find(name)->second.name(), name);
+    EXPECT_EQ(proxy.find(name)->second.name(), name);
 }
 
 TYPED_TEST(DatasetProxyTest, find_and_contains) {

--- a/docs/user-guide/sparse-data.ipynb
+++ b/docs/user-guide/sparse-data.ipynb
@@ -146,15 +146,14 @@
    "outputs": [],
    "source": [
     "d = sc.Dataset(\n",
-    "        {'a': var,\n",
-    "         'dense': sc.Variable([Dim.X, Dim.Y], values=np.ones(shape=(4, 3)))},\n",
+    "        {'dense': sc.Variable([Dim.X, Dim.Y], values=np.ones(shape=(4, 3)))},\n",
     "         coords={\n",
     "             Dim.X: sc.Variable([Dim.X], values=np.arange(4.0)),\n",
     "             Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0))})\n",
-    "d.set_sparse_coord('a', var)\n",
+    "d['a'] = sc.DataArray(data=var, coords={Dim.Y: var})\n",
     "var[Dim.X, 0].values = np.arange(7)\n",
     "var[Dim.X, 3].values = np.ones(2)\n",
-    "d.set_sparse_coord('b', var)\n",
+    "d['b'] = sc.DataArray(coords={Dim.Y: var})\n",
     "sc.show(d)\n",
     "d"
    ]

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -174,12 +174,7 @@ void init_dataset(py::module &m) {
            [](Dataset &self, const std::string &name, const DataArray &data) {
              self.setData(name, data);
            })
-      .def("clear", &Dataset::clear)
-      .def("set_sparse_coord", &Dataset::setSparseCoord)
-      .def("set_sparse_labels", &Dataset::setSparseLabels)
-      .def("set_coord", &Dataset::setCoord)
-      .def("set_labels", &Dataset::setLabels)
-      .def("set_attr", &Dataset::setAttr);
+      .def("clear", &Dataset::clear);
 
   bind_dataset_proxy_methods(dataset);
   bind_dataset_proxy_methods(datasetProxy);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -92,6 +92,28 @@ void init_dataset(py::module &m) {
   bind_mutable_proxy<AttrsProxy, AttrsConstProxy>(m, "Attrs");
 
   py::class_<DataArray> dataArray(m, "DataArray");
+  dataArray.def(py::init([](const std::optional<Variable> &data,
+                            const std::map<Dim, Variable> &coords,
+                            const std::map<std::string, Variable> &labels) {
+                  Dataset d;
+                  const std::string name = "";
+                  if (data)
+                    d.setData(name, *data);
+                  for (const auto & [ dim, item ] : coords)
+                    if (item.dims().sparse())
+                      d.setSparseCoord(name, item);
+                    else
+                      d.setCoord(dim, item);
+                  for (const auto & [ n, item ] : labels)
+                    if (item.dims().sparse())
+                      d.setSparseLabels(name, n, item);
+                    else
+                      d.setLabels(n, item);
+                  return DataArray(d[name]);
+                }),
+                py::arg("data") = std::nullopt,
+                py::arg("coords") = std::map<Dim, Variable>{},
+                py::arg("labels") = std::map<std::string, Variable>{});
   py::class_<DataConstProxy>(m, "DataConstProxy");
   py::class_<DataProxy, DataConstProxy> dataProxy(m, "DataProxy");
   dataProxy.def_property_readonly(

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -24,21 +24,7 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
   proxy.def("__len__", &T::size)
       .def("__getitem__", &T::operator[], py::return_value_policy::move,
            py::keep_alive<0, 1>())
-      .def("__setitem__",
-           [](T &self, const typename T::key_type &key, const Variable &var) {
-             if (!self.slices().empty())
-               throw std::runtime_error(
-                   "Cannot add coord/labels/attr field to a slice.");
-             // TODO prevent if parent is a DataProxy
-             // TODO can we handle sparse? Throw?
-             // TODO how to prevent abuse of parent pointer?
-             if constexpr (std::is_same_v<T, CoordsProxy>)
-               self.parent().setCoord(key, var);
-             if constexpr (std::is_same_v<T, LabelsProxy>)
-               self.parent().setLabels(key, var);
-             if constexpr (std::is_same_v<T, AttrsProxy>)
-               self.parent().setAttr(key, var);
-           })
+      .def("__setitem__", &T::set)
       .def("__iter__",
            [](T &self) {
              return py::make_iterator(self.begin(), self.end(),

--- a/python/src/scipp/plot.py
+++ b/python/src/scipp/plot.py
@@ -209,7 +209,7 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
 
     # Create temporary Dataset
     ds = sp.Dataset()
-    ds.set_coord(dim, sp.Variable([dim], values=coords[dim].values))
+    ds.coords[dim] = sp.Variable([dim], values=coords[dim].values)
     # A dictionary to hold the DataProxy objects
     data = dict()
 

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -89,6 +89,26 @@ def test_coord_setitem_sparse():
     # Currently there is no way to set a sparse coord from a sparse variable
     # in this way, since otherwise 'a' would not exist in d.
     d['a'].coords[Dim.X] = sparse
+    assert len(d.coords) == 1
+    assert len(d['a'].coords) == 1
+    assert d['a'].coords[Dim.X] == sparse
+    assert d['a'].coords[Dim.X] != var
+    assert d['a'].coords[Dim.X] != d.coords[Dim.X]
+    # This would not work:
+    with pytest.raises(IndexError):
+        d['b'].coords[Dim.X] = sparse
+
+
+def test_create_sparse_via_DataArray():
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset(coords={Dim.X: var})
+    sparse = sc.Variable([sc.Dim.X], [sc.Dimensions.Sparse])
+    d['a'] = sc.DataArray(coords={Dim.X: sparse})
+    assert len(d.coords) == 1
+    assert len(d['a'].coords) == 1
+    assert d['a'].coords[Dim.X] == sparse
+    assert d['a'].coords[Dim.X] != var
+    assert d['a'].coords[Dim.X] != d.coords[Dim.X]
 
 
 def test_contains_coord():

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -65,11 +65,30 @@ def test_set_coord():
 
 
 def test_coord_setitem():
-    d = sc.Dataset()
-    d.coords[Dim.X] = sc.Variable(1.0)
-    assert len(d) == 0
-    assert len(d.coords) == 1
-    assert d.coords[Dim.X] == sc.Variable(1.0)
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset({'a': var}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].coords[Dim.Y] = sc.Variable(1.0)
+    with pytest.raises(RuntimeError):
+        d['a'].coords[Dim.Y] = sc.Variable(1.0)
+    d.coords[Dim.Y] = sc.Variable(1.0)
+    assert len(d) == 1
+    assert len(d.coords) == 2
+    assert d.coords[Dim.Y] == sc.Variable(1.0)
+
+
+def test_coord_setitem_sparse():
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    sparse = sc.Variable([sc.Dim.X], [sc.Dimensions.Sparse])
+    d = sc.Dataset({'a': sparse}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d.coords[Dim.X] = sparse
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].coords[Dim.X] = sparse
+    # This is a slightly weird case with sparse data before coord is set.
+    # Currently there is no way to set a sparse coord from a sparse variable
+    # in this way, since otherwise 'a' would not exist in d.
+    d['a'].coords[Dim.X] = sparse
 
 
 def test_contains_coord():
@@ -88,11 +107,27 @@ def test_set_labels():
 
 
 def test_labels_setitem():
-    d = sc.Dataset()
-    d.labels["a"] = sc.Variable(1.0)
-    assert len(d) == 0
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset({'a': var}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].labels['label'] = sc.Variable(1.0)
+    with pytest.raises(RuntimeError):
+        d['a'].labels['label'] = sc.Variable(1.0)
+    d.labels['label'] = sc.Variable(1.0)
+    assert len(d) == 1
     assert len(d.labels) == 1
-    assert d.labels["a"] == sc.Variable(1.0)
+    assert d.labels['label'] == sc.Variable(1.0)
+
+
+def test_labels_setitem_sparse():
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    sparse = sc.Variable([sc.Dim.X], [sc.Dimensions.Sparse])
+    d = sc.Dataset({'a': sparse}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d.labels['label'] = sparse
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].labels['label'] = sparse
+    d['a'].labels['label'] = sparse
 
 
 def test_contains_labels():
@@ -111,11 +146,29 @@ def test_set_attrs():
 
 
 def test_attrs_setitem():
-    d = sc.Dataset()
-    d.attrs["b"] = sc.Variable(1.0)
-    assert len(d) == 0
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    d = sc.Dataset({'a': var}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].attrs['attr'] = sc.Variable(1.0)
+    with pytest.raises(RuntimeError):
+        d['a'].attrs['attr'] = sc.Variable(1.0)
+    d.attrs['attr'] = sc.Variable(1.0)
+    assert len(d) == 1
     assert len(d.attrs) == 1
-    assert d.attrs["b"] == sc.Variable(1.0)
+    assert d.attrs['attr'] == sc.Variable(1.0)
+
+
+def test_attrs_setitem_sparse():
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    sparse = sc.Variable([sc.Dim.X], [sc.Dimensions.Sparse])
+    d = sc.Dataset({'a': sparse}, coords={Dim.X: var})
+    with pytest.raises(RuntimeError):
+        d.attrs['attr'] = sparse
+    with pytest.raises(RuntimeError):
+        d[Dim.X, 2:3].attrs['attr'] = sparse
+    # Attributes cannot be sparse
+    with pytest.raises(RuntimeError):
+        d['a'].attrs['attr'] = sparse
 
 
 def test_contains_attrs():

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -276,6 +276,7 @@ def test_chained_slicing():
 
     assert d[Dim.X, 1][Dim.Z, 5] == expected
 
+
 def test_coords_proxy_comparison_operators():
     d = sc.Dataset(
         {
@@ -326,12 +327,8 @@ def test_dataset_histogram():
 
 
 def test_dataset_merge():
-    a = sc.Dataset({
-        'd1': sc.Variable([Dim.X], values=np.array([1, 2, 3]))
-    })
-    b = sc.Dataset({
-        'd2': sc.Variable([Dim.X], values=np.array([4, 5, 6]))
-    })
+    a = sc.Dataset({'d1': sc.Variable([Dim.X], values=np.array([1, 2, 3]))})
+    b = sc.Dataset({'d2': sc.Variable([Dim.X], values=np.array([4, 5, 6]))})
     c = sc.merge(a, b)
     assert a['d1'] == c['d1']
     assert b['d2'] == c['d2']

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -254,22 +254,27 @@ def test_slice():
 
 
 def test_chained_slicing():
-    d = sc.Dataset()
-    d.set_coord(Dim.X, sc.Variable([Dim.X], values=np.arange(11.0)))
-    d.set_coord(Dim.Y, sc.Variable([Dim.Y], values=np.arange(11.0)))
-    d.set_coord(Dim.Z, sc.Variable([Dim.Z], values=np.arange(11.0)))
-    d["a"] = sc.Variable([Dim.Z, Dim.Y, Dim.X],
-                         values=np.arange(1000.0).reshape(10, 10, 10))
-    d["b"] = sc.Variable([Dim.X, Dim.Z],
-                         values=np.arange(0.0, 10.0, 0.1).reshape(10, 10))
+    d = sc.Dataset(
+        {
+            'a':
+            sc.Variable([Dim.Z, Dim.Y, Dim.X],
+                        values=np.arange(1000.0).reshape(10, 10, 10)),
+            'b':
+            sc.Variable([Dim.X, Dim.Z],
+                        values=np.arange(0.0, 10.0, 0.1).reshape(10, 10))
+        },
+        coords={
+            Dim.X: sc.Variable([Dim.X], values=np.arange(11.0)),
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(11.0)),
+            Dim.Z: sc.Variable([Dim.Z], values=np.arange(11.0))
+        })
 
     expected = sc.Dataset()
-    expected.set_coord(Dim.Y, sc.Variable([Dim.Y], values=np.arange(11.0)))
+    expected.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(11.0))
     expected["a"] = sc.Variable([Dim.Y], values=np.arange(501.0, 600.0, 10.0))
     expected["b"] = sc.Variable(1.5)
 
     assert d[Dim.X, 1][Dim.Z, 5] == expected
-
 
 def test_coords_proxy_comparison_operators():
     d = sc.Dataset(

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -64,6 +64,14 @@ def test_set_coord():
     assert d.coords[Dim.X] == sc.Variable(1.0)
 
 
+def test_coord_setitem():
+    d = sc.Dataset()
+    d.coords[Dim.X] = sc.Variable(1.0)
+    assert len(d) == 0
+    assert len(d.coords) == 1
+    assert d.coords[Dim.X] == sc.Variable(1.0)
+
+
 def test_contains_coord():
     d = sc.Dataset()
     assert Dim.X not in d.coords
@@ -79,6 +87,14 @@ def test_set_labels():
     assert d.labels["a"] == sc.Variable(1.0)
 
 
+def test_labels_setitem():
+    d = sc.Dataset()
+    d.labels["a"] = sc.Variable(1.0)
+    assert len(d) == 0
+    assert len(d.labels) == 1
+    assert d.labels["a"] == sc.Variable(1.0)
+
+
 def test_contains_labels():
     d = sc.Dataset()
     assert "a" not in d.labels
@@ -89,6 +105,14 @@ def test_contains_labels():
 def test_set_attrs():
     d = sc.Dataset()
     d.set_attr("b", sc.Variable(1.0))
+    assert len(d) == 0
+    assert len(d.attrs) == 1
+    assert d.attrs["b"] == sc.Variable(1.0)
+
+
+def test_attrs_setitem():
+    d = sc.Dataset()
+    d.attrs["b"] = sc.Variable(1.0)
     assert len(d) == 0
     assert len(d.attrs) == 1
     assert d.attrs["b"] == sc.Variable(1.0)

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -29,9 +29,7 @@ def make_2d_dataset(variances=False):
     c = M/2.0
     r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2)
     a = np.sin(r)
-    d1 = sp.Dataset()
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X], values=xx, unit=sp.units.m))
-    d1.set_coord(sp.Dim.Y, sp.Variable([sp.Dim.Y], values=yy, unit=sp.units.m))
+    d1 = sp.Dataset(coords={sp.Dim.X : sp.Variable([sp.Dim.X], values=xx, unit=sp.units.m), sp.Dim.Y : sp.Variable([sp.Dim.Y], values=yy, unit=sp.units.m)})
     params = {"values": a}
     if variances:
         params["variances"] = np.random.rand(M, N) + (x == y)
@@ -43,8 +41,8 @@ def make_2d_dataset(variances=False):
 def test_plot_1d():
     d1 = sp.Dataset()
     N = 100
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
@@ -53,8 +51,8 @@ def test_plot_1d():
 def test_plot_1d_with_variances():
     d1 = sp.Dataset()
     N = 100
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                variances=np.random.rand(N),
                                unit=sp.units.counts)
@@ -64,8 +62,8 @@ def test_plot_1d_with_variances():
 def test_plot_1d_bin_edges():
     d1 = sp.Dataset()
     N = 100
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
@@ -74,8 +72,8 @@ def test_plot_1d_bin_edges():
 def test_plot_1d_bin_edges_with_variances():
     d1 = sp.Dataset()
     N = 100
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                variances=np.random.rand(N),
                                unit=sp.units.counts)
@@ -85,8 +83,8 @@ def test_plot_1d_bin_edges_with_variances():
 def test_plot_1d_two_entries():
     d1 = sp.Dataset()
     N = 100
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                unit=sp.units.counts)
     d1["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N),
@@ -97,13 +95,13 @@ def test_plot_1d_two_entries():
 def test_plot_1d_list_of_datasets():
     N = 100
     d1 = sp.Dataset()
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
     d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N))
     d1["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N))
     d2 = sp.Dataset()
-    d2.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us))
+    d2.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
     d2["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
                                variances=np.random.rand(N))
     d2["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N),
@@ -147,10 +145,10 @@ def test_plot_waterfall():
     N = 100
     M = 5
     d1 = sp.Dataset()
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us))
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X],
-                 values=np.arange(M).astype(np.float64), unit=sp.units.m))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
+    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
+                 values=np.arange(M).astype(np.float64), unit=sp.units.m)
     d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
                                values=10.0*np.random.rand(M, N),
                                variances=np.random.rand(M, N))
@@ -161,10 +159,10 @@ def test_plot_collapse():
     N = 100
     M = 5
     d1 = sp.Dataset()
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us))
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X],
-                 values=np.arange(M).astype(np.float64), unit=sp.units.m))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
+    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
+                 values=np.arange(M).astype(np.float64), unit=sp.units.m)
     d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
                                values=10.0*np.random.rand(M, N),
                                variances=np.random.rand(M, N))
@@ -176,12 +174,12 @@ def test_plot_sliceviewer():
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64)))
-    d1.set_coord(sp.Dim.Y, sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64)))
-    d1.set_coord(sp.Dim.Z, sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64)))
+    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
+                 np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
+                 np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
+                 np.arange(n3).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
                                n3, n2, n1).astype(np.float64))
@@ -194,14 +192,14 @@ def test_plot_sliceviewer_with_two_sliders():
     n2 = 30
     n3 = 40
     n4 = 50
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64)))
-    d1.set_coord(sp.Dim.Y, sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64)))
-    d1.set_coord(sp.Dim.Z, sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64)))
-    d1.set_coord(sp.Dim.Tof, sp.Variable([sp.Dim.Tof],
-                 np.arange(n4).astype(np.float64)))
+    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
+                 np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
+                 np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
+                 np.arange(n3).astype(np.float64))
+    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
+                 np.arange(n4).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Tof, sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3 * n4).reshape(
                                n4, n3, n2, n1).astype(np.float64))
@@ -213,12 +211,12 @@ def test_plot_sliceviewer_with_axes():
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.set_coord(sp.Dim.X, sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64)))
-    d1.set_coord(sp.Dim.Y, sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64)))
-    d1.set_coord(sp.Dim.Z, sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64)))
+    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
+                 np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
+                 np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
+                 np.arange(n3).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
                                n3, n2, n1).astype(np.float64))

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -25,15 +25,20 @@ def make_2d_dataset(variances=False):
     xx = np.arange(N, dtype=np.float64)
     yy = np.arange(M, dtype=np.float64)
     x, y = np.meshgrid(xx, yy)
-    b = N/20.0
-    c = M/2.0
-    r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2)
+    b = N / 20.0
+    c = M / 2.0
+    r = np.sqrt(((x - c) / b)**2 + ((y - c) / b)**2)
     a = np.sin(r)
-    d1 = sp.Dataset(coords={sp.Dim.X : sp.Variable([sp.Dim.X], values=xx, unit=sp.units.m), sp.Dim.Y : sp.Variable([sp.Dim.Y], values=yy, unit=sp.units.m)})
+    d1 = sp.Dataset(
+        coords={
+            sp.Dim.X: sp.Variable([sp.Dim.X], values=xx, unit=sp.units.m),
+            sp.Dim.Y: sp.Variable([sp.Dim.Y], values=yy, unit=sp.units.m)
+        })
     params = {"values": a}
     if variances:
         params["variances"] = np.random.rand(M, N) + (x == y)
-    d1["Sample"] = sp.Variable([sp.Dim.Y, sp.Dim.X], unit=sp.units.counts,
+    d1["Sample"] = sp.Variable([sp.Dim.Y, sp.Dim.X],
+                               unit=sp.units.counts,
                                **params)
     return d1
 
@@ -41,9 +46,11 @@ def make_2d_dataset(variances=False):
 def test_plot_1d():
     d1 = sp.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N).astype(np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
 
@@ -51,9 +58,11 @@ def test_plot_1d():
 def test_plot_1d_with_variances():
     d1 = sp.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N).astype(np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
@@ -62,9 +71,12 @@ def test_plot_1d_with_variances():
 def test_plot_1d_bin_edges():
     d1 = sp.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N + 1).astype(
+                                            np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
 
@@ -72,9 +84,12 @@ def test_plot_1d_bin_edges():
 def test_plot_1d_bin_edges_with_variances():
     d1 = sp.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N + 1).astype(
+                                            np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N),
                                unit=sp.units.counts)
     do_plot(d1)
@@ -83,11 +98,14 @@ def test_plot_1d_bin_edges_with_variances():
 def test_plot_1d_two_entries():
     d1 = sp.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N).astype(np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                unit=sp.units.counts)
-    d1["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N),
+    d1["Background"] = sp.Variable([sp.Dim.Tof],
+                                   values=2.0 * np.random.rand(N),
                                    unit=sp.units.counts)
     do_plot(d1)
 
@@ -95,16 +113,21 @@ def test_plot_1d_two_entries():
 def test_plot_1d_list_of_datasets():
     N = 100
     d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N))
-    d1["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N))
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N).astype(np.float64),
+                                        unit=sp.units.us)
+    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0 * np.random.rand(N))
+    d1["Background"] = sp.Variable([sp.Dim.Tof],
+                                   values=2.0 * np.random.rand(N))
     d2 = sp.Dataset()
-    d2.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N).astype(np.float64), unit=sp.units.us)
-    d2["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d2.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N).astype(np.float64),
+                                        unit=sp.units.us)
+    d2["Sample"] = sp.Variable([sp.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N))
-    d2["Background"] = sp.Variable([sp.Dim.Tof], values=2.0*np.random.rand(N),
+    d2["Background"] = sp.Variable([sp.Dim.Tof],
+                                   values=2.0 * np.random.rand(N),
                                    variances=np.random.rand(N))
     do_plot([d1, d2])
 
@@ -115,12 +138,12 @@ def test_plot_2d_image():
 
 
 @pytest.mark.skip(reason="This test fails from time to time because objects "
-                         "are running out of scope, so we disable it for now. "
-                         "More specifically, in plot.py L306:\n"
-                         "  if (zlabs[0] == xlabs[0]) and "
-                         "(zlabs[1] == ylabs[0]):\n"
-                         "xlabs and ylabs sometimes contains the same thing, "
-                         "when they should in fact be different")
+                  "are running out of scope, so we disable it for now. "
+                  "More specifically, in plot.py L306:\n"
+                  "  if (zlabs[0] == xlabs[0]) and "
+                  "(zlabs[1] == ylabs[0]):\n"
+                  "xlabs and ylabs sometimes contains the same thing, "
+                  "when they should in fact be different")
 def test_plot_2d_image_with_axes():
     d1 = make_2d_dataset()
     do_plot(d1, axes=[sp.Dim.X, sp.Dim.Y])
@@ -145,12 +168,15 @@ def test_plot_waterfall():
     N = 100
     M = 5
     d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
-    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
-                 values=np.arange(M).astype(np.float64), unit=sp.units.m)
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N + 1).astype(
+                                            np.float64),
+                                        unit=sp.units.us)
+    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                      values=np.arange(M).astype(np.float64),
+                                      unit=sp.units.m)
     d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
-                               values=10.0*np.random.rand(M, N),
+                               values=10.0 * np.random.rand(M, N),
                                variances=np.random.rand(M, N))
     do_plot(d1, waterfall=sp.Dim.X)
 
@@ -159,12 +185,15 @@ def test_plot_collapse():
     N = 100
     M = 5
     d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 values=np.arange(N+1).astype(np.float64), unit=sp.units.us)
-    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
-                 values=np.arange(M).astype(np.float64), unit=sp.units.m)
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        values=np.arange(N + 1).astype(
+                                            np.float64),
+                                        unit=sp.units.us)
+    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                      values=np.arange(M).astype(np.float64),
+                                      unit=sp.units.m)
     d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
-                               values=10.0*np.random.rand(M, N),
+                               values=10.0 * np.random.rand(M, N),
                                variances=np.random.rand(M, N))
     do_plot(d1, collapse=sp.Dim.Tof)
 
@@ -174,15 +203,15 @@ def test_plot_sliceviewer():
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64))
+    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                      np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+                                      np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+                                      np.arange(n3).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
-                               n3, n2, n1).astype(np.float64))
+                                   n3, n2, n1).astype(np.float64))
     do_plot(d1)
 
 
@@ -192,17 +221,17 @@ def test_plot_sliceviewer_with_two_sliders():
     n2 = 30
     n3 = 40
     n4 = 50
-    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64))
-    d1.coords[sp.Dim.Tof]= sp.Variable([sp.Dim.Tof],
-                 np.arange(n4).astype(np.float64))
+    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                      np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+                                      np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+                                      np.arange(n3).astype(np.float64))
+    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+                                        np.arange(n4).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Tof, sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3 * n4).reshape(
-                               n4, n3, n2, n1).astype(np.float64))
+                                   n4, n3, n2, n1).astype(np.float64))
     do_plot(d1)
 
 
@@ -211,13 +240,13 @@ def test_plot_sliceviewer_with_axes():
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.coords[sp.Dim.X]= sp.Variable([sp.Dim.X],
-                 np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y]= sp.Variable([sp.Dim.Y],
-                 np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z]= sp.Variable([sp.Dim.Z],
-                 np.arange(n3).astype(np.float64))
+    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                      np.arange(n1).astype(np.float64))
+    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+                                      np.arange(n2).astype(np.float64))
+    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+                                      np.arange(n3).astype(np.float64))
     d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
-                               n3, n2, n1).astype(np.float64))
+                                   n3, n2, n1).astype(np.float64))
     do_plot(d1, axes=[sp.Dim.Y, sp.Dim.X, sp.Dim.Z])

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -2,37 +2,36 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Neil Vaytet
-import scipp as sp
 import numpy as np
+import scipp as sp
+from scipp import Dim
 
 
 def test_dataset_with_1d_data():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Tof,
-                sp.Variable([sp.Dim.Tof],
-                            values=np.arange(N).astype(np.float64)))
-    d['Counts'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N))
+    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64))
+    d['Counts'] = sp.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
     sp.table(d)
 
 
 def test_dataset_with_1d_data_with_bin_edges():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Row,
-                sp.Variable([sp.Dim.Row],
-                            values=np.arange(N+1).astype(np.float64)))
-    d['Counts'] = sp.Variable([sp.Dim.Row], values=10.0*np.random.rand(N))
+    d.coords[Dim.Row] = sp.Variable([Dim.Row],
+                                    values=np.arange(N + 1).astype(np.float64))
+    d['Counts'] = sp.Variable([Dim.Row], values=10.0 * np.random.rand(N))
     sp.table(d)
 
 
 def test_dataset_with_1d_data_with_variances():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Tof,
-                sp.Variable([sp.Dim.Tof],
-                            values=np.arange(N).astype(np.float64)))
-    d['Counts'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64))
+    d['Counts'] = sp.Variable([Dim.Tof],
+                              values=10.0 * np.random.rand(N),
                               variances=np.random.rand(N))
     sp.table(d)
 
@@ -40,11 +39,11 @@ def test_dataset_with_1d_data_with_variances():
 def test_dataset_with_1d_data_with_coord_variances():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Tof,
-                sp.Variable([sp.Dim.Tof],
-                            values=np.arange(N).astype(np.float64),
-                            variances=0.1*np.random.rand(N)))
-    d['Counts'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
+    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64),
+                                    variances=0.1 * np.random.rand(N))
+    d['Counts'] = sp.Variable([Dim.Tof],
+                              values=10.0 * np.random.rand(N),
                               variances=np.random.rand(N))
     sp.table(d)
 
@@ -52,13 +51,14 @@ def test_dataset_with_1d_data_with_coord_variances():
 def test_dataset_with_1d_data_with_units():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Tof,
-                sp.Variable([sp.Dim.Tof],
-                            values=np.arange(N).astype(np.float64),
-                            unit=sp.units.us,
-                            variances=0.1*np.random.rand(N)))
-    d['Sample'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
-                              unit=sp.units.m, variances=np.random.rand(N))
+    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64),
+                                    unit=sp.units.us,
+                                    variances=0.1 * np.random.rand(N))
+    d['Sample'] = sp.Variable([Dim.Tof],
+                              values=10.0 * np.random.rand(N),
+                              unit=sp.units.m,
+                              variances=np.random.rand(N))
     sp.table(d)
 
 
@@ -71,20 +71,23 @@ def test_dataset_with_0d_data():
 def test_dataset_with_everything():
     d = sp.Dataset()
     N = 10
-    d.set_coord(sp.Dim.Tof,
-                sp.Variable([sp.Dim.Tof],
-                            values=np.arange(N).astype(np.float64),
-                            unit=sp.units.us,
-                            variances=0.1*np.random.rand(N)))
-    d['Counts'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N))
-    d['Sample'] = sp.Variable([sp.Dim.Tof], values=10.0*np.random.rand(N),
-                              unit=sp.units.m, variances=np.random.rand(N))
+    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64),
+                                    unit=sp.units.us,
+                                    variances=0.1 * np.random.rand(N))
+    d['Counts'] = sp.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
+    d['Sample'] = sp.Variable([Dim.Tof],
+                              values=10.0 * np.random.rand(N),
+                              unit=sp.units.m,
+                              variances=np.random.rand(N))
     d['Scalar'] = sp.Variable(1.2)
     sp.table(d)
 
 
 def test_variable():
     N = 10
-    v = sp.Variable([sp.Dim.Tof], values=np.arange(N).astype(np.float64),
-                    unit=sp.units.us, variances=0.1*np.random.rand(N))
+    v = sp.Variable([Dim.Tof],
+                    values=np.arange(N).astype(np.float64),
+                    unit=sp.units.us,
+                    variances=0.1 * np.random.rand(N))
     sp.table(v)


### PR DESCRIPTION
Fixes #397.

`set_coord` and similar setters that are straining the users/developers memory are removed, in favor of `__setitem__` for the respective proxies. This also removes weird inconsistencies in the arguments when setting sparse coords or labels.

The only case requiring special handling is inserting a sparse coord for an item that does not exist. This can now be done via `DataArray`, so `set_sparse_coord` could be removed as well.

Similar `__delitem__` can be provided in a follow-up PR.