### PR TITLE
Various cleanup/improvements around Dataset

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1144,13 +1144,9 @@ Dataset histogram(const Dataset &dataset, const Dim &dim) {
   return histogram(dataset, bins);
 }
 
-template <class A, class B> Dataset merge_datasets(const A &a, const B &b) {
+Dataset merge(const DatasetConstProxy &a, const DatasetConstProxy &b) {
   return Dataset(union_(a, b), union_(a.coords(), b.coords()),
                  union_(a.labels(), b.labels()), union_(a.attrs(), b.attrs()));
-}
-
-Dataset merge(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
-  return merge_datasets(lhs, rhs);
 }
 
 } // namespace scipp::core

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -63,19 +63,6 @@ auto makeProxyItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
 Dataset::Dataset(const DatasetConstProxy &proxy)
     : Dataset(proxy, proxy.coords(), proxy.labels(), proxy.attrs()) {}
 
-template <class DataMap, class CoordMap, class LabelsMap, class AttrMap>
-Dataset::Dataset(DataMap data, CoordMap coords, LabelsMap labels,
-                 AttrMap attrs) {
-  for (auto && [ dim, coord ] : coords)
-    setCoord(dim, std::move(coord));
-  for (auto && [ name, labs ] : labels)
-    setLabels(std::string(name), std::move(labs));
-  for (auto && [ name, attr ] : attrs)
-    setAttr(std::string(name), std::move(attr));
-  for (auto && [ name, item ] : data)
-    setData(std::string(name), std::move(item));
-}
-
 Dataset::operator DatasetConstProxy() const { return DatasetConstProxy(*this); }
 Dataset::operator DatasetProxy() { return DatasetProxy(*this); }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -268,7 +268,7 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
       setSparseCoord(name, coord);
     } else {
       if (const auto it = m_coords.find(dim); it != m_coords.end())
-        expect::variablesMatch(coord, it->second);
+        expect::equals(coord, it->second);
       else
         setCoord(dim, coord);
     }
@@ -278,14 +278,14 @@ void Dataset::setData(const std::string &name, const DataConstProxy &data) {
       setSparseLabels(name, std::string(nm), labs);
     } else {
       if (const auto it = m_labels.find(std::string(nm)); it != m_labels.end())
-        expect::variablesMatch(labs, it->second);
+        expect::equals(labs, it->second);
       else
         setLabels(std::string(nm), labs);
     }
   }
   for (const auto & [ nm, attr ] : data.attrs()) {
     if (const auto it = m_attrs.find(std::string(nm)); it != m_attrs.end())
-      expect::variablesMatch(attr, it->second);
+      expect::equals(attr, it->second);
     else
       setAttr(std::string(nm), attr);
   }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -60,15 +60,20 @@ auto makeProxyItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
   return items;
 }
 
-Dataset::Dataset(const DatasetConstProxy &proxy) {
-  for (const auto & [ dim, coord ] : proxy.coords())
-    setCoord(dim, coord);
-  for (const auto & [ name, labels ] : proxy.labels())
-    setLabels(std::string(name), labels);
-  for (const auto & [ name, attr ] : proxy.attrs())
-    setAttr(std::string(name), attr);
-  for (const auto & [ name, item ] : proxy)
-    setData(std::string(name), item);
+Dataset::Dataset(const DatasetConstProxy &proxy)
+    : Dataset(proxy, proxy.coords(), proxy.labels(), proxy.attrs()) {}
+
+template <class DataMap, class CoordMap, class LabelsMap, class AttrMap>
+Dataset::Dataset(DataMap data, CoordMap coords, LabelsMap labels,
+                 AttrMap attrs) {
+  for (auto && [ dim, coord ] : coords)
+    setCoord(dim, std::move(coord));
+  for (auto && [ name, labs ] : labels)
+    setLabels(std::string(name), std::move(labs));
+  for (auto && [ name, attr ] : attrs)
+    setAttr(std::string(name), std::move(attr));
+  for (auto && [ name, item ] : data)
+    setData(std::string(name), std::move(item));
 }
 
 Dataset::operator DatasetConstProxy() const { return DatasetConstProxy(*this); }
@@ -1155,66 +1160,9 @@ Dataset histogram(const Dataset &dataset, const Dim &dim) {
   return histogram(dataset, bins);
 }
 
-template <class A, class B>
-void merge_validate_proxies(const A &lhs, const B &rhs) {
-  for (const auto & [ k, v ] : lhs) {
-    /* Throw if an item is present in both proxies but they are not equal */
-    if (rhs.contains(k) && rhs[k] != v) {
-      throw std::runtime_error("Both datasets contain an item with the same "
-                               "key that does not match.");
-    }
-  }
-}
-
-template <class T> void merge_copy_data(Dataset &dest, const T &src) {
-  for (const auto & [ name, data ] : src) {
-    if (!dest.contains(name)) {
-      dest.setData(std::string(name), data);
-    }
-  }
-}
-
-template <class T> void merge_copy_coords(Dataset &dest, const T &src) {
-  for (const auto & [ dim, coord ] : src.coords()) {
-    if (!dest.coords().contains(dim)) {
-      dest.setCoord(dim, coord);
-    }
-  }
-}
-
-template <class T> void merge_copy_labels(Dataset &dest, const T &src) {
-  for (const auto & [ name, label ] : src.labels()) {
-    if (!dest.labels().contains(name)) {
-      dest.setLabels(std::string(name), label);
-    }
-  }
-}
-
-template <class T> void merge_copy_attrs(Dataset &dest, const T &src) {
-  for (const auto & [ name, attr ] : src.attrs()) {
-    if (!dest.attrs().contains(name)) {
-      dest.setAttr(std::string(name), attr);
-    }
-  }
-}
-
-template <class A, class B> Dataset merge_datasets(const A &lhs, const B &rhs) {
-  merge_validate_proxies(lhs.coords(), rhs.coords());
-  merge_validate_proxies(lhs.labels(), rhs.labels());
-  merge_validate_proxies(lhs.attrs(), rhs.attrs());
-  merge_validate_proxies(lhs, rhs);
-
-  Dataset d;
-  merge_copy_data(d, lhs);
-  merge_copy_data(d, rhs);
-  merge_copy_coords(d, lhs);
-  merge_copy_coords(d, rhs);
-  merge_copy_labels(d, lhs);
-  merge_copy_labels(d, rhs);
-  merge_copy_attrs(d, lhs);
-  merge_copy_attrs(d, rhs);
-
-  return d;
+template <class A, class B> Dataset merge_datasets(const A &a, const B &b) {
+  return Dataset(union_(a, b), union_(a.coords(), b.coords()),
+                 union_(a.labels(), b.labels()), union_(a.attrs(), b.attrs()));
 }
 
 Dataset merge(const Dataset &lhs, const Dataset &rhs) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -63,9 +63,6 @@ auto makeProxyItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
 Dataset::Dataset(const DatasetConstProxy &proxy)
     : Dataset(proxy, proxy.coords(), proxy.labels(), proxy.attrs()) {}
 
-Dataset::operator DatasetConstProxy() const { return DatasetConstProxy(*this); }
-Dataset::operator DatasetProxy() { return DatasetProxy(*this); }
-
 /// Removes all data items from the Dataset.
 ///
 /// Coordinates, labels and attributes are not modified.
@@ -1152,15 +1149,6 @@ template <class A, class B> Dataset merge_datasets(const A &a, const B &b) {
                  union_(a.labels(), b.labels()), union_(a.attrs(), b.attrs()));
 }
 
-Dataset merge(const Dataset &lhs, const Dataset &rhs) {
-  return merge_datasets(lhs, rhs);
-}
-Dataset merge(const DatasetConstProxy &lhs, const Dataset &rhs) {
-  return merge_datasets(lhs, rhs);
-}
-Dataset merge(const Dataset &lhs, const DatasetConstProxy &rhs) {
-  return merge_datasets(lhs, rhs);
-}
 Dataset merge(const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
   return merge_datasets(lhs, rhs);
 }

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -233,11 +233,6 @@ std::string to_string(const DatasetConstProxy &dataset) {
 
 namespace except {
 
-DimensionMismatchError::DimensionMismatchError(const Dimensions &expected,
-                                               const Dimensions &actual)
-    : DimensionError("Expected dimensions " + to_string(expected) + ", got " +
-                     to_string(actual) + ".") {}
-
 DimensionNotFoundError::DimensionNotFoundError(const Dimensions &expected,
                                                const Dim actual)
     : DimensionError("Expected dimension to be a non-sparse dimension of " +
@@ -251,10 +246,6 @@ DimensionLengthError::DimensionLengthError(const Dimensions &expected,
                      ", got " + to_string(actual) +
                      " with mismatching length " + std::to_string(length) +
                      ".") {}
-
-UnitMismatchError::UnitMismatchError(const units::Unit &a, const units::Unit &b)
-    : UnitError("Expected " + to_string(a) + " to be equal to " + to_string(b) +
-                ".") {}
 
 } // namespace except
 

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -252,26 +252,6 @@ DimensionLengthError::DimensionLengthError(const Dimensions &expected,
                      " with mismatching length " + std::to_string(length) +
                      ".") {}
 
-DatasetError::DatasetError(const Dataset &dataset, const std::string &message)
-    : std::runtime_error(to_string(dataset) + message) {}
-DatasetError::DatasetError(const DatasetConstProxy &dataset,
-                           const std::string &message)
-    : std::runtime_error(to_string(dataset) + message) {}
-
-VariableError::VariableError(const Variable &variable,
-                             const std::string &message)
-    : std::runtime_error(to_string(variable) + message) {}
-VariableError::VariableError(const VariableConstProxy &variable,
-                             const std::string &message)
-    : std::runtime_error(to_string(variable) + message) {}
-
-DataArrayError::DataArrayError(const DataArray &data,
-                               const std::string &message)
-    : std::runtime_error(to_string(data) + message) {}
-DataArrayError::DataArrayError(const DataConstProxy &data,
-                               const std::string &message)
-    : std::runtime_error(to_string(data) + message) {}
-
 UnitMismatchError::UnitMismatchError(const units::Unit &a, const units::Unit &b)
     : UnitError("Expected " + to_string(a) + " to be equal to " + to_string(b) +
                 ".") {}

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -256,16 +256,6 @@ void dimensionMatches(const Dimensions &dims, const Dim dim,
     throw except::DimensionLengthError(dims, dim, length);
 }
 
-void equals(const units::Unit &a, const units::Unit &b) {
-  if (!(a == b))
-    throw except::UnitMismatchError(a, b);
-}
-
-void equals(const Dimensions &a, const Dimensions &b) {
-  if (!(a == b))
-    throw except::DimensionMismatchError(a, b);
-}
-
 void validSlice(const Dimensions &dims, const Slice &slice) {
   if (!dims.contains(slice.dim) || slice.begin < 0 ||
       slice.begin >= std::min(slice.end >= 0 ? slice.end + 1 : dims[slice.dim],

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -159,6 +159,10 @@ std::string to_string(const VariableConstProxy &variable) {
   return format_variable("<scipp.VariableProxy>", variable);
 }
 
+std::string to_string(const DataArray &data) {
+  return to_string(DataConstProxy(data));
+}
+
 std::string to_string(const DataConstProxy &data) {
   return format_data_proxy("<scipp.DataProxy>", data);
 }
@@ -260,6 +264,13 @@ VariableError::VariableError(const Variable &variable,
 VariableError::VariableError(const VariableConstProxy &variable,
                              const std::string &message)
     : std::runtime_error(to_string(variable) + message) {}
+
+DataArrayError::DataArrayError(const DataArray &data,
+                               const std::string &message)
+    : std::runtime_error(to_string(data) + message) {}
+DataArrayError::DataArrayError(const DataConstProxy &data,
+                               const std::string &message)
+    : std::runtime_error(to_string(data) + message) {}
 
 UnitMismatchError::UnitMismatchError(const units::Unit &a, const units::Unit &b)
     : UnitError("Expected " + to_string(a) + " to be equal to " + to_string(b) +

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -239,8 +239,18 @@ public:
 
   Dataset() = default;
   explicit Dataset(const DatasetConstProxy &proxy);
+
   template <class DataMap, class CoordMap, class LabelsMap, class AttrMap>
-  Dataset(DataMap data, CoordMap coords, LabelsMap labels, AttrMap attrs);
+  Dataset(DataMap data, CoordMap coords, LabelsMap labels, AttrMap attrs) {
+    for (auto && [ dim, coord ] : coords)
+      setCoord(dim, std::move(coord));
+    for (auto && [ name, labs ] : labels)
+      setLabels(std::string(name), std::move(labs));
+    for (auto && [ name, attr ] : attrs)
+      setAttr(std::string(name), std::move(attr));
+    for (auto && [ name, item ] : data)
+      setData(std::string(name), std::move(item));
+  }
 
   operator DatasetConstProxy() const;
   operator DatasetProxy();

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -233,10 +233,14 @@ class DatasetProxy;
 /// Collection of data arrays.
 class SCIPP_CORE_EXPORT Dataset {
 public:
+  using key_type = std::string;
+  using mapped_type = DataArray;
   using value_type = std::pair<const std::string &, DataConstProxy>;
 
   Dataset() = default;
   explicit Dataset(const DatasetConstProxy &proxy);
+  template <class DataMap, class CoordMap, class LabelsMap, class AttrMap>
+  Dataset(DataMap data, CoordMap coords, LabelsMap labels, AttrMap attrs);
 
   operator DatasetConstProxy() const;
   operator DatasetProxy();
@@ -377,6 +381,7 @@ private:
 
 public:
   using key_type = Key;
+  using mapped_type = Variable;
 
   ConstProxy(
       std::unordered_map<Key, std::pair<const Variable *, Variable *>> &&items,
@@ -576,19 +581,16 @@ public:
   }
 };
 
-template <class Id, class Key>
-auto union_(const ConstProxy<Id, Key> &a, const ConstProxy<Id, Key> &b) {
-  std::map<std::conditional_t<std::is_same_v<Key, Dim>, Dim, std::string>,
-           Variable>
-      out;
+template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
+  std::map<typename T1::key_type, typename T1::mapped_type> out;
 
   for (const auto & [ key, item ] : a)
-    out[key] = item;
+    out.emplace(key, item);
   for (const auto & [ key, item ] : b) {
     if (const auto it = a.find(key); it != a.end())
       expect::variablesMatch(item, it->second);
     else
-      out[key] = item;
+      out.emplace(key, item);
   }
   return out;
 }
@@ -598,6 +600,9 @@ class SCIPP_CORE_EXPORT DatasetConstProxy {
   explicit DatasetConstProxy() : m_dataset(nullptr) {}
 
 public:
+  using key_type = std::string;
+  using mapped_type = DataArray;
+
   explicit DatasetConstProxy(const Dataset &dataset) : m_dataset(&dataset) {
     for (const auto &item : dataset.m_data)
       m_indices.emplace_back(item.first);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -252,9 +252,6 @@ public:
       setData(std::string(name), std::move(item));
   }
 
-  operator DatasetConstProxy() const;
-  operator DatasetProxy();
-
   /// Return the number of data items in the dataset.
   ///
   /// This does not include coordinates or attributes, but only all named
@@ -613,7 +610,7 @@ public:
   using key_type = std::string;
   using mapped_type = DataArray;
 
-  explicit DatasetConstProxy(const Dataset &dataset) : m_dataset(&dataset) {
+  DatasetConstProxy(const Dataset &dataset) : m_dataset(&dataset) {
     for (const auto &item : dataset.m_data)
       m_indices.emplace_back(item.first);
   }
@@ -712,7 +709,7 @@ private:
       : DatasetConstProxy(std::move(base)), m_mutableDataset(dataset) {}
 
 public:
-  explicit DatasetProxy(Dataset &dataset)
+  DatasetProxy(Dataset &dataset)
       : DatasetConstProxy(dataset), m_mutableDataset(&dataset) {}
 
   CoordsProxy coords() const noexcept;
@@ -924,11 +921,6 @@ SCIPP_CORE_EXPORT Dataset histogram(const Dataset &dataset,
                                     const Variable &bins);
 SCIPP_CORE_EXPORT Dataset histogram(const Dataset &dataset, const Dim &dim);
 
-SCIPP_CORE_EXPORT Dataset merge(const Dataset &lhs, const Dataset &rhs);
-SCIPP_CORE_EXPORT Dataset merge(const DatasetConstProxy &lhs,
-                                const Dataset &rhs);
-SCIPP_CORE_EXPORT Dataset merge(const Dataset &lhs,
-                                const DatasetConstProxy &rhs);
 SCIPP_CORE_EXPORT Dataset merge(const DatasetConstProxy &lhs,
                                 const DatasetConstProxy &rhs);
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -921,8 +921,8 @@ SCIPP_CORE_EXPORT Dataset histogram(const Dataset &dataset,
                                     const Variable &bins);
 SCIPP_CORE_EXPORT Dataset histogram(const Dataset &dataset, const Dim &dim);
 
-SCIPP_CORE_EXPORT Dataset merge(const DatasetConstProxy &lhs,
-                                const DatasetConstProxy &rhs);
+SCIPP_CORE_EXPORT Dataset merge(const DatasetConstProxy &a,
+                                const DatasetConstProxy &b);
 
 } // namespace scipp::core
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -595,7 +595,7 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
     out.emplace(key, item);
   for (const auto & [ key, item ] : b) {
     if (const auto it = a.find(key); it != a.end())
-      expect::variablesMatch(item, it->second);
+      expect::equals(item, it->second);
     else
       out.emplace(key, item);
   }

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -75,9 +75,18 @@ struct SCIPP_CORE_EXPORT TypeError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-struct SCIPP_CORE_EXPORT DimensionError : public std::runtime_error {
+template <class T> struct Error : public std::runtime_error {
   using std::runtime_error::runtime_error;
+  template <class T2>
+  Error(const T2 &object, const std::string &message)
+      : std::runtime_error(to_string(object) + message) {}
 };
+
+using DataArrayError = Error<DataArray>;
+using DatasetError = Error<Dataset>;
+using DimensionError = Error<Dimensions>;
+using UnitError = Error<units::Unit>;
+using VariableError = Error<Variable>;
 
 struct SCIPP_CORE_EXPORT DimensionMismatchError : public DimensionError {
   DimensionMismatchError(const Dimensions &expected, const Dimensions &actual);
@@ -97,35 +106,16 @@ struct SCIPP_CORE_EXPORT SparseDimensionError : public DimensionError {
       : DimensionError("Unsupported operation for sparse dimensions.") {}
 };
 
-struct SCIPP_CORE_EXPORT DatasetError : public std::runtime_error {
-  DatasetError(const Dataset &dataset, const std::string &message);
-  DatasetError(const DatasetConstProxy &dataset, const std::string &message);
-};
-
-struct SCIPP_CORE_EXPORT VariableError : public std::runtime_error {
-  VariableError(const Variable &variable, const std::string &message);
-  VariableError(const VariableConstProxy &variable, const std::string &message);
-};
-
 struct SCIPP_CORE_EXPORT VariableMismatchError : public VariableError {
   template <class A, class B>
   VariableMismatchError(const A &a, const B &b)
       : VariableError(a, "expected to match\n" + to_string(b)) {}
 };
 
-struct SCIPP_CORE_EXPORT DataArrayError : public std::runtime_error {
-  DataArrayError(const DataArray &data, const std::string &message);
-  DataArrayError(const DataConstProxy &data, const std::string &message);
-};
-
 struct SCIPP_CORE_EXPORT DataArrayMismatchError : public DataArrayError {
   template <class A, class B>
   DataArrayMismatchError(const A &a, const B &b)
       : DataArrayError(a, "expected to match\n" + to_string(b)) {}
-};
-
-struct SCIPP_CORE_EXPORT UnitError : public std::runtime_error {
-  using std::runtime_error::runtime_error;
 };
 
 struct SCIPP_CORE_EXPORT SizeError : public std::runtime_error {

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -103,15 +103,15 @@ using VariableMismatchError = MismatchError<Variable>;
 // We need deduction guides such that, e.g., the exception for a Variable
 // mismatch and VariableProxy mismatch are the same type.
 template <class T>
-MismatchError(const units::Unit &, const T &)->UnitMismatchError;
+MismatchError(const units::Unit &, const T &)->MismatchError<units::Unit>;
 template <class T>
-MismatchError(const VariableConstProxy &, const T &)->VariableMismatchError;
+MismatchError(const VariableConstProxy &, const T &)->MismatchError<Variable>;
 template <class T>
-MismatchError(const DatasetConstProxy &, const T &)->DatasetMismatchError;
+MismatchError(const DatasetConstProxy &, const T &)->MismatchError<Dataset>;
 template <class T>
-MismatchError(const DataConstProxy &, const T &)->DataArrayMismatchError;
+MismatchError(const DataConstProxy &, const T &)->MismatchError<DataArray>;
 template <class T>
-MismatchError(const Dimensions &, const T &)->DimensionMismatchError;
+MismatchError(const Dimensions &, const T &)->MismatchError<Dimensions>;
 
 struct SCIPP_CORE_EXPORT DimensionNotFoundError : public DimensionError {
   DimensionNotFoundError(const Dimensions &expected, const Dim actual);

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -88,9 +88,17 @@ using DimensionError = Error<Dimensions>;
 using UnitError = Error<units::Unit>;
 using VariableError = Error<Variable>;
 
-struct SCIPP_CORE_EXPORT DimensionMismatchError : public DimensionError {
-  DimensionMismatchError(const Dimensions &expected, const Dimensions &actual);
+template <class T> struct MismatchError : public Error<T> {
+  template <class A, class B>
+  MismatchError(const A &a, const B &b)
+      : Error<T>(a, " expected to be equal to " + to_string(b)) {}
 };
+
+using DataArrayMismatchError = MismatchError<DataArray>;
+using DatasetMismatchError = MismatchError<Dataset>;
+using DimensionMismatchError = MismatchError<Dimensions>;
+using UnitMismatchError = MismatchError<units::Unit>;
+using VariableMismatchError = MismatchError<Variable>;
 
 struct SCIPP_CORE_EXPORT DimensionNotFoundError : public DimensionError {
   DimensionNotFoundError(const Dimensions &expected, const Dim actual);
@@ -106,24 +114,8 @@ struct SCIPP_CORE_EXPORT SparseDimensionError : public DimensionError {
       : DimensionError("Unsupported operation for sparse dimensions.") {}
 };
 
-struct SCIPP_CORE_EXPORT VariableMismatchError : public VariableError {
-  template <class A, class B>
-  VariableMismatchError(const A &a, const B &b)
-      : VariableError(a, "expected to match\n" + to_string(b)) {}
-};
-
-struct SCIPP_CORE_EXPORT DataArrayMismatchError : public DataArrayError {
-  template <class A, class B>
-  DataArrayMismatchError(const A &a, const B &b)
-      : DataArrayError(a, "expected to match\n" + to_string(b)) {}
-};
-
 struct SCIPP_CORE_EXPORT SizeError : public std::runtime_error {
   using std::runtime_error::runtime_error;
-};
-
-struct SCIPP_CORE_EXPORT UnitMismatchError : public UnitError {
-  UnitMismatchError(const units::Unit &a, const units::Unit &b);
 };
 
 struct SCIPP_CORE_EXPORT SliceError : public std::out_of_range {

--- a/core/test/except_test.cpp
+++ b/core/test/except_test.cpp
@@ -11,30 +11,6 @@
 using namespace scipp;
 using namespace scipp::core;
 
-TEST(DimensionMismatchError, what) {
-  Dimensions dims{{Dim::X, 1}, {Dim::Y, 2}};
-  except::DimensionMismatchError error(dims, Dimensions{});
-  EXPECT_EQ(
-      error.what(),
-      std::string("Expected dimensions {{Dim.X, 1}, {Dim.Y, 2}}, got {}."));
-}
-
-TEST(DimensionNotFoundError, what) {
-  Dimensions dims{{Dim::X, 1}, {Dim::Y, 2}};
-  except::DimensionNotFoundError error(dims, Dim::Z);
-  EXPECT_EQ(error.what(),
-            std::string("Expected dimension to be a non-sparse dimension of "
-                        "{{Dim.X, 1}, {Dim.Y, 2}}, got Dim.Z."));
-}
-
-TEST(DimensionLengthError, what) {
-  Dimensions dims{{Dim::X, 1}, {Dim::Y, 2}};
-  except::DimensionLengthError error(dims, Dim::Y, 3);
-  EXPECT_EQ(error.what(),
-            std::string("Expected dimension to be in {{Dim.X, 1}, {Dim.Y, "
-                        "2}}, got Dim.Y with mismatching length 3."));
-}
-
 TEST(StringFormattingTest, to_string_Dataset) {
   Dataset a;
   a.setData("a", makeVariable<double>({}));

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -76,7 +76,7 @@ TEST(Variable, operator_plus_equal_different_unit) {
   auto different_unit(a);
   different_unit.setUnit(units::m);
   EXPECT_THROW_MSG(a += different_unit, except::UnitMismatchError,
-                   "Expected dimensionless to be equal to m.");
+                   "dimensionless expected to be equal to m");
 }
 
 TEST(Variable, operator_plus_equal_non_arithmetic_type) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -105,8 +105,7 @@ bool Variable::operator!=(const VariableConstProxy &other) const {
 
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
   setUnit(other.unit());
-  if (dims() != other.dims())
-    throw except::DimensionMismatchError(dims(), other.dims());
+  expect::equals(dims(), other.dims());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);
   return *this;
 }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -128,8 +128,10 @@ void init_dataset(py::module &m) {
   bind_data_array_properties(dataArray);
   bind_data_array_properties(dataProxy);
 
-  py::class_<DatasetConstProxy>(m, "DatasetConstProxy");
+  py::class_<DatasetConstProxy>(m, "DatasetConstProxy")
+      .def(py::init<const Dataset &>());
   py::class_<DatasetProxy, DatasetConstProxy> datasetProxy(m, "DatasetProxy");
+  datasetProxy.def(py::init<Dataset &>());
 
   py::class_<Dataset> dataset(m, "Dataset");
   dataset.def(py::init<>())
@@ -237,27 +239,6 @@ void init_dataset(py::module &m) {
         "Returns a new Dataset with histograms for sparse dims");
 
   m.def("merge",
-        [](const Dataset &lhs, const Dataset &rhs) {
-          return core::merge(lhs, rhs);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns the union (outer merge) of two datasets");
-
-  m.def("merge",
-        [](const DatasetConstProxy &lhs, const Dataset &rhs) {
-          return core::merge(lhs, rhs);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns the union (outer merge) of two datasets");
-
-  m.def("merge",
-        [](const Dataset &lhs, const DatasetConstProxy &rhs) {
-          return core::merge(lhs, rhs);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns the union (outer merge) of two datasets");
-
-  m.def("merge",
         [](const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
           return core::merge(lhs, rhs);
         },
@@ -265,4 +246,5 @@ void init_dataset(py::module &m) {
         "Returns the union (outer merge) of two datasets");
 
   py::implicitly_convertible<DataArray, DataConstProxy>();
+  py::implicitly_convertible<Dataset, DatasetConstProxy>();
 }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -135,19 +135,14 @@ void init_dataset(py::module &m) {
   dataset.def(py::init<>())
       .def(py::init([](const std::map<std::string, Variable> &data,
                        const std::map<Dim, Variable> &coords,
-                       const std::map<std::string, Variable> &labels) {
-             Dataset d;
-             for (const auto & [ name, item ] : data)
-               d.setData(name, item);
-             for (const auto & [ dim, item ] : coords)
-               d.setCoord(dim, item);
-             for (const auto & [ name, item ] : labels)
-               d.setLabels(name, item);
-             return d;
+                       const std::map<std::string, Variable> &labels,
+                       const std::map<std::string, Variable> &attrs) {
+             return Dataset(data, coords, labels, attrs);
            }),
            py::arg("data") = std::map<std::string, Variable>{},
            py::arg("coords") = std::map<Dim, Variable>{},
-           py::arg("labels") = std::map<std::string, Variable>{})
+           py::arg("labels") = std::map<std::string, Variable>{},
+           py::arg("attrs") = std::map<std::string, Variable>{})
       .def(py::init([](const DatasetProxy &other) { return Dataset{other}; }))
       .def("__setitem__", [](Dataset &self, const std::string &name,
                              Variable data) { self.setData(name, data); })


### PR DESCRIPTION
- `Dataset` constructor from maps, similar to what already existed in Python.
- Generalize `union_` to work with other map-like objects...
- Such that the `merge` implementation becomes simpler.
- Fix implicit conversions in Python bindings such that we can avoid overloading on (combinations of) `Dataset` and `DatasetConstProxy`.
- Templated exception types for less duplication.