### PR TITLE
Add Matplotlib to Conda runtime dependecies

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - python {{ python }}
   run:
     - ipywidgets 7.*
+    - matplotlib
     - numpy {{ numpy }}
     - plotly 3.*
     - python {{ python }}


### PR DESCRIPTION
This is used for plotting and scipp can not be used without it.

On a related note, why was the runtime check for plotting dependencies removed?
It seems odd that being able to use scipp at all should be dependent on plotting libraries.