### PR TITLE
Delay plot imports

### DIFF
--- a/python/src/scipp/plot.py
+++ b/python/src/scipp/plot.py
@@ -19,7 +19,7 @@ import scipp as sp
 # happens inside the same cell as the call to plot.
 try:
     import matplotlib.pyplot as plt # noqa
-except ImportError: # Catch error in case matplotlib is not installed
+except ImportError:  # Catch error in case matplotlib is not installed
     pass
 
 


### PR DESCRIPTION
Imports for `plotly` and `matplotlib` were not correctly delayed, making the use of `scipp` impossible without having at least `matplotlib` installed. You also needed `plotly` installed if you wanted to plot, even if the plots were to use `matplotlib`.

This should fix this. See #450 