### PR TITLE
Move plotting dependencies out of package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ RUN rm -r "/home/$NB_USER/work"
 # Enable Plotly JupyterLab extension
 RUN jupyter labextension install @jupyterlab/plotly-extension@0.18.1
 
-# Install Scipp
-RUN conda install --yes -c scipp/label/dev scipp
+# Install Scipp and dependencies
+RUN conda install --yes \
+      -c scipp/label/dev \
+      matplotlib \
+      plotly \
+      scipp
 
 # Add the demo notebooks and Python examples
 ADD 'python/demo/' "/home/$NB_USER/demo"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,9 +13,7 @@ requirements:
     - git
     - python {{ python }}
   run:
-    - ipywidgets 7.*
     - numpy {{ numpy }}
-    - plotly 3.*
     - python {{ python }}
 
 build:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,3 +14,5 @@ dependencies:
   - pip:
     - nbsphinx
   - scipp
+  - matplotlib
+  - plotly


### PR DESCRIPTION
Plotting dependencies are no longer part of the scipp Conda package.

Dependencies are now manually installed in Docker and Read the Docs environments.