### PR TITLE
Strong exception guarantee for in-place binary operations with dataset

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -4,8 +4,10 @@
 /// @author Simon Heybrock
 #include <ostream>
 
+#include "operators.h"
 #include "scipp/core/dataset.h"
 #include "scipp/core/except.h"
+#include "scipp/core/transform.h"
 
 namespace scipp::core {
 
@@ -780,24 +782,14 @@ constexpr static auto divide = [](const auto &a, const auto &b) {
   return a / b;
 };
 
-constexpr static auto plus_equals = [](auto &&a, const auto &b) {
-  return a += b;
-};
-
-constexpr static auto minus_equals = [](auto &&a, const auto &b) {
-  return a -= b;
-};
-
-constexpr static auto times_equals = [](auto &&a, const auto &b) {
-  return a *= b;
-};
-
-constexpr static auto divide_equals = [](auto &&a, const auto &b) {
-  return a /= b;
-};
-
 template <class Op, class A, class B>
 auto &apply(const Op &op, A &a, const B &b) {
+  // auto dry_run = [&]() {
+  //  for (const auto & [ name, item ] : b) {
+  //    expect::coordsAndLabelsAreSuperset(*this, other);
+  //    dry_run::transform_in_place(a[name].data(), item.data(), op);
+  //  }
+  //}();
   for (const auto & [ name, item ] : b)
     op(a[name], item);
   return a;
@@ -849,51 +841,51 @@ auto apply_with_broadcast(const Op &op, const DataConstProxy &a, const B &b) {
 }
 
 Dataset &Dataset::operator+=(const DataConstProxy &other) {
-  return apply_with_delay(plus_equals, *this, other);
+  return apply_with_delay(operator_detail::plus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator-=(const DataConstProxy &other) {
-  return apply_with_delay(minus_equals, *this, other);
+  return apply_with_delay(operator_detail::minus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator*=(const DataConstProxy &other) {
-  return apply_with_delay(times_equals, *this, other);
+  return apply_with_delay(operator_detail::times_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator/=(const DataConstProxy &other) {
-  return apply_with_delay(divide_equals, *this, other);
+  return apply_with_delay(operator_detail::divide_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator+=(const DatasetConstProxy &other) {
-  return apply(plus_equals, *this, other);
+  return apply(operator_detail::plus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator-=(const DatasetConstProxy &other) {
-  return apply(minus_equals, *this, other);
+  return apply(operator_detail::minus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator*=(const DatasetConstProxy &other) {
-  return apply(times_equals, *this, other);
+  return apply(operator_detail::times_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator/=(const DatasetConstProxy &other) {
-  return apply(divide_equals, *this, other);
+  return apply(operator_detail::divide_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator+=(const Dataset &other) {
-  return apply(plus_equals, *this, other);
+  return apply(operator_detail::plus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator-=(const Dataset &other) {
-  return apply(minus_equals, *this, other);
+  return apply(operator_detail::minus_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator*=(const Dataset &other) {
-  return apply(times_equals, *this, other);
+  return apply(operator_detail::times_equals{}, *this, other);
 }
 
 Dataset &Dataset::operator/=(const Dataset &other) {
-  return apply(divide_equals, *this, other);
+  return apply(operator_detail::divide_equals{}, *this, other);
 }
 
 std::unordered_map<Dim, scipp::index> Dataset::dimensions() const {
@@ -905,51 +897,51 @@ std::unordered_map<Dim, scipp::index> Dataset::dimensions() const {
 }
 
 DatasetProxy DatasetProxy::operator+=(const DataConstProxy &other) const {
-  return apply_with_delay(plus_equals, *this, other);
+  return apply_with_delay(operator_detail::plus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator-=(const DataConstProxy &other) const {
-  return apply_with_delay(minus_equals, *this, other);
+  return apply_with_delay(operator_detail::minus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator*=(const DataConstProxy &other) const {
-  return apply_with_delay(times_equals, *this, other);
+  return apply_with_delay(operator_detail::times_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator/=(const DataConstProxy &other) const {
-  return apply_with_delay(divide_equals, *this, other);
+  return apply_with_delay(operator_detail::divide_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator+=(const DatasetConstProxy &other) const {
-  return apply(plus_equals, *this, other);
+  return apply(operator_detail::plus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator-=(const DatasetConstProxy &other) const {
-  return apply(minus_equals, *this, other);
+  return apply(operator_detail::minus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator*=(const DatasetConstProxy &other) const {
-  return apply(times_equals, *this, other);
+  return apply(operator_detail::times_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator/=(const DatasetConstProxy &other) const {
-  return apply(divide_equals, *this, other);
+  return apply(operator_detail::divide_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator+=(const Dataset &other) const {
-  return apply(plus_equals, *this, other);
+  return apply(operator_detail::plus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator-=(const Dataset &other) const {
-  return apply(minus_equals, *this, other);
+  return apply(operator_detail::minus_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator*=(const Dataset &other) const {
-  return apply(times_equals, *this, other);
+  return apply(operator_detail::times_equals{}, *this, other);
 }
 
 DatasetProxy DatasetProxy::operator/=(const Dataset &other) const {
-  return apply(divide_equals, *this, other);
+  return apply(operator_detail::divide_equals{}, *this, other);
 }
 
 std::ostream &operator<<(std::ostream &os, const DataConstProxy &data) {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -570,7 +570,7 @@ template <class Op>
 void dry_run_op(const DataProxy &a, const DataConstProxy &b, Op op) {
   expect::coordsAndLabelsAreSuperset(a, b);
   // This dry run relies on the knowledge that the implementation of operations
-  // fro variable simply calls transform_in_place and nothing else.
+  // for variable simply calls transform_in_place and nothing else.
   dry_run::transform_in_place(a.data(), b.data(), op);
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -784,12 +784,10 @@ constexpr static auto divide = [](const auto &a, const auto &b) {
 
 template <class Op, class A, class B>
 auto &apply(const Op &op, A &a, const B &b) {
-  // auto dry_run = [&]() {
-  //  for (const auto & [ name, item ] : b) {
-  //    expect::coordsAndLabelsAreSuperset(*this, other);
-  //    dry_run::transform_in_place(a[name].data(), item.data(), op);
-  //  }
-  //}();
+  // for (const auto & [ name, item ] : b) {
+  //  expect::coordsAndLabelsAreSuperset(a[name], item);
+  //  dry_run::transform_in_place(a[name].data(), item.data(), op);
+  //}
   for (const auto & [ name, item ] : b)
     op(a[name], item);
   return a;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -875,13 +875,6 @@ SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const DatasetProxy &dataset);
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const Dataset &dataset);
-SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
-                                           const VariableConstProxy &variable);
-SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
-                                           const VariableProxy &variable);
-SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
-                                           const Variable &variable);
-SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os, const Dim dim);
 
 SCIPP_CORE_EXPORT DataArray operator+(const DataConstProxy &a,
                                       const DataConstProxy &b);

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -719,6 +719,13 @@ void accumulate_in_place(Var &&var, const Var1 &other, Op op) {
                              std::forward<Var>(var), other, op);
 }
 
+namespace dry_run {
+template <class... Ts, class Var, class Op>
+void transform_in_place(Var &&var, Op op) {
+  in_place<true>::transform<Ts...>(std::forward<Var>(var), op);
+}
+} // namespace dry_run
+
 /// Transform the data elements of a variable and return a new Variable.
 ///
 /// This overload is equivalent to std::transform with a single input range, but

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -428,6 +428,14 @@ template <class... Ts> overloaded_sparse(Ts...)->overloaded_sparse<Ts...>;
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
 
+template <class... TypePairs, class Op>
+static constexpr auto type_pairs(Op) noexcept {
+  if constexpr (sizeof...(TypePairs) == 0)
+    return typename Op::types{};
+  else
+    return std::tuple_cat(TypePairs{}...);
+}
+
 /// Helper class wrapping functions for in-place transform.
 ///
 /// The dry_run template argument can be used to disable any actual modification
@@ -689,8 +697,7 @@ template <bool dry_run> struct in_place {
     // Stop early in bad cases of changing units (if `var` is a slice):
     var.expectCanSetUnit(unit);
     // Wrapped implementation to convert multiple tuples into a parameter pack.
-    transform(std::tuple_cat(TypePairs{}...), std::forward<Var>(var), other,
-              op);
+    transform(type_pairs<TypePairs...>(op), std::forward<Var>(var), other, op);
     if constexpr (dry_run)
       return;
     var.setUnit(unit);

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -143,47 +143,6 @@ auto check_and_get_size(const T1 &a, const T2 &b) {
 
 struct SparseFlag {};
 
-template <class Op, class T, class... Ts>
-void transform_in_place_with_variance_impl(Op op, ValuesAndVariances<T> arg,
-                                           Ts &&... other) {
-  auto & [ vals, vars ] = arg;
-  // For sparse data we can fail for any subitem if the sizes to not match. To
-  // avoid partially modifying (and thus corrupting) data in an in-place
-  // operation we need to do the checks before any modification happens.
-  if constexpr (is_sparse_v<decltype(vals[0])>) {
-    for (scipp::index i = 0; i < scipp::size(vals); ++i) {
-      ValuesAndVariances _{vals[i], vars[i]};
-      if constexpr (std::is_base_of_v<SparseFlag, Op>)
-        static_cast<void>(
-            check_and_get_size(_, value_and_maybe_variance(other, i)...));
-      else
-        static_cast<void>((value_and_maybe_variance(other, i), ...));
-    }
-  }
-  // WARNING: Do not parallelize this loop in all cases! The output may have a
-  // dimension with stride zero so parallelization must be done with care.
-  for (scipp::index i = 0; i < scipp::size(vals); ++i) {
-    // Two cases are distinguished here:
-    // 1. In the case of sparse data we create ValuesAndVariances, which hold
-    //    references that can be modified.
-    // 2. For dense data we create ValueAndVariance, which performs and element
-    //    copy, so the result has to be updated after the call to `op`.
-    // Note that in the case of sparse data we actually have a recursive call to
-    // this function for the iteration over each individual sparse_container.
-    // This then falls into case 2 and thus the recursion terminates with the
-    // second level.
-    if constexpr (is_sparse_v<decltype(vals[0])>) {
-      ValuesAndVariances _{vals[i], vars[i]};
-      op(_, value_and_maybe_variance(other, i)...);
-    } else {
-      ValueAndVariance _{vals[i], vars[i]};
-      op(_, value_and_maybe_variance(other, i)...);
-      vals[i] = _.value;
-      vars[i] = _.variance;
-    }
-  }
-}
-
 template <class Op, class Out, class... Ts>
 void transform_elements_with_variance(Op op, ValuesAndVariances<Out> out,
                                       Ts &&... other) {
@@ -199,21 +158,6 @@ void transform_elements_with_variance(Op op, ValuesAndVariances<Out> out,
       ovars[i] = out_i.variance;
     }
   }
-}
-
-template <class Op, class T, class... Ts>
-void transform_in_place_impl(Op op, T &&vals, Ts &&... other) {
-  // For sparse data we can fail for any subitem if the sizes to not match. To
-  // avoid partially modifying (and thus corrupting) data in an in-place
-  // operation we need to do the checks before any modification happens.
-  if constexpr (is_sparse_v<decltype(vals[0])> &&
-                std::is_base_of_v<SparseFlag, Op>)
-    for (scipp::index i = 0; i < scipp::size(vals); ++i)
-      static_cast<void>(check_and_get_size(vals[i], other[i]...));
-  // WARNING: Do not parallelize this loop in all cases! The output may have a
-  // dimension with stride zero so parallelization must be done with care.
-  for (scipp::index i = 0; i < scipp::size(vals); ++i)
-    op(vals[i], other[i]...);
 }
 
 template <class Op, class Out, class T, class... Ts>
@@ -269,25 +213,6 @@ template <class T> constexpr auto maybe_eval(T &&_) {
     return std::forward<T>(_);
 }
 
-/// Functor for implementing in-place operations with sparse data.
-///
-/// This is (conditionally) added to an overloaded set of operators provided by
-/// the user. If the data is sparse the overloads by this functor will match in
-/// place of the user-provided ones. We then recursively call the transform
-/// function. In this second call we have descended into the sparse container so
-/// now the user-provided overload will match directly.
-template <class Op> struct TransformSparseInPlace : public SparseFlag {
-  Op op;
-  TransformSparseInPlace(Op op_) : op(op_) {}
-  template <class... Ts> constexpr void operator()(Ts &&... args) const {
-    static_cast<void>(check_and_get_size(args...));
-    if constexpr ((has_variances_v<Ts> || ...))
-      transform_in_place_with_variance_impl(op, maybe_broadcast(args)...);
-    else
-      transform_in_place_impl(op, maybe_broadcast(args)...);
-  }
-};
-
 /// Functor for implementing operations with sparse data, see also
 /// TransformSparseInPlace.
 template <class Op> struct TransformSparse {
@@ -307,21 +232,6 @@ template <class Op> struct TransformSparse {
   }
 };
 
-/// Helper for in-place transform implementation, performing branching between
-/// output with and without variances.
-template <class T1, class Op> void do_transform_in_place(T1 &a, Op op) {
-  auto a_val = a.values();
-  if (a.hasVariances()) {
-    if constexpr (canHaveVariances<typename T1::value_type>()) {
-      auto a_var = a.variances();
-      transform_in_place_with_variance_impl(op,
-                                            ValuesAndVariances{a_val, a_var});
-    }
-  } else {
-    transform_in_place_impl(op, a_val);
-  }
-}
-
 /// Helper for transform implementation, performing branching between output
 /// with and without variances.
 template <class T1, class Out, class Op>
@@ -337,35 +247,6 @@ void do_transform(const T1 &a, Out &out, Op op) {
     }
   } else {
     transform_elements(op, out_val, a_val);
-  }
-}
-
-/// Helper for in-place transform implementation, performing branching between
-/// output with and without variances as well as handling other operands with
-/// and without variances.
-template <class T1, class T2, class Op>
-void do_transform_in_place(T1 &a, const T2 &b, Op op) {
-  auto a_val = a.values();
-  auto b_val = b.values();
-  if (a.hasVariances()) {
-    if constexpr (canHaveVariances<typename T1::value_type>() &&
-                  canHaveVariances<typename T2::value_type>()) {
-      auto a_var = a.variances();
-      if (b.hasVariances()) {
-        auto b_var = b.variances();
-        transform_in_place_with_variance_impl(op,
-                                              ValuesAndVariances{a_val, a_var},
-                                              ValuesAndVariances{b_val, b_var});
-      } else {
-        transform_in_place_with_variance_impl(
-            op, ValuesAndVariances{a_val, a_var}, b_val);
-      }
-    }
-  } else if (b.hasVariances()) {
-    throw std::runtime_error(
-        "RHS in operation has variances but LHS does not.");
-  } else {
-    transform_in_place_impl(op, a_val, b_val);
   }
 }
 
@@ -415,61 +296,6 @@ template <class T> struct as_view {
   const Dimensions &dims;
 };
 template <class T> as_view(T &data, const Dimensions &dims)->as_view<T>;
-
-/// Functor for in-place transformation, applying `op` to all elements.
-///
-/// This is responsible for converting the client-provided functor `Op` which
-/// operates on elements to a functor for the data container, which is required
-/// by `visit`.
-template <class Op> struct TransformInPlace {
-  Op op;
-  template <class T> void operator()(T &&handle) const {
-    auto view = as_view{*handle, handle->dims()};
-    if (handle->isContiguous())
-      do_transform_in_place(*handle, op);
-    else
-      do_transform_in_place(view, op);
-  }
-
-  template <class A, class B> void operator()(A &&a, B &&b) const {
-    const auto &dimsA = a->dims();
-    const auto &dimsB = b->dims();
-    if constexpr (std::is_same_v<typename std::remove_reference_t<decltype(
-                                     *a)>::value_type,
-                                 typename std::remove_reference_t<decltype(
-                                     *b)>::value_type>) {
-      if (a->valuesView(dimsA).overlaps(b->valuesView(dimsA))) {
-        // If there is an overlap between lhs and rhs we copy the rhs before
-        // applying the operation.
-        return operator()(a, b->copyT());
-      }
-    }
-
-    if (a->isContiguous() && dimsA.contains(dimsB)) {
-      if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-        do_transform_in_place(*a, *b, op);
-      } else {
-        do_transform_in_place(*a, as_view{*b, dimsA}, op);
-      }
-    } else if (dimsA.contains(dimsB)) {
-      auto a_view = as_view{*a, dimsA};
-      if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-        do_transform_in_place(a_view, *b, op);
-      } else {
-        do_transform_in_place(a_view, as_view{*b, dimsA}, op);
-      }
-    } else {
-      // LHS has fewer dimensions than RHS, e.g., for computing sum. Use view.
-      auto a_view = as_view{*a, dimsB};
-      if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-        do_transform_in_place(a_view, *b, op);
-      } else {
-        do_transform_in_place(a_view, as_view{*b, dimsB}, op);
-      }
-    }
-  }
-};
-template <class Op> TransformInPlace(Op)->TransformInPlace<Op>;
 
 template <class Op> struct Transform {
   Op op;
@@ -602,6 +428,249 @@ template <class... Ts> overloaded_sparse(Ts...)->overloaded_sparse<Ts...>;
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
 
+template <bool dry_run> struct in_place {
+  template <class Op, class T, class... Ts>
+  static void transform_in_place_with_variance_impl(
+      Op op, detail::ValuesAndVariances<T> arg, Ts &&... other) {
+    using namespace detail;
+    auto & [ vals, vars ] = arg;
+    // For sparse data we can fail for any subitem if the sizes to not match. To
+    // avoid partially modifying (and thus corrupting) data in an in-place
+    // operation we need to do the checks before any modification happens.
+    if constexpr (is_sparse_v<decltype(vals[0])>) {
+      for (scipp::index i = 0; i < scipp::size(vals); ++i) {
+        ValuesAndVariances _{vals[i], vars[i]};
+        if constexpr (std::is_base_of_v<SparseFlag, Op>)
+          static_cast<void>(
+              check_and_get_size(_, value_and_maybe_variance(other, i)...));
+        else
+          static_cast<void>((value_and_maybe_variance(other, i), ...));
+      }
+    }
+    // WARNING: Do not parallelize this loop in all cases! The output may have a
+    // dimension with stride zero so parallelization must be done with care.
+    for (scipp::index i = 0; i < scipp::size(vals); ++i) {
+      // Two cases are distinguished here:
+      // 1. In the case of sparse data we create ValuesAndVariances, which hold
+      //    references that can be modified.
+      // 2. For dense data we create ValueAndVariance, which performs and
+      // element
+      //    copy, so the result has to be updated after the call to `op`.
+      // Note that in the case of sparse data we actually have a recursive call
+      // to this function for the iteration over each individual
+      // sparse_container. This then falls into case 2 and thus the recursion
+      // terminates with the second level.
+      if constexpr (is_sparse_v<decltype(vals[0])>) {
+        ValuesAndVariances _{vals[i], vars[i]};
+        op(_, value_and_maybe_variance(other, i)...);
+      } else {
+        ValueAndVariance _{vals[i], vars[i]};
+        op(_, value_and_maybe_variance(other, i)...);
+        vals[i] = _.value;
+        vars[i] = _.variance;
+      }
+    }
+  }
+
+  template <class Op, class T, class... Ts>
+  static void transform_in_place_impl(Op op, T &&vals, Ts &&... other) {
+    using namespace detail;
+    // For sparse data we can fail for any subitem if the sizes to not match. To
+    // avoid partially modifying (and thus corrupting) data in an in-place
+    // operation we need to do the checks before any modification happens.
+    if constexpr (is_sparse_v<decltype(vals[0])> &&
+                  std::is_base_of_v<SparseFlag, Op>)
+      for (scipp::index i = 0; i < scipp::size(vals); ++i)
+        static_cast<void>(check_and_get_size(vals[i], other[i]...));
+    // WARNING: Do not parallelize this loop in all cases! The output may have a
+    // dimension with stride zero so parallelization must be done with care.
+    for (scipp::index i = 0; i < scipp::size(vals); ++i)
+      op(vals[i], other[i]...);
+  }
+
+  /// Helper for in-place transform implementation, performing branching between
+  /// output with and without variances.
+  template <class T1, class Op>
+  static void do_transform_in_place(T1 &a, Op op) {
+    using namespace detail;
+    auto a_val = a.values();
+    if (a.hasVariances()) {
+      if constexpr (canHaveVariances<typename T1::value_type>()) {
+        auto a_var = a.variances();
+        transform_in_place_with_variance_impl(op,
+                                              ValuesAndVariances{a_val, a_var});
+      }
+    } else {
+      transform_in_place_impl(op, a_val);
+    }
+  }
+
+  /// Helper for in-place transform implementation, performing branching between
+  /// output with and without variances as well as handling other operands with
+  /// and without variances.
+  template <class T1, class T2, class Op>
+  static void do_transform_in_place(T1 &a, const T2 &b, Op op) {
+    using namespace detail;
+    auto a_val = a.values();
+    auto b_val = b.values();
+    if (a.hasVariances()) {
+      if constexpr (canHaveVariances<typename T1::value_type>() &&
+                    canHaveVariances<typename T2::value_type>()) {
+        auto a_var = a.variances();
+        if (b.hasVariances()) {
+          auto b_var = b.variances();
+          transform_in_place_with_variance_impl(
+              op, ValuesAndVariances{a_val, a_var},
+              ValuesAndVariances{b_val, b_var});
+        } else {
+          transform_in_place_with_variance_impl(
+              op, ValuesAndVariances{a_val, a_var}, b_val);
+        }
+      }
+    } else if (b.hasVariances()) {
+      throw std::runtime_error(
+          "RHS in operation has variances but LHS does not.");
+    } else {
+      transform_in_place_impl(op, a_val, b_val);
+    }
+  }
+
+  /// Functor for implementing in-place operations with sparse data.
+  ///
+  /// This is (conditionally) added to an overloaded set of operators provided
+  /// by the user. If the data is sparse the overloads by this functor will
+  /// match in place of the user-provided ones. We then recursively call the
+  /// transform function. In this second call we have descended into the sparse
+  /// container so now the user-provided overload will match directly.
+  template <class Op>
+  struct TransformSparseInPlace : public detail::SparseFlag {
+    Op op;
+    TransformSparseInPlace(Op op_) : op(op_) {}
+    template <class... Ts> constexpr void operator()(Ts &&... args) const {
+      using namespace detail;
+      static_cast<void>(check_and_get_size(args...));
+      if constexpr ((has_variances_v<Ts> || ...))
+        transform_in_place_with_variance_impl(op, maybe_broadcast(args)...);
+      else
+        transform_in_place_impl(op, maybe_broadcast(args)...);
+    }
+  };
+
+  /// Functor for in-place transformation, applying `op` to all elements.
+  ///
+  /// This is responsible for converting the client-provided functor `Op` which
+  /// operates on elements to a functor for the data container, which is
+  /// required by `visit`.
+  template <class Op> struct TransformInPlace {
+    Op op;
+    template <class T> void operator()(T &&handle) const {
+      using namespace detail;
+      auto view = as_view{*handle, handle->dims()};
+      if (handle->isContiguous())
+        do_transform_in_place(*handle, op);
+      else
+        do_transform_in_place(view, op);
+    }
+
+    template <class A, class B> void operator()(A &&a, B &&b) const {
+      using namespace detail;
+      const auto &dimsA = a->dims();
+      const auto &dimsB = b->dims();
+      if constexpr (std::is_same_v<typename std::remove_reference_t<decltype(
+                                       *a)>::value_type,
+                                   typename std::remove_reference_t<decltype(
+                                       *b)>::value_type>) {
+        if (a->valuesView(dimsA).overlaps(b->valuesView(dimsA))) {
+          // If there is an overlap between lhs and rhs we copy the rhs before
+          // applying the operation.
+          return operator()(a, b->copyT());
+        }
+      }
+
+      if (a->isContiguous() && dimsA.contains(dimsB)) {
+        if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          do_transform_in_place(*a, *b, op);
+        } else {
+          do_transform_in_place(*a, as_view{*b, dimsA}, op);
+        }
+      } else if (dimsA.contains(dimsB)) {
+        auto a_view = as_view{*a, dimsA};
+        if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          do_transform_in_place(a_view, *b, op);
+        } else {
+          do_transform_in_place(a_view, as_view{*b, dimsA}, op);
+        }
+      } else {
+        // LHS has fewer dimensions than RHS, e.g., for computing sum. Use view.
+        auto a_view = as_view{*a, dimsB};
+        if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
+          do_transform_in_place(a_view, *b, op);
+        } else {
+          do_transform_in_place(a_view, as_view{*b, dimsB}, op);
+        }
+      }
+    }
+  };
+  // gcc cannot deal with deduction guide for nested class => helper function.
+  template <class Op> static auto makeTransformInPlace(Op op) {
+    return TransformInPlace<Op>{op};
+  }
+
+  template <class... Ts, class Var, class Op>
+  static void transform(Var &&var, Op op) {
+    using namespace detail;
+    auto unit = var.unit();
+    op(unit);
+    // Stop early in bad cases of changing units (if `var` is a slice):
+    var.expectCanSetUnit(unit);
+    try {
+      // If a sparse_container<T> is specified explicitly as a type we assume
+      // that the caller provides a matching overload. Otherwise we assume the
+      // provided operator is for individual elements (regardless of whether
+      // they are elements of dense or sparse data), so we add overloads for
+      // sparse data processing.
+      if constexpr ((is_sparse_v<Ts> || ...)) {
+        scipp::core::visit_impl<Ts...>::apply(makeTransformInPlace(op),
+                                              var.dataHandle());
+      } else {
+        scipp::core::visit(augment::insert_sparse(std::tuple<Ts...>{}))
+            .apply(makeTransformInPlace(detail::overloaded_sparse{
+                       op, TransformSparseInPlace<Op>{op}}),
+                   var.dataHandle());
+      }
+    } catch (const std::bad_variant_access &) {
+      throw std::runtime_error("Operation not implemented for this type.");
+    }
+    var.setUnit(unit);
+  }
+
+  template <class... Ts, class Var, class Var1, class Op>
+  static void transform(std::tuple<Ts...> &&, Var &&var, const Var1 &other,
+                        Op op) {
+    using namespace detail;
+    try {
+      if constexpr (((is_sparse_v<typename Ts::first_type> ||
+                      is_sparse_v<typename Ts::second_type>) ||
+                     ...)) {
+        scipp::core::visit_impl<Ts...>::apply(
+            makeTransformInPlace(op), var.dataHandle(), other.dataHandle());
+      } else {
+        // Note that if only one of the inputs is sparse it must be the one
+        // being transformed in-place, so there are only three cases here.
+        scipp::core::visit(
+            augment::insert_sparse_in_place_pairs(std::tuple<Ts...>{}))
+            .apply(makeTransformInPlace(detail::overloaded_sparse{
+                       op, TransformSparseInPlace<Op>{op}}),
+                   var.dataHandle(), other.dataHandle());
+      }
+    } catch (const std::bad_variant_access &) {
+      throw except::TypeError("Cannot apply operation to item dtypes " +
+                              to_string(var.dtype()) + " and " +
+                              to_string(other.dtype()) + '.');
+    }
+  }
+};
+
 /// Transform the data elements of a variable in-place.
 ///
 /// Note that this is deliberately not named `for_each`: Unlike std::for_each,
@@ -610,59 +679,8 @@ template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
 /// identical to the input range, but avoids potentially costly element copies.
 template <class... Ts, class Var, class Op>
 void transform_in_place(Var &&var, Op op) {
-  using namespace detail;
-  auto unit = var.unit();
-  op(unit);
-  // Stop early in bad cases of changing units (if `var` is a slice):
-  var.expectCanSetUnit(unit);
-  try {
-    // If a sparse_container<T> is specified explicitly as a type we assume that
-    // the caller provides a matching overload. Otherwise we assume the provided
-    // operator is for individual elements (regardless of whether they are
-    // elements of dense or sparse data), so we add overloads for sparse data
-    // processing.
-    if constexpr ((is_sparse_v<Ts> || ...)) {
-      scipp::core::visit_impl<Ts...>::apply(TransformInPlace{op},
-                                            var.dataHandle());
-    } else {
-      scipp::core::visit(augment::insert_sparse(std::tuple<Ts...>{}))
-          .apply(TransformInPlace{detail::overloaded_sparse{
-                     op, TransformSparseInPlace<Op>{op}}},
-                 var.dataHandle());
-    }
-  } catch (const std::bad_variant_access &) {
-    throw std::runtime_error("Operation not implemented for this type.");
-  }
-  var.setUnit(unit);
+  in_place<false>::transform<Ts...>(std::forward<Var>(var), op);
 }
-
-namespace detail {
-template <class... Ts, class Var, class Var1, class Op>
-void transform_in_place(std::tuple<Ts...> &&, Var &&var, const Var1 &other,
-                        Op op) {
-  using namespace detail;
-  try {
-    if constexpr (((is_sparse_v<typename Ts::first_type> ||
-                    is_sparse_v<typename Ts::second_type>) ||
-                   ...)) {
-      scipp::core::visit_impl<Ts...>::apply(
-          TransformInPlace{op}, var.dataHandle(), other.dataHandle());
-    } else {
-      // Note that if only one of the inputs is sparse it must be the one being
-      // transformed in-place, so there are only three cases here.
-      scipp::core::visit(
-          augment::insert_sparse_in_place_pairs(std::tuple<Ts...>{}))
-          .apply(TransformInPlace{detail::overloaded_sparse{
-                     op, TransformSparseInPlace<Op>{op}}},
-                 var.dataHandle(), other.dataHandle());
-    }
-  } catch (const std::bad_variant_access &) {
-    throw except::TypeError("Cannot apply operation to item dtypes " +
-                            to_string(var.dtype()) + " and " +
-                            to_string(other.dtype()) + '.');
-  }
-}
-} // namespace detail
 
 /// Transform the data elements of a variable in-place.
 ///
@@ -677,7 +695,7 @@ void transform_in_place(Var &&var, const Var1 &other, Op op) {
   // Stop early in bad cases of changing units (if `var` is a slice):
   var.expectCanSetUnit(unit);
   // Wrapped implementation to convert multiple tuples into a parameter pack.
-  detail::transform_in_place(std::tuple_cat(TypePairs{}...),
+  in_place<false>::transform(std::tuple_cat(TypePairs{}...),
                              std::forward<Var>(var), other, op);
   var.setUnit(unit);
 }
@@ -697,7 +715,7 @@ template <class... TypePairs, class Var, class Var1, class Op>
 void accumulate_in_place(Var &&var, const Var1 &other, Op op) {
   expect::contains(other.dims(), var.dims());
   // Wrapped implementation to convert multiple tuples into a parameter pack.
-  detail::transform_in_place(std::tuple_cat(TypePairs{}...),
+  in_place<false>::transform(std::tuple_cat(TypePairs{}...),
                              std::forward<Var>(var), other, op);
 }
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -804,6 +804,14 @@ SCIPP_CORE_EXPORT Variable sum(const Variable &var, const Dim dim);
 template <class T>
 VariableView<const T> getView(const Variable &var, const Dimensions &dims);
 
+SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
+                                           const VariableConstProxy &variable);
+SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
+                                           const VariableProxy &variable);
+SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
+                                           const Variable &variable);
+SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os, const Dim dim);
+
 } // namespace scipp::core
 
 #endif // VARIABLE_H

--- a/core/include/scipp/core/visit.h
+++ b/core/include/scipp/core/visit.h
@@ -11,20 +11,6 @@
 
 namespace scipp::core {
 
-template <class... Ts> struct pair_self {
-  using type = std::tuple<std::pair<Ts, Ts>...>;
-};
-// template <class... Ts> struct pair_product {
-//  using type = decltype(std::tuple_cat(std::tuple<std::pair<Ts,
-//  Ts...>>{}...));
-//};
-template <class... Ts> struct pair_custom { using type = std::tuple<Ts...>; };
-
-template <class... Ts> using pair_self_t = typename pair_self<Ts...>::type;
-// template <class... Ts>
-// using pair_product_t = typename pair_product<Ts...>::type;
-template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
-
 template <class F, class Variant, class... Ts>
 decltype(auto) invoke_active(F &&f, Variant &&v, const std::tuple<Ts...> &) {
   using Ret = decltype(std::invoke(

--- a/core/operators.h
+++ b/core/operators.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_OPERATORS_H
+#define SCIPP_CORE_OPERATORS_H
+
+#include <Eigen/Dense>
+
+namespace scipp::core {
+
+template <class... Ts> struct pair_self {
+  using type = std::tuple<std::pair<Ts, Ts>...>;
+};
+// template <class... Ts> struct pair_product {
+//  using type = decltype(std::tuple_cat(std::tuple<std::pair<Ts,
+//  Ts...>>{}...));
+//};
+template <class... Ts> struct pair_custom { using type = std::tuple<Ts...>; };
+
+template <class... Ts> using pair_self_t = typename pair_self<Ts...>::type;
+// template <class... Ts>
+// using pair_product_t = typename pair_product<Ts...>::type;
+template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
+
+namespace operator_detail {
+struct plus_equals {
+  template <class A, class B>
+  constexpr auto operator()(A &&a, const B &b) const
+      noexcept(noexcept(a += b)) {
+    return a += b;
+  }
+  using types = pair_self_t<double, float, int64_t, Eigen::Vector3d>;
+};
+struct minus_equals {
+  template <class A, class B>
+  constexpr auto operator()(A &&a, const B &b) const
+      noexcept(noexcept(a -= b)) {
+    return a -= b;
+  }
+  using types = pair_self_t<double, float, int64_t, Eigen::Vector3d>;
+};
+struct times_equals {
+  template <class A, class B>
+  constexpr auto operator()(A &&a, const B &b) const
+      noexcept(noexcept(a *= b)) {
+    return a *= b;
+  }
+  using types = decltype(
+      std::tuple_cat(pair_self_t<double, float, int64_t>{},
+                     pair_custom_t<std::pair<Eigen::Vector3d, double>>{}));
+};
+struct divide_equals {
+  template <class A, class B>
+  constexpr auto operator()(A &&a, const B &b) const
+      noexcept(noexcept(a /= b)) {
+    return a /= b;
+  }
+  using types = decltype(
+      std::tuple_cat(pair_self_t<double, float, int64_t>{},
+                     pair_custom_t<std::pair<Eigen::Vector3d, double>>{}));
+};
+} // namespace operator_detail
+
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_OPERATORS_H

--- a/core/operators.h
+++ b/core/operators.h
@@ -12,15 +12,9 @@ namespace scipp::core {
 template <class... Ts> struct pair_self {
   using type = std::tuple<std::pair<Ts, Ts>...>;
 };
-// template <class... Ts> struct pair_product {
-//  using type = decltype(std::tuple_cat(std::tuple<std::pair<Ts,
-//  Ts...>>{}...));
-//};
 template <class... Ts> struct pair_custom { using type = std::tuple<Ts...>; };
 
 template <class... Ts> using pair_self_t = typename pair_self<Ts...>::type;
-// template <class... Ts>
-// using pair_product_t = typename pair_product<Ts...>::type;
 template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
 
 namespace operator_detail {

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -867,6 +867,13 @@ TEST(DatasetInPlaceStrongExceptionGuarantee, sparse) {
   set_sparse_variances(bad, {{0.5, 0.6}, {0.8}});
   DataArray good_array(good, {}, {});
 
+  // We have no control over the iteration order in the implementation of binary
+  // operations. All we know that data is in some sort of (unordered) map.
+  // Therefore, we try all permutations of key names and insertion order, hoping
+  // to cover also those that first process good items, then bad items (if bad
+  // items are processed first, the exception guarantees of the underlying
+  // binary operations for Variable are doing the job on their own, but we need
+  // to exercise those for Dataset here).
   for (const auto &keys : {std::pair{"a", "b"}, std::pair{"b", "a"}}) {
     auto & [ key1, key2 ] = keys;
     for (const auto &values : {std::pair{good, bad}, std::pair{bad, good}}) {

--- a/core/test/make_sparse.h
+++ b/core/test/make_sparse.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_TEST_MAKE_SPARSE_H
+#define SCIPP_CORE_TEST_MAKE_SPARSE_H
+
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+inline auto make_sparse_variable_with_variance() {
+  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  return makeVariable<double>(
+      dims, {sparse_container<double>(), sparse_container<double>()},
+      {sparse_container<double>(), sparse_container<double>()});
+}
+
+inline auto make_sparse_variable() {
+  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  return makeVariable<double>(dims);
+}
+
+inline void
+set_sparse_values(Variable &var,
+                  const std::vector<sparse_container<double>> &data) {
+  auto vals = var.sparseValues<double>();
+  for (scipp::index i = 0; i < scipp::size(data); ++i)
+    vals[i] = data[i];
+}
+
+inline void
+set_sparse_variances(Variable &var,
+                     const std::vector<sparse_container<double>> &data) {
+  auto vals = var.sparseVariances<double>();
+  for (scipp::index i = 0; i < scipp::size(data); ++i)
+    vals[i] = data[i];
+}
+
+#endif // SCIPP_CORE_TEST_MAKE_SPARSE_H

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -750,3 +750,14 @@ TEST(TransformTest, user_op_with_variances) {
   EXPECT_EQ(result, expected);
   EXPECT_EQ(result, var);
 }
+
+TEST(TransformTest, in_place_dry_run) {
+  auto a = make_sparse_variable_with_variance();
+  a.setUnit(units::m * units::m);
+  set_sparse_values(a, {{1, 2, 3}, {4}});
+  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  const auto original(a);
+
+  dry_run::transform_in_place<double>(a, [](auto &a_) { a_ = sqrt(a_); });
+  EXPECT_EQ(a, original);
+}

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -5,6 +5,7 @@
 
 #include "test_macros.h"
 
+#include "../operators.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -6,6 +6,7 @@
 #include "test_macros.h"
 
 #include "../operators.h"
+#include "make_sparse.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
@@ -549,32 +550,6 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
                          except::SizeError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place),
                except::SizeError);
-}
-
-auto make_sparse_variable_with_variance() {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  return makeVariable<double>(
-      dims, {sparse_container<double>(), sparse_container<double>()},
-      {sparse_container<double>(), sparse_container<double>()});
-}
-
-auto make_sparse_variable() {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  return makeVariable<double>(dims);
-}
-
-void set_sparse_values(Variable &var,
-                       const std::vector<sparse_container<double>> &data) {
-  auto vals = var.sparseValues<double>();
-  for (scipp::index i = 0; i < scipp::size(data); ++i)
-    vals[i] = data[i];
-}
-
-void set_sparse_variances(Variable &var,
-                          const std::vector<sparse_container<double>> &data) {
-  auto vals = var.sparseVariances<double>();
-  for (scipp::index i = 0; i < scipp::size(data); ++i)
-    vals[i] = data[i];
 }
 
 TEST_F(TransformBinaryTest, sparse_val_var_with_sparse_val_var) {

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -753,11 +753,18 @@ TEST(TransformTest, user_op_with_variances) {
 
 TEST(TransformTest, in_place_dry_run) {
   auto a = make_sparse_variable_with_variance();
-  a.setUnit(units::m * units::m);
+  a.setUnit(units::m);
   set_sparse_values(a, {{1, 2, 3}, {4}});
   set_sparse_variances(a, {{5, 6, 7}, {8}});
   const auto original(a);
+  // TODO
+  // test that all possible errors are caught
+  // test with slices (special unit check)
+  // test without variances
 
-  dry_run::transform_in_place<double>(a, [](auto &a_) { a_ = sqrt(a_); });
+  dry_run::transform_in_place<double>(a, [](auto &a_) { a_ *= a_; });
+  EXPECT_EQ(a, original);
+  dry_run::transform_in_place<pair_self_t<double>>(
+      a, a, [](auto &a_, auto &&b_) { a_ *= b_; });
   EXPECT_EQ(a, original);
 }

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <string>
 
+#include "operators.h"
 #include "scipp/core/apply.h"
 #include "scipp/core/counts.h"
 #include "scipp/core/dataset.h"

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include <cmath>
 
+#include "operators.h"
 #include "scipp/core/except.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
@@ -11,13 +12,9 @@
 namespace scipp::core {
 
 template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
-  // Addition with different Variable type is supported, mismatch of underlying
-  // element types is handled in DataModel::operator+=.
-  // Different name is ok for addition.
   // Note: This will broadcast/transpose the RHS if required. We do not support
   // changing the dimensions of the LHS though!
-  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { a += b; });
+  transform_in_place(variable, other, operator_detail::plus_equals{});
   return variable;
 }
 
@@ -53,8 +50,7 @@ Variable &Variable::operator+=(const double value) & {
 }
 
 template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<double, float, int64_t, Eigen::Vector3d>>(
-      variable, other, [](auto &&a, auto &&b) { a -= b; });
+  transform_in_place(variable, other, operator_detail::minus_equals{});
   return variable;
 }
 
@@ -74,9 +70,7 @@ Variable &Variable::operator-=(const double value) & {
 }
 
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<double, float, int64_t>,
-                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { a *= b; });
+  transform_in_place(variable, other, operator_detail::times_equals{});
   return variable;
 }
 
@@ -98,9 +92,7 @@ Variable &Variable::operator*=(const double value) & {
 }
 
 template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<double, float, int64_t>,
-                     pair_custom_t<std::pair<Eigen::Vector3d, double>>>(
-      variable, other, [](auto &&a, auto &&b) { a /= b; });
+  transform_in_place(variable, other, operator_detail::divide_equals{});
   return variable;
 }
 


### PR DESCRIPTION
Fixes #248.

**I suggest to to exclude the first commit from review: It only moves around a lot of code. If you include it the diff will be unreadable.**

After many ideas that were dead ends (see issue), I finally found a reasonable way to implement this, without duplicating too much code. Essentially we are just doing all checks in advance.

This adds some performance penalty, but until we show that this is an issue I would not worry too much about this. If it turns out to be an issue, improvements could be made, e.g., the coord checks could be skipped in the second iteration.