### PR TITLE
Variable implicit conversion

### DIFF
--- a/core/except.cpp
+++ b/core/except.cpp
@@ -67,7 +67,7 @@ std::string to_string(const Slice &slice) {
 
 std::string to_string(const units::Unit &unit) { return unit.name(); }
 
-std::string make_dims_labels(const Variable &variable,
+std::string make_dims_labels(const VariableConstProxy &variable,
                              const Dimensions &datasetDims) {
   const auto &dims = variable.dims();
   if (dims.empty())

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -339,6 +339,28 @@ public:
   void setSparseLabels(const std::string &name, const std::string &labelName,
                        Variable labels);
 
+  void setCoord(const Dim dim, const VariableConstProxy &coord) {
+    setCoord(dim, Variable(coord));
+  }
+  void setLabels(const std::string &labelName,
+                 const VariableConstProxy &labels) {
+    setLabels(labelName, Variable(labels));
+  }
+  void setAttr(const std::string &attrName, const VariableConstProxy &attr) {
+    setAttr(attrName, Variable(attr));
+  }
+  void setData(const std::string &name, const VariableConstProxy &data) {
+    setData(name, Variable(data));
+  }
+  void setSparseCoord(const std::string &name,
+                      const VariableConstProxy &coord) {
+    setSparseCoord(name, Variable(coord));
+  }
+  void setSparseLabels(const std::string &name, const std::string &labelName,
+                       const VariableConstProxy &labels) {
+    setSparseLabels(name, labelName, Variable(labels));
+  }
+
   DatasetConstProxy slice(const Slice slice1) const &;
   DatasetConstProxy slice(const Slice slice1, const Slice slice2) const &;
   DatasetConstProxy slice(const Slice slice1, const Slice slice2,

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -245,7 +245,7 @@ public:
   // Having this non-explicit is convenient when passing (potential)
   // variable slices to functions that do not support slices, but implicit
   // conversion may introduce risks, so there is a trade-of here.
-  Variable(const VariableConstProxy &slice);
+  explicit Variable(const VariableConstProxy &slice);
   Variable(const Variable &parent, const Dimensions &dims);
   Variable(const VariableConstProxy &parent, const Dimensions &dims);
   Variable(const Variable &parent, VariableConceptHandle data);
@@ -519,8 +519,7 @@ Variable makeVariable(const Dimensions &dimensions, Args &&... args) {
 /// Non-mutable view into (a subset of) a Variable.
 class SCIPP_CORE_EXPORT VariableConstProxy {
 public:
-  explicit VariableConstProxy(const Variable &variable)
-      : m_variable(&variable) {}
+  VariableConstProxy(const Variable &variable) : m_variable(&variable) {}
   VariableConstProxy(const Variable &variable, const Dimensions &dims)
       : m_variable(&variable), m_view(variable.data().reshape(dims)) {}
   VariableConstProxy(const VariableConstProxy &other) = default;
@@ -623,7 +622,7 @@ protected:
  * VariableConstProxy will automatically work also for this mutable variant. */
 class SCIPP_CORE_EXPORT VariableProxy : public VariableConstProxy {
 public:
-  explicit VariableProxy(Variable &variable)
+  VariableProxy(Variable &variable)
       : VariableConstProxy(variable), m_mutableVariable(&variable) {}
   // Note that we use the basic constructor of VariableConstProxy to avoid
   // creation of a const m_view, which would be overwritten immediately.
@@ -748,14 +747,22 @@ SCIPP_CORE_EXPORT Variable operator/(const VariableConstProxy &a,
 // Note: If the left-hand-side in an addition is a VariableProxy this simply
 // implicitly converts it to a Variable. A copy for the return value is required
 // anyway so this is a convenient way to avoid defining more overloads.
-SCIPP_CORE_EXPORT Variable operator+(Variable a, const double b);
-SCIPP_CORE_EXPORT Variable operator-(Variable a, const double b);
-SCIPP_CORE_EXPORT Variable operator*(Variable a, const double b);
-SCIPP_CORE_EXPORT Variable operator/(Variable a, const double b);
-SCIPP_CORE_EXPORT Variable operator+(const double a, Variable b);
-SCIPP_CORE_EXPORT Variable operator-(const double a, Variable b);
-SCIPP_CORE_EXPORT Variable operator*(const double a, Variable b);
-SCIPP_CORE_EXPORT Variable operator/(const double a, Variable b);
+SCIPP_CORE_EXPORT Variable operator+(const VariableConstProxy &a,
+                                     const double b);
+SCIPP_CORE_EXPORT Variable operator-(const VariableConstProxy &a,
+                                     const double b);
+SCIPP_CORE_EXPORT Variable operator*(const VariableConstProxy &a,
+                                     const double b);
+SCIPP_CORE_EXPORT Variable operator/(const VariableConstProxy &a,
+                                     const double b);
+SCIPP_CORE_EXPORT Variable operator+(const double a,
+                                     const VariableConstProxy &b);
+SCIPP_CORE_EXPORT Variable operator-(const double a,
+                                     const VariableConstProxy &b);
+SCIPP_CORE_EXPORT Variable operator*(const double a,
+                                     const VariableConstProxy &b);
+SCIPP_CORE_EXPORT Variable operator/(const double a,
+                                     const VariableConstProxy &b);
 template <class T>
 Variable operator*(Variable a, const boost::units::quantity<T> &quantity) {
   return std::move(a *= quantity);

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -169,7 +169,7 @@ TEST_F(TransformBinaryTest, var_with_view) {
 
 TEST_F(TransformBinaryTest, in_place_self_overlap_without_variance) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2});
-  Variable slice_copy = a.slice({Dim::X, 1});
+  Variable slice_copy(a.slice({Dim::X, 1}));
   auto reference = a * slice_copy;
   transform_in_place<pair_self_t<double>>(a, a.slice({Dim::X, 1}), op_in_place);
   ASSERT_EQ(a, reference);
@@ -177,7 +177,7 @@ TEST_F(TransformBinaryTest, in_place_self_overlap_without_variance) {
 
 TEST_F(TransformBinaryTest, in_place_self_overlap_with_variance) {
   auto a = makeVariable<double>({Dim::X, 2}, {1.1, 2.2}, {1.0, 2.0});
-  Variable slice_copy = a.slice({Dim::X, 1});
+  Variable slice_copy(a.slice({Dim::X, 1}));
   auto reference = a * slice_copy;
   // With self-overlap the implementation needs to make a copy of the rhs. This
   // is a regression test: An initial implementation was unintentionally

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -575,19 +575,19 @@ TEST(VariableProxy, variable_assign_from_slice) {
                            {11, 12, 13, 21, 22, 23, 31, 32, 33},
                            {44, 45, 46, 54, 55, 56, 64, 65, 66});
 
-  target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2});
+  target = Variable(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}));
   EXPECT_EQ(target, makeVariable<double>(dims, units::m, {11, 12, 21, 22},
                                          {44, 45, 54, 55}));
 
-  target = source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2});
+  target = Variable(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}));
   EXPECT_EQ(target, makeVariable<double>(dims, units::m, {12, 13, 22, 23},
                                          {45, 46, 55, 56}));
 
-  target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3});
+  target = Variable(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}));
   EXPECT_EQ(target, makeVariable<double>(dims, units::m, {21, 22, 31, 32},
                                          {54, 55, 64, 65}));
 
-  target = source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3});
+  target = Variable(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}));
   EXPECT_EQ(target, makeVariable<double>(dims, units::m, {22, 23, 32, 33},
                                          {55, 56, 65, 66}));
 }
@@ -599,7 +599,7 @@ TEST(VariableProxy, variable_assign_from_slice_clears_variances) {
       makeVariable<double>({{Dim::Y, 3}, {Dim::X, 3}}, units::m,
                            {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
-  target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2});
+  target = Variable(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}));
   EXPECT_EQ(target, makeVariable<double>(dims, units::m, {11, 12, 21, 22}));
 }
 
@@ -608,7 +608,7 @@ TEST(VariableProxy, variable_self_assign_via_slice) {
                                      {11, 12, 13, 21, 22, 23, 31, 32, 33},
                                      {44, 45, 46, 54, 55, 56, 64, 65, 66});
 
-  target = target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3});
+  target = Variable(target.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}));
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target, makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}},
@@ -754,7 +754,7 @@ TEST(VariableTest, reshape_mutable) {
 TEST(VariableTest, rename) {
   auto var = makeVariable<double>({{Dim::X, 2}, {Dim::Y, 3}},
                                   {1, 2, 3, 4, 5, 6}, {7, 8, 9, 10, 11, 12});
-  const Variable expected = var.reshape({{Dim::X, 2}, {Dim::Z, 3}});
+  const Variable expected(var.reshape({{Dim::X, 2}, {Dim::Z, 3}}));
 
   var.rename(Dim::Y, Dim::Z);
   ASSERT_EQ(var, expected);

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -154,14 +154,16 @@ VariableConstProxy Variable::slice(const Slice slice) const & {
 }
 
 Variable Variable::slice(const Slice slice) const && {
-  return {this->slice(slice)};
+  return Variable{this->slice(slice)};
 }
 
 VariableProxy Variable::slice(const Slice slice) & {
   return {*this, slice.dim(), slice.begin(), slice.end()};
 }
 
-Variable Variable::slice(const Slice slice) && { return {this->slice(slice)}; }
+Variable Variable::slice(const Slice slice) && {
+  return Variable{this->slice(slice)};
+}
 
 VariableConstProxy Variable::reshape(const Dimensions &dims) const & {
   return {*this, dims};
@@ -458,7 +460,7 @@ Variable broadcast(Variable var, const Dimensions &dims) {
 
 void swap(Variable &var, const Dim dim, const scipp::index a,
           const scipp::index b) {
-  const Variable tmp = var.slice({dim, a});
+  const Variable tmp(var.slice({dim, a}));
   var.slice({dim, a}).assign(var.slice({dim, b}));
   var.slice({dim, b}).assign(tmp);
 }

--- a/core/variable_binary_ops.cpp
+++ b/core/variable_binary_ops.cpp
@@ -226,16 +226,36 @@ Variable operator*(const VariableConstProxy &a, const VariableConstProxy &b) {
 Variable operator/(const VariableConstProxy &a, const VariableConstProxy &b) {
   return divide(a, b);
 }
-// Note: The std::move here is necessary because RVO does not work for variables
-// that are function parameters.
-Variable operator+(Variable a, const double b) { return std::move(a += b); }
-Variable operator-(Variable a, const double b) { return std::move(a -= b); }
-Variable operator*(Variable a, const double b) { return std::move(a *= b); }
-Variable operator/(Variable a, const double b) { return std::move(a /= b); }
-Variable operator+(const double a, Variable b) { return std::move(b += a); }
-Variable operator-(const double a, Variable b) { return -(b -= a); }
-Variable operator*(const double a, Variable b) { return std::move(b *= a); }
-Variable operator/(const double a, Variable b) {
+Variable operator+(const VariableConstProxy &a_, const double b) {
+  Variable a(a_);
+  return a += b;
+}
+Variable operator-(const VariableConstProxy &a_, const double b) {
+  Variable a(a_);
+  return a -= b;
+}
+Variable operator*(const VariableConstProxy &a_, const double b) {
+  Variable a(a_);
+  return a *= b;
+}
+Variable operator/(const VariableConstProxy &a_, const double b) {
+  Variable a(a_);
+  return a /= b;
+}
+Variable operator+(const double a, const VariableConstProxy &b_) {
+  Variable b(b_);
+  return b += a;
+}
+Variable operator-(const double a, const VariableConstProxy &b_) {
+  Variable b(b_);
+  return -(b -= a);
+}
+Variable operator*(const double a, const VariableConstProxy &b_) {
+  Variable b(b_);
+  return b *= a;
+}
+Variable operator/(const double a, const VariableConstProxy &b_proxy) {
+  Variable b(b_proxy);
   b.setUnit(units::Unit(units::dimensionless) / b.unit());
   transform_in_place<double, float>(
       b, overloaded{[a](double &b_) { b_ = a / b_; },

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -148,19 +148,20 @@ void init_dataset(py::module &m) {
 
   py::class_<Dataset> dataset(m, "Dataset");
   dataset.def(py::init<>())
-      .def(py::init([](const std::map<std::string, Variable> &data,
-                       const std::map<Dim, Variable> &coords,
-                       const std::map<std::string, Variable> &labels,
-                       const std::map<std::string, Variable> &attrs) {
+      .def(py::init([](const std::map<std::string, VariableConstProxy> &data,
+                       const std::map<Dim, VariableConstProxy> &coords,
+                       const std::map<std::string, VariableConstProxy> &labels,
+                       const std::map<std::string, VariableConstProxy> &attrs) {
              return Dataset(data, coords, labels, attrs);
            }),
-           py::arg("data") = std::map<std::string, Variable>{},
-           py::arg("coords") = std::map<Dim, Variable>{},
-           py::arg("labels") = std::map<std::string, Variable>{},
-           py::arg("attrs") = std::map<std::string, Variable>{})
+           py::arg("data") = std::map<std::string, VariableConstProxy>{},
+           py::arg("coords") = std::map<Dim, VariableConstProxy>{},
+           py::arg("labels") = std::map<std::string, VariableConstProxy>{},
+           py::arg("attrs") = std::map<std::string, VariableConstProxy>{})
       .def(py::init([](const DatasetProxy &other) { return Dataset{other}; }))
-      .def("__setitem__", [](Dataset &self, const std::string &name,
-                             Variable data) { self.setData(name, data); })
+      .def("__setitem__",
+           [](Dataset &self, const std::string &name,
+              const VariableConstProxy &data) { self.setData(name, data); })
       .def("__setitem__",
            [](Dataset &self, const std::string &name,
               const DataConstProxy &data) { self.setData(name, data); })

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -165,14 +165,6 @@ void init_dataset(py::module &m) {
       .def("__setitem__",
            [](Dataset &self, const std::string &name,
               const DataConstProxy &data) { self.setData(name, data); })
-      // TODO: nvaytet: I do not understand why this is not covered by the
-      // py::implicitly_convertible<VariableProxy, Variable>();
-      // statement in variable.cpp, but this is needed if a VariableProxy is
-      // used instead of a Variable.
-      // Maybe it's because it's in a different file?
-      .def("__setitem__",
-           [](Dataset &self, const std::string &name,
-              const VariableProxy &data) { self.setData(name, data); })
       .def("__setitem__",
            [](Dataset &self, const std::tuple<Dim, scipp::index> &index,
               DatasetProxy &other) {

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -199,7 +199,8 @@ void init_variable(py::module &m) {
   bind_init_1D<int32_t>(variable);
   bind_init_1D<double>(variable);
 
-  py::class_<VariableConstProxy>(m, "VariableConstProxy");
+  py::class_<VariableConstProxy>(m, "VariableConstProxy")
+      .def(py::init<const Variable &>());
   py::class_<VariableProxy, VariableConstProxy> variableProxy(
       m, "VariableProxy", py::buffer_protocol());
   variableProxy.def_buffer(&make_py_buffer_info);
@@ -253,9 +254,7 @@ void init_variable(py::module &m) {
   bind_data_properties(variable);
   bind_data_properties(variableProxy);
 
-  // Implicit conversion VariableProxy -> Variable. Reduces need for excessive
-  // operator overload definitions
-  py::implicitly_convertible<VariableProxy, Variable>();
+  py::implicitly_convertible<Variable, VariableConstProxy>();
 
   m.def("abs", [](const Variable &self) { return abs(self); },
         py::call_guard<py::gil_scoped_release>(), R"(


### PR DESCRIPTION
Previously we had an implicit conversion from `VariableConstProxy` to `Variable`. This made it easy to implement functions that accept variables by value (letting you move inputs, avoiding copies), but at the same time support passing slices.

However, it now seems more relevant to avoid unintentional costly creation of variables. This PR changes the direction of the implicit conversion: `Variable` -> `Variable(Const)Proxy` is now possible, this is essentially free.

This brings the behavior in-line with that for `DataArray` -> `DataProxy` and `Dataset` -> `DatasetProxy`.