### PR TITLE
Unit without variant and cryptic error messages

### DIFF
--- a/common/include/scipp/common/traits.h
+++ b/common/include/scipp/common/traits.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_COMMON_TRAITS_H
+#define SCIPP_COMMON_TRAITS_H
+
+namespace scipp::common {
+
+// https://stackoverflow.com/a/18063608
+template <class T, class Tuple> struct index_in_tuple;
+
+template <class T, class... Types>
+struct index_in_tuple<T, std::tuple<T, Types...>> {
+  static const std::size_t value = 0;
+};
+
+template <class T, class U, class... Types>
+struct index_in_tuple<T, std::tuple<U, Types...>> {
+  static const std::size_t value =
+      1 + index_in_tuple<T, std::tuple<Types...>>::value;
+};
+
+} // namespace scipp::common
+
+#endif // SCIPP_COMMON_TRAITS_H

--- a/units/dummy.cpp
+++ b/units/dummy.cpp
@@ -7,7 +7,7 @@
 
 namespace scipp::units {
 
-INSTANTIATE(dummy::supported_units, dummy::counts_unit)
+INSTANTIATE(dummy::Unit)
 SCIPP_UNITS_DEFINE_DIMENSIONS(dummy)
 
 } // namespace scipp::units

--- a/units/include/scipp/units/dummy.h
+++ b/units/include/scipp/units/dummy.h
@@ -14,16 +14,24 @@ inline
 #endif
     namespace dummy {
 
-using supported_units = decltype(detail::make_unit(
-    std::make_tuple(m), std::make_tuple(dimensionless, dimensionless / m, s,
-                                        dimensionless / s, m / s)));
-
-using counts_unit = decltype(dimensionless);
-using Unit = Unit_impl<supported_units, counts_unit>;
+class SCIPP_UNITS_EXPORT Unit : public Unit_impl<Unit> {
+public:
+  using Unit_impl<Unit>::Unit_impl;
+};
 
 SCIPP_UNITS_DECLARE_DIMENSIONS(X, Y, Z)
 
 } // namespace dummy
+
+template <> struct supported_units<dummy::Unit> {
+  using type = decltype(detail::make_unit(
+      std::make_tuple(m), std::make_tuple(dimensionless, dimensionless / m, s,
+                                          dimensionless / s, m / s)));
+};
+template <> struct counts_unit<dummy::Unit> {
+  using type = decltype(dimensionless);
+};
+
 } // namespace scipp::units
 
 #endif // SCIPP_UNITS_DUMMY_H

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -138,23 +138,31 @@ static constexpr decltype(detail::tof::energy{} * dimensionless) meV;
 static constexpr decltype(detail::tof::tof{} * dimensionless) us;
 static constexpr decltype(detail::tof::velocity{} * dimensionless) c;
 
-using supported_units = decltype(detail::make_unit(
-    std::make_tuple(m, dimensionless / m),
-    std::make_tuple(dimensionless, counts, s, kg, angstrom, meV, us,
-                    dimensionless / us, dimensionless / s, counts / us,
-                    counts / angstrom, counts / meV, m *m *m,
-                    meV *us *us / (m * m), meV *us *us *dimensionless,
-                    kg *m / s, m / s, c, c *m, meV / c, dimensionless / c, K,
-                    us / angstrom, us / (m * angstrom))));
-
-using counts_unit = decltype(counts);
-using Unit = Unit_impl<supported_units, counts_unit>;
+class Unit : public Unit_impl<Unit> {
+public:
+  using Unit_impl<Unit>::Unit_impl;
+};
 
 SCIPP_UNITS_DECLARE_DIMENSIONS(DSpacing, Energy, EnergyTransfer, Position, Q,
                                Qx, Qy, Qz, Row, Spectrum, Time, Tof, Wavelength,
                                X, Y, Z)
 
 } // namespace neutron
+
+template <> struct supported_units<neutron::Unit> {
+  using type = decltype(detail::make_unit(
+      std::make_tuple(m, dimensionless / m),
+      std::make_tuple(dimensionless, counts, s, kg, angstrom, meV, us,
+                      dimensionless / us, dimensionless / s, counts / us,
+                      counts / angstrom, counts / meV, m *m *m,
+                      meV *us *us / (m * m), meV *us *us *dimensionless,
+                      kg *m / s, m / s, c, c *m, meV / c, dimensionless / c, K,
+                      us / angstrom, us / (m * angstrom))));
+};
+template <> struct counts_unit<neutron::Unit> {
+  using type = decltype(counts);
+};
+
 } // namespace scipp::units
 
 #endif // SCIPP_UNITS_NEUTRON_H

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -38,7 +38,7 @@ template <class... Ts> auto make_name_lut(std::variant<Ts...>) {
 template <class T, class Counts>
 std::string Unit_impl<T, Counts>::name() const {
   static const auto names = make_name_lut(T{});
-  return names[m_unit.index()];
+  return names[index()];
 }
 
 template <class T, class Counts> bool Unit_impl<T, Counts>::isCounts() const {
@@ -61,12 +61,12 @@ constexpr auto make_count_density_lut(std::variant<Ts...>) {
 template <class T, class Counts>
 bool Unit_impl<T, Counts>::isCountDensity() const {
   static constexpr auto lut = make_count_density_lut<Counts>(T{});
-  return lut[m_unit.index()];
+  return lut[index()];
 }
 
 template <class T, class Counts>
 bool Unit_impl<T, Counts>::operator==(const Unit_impl<T, Counts> &other) const {
-  return operator()() == other();
+  return index() == other.index();
 }
 template <class T, class Counts>
 bool Unit_impl<T, Counts>::operator!=(const Unit_impl<T, Counts> &other) const {
@@ -161,7 +161,7 @@ template <class T, class Counts>
 Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
                                const Unit_impl<T, Counts> &b) {
   static constexpr auto lut = make_times_lut(T{});
-  auto resultIndex = lut[a().index()][b().index()];
+  auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of multiplication: (" +
                             a.name() + ") * (" + b.name() + ')');
@@ -172,7 +172,7 @@ template <class T, class Counts>
 Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
                                const Unit_impl<T, Counts> &b) {
   static constexpr auto lut = make_divide_lut(T{});
-  auto resultIndex = lut[a().index()][b().index()];
+  auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of division: (" +
                             a.name() + ") / (" + b.name() + ')');
@@ -192,7 +192,7 @@ Unit_impl<T, Counts> abs(const Unit_impl<T, Counts> &a) {
 template <class T, class Counts>
 Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a) {
   static constexpr auto lut = make_sqrt_lut(T{});
-  auto resultIndex = lut[a().index()];
+  auto resultIndex = lut[a.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of sqrt: sqrt(" +
                             a.name() + ").");

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -29,14 +29,13 @@ template <class... Ts> auto make_name_lut(std::tuple<Ts...>) {
   return std::array{std::string(boost::lexical_cast<std::string>(Ts{}))...};
 }
 
-template <class T, class Counts>
-std::string Unit_impl<T, Counts>::name() const {
-  static const auto names = make_name_lut(T{});
+template <class Derived> std::string Unit_impl<Derived>::name() const {
+  static const auto names = make_name_lut(supported_units_t<Derived>{});
   return names[index()];
 }
 
-template <class T, class Counts> bool Unit_impl<T, Counts>::isCounts() const {
-  return *this == Counts();
+template <class Derived> bool Unit_impl<Derived>::isCounts() const {
+  return *this == counts_unit_t<Derived>();
 }
 
 template <class Counts, class... Ts>
@@ -52,52 +51,52 @@ constexpr auto make_count_density_lut(std::tuple<Ts...>) {
   }
 }
 
-template <class T, class Counts>
-bool Unit_impl<T, Counts>::isCountDensity() const {
-  static constexpr auto lut = make_count_density_lut<Counts>(T{});
+template <class Derived> bool Unit_impl<Derived>::isCountDensity() const {
+  static constexpr auto lut = make_count_density_lut<counts_unit_t<Derived>>(
+      supported_units_t<Derived>{});
   return lut[index()];
 }
 
-template <class T, class Counts>
-bool Unit_impl<T, Counts>::operator==(const Unit_impl<T, Counts> &other) const {
+template <class Derived>
+bool Unit_impl<Derived>::operator==(const Unit_impl<Derived> &other) const {
   return index() == other.index();
 }
-template <class T, class Counts>
-bool Unit_impl<T, Counts>::operator!=(const Unit_impl<T, Counts> &other) const {
+template <class Derived>
+bool Unit_impl<Derived>::operator!=(const Unit_impl<Derived> &other) const {
   return !(*this == other);
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> Unit_impl<T, Counts>::operator+=(const Unit_impl &other) {
+template <class Derived>
+Unit_impl<Derived> &Unit_impl<Derived>::operator+=(const Unit_impl &other) {
   return *this = *this + other;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> Unit_impl<T, Counts>::operator-=(const Unit_impl &other) {
+template <class Derived>
+Unit_impl<Derived> &Unit_impl<Derived>::operator-=(const Unit_impl &other) {
   return *this = *this - other;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> Unit_impl<T, Counts>::operator*=(const Unit_impl &other) {
+template <class Derived>
+Unit_impl<Derived> &Unit_impl<Derived>::operator*=(const Unit_impl &other) {
   return *this = *this * other;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> Unit_impl<T, Counts>::operator/=(const Unit_impl &other) {
+template <class Derived>
+Unit_impl<Derived> &Unit_impl<Derived>::operator/=(const Unit_impl &other) {
   return *this = *this / other;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator+(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b) {
+template <class Derived>
+Unit_impl<Derived> operator+(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b) {
   if (a == b)
     return a;
   throw except::UnitError("Cannot add " + a.name() + " and " + b.name() + ".");
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b) {
+template <class Derived>
+Unit_impl<Derived> operator-(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b) {
   if (a == b)
     return a;
   throw except::UnitError("Cannot subtract " + a.name() + " and " + b.name() +
@@ -152,63 +151,75 @@ template <class... Ts> constexpr auto make_sqrt_lut(std::tuple<Ts...>) {
   return std::array{sqrt_(Ts{})...};
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b) {
-  static constexpr auto lut = make_times_lut(T{});
+template <class Derived>
+Unit_impl<Derived> operator*(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b) {
+  static constexpr auto lut = make_times_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of multiplication: (" +
                             a.name() + ") * (" + b.name() + ')');
-  return Unit_impl<T, Counts>::fromIndex(resultIndex);
+  return Unit_impl<Derived>::fromIndex(resultIndex);
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b) {
-  static constexpr auto lut = make_divide_lut(T{});
+template <class Derived>
+Unit_impl<Derived> operator/(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b) {
+  static constexpr auto lut = make_divide_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of division: (" +
                             a.name() + ") / (" + b.name() + ')');
-  return Unit_impl<T, Counts>::fromIndex(resultIndex);
+  return Unit_impl<Derived>::fromIndex(resultIndex);
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a) {
+template <class Derived>
+Unit_impl<Derived> operator-(const Unit_impl<Derived> &a) {
   return a;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> abs(const Unit_impl<T, Counts> &a) {
+template <class Derived> Unit_impl<Derived> abs(const Unit_impl<Derived> &a) {
   return a;
 }
 
-template <class T, class Counts>
-Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a) {
-  static constexpr auto lut = make_sqrt_lut(T{});
+template <class Derived> Unit_impl<Derived> sqrt(const Unit_impl<Derived> &a) {
+  static constexpr auto lut = make_sqrt_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()];
   if (resultIndex < 0)
     throw except::UnitError("Unsupported unit as result of sqrt: sqrt(" +
                             a.name() + ").");
-  return Unit_impl<T, Counts>::fromIndex(resultIndex);
+  return Unit_impl<Derived>::fromIndex(resultIndex);
 }
 
-#define INSTANTIATE(Units, Counts)                                             \
-  template class SCIPP_UNITS_EXPORT Unit_impl<Units, Counts>;                  \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> operator+(              \
-      const Unit_impl<Units, Counts> &, const Unit_impl<Units, Counts> &);     \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> operator-(              \
-      const Unit_impl<Units, Counts> &, const Unit_impl<Units, Counts> &);     \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> operator*(              \
-      const Unit_impl<Units, Counts> &, const Unit_impl<Units, Counts> &);     \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> operator/(              \
-      const Unit_impl<Units, Counts> &, const Unit_impl<Units, Counts> &);     \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> operator-(              \
-      const Unit_impl<Units, Counts> &);                                       \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> abs(                    \
-      const Unit_impl<Units, Counts> &a);                                      \
-  template SCIPP_UNITS_EXPORT Unit_impl<Units, Counts> sqrt(                   \
-      const Unit_impl<Units, Counts> &a);
+#define INSTANTIATE(Derived)                                                   \
+  template SCIPP_UNITS_EXPORT std::string Unit_impl<Derived>::name() const;    \
+  template SCIPP_UNITS_EXPORT bool Unit_impl<Derived>::isCounts() const;       \
+  template SCIPP_UNITS_EXPORT bool Unit_impl<Derived>::isCountDensity() const; \
+  template SCIPP_UNITS_EXPORT bool Unit_impl<Derived>::operator==(             \
+      const Unit_impl<Derived> &) const;                                       \
+  template SCIPP_UNITS_EXPORT bool Unit_impl<Derived>::operator!=(             \
+      const Unit_impl<Derived> &) const;                                       \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
+      &Unit_impl<Derived>::operator+=(const Unit_impl<Derived> &);             \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
+      &Unit_impl<Derived>::operator-=(const Unit_impl<Derived> &);             \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
+      &Unit_impl<Derived>::operator*=(const Unit_impl<Derived> &);             \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
+      &Unit_impl<Derived>::operator/=(const Unit_impl<Derived> &);             \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator+(                    \
+      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator-(                    \
+      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator*(                    \
+      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator/(                    \
+      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator-(                    \
+      const Unit_impl<Derived> &);                                             \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> abs(                          \
+      const Unit_impl<Derived> &a);                                            \
+  template SCIPP_UNITS_EXPORT Unit_impl<Derived> sqrt(                         \
+      const Unit_impl<Derived> &a);
 
 } // namespace scipp::units

--- a/units/include/scipp/units/unit.tcc
+++ b/units/include/scipp/units/unit.tcc
@@ -67,38 +67,36 @@ bool Unit_impl<Derived>::operator!=(const Unit_impl<Derived> &other) const {
 }
 
 template <class Derived>
-Unit_impl<Derived> &Unit_impl<Derived>::operator+=(const Unit_impl &other) {
-  return *this = *this + other;
+Derived &Unit_impl<Derived>::operator+=(const Unit_impl &other) {
+  return static_cast<Derived &>(*this = *this + other);
 }
 
 template <class Derived>
-Unit_impl<Derived> &Unit_impl<Derived>::operator-=(const Unit_impl &other) {
-  return *this = *this - other;
+Derived &Unit_impl<Derived>::operator-=(const Unit_impl &other) {
+  return static_cast<Derived &>(*this = *this - other);
 }
 
 template <class Derived>
-Unit_impl<Derived> &Unit_impl<Derived>::operator*=(const Unit_impl &other) {
-  return *this = *this * other;
+Derived &Unit_impl<Derived>::operator*=(const Unit_impl &other) {
+  return static_cast<Derived &>(*this = *this * other);
 }
 
 template <class Derived>
-Unit_impl<Derived> &Unit_impl<Derived>::operator/=(const Unit_impl &other) {
-  return *this = *this / other;
+Derived &Unit_impl<Derived>::operator/=(const Unit_impl &other) {
+  return static_cast<Derived &>(*this = *this / other);
 }
 
 template <class Derived>
-Unit_impl<Derived> operator+(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b) {
+Derived operator+(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b) {
   if (a == b)
-    return a;
+    return static_cast<const Derived &>(a);
   throw except::UnitError("Cannot add " + a.name() + " and " + b.name() + ".");
 }
 
 template <class Derived>
-Unit_impl<Derived> operator-(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b) {
+Derived operator-(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b) {
   if (a == b)
-    return a;
+    return static_cast<const Derived &>(a);
   throw except::UnitError("Cannot subtract " + a.name() + " and " + b.name() +
                           ".");
 }
@@ -152,8 +150,7 @@ template <class... Ts> constexpr auto make_sqrt_lut(std::tuple<Ts...>) {
 }
 
 template <class Derived>
-Unit_impl<Derived> operator*(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b) {
+Derived operator*(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b) {
   static constexpr auto lut = make_times_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
@@ -163,8 +160,7 @@ Unit_impl<Derived> operator*(const Unit_impl<Derived> &a,
 }
 
 template <class Derived>
-Unit_impl<Derived> operator/(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b) {
+Derived operator/(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b) {
   static constexpr auto lut = make_divide_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()][b.index()];
   if (resultIndex < 0)
@@ -173,16 +169,15 @@ Unit_impl<Derived> operator/(const Unit_impl<Derived> &a,
   return Unit_impl<Derived>::fromIndex(resultIndex);
 }
 
-template <class Derived>
-Unit_impl<Derived> operator-(const Unit_impl<Derived> &a) {
-  return a;
+template <class Derived> Derived operator-(const Unit_impl<Derived> &a) {
+  return static_cast<const Derived &>(a);
 }
 
-template <class Derived> Unit_impl<Derived> abs(const Unit_impl<Derived> &a) {
-  return a;
+template <class Derived> Derived abs(const Unit_impl<Derived> &a) {
+  return static_cast<const Derived &>(a);
 }
 
-template <class Derived> Unit_impl<Derived> sqrt(const Unit_impl<Derived> &a) {
+template <class Derived> Derived sqrt(const Unit_impl<Derived> &a) {
   static constexpr auto lut = make_sqrt_lut(supported_units_t<Derived>{});
   auto resultIndex = lut[a.index()];
   if (resultIndex < 0)
@@ -199,27 +194,24 @@ template <class Derived> Unit_impl<Derived> sqrt(const Unit_impl<Derived> &a) {
       const Unit_impl<Derived> &) const;                                       \
   template SCIPP_UNITS_EXPORT bool Unit_impl<Derived>::operator!=(             \
       const Unit_impl<Derived> &) const;                                       \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
-      &Unit_impl<Derived>::operator+=(const Unit_impl<Derived> &);             \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
-      &Unit_impl<Derived>::operator-=(const Unit_impl<Derived> &);             \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
-      &Unit_impl<Derived>::operator*=(const Unit_impl<Derived> &);             \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived>                               \
-      &Unit_impl<Derived>::operator/=(const Unit_impl<Derived> &);             \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator+(                    \
-      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator-(                    \
-      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator*(                    \
-      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator/(                    \
-      const Unit_impl<Derived> &, const Unit_impl<Derived> &);                 \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> operator-(                    \
+  template SCIPP_UNITS_EXPORT Derived &Unit_impl<Derived>::operator+=(         \
       const Unit_impl<Derived> &);                                             \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> abs(                          \
-      const Unit_impl<Derived> &a);                                            \
-  template SCIPP_UNITS_EXPORT Unit_impl<Derived> sqrt(                         \
-      const Unit_impl<Derived> &a);
+  template SCIPP_UNITS_EXPORT Derived &Unit_impl<Derived>::operator-=(         \
+      const Unit_impl<Derived> &);                                             \
+  template SCIPP_UNITS_EXPORT Derived &Unit_impl<Derived>::operator*=(         \
+      const Unit_impl<Derived> &);                                             \
+  template SCIPP_UNITS_EXPORT Derived &Unit_impl<Derived>::operator/=(         \
+      const Unit_impl<Derived> &);                                             \
+  template SCIPP_UNITS_EXPORT Derived operator+(const Unit_impl<Derived> &,    \
+                                                const Unit_impl<Derived> &);   \
+  template SCIPP_UNITS_EXPORT Derived operator-(const Unit_impl<Derived> &,    \
+                                                const Unit_impl<Derived> &);   \
+  template SCIPP_UNITS_EXPORT Derived operator*(const Unit_impl<Derived> &,    \
+                                                const Unit_impl<Derived> &);   \
+  template SCIPP_UNITS_EXPORT Derived operator/(const Unit_impl<Derived> &,    \
+                                                const Unit_impl<Derived> &);   \
+  template SCIPP_UNITS_EXPORT Derived operator-(const Unit_impl<Derived> &);   \
+  template SCIPP_UNITS_EXPORT Derived abs(const Unit_impl<Derived> &a);        \
+  template SCIPP_UNITS_EXPORT Derived sqrt(const Unit_impl<Derived> &a);
 
 } // namespace scipp::units

--- a/units/include/scipp/units/unit_impl.h
+++ b/units/include/scipp/units/unit_impl.h
@@ -52,8 +52,8 @@ public:
     m_index = common::index_in_tuple<decltype(unit),
                                      supported_units_t<Derived>>::value;
   }
-  static constexpr Unit_impl fromIndex(const int64_t index) {
-    Unit_impl u;
+  static constexpr Derived fromIndex(const int64_t index) {
+    Derived u;
     u.m_index = index;
     return u;
   }
@@ -65,13 +65,13 @@ public:
   bool isCounts() const;
   bool isCountDensity() const;
 
-  bool operator==(const Unit_impl &other) const;
-  bool operator!=(const Unit_impl &other) const;
+  bool operator==(const Unit_impl<Derived> &other) const;
+  bool operator!=(const Unit_impl<Derived> &other) const;
 
-  Unit_impl &operator+=(const Unit_impl &other);
-  Unit_impl &operator-=(const Unit_impl &other);
-  Unit_impl &operator*=(const Unit_impl &other);
-  Unit_impl &operator/=(const Unit_impl &other);
+  Derived &operator+=(const Unit_impl<Derived> &other);
+  Derived &operator-=(const Unit_impl<Derived> &other);
+  Derived &operator*=(const Unit_impl<Derived> &other);
+  Derived &operator/=(const Unit_impl<Derived> &other);
 
 private:
   scipp::index m_index{
@@ -81,21 +81,16 @@ private:
 };
 
 template <class Derived>
-Unit_impl<Derived> operator+(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b);
+Derived operator+(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b);
 template <class Derived>
-Unit_impl<Derived> operator-(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b);
+Derived operator-(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b);
 template <class Derived>
-Unit_impl<Derived> operator*(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b);
+Derived operator*(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b);
 template <class Derived>
-Unit_impl<Derived> operator/(const Unit_impl<Derived> &a,
-                             const Unit_impl<Derived> &b);
-template <class Derived>
-Unit_impl<Derived> operator-(const Unit_impl<Derived> &a);
-template <class Derived> Unit_impl<Derived> abs(const Unit_impl<Derived> &a);
-template <class Derived> Unit_impl<Derived> sqrt(const Unit_impl<Derived> &a);
+Derived operator/(const Unit_impl<Derived> &a, const Unit_impl<Derived> &b);
+template <class Derived> Derived operator-(const Unit_impl<Derived> &a);
+template <class Derived> Derived abs(const Unit_impl<Derived> &a);
+template <class Derived> Derived sqrt(const Unit_impl<Derived> &a);
 
 } // namespace scipp::units
 

--- a/units/include/scipp/units/unit_impl.h
+++ b/units/include/scipp/units/unit_impl.h
@@ -22,9 +22,9 @@ static constexpr boost::units::si::time s;
 static constexpr boost::units::si::mass kg;
 static constexpr boost::units::si::temperature K;
 
-// Define a std::variant which will hold the set of allowed units. Any unit that
-// does not exist in the variant will either fail to compile or throw a
-// std::runtime_error during operations such as multiplication or division.
+// Define a std::tuple which will hold the set of allowed units. Any unit that
+// does not exist in the variant will either fail to compile or throw during
+// operations such as multiplication or division.
 namespace detail {
 template <class... Ts, class... Extra>
 std::tuple<Ts...,
@@ -39,8 +39,6 @@ make_unit(const std::tuple<Ts...> &, const std::tuple<Extra...> &) {
 
 template <class T, class Counts> class Unit_impl {
 public:
-  using unit_t = T;
-
   constexpr Unit_impl() = default;
   // TODO should this be explicit?
   template <class Dim, class System, class Enable>

--- a/units/include/scipp/units/unit_impl.h
+++ b/units/include/scipp/units/unit_impl.h
@@ -12,6 +12,8 @@
 #include <boost/units/systems/si.hpp>
 #include <boost/units/unit.hpp>
 
+#include "scipp/common/index.h"
+
 namespace scipp::units {
 // Helper variables to make the declaration units more succinct.
 static constexpr boost::units::si::dimensionless dimensionless;
@@ -52,9 +54,7 @@ public:
     return Unit_impl(m_lut[index]);
   }
 
-  constexpr const Unit_impl::unit_t &operator()() const noexcept {
-    return m_unit;
-  }
+  constexpr scipp::index index() const noexcept { return m_unit.index(); }
 
   std::string name() const;
 

--- a/units/include/scipp/units/unit_impl.h
+++ b/units/include/scipp/units/unit_impl.h
@@ -37,13 +37,20 @@ make_unit(const std::tuple<Ts...> &, const std::tuple<Extra...> &) {
 
 } // namespace detail
 
-template <class T, class Counts> class Unit_impl {
+template <class Unit> struct supported_units;
+template <class Unit> struct counts_unit;
+template <class Unit>
+using supported_units_t = typename supported_units<Unit>::type;
+template <class Unit> using counts_unit_t = typename counts_unit<Unit>::type;
+
+template <class Derived> class SCIPP_UNITS_EXPORT Unit_impl {
 public:
   constexpr Unit_impl() = default;
   // TODO should this be explicit?
   template <class Dim, class System, class Enable>
   Unit_impl(boost::units::unit<Dim, System, Enable> unit) {
-    m_index = common::index_in_tuple<decltype(unit), T>::value;
+    m_index = common::index_in_tuple<decltype(unit),
+                                     supported_units_t<Derived>>::value;
   }
   static constexpr Unit_impl fromIndex(const int64_t index) {
     Unit_impl u;
@@ -58,38 +65,37 @@ public:
   bool isCounts() const;
   bool isCountDensity() const;
 
-  bool operator==(const Unit_impl<T, Counts> &other) const;
-  bool operator!=(const Unit_impl<T, Counts> &other) const;
+  bool operator==(const Unit_impl &other) const;
+  bool operator!=(const Unit_impl &other) const;
 
-  Unit_impl operator+=(const Unit_impl &other);
-  Unit_impl operator-=(const Unit_impl &other);
-  Unit_impl operator*=(const Unit_impl &other);
-  Unit_impl operator/=(const Unit_impl &other);
+  Unit_impl &operator+=(const Unit_impl &other);
+  Unit_impl &operator-=(const Unit_impl &other);
+  Unit_impl &operator*=(const Unit_impl &other);
+  Unit_impl &operator/=(const Unit_impl &other);
 
 private:
   scipp::index m_index{
-      common::index_in_tuple<std::decay_t<decltype(dimensionless)>, T>::value};
+      common::index_in_tuple<std::decay_t<decltype(dimensionless)>,
+                             supported_units_t<Derived>>::value};
   // TODO need to support scale
 };
 
-template <class T, class Counts>
-Unit_impl<T, Counts> operator+(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b);
-template <class T, class Counts>
-Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b);
-template <class T, class Counts>
-Unit_impl<T, Counts> operator*(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b);
-template <class T, class Counts>
-Unit_impl<T, Counts> operator/(const Unit_impl<T, Counts> &a,
-                               const Unit_impl<T, Counts> &b);
-template <class T, class Counts>
-Unit_impl<T, Counts> operator-(const Unit_impl<T, Counts> &a);
-template <class T, class Counts>
-Unit_impl<T, Counts> abs(const Unit_impl<T, Counts> &a);
-template <class T, class Counts>
-Unit_impl<T, Counts> sqrt(const Unit_impl<T, Counts> &a);
+template <class Derived>
+Unit_impl<Derived> operator+(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b);
+template <class Derived>
+Unit_impl<Derived> operator-(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b);
+template <class Derived>
+Unit_impl<Derived> operator*(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b);
+template <class Derived>
+Unit_impl<Derived> operator/(const Unit_impl<Derived> &a,
+                             const Unit_impl<Derived> &b);
+template <class Derived>
+Unit_impl<Derived> operator-(const Unit_impl<Derived> &a);
+template <class Derived> Unit_impl<Derived> abs(const Unit_impl<Derived> &a);
+template <class Derived> Unit_impl<Derived> sqrt(const Unit_impl<Derived> &a);
 
 } // namespace scipp::units
 

--- a/units/neutron.cpp
+++ b/units/neutron.cpp
@@ -6,6 +6,6 @@
 #include "scipp/units/unit.tcc"
 
 namespace scipp::units {
-INSTANTIATE(neutron::supported_units, neutron::counts_unit)
+INSTANTIATE(neutron::Unit)
 SCIPP_UNITS_DEFINE_DIMENSIONS(neutron)
 } // namespace scipp::units


### PR DESCRIPTION
Previously any compilation error related to unit (and by extension, several related to `Variable`, which has a `Unit` field) were extremely verbose and unreadable: A full list of all `boost::units` related meta code was included, since we used a `std::variant` of all known types internally.

Earlier we avoided the actual need for variant by building a LUT at compile time. This had been necessary since multi-argument `std::visit` was cuasing massive binary sizes. Therefore, we could now eliminate `std::variant` (or `std::tuple`) entirely from the `Unit` type. Using CRTP instead to ensure that distinct unit classes are incompatible.