### PR TITLE
(Python) API additions

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -65,6 +65,13 @@ auto makeProxyItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
 Dataset::Dataset(const DatasetConstProxy &proxy)
     : Dataset(proxy, proxy.coords(), proxy.labels(), proxy.attrs()) {}
 
+Dataset::Dataset(const DataConstProxy &data) { setData(data.name(), data); }
+
+Dataset::Dataset(const std::map<std::string, DataConstProxy> &data) {
+  for (const auto & [ name, item ] : data)
+    setData(name, item);
+}
+
 /// Removes all data items from the Dataset.
 ///
 /// Coordinates, labels and attributes are not modified.

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -253,6 +253,8 @@ public:
 
   Dataset() = default;
   explicit Dataset(const DatasetConstProxy &proxy);
+  explicit Dataset(const DataConstProxy &data);
+  explicit Dataset(const std::map<std::string, DataConstProxy> &data);
 
   template <class DataMap, class CoordMap, class LabelsMap, class AttrMap>
   Dataset(DataMap data, CoordMap coords, LabelsMap labels, AttrMap attrs) {

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -76,14 +76,6 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
         [](T &self, const std::string &name) { return self[name]; },
         py::keep_alive<0, 1>());
   c.def("__contains__", &T::contains);
-  c.def("__eq__",
-        [](const T &self, const Dataset &other) { return self == other; });
-  c.def("__eq__",
-        [](const T &self, const DatasetProxy &other) { return self == other; });
-  c.def("__ne__",
-        [](const T &self, const Dataset &other) { return self == other; });
-  c.def("__ne__",
-        [](const T &self, const DatasetProxy &other) { return self == other; });
   c.def("copy", [](const T &self) { return Dataset(self); },
         "Return a (deep) copy.");
 }
@@ -147,7 +139,8 @@ void init_dataset(py::module &m) {
   datasetProxy.def(py::init<Dataset &>());
 
   py::class_<Dataset> dataset(m, "Dataset");
-  dataset.def(py::init<>())
+  dataset.def(py::init<const std::map<std::string, DataConstProxy> &>())
+      .def(py::init<const DataConstProxy &>())
       .def(py::init([](const std::map<std::string, VariableConstProxy> &data,
                        const std::map<Dim, VariableConstProxy> &coords,
                        const std::map<std::string, VariableConstProxy> &labels,

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -26,6 +26,30 @@ def test_create():
     assert d['x'].data == x
 
 
+def test_create_from_data_array():
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    base = sc.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
+    d = sc.Dataset(base['a'])
+    assert d == base
+
+
+def test_create_from_data_arrays():
+    var1 = sc.Variable([Dim.X], values=np.arange(4))
+    var2 = sc.Variable([Dim.X], values=np.ones(4))
+    base = sc.Dataset({
+        'a': var1,
+        'b': var2
+    },
+                      coords={Dim.X: var1},
+                      labels={'aux': var1})
+    d = sc.Dataset({'a': base['a'], 'b': base['b']})
+    assert d == base
+    swapped = sc.Dataset({'a': base['b'], 'b': base['a']})
+    assert swapped != base
+    assert swapped['a'] == base['b']
+    assert swapped['b'] == base['a']
+
+
 def test_clear():
     d = sc.Dataset()
     d['a'] = sc.Variable([Dim.X], values=np.arange(3))

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -110,6 +110,12 @@ def test_create_scalar_quantity():
     assert var.unit == sp.units.m
 
 
+def test_create_via_unit():
+    expected = sp.Variable(1.2, unit=sp.units.m)
+    var = 1.2 * sp.units.m
+    assert var == expected
+
+
 def test_create_1D_string():
     var = sp.Variable(dims=[Dim.Row], values=['a', 'bb'], unit=sp.units.m)
     assert len(var.values) == 2

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/variable.h"
 #include "scipp/units/unit.h"
 
 #include "bind_enum.h"
@@ -24,6 +25,13 @@ void init_units_neutron(py::module &m) {
       .def(py::self - py::self)
       .def(py::self * py::self)
       .def(py::self / py::self)
+      .def("__rmul__",
+           [](const units::Unit &self, double factor) {
+             auto var = core::makeVariable<double>(factor);
+             var.setUnit(self);
+             return var;
+           },
+           "Return a scalar Variable with value and unit.")
       .def("__pow__",
            [](const units::Unit &self, int power) -> units::Unit {
              switch (power) {


### PR DESCRIPTION
- Support creating scalar variables as `1.23 * scipp.units.m`.
- Support creation of `Dataset` from `DataArray` or dict of data arrays.
- Fix broken Python `Dataset::operator!=`.