### PR TITLE
Make figure twice as wide when plotting image with variances

### DIFF
--- a/python/src/scipp/plot_matplotlib.py
+++ b/python/src/scipp/plot_matplotlib.py
@@ -112,6 +112,8 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
 
     if input_data.variances is not None and show_variances:
         fig, ax = plt.subplots(1, 2, sharex=True, sharey=True)
+        fig_size = fig.get_size_inches()
+        fig.set_size_inches(fig_size[0]*2, fig_size[1])
         # Append parameters to data dictionary
         data["variances"] = {"cbmin": "min_var", "cbmax": "max_var",
                              "name": "variances"}


### PR DESCRIPTION
Before:
![Screenshot at 2019-08-28 17-31-06](https://user-images.githubusercontent.com/39047984/63870159-b2f45300-c9b9-11e9-97bb-078ad9ccfa21.png)
After:
![Screenshot at 2019-08-28 17-31-29](https://user-images.githubusercontent.com/39047984/63870176-ba1b6100-c9b9-11e9-8d96-697fbf49de4e.png)
