### PR TITLE
Copy metadata in DataArray operations

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -13,21 +13,22 @@ DataArray::DataArray(const DataConstProxy &proxy) {
 DataArray::DataArray(std::optional<Variable> data,
                      std::map<Dim, Variable> coords,
                      std::map<std::string, Variable> labels,
-                     std::map<std::string, Variable> attrs) {
+                     std::map<std::string, Variable> attrs,
+                     const std::string &name) {
   if (data)
-    m_holder.setData("", std::move(*data));
+    m_holder.setData(name, std::move(*data));
   for (auto & [ dim, c ] : coords)
     if (c.dims().sparse())
-      m_holder.setSparseCoord("", std::move(c));
+      m_holder.setSparseCoord(name, std::move(c));
     else
       m_holder.setCoord(dim, std::move(c));
-  for (auto & [ name, l ] : labels)
+  for (auto & [ label_name, l ] : labels)
     if (l.dims().sparse())
-      m_holder.setSparseLabels("", name, std::move(l));
+      m_holder.setSparseLabels(name, label_name, std::move(l));
     else
-      m_holder.setLabels(name, std::move(l));
-  for (auto & [ name, a ] : attrs)
-    m_holder.setAttr(name, std::move(a));
+      m_holder.setLabels(label_name, std::move(l));
+  for (auto & [ attr_name, a ] : attrs)
+    m_holder.setAttr(attr_name, std::move(a));
 }
 
 DataArray::operator DataConstProxy() const { return get(); }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1179,8 +1179,11 @@ DataArray histogram(const DataConstProxy &sparse,
 
   std::map<Dim, Variable> coords;
   coords.emplace(dim, binEdges);
-  return {std::move(result), std::move(coords),
-          std::map<std::string, Variable>()};
+  for (const auto & [ k, v ] : sparse.coords())
+    coords.emplace(k, Variable(v));
+
+  return {std::move(result), std::move(coords), proxy_to_map(sparse.labels()),
+          proxy_to_map(sparse.attrs()), sparse.name()};
 }
 
 DataArray histogram(const DataConstProxy &sparse, const Variable &binEdges) {
@@ -1292,7 +1295,8 @@ DataArray apply_and_drop_dim(const DataConstProxy &a, Func func, const Dim dim,
       attrs.emplace(name, attr);
 
   return DataArray(func(a.data(), dim, std::forward<Args>(args)...),
-                   std::move(coords), std::move(labels), std::move(attrs));
+                   std::move(coords), std::move(labels), std::move(attrs),
+                   a.name());
 }
 
 template <class Func, class... Args>

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -643,6 +643,13 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
   return out;
 }
 
+template <class T> auto proxy_to_map(const T &a) {
+  std::map<typename T::key_type, typename T::mapped_type> out;
+  for (const auto & [ key, item ] : a)
+    out.emplace(key, item);
+  return out;
+}
+
 /// Const proxy for Dataset, implementing slicing and item selection.
 class SCIPP_CORE_EXPORT DatasetConstProxy {
   explicit DatasetConstProxy() : m_dataset(nullptr) {}
@@ -816,7 +823,8 @@ public:
   explicit DataArray(const DataConstProxy &proxy);
   DataArray(std::optional<Variable> data, std::map<Dim, Variable> coords = {},
             std::map<std::string, Variable> labels = {},
-            std::map<std::string, Variable> attrs = {});
+            std::map<std::string, Variable> attrs = {},
+            const std::string &name = "");
 
   operator DataConstProxy() const;
   operator DataProxy();

--- a/core/test/histogram_test.cpp
+++ b/core/test/histogram_test.cpp
@@ -48,7 +48,7 @@ auto make_single_sparse() {
 DataArray make_expected(const Variable &var, const Variable &edges) {
   auto dim = var.dims().inner();
   std::map<Dim, Variable> coords = {{dim, edges}};
-  auto expected = DataArray(var, coords, std::map<std::string, Variable>());
+  auto expected = DataArray(var, coords);
   return expected;
 }
 

--- a/core/test/rebin_test.cpp
+++ b/core/test/rebin_test.cpp
@@ -15,7 +15,7 @@ protected:
       {{Dim::Y, 2}, {Dim::X, 4}}, units::counts, {1, 2, 3, 4, 5, 6, 7, 8});
   Variable x = makeVariable<double>({Dim::X, 5}, {1, 2, 3, 4, 5});
   Variable y = makeVariable<double>({Dim::Y, 3}, {1, 2, 3});
-  DataArray array{counts, {{Dim::X, x}, {Dim::Y, y}}, {}};
+  DataArray array{counts, {{Dim::X, x}, {Dim::Y, y}}, {}, {}, "data"};
   DataArray array_with_variances{
       makeVariable<double>({{Dim::Y, 2}, {Dim::X, 4}}, units::counts,
                            {1, 2, 3, 4, 5, 6, 7, 8},
@@ -23,6 +23,11 @@ protected:
       {{Dim::X, x}, {Dim::Y, y}},
       {}};
 };
+
+TEST_F(RebinTest, result_name) {
+  auto edges = makeVariable<double>({Dim::X, 3}, {1, 3, 5});
+  ASSERT_EQ(rebin(array, Dim::X, edges).name(), "data");
+}
 
 TEST_F(RebinTest, inner_data_array) {
   auto edges = makeVariable<double>({Dim::X, 3}, {1, 3, 5});


### PR DESCRIPTION
Fixes #495.

- Copes coordinates, labels and attributes for functions returning `DataArray`
- Gives results as `DataArray`s a sensible name based on the input