### PR TITLE
Neutron demo notebook and related fixes

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -10,29 +10,6 @@ DataArray::DataArray(const DataConstProxy &proxy) {
   m_holder.setData(proxy.name(), proxy);
 }
 
-DataArray::DataArray(std::optional<Variable> data,
-                     std::map<Dim, Variable> coords,
-                     std::map<std::string, Variable> labels,
-                     std::map<std::string, Variable> attrs) {
-  if (data)
-    m_holder.setData("", std::move(*data));
-  for (auto & [ dim, c ] : coords)
-    if (c.dims().sparse())
-      m_holder.setSparseCoord("", std::move(c));
-    else
-      m_holder.setCoord(dim, std::move(c));
-  for (auto & [ name, l ] : labels)
-    if (l.dims().sparse())
-      m_holder.setSparseLabels("", name, std::move(l));
-    else
-      m_holder.setLabels(name, std::move(l));
-  for (auto & [ name, a ] : attrs)
-    m_holder.setAttr(name, std::move(a));
-  if (m_holder.size() != 1)
-    throw std::runtime_error(
-        "DataArray must have either data or a sparse coordinate.");
-}
-
 DataArray::operator DataConstProxy() const { return get(); }
 DataArray::operator DataProxy() { return get(); }
 
@@ -60,22 +37,22 @@ DataArray &DataArray::operator/=(const DataConstProxy &other) {
   return *this;
 }
 
-DataArray &DataArray::operator+=(const Variable &other) {
+DataArray &DataArray::operator+=(const VariableConstProxy &other) {
   data() += other;
   return *this;
 }
 
-DataArray &DataArray::operator-=(const Variable &other) {
+DataArray &DataArray::operator-=(const VariableConstProxy &other) {
   data() -= other;
   return *this;
 }
 
-DataArray &DataArray::operator*=(const Variable &other) {
+DataArray &DataArray::operator*=(const VariableConstProxy &other) {
   data() *= other;
   return *this;
 }
 
-DataArray &DataArray::operator/=(const Variable &other) {
+DataArray &DataArray::operator/=(const VariableConstProxy &other) {
   data() /= other;
   return *this;
 }
@@ -98,6 +75,38 @@ DataArray operator*(const DataConstProxy &a, const DataConstProxy &b) {
 DataArray operator/(const DataConstProxy &a, const DataConstProxy &b) {
   return {a.data() / b.data(), union_(a.coords(), b.coords()),
           union_(a.labels(), b.labels())};
+}
+
+DataArray operator+(const DataConstProxy &a, const VariableConstProxy &b) {
+  return DataArray(a.data() + b, a.coords(), a.labels(), a.attrs());
+}
+
+DataArray operator-(const DataConstProxy &a, const VariableConstProxy &b) {
+  return DataArray(a.data() - b, a.coords(), a.labels(), a.attrs());
+}
+
+DataArray operator*(const DataConstProxy &a, const VariableConstProxy &b) {
+  return DataArray(a.data() * b, a.coords(), a.labels(), a.attrs());
+}
+
+DataArray operator/(const DataConstProxy &a, const VariableConstProxy &b) {
+  return DataArray(a.data() / b, a.coords(), a.labels(), a.attrs());
+}
+
+DataArray operator+(const VariableConstProxy &a, const DataConstProxy &b) {
+  return DataArray(a + b.data(), b.coords(), b.labels(), b.attrs());
+}
+
+DataArray operator-(const VariableConstProxy &a, const DataConstProxy &b) {
+  return DataArray(a - b.data(), b.coords(), b.labels(), b.attrs());
+}
+
+DataArray operator*(const VariableConstProxy &a, const DataConstProxy &b) {
+  return DataArray(a * b.data(), b.coords(), b.labels(), b.attrs());
+}
+
+DataArray operator/(const VariableConstProxy &a, const DataConstProxy &b) {
+  return DataArray(a / b.data(), b.coords(), b.labels(), b.attrs());
 }
 
 } // namespace scipp::core

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -13,6 +13,21 @@ DataArray::DataArray(const DataConstProxy &proxy) {
 DataArray::operator DataConstProxy() const { return get(); }
 DataArray::operator DataProxy() { return get(); }
 
+void requireValid(const DataArray &a) {
+  if (!a)
+    throw std::runtime_error("Invalid DataArray.");
+}
+
+DataConstProxy DataArray::get() const {
+  requireValid(*this);
+  return m_holder.begin()->second;
+}
+
+DataProxy DataArray::get() {
+  requireValid(*this);
+  return m_holder.begin()->second;
+}
+
 DataArray &DataArray::operator+=(const DataConstProxy &other) {
   expect::coordsAndLabelsAreSuperset(*this, other);
   data() += other.data();

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -28,6 +28,9 @@ DataArray::DataArray(std::optional<Variable> data,
       m_holder.setLabels(name, std::move(l));
   for (auto & [ name, a ] : attrs)
     m_holder.setAttr(name, std::move(a));
+  if (m_holder.size() != 1)
+    throw std::runtime_error(
+        "DataArray must have either data or a sparse coordinate.");
 }
 
 DataArray::operator DataConstProxy() const { return get(); }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -606,22 +606,22 @@ DataProxy DataProxy::operator/=(const DataConstProxy &other) const {
   return *this;
 }
 
-DataProxy DataProxy::operator+=(const Variable &other) const {
+DataProxy DataProxy::operator+=(const VariableConstProxy &other) const {
   data() += other;
   return *this;
 }
 
-DataProxy DataProxy::operator-=(const Variable &other) const {
+DataProxy DataProxy::operator-=(const VariableConstProxy &other) const {
   data() -= other;
   return *this;
 }
 
-DataProxy DataProxy::operator*=(const Variable &other) const {
+DataProxy DataProxy::operator*=(const VariableConstProxy &other) const {
   data() *= other;
   return *this;
 }
 
-DataProxy DataProxy::operator/=(const Variable &other) const {
+DataProxy DataProxy::operator/=(const VariableConstProxy &other) const {
   data() /= other;
   return *this;
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1227,10 +1227,14 @@ Variable join_edges(const VariableConstProxy &a, const VariableConstProxy &b,
 /// that labels are "labelling" their inner dimension.
 template <class T, class Key>
 Dim dim_of_coord_or_labels(const T &dict, const Key &key) {
-  if constexpr (std::is_same_v<Key, Dim>)
+  if constexpr (std::is_same_v<Key, Dim>) {
     return key;
-  else
-    return dict[key].dims().inner();
+  } else {
+    if (dict[key].dims().ndims() == 0)
+      return Dim::Invalid;
+    else
+      return dict[key].dims().inner();
+  }
 }
 
 namespace {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1349,5 +1349,7 @@ VariableConstProxy same(const VariableConstProxy &a,
 
 INSTANTIATE_VARIABLE(Dataset)
 INSTANTIATE_VARIABLE(sparse_container<Dataset>)
+INSTANTIATE_VARIABLE(DataArray)
+INSTANTIATE_VARIABLE(sparse_container<DataArray>)
 
 } // namespace scipp::core

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1154,6 +1154,9 @@ DataArray histogram(const DataConstProxy &sparse,
     throw std::logic_error("Only the simple case histograms may be constructed "
                            "for now: 2 dims including sparse.");
   auto dim = binEdges.dims().inner();
+  if (binEdges.unit() != sparse.coords()[dim].unit())
+    throw std::logic_error(
+        "Bin edges must have same unit as the sparse input coordinate.");
   if (binEdges.dtype() != dtype<double> ||
       sparse.coords()[dim].dtype() != DType::Double)
     throw std::logic_error("Histogram is only available for double type.");

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -54,9 +54,9 @@ auto makeProxyItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
   if (sparse) {
     if constexpr (std::is_same_v<T2, const Variable> ||
                   std::is_same_v<T2, Variable>) {
-      items.emplace(sparseDim, makeProxyItem(&*sparse));
+      items.emplace(sparseDim, makeProxyItem(sparse));
     } else if constexpr (!std::is_same_v<T2, void>) {
-      for (const auto &item : *sparse)
+      for (auto &item : *sparse)
         items.emplace(item.first, makeProxyItem(&item.second));
     }
   }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1230,14 +1230,10 @@ Variable join_edges(const VariableConstProxy &a, const VariableConstProxy &b,
 /// that labels are "labelling" their inner dimension.
 template <class T, class Key>
 Dim dim_of_coord_or_labels(const T &dict, const Key &key) {
-  if constexpr (std::is_same_v<Key, Dim>) {
+  if constexpr (std::is_same_v<Key, Dim>)
     return key;
-  } else {
-    if (dict[key].dims().ndims() == 0)
-      return Dim::Invalid;
-    else
-      return dict[key].dims().inner();
-  }
+  else
+    return dict[key].dims().inner();
 }
 
 namespace {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1260,7 +1260,7 @@ auto concat(const T1 &a, const T2 &b, const Dim dim, const Dimensions &dimsA,
 
 DataArray concatenate(const DataConstProxy &a, const DataConstProxy &b,
                       const Dim dim) {
-  if (a == b)
+  if (!a.dims().contains(dim) && a == b)
     return DataArray{a};
   return DataArray(concatenate(a.data(), b.data(), dim),
                    concat(a.coords(), b.coords(), dim, a.dims(), b.dims()),

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -180,12 +180,11 @@ void Dimensions::addInner(const Dim label, const scipp::index size) {
 }
 
 /// Return the innermost dimension. Throws if *this is empty.
-Dim Dimensions::inner() const {
+Dim Dimensions::inner() const noexcept {
   if (sparse())
     return sparseDim();
   if (m_ndim == 0)
-    throw except::DimensionError(
-        "Expected Dimensions with at least 1 dimension.");
+    return Dim::Invalid;
   return m_dims[m_ndim - 1];
 }
 

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -34,6 +34,8 @@ std::string to_string(const DType dtype) {
     return "string";
   case DType::Bool:
     return "bool";
+  case DType::DataArray:
+    return "DataArray";
   case DType::Dataset:
     return "Dataset";
   case DType::Float:
@@ -50,6 +52,8 @@ std::string to_string(const DType dtype) {
     return "sparse_double";
   case DType::SparseInt64:
     return "sparse_int64";
+  case DType::SparseInt32:
+    return "sparse_int32";
   case DType::EigenVector3d:
     return "vector_3_double";
   case DType::Unknown:

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -614,7 +614,9 @@ public:
       if constexpr (std::is_same_v<Base, AttrsConstProxy>)
         throw std::runtime_error("Attributes cannot be sparse.");
     } else {
-      if (m_name)
+      // TODO Would like to add coords for DataArray, as a temporary hack we
+      // allow adding dense coords of the parent size is 1.
+      if (m_name && m_parent->size() != 1)
         throw std::runtime_error(
             "Dense coord/labels/attr must be added to "
             "coords of dataset, not coords of dataset items.");

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -902,6 +902,13 @@ public:
     setCoord(dim, Variable(coord));
   }
 
+  template <class... Ts> auto slice(const Ts... slices) const {
+    return get().slice(slices...);
+  }
+  template <class... Ts> auto slice(const Ts... slices) {
+    return get().slice(slices...);
+  }
+
 private:
   DataConstProxy get() const noexcept { return m_holder.begin()->second; }
   DataProxy get() noexcept { return m_holder.begin()->second; }

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -815,6 +815,7 @@ private:
 /// Data array, a variable with coordinates, labels, and attributes.
 class SCIPP_CORE_EXPORT DataArray {
 public:
+  DataArray() = default;
   explicit DataArray(const DataConstProxy &proxy);
   template <class CoordMap = std::map<Dim, Variable>,
             class LabelsMap = std::map<std::string, Variable>,
@@ -840,21 +841,22 @@ public:
           "DataArray must have either data or a sparse coordinate.");
   }
 
+  explicit operator bool() const noexcept { return !m_holder.empty(); }
   operator DataConstProxy() const;
   operator DataProxy();
 
-  const std::string &name() const noexcept { return m_holder.begin()->first; }
+  const std::string &name() const { return m_holder.begin()->first; }
 
-  CoordsConstProxy coords() const noexcept { return get().coords(); }
-  CoordsProxy coords() noexcept { return get().coords(); }
+  CoordsConstProxy coords() const { return get().coords(); }
+  CoordsProxy coords() { return get().coords(); }
 
-  LabelsConstProxy labels() const noexcept { return get().labels(); }
-  LabelsProxy labels() noexcept { return get().labels(); }
+  LabelsConstProxy labels() const { return get().labels(); }
+  LabelsProxy labels() { return get().labels(); }
 
-  AttrsConstProxy attrs() const noexcept { return get().attrs(); }
-  AttrsProxy attrs() noexcept { return get().attrs(); }
+  AttrsConstProxy attrs() const { return get().attrs(); }
+  AttrsProxy attrs() { return get().attrs(); }
 
-  Dimensions dims() const noexcept { return get().dims(); }
+  Dimensions dims() const { return get().dims(); }
   DType dtype() const { return get().dtype(); }
   units::Unit unit() const { return get().unit(); }
 
@@ -865,9 +867,9 @@ public:
   }
 
   /// Return true if the data array contains data values.
-  bool hasData() const noexcept { return get().hasData(); }
+  bool hasData() const { return get().hasData(); }
   /// Return true if the data array contains data variances.
-  bool hasVariances() const noexcept { return get().hasVariances(); }
+  bool hasVariances() const { return get().hasVariances(); }
 
   /// Return untyped const proxy for data (values and optional variances).
   VariableConstProxy data() const { return get().data(); }
@@ -910,8 +912,8 @@ public:
   }
 
 private:
-  DataConstProxy get() const noexcept { return m_holder.begin()->second; }
-  DataProxy get() noexcept { return m_holder.begin()->second; }
+  DataConstProxy get() const;
+  DataProxy get();
 
   Dataset m_holder;
 };

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -102,7 +102,7 @@ public:
 
   scipp::index operator[](const Dim dim) const;
 
-  Dim inner() const;
+  Dim inner() const noexcept;
 
   /// Return true if `dim` is one of the labels in *this.
   constexpr bool contains(const Dim dim) const noexcept {

--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -12,6 +12,7 @@
 
 namespace scipp::core {
 
+class DataArray;
 class Dataset;
 
 template <class T>
@@ -35,6 +36,7 @@ enum class DType {
   SparseFloat,
   SparseInt64,
   SparseInt32,
+  DataArray,
   Dataset,
   EigenVector3d,
   Unknown
@@ -54,6 +56,7 @@ template <>
 constexpr DType dtype<sparse_container<int64_t>> = DType::SparseInt64;
 template <>
 constexpr DType dtype<sparse_container<int32_t>> = DType::SparseInt32;
+template <> constexpr DType dtype<DataArray> = DType::DataArray;
 template <> constexpr DType dtype<Dataset> = DType::Dataset;
 template <> constexpr DType dtype<Eigen::Vector3d> = DType::EigenVector3d;
 

--- a/core/include/scipp/core/tag_util.h
+++ b/core/include/scipp/core/tag_util.h
@@ -47,7 +47,8 @@ auto apply(const DType dtype, Args &&... args) {
   return callDType<Callable>(
       std::tuple<double, float, int64_t, int32_t, std::string, bool,
                  sparse_container<double>, sparse_container<float>,
-                 sparse_container<int64_t>, Dataset, Eigen::Vector3d>{},
+                 sparse_container<int64_t>, DataArray, Dataset,
+                 Eigen::Vector3d>{},
       dtype, std::forward<Args>(args)...);
 }
 

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -212,7 +212,7 @@
    "metadata": {},
    "source": [
     "## More advanced operations with multi-dimensional datasets\n",
-    "Operations like `concatenate` and `sort` work just like with one-dimensional datasets."
+    "Operations like `concatenate` and `merge` work just like with one-dimensional datasets."
    ]
   },
   {
@@ -296,7 +296,7 @@
    "outputs": [],
    "source": [
     "print(d)\n",
-    "sc.plot(d[Dim.Z, 0], backend='plotly')"
+    "sc.plot(d[Dim.Z, 0])"
    ]
   },
   {
@@ -330,7 +330,7 @@
    "outputs": [],
    "source": [
     "print(d)\n",
-    "sc.plot(d[Dim.Z, 0], backend='plotly')"
+    "sc.plot(d[Dim.Z, 0])"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "metadata": {},
    "source": [
     "### Exercise 3\n",
-    " 1. Use `ds.mean` to compute the mean of the data for Alice along the Z dimension.\n",
+    " 1. Use `sc.mean` to compute the mean of the data for Alice along the Z dimension.\n",
     " 2. Do the same with `numpy`, what are the complications you encounter, that are not present when using the dataset?"
    ]
   },

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -172,6 +172,8 @@ template <class... Ts> class as_VariableViewImpl {
       return {Getter::template get<sparse_container<float>>(proxy)};
     case dtype<sparse_container<int64_t>>:
       return {Getter::template get<sparse_container<int64_t>>(proxy)};
+    case dtype<DataArray>:
+      return {Getter::template get<DataArray>(proxy)};
     case dtype<Dataset>:
       return {Getter::template get<Dataset>(proxy)};
     case dtype<Eigen::Vector3d>:
@@ -326,7 +328,8 @@ public:
 using as_VariableView =
     as_VariableViewImpl<double, float, int64_t, int32_t, bool, std::string,
                         sparse_container<double>, sparse_container<float>,
-                        sparse_container<int64_t>, Dataset, Eigen::Vector3d>;
+                        sparse_container<int64_t>, DataArray, Dataset,
+                        Eigen::Vector3d>;
 
 template <class T, class... Ignored>
 void bind_data_properties(pybind11::class_<T, Ignored...> &c) {

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -99,7 +99,7 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
   bind_coord_properties(c);
   bind_comparison<DataConstProxy>(c);
   bind_in_place_binary<DataProxy>(c);
-  bind_in_place_binary<Variable>(c);
+  bind_in_place_binary<VariableConstProxy>(c);
   bind_data_properties(c);
 }
 
@@ -206,6 +206,7 @@ void init_dataset(py::module &m) {
   bind_binary<Dataset>(dataProxy);
   bind_binary<DatasetProxy>(dataProxy);
   bind_binary<DataProxy>(dataProxy);
+  bind_binary<VariableConstProxy>(dataProxy);
 
   m.def("concatenate",
         py::overload_cast<const DataConstProxy &, const DataConstProxy &,

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -88,7 +88,7 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
         "Return a (deep) copy.");
   c.def_property("data",
                  py::cpp_function(
-                     [](const T &self) {
+                     [](T &self) {
                        return self.hasData() ? py::cast(self.data())
                                              : py::none();
                      },

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -98,9 +98,10 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
                  });
   bind_coord_properties(c);
   bind_comparison<DataConstProxy>(c);
+  bind_data_properties(c);
+  bind_slice_methods(c);
   bind_in_place_binary<DataProxy>(c);
   bind_in_place_binary<VariableConstProxy>(c);
-  bind_data_properties(c);
   bind_binary<Dataset>(c);
   bind_binary<DatasetProxy>(c);
   bind_binary<DataProxy>(c);
@@ -187,7 +188,6 @@ void init_dataset(py::module &m) {
 
   bind_slice_methods(dataset);
   bind_slice_methods(datasetProxy);
-  bind_slice_methods(dataProxy);
 
   bind_comparison<Dataset>(dataset);
   bind_comparison<DatasetProxy>(dataset);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -101,6 +101,10 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
   bind_in_place_binary<DataProxy>(c);
   bind_in_place_binary<VariableConstProxy>(c);
   bind_data_properties(c);
+  bind_binary<Dataset>(c);
+  bind_binary<DatasetProxy>(c);
+  bind_binary<DataProxy>(c);
+  bind_binary<VariableConstProxy>(c);
 }
 
 void init_dataset(py::module &m) {
@@ -203,10 +207,6 @@ void init_dataset(py::module &m) {
   bind_binary<Dataset>(datasetProxy);
   bind_binary<DatasetProxy>(datasetProxy);
   bind_binary<DataProxy>(datasetProxy);
-  bind_binary<Dataset>(dataProxy);
-  bind_binary<DatasetProxy>(dataProxy);
-  bind_binary<DataProxy>(dataProxy);
-  bind_binary<VariableConstProxy>(dataProxy);
 
   m.def("concatenate",
         py::overload_cast<const DataConstProxy &, const DataConstProxy &,

--- a/python/demo/demo-part3.ipynb
+++ b/python/demo/demo-part3.ipynb
@@ -24,9 +24,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Converters from Mantid workspaces\n",
+    "## Loading Nexus files\n",
     "\n",
-    "For convenience and testing, very basic converters from Mantid's `EventWorkspace` and `Workspace2D` to `Dataset` are available:"
+    "Scipp does not support native loading of Nexus files at this point.\n",
+    "However, it can leverage Mantid to do this:"
    ]
   },
   {
@@ -39,18 +40,21 @@
     "\n",
     "d = sc.Dataset()\n",
     "# Load only a single bank to reduce memory consumption, so we can run this on a laptop\n",
-    "d[\"sample\"] = load(filename='PG3_4844_event.nxs', BankName='bank184', drop_pulse_times=False)\n",
-    "d[\"vanadium\"] = load(filename='PG3_4866_event.nxs', BankName='bank184', drop_pulse_times=True)"
+    "d[\"sample\"] = load(filename='PG3_4844_event.nxs', BankName='bank184', load_pulse_times=True)\n",
+    "d[\"vanadium\"] = load(filename='PG3_4866_event.nxs', BankName='bank184', load_pulse_times=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Nested data in a dataset: Instrument geometry and event lists\n",
+    "Note that internally this calls `Load` or `LoadEventNexus` provided by Mantid.\n",
+    "Scipp then converts from Mantid's `EventWorkspace` and `Workspace2D` to `DataArray`.\n",
+    "Currently not all information from the Mantid workspaces is preserved in the data array.\n",
     "\n",
-    "Some of the content of the workspaces is not easily representable as a plain multi-dimensional array.\n",
-    "A number of variables in the dataset obtained from the workspace thus have item type `Dataset`:"
+    "## Understanding the contents of the created dataset\n",
+    "\n",
+    "The dataset with loaded sample and vanadium data looks as follows:"
    ]
   },
   {
@@ -66,11 +70,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The returned `Dataset` `d` contains a label named `\"component_info:` which is similar to the `ComponentInfo` in Mantid.\n",
-    "It contains information about the components in the beamline.\n",
+    "We give a short discussion of each of the entries to familiarize ourselves with how data from a Mantid workspace is mapped onto a data array or dataset.\n",
     "\n",
-    "For the time being, it only contains the positions for source and sample.\n",
-    "Since it is stored as a single label, we access it via the `value` property."
+    "### Dimensions and coordinates\n",
+    "\n",
+    "#### Position\n",
+    "\n",
+    "In most Mantid workspaces each spectrum corresponds to data measured at a detector pixel, i.e., at a specific position or region in space.\n",
+    "Therefore we use `Dim.Position` for the \"spectrum\" dimension.\n",
+    "\n",
+    "Note that this deliberately avoids a more generic `Dim.Spectrum` since that hides the true meaning and is ambigous.\n",
+    "For example, after converting data to `Q` we want to avoid having \"compatible\" dimensions of a data and would use `Dim.Q`.\n",
+    "The double meaning of what a \"spectrum\" actually is in Mantid is thus avoided.\n",
+    "\n",
+    "The position dimensions comes with a coordinate:"
    ]
   },
   {
@@ -79,28 +92,116 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.labels[\"component_info\"].value[\"position\"].values"
+    "d.coords[Dim.Position]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Bonus note 1:\n",
+    "The position coordinate stores the positions of all spectra.\n",
+    "Each position is a 3-component vector (X, Y, Z).\n",
+    "\n",
+    "#### Time-of-flight\n",
+    "\n",
+    "In contrast to a `EventWorkspace` in Mantid, a dataset does not necessarily come with a time-of-flight (TOF) coordinate (bin edges) on top of the TOF values for the events.\n",
+    "Therefore `Dim.Tof` does not have a corresponding *dense* coordinate.\n",
+    "See below for *sparse* TOF coordinates.\n",
+    "\n",
+    "### Labels\n",
+    "\n",
+    "Scipp stores auxiliary \"coordinate\" information as labels.\n",
+    "Labels or coords (and not attributes) are used to ensure that information is compatible in operations involving multiple data arrays or dataset.\n",
+    "\n",
+    "This actually happended internally when we first loaded the files for sample and vanadium and inserted them into the same dataset:\n",
+    "If the files had had different spectrum positions or spectrum numbers the insertion of the second item would have failed due to incompatible coordinates or labels.\n",
+    "\n",
+    "#### Spectrum numbers\n",
+    "\n",
+    "Spectrum numbers are an auxiliary coordinate for `Dim.Position`, in other words they can be used to \"label\" the position coordinate, e.g., in an a plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.labels['spectrum_number']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Beamline geometry\n",
+    "\n",
+    "Apart from positions of spectra we require additional geometry information for various components in a neutron beamline (instrument).\n",
+    "This is stored in the `component_info` labels, which contain a single nested dataset.\n",
+    "The contents of this dataset are not particularely easy to parse and we instead recommend the use of helper functions such as `sample_position` which will be discussed below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.labels['component_info'].value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We emphazise the importance of storing this information as labels.\n",
+    "This ensures that we cannot accidentally combine data obtained with, e.g., different sample positions.\n",
+    "\n",
+    "For convenient and standardized access, as well as access of derived information such as scattering angles, a number of helper functions is provided.\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.neutron.sample_position(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.neutron.scattering_angle(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a full list of available beamline-geometry helpers please refer to the [documentation](https://scipp.readthedocs.io/en/latest/additional-modules/scipp-neutron.html#beamline-geometry)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Bonus note:\n",
     " For the most part, the structure of `ComponentInfo` (and `DetectorInfo`) in Mantid is easily represented by a `Dataset`, i.e., very little change is required.\n",
     " For example, scanning is simply handled by an extra dimension of, e.g., the position and rotation variables.\n",
-    " By using `Dataset` to handle this, we can use exactly the same tools and do not need to implement or learn a new API.*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Neutron events are stored in a format known as **sparse data** (see [the scipp documentation](https://scipp.readthedocs.io/en/latest/user-guide/sparse-data.html) for more information).\n",
+    " By using `Dataset` to handle this, we can use exactly the same tools and do not need to implement or learn a new API.*\n",
     "\n",
-    "This storage format allows to have many arrays of arbitrary length to store the data (which are actually stored as coordinates), which is very convenient when we want to store the equivalent of one Mantid `EventList` per detector pixel.\n",
+    "### Event data\n",
     "\n",
-    "For example, if we want to display the event list for spectrum number 500:"
+    "Neutron events are stored as **sparse data** in contrast to the regular gridded (\"dense\") data of, e.g., histogrammed data.\n",
+    "See [the scipp documentation](https://scipp.readthedocs.io/en/latest/user-guide/sparse-data.html) for more information.\n",
+    "\n",
+    "The number of neutrons detected at each position is different and thus scipp has no fixed definition for the length of the \"sparse\" dimension.\n",
+    "This looks as follows:"
    ]
   },
   {
@@ -109,29 +210,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d['sample'][sc.Dim.Position, 500]\n",
-    "d['sample'][sc.Dim.Position, 500].coords[sc.Dim.Tof].values"
+    "sc.show(d[Dim.Position, 10:20])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We could in principle also choose other, more efficient, event storage formats.\n",
-    " At this point, using a dataset as an event list is convenient because it lets us reuse the same functionality:"
+    "This data structure is to be interpreted as follows:\n",
+    "\n",
+    "- Each position sees a different number of events, and events arrive at random time.\n",
+    "  Therefore, there is a time-of-flight for *every pixel*, for *every event*, and for *every data item* (`\"vanadium\"` and `\"sample\"`).\n",
+    "  This **sparse coordinate** has the following properties:\n",
+    "  - The sparse coord for `Dim.Tof` is associated with a data item and not global for the dataset.\n",
+    "  - The sparse coord for `Dim.Tof` depends on `Dim.Position`.\n",
+    "  - The sparse coord for `Dim.Tof` has a different length at each position.\n",
+    "- Extra information such as pulse times are stored as sparse labels.\n",
+    "  What was said above for sparse coords also applies to sparse labels.\n",
+    "  The length at each position matches the corresponding length of the sparse coordinate.\n",
+    "- Values and variances are optional.\n",
+    "  The would represent weight and weight uncertainties of events.\n",
+    "  If they are not present an implicit weight of `1` is assumed, i.e., each coord value corresponds to a single neutron.\n",
+    "\n",
+    "The time-of-flight values for an individual pixel can be accessed as follows:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "events = d['sample'][sc.Dim.Position, 500].coords[sc.Dim.Tof].values\n",
-    "d['sample'][sc.Dim.Position, 500].coords[sc.Dim.Tof].values = np.sort(events)\n",
-    "sc.table(d['sample'][sc.Dim.Position, 500].coords[sc.Dim.Tof].values)"
+    "d['sample'][sc.Dim.Position, 10].coords[sc.Dim.Tof].values"
    ]
   },
   {
@@ -149,10 +259,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ds.events.sort_by_tof(d)\n",
-    "bins = sc.Variable([Dim.Tof], values=np.arange(1000.0, 20000.0, 50.0))\n",
-    "binned = sc.histogram(d, bins)\n",
-    "d = sc.merge(d, binned)\n",
+    "bins = sc.Variable([Dim.Tof], values=np.arange(1000.0, 20000.0, 50.0), unit=sc.units.us)\n",
+    "d = sc.histogram(d, bins)\n",
     "d"
    ]
   },
@@ -164,7 +272,7 @@
    },
    "outputs": [],
    "source": [
-    "ds.plot(d.subset[Data.Value, 'sample'], axes=[Coord.SpectrumNumber, Coord.Tof])"
+    "sc.plot(d['sample'], axes=['spectrum_number', Dim.Tof])"
    ]
   },
   {
@@ -184,25 +292,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "panel = ds.Dataset()\n",
+    "panel = sc.Dataset()\n",
     "# 154 and 7 are the extents of the panel\n",
-    "panel[Data.Value, 'sample'] = d[Data.Value, 'sample'].reshape([Dim.X, Dim.Y, Dim.Tof], (154,7,379))\n",
-    "panel[Coord.Tof] = d[Coord.Tof]\n",
+    "panel['sample'] = sc.reshape(d['sample'].data, [Dim.X, Dim.Y, Dim.Tof], (154,7,379))\n",
+    "panel.coords[Dim.Tof] = d.coords[Dim.Tof]\n",
     "# Note that the scale is meaningless, could use real instrument parameters\n",
-    "panel[Coord.X] = ([Dim.X], np.arange(154))\n",
-    "panel[Coord.Y] = ([Dim.Y], np.arange(7))\n",
-    "# Move TOF slider around 12000 to see refraction lines moving across the panel\n",
-    "ds.plot(panel[Dim.Tof, 180:260], axes=[Coord.Tof, Coord.Y, Coord.X])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del(d[Data.Events, 'sample'])\n",
-    "del(d[Data.Events, 'vanadium'])"
+    "panel.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(154))\n",
+    "panel.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(7))\n",
+    "# Move TOF slider around 12000 to see diffraction lines moving across the panel\n",
+    "sc.plot(panel[Dim.Tof, 180:260], axes=[Dim.Tof, Dim.Y, Dim.X])"
    ]
   },
   {
@@ -222,27 +320,26 @@
    "outputs": [],
    "source": [
     "# Histogram-mode beam monitor\n",
-    "beam = ds.Dataset()\n",
-    "beam[Coord.Tof] = ([Dim.Tof], np.arange(1001.0))\n",
-    "beam[Data.Value] = ([Dim.Tof], np.random.rand(1000))\n",
-    "beam[Data.Variance] = beam[Data.Value]\n",
-    "beam[Data.Value].unit = ds.units.counts\n",
-    "beam[Data.Variance].unit = ds.units.counts * ds.units.counts\n",
+    "beam = sc.Dataset()\n",
+    "beam.coords[Dim.Tof] = sc.Variable([Dim.Tof], values=np.arange(0.0, 20000.0, 1000.0))\n",
+    "beam[''] = sc.Variable([Dim.Tof], values=np.random.rand(len(beam.coords[Dim.Tof].values)), unit=sc.units.counts)\n",
+    "beam[''].variances = beam[''].values\n",
     "\n",
     "# Event-mode transmission monitor\n",
-    "transmission = ds.Dataset()\n",
-    "transmission[Data.Tof] = ([Dim.Event], 20000.0 * np.random.rand(123456))\n",
+    "transmission = sc.Dataset()\n",
+    "events = sc.Variable([Dim.Tof], shape=[sc.Dimensions.Sparse])\n",
+    "events.values = np.random.rand(123456)\n",
+    "transmission[''] = sc.DataArray(coords={Dim.Tof: events})\n",
     "\n",
     "# Beam profile monitor\n",
-    "profile = ds.Dataset()\n",
-    "profile[Coord.X] = ([Dim.X], np.arange(-0.1, 0.11, 0.01))\n",
-    "profile[Coord.Y] = ([Dim.Y], np.arange(-0.1, 0.11, 0.01))\n",
-    "profile[Data.Value] = ([Dim.Y, Dim.X], np.random.rand(20, 20))\n",
+    "profile = sc.Dataset()\n",
+    "profile.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(-0.1, 0.11, 0.01))\n",
+    "profile.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(-0.1, 0.11, 0.01))\n",
+    "profile[''] = sc.Variable([Dim.Y, Dim.X], values=np.random.rand(20, 20), unit=sc.units.counts)\n",
     "for i in 1,2,3,4:\n",
-    "    profile[Dim.X, i:-i][Dim.Y, i:-i] += 1.0\n",
-    "profile[Data.Value].unit = ds.units.counts\n",
+    "    profile[''][Dim.X, i:-i][Dim.Y, i:-i] += 1.0 * sc.units.counts\n",
     "\n",
-    "ds.plot(profile)"
+    "sc.plot(profile)"
    ]
   },
   {
@@ -251,9 +348,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d[Coord.Monitor, 'transmission'] = ([], transmission)\n",
-    "d[Coord.Monitor, 'beam'] = ([], beam)\n",
-    "d[Coord.Monitor, 'profile'] = ([], profile)\n",
+    "sc.Variable(value=transmission)\n",
+    "d.labels['transmission'] = sc.Variable(value=transmission)\n",
+    "d.labels['beam'] = sc.Variable(value=beam)\n",
+    "d.labels['profile'] = sc.Variable(value=profile)\n",
     "d"
    ]
   },
@@ -274,8 +372,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_over_beam = d.subset['sample'] / ds.rebin(d[Coord.Monitor, 'beam'].scalar, d[Coord.Tof])\n",
-    "sample_over_beam"
+    "sample_over_beam = d['sample'] / sc.rebin(d.labels['beam'].value, Dim.Tof, d.coords[Dim.Tof])\n",
+    "sc.plot(sample_over_beam, axes=['spectrum_number', Dim.Tof])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result is meaningless since our \"monitor\" contained just random noise."
    ]
   },
   {
@@ -291,10 +396,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_scan = ds.concatenate(d, d * 0.8, Dim.Temperature)\n",
-    "temp_scan = ds.concatenate(temp_scan, temp_scan * 0.64, Dim.Temperature)\n",
-    "temp_scan[Coord.Temperature] = ([Dim.Temperature], [273.0, 180.0, 100.0, 4.3])\n",
-    "temp_scan"
+    "sample = d['sample']\n",
+    "temp_scan = sc.concatenate(sample, sample * (0.8 * sc.units.dimensionless), Dim.Temperature)\n",
+    "temp_scan = sc.concatenate(temp_scan, temp_scan * (0.64 * sc.units.dimensionless), Dim.Temperature)\n",
+    "temp_scan.coords[Dim.Temperature] = sc.Variable([Dim.Temperature], values=[273.0, 180.0, 100.0, 4.3])"
    ]
   },
   {
@@ -303,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.plot(temp_scan.subset[Data.Value, 'sample'][Dim.Position, 20:], axes=[Coord.SpectrumNumber, Coord.Temperature, Coord.Tof])"
+    "#sc.plot(temp_scan[Dim.Position, 20:][Dim.Tof, 100], axes=['spectrum_number', Dim.Temperature])"
    ]
   },
   {
@@ -312,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.plot(temp_scan.subset[Data.Value, 'sample'][Dim.Position, 500], collapse=Dim.Temperature)"
+    "sc.plot(temp_scan[Dim.Position, 500], collapse=Dim.Tof)"
    ]
   },
   {
@@ -328,7 +433,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = ds.convert(d, Dim.Tof, Dim.DSpacing)"
+    "d = sc.neutron.convert(d, Dim.Tof, Dim.DSpacing)"
    ]
   },
   {
@@ -338,7 +443,7 @@
    "outputs": [],
    "source": [
     "# Plotting cannot handle ragged coordinates at this point, rebin to edges of first spectrum\n",
-    "d = ds.rebin(d, d[Coord.DSpacing][Dim.Position, 0])"
+    "d = sc.rebin(d, Dim.DSpacing, d.coords[Dim.DSpacing][Dim.Position, 0])"
    ]
   },
   {
@@ -349,8 +454,7 @@
    },
    "outputs": [],
    "source": [
-    "ds.plot(d.subset[Data.Value, 'sample'], axes=[Coord.SpectrumNumber, Coord.DSpacing])\n",
-    "ds.plot(d.subset[Data.Value, 'vanadium'], axes=[Coord.SpectrumNumber, Coord.DSpacing])"
+    "sc.plot(d, axes=['spectrum_number', Dim.DSpacing])"
    ]
   },
   {
@@ -366,8 +470,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summed = ds.sum(d, Dim.Position)\n",
-    "ds.plot(summed)"
+    "summed = sc.sum(d, Dim.Position)\n",
+    "sc.plot(summed)"
    ]
   },
   {
@@ -378,8 +482,8 @@
    },
    "outputs": [],
    "source": [
-    "normalized = summed.subset['sample'] / summed.subset['vanadium']\n",
-    "ds.plot(normalized)"
+    "normalized = summed['sample'] / summed['vanadium']\n",
+    "sc.plot(normalized)"
    ]
   },
   {
@@ -426,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/python/demo/demo-part3.ipynb
+++ b/python/demo/demo-part3.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dataset in a Nutshell - Part 3: Neutron Data\n",
+    "# Neutron Data\n",
     "\n",
-    " This is the continuation of [Dataset in a Nutshell - Part 2](demo-part2.ipynb)."
+    " This is the continuation from [Multi-dimensional datasets](https://scipp.readthedocs.io/en/latest/tutorials/multi-d-datasets.html) tutorial."
    ]
   },
   {
@@ -114,7 +114,7 @@
     "Labels or coords (and not attributes) are used to ensure that information is compatible in operations involving multiple data arrays or dataset.\n",
     "\n",
     "This actually happended internally when we first loaded the files for sample and vanadium and inserted them into the same dataset:\n",
-    "If the files had had different spectrum positions or spectrum numbers the insertion of the second item would have failed due to incompatible coordinates or labels.\n",
+    "If the files had had different spectrum positions or spectrum numbers the insertion of the `'vanadium'` data would have failed due to incompatible coordinates or labels.\n",
     "\n",
     "#### Spectrum numbers\n",
     "\n",
@@ -156,6 +156,9 @@
    "source": [
     "We emphazise the importance of storing this information as labels.\n",
     "This ensures that we cannot accidentally combine data obtained with, e.g., different sample positions.\n",
+    "\n",
+    "*Bonus note:\n",
+    "If we ever* **do** *want to combine data with different samples we can either remove this information from the dataset, or change it to an* **attribute**.\n",
     "\n",
     "For convenient and standardized access, as well as access of derived information such as scattering angles, a number of helper functions is provided.\n",
     "For example:"
@@ -220,19 +223,19 @@
     "This data structure is to be interpreted as follows:\n",
     "\n",
     "- Each position sees a different number of events, and events arrive at random time.\n",
-    "  Therefore, there is a time-of-flight for *every pixel*, for *every event*, and for *every data item* (`\"vanadium\"` and `\"sample\"`).\n",
+    "  Therefore, there is a time-of-flight for *every pixel*, for *every event*, and for *every data item* (`'vanadium'` and `'sample'`).\n",
     "  This **sparse coordinate** has the following properties:\n",
-    "  - The sparse coord for `Dim.Tof` is associated with a data item and not global for the dataset.\n",
+    "  - The sparse coord for `Dim.Tof` is associated with a data item and is not global for the dataset.\n",
     "  - The sparse coord for `Dim.Tof` depends on `Dim.Position`.\n",
     "  - The sparse coord for `Dim.Tof` has a different length at each position.\n",
     "- Extra information such as pulse times are stored as sparse labels.\n",
     "  What was said above for sparse coords also applies to sparse labels.\n",
     "  The length at each position matches the corresponding length of the sparse coordinate.\n",
     "- Values and variances are optional.\n",
-    "  The would represent weight and weight uncertainties of events.\n",
+    "  They would represent weight and weight uncertainties of events.\n",
     "  If they are not present an implicit weight of `1` is assumed, i.e., each coord value corresponds to a single neutron.\n",
     "\n",
-    "The time-of-flight values for an individual pixel can be accessed as follows:"
+    "The time-of-flight values for an individual pixel could be accessed as follows:"
    ]
   },
   {
@@ -241,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d['sample'][sc.Dim.Position, 10].coords[sc.Dim.Tof].values"
+    "d['sample'].coords[sc.Dim.Tof][sc.Dim.Position, 10].values"
    ]
   },
   {
@@ -320,24 +323,26 @@
    "outputs": [],
    "source": [
     "# Histogram-mode beam monitor\n",
-    "beam = sc.Dataset()\n",
-    "beam.coords[Dim.Tof] = sc.Variable([Dim.Tof], values=np.arange(0.0, 20000.0, 1000.0))\n",
-    "beam[''] = sc.Variable([Dim.Tof], values=np.random.rand(len(beam.coords[Dim.Tof].values)), unit=sc.units.counts)\n",
-    "beam[''].variances = beam[''].values\n",
+    "edges = np.arange(0.0, 20000.0, 1000.0)\n",
+    "counts = np.random.rand(len(edges-1))\n",
+    "beam = sc.DataArray(\n",
+    "    data=sc.Variable([Dim.Tof], values=counts, variances=counts, unit=sc.units.counts),\n",
+    "    coords={Dim.Tof: sc.Variable([Dim.Tof], values=edges)})\n",
     "\n",
     "# Event-mode transmission monitor\n",
-    "transmission = sc.Dataset()\n",
     "events = sc.Variable([Dim.Tof], shape=[sc.Dimensions.Sparse])\n",
     "events.values = np.random.rand(123456)\n",
-    "transmission[''] = sc.DataArray(coords={Dim.Tof: events})\n",
+    "transmission = sc.DataArray(coords={Dim.Tof: events})\n",
     "\n",
     "# Beam profile monitor\n",
-    "profile = sc.Dataset()\n",
-    "profile.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(-0.1, 0.11, 0.01))\n",
-    "profile.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(-0.1, 0.11, 0.01))\n",
-    "profile[''] = sc.Variable([Dim.Y, Dim.X], values=np.random.rand(20, 20), unit=sc.units.counts)\n",
+    "profile = sc.DataArray(\n",
+    "    data=sc.Variable([Dim.Y, Dim.X], values=np.random.rand(20, 20), unit=sc.units.counts),\n",
+    "    coords={\n",
+    "        Dim.X: sc.Variable([Dim.X], values=np.arange(-0.1, 0.11, 0.01)),\n",
+    "        Dim.Y: sc.Variable([Dim.Y], values=np.arange(-0.1, 0.11, 0.01))\n",
+    "    })\n",
     "for i in 1,2,3,4:\n",
-    "    profile[''][Dim.X, i:-i][Dim.Y, i:-i] += 1.0 * sc.units.counts\n",
+    "    profile[Dim.X, i:-i][Dim.Y, i:-i] += 1.0 * sc.units.counts\n",
     "\n",
     "sc.plot(profile)"
    ]
@@ -399,7 +404,7 @@
     "sample = d['sample']\n",
     "temp_scan = sc.concatenate(sample, sample * (0.8 * sc.units.dimensionless), Dim.Temperature)\n",
     "temp_scan = sc.concatenate(temp_scan, temp_scan * (0.64 * sc.units.dimensionless), Dim.Temperature)\n",
-    "temp_scan.coords[Dim.Temperature] = sc.Variable([Dim.Temperature], values=[273.0, 180.0, 100.0, 4.3])"
+    "temp_scan.coords[Dim.Temperature] = sc.Variable([Dim.Temperature], values=[4.3, 100.0, 180.0, 273.0])"
    ]
   },
   {
@@ -408,7 +413,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#sc.plot(temp_scan[Dim.Position, 20:][Dim.Tof, 100], axes=['spectrum_number', Dim.Temperature])"
+    "sc.plot(temp_scan[Dim.Position, 20:], axes=[Dim.Tof, Dim.Temperature, 'spectrum_number'])"
    ]
   },
   {
@@ -424,7 +429,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Unit conversion"
+    "### Unit conversion\n",
+    "\n",
+    "Unit conversion is available in the `scipp.neutron` submodule.\n",
+    "Converting a data array or dataset to a different unit implies changing one of the dimensions and its coordinate.\n",
+    "Conversion can also be done with sparse data (events), but we are using the histogrammed data here:"
    ]
   },
   {

--- a/python/src/scipp/plot_matplotlib.py
+++ b/python/src/scipp/plot_matplotlib.py
@@ -101,8 +101,10 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
 
     # Get coordinates axes and dimensions
     coords = input_data.coords
+    labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
-        process_dimensions(input_data=input_data, coords=coords, axes=axes)
+        process_dimensions(input_data=input_data, coords=coords,
+                labels=labels, axes=axes)
 
     # Parse colorbar
     cbar = parse_colorbar(config.cb, cb)
@@ -123,8 +125,8 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
 
     for i, (key, val) in enumerate(sorted(data.items())):
 
-        ax[i].set_xlabel(axis_label(xcoord))
-        ax[i].set_ylabel(axis_label(ycoord))
+        ax[i].set_xlabel(xcoord)
+        ax[i].set_ylabel(ycoord)
 
         z = getattr(input_data, key)
         # Check if dimensions of arrays agree, if not, plot the transpose

--- a/python/src/scipp/plot_matplotlib.py
+++ b/python/src/scipp/plot_matplotlib.py
@@ -104,7 +104,7 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
     labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
         process_dimensions(input_data=input_data, coords=coords,
-                labels=labels, axes=axes)
+                           labels=labels, axes=axes)
 
     # Parse colorbar
     cbar = parse_colorbar(config.cb, cb)

--- a/python/src/scipp/plot_plotly.py
+++ b/python/src/scipp/plot_plotly.py
@@ -140,7 +140,7 @@ def plot_image(input_data, name=None, axes=None, contours=False, cb=None,
     labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
         process_dimensions(input_data=input_data, coords=coords,
-                labels=labels, axes=axes)
+                           labels=labels, axes=axes)
 
     if contours:
         plot_type = 'contour'
@@ -492,7 +492,7 @@ def plot_waterfall(input_data, dim=None, name=None, axes=None, filename=None,
     labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
         process_dimensions(input_data=input_data, coords=coords,
-                labels=labels, axes=axes)
+                           labels=labels, axes=axes)
 
     data = []
     z = input_data.values

--- a/python/src/scipp/plot_plotly.py
+++ b/python/src/scipp/plot_plotly.py
@@ -5,7 +5,7 @@
 import numpy as np
 from collections import namedtuple
 from .tools import edges_to_centers, axis_label, parse_colorbar, \
-                   process_dimensions
+                   process_dimensions, get_coord_array
 
 # Plotly imports
 from IPython.display import display
@@ -592,8 +592,9 @@ class SliceViewer:
 
         # Get the dimensions of the image to be displayed
         self.coords = self.input_data.coords
-        self.xcoord = self.coords[axes[-1]]
-        self.ycoord = self.coords[axes[-2]]
+        self.labels = self.input_data.labels
+        _, self.xcoord = get_coord_array(self.coords, self.labels, axes[-1])
+        _, self.ycoord = get_coord_array(self.coords, self.labels, axes[-2])
         self.xlabs = self.xcoord.dims
         self.ylabs = self.ycoord.dims
 

--- a/python/src/scipp/plot_plotly.py
+++ b/python/src/scipp/plot_plotly.py
@@ -135,12 +135,12 @@ def plot_image(input_data, name=None, axes=None, contours=False, cb=None,
     if figsize is None:
         figsize = [config.width, config.height]
 
-    coords = input_data.coords
-
     # Get coordinates axes and dimensions
     coords = input_data.coords
+    labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
-        process_dimensions(input_data=input_data, coords=coords, axes=axes)
+        process_dimensions(input_data=input_data, coords=coords,
+                labels=labels, axes=axes)
 
     if contours:
         plot_type = 'contour'
@@ -154,8 +154,8 @@ def plot_image(input_data, name=None, axes=None, contours=False, cb=None,
     title = axis_label(var=input_data, name=name, log=cbar["log"])
 
     layout = dict(
-        xaxis=dict(title=axis_label(xcoord)),
-        yaxis=dict(title=axis_label(ycoord)),
+        xaxis=dict(title=xcoord),
+        yaxis=dict(title=ycoord),
         height=figsize[1],
         width=figsize[0]
     )
@@ -489,8 +489,10 @@ def plot_waterfall(input_data, dim=None, name=None, axes=None, filename=None,
 
     # Get coordinates axes and dimensions
     coords = input_data.coords
+    labels = input_data.labels
     xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs = \
-        process_dimensions(input_data=input_data, coords=coords, axes=axes)
+        process_dimensions(input_data=input_data, coords=coords,
+                labels=labels, axes=axes)
 
     data = []
     z = input_data.values
@@ -530,9 +532,9 @@ def plot_waterfall(input_data, dim=None, name=None, axes=None, filename=None,
     layout = dict(
         scene=dict(
             xaxis=dict(
-                title=axis_label(xcoord)),
+                title=xcoord),
             yaxis=dict(
-                title=axis_label(ycoord)),
+                title=ycoord),
             zaxis=dict(
                 title=axis_label(var=input_data,
                                  name=name)),

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -92,8 +92,8 @@ class VariableDrawer():
             data = self._variable.values
         for vals in data:
             extent = max(extent, len(vals))
-        max_extent = _cubes_in_full_width/2/self._sparse_box_scale
-        self._x_stride = max(1, ceil(extent/max_extent))
+        max_extent = _cubes_in_full_width / 2 / self._sparse_box_scale
+        self._x_stride = max(1, ceil(extent / max_extent))
         return min(extent, max_extent)
 
     def size(self):
@@ -138,7 +138,7 @@ class VariableDrawer():
         if len(shape) <= 3:
             lz, ly, lx = self._extents()
             if lx == self._sparse_flag:
-                self._sparse_extent() # dummy call to init stride
+                self._sparse_extent()  # dummy call to init stride
             for z in range(lz):
                 for y in reversed(range(ly)):
                     true_lx = lx

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -93,7 +93,7 @@ class VariableDrawer():
         for vals in data:
             extent = max(extent, len(vals))
         max_extent = _cubes_in_full_width/2/self._sparse_box_scale
-        self._x_stride = ceil(extent/max_extent)
+        self._x_stride = max(1, ceil(extent/max_extent))
         return min(extent, max_extent)
 
     def size(self):

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from math import ceil
 
 import numpy as np
 import scipp as sc
@@ -41,6 +42,7 @@ class VariableDrawer():
         # special extent value indicating sparse dimension
         self._sparse_flag = -1
         self._sparse_box_scale = 0.3
+        self._x_stride = 1
 
     def _draw_box(self, origin_x, origin_y, color, xlen=1):
         return " ".join([
@@ -90,7 +92,9 @@ class VariableDrawer():
             data = self._variable.values
         for vals in data:
             extent = max(extent, len(vals))
-        return extent
+        max_extent = _cubes_in_full_width/2/self._sparse_box_scale
+        self._x_stride = ceil(extent/max_extent)
+        return min(extent, max_extent)
 
     def size(self):
         """Return the size (width and height) of the rendered output"""
@@ -133,6 +137,8 @@ class VariableDrawer():
 
         if len(shape) <= 3:
             lz, ly, lx = self._extents()
+            if lx == self._sparse_flag:
+                self._sparse_extent() # dummy call to init stride
             for z in range(lz):
                 for y in reversed(range(ly)):
                     true_lx = lx
@@ -140,7 +146,7 @@ class VariableDrawer():
                     sparse = False
                     if lx == self._sparse_flag:
                         # TODO This works only for 2D and no transpose
-                        true_lx = len(data[ly - y - 1])
+                        true_lx = ceil(len(data[ly - y - 1]) / self._x_stride)
                         if true_lx == 0:
                             true_lx = 1
                             x_scale *= 0
@@ -346,9 +352,11 @@ class DatasetDrawer():
             if coord.sparse_dim is not None:
                 continue
             item = (dim, coord, _colors['coord'])
-            if dim == dims[-1]:
+            if len(coord.dims) == 0:
+                area_0d.append(item)
+            elif coord.dims[-1] == dims[-1]:
                 area_x.append(item)
-            elif dim == dims[-2]:
+            elif coord.dims[-1] == dims[-2]:
                 area_y.append(item)
             else:
                 area_z.append(item)
@@ -356,11 +364,12 @@ class DatasetDrawer():
         for name, labels in dataset.labels:
             if labels.sparse_dim is not None:
                 continue
-            dim = labels.dims[-1]
             item = (name, labels, _colors['labels'])
-            if dim == dims[-1]:
+            if len(labels.dims) == 0:
+                area_0d.append(item)
+            elif labels.dims[-1] == dims[-1]:
                 area_x.append(item)
-            elif dim == dims[-2]:
+            elif labels.dims[-1] == dims[-2]:
                 area_y.append(item)
             else:
                 area_z.append(item)
@@ -368,11 +377,12 @@ class DatasetDrawer():
         for name, attr in dataset.attrs:
             if attr.sparse_dim is not None:
                 continue
-            dim = attr.dims[-1]
             item = (name, attr, _colors['attr'])
-            if dim == dims[-1]:
+            if len(attr.dims) == 0:
+                area_0d.append(item)
+            elif attr.dims[-1] == dims[-1]:
                 area_x.append(item)
-            elif dim == dims[-2]:
+            elif attr.dims[-1] == dims[-2]:
                 area_y.append(item)
             else:
                 area_z.append(item)

--- a/python/src/scipp/tools.py
+++ b/python/src/scipp/tools.py
@@ -52,7 +52,7 @@ def parse_colorbar(default, cb, plotly=False):
     return cbar
 
 
-def process_dimensions(input_data, coords, axes):
+def process_dimensions(input_data, coords, labels, axes):
     """
     Make x and y arrays from dimensions and check for bins edges
     """
@@ -64,9 +64,18 @@ def process_dimensions(input_data, coords, axes):
     else:
         axes = axes[-2:]
 
-    # Get coordinate arrays
-    xcoord = coords[axes[-1]]
-    ycoord = coords[axes[-2]]
+    def get_coord_array(coords, axis):
+        name = None
+        if isinstance(axis, sp.Dim):
+            var = coords[axis]
+        elif isinstance(axis, str):
+            var = labels[axis]
+            name = axis
+        else:
+            var = axis
+        return axis_label(var, name=name), var
+    xcoord_name, xcoord = get_coord_array(coords, axes[-1])
+    ycoord_name, ycoord = get_coord_array(coords, axes[-2])
     x = xcoord.values
     y = ycoord.values
 
@@ -108,4 +117,4 @@ def process_dimensions(input_data, coords, axes):
     else:
         raise RuntimeError("Dimensions of y Coord ({}) and Value ({}) do not "
                            "match.".format(ny[0], nz[iy]))
-    return xcoord, ycoord, xe, ye, xc, yc, xlabs, ylabs, zlabs
+    return xcoord_name, ycoord_name, xe, ye, xc, yc, xlabs, ylabs, zlabs

--- a/python/src/scipp/tools.py
+++ b/python/src/scipp/tools.py
@@ -52,6 +52,18 @@ def parse_colorbar(default, cb, plotly=False):
     return cbar
 
 
+def get_coord_array(coords, labels, axis):
+    name = None
+    if isinstance(axis, sp.Dim):
+        var = coords[axis]
+    elif isinstance(axis, str):
+        var = labels[axis]
+        name = axis
+    else:
+        var = axis
+    return axis_label(var, name=name), var
+
+
 def process_dimensions(input_data, coords, labels, axes):
     """
     Make x and y arrays from dimensions and check for bins edges
@@ -64,18 +76,8 @@ def process_dimensions(input_data, coords, labels, axes):
     else:
         axes = axes[-2:]
 
-    def get_coord_array(coords, axis):
-        name = None
-        if isinstance(axis, sp.Dim):
-            var = coords[axis]
-        elif isinstance(axis, str):
-            var = labels[axis]
-            name = axis
-        else:
-            var = axis
-        return axis_label(var, name=name), var
-    xcoord_name, xcoord = get_coord_array(coords, axes[-1])
-    ycoord_name, ycoord = get_coord_array(coords, axes[-2])
+    xcoord_name, xcoord = get_coord_array(coords, labels, axes[-1])
+    ycoord_name, ycoord = get_coord_array(coords, labels, axes[-2])
     x = xcoord.values
     y = ycoord.values
 

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -85,8 +85,6 @@ def test_coord_setitem():
     d = sc.Dataset({'a': var}, coords={Dim.X: var})
     with pytest.raises(RuntimeError):
         d[Dim.X, 2:3].coords[Dim.Y] = sc.Variable(1.0)
-    with pytest.raises(RuntimeError):
-        d['a'].coords[Dim.Y] = sc.Variable(1.0)
     d.coords[Dim.Y] = sc.Variable(1.0)
     assert len(d) == 1
     assert len(d.coords) == 2
@@ -139,8 +137,6 @@ def test_labels_setitem():
     d = sc.Dataset({'a': var}, coords={Dim.X: var})
     with pytest.raises(RuntimeError):
         d[Dim.X, 2:3].labels['label'] = sc.Variable(1.0)
-    with pytest.raises(RuntimeError):
-        d['a'].labels['label'] = sc.Variable(1.0)
     d.labels['label'] = sc.Variable(1.0)
     assert len(d) == 1
     assert len(d.labels) == 1
@@ -170,8 +166,6 @@ def test_attrs_setitem():
     d = sc.Dataset({'a': var}, coords={Dim.X: var})
     with pytest.raises(RuntimeError):
         d[Dim.X, 2:3].attrs['attr'] = sc.Variable(1.0)
-    with pytest.raises(RuntimeError):
-        d['a'].attrs['attr'] = sc.Variable(1.0)
     d.attrs['attr'] = sc.Variable(1.0)
     assert len(d) == 1
     assert len(d.attrs) == 1
@@ -380,7 +374,9 @@ def test_dataset_histogram():
 
 
 def test_histogram_and_setitem():
-    var = sc.Variable(dims=[Dim.X, Dim.Tof], shape=[2, sc.Dimensions.Sparse])
+    var = sc.Variable(dims=[Dim.X, Dim.Tof],
+                      shape=[2, sc.Dimensions.Sparse],
+                      unit=sc.units.us)
     var[Dim.X, 0].values = np.arange(3)
     var[Dim.X, 0].values.append(42)
     var[Dim.X, 0].values.extend(np.ones(3))

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -403,12 +403,10 @@ def test_dataset_merge():
 def test_dataset_concatenate():
     a = sc.Dataset(
         {'data': sc.Variable([Dim.X], values=np.array([11, 12]))},
-        coords={Dim.X: sc.Variable([Dim.X], values=np.array([1, 2]))}
-    )
+        coords={Dim.X: sc.Variable([Dim.X], values=np.array([1, 2]))})
     b = sc.Dataset(
         {'data': sc.Variable([Dim.X], values=np.array([13, 14]))},
-        coords={Dim.X: sc.Variable([Dim.X], values=np.array([3, 4]))}
-    )
+        coords={Dim.X: sc.Variable([Dim.X], values=np.array([3, 4]))})
 
     c = sc.concatenate(a, b, Dim.X)
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -121,7 +121,7 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
                                  const std::vector<scipp::index> &shape,
                                  const units::Unit unit, py::object &dtype,
                                  const bool variances) {
-  return CallDType<double, float, int64_t, int32_t, bool, Dataset,
+  return CallDType<double, float, int64_t, int32_t, bool, DataArray, Dataset,
                    Eigen::Vector3d>::
       apply<MakeVariableDefaultInit>(scippy::scipp_dtype(dtype), labels, shape,
                                      unit, variances);
@@ -166,6 +166,7 @@ template <class T> void bind_init_1D(py::class_<Variable> &c) {
 void init_variable(py::module &m) {
   py::class_<Variable> variable(m, "Variable", R"(
     Array of values with dimension labels and a unit, optionally including an array of variances.)");
+  bind_init_0D<DataArray>(variable);
   bind_init_0D<Dataset>(variable);
   bind_init_0D<int64_t>(variable);
   bind_init_0D<int32_t>(variable);

--- a/python/variable_view.cpp
+++ b/python/variable_view.cpp
@@ -65,6 +65,7 @@ void init_variable_view(py::module &m) {
   declare_span<const std::string>(m, "string_const");
   declare_span<std::string>(m, "string");
   declare_span<const Dim>(m, "Dim_const");
+  declare_span<DataArray>(m, "DataArray");
   declare_span<Dataset>(m, "Dataset");
   declare_span<Eigen::Vector3d>(m, "Eigen_Vector3d");
   declare_span<sparse_container<double>>(m, "sparse_double");
@@ -80,6 +81,7 @@ void init_variable_view(py::module &m) {
   declare_VariableView<sparse_container<double>>(m, "sparse_double");
   declare_VariableView<sparse_container<float>>(m, "sparse_float");
   declare_VariableView<sparse_container<int64_t>>(m, "sparse_int64_t");
+  declare_VariableView<DataArray>(m, "DataArray");
   declare_VariableView<Dataset>(m, "Dataset");
   declare_VariableView<Eigen::Vector3d>(m, "Eigen_Vector3d");
 }

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -144,8 +144,8 @@ public:
 };
 
 SCIPP_UNITS_DECLARE_DIMENSIONS(DSpacing, Energy, EnergyTransfer, Position, Q,
-                               Qx, Qy, Qz, Row, Spectrum, Time, Tof, Wavelength,
-                               X, Y, Z)
+                               Qx, Qy, Qz, Row, Spectrum, Temperature, Time,
+                               Tof, Wavelength, X, Y, Z)
 
 } // namespace neutron
 


### PR DESCRIPTION
Fixes #379.

A surprisingly large number of issues and missing features was found when updating the notebook:

- fix `scipp.show` to support 0-D coords, and work with large sparse data
- fix `scipp.compat.mantid.load` for non-event data
- `concatenate` could not handle 0-D labels
- avoid fall-through in `concatenate` when dimension exists, fixes #509
- unit of bin edges in `histogram` was not checked
- bug when creating a `LabelsProxy` with sparse labels, led to segmentation fault, fixes #508
- various missing binary arithmetic operations
- support slicing for `DataArray`
- support `DataArray` as element type in `Variable`.
- support labelling axes in `scipp.plot` with things that are not coords.