### PR TITLE
Conda release Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,18 @@ jobs:
         - .travis/conda_build_and_deploy.sh --label 'dev'
         - .travis/trigger_docker_build.sh
         - .travis/trigger_readthedocs_build.sh
+    - stage: "Release"
+      name: "release conda linux"
+      if: NOT type = cron AND branch = master AND NOT type = pull_request
+      on:
+        tag: true
+      git:
+        depth: false
+      env:
+        - PATH="$HOME/miniconda/bin:$PATH"
+      install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
+      script:
+        - .travis/conda_build_and_deploy.sh
     - os: osx
       osx_image: xcode10.2
       name: "conda osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ jobs:
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
         - .travis/conda_build_and_deploy.sh
+        - .travis/conda_build_and_deploy.sh --python 3.6
     - os: osx
       osx_image: xcode10.2
       name: "release conda osx"
@@ -107,14 +108,3 @@ jobs:
       install:
         - .travis/install_conda.sh "Miniconda3-latest-MacOSX-x86_64.sh"
       script: .travis/conda_build_and_deploy.sh
-    - name: "release conda linux python3.6"
-      if: type = cron AND branch = master
-      on:
-        tags: true
-      git:
-        depth: false
-      env:
-        - PATH="$HOME/miniconda/bin:$PATH"
-      install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
-      script:
-        - .travis/conda_build_and_deploy.sh --python 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - PATH="$HOME/miniconda/bin:$PATH"
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
-        - .travis/conda_build_and_deploy.sh
+        - .travis/conda_build_and_deploy.sh --label 'dev'
         - .travis/trigger_docker_build.sh
         - .travis/trigger_readthedocs_build.sh
     - os: osx
@@ -69,7 +69,7 @@ jobs:
         - OSX_VERSION=10.14
       install:
         - .travis/install_conda.sh "Miniconda3-latest-MacOSX-x86_64.sh"
-      script: .travis/conda_build_and_deploy.sh
+      script: .travis/conda_build_and_deploy.sh --label 'dev'
     - name: "conda linux python3.6"
       if: type = cron AND branch = master
       git:
@@ -78,4 +78,4 @@ jobs:
         - PATH="$HOME/miniconda/bin:$PATH"
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
-        - .travis/conda_build_and_deploy.sh --python 3.6
+        - .travis/conda_build_and_deploy.sh --label 'dev' --python 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       name: "release conda linux"
       if: NOT type = cron AND branch = master AND NOT type = pull_request
       on:
-        tag: true
+        tags: true
       git:
         depth: false
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,18 +56,6 @@ jobs:
         - .travis/conda_build_and_deploy.sh --label 'dev'
         - .travis/trigger_docker_build.sh
         - .travis/trigger_readthedocs_build.sh
-    - stage: "Release"
-      name: "release conda linux"
-      if: NOT type = cron AND branch = master AND NOT type = pull_request
-      on:
-        tags: true
-      git:
-        depth: false
-      env:
-        - PATH="$HOME/miniconda/bin:$PATH"
-      install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
-      script:
-        - .travis/conda_build_and_deploy.sh
     - os: osx
       osx_image: xcode10.2
       name: "conda osx"
@@ -91,3 +79,42 @@ jobs:
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
         - .travis/conda_build_and_deploy.sh --label 'dev' --python 3.6
+    - stage: "Release"
+      name: "release conda linux"
+      if: NOT type = cron AND branch = master AND NOT type = pull_request
+      on:
+        tags: true
+      git:
+        depth: false
+      env:
+        - PATH="$HOME/miniconda/bin:$PATH"
+      install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
+      script:
+        - .travis/conda_build_and_deploy.sh
+    - os: osx
+      osx_image: xcode10.2
+      name: "release conda osx"
+      if: NOT type = cron AND branch = master AND NOT type = pull_request
+      on:
+        tags: true
+      git:
+        depth: false
+      env:
+        - PATH="$HOME/miniconda/bin:$PATH"
+        - CC=/usr/bin/clang
+        - CXX=/usr/bin/clang++
+        - OSX_VERSION=10.14
+      install:
+        - .travis/install_conda.sh "Miniconda3-latest-MacOSX-x86_64.sh"
+      script: .travis/conda_build_and_deploy.sh
+    - name: "release conda linux python3.6"
+      if: type = cron AND branch = master
+      on:
+        tags: true
+      git:
+        depth: false
+      env:
+        - PATH="$HOME/miniconda/bin:$PATH"
+      install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
+      script:
+        - .travis/conda_build_and_deploy.sh --python 3.6

--- a/.travis/conda_build_and_deploy.sh
+++ b/.travis/conda_build_and_deploy.sh
@@ -6,6 +6,5 @@ set -x
 conda-build \
   --user 'scipp' \
   --token "$ANACONDA_TOKEN" \
-  --label 'dev' \
   $@ \
   ./conda


### PR DESCRIPTION
@DanNixon I made a start on configuring Travis to make conda packages for the default (not `dev`) label in conda. This should happen automatically when tagging a release. Could you have a look if this makes sense? If feel a bit bad about the duplication, and also we would need to add more of this for the OSX and 3.6 packages.