### PR TITLE
Disable LTO for Mac unit-test builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
       before_install: brew install ccache
       env:
         - PYTHON_EXECUTABLE="/usr/local/bin/python3"
-      script: .travis/run_tests.sh
+      script: .travis/run_tests.sh -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
     - stage: "Deploy"
       name: "conda linux"
       if: NOT type = cron AND branch = master AND NOT type = pull_request

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -4,7 +4,7 @@
 mkdir -p build
 mkdir -p install
 cd build
-cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DCMAKE_INSTALL_PREFIX=../install .. || exit 1
+cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install .. || exit 1
 make -j2 install || exit 1
 
 # Units tests


### PR DESCRIPTION
Maybe this will fix the slow builds?