### PR TITLE
Fix install target

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -5,7 +5,7 @@ mkdir -p build
 mkdir -p install
 cd build
 cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install .. || exit 1
-make -j2 install || exit 1
+make -j2 all-test install || exit 1
 
 # Units tests
 ./units/test/scipp-units-test

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -5,7 +5,7 @@ mkdir -p build
 mkdir -p install
 cd build
 cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install .. || exit 1
-make -j2 all-test install || exit 1
+make -j2 all-tests install || exit 1
 
 # Units tests
 ./units/test/scipp-units-test

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -5,7 +5,7 @@ mkdir -p build
 mkdir -p install
 cd build
 cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install .. || exit 1
-make -j2 all-tests install || exit 1
+make -j2 all-targets install || exit 1
 
 # Units tests
 ./units/test/scipp-units-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,8 @@ add_subdirectory(test)
 # Custom target for building everyting. all excludes tests by default
 add_custom_target(all-tests
                    DEPENDS 
-		     all
+		     ALL 
 		     scipp-common-test
-                     scipp-core-test
+		     scipp-core-test
 		     scipp-unit-test
 	             scipp-neutron-test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,9 @@ add_subdirectory(test)
 # Custom target for building everyting. all excludes tests by default
 add_custom_target(all-tests
                    DEPENDS 
-		     ALL 
 		     scipp-common-test
 		     scipp-core-test
 		     scipp-unit-test
 	             scipp-neutron-test)
+add_custom_target(all-targets ALL DEPENDS all-tests)
+	 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ add_custom_target(all-tests
                    DEPENDS 
 		     scipp-common-test
 		     scipp-core-test
-		     scipp-unit-test
+		     scipp-units-test
 	             scipp-neutron-test)
 add_custom_target(all-targets ALL DEPENDS all-tests)
 	 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,10 +112,9 @@ add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
 # Custom target for building everyting. all excludes tests by default
-add_custom_target(all-tests
+add_custom_target(all-tests ALL
                    DEPENDS 
-		     ALL 
 		     scipp-common-test
 		     scipp-core-test
-		     scipp-unit-test
+		     scipp-units-test
 	             scipp-neutron-test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,3 +111,11 @@ add_subdirectory(core)
 add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
+# Custom target for building everyting. all excludes tests by default
+add_custom_target(all-tests
+                   DEPENDS 
+		     all
+		     scipp-common-test
+                     scipp-core-test
+		     scipp-unit-test
+	             scipp-neutron-test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,10 @@ add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
 # Custom target for building everyting. all excludes tests by default
-add_custom_target(all-tests ALL
+add_custom_target(all-tests
                    DEPENDS 
+		     ALL 
 		     scipp-common-test
 		     scipp-core-test
-		     scipp-units-test
+		     scipp-unit-test
 	             scipp-neutron-test)

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-common-test")
-add_executable(${TARGET_NAME} index_test.cpp)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL index_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE
                       scipp-common

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -5,7 +5,6 @@ mkdir -p 'build' && cd 'build'
 
 # Perform CMake configuration
 cmake \
-  -G"Ninja" \
   -DPYTHON_EXECUTABLE="$CONDA_PREFIX/bin/python" \
   -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_VERSION \

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-core-test")
-add_executable(${TARGET_NAME}
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                bool_test.cpp
                concatenate_test.cpp
                coords_proxy_test.cpp

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-neutron-test")
-add_executable(${TARGET_NAME}
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                #EventWorkspace_test.cpp
                #example_instrument_test.cpp
                #Run_test.cpp

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-units-test")
-add_executable(${TARGET_NAME} dimension_test.cpp unit_test.cpp)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dimension_test.cpp unit_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE
                       scipp-units


### PR DESCRIPTION
Fixes #527 

Brings build times down from >1000s real for `install` to  <300s real for `install` for cold-cache `make -j1`  builds

Note that the nature of the `ALL` target has changed, devs would have to use new `all-tests` target to achieve same result.