### PR TITLE
Clean up around all-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,8 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
 
 enable_testing()
 
-set(TEST_TARGETS "" CACHE INTERNAL "")
+# Custom target for building tests. all excludes tests by default
+add_custom_target(all-tests)
 add_subdirectory(common)
 add_subdirectory(benchmark)
 add_subdirectory(units)
@@ -112,8 +113,3 @@ add_subdirectory(core)
 add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
-# Custom target for building tests. all excludes tests by default
-add_custom_target(all-tests
-                   DEPENDS 
-		   ${TEST_TARGETS})
-message(status "all-tests test targets include: ${TEST_TARGETS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
 
 enable_testing()
 
+set(TEST_TARGETS "" CACHE INTERNAL "")
 add_subdirectory(common)
 add_subdirectory(benchmark)
 add_subdirectory(units)
@@ -111,10 +112,8 @@ add_subdirectory(core)
 add_subdirectory(neutron)
 add_subdirectory(python)
 add_subdirectory(test)
-# Custom target for building everyting. all excludes tests by default
+# Custom target for building tests. all excludes tests by default
 add_custom_target(all-tests
                    DEPENDS 
-		     scipp-common-test
-		     scipp-core-test
-		     scipp-units-test
-	             scipp-neutron-test)
+		   ${TEST_TARGETS})
+message(status "all-tests test targets include: ${TEST_TARGETS}")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Scipp mainly provides the `Dataset` container, which is inspired by `xarray.Data
 ## Build instructions
 
 It is not necessary to build `scipp` from source if only the Python package is required.
-See https://scipp.readthedocs.io/en/latest/getting-started/installation.html on how to install using `conda` or `docker` instead.
+See https://scipp.readthedocs.io/en/latest/getting-started/installation.html on how do install using `conda` or `docker` instead.
 
 ### Prerequisites (OSX only)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Scipp mainly provides the `Dataset` container, which is inspired by `xarray.Data
 ## Build instructions
 
 It is not necessary to build `scipp` from source if only the Python package is required.
-See https://scipp.readthedocs.io/en/latest/getting-started/installation.html on how do install using `conda` or `docker` instead.
+See https://scipp.readthedocs.io/en/latest/getting-started/installation.html on how to install using `conda` or `docker` instead.
 
 ### Prerequisites (OSX only)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd build
 cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
 make -j4 all-tests install
 ```
-Note that the `all` and `install` targets to NOT include the tests. Those must be build separately via `all-tests`.
+Note that the `all` and `install` targets do NOT include the tests. Those must be build separately via `all-tests`.
 
 To use the `scipp` Python module:
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ mkdir -p build
 mkdir -p install
 cd build
 cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
-make -j4 install
+make -j4 all-tests install
 ```
+Note that the `all` and `install` targets to NOT include the tests. Those must be build separately via `all-tests`.
 
 To use the `scipp` Python module:
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-common-test")
+set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL index_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-common-test")
-set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
+add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL index_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-core-test")
-set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
+add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                bool_test.cpp
                concatenate_test.cpp

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-core-test")
+set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                bool_test.cpp
                concatenate_test.cpp

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-neutron-test")
-set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
+add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                #EventWorkspace_test.cpp
                #example_instrument_test.cpp

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-neutron-test")
+set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                #EventWorkspace_test.cpp
                #example_instrument_test.cpp

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-units-test")
-set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
+add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dimension_test.cpp unit_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-units-test")
+set(TEST_TARGETS "${TEST_TARGETS} ${TARGET_NAME}" CACHE INTERNAL "")
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dimension_test.cpp unit_test.cpp)
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE


### PR DESCRIPTION
`all-tests` phoney target introduced recently.

Small clean-up to improve maintenance around that list of targets.

Check documentation, and review - but if the builds are passing then the changes here must be working.