### PR TITLE
Use travis_wait subprocess polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
         - PATH="$HOME/miniconda/bin:$PATH"
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
-        - .travis/conda_build_and_deploy.sh --label 'dev' --python 3.6
+        - travis_wait .travis/conda_build_and_deploy.sh --label 'dev' --python 3.6
     - stage: "Deploy"
       name: "release conda linux"
       if: NOT type = cron AND NOT type = pull_request AND tag =~ /^v\d+(\.\d+)*/
@@ -107,4 +107,4 @@ jobs:
         - OSX_VERSION=10.14
       install:
         - .travis/install_conda.sh "Miniconda3-latest-MacOSX-x86_64.sh"
-      script: .travis/conda_build_and_deploy.sh
+      script: travis_wait .travis/conda_build_and_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
         - OSX_VERSION=10.14
       install:
         - .travis/install_conda.sh "Miniconda3-latest-MacOSX-x86_64.sh"
-      script: .travis/conda_build_and_deploy.sh --label 'dev'
+      script: travis_wait .travis/conda_build_and_deploy.sh --label 'dev'
     - stage: "Deploy"
       name: "conda linux python3.6"
       if: type = cron AND branch = master
@@ -91,8 +91,8 @@ jobs:
         - PATH="$HOME/miniconda/bin:$PATH"
       install: .travis/install_conda.sh "Miniconda3-latest-Linux-x86_64.sh"
       script:
-        - .travis/conda_build_and_deploy.sh
-        - .travis/conda_build_and_deploy.sh --python 3.6
+        - travis_wait .travis/conda_build_and_deploy.sh
+        - travis_wait .travis/conda_build_and_deploy.sh --python 3.6
     - stage: "Deploy"
       os: osx
       osx_image: xcode10.2

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -19,11 +19,6 @@ if [ $rc -ne 0 ]; then
   exit $rc
 fi
 
-# build targets in sequence to prevent timeout travis_wait might be better solution
-ninja clean
-ninja scipp-core -v
-ninja scipp-neutron -v
-ninja _scipp -v
 # Build, install and move scipp Python library to site packages location
 ninja install -v && \
   mv "$CONDA_PREFIX/scipp" "$CONDA_PREFIX"/lib/python*/


### PR DESCRIPTION
This is a hypothetical fix - as in I have not tried it on the travis conda build jobs as has to be on master first, so do not merge at this point.

The idea is that travis wait will provide log output every minute for 20 minutes and that will keep the job alive for >10 minutes.

Pro - Don't have to have hard-coded sub-target list (in right order) in order to get frequent update.
Cons - Output will be less useful than seeing which targets have been built.