### PR TITLE
Add channel `mantid` for correct poco package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN conda install --yes setuptools
 RUN conda install --yes \
       -c conda-forge \
       -c scipp/label/dev \
+      -c mantid \
       -c mantid/label/nightly \
       ipython \
       matplotlib \


### PR DESCRIPTION
Add channel `mantid` with the proper poco package.