### PR TITLE
Fix issue with concatenate fail when it should create 2D coord.

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -1251,7 +1251,12 @@ auto concat(const T1 &a, const T2 &b, const Dim dim, const Dimensions &dimsA,
       else
         out.emplace(key, join_edges(a_, b[key], dim));
     } else {
-      out.emplace(key, same(a_, b[key]));
+      // 1D coord is kept only if both inputs have matching 1D coords.
+      if (a_.dims().contains(dim) || b[key].dims().contains(dim) ||
+          a_ != b[key])
+        out.emplace(key, concatenate(a_, b[key], dim));
+      else
+        out.emplace(key, same(a_, b[key]));
     }
   }
   return out;

--- a/core/test/concatenate_test.cpp
+++ b/core/test/concatenate_test.cpp
@@ -111,3 +111,29 @@ TEST(ConcatenateTest, non_dependant_data_is_stacked) {
   EXPECT_EQ(d["data_1"].data(), makeVariable<int>({{Dim::Y, 2}, {Dim::X, 3}},
                                                   {11, 12, 13, 14, 15, 16}));
 }
+
+TEST(ConcatenateTest, concat_2d_coord) {
+  Dataset a;
+  a.setCoord(Dim::X, makeVariable<double>({Dim::X, 3}, {1, 2, 3}));
+  a.setData("data_1", makeVariable<double>({Dim::X, 3}, {11, 12, 13}));
+  a.setLabels("label_1", makeVariable<int>({Dim::X, 3}, {21, 22, 23}));
+
+  Dataset b(a);
+  b.coords()[Dim::X] += 3;
+  b["data_1"].data() += 1;
+
+  Dataset expected;
+  expected.setCoord(Dim::X,
+                    makeVariable<double>({{Dim::Y, 4}, {Dim::X, 3}},
+                                         {1, 2, 3, 4, 5, 6, 4, 5, 6, 1, 2, 3}));
+  expected.setData("data_1", makeVariable<double>({{Dim::Y, 4}, {Dim::X, 3}},
+                                                  {11, 12, 13, 12, 13, 14, 12,
+                                                   13, 14, 11, 12, 13}));
+  expected.setLabels("label_1", makeVariable<int>({Dim::X, 3}, {21, 22, 23}));
+
+  const auto ab = concatenate(a, b, Dim::Y);
+  const auto ba = concatenate(b, a, Dim::Y);
+  const auto abba = concatenate(ab, ba, Dim::Y);
+
+  EXPECT_EQ(abba, expected);
+}


### PR DESCRIPTION
Fix an issue reported by @mads-bertelsen. The original implementation did not support anything but 1D coords, and therefore also failed when sparse data was present.