### PR TITLE
Safer transform in place

### DIFF
--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -467,9 +467,15 @@ template <bool dry_run> struct in_place {
       // terminates with the second level.
       if constexpr (is_sparse_v<decltype(vals[0])>) {
         ValuesAndVariances _{vals[i], vars[i]};
+        static_assert(
+            std::is_same_v<
+                decltype(op(_, value_and_maybe_variance(other, i)...)), void>);
         op(_, value_and_maybe_variance(other, i)...);
       } else {
         ValueAndVariance _{vals[i], vars[i]};
+        static_assert(
+            std::is_same_v<
+                decltype(op(_, value_and_maybe_variance(other, i)...)), void>);
         op(_, value_and_maybe_variance(other, i)...);
         vals[i] = _.value;
         vars[i] = _.variance;
@@ -491,8 +497,10 @@ template <bool dry_run> struct in_place {
       return;
     // WARNING: Do not parallelize this loop in all cases! The output may have a
     // dimension with stride zero so parallelization must be done with care.
-    for (scipp::index i = 0; i < scipp::size(vals); ++i)
+    for (scipp::index i = 0; i < scipp::size(vals); ++i) {
+      static_assert(std::is_same_v<decltype(op(vals[i], other[i]...)), void>);
       op(vals[i], other[i]...);
+    }
   }
 
   /// Helper for in-place transform implementation, performing branching between

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -426,6 +426,13 @@ static constexpr auto type_pairs(Op) noexcept {
     return std::tuple_cat(TypePairs{}...);
 }
 
+template <class Op, class... Args>
+static constexpr void call_in_place(Op &&op, Args &&... args) noexcept {
+  static_assert(
+      std::is_same_v<decltype(op(std::forward<Args>(args)...)), void>);
+  op(std::forward<Args>(args)...);
+}
+
 /// Helper class wrapping functions for in-place transform.
 ///
 /// The dry_run template argument can be used to disable any actual modification
@@ -467,16 +474,10 @@ template <bool dry_run> struct in_place {
       // terminates with the second level.
       if constexpr (is_sparse_v<decltype(vals[0])>) {
         ValuesAndVariances _{vals[i], vars[i]};
-        static_assert(
-            std::is_same_v<
-                decltype(op(_, value_and_maybe_variance(other, i)...)), void>);
-        op(_, value_and_maybe_variance(other, i)...);
+        call_in_place(op, _, value_and_maybe_variance(other, i)...);
       } else {
         ValueAndVariance _{vals[i], vars[i]};
-        static_assert(
-            std::is_same_v<
-                decltype(op(_, value_and_maybe_variance(other, i)...)), void>);
-        op(_, value_and_maybe_variance(other, i)...);
+        call_in_place(op, _, value_and_maybe_variance(other, i)...);
         vals[i] = _.value;
         vars[i] = _.variance;
       }
@@ -497,10 +498,8 @@ template <bool dry_run> struct in_place {
       return;
     // WARNING: Do not parallelize this loop in all cases! The output may have a
     // dimension with stride zero so parallelization must be done with care.
-    for (scipp::index i = 0; i < scipp::size(vals); ++i) {
-      static_assert(std::is_same_v<decltype(op(vals[i], other[i]...)), void>);
-      op(vals[i], other[i]...);
-    }
+    for (scipp::index i = 0; i < scipp::size(vals); ++i)
+      call_in_place(op, vals[i], other[i]...);
   }
 
   /// Helper for in-place transform implementation, performing branching between

--- a/core/operators.h
+++ b/core/operators.h
@@ -20,25 +20,25 @@ template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
 namespace operator_detail {
 struct plus_equals {
   template <class A, class B>
-  constexpr auto operator()(A &&a, const B &b) const
+  constexpr void operator()(A &&a, const B &b) const
       noexcept(noexcept(a += b)) {
-    return a += b;
+    a += b;
   }
   using types = pair_self_t<double, float, int64_t, Eigen::Vector3d>;
 };
 struct minus_equals {
   template <class A, class B>
-  constexpr auto operator()(A &&a, const B &b) const
+  constexpr void operator()(A &&a, const B &b) const
       noexcept(noexcept(a -= b)) {
-    return a -= b;
+    a -= b;
   }
   using types = pair_self_t<double, float, int64_t, Eigen::Vector3d>;
 };
 struct times_equals {
   template <class A, class B>
-  constexpr auto operator()(A &&a, const B &b) const
+  constexpr void operator()(A &&a, const B &b) const
       noexcept(noexcept(a *= b)) {
-    return a *= b;
+    a *= b;
   }
   using types = decltype(
       std::tuple_cat(pair_self_t<double, float, int64_t>{},
@@ -47,9 +47,9 @@ struct times_equals {
 };
 struct divide_equals {
   template <class A, class B>
-  constexpr auto operator()(A &&a, const B &b) const
+  constexpr void operator()(A &&a, const B &b) const
       noexcept(noexcept(a /= b)) {
-    return a /= b;
+    a /= b;
   }
   using types = decltype(
       std::tuple_cat(pair_self_t<double, float, int64_t>{},

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -322,11 +322,11 @@ Variable mean(const VariableConstProxy &var, const Dim dim) {
   // In principle we *could* support mean/sum over sparse dimension.
   expect::notSparse(var);
   auto summed = sum(var, dim);
-  double scale = 1.0 / static_cast<double>(var.dims()[dim]);
+  auto scale = makeVariable<double>(1.0 / static_cast<double>(var.dims()[dim]));
   if (isInt(var.dtype()))
-    summed = summed * makeVariable<double>(scale);
+    summed = summed * scale;
   else
-    summed *= makeVariable<double>(scale);
+    summed *= scale;
   return summed;
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -318,15 +318,6 @@ Variable sum(const VariableConstProxy &var, const Dim dim) {
   return summed;
 }
 
-struct multiply_variance {
-  template <class T>
-  scipp::core::detail::ValueAndVariance<T>
-  operator()(const scipp::core::detail::ValueAndVariance<T> &vv) const {
-    return {vv.value, vv.variance * multiplier};
-  }
-  double multiplier;
-};
-
 Variable mean(const VariableConstProxy &var, const Dim dim) {
   // In principle we *could* support mean/sum over sparse dimension.
   expect::notSparse(var);
@@ -336,9 +327,6 @@ Variable mean(const VariableConstProxy &var, const Dim dim) {
     summed = summed * makeVariable<double>(scale);
   else
     summed *= makeVariable<double>(scale);
-  if (summed.hasVariances())
-    transform_in_place<double, float>(
-        summed, overloaded{multiply_variance{scale}, [](const auto &) {}});
   return summed;
 }
 


### PR DESCRIPTION
Add a `static_assert` in `transform_in_place` that forbids functors that do not return `void`. `transform_in_place` ignores the return value (it assumes modification happens through a reference), so a functor not returning `void` is likely (but not necessarily) a bug.

- Also remove two bugs in `mean` that cancel each other. Note that the unit test was correct and passed.
- Note a minor drawback of this assert: We cannot use functors that return a reference to the input, as is common practice for operators like `+=`. In practice, I do not think this is a problem. In the "worst" case client code will have to wrap their operators.