### PR TITLE
First benchmarks for transform

### DIFF
--- a/CMake/GoogleBenchmark.in
+++ b/CMake/GoogleBenchmark.in
@@ -7,7 +7,7 @@ find_package(Git)
 include(ExternalProject)
 ExternalProject_Add(googlebenchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           "v1.4.0"
+  GIT_TAG           master
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googlebenchmark-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googlebenchmark-build"
   CONFIGURE_COMMAND ""

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+add_executable(transform_benchmark EXCLUDE_FROM_ALL transform_benchmark.cpp)
+target_link_libraries(transform_benchmark LINK_PRIVATE scipp-core benchmark)
+
 add_executable(variable_benchmark EXCLUDE_FROM_ALL variable_benchmark.cpp)
 target_link_libraries(variable_benchmark LINK_PRIVATE scipp-core benchmark)
 

--- a/benchmark/transform_benchmark.cpp
+++ b/benchmark/transform_benchmark.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <benchmark/benchmark.h>
+
+#include "scipp/core/transform.h"
+#include "scipp/core/variable.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+using Types = std::tuple<std::pair<double, double>>;
+
+template <class Func> void run(benchmark::State &state, Func func) {
+  const auto nx = 100;
+  const auto ny = state.range(0);
+  const auto n = nx * ny;
+  auto a = makeVariable<double>({{Dim::Y, ny}, {Dim::X, nx}});
+  auto b = a;
+  static constexpr auto op{[](auto &a_, const auto &b_) { a_ *= b_; }};
+
+  func(state, a, b, op);
+
+  state.SetItemsProcessed(state.iterations() * n);
+  state.SetBytesProcessed(state.iterations() * n * 3 * sizeof(double));
+  state.counters["size"] =
+      benchmark::Counter(n * 2 * sizeof(double), benchmark::Counter::kDefaults,
+                         benchmark::Counter::OneK::kIs1024);
+}
+
+static void BM_transform_in_place(benchmark::State &state) {
+  run(state, [](auto &state_, auto &&... args) {
+    for (auto _ : state_) {
+      transform_in_place<Types>(args...);
+    }
+  });
+}
+
+static void BM_transform_in_place_proxy(benchmark::State &state) {
+  run(state, [](auto &state_, auto &a, auto &b, auto &op) {
+    VariableProxy a_proxy(a);
+    VariableConstProxy b_proxy(b);
+    for (auto _ : state_) {
+      transform_in_place<Types>(a_proxy, b_proxy, op);
+    }
+  });
+}
+
+static void BM_transform_in_place_slice(benchmark::State &state) {
+  run(state, [](auto &state_, auto &a, auto &b, auto &op) {
+    // Strictly speaking our counters are off by 1% since we exclude 1 out of
+    // 100 X elements here.
+    auto a_slice = a.slice({Dim::X, 0, 99});
+    auto b_slice = b.slice({Dim::X, 1, 100});
+    for (auto _ : state_) {
+      transform_in_place<Types>(a_slice, b_slice, op);
+    }
+  });
+}
+
+BENCHMARK(BM_transform_in_place)->RangeMultiplier(2)->Range(1, 2 << 18);
+BENCHMARK(BM_transform_in_place_proxy)->RangeMultiplier(2)->Range(1, 2 << 18);
+BENCHMARK(BM_transform_in_place_slice)->RangeMultiplier(2)->Range(1, 2 << 18);
+
+BENCHMARK_MAIN();

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -154,7 +154,16 @@ private:
                            Dim::Invalid};
 };
 
+SCIPP_CORE_EXPORT constexpr Dimensions merge(const Dimensions &a) noexcept {
+  return a;
+}
 SCIPP_CORE_EXPORT Dimensions merge(const Dimensions &a, const Dimensions &b);
+
+template <class... Ts>
+Dimensions merge(const Dimensions &a, const Dimensions &b,
+                 const Ts &... other) {
+  return merge(merge(a, b), other...);
+}
 
 } // namespace scipp::core
 


### PR DESCRIPTION
Implement basic benchmarks for transform, see #558.

Results:
- Good performance for contiguous ranges (exceeding 50 GB/s when in cache, 15 GB/s from main memory).
- Similar performance for sparse data, worse for very small (<10) "event lists".
- Very bad performance for non-contiguous ranges (120 MB/s) this is due to the current implementation of transform, which uses index-access. I have a branch that uses iterators instead and improves this to 8 GB/s --- still much worse than for contiguous data, but maybe acceptable for now. The main problem is that the changes are not so trivial and incomplete for now (how to iterate over all ranges in parameters pack, and similar complications) so I am not including this in this PR.