### PR TITLE
is_approx

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(TARGET_NAME "scipp-core")
 set(INC_FILES
     include/scipp/core/aligned_allocator.h
+    include/scipp/core/comparison.h
     include/scipp/core/dataset.h
     include/scipp/core/dataset_index.h
     include/scipp/core/dimensions.h
@@ -19,6 +20,7 @@ set(INC_FILES
 
 set(SRC_FILES
     counts.cpp
+    comparison.cpp
     data_array.cpp
     dataset.cpp
     dataset_binary_arithmetic.cpp

--- a/core/comparison.cpp
+++ b/core/comparison.cpp
@@ -1,0 +1,4 @@
+#include "scipp/core/comparison.h"
+#include "math.h"
+
+namespace scipp::core {}

--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -13,7 +13,7 @@ namespace scipp::core {
 
 template <typename T>
 bool approx_same(const Variable &a, const Variable &b, const T &tolerance) {
-  const auto abs_tolerance = abs(tolerance);
+  const auto abs_tolerance = tolerance;
   auto in_tolerance = transform<pair_self_t<double>>(
       a, b,
       scipp::overloaded{[abs_tolerance](const auto &u, const auto &v) {

--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+
+#ifndef SCIPP_COMPARISON_H
+#define SCIPP_COMPARISON_H
+
+#include "../operators.h"
+#include "scipp/core/dimensions.h"
+#include "scipp/core/transform.h"
+#include "scipp/core/variable.h"
+
+namespace scipp::core {
+
+template <typename T>
+bool approx_same(const Variable &a, const Variable &b, const T &tolerance) {
+  const auto abs_tolerance = abs(tolerance);
+  auto in_tolerance = transform<pair_self_t<double>>(
+      a, b,
+      scipp::overloaded{[abs_tolerance](const auto &u, const auto &v) {
+                          return abs(u - v) < abs_tolerance;
+                        },
+                        [](const units::Unit &, const units::Unit &) {
+                          return units::dimensionless;
+                        }});
+  return std::all_of(in_tolerance.template values<bool>().begin(),
+                     in_tolerance.template values<bool>().end(),
+                     [](const auto &val) { return val; });
+}
+
+} // namespace scipp::core
+
+#endif // SCIPP_COMPARISON_H

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -127,6 +127,22 @@ constexpr auto operator/(const T1 a, const ValueAndVariance<T2> b) noexcept {
                                            (b.value * b.value) /
                                            (b.value * b.value)};
 }
+template <class T1, class T2>
+constexpr auto operator<(const ValueAndVariance<T1> a, const T2 b) noexcept {
+  return ValueAndVariance{a.value < b, a.variance};
+}
+template <class T1, class T2>
+constexpr auto operator>(const ValueAndVariance<T1> a, const T2 b) noexcept {
+  return ValueAndVariance{a.value > b, a.variance};
+}
+template <class T1, class T2>
+constexpr auto operator>=(const ValueAndVariance<T1> a, const T2 b) noexcept {
+  return ValueAndVariance{a.value >= b, a.variance};
+}
+template <class T1, class T2>
+constexpr auto operator<=(const ValueAndVariance<T1> a, const T2 b) noexcept {
+  return ValueAndVariance{a.value <= b, a.variance};
+}
 
 /// Deduction guide for class ValueAndVariances. Using decltype to deal with
 /// potential mixed-type val and var arguments arising in binary operations

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                concatenate_test.cpp
                coords_proxy_test.cpp
                counts_test.cpp
+               comparison_test.cpp
                data_array_comparison_test.cpp
                data_array_test.cpp
                data_proxy_test.cpp

--- a/core/test/comparison_test.cpp
+++ b/core/test/comparison_test.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/comparison.h"
+#include "scipp/core/variable.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(Comparison, is_approx) {
+  const double delta = 0.1;
+  const auto a =
+      makeVariable<double>({Dim::X, 2}, units::m, {1.0 + delta, 2.0});
+  const auto b = makeVariable<double>({Dim::X, 2}, units::m, {1.0, 2.0});
+  ASSERT_TRUE(approx_same(a, b, delta + 0.001));
+  ASSERT_FALSE(approx_same(a, b, delta - 0.001));
+}

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -287,7 +287,7 @@ TEST_F(TransformBinaryTest, in_place_unit_change) {
 
 template <typename T>
 bool approx_same(const Variable &a, const Variable &b, const T &tolerance) {
-  const auto abs_tolerance = abs(tolerance);
+  const auto abs_tolerance = tolearance;
   auto in_tolerance = transform<pair_self_t<double>>(
       a, b,
       scipp::overloaded{[abs_tolerance](const auto &u, const auto &v) {


### PR DESCRIPTION
Fixes #519

Basically use returning `transform` to perform an element by element `abs(x - y) < tol` type comparison and check all true. Light-weight function `is_approx` does work.