### PR TITLE
Transform performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ else()
   set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 endif()
 
+# Optimization flags
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --param inline-unit-growth=100")
+endif()
+
 # Get version from git-describe
 execute_process(
   COMMAND git describe --tag

--- a/benchmark/transform_benchmark.cpp
+++ b/benchmark/transform_benchmark.cpp
@@ -47,25 +47,29 @@ static void BM_transform_in_place(benchmark::State &state) {
 }
 
 static void BM_transform_in_place_proxy(benchmark::State &state) {
-  run(state, [](auto &state_, auto &a, auto &b, auto &op) {
-    VariableProxy a_proxy(a);
-    VariableConstProxy b_proxy(b);
-    for (auto _ : state_) {
-      transform_in_place<Types>(a_proxy, b_proxy, op);
-    }
-  });
+  run(state,
+      [](auto &state_, auto &a, auto &b, auto &op) {
+        VariableProxy a_proxy(a);
+        VariableConstProxy b_proxy(b);
+        for (auto _ : state_) {
+          transform_in_place<Types>(a_proxy, b_proxy, op);
+        }
+      },
+      state.range(1));
 }
 
 static void BM_transform_in_place_slice(benchmark::State &state) {
-  run(state, [](auto &state_, auto &a, auto &b, auto &op) {
-    // Strictly speaking our counters are off by 1% since we exclude 1 out of
-    // 100 X elements here.
-    auto a_slice = a.slice({Dim::X, 0, 99});
-    auto b_slice = b.slice({Dim::X, 1, 100});
-    for (auto _ : state_) {
-      transform_in_place<Types>(a_slice, b_slice, op);
-    }
-  });
+  run(state,
+      [](auto &state_, auto &a, auto &b, auto &op) {
+        // Strictly speaking our counters are off by 1% since we exclude 1 out
+        // of 100 X elements here.
+        auto a_slice = a.slice({Dim::X, 0, 99});
+        auto b_slice = b.slice({Dim::X, 1, 100});
+        for (auto _ : state_) {
+          transform_in_place<Types>(a_slice, b_slice, op);
+        }
+      },
+      state.range(1));
 }
 
 // {false, true} -> variances

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -114,6 +114,8 @@ static constexpr auto value_and_maybe_variance(const T &range,
     return range[i];
   }
 }
+/// This is a temporary duplication and should eventually fully replace
+/// value_and_maybe_variance.
 template <class T>
 static constexpr decltype(auto)
 value_and_maybe_variance2(T &&range, const scipp::index i) {
@@ -416,7 +418,7 @@ template <class Op, class SparseOp> struct overloaded_sparse : Op, SparseOp {
       // passed BY REFERENCE and NOT BY VALUE. Passing by value leads to
       // construction of expressions of values on the stack, which are then
       // returned from the operator. One way to identify this is using
-      // address-sanitizer, which find a `stack-use-after-scope`.
+      // address-sanitizer, which finds a `stack-use-after-scope`.
       return Op::template operator()<Ts...>(std::forward<Ts>(args)...);
     else
       return Op::template operator()(std::forward<Ts>(args)...);

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -445,7 +445,7 @@ template <class Range> static auto begin_or_value(Range &&r) noexcept {
 }
 template <class Range> static auto end_or_value(Range &&r) noexcept {
   if constexpr (detail::is_broadcast_v<std::decay_t<Range>>)
-    return nullptr;
+    return r;
   else
     return r.end();
 }
@@ -473,8 +473,7 @@ template <class Tuple> static void increment(Tuple &&t) noexcept {
   std::apply(do_increment, t);
 }
 static auto do_dereference = [](auto &&... r) noexcept {
-  return std::tuple<decltype(maybe_dereference(r)) &...>{
-      maybe_dereference(r)...};
+  return std::forward_as_tuple(maybe_dereference(r)...);
 };
 template <class Tuple> static auto dereference(Tuple &&t) noexcept {
   return std::apply(do_dereference, t);

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -96,8 +96,6 @@ struct has_variances<ValueAndVariance<T>> : std::true_type {};
 template <class T>
 struct has_variances<ValuesAndVariances<T>> : std::true_type {};
 template <class T>
-struct has_variances<ValuesAndVariances<T> &> : std::true_type {};
-template <class T>
 inline constexpr bool has_variances_v = has_variances<T>::value;
 
 /// Helper for the transform implementation to unify iteration of data with and
@@ -206,8 +204,6 @@ struct element_type<ValuesAndVariances<const sparse_container<T>>> {
   using type = T;
 };
 template <class T> using element_type_t = typename element_type<T>::type;
-template <class T>
-using const_element_type_t = const typename element_type<T>::type;
 
 /// Broadcast a constant to arbitrary size. Helper for TransformSparse.
 ///
@@ -453,11 +449,6 @@ static constexpr void increment_impl(T &&indices,
 template <class T> static constexpr void increment(T &indices) noexcept {
   increment_impl(indices, std::make_index_sequence<std::tuple_size_v<T>>{});
 }
-
-template <class T> struct is_VariableView : std::false_type {};
-template <class T> struct is_VariableView<VariableView<T>> : std::true_type {};
-template <class T>
-inline constexpr bool is_VariableView_v = is_VariableView<T>::value;
 
 template <class T> static constexpr auto begin_index(T &&iterable) noexcept {
   if constexpr (is_VariableView_v<std::decay_t<T>>)

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -461,22 +461,23 @@ template <class Range> static auto &maybe_dereference(Range &&r) noexcept {
 }
 
 template <class... Ranges> static auto begin(Ranges &&... r) noexcept {
-  return std::tuple{begin_or_value(r)...};
+  return std::tuple{begin_or_value(std::forward<Ranges>(r))...};
 }
 template <class... Ranges> static auto end(Ranges &&... r) noexcept {
-  return std::tuple{end_or_value(r)...};
+  return std::tuple{end_or_value(std::forward<Ranges>(r))...};
 }
 static auto do_increment = [](auto &&... r) noexcept {
-  (maybe_increment(r), ...);
+  (maybe_increment(std::forward<decltype(r)>(r)), ...);
 };
 template <class Tuple> static void increment(Tuple &&t) noexcept {
-  std::apply(do_increment, t);
+  std::apply(do_increment, std::forward<Tuple>(t));
 }
 static auto do_dereference = [](auto &&... r) noexcept {
-  return std::forward_as_tuple(maybe_dereference(r)...);
+  return std::forward_as_tuple(
+      maybe_dereference(std::forward<decltype(r)>(r))...);
 };
 template <class Tuple> static auto dereference(Tuple &&t) noexcept {
-  return std::apply(do_dereference, t);
+  return std::apply(do_dereference, std::forward<Tuple>(t));
 }
 } // namespace iter_detail
 

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -135,6 +135,12 @@ template <class T1, class T2>
 ValueAndVariance(const T1 &val, const T2 &var)
     ->ValueAndVariance<decltype(T1() + T2())>;
 
+template <class T> struct is_ValueAndVariance : std::false_type {};
+template <class T>
+struct is_ValueAndVariance<ValueAndVariance<T>> : std::true_type {};
+template <class T>
+inline constexpr bool is_ValueAndVariance_v = is_ValueAndVariance<T>::value;
+
 } // namespace detail
 
 } // namespace scipp::core

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -128,10 +128,10 @@ public:
   const T *data() const { return m_variable + m_offset; }
   T *data() { return m_variable + m_offset; }
 
-  constexpr ViewIndex begin_index() const noexcept {
+  ViewIndex begin_index() const noexcept {
     return {m_targetDimensions, m_dimensions};
   }
-  constexpr ViewIndex end_index() const noexcept {
+  ViewIndex end_index() const noexcept {
     ViewIndex i{m_targetDimensions, m_dimensions};
     i.setIndex(size());
     return i;

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -180,6 +180,11 @@ VariableView<T> makeVariableView(T *variable, const scipp::index offset,
   return VariableView<T>(variable, offset, targetDimensions, dimensions);
 }
 
+template <class T> struct is_VariableView : std::false_type {};
+template <class T> struct is_VariableView<VariableView<T>> : std::true_type {};
+template <class T>
+inline constexpr bool is_VariableView_v = is_VariableView<T>::value;
+
 } // namespace scipp::core
 
 #endif // VARIABLE_VIEW_H

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -128,6 +128,15 @@ public:
   const T *data() const { return m_variable + m_offset; }
   T *data() { return m_variable + m_offset; }
 
+  constexpr ViewIndex begin_index() const noexcept {
+    return {m_targetDimensions, m_dimensions};
+  }
+  constexpr ViewIndex end_index() const noexcept {
+    ViewIndex i{m_targetDimensions, m_dimensions};
+    i.setIndex(size());
+    return i;
+  }
+
   scipp::index size() const { return m_targetDimensions.volume(); }
 
   bool operator==(const VariableView<T> &other) const {

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -99,7 +99,7 @@ public:
     friend class boost::iterator_core_access;
 
     bool equal(const iterator &other) const { return m_index == other.m_index; }
-    void increment() { m_index.increment(); }
+    constexpr void increment() noexcept { m_index.increment(); }
     auto &dereference() const { return m_variable[m_index.get()]; }
     void decrement() { m_index.setIndex(m_index.index() - 1); }
     void advance(int64_t delta) {

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -53,6 +53,9 @@ public:
   bool operator==(const ViewIndex &other) const {
     return m_fullIndex == other.m_fullIndex;
   }
+  bool operator!=(const ViewIndex &other) const {
+    return m_fullIndex != other.m_fullIndex;
+  }
 
 private:
   // NOTE:

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -15,9 +15,7 @@ public:
   ViewIndex(const Dimensions &targetDimensions,
             const Dimensions &dataDimensions);
 
-  void increment() {
-    m_index += m_delta[0];
-    ++m_coord[0];
+  constexpr void increment_outer() noexcept {
     scipp::index d = 0;
     while ((m_coord[d] == m_extent[d]) && (d < NDIM_MAX - 1)) {
       m_index += m_delta[d + 1];
@@ -25,6 +23,12 @@ public:
       m_coord[d] = 0;
       ++d;
     }
+  }
+  constexpr void increment() noexcept {
+    m_index += m_delta[0];
+    ++m_coord[0];
+    if (m_coord[0] == m_extent[0])
+      increment_outer();
     ++m_fullIndex;
   }
 

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -32,7 +32,7 @@ public:
     ++m_fullIndex;
   }
 
-  void setIndex(const scipp::index index) {
+  constexpr void setIndex(const scipp::index index) noexcept {
     m_fullIndex = index;
     if (m_dims == 0)
       return;
@@ -47,13 +47,13 @@ public:
       m_index += m_factors[j] * m_coord[m_offsets[j]];
   }
 
-  scipp::index get() const { return m_index; }
-  scipp::index index() const { return m_fullIndex; }
+  constexpr scipp::index get() const noexcept { return m_index; }
+  constexpr scipp::index index() const noexcept { return m_fullIndex; }
 
-  bool operator==(const ViewIndex &other) const {
+  constexpr bool operator==(const ViewIndex &other) const noexcept {
     return m_fullIndex == other.m_fullIndex;
   }
-  bool operator!=(const ViewIndex &other) const {
+  constexpr bool operator!=(const ViewIndex &other) const noexcept {
     return m_fullIndex != other.m_fullIndex;
   }
 


### PR DESCRIPTION
Implement `transform_in_place` without the use of `operator[]`, which is very slow for `VariableView`, i.e., whenever operating with sliced variables.

The required changes were relatively complicated since operating with a parameter-pack of arguments in combination with iterators and the complication of broadcasting and variances is not straightforward. Note that an earlier attempt using iterators was abandoned since it got too complex. Instead I am now directly using the indices underlying the iterator implementation (`ViewIndex`), which turned out to be much simpler.

Performance increases from approx. 100 MB/s to 10-15 GB/s. This is roughly what we get from main memory. If data is in cache this implementation is still about 3x slower than with non-sliced data. It is not clear if this will ever be an actual problem (it might if we implement ways to operate on smaller chunks that fit into cache).

As a follow-up step, similar changes should be implemented for `transform`.

Also fixes the benchmark, which previously did not use variances in some cases, even though it should.