### PR TITLE
Mantid TableWorkspace converter to Dataset

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -160,16 +160,18 @@ def convert_EventWorkspace_to_dataset(ws, load_pulse_times, EventType):
         coords_labs_data["data"] = weights
     return sc.DataArray(**coords_labs_data)
 
+
 def convert_TableWorkspace_to_dataset(ws, error_connection=None):
     """
     Converts from a Mantid TableWorkspace to a scipp dataset. A TableWorkspace
     have optional declaration of connection between data and error using the
     plottype which can be none, X, Y, Z, Xerr, Yerr. This function collects
-    the data and its error into a single scipp variable if there is no ambiguity
-    in what column contains the error for what data column. This means a maximum
-    of one Xerr and one Yerr column. For more advanced TableWorkspaces, the user
-    can specify the connection between data and error manually using the
-    error_connections keyword argument, which overwrites automatic assignment.
+    the data and its error into a single scipp variable if there is no
+    ambiguity in what column contains the error for what data column. This
+    means a maximum of one Xerr and one Yerr column. For more advanced
+    TableWorkspaces, the user can specify the connection between data and error
+    manually using the error_connections keyword argument, which overwrites
+    automatic assignment.
 
     Parameters
     ----------
@@ -184,8 +186,8 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
 
     # Extract information from workspace
     n_columns = ws.columnCount()
-    columnNames = ws.getColumnNames() # list of names matching each column
-    columnTypes = ws.columnTypes() # list of types matching each column
+    columnNames = ws.getColumnNames()  # list of names matching each column
+    columnTypes = ws.columnTypes()  # list of types matching each column
 
     if error_connection is None:
         # Generate error connection
@@ -202,15 +204,15 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
         Y_index = 2
         Yerr_index = 5
 
-        if plottype_list.count(Xerr_index) > 1: # More than one Xerr
+        if plottype_list.count(Xerr_index) > 1:  # More than one Xerr
             raise RuntimeError(
                 "Multiple Xerr columns in TableWorkspace, error_connection "
                 "need to be specified manually for the scipp "
                 "convert_TableWorkspace_to_dataset function.")
-        elif plottype_list.count(Xerr_index) is 1:
+        elif plottype_list.count(Xerr_index) == 1:
             error_index = plottype_list.index(Xerr_index)
-            errorName = columNames[error_index]
-            if plottype_list.count(X_index) is 1: # Unique X for Xerr
+            errorName = columnNames[error_index]
+            if plottype_list.count(X_index) == 1:  # Unique X for Xerr
                 data_index = plottype_list.index(X_index)
                 data_name = columnNames[data_index]
                 error_connection[data_name] = errorName
@@ -220,15 +222,15 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
                     "error_connection need to be specified manually for the "
                     "scipp convert_TableWorkspace_to_dataset function.")
 
-        if plottype_list.count(Yerr_index) > 1: # More than one Yerr
+        if plottype_list.count(Yerr_index) > 1:  # More than one Yerr
             raise RuntimeError(
                 "Multiple Yerr columns in TableWorkspace, error_connection "
                 "need to be specified manually for the scipp "
                 "convert_TableWorkspace_to_dataset function.")
-        elif plottype_list.count(Yerr_index) is 1:
+        elif plottype_list.count(Yerr_index) == 1:
             error_index = plottype_list.index(Yerr_index)
-            errorName = columNames[error_index]
-            if plottype_list.count(Y_index) is 1: # Unique Y for Yerr
+            errorName = columnNames[error_index]
+            if plottype_list.count(Y_index) == 1:  # Unique Y for Yerr
                 data_index = plottype_list.index(Y_index)
                 data_name = columnNames[data_index]
                 error_connection[data_name] = errorName
@@ -246,10 +248,10 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
     variables = {}
     for i in range(n_columns):
         if columnTypes[i] in blacklist_types:
-            continue # skips loading data of this type
+            continue  # skips loading data of this type
 
         data_name = columnNames[i]
-        if len(error_connection) is 0:
+        if len(error_connection) == 0:
             variables[data_name] = sc.Variable([sc.Dim.Row],
                                                values=ws.column(i))
         elif data_name in error_connection:
@@ -273,7 +275,8 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
             variables[data_name] = sc.Variable([sc.Dim.Row],
                                                values=ws.column(i))
 
-    return sc.Dataset(variables) # Return scipp dataset built from the variables
+    return sc.Dataset(variables)  # Return scipp dataset with the variables
+
 
 def load(filename="",
          load_pulse_times=True,

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -247,15 +247,16 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None):
             continue # skips loading data of this type
 
         data_name = columnNames[i]
-        if error_connection is None:
+        if len(error_connection) is 0:
             variables[data_name] = sc.Variable([sc.Dim.Row],
                                                values=ws.column(i))
         elif data_name in error_connection:
             # This data has error availble
             error_index = error_connection[data_name]
+            variance = np.array(ws.column(error_index))**2
             variables[data_name] = sc.Variable([sc.Dim.Row],
                                                values=ws.column(i),
-                                               variance=ws.colum(error_index))
+                                               variance=variance)
         elif data_name not in error_connection.values():
             # This data is not an error for another dataset, and has no error
             variables[data_name] = sc.Variable([sc.Dim.Row],


### PR DESCRIPTION
he file mantid.py containing converters was updated with convert_TableWorkspace_to_dataset, and the load wrapper was modified to include this.
The code is able to consolidate columns with data and errors into one scipp variable with variance. It provides an error if either data or variance is of type string. A keyword argument is used to select data/error pairs.
The code was tested with nexus files generated by Mantid.

- Int, double, string, vector_3_double works
- variance for doubles work (when using error_connection keyword argument)
- plottype was not saved with the Mantid nexus file, could not test