### PR TITLE
Support bool transform and transform_in_place

### DIFF
--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -747,7 +747,8 @@ template <bool dry_run> struct in_place {
 /// identical to the input range, but avoids potentially costly element copies.
 template <class... Ts, class Var, class Op>
 void transform_in_place(Var &&var, Op op) {
-  in_place<false>::transform<Ts...>(std::forward<Var>(var), op);
+  in_place<false>::transform<underlying_type_t<Ts>...>(std::forward<Var>(var),
+                                                       op);
 }
 
 /// Transform the data elements of a variable in-place.
@@ -757,7 +758,8 @@ void transform_in_place(Var &&var, Op op) {
 /// costly element copies.
 template <class... TypePairs, class Var, class Var1, class Op>
 void transform_in_place(Var &&var, const Var1 &other, Op op) {
-  in_place<false>::transform<TypePairs...>(std::forward<Var>(var), other, op);
+  in_place<false>::transform<underlying_type_t<TypePairs>...>(
+      std::forward<Var>(var), other, op);
 }
 
 /// Accumulate data elements of a variable in-place.
@@ -775,18 +777,20 @@ template <class... TypePairs, class Var, class Var1, class Op>
 void accumulate_in_place(Var &&var, const Var1 &other, Op op) {
   expect::contains(other.dims(), var.dims());
   // Wrapped implementation to convert multiple tuples into a parameter pack.
-  in_place<false>::transform(std::tuple_cat(TypePairs{}...),
+  in_place<false>::transform(std::tuple_cat(underlying_type_t<TypePairs>{}...),
                              std::forward<Var>(var), other, op);
 }
 
 namespace dry_run {
 template <class... Ts, class Var, class Op>
 void transform_in_place(Var &&var, Op op) {
-  in_place<true>::transform<Ts...>(std::forward<Var>(var), op);
+  in_place<true>::transform<underlying_type_t<Ts>...>(std::forward<Var>(var),
+                                                      op);
 }
 template <class... TypePairs, class Var, class Var1, class Op>
 void transform_in_place(Var &&var, const Var1 &other, Op op) {
-  in_place<true>::transform<TypePairs...>(std::forward<Var>(var), other, op);
+  in_place<true>::transform<underlying_type_t<TypePairs>...>(
+      std::forward<Var>(var), other, op);
 }
 } // namespace dry_run
 

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -801,11 +801,12 @@ template <class... Ts, class Var, class Op>
   auto unit = op(var.unit());
   Variable result;
   try {
-    if constexpr ((is_sparse_v<Ts> || ...)) {
-      result = scipp::core::visit_impl<Ts...>::apply(Transform{op},
-                                                     var.dataHandle());
+    if constexpr ((is_sparse_v<underlying_type_t<Ts>> || ...)) {
+      result = scipp::core::visit_impl<underlying_type_t<Ts>...>::apply(
+          Transform{op}, var.dataHandle());
     } else {
-      result = scipp::core::visit(augment::insert_sparse(std::tuple<Ts...>{}))
+      result = scipp::core::visit(augment::insert_sparse(
+                                      std::tuple<underlying_type_t<Ts>...>{}))
                    .apply(Transform{detail::overloaded_sparse{
                               op, TransformSparse<Op>{op}}},
                           var.dataHandle());
@@ -852,8 +853,8 @@ template <class... TypePairs, class Var1, class Var2, class Op>
 [[nodiscard]] Variable transform(const Var1 &var1, const Var2 &var2, Op op) {
   auto unit = op(var1.unit(), var2.unit());
   // Wrapped implementation to convert multiple tuples into a parameter pack.
-  auto result =
-      detail::transform(std::tuple_cat(TypePairs{}...), var1, var2, op);
+  auto result = detail::transform(
+      std::tuple_cat(underlying_type_t<TypePairs>{}...), var1, var2, op);
   result.setUnit(unit);
   return result;
 }

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -33,15 +33,20 @@ struct is_sparse_container<sparse_container<T>> : std::true_type {};
 template <class T> struct underlying_type { using type = T; };
 template <> struct underlying_type<bool> { using type = Bool; };
 template <class T> using underlying_type_t = typename underlying_type<T>::type;
+template <class... A, class... B>
+struct underlying_type<std::tuple<std::pair<A, B>...>> {
+  using type =
+      std::tuple<std::pair<underlying_type_t<A>, underlying_type_t<B>>...>;
+};
 
 class Variable;
 template <class... Known> class VariableConceptHandle_impl;
 // Any item type that is listed here explicitly can be used with the templated
 // `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
 using VariableConceptHandle = VariableConceptHandle_impl<
-    double, float, int64_t, int32_t, Eigen::Vector3d, sparse_container<double>,
-    sparse_container<float>, sparse_container<int64_t>,
-    sparse_container<int32_t>>;
+    double, float, int64_t, int32_t, bool, Eigen::Vector3d,
+    sparse_container<double>, sparse_container<float>,
+    sparse_container<int64_t>, sparse_container<int32_t>>;
 
 /// Abstract base class for any data that can be held by Variable. Also used to
 /// hold views to data by (Const)VariableProxy. This is using so-called
@@ -188,7 +193,7 @@ public:
       : m_object(std::unique_ptr<VariableConcept>(nullptr)) {}
   template <class T> VariableConceptHandle_impl(T object) {
     using value_t = typename T::element_type::value_type;
-    if constexpr ((std::is_same_v<value_t, Known> || ...))
+    if constexpr ((std::is_same_v<value_t, underlying_type_t<Known>> || ...))
       m_object = std::unique_ptr<VariableConceptT<value_t>>(std::move(object));
     else
       m_object = std::unique_ptr<VariableConcept>(std::move(object));
@@ -222,15 +227,16 @@ public:
   auto variant() const noexcept {
     return std::visit(
         [](auto &&arg) {
-          return std::variant<const VariableConcept *,
-                              const VariableConceptT<Known> *...>{arg.get()};
+          return std::variant<
+              const VariableConcept *,
+              const VariableConceptT<underlying_type_t<Known>> *...>{arg.get()};
         },
         m_object);
   }
 
 private:
   std::variant<std::unique_ptr<VariableConcept>,
-               std::unique_ptr<VariableConceptT<Known>>...>
+               std::unique_ptr<VariableConceptT<underlying_type_t<Known>>>...>
       m_object;
 };
 

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -127,6 +127,21 @@ TEST(TransformTest, apply_unary_dtype_preserved) {
   EXPECT_TRUE(equals(outF.values<float>(), {-1.1f, -2.2f}));
 }
 
+TEST(TransformTest, dtype_bool) {
+  const auto var = makeVariable<bool>({Dim::X, 2}, {true, false});
+  EXPECT_EQ(
+      transform<bool>(var, overloaded{[](const units::Unit &u) { return u; },
+                                      [](const auto x) { return !x; }}),
+      makeVariable<bool>({Dim::X, 2}, {false, true}));
+  EXPECT_EQ(transform<pair_self_t<bool>>(
+                var, var,
+                overloaded{[](const units::Unit &a, const units::Unit &b) {
+                             return a;
+                           },
+                           [](const auto x, const auto y) { return !x || y; }}),
+            makeVariable<bool>({Dim::X, 2}, {true, true}));
+}
+
 class TransformBinaryTest : public ::testing::Test {
 protected:
   static constexpr auto op_in_place{[](auto &x, const auto &y) { x *= y; }};


### PR DESCRIPTION
`bool` was missing from the list of built-in types. Also had to add some type translation in various `transform` functions.