### PR TITLE
Index view and sort

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(INC_FILES
     include/scipp/core/tag_util.h
     include/scipp/core/counts.h
     include/scipp/core/slice.h
+    include/scipp/core/sort.h
     include/scipp/core/variable_view.h
     include/scipp/core/variable.h
     include/scipp/core/variable.tcc
@@ -28,6 +29,7 @@ set(SRC_FILES
     except.cpp
     rebin.cpp
     slice.cpp
+    sort.cpp
     string.cpp
     trigonometry.cpp
     variable.cpp

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -569,6 +569,12 @@ DataProxy DataProxy::assign(const VariableConstProxy &other) const {
   return *this;
 }
 
+DatasetProxy DatasetProxy::assign(const DatasetConstProxy &other) const {
+  for (const auto & [ name, data ] : other)
+    operator[](name).assign(data);
+  return *this;
+}
+
 /// Return a const proxy to all coordinates of the dataset slice.
 ///
 /// This proxy includes only "dimension-coordinates". To access

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -570,7 +570,6 @@ DataProxy DataProxy::assign(const VariableConstProxy &other) const {
 }
 
 DatasetProxy DatasetProxy::assign(const DatasetConstProxy &other) const {
-  // TODO Why is this not throwing?
   for (const auto & [ name, data ] : other)
     operator[](name).assign(data);
   return *this;

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -570,6 +570,7 @@ DataProxy DataProxy::assign(const VariableConstProxy &other) const {
 }
 
 DatasetProxy DatasetProxy::assign(const DatasetConstProxy &other) const {
+  // TODO Why is this not throwing?
   for (const auto & [ name, data ] : other)
     operator[](name).assign(data);
   return *this;

--- a/core/dataset_operations.cpp
+++ b/core/dataset_operations.cpp
@@ -65,7 +65,7 @@ DataArray histogram(const DataConstProxy &sparse,
   if (sparse.hasData())
     throw except::SparseDataError(
         "`histogram` is not implemented for sparse data with values yet.");
-  if (sparse.dims().ndims() > 1)
+  if (sparse.dims().ndim() > 1)
     throw std::logic_error("Only the simple case histograms may be constructed "
                            "for now: 2 dims including sparse.");
   auto dim = binEdges.dims().inner();
@@ -245,5 +245,11 @@ VariableConstProxy same(const VariableConstProxy &a,
   expect::equals(a, b);
   return a;
 }
+
+/// Return a deep copy of a DataArray or of a DataProxy.
+DataArray copy(const DataConstProxy &array) { return DataArray(array); }
+
+/// Return a deep copy of a Dataset or of a DatasetProxy.
+Dataset copy(const DatasetConstProxy &dataset) { return Dataset(dataset); }
 
 } // namespace scipp::core

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -816,9 +816,14 @@ public:
   DatasetProxy operator*=(const Dataset &other) const;
   DatasetProxy operator/=(const Dataset &other) const;
 
+  DatasetProxy assign(const DatasetConstProxy &other) const;
+
 private:
   Dataset *m_mutableDataset;
 };
+
+SCIPP_CORE_EXPORT DataArray copy(const DataConstProxy &array);
+SCIPP_CORE_EXPORT Dataset copy(const DatasetConstProxy &dataset);
 
 /// Data array, a variable with coordinates, labels, and attributes.
 class SCIPP_CORE_EXPORT DataArray {
@@ -913,11 +918,33 @@ public:
     setCoord(dim, Variable(coord));
   }
 
-  template <class... Ts> auto slice(const Ts... slices) const {
-    return get().slice(slices...);
+  DataConstProxy slice(const Slice slice1) const & {
+    return get().slice(slice1);
   }
-  template <class... Ts> auto slice(const Ts... slices) {
-    return get().slice(slices...);
+  DataConstProxy slice(const Slice slice1, const Slice slice2) const & {
+    return get().slice(slice1, slice2);
+  }
+  DataConstProxy slice(const Slice slice1, const Slice slice2,
+                       const Slice slice3) const & {
+    return get().slice(slice1, slice2, slice3);
+  }
+  DataProxy slice(const Slice slice1) & { return get().slice(slice1); }
+  DataProxy slice(const Slice slice1, const Slice slice2) & {
+    return get().slice(slice1, slice2);
+  }
+  DataProxy slice(const Slice slice1, const Slice slice2,
+                  const Slice slice3) & {
+    return get().slice(slice1, slice2, slice3);
+  }
+  DataArray slice(const Slice slice1) const && {
+    return copy(get().slice(slice1));
+  }
+  DataArray slice(const Slice slice1, const Slice slice2) const && {
+    return copy(get().slice(slice1, slice2));
+  }
+  DataArray slice(const Slice slice1, const Slice slice2,
+                  const Slice slice3) const && {
+    return copy(get().slice(slice1, slice2, slice3));
   }
 
 private:

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -81,7 +81,7 @@ public:
   }
 
   /// Return number of non-sparse dims
-  constexpr uint16_t ndims() const noexcept { return m_ndim; }
+  constexpr uint16_t ndim() const noexcept { return m_ndim; }
 
   scipp::span<const Dim> labels() const && = delete;
   /// Return the labels of the space defined by *this, including the label of a

--- a/core/include/scipp/core/indexed_slice_view.h
+++ b/core/include/scipp/core/indexed_slice_view.h
@@ -18,7 +18,7 @@ private:
   struct make_item {
     const IndexedSliceView *view;
     auto operator()(const scipp::index index) const {
-      return view->m_data->slice({view->m_dim, index});
+      return view->m_data->slice({view->m_dim, index, index + 1});
     }
   };
 
@@ -30,7 +30,7 @@ public:
   constexpr scipp::index size() const noexcept { return m_index.size(); }
 
   auto operator[](const scipp::index index) const {
-    return m_data->slice({m_dim, m_index[index]});
+    return m_data->slice({m_dim, m_index[index], m_index[index] + 1});
   }
 
   /// Return iterator to the beginning of all slices.
@@ -50,16 +50,9 @@ private:
   std::vector<scipp::index> m_index;
 };
 
-template <class T> auto copy(const IndexedSliceView<T> &view) {
-  auto out = copy(view.data());
-  scipp::index i = 0;
-  for (const auto &slice : view)
-    out.slice({view.dim(), i++}).assign(slice);
-  return out;
-}
-
 template <class T> auto concatenate(const IndexedSliceView<T> &view) {
   // TODO Recursive implementation a bit like merge sort for better performance.
+  // Could also try to find continuous ranges in indices.
   auto out = copy(view[0]);
   for (scipp::index i = 1; i < view.size(); ++i)
     out = concatenate(out, view[i], view.dim());

--- a/core/include/scipp/core/indexed_slice_view.h
+++ b/core/include/scipp/core/indexed_slice_view.h
@@ -42,11 +42,29 @@ public:
     return boost::make_transform_iterator(m_index.end(), make_item{this});
   }
 
+  const auto &data() const noexcept { return *m_data; }
+
 private:
   T *m_data;
   Dim m_dim;
   std::vector<scipp::index> m_index;
 };
+
+template <class T> auto copy(const IndexedSliceView<T> &view) {
+  auto out = copy(view.data());
+  scipp::index i = 0;
+  for (const auto &slice : view)
+    out.slice({view.dim(), i++}).assign(slice);
+  return out;
+}
+
+template <class T> auto concatenate(const IndexedSliceView<T> &view) {
+  // TODO Recursive implementation a bit like merge sort for better performance.
+  auto out = copy(view[0]);
+  for (scipp::index i = 1; i < view.size(); ++i)
+    out = concatenate(out, view[i], view.dim());
+  return out;
+}
 
 } // namespace scipp::core
 

--- a/core/include/scipp/core/indexed_slice_view.h
+++ b/core/include/scipp/core/indexed_slice_view.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_INDEXED_SLICE_VIEW_H
+#define SCIPP_CORE_INDEXED_SLICE_VIEW_H
+
+#include <vector>
+
+#include <boost/iterator/transform_iterator.hpp>
+
+#include <scipp/units/unit.h>
+
+namespace scipp::core {
+
+template <class T> class IndexedSliceView {
+private:
+  struct make_item {
+    const IndexedSliceView *view;
+    auto operator()(const scipp::index index) const {
+      return view->m_data->slice({view->m_dim, index});
+    }
+  };
+
+public:
+  IndexedSliceView(T &data, const Dim dim, std::vector<scipp::index> index)
+      : m_data(&data), m_dim(dim), m_index(index) {}
+
+  constexpr Dim dim() const noexcept { return m_dim; }
+  constexpr scipp::index size() const noexcept { return m_index.size(); }
+
+  auto operator[](const scipp::index index) const {
+    return m_data->slice({m_dim, m_index[index]});
+  }
+
+  /// Return iterator to the beginning of all slices.
+  auto begin() const noexcept {
+    return boost::make_transform_iterator(m_index.begin(), make_item{this});
+  }
+  /// Return iterator to the end of all slices.
+  auto end() const noexcept {
+    return boost::make_transform_iterator(m_index.end(), make_item{this});
+  }
+
+private:
+  T *m_data;
+  Dim m_dim;
+  std::vector<scipp::index> m_index;
+};
+
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_INDEXED_SLICE_VIEW_H

--- a/core/include/scipp/core/indexed_slice_view.h
+++ b/core/include/scipp/core/indexed_slice_view.h
@@ -13,6 +13,12 @@
 
 namespace scipp::core {
 
+/// Index-based view of slices of a variable, data array, or dataset.
+///
+/// The main purpose is to provide common means of handling a collection of
+/// slices along a specific dimension. Indices allow for reordering or filtering
+/// slices. This class is mainly used for implementing other functionality like
+/// `sort` and is typically not used directly.
 template <class T> class IndexedSliceView {
 private:
   struct make_item {
@@ -23,12 +29,16 @@ private:
   };
 
 public:
+  /// Construct view over given data, slicing along `dim` for all given indices.
   IndexedSliceView(T &data, const Dim dim, std::vector<scipp::index> index)
       : m_data(&data), m_dim(dim), m_index(index) {}
 
+  /// Slicing dimension.
   constexpr Dim dim() const noexcept { return m_dim; }
+  /// Number of slices.
   constexpr scipp::index size() const noexcept { return m_index.size(); }
 
+  /// The slice with given index.
   auto operator[](const scipp::index index) const {
     return m_data->slice({m_dim, m_index[index], m_index[index] + 1});
   }
@@ -42,14 +52,13 @@ public:
     return boost::make_transform_iterator(m_index.end(), make_item{this});
   }
 
-  const auto &data() const noexcept { return *m_data; }
-
 private:
   T *m_data;
   Dim m_dim;
   std::vector<scipp::index> m_index;
 };
 
+/// Concatenate all slices of an IndexedSliceView along the view's dimension.
 template <class T> auto concatenate(const IndexedSliceView<T> &view) {
   // TODO Recursive implementation a bit like merge sort for better performance.
   // Could also try to find continuous ranges in indices.

--- a/core/include/scipp/core/sort.h
+++ b/core/include/scipp/core/sort.h
@@ -9,7 +9,6 @@
 
 #include <scipp/core/dataset.h>
 #include <scipp/core/variable.h>
-#include <scipp/units/unit.h>
 
 namespace scipp::core {
 

--- a/core/include/scipp/core/sort.h
+++ b/core/include/scipp/core/sort.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_SORT_H
+#define SCIPP_CORE_SORT_H
+
+#include <vector>
+
+#include <scipp/core/dataset.h>
+#include <scipp/core/variable.h>
+#include <scipp/units/unit.h>
+
+namespace scipp::core {
+
+SCIPP_CORE_EXPORT Variable sort(const VariableConstProxy &var,
+                                const VariableConstProxy &key);
+SCIPP_CORE_EXPORT DataArray sort(const DataConstProxy &array,
+                                 const VariableConstProxy &key);
+SCIPP_CORE_EXPORT DataArray sort(const DataConstProxy &array, const Dim &key);
+SCIPP_CORE_EXPORT DataArray sort(const DataConstProxy &array,
+                                 const std::string &key);
+SCIPP_CORE_EXPORT Dataset sort(const DatasetConstProxy &dataset,
+                               const VariableConstProxy &key);
+SCIPP_CORE_EXPORT Dataset sort(const DatasetConstProxy &dataset,
+                               const Dim &key);
+SCIPP_CORE_EXPORT Dataset sort(const DatasetConstProxy &dataset,
+                               const std::string &key);
+
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_SORT_H

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -815,6 +815,7 @@ SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
 SCIPP_CORE_EXPORT Variable sqrt(const Variable &var);
 
 SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var, const Dim dim);
+SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 
 // Trigonometrics
 SCIPP_CORE_EXPORT Variable sin(const Variable &var);

--- a/core/rebin.cpp
+++ b/core/rebin.cpp
@@ -151,7 +151,7 @@ Variable rebin(const VariableConstProxy &var, const Dim dim,
   if (rebinned.dims().inner() == dim) {
     apply_in_place<double, float>(do_rebin, rebinned, var, oldCoord, newCoord);
   } else {
-    if (newCoord.dims().ndims() > 1)
+    if (newCoord.dims().ndim() > 1)
       throw std::runtime_error(
           "Not inner rebin works only for 1d coordinates for now.");
     switch (rebinned.dtype()) {

--- a/core/slice.cpp
+++ b/core/slice.cpp
@@ -1,9 +1,13 @@
-#include "scipp/core/slice.h"
-#include "scipp/core/except.h"
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Owen Arnold
 #include <string>
 
-namespace scipp {
-namespace core {
+#include "scipp/core/slice.h"
+#include "scipp/core/except.h"
+
+namespace scipp::core {
 
 namespace {
 void validate_begin(const scipp::index begin_) {
@@ -48,5 +52,5 @@ bool Slice::operator==(const Slice &other) const {
          m_end == other.m_end;
 }
 bool Slice::operator!=(const Slice &other) const { return !(*this == other); }
-} // namespace core
-} // namespace scipp
+
+} // namespace scipp::core

--- a/core/slice.cpp
+++ b/core/slice.cpp
@@ -4,8 +4,8 @@
 /// @author Owen Arnold
 #include <string>
 
-#include "scipp/core/slice.h"
 #include "scipp/core/except.h"
+#include "scipp/core/slice.h"
 
 namespace scipp::core {
 

--- a/core/sort.cpp
+++ b/core/sort.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <numeric>
+
+#include "scipp/core/except.h"
+#include "scipp/core/indexed_slice_view.h"
+#include "scipp/core/sort.h"
+#include "scipp/core/tag_util.h"
+
+namespace scipp::core {
+
+template <class T> struct MakePermutation {
+  static auto apply(const VariableConstProxy &key) {
+    if (key.dims().ndim() != 1)
+      throw except::DimensionError("Sort key must be 1-dimensional");
+
+    // Variances are ignored for sorting.
+    const auto &values = key.values<T>();
+
+    std::vector<scipp::index> permutation(values.size());
+    std::iota(permutation.begin(), permutation.end(), 0);
+    std::sort(
+        permutation.begin(), permutation.end(),
+        [&](scipp::index i, scipp::index j) { return values[i] < values[j]; });
+    return permutation;
+  }
+};
+
+auto makePermutation(const VariableConstProxy &key) {
+  return CallDType<double, float, int64_t, int32_t, bool,
+                   std::string>::apply<MakePermutation>(key.dtype(), key);
+}
+
+Variable sort(const VariableConstProxy &var, const VariableConstProxy &key) {
+  return copy(IndexedSliceView{var, key.dims().inner(), makePermutation(key)});
+}
+
+DataArray sort(const DataConstProxy &array, const VariableConstProxy &key) {
+  return copy(
+      IndexedSliceView{array, key.dims().inner(), makePermutation(key)});
+}
+
+DataArray sort(const DataConstProxy &array, const Dim &key) {
+  return sort(array, array.coords()[key]);
+}
+
+DataArray sort(const DataConstProxy &array, const std::string &key) {
+  return sort(array, array.labels()[key]);
+}
+
+Dataset sort(const DatasetConstProxy &dataset, const VariableConstProxy &key) {
+  return copy(
+      IndexedSliceView{dataset, key.dims().inner(), makePermutation(key)});
+}
+
+Dataset sort(const DatasetConstProxy &dataset, const Dim &key) {
+  return sort(dataset, dataset.coords()[key]);
+}
+
+Dataset sort(const DatasetConstProxy &dataset, const std::string &key) {
+  return sort(dataset, dataset.labels()[key]);
+}
+
+} // namespace scipp::core

--- a/core/sort.cpp
+++ b/core/sort.cpp
@@ -34,11 +34,12 @@ auto makePermutation(const VariableConstProxy &key) {
 }
 
 Variable sort(const VariableConstProxy &var, const VariableConstProxy &key) {
-  return copy(IndexedSliceView{var, key.dims().inner(), makePermutation(key)});
+  return concatenate(
+      IndexedSliceView{var, key.dims().inner(), makePermutation(key)});
 }
 
 DataArray sort(const DataConstProxy &array, const VariableConstProxy &key) {
-  return copy(
+  return concatenate(
       IndexedSliceView{array, key.dims().inner(), makePermutation(key)});
 }
 
@@ -51,7 +52,7 @@ DataArray sort(const DataConstProxy &array, const std::string &key) {
 }
 
 Dataset sort(const DatasetConstProxy &dataset, const VariableConstProxy &key) {
-  return copy(
+  return concatenate(
       IndexedSliceView{dataset, key.dims().inner(), makePermutation(key)});
 }
 

--- a/core/sort.cpp
+++ b/core/sort.cpp
@@ -33,33 +33,40 @@ auto makePermutation(const VariableConstProxy &key) {
                    std::string>::apply<MakePermutation>(key.dtype(), key);
 }
 
+/// Return a Variable sorted based on key.
 Variable sort(const VariableConstProxy &var, const VariableConstProxy &key) {
   return concatenate(
       IndexedSliceView{var, key.dims().inner(), makePermutation(key)});
 }
 
+/// Return a DataArray sorted based on key.
 DataArray sort(const DataConstProxy &array, const VariableConstProxy &key) {
   return concatenate(
       IndexedSliceView{array, key.dims().inner(), makePermutation(key)});
 }
 
+/// Return a DataArray sorted based on coordinate.
 DataArray sort(const DataConstProxy &array, const Dim &key) {
   return sort(array, array.coords()[key]);
 }
 
+/// Return a DataArray sorted based on labels.
 DataArray sort(const DataConstProxy &array, const std::string &key) {
   return sort(array, array.labels()[key]);
 }
 
+/// Return a Dataset sorted based on key.
 Dataset sort(const DatasetConstProxy &dataset, const VariableConstProxy &key) {
   return concatenate(
       IndexedSliceView{dataset, key.dims().inner(), makePermutation(key)});
 }
 
+/// Return a Dataset sorted based on coordinate.
 Dataset sort(const DatasetConstProxy &dataset, const Dim &key) {
   return sort(dataset, dataset.coords()[key]);
 }
 
+/// Return a Dataset sorted based on labels.
 Dataset sort(const DatasetConstProxy &dataset, const std::string &key) {
   return sort(dataset, dataset.labels()[key]);
 }

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                merge_test.cpp
                rebin_test.cpp
                slice_test.cpp
+               sort_test.cpp
                transform_test.cpp
                value_and_variance_test.cpp
                variable_custom_type_test.cpp

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                dimensions_test.cpp
                except_test.cpp
                histogram_test.cpp
+               indexed_slice_view_test.cpp
                mean_test.cpp
                merge_test.cpp
                rebin_test.cpp

--- a/core/test/indexed_slice_view_test.cpp
+++ b/core/test/indexed_slice_view_test.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+
+#include "scipp/core/indexed_slice_view.h"
+#include "scipp/core/variable.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(IndexedSliceViewTest, variable) {
+  const auto var = makeVariable<double>({Dim::X, 4}, {1, 2, 3, 4});
+  const auto view = IndexedSliceView{var, Dim::X, {2, 2, 0, 3, 1}};
+  EXPECT_EQ(view.dim(), Dim::X);
+  EXPECT_EQ(view.size(), 5);
+  EXPECT_EQ(view[0], var.slice({Dim::X, 2}));
+  EXPECT_EQ(view[1], var.slice({Dim::X, 2}));
+  EXPECT_EQ(view[2], var.slice({Dim::X, 0}));
+  EXPECT_EQ(view[3], var.slice({Dim::X, 3}));
+  EXPECT_EQ(view[4], var.slice({Dim::X, 1}));
+  EXPECT_EQ(std::distance(view.begin(), view.end()), 5);
+  auto begin = view.begin();
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 2}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 2}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 0}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 3}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 1}));
+  EXPECT_EQ(begin, view.end());
+}

--- a/core/test/indexed_slice_view_test.cpp
+++ b/core/test/indexed_slice_view_test.cpp
@@ -15,17 +15,17 @@ TEST(IndexedSliceViewTest, variable) {
   const auto view = IndexedSliceView{var, Dim::X, {2, 2, 0, 3, 1}};
   EXPECT_EQ(view.dim(), Dim::X);
   EXPECT_EQ(view.size(), 5);
-  EXPECT_EQ(view[0], var.slice({Dim::X, 2}));
-  EXPECT_EQ(view[1], var.slice({Dim::X, 2}));
-  EXPECT_EQ(view[2], var.slice({Dim::X, 0}));
-  EXPECT_EQ(view[3], var.slice({Dim::X, 3}));
-  EXPECT_EQ(view[4], var.slice({Dim::X, 1}));
+  EXPECT_EQ(view[0], var.slice({Dim::X, 2, 3}));
+  EXPECT_EQ(view[1], var.slice({Dim::X, 2, 3}));
+  EXPECT_EQ(view[2], var.slice({Dim::X, 0, 1}));
+  EXPECT_EQ(view[3], var.slice({Dim::X, 3, 4}));
+  EXPECT_EQ(view[4], var.slice({Dim::X, 1, 2}));
   EXPECT_EQ(std::distance(view.begin(), view.end()), 5);
   auto begin = view.begin();
-  EXPECT_EQ(*begin++, var.slice({Dim::X, 2}));
-  EXPECT_EQ(*begin++, var.slice({Dim::X, 2}));
-  EXPECT_EQ(*begin++, var.slice({Dim::X, 0}));
-  EXPECT_EQ(*begin++, var.slice({Dim::X, 3}));
-  EXPECT_EQ(*begin++, var.slice({Dim::X, 1}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 2, 3}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 2, 3}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 0, 1}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 3, 4}));
+  EXPECT_EQ(*begin++, var.slice({Dim::X, 1, 2}));
   EXPECT_EQ(begin, view.end());
 }

--- a/core/test/sort_test.cpp
+++ b/core/test/sort_test.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include "test_macros.h"
+#include <gtest/gtest.h>
+
+#include "scipp/core/sort.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(SortTest, variable_1d) {
+  const auto var =
+      makeVariable<int>({Dim::X, 3}, units::m, {1, 2, 3}, {4, 5, 6});
+  const auto key = makeVariable<int>({Dim::X, 3}, {10, 20, -1});
+  const auto expected =
+      makeVariable<int>({Dim::X, 3}, units::m, {3, 1, 2}, {6, 4, 5});
+
+  EXPECT_EQ(sort(var, key), expected);
+}
+
+TEST(SortTest, variable_2d) {
+  const auto var = makeVariable<int>({{Dim::Y, 2}, {Dim::X, 3}}, units::m,
+                                     {1, 2, 3, 4, 5, 6});
+
+  const auto keyX = makeVariable<int>({Dim::X, 3}, {10, 20, -1});
+  const auto expectedX = makeVariable<int>({{Dim::Y, 2}, {Dim::X, 3}}, units::m,
+                                           {3, 1, 2, 6, 4, 5});
+
+  const auto keyY = makeVariable<int>({Dim::Y, 2}, {1, 0});
+  const auto expectedY = makeVariable<int>({{Dim::Y, 2}, {Dim::X, 3}}, units::m,
+                                           {4, 5, 6, 1, 2, 3});
+
+  EXPECT_EQ(sort(var, keyX), expectedX);
+  EXPECT_EQ(sort(var, keyY), expectedY);
+}

--- a/core/test/sort_test.cpp
+++ b/core/test/sort_test.cpp
@@ -33,3 +33,25 @@ TEST(SortTest, variable_2d) {
   EXPECT_EQ(sort(var, keyX), expectedX);
   EXPECT_EQ(sort(var, keyY), expectedY);
 }
+
+TEST(SortTest, dataset_1d) {
+  Dataset d;
+  d.setData("a",
+            makeVariable<int>({Dim::X, 3}, units::m, {1, 2, 3}, {4, 5, 6}));
+  d.setData("b", makeVariable<double>({Dim::X, 3}, units::s, {0.1, 0.2, 0.3}));
+  d.setData("scalar", makeVariable<double>(1.2));
+  d.setCoord(Dim::X, makeVariable<double>({Dim::X, 3}, units::m, {1, 2, 3}));
+
+  Dataset expected;
+  expected.setData(
+      "a", makeVariable<int>({Dim::X, 3}, units::m, {3, 1, 2}, {6, 4, 5}));
+  expected.setData(
+      "b", makeVariable<double>({Dim::X, 3}, units::s, {0.3, 0.1, 0.2}));
+  expected.setData("scalar", makeVariable<double>(1.2));
+  expected.setCoord(Dim::X,
+                    makeVariable<double>({Dim::X, 3}, units::m, {3, 1, 2}));
+
+  const auto key = makeVariable<int>({Dim::X, 3}, {10, 20, -1});
+
+  EXPECT_EQ(sort(d, key), expected);
+}

--- a/core/test/sort_test.cpp
+++ b/core/test/sort_test.cpp
@@ -47,11 +47,13 @@ TEST(SortTest, dataset_1d) {
       "a", makeVariable<int>({Dim::X, 3}, units::m, {3, 1, 2}, {6, 4, 5}));
   expected.setData(
       "b", makeVariable<double>({Dim::X, 3}, units::s, {0.3, 0.1, 0.2}));
-  expected.setData("scalar", makeVariable<double>(1.2));
   expected.setCoord(Dim::X,
                     makeVariable<double>({Dim::X, 3}, units::m, {3, 1, 2}));
 
   const auto key = makeVariable<int>({Dim::X, 3}, {10, 20, -1});
 
+  // Note that the result does not contain `scalar`. Is this a bug or a feature?
+  // - Should we throw if there is any scalar data/coord?
+  // - Should we preserve scalars?
   EXPECT_EQ(sort(d, key), expected);
 }

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -218,4 +218,7 @@ Variable reverse(Variable var, const Dim dim) {
   return var;
 }
 
+/// Return a deep copy of a Variable or of a VariableProxy.
+Variable copy(const VariableConstProxy &var) { return Variable(var); }
+
 } // namespace scipp::core

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -36,6 +36,7 @@ General
    norm
    rebin
    reshape
+   sort
    sqrt
    sum
 

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -6,6 +6,7 @@
 
 #include "scipp/core/dataset.h"
 #include "scipp/core/except.h"
+#include "scipp/core/sort.h"
 
 #include "bind_data_access.h"
 #include "bind_operators.h"
@@ -336,6 +337,62 @@ void init_dataset(py::module &m) {
         :raises: If data cannot be rebinned, e.g., if the unit is not counts, or the existing coordinate is not a bin-edge coordinate.
         :return: A new dataset with data rebinned according to the new coordinate.
         :rtype: Dataset)");
+
+  m.def("sort",
+        py::overload_cast<const DataConstProxy &, const VariableConstProxy &>(
+            &sort),
+        py::arg("data"), py::arg("key"),
+        py::call_guard<py::gil_scoped_release>(),
+        R"(Sort data array along a dimension by a sort key.
+
+        :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+        :return: New sorted data array.
+        :rtype: DataArray)");
+  m.def(
+      "sort", py::overload_cast<const DataConstProxy &, const Dim &>(&sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort data array along a dimension by the coordinate values for that dimension.
+
+      :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+      :return: New sorted data array.
+      :rtype: DataArray)");
+  m.def(
+      "sort",
+      py::overload_cast<const DataConstProxy &, const std::string &>(&sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort data array along a dimension by the label values for the given key.
+
+      :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+      :return: New sorted data array.
+      :rtype: DataArray)");
+
+  m.def(
+      "sort",
+      py::overload_cast<const DatasetConstProxy &, const VariableConstProxy &>(
+          &sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort dataset along a dimension by a sort key.
+
+        :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+        :return: New sorted dataset.
+        :rtype: Dataset)");
+  m.def(
+      "sort", py::overload_cast<const DatasetConstProxy &, const Dim &>(&sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort dataset along a dimension by the coordinate values for that dimension.
+
+      :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+      :return: New sorted dataset.
+      :rtype: Dataset)");
+  m.def(
+      "sort",
+      py::overload_cast<const DatasetConstProxy &, const std::string &>(&sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort dataset along a dimension by the label values for the given key.
+
+      :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+      :return: New sorted dataset.
+      :rtype: Dataset)");
 
   py::implicitly_convertible<DataArray, DataConstProxy>();
   py::implicitly_convertible<DataArray, DataProxy>();

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -545,6 +545,37 @@ def test_dataset_proxy_set_variance():
     np.testing.assert_array_equal(d["a"].variances, variances)
 
 
+def test_sort():
+    d = sc.Dataset(
+        {
+            'a':
+            sc.Variable(dims=[Dim.X, Dim.Y], values=np.arange(6).reshape(2,
+                                                                         3)),
+            'b':
+            sc.Variable(dims=[Dim.X], values=['b', 'a'])
+        },
+        coords={
+            Dim.X: sc.Variable([Dim.X], values=np.arange(2.0),
+                               unit=sc.units.m),
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)
+        },
+        labels={'aux': sc.Variable([Dim.X], values=np.arange(2.0))})
+    expected = sc.Dataset(
+        {
+            'a':
+            sc.Variable(dims=[Dim.X, Dim.Y],
+                        values=np.flip(np.arange(6).reshape(2, 3), axis=0)),
+            'b':
+            sc.Variable(dims=[Dim.X], values=['a', 'b'])
+        },
+        coords={
+            Dim.X: sc.Variable([Dim.X], values=[1.0, 0.0], unit=sc.units.m),
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(3.0), unit=sc.units.m)
+        },
+        labels={'aux': sc.Variable([Dim.X], values=[1.0, 0.0])})
+    assert sc.sort(d, d['b'].data) == expected
+
+
 # def test_delitem(self):
 #    dataset = sc.Dataset()
 #    dataset[sc.Data.Value, "data"] = ([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -7,6 +7,7 @@
 
 #include "scipp/core/dataset.h"
 #include "scipp/core/except.h"
+#include "scipp/core/sort.h"
 #include "scipp/core/tag_util.h"
 #include "scipp/core/variable.h"
 
@@ -343,6 +344,18 @@ void init_variable(py::module &m) {
         :seealso: :py:class:`scipp.abs` for scalar dtype
         :return: New variable with scalar elements computed as the norm values if the input elements.
         :rtype: Variable)");
+
+  m.def(
+      "sort",
+      py::overload_cast<const VariableConstProxy &, const VariableConstProxy &>(
+          &sort),
+      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      R"(Sort variable along a dimension by a sort key.
+
+      :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
+      :return: New sorted variable.
+      :rtype: Variable)");
+
   m.def("split",
         py::overload_cast<const Variable &, const Dim,
                           const std::vector<scipp::index> &>(&split),


### PR DESCRIPTION
Fixes #393. The main addition in this PR is `IndexedSliceView`. It supports creation of and iteration over slices of a container (variable, data array, dataset, and their proxies). One use for this is sorting, but the idea is to use this for other features in the future, such as filtering, or `groupby` operations (see http://xarray.pydata.org/en/stable/groupby.html).

- Added `sort` for variable, data array, dataset, and their proxies.
- Sorting sparse data is not supported yet. This will require a different approach.
- Sorting in this way is inefficient, and may need to be improved in the future. Part of this is a better `concatenate` implementation, but we may also want to support in-place sorting.

Sorting is mainly useful for tables. It can also be used to plot neutron data, e.g., against 2-theta. Essentially `sort` can be seen as replacing Mantid's `ConvertSpectrumAxis`.

Note that eventually we may also want to support and advanced index view which operates in a more transparent way and could be used with `transform`. This would be much more involved and is postponed until required.