### PR TITLE
Added diffraction module with loader for diffraction calibration files.

### DIFF
--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock, Neil Vaytet
+
+import scipp as sc
+
+
+def loadCal(Filename="", InstrumentName="",
+            InstrumentFilename="",
+            GroupFilename="",
+            TofMin=None, TofMax=None):
+    """
+    Function that loads calibration files using the Mantid algorithm
+    LoadDiffCal. This algorithm produces up to three workspaces, a
+    TableWorkspace containing conversion factors between TOF and d, a
+    GroupingWorkspace with detector groups and a MaskWorkspace for masking.
+    The information from the TableWorkspace and GroupingWorkspace is converted
+    to a Scipp dataset and returned, while the MaskWorkspace is ignored for
+    now. Only the keyword paramters Filename and InstrumentName are mandatory.
+
+    Example of use:
+
+      from scipp.neutron.diffraction import load
+      cal = loadCal(Filename='cal_file.cal', InstrumentName='WISH')
+
+    Note that this function requires mantid to be installed and available in
+    the same Python environment as scipp.
+
+    :param str Filename: The name of the cal file to be loaded.
+    :param str InstrumentName: Name of Mantid instrument to use.
+    :param str InstrumentFilename: If specified, over-write the instrument
+                                    definition in the final Dataset with the
+                                    geometry contained in the file.
+    :param str GroupFilename: If specified, over-writes the grouping from
+                               CallFileName.
+    :param float TofMin: Minimum time of flight (default 0)
+    :param float TofMax: Maximum time of flight
+    :raises: If the Mantid workspace type returned by the Mantid loader is not
+             either EventWorkspace or Workspace2D.
+    :return: A Dataset containing the calibration data and grouping.
+    :rtype: Dataset
+    """
+
+    try:
+        import mantid.simpleapi as mantid
+    except ImportError as e:
+        raise ImportError(
+            "Mantid Python API was not found, please install Mantid framework "
+            "as detailed in the installation instructions (https://scipp."
+            "readthedocs.io/en/latest/getting-started/installation.html)"
+        ) from e
+
+    output = mantid.LoadDiffCal(Filename=Filename,
+                                InstrumentName=InstrumentName,
+                                WorkspaceName="cal_output",
+                                InstrumentFilename=InstrumentFilename,
+                                GroupFilename="",
+                                TofMin=TofMin, TofMax=TofMax)
+
+    cal_ws = output.OutputCalWorkspace
+    cal_data = sc.compat.mantid.convert_TableWorkspace_to_dataset(cal_ws)
+
+    # Modify units of cal_data
+    cal_data["difc"].unit = sc.units.us/sc.units.angstrom
+    # Currently unsupported unit on python 3.6
+    # cal_data["difa"].unit = sc.units.us/sc.units.angstrom/sc.units.angstrom
+    cal_data["tzero"].unit = sc.units.us
+
+    # Mask data not used yet
+    # output.OutputMaskWorkspace)
+
+    group_ws = output.OutputGroupingWorkspace
+
+    group_list = []
+    for i in range(group_ws.getNumberHistograms()):
+        group_list.append(group_ws.readY(i))
+
+    group_var = sc.Variable([sc.Dim.Row], values=group_list)
+
+    cal_data["group"] = group_var
+
+    return cal_data

--- a/python/src/scipp/neutron/exceptions.py
+++ b/python/src/scipp/neutron/exceptions.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @author Mads Bertelsen
+
+MantidNotFoundError = ImportError(
+      "Mantid Python API was not found, please install Mantid framework "
+      "as detailed in the installation instructions (https://scipp."
+      "readthedocs.io/en/latest/getting-started/installation.html)")

--- a/python/src/scipp/neutron/load.py
+++ b/python/src/scipp/neutron/load.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @author Mads Bertelsen
+
+import scipp as sc
+import scipp.neutron.exceptions as exceptions
+
+
+def load_calibration(filename, mantid_LoadDiffCal_args={}):
+    """
+    Function that loads calibration files using the Mantid algorithm
+    LoadDiffCal. This algorithm produces up to three workspaces, a
+    TableWorkspace containing conversion factors between TOF and d, a
+    GroupingWorkspace with detector groups and a MaskWorkspace for masking.
+    The information from the TableWorkspace and GroupingWorkspace is converted
+    to a Scipp dataset and returned, while the MaskWorkspace is ignored for
+    now. Only the keyword paramters Filename and InstrumentName are mandatory.
+
+    Example of use:
+
+      from scipp.neutron.diffraction import load
+      input = {"InstrumentName": "WISH"}
+      cal = loadCal('cal_file.cal', mantid_LoadDiffCal_args=input')
+
+    Note that this function requires mantid to be installed and available in
+    the same Python environment as scipp.
+
+    :param str filename: The name of the cal file to be loaded.
+    :param dict mantid_LoadDiffCal_args : Dictionary with arguments for the
+                                          LoadDiffCal Mantid algorithm.
+                                          Currently InstrumentName is required.
+    :raises: If the InstrumentName given in mantid_LoadDiffCal_args is not
+             valid.
+    :return: A Dataset containing the calibration data and grouping.
+    :rtype: Dataset
+    """
+
+    try:
+        import mantid.simpleapi as mantid
+    except ImportError as e:
+        raise exceptions.MantidNotFoundError from e
+
+    if "WorkspaceName" not in mantid_LoadDiffCal_args:
+        mantid_LoadDiffCal_args["WorkspaceName"] = "cal_output"
+
+    output = mantid.LoadDiffCal(Filename=filename, **mantid_LoadDiffCal_args)
+
+    cal_ws = output.OutputCalWorkspace
+    cal_data = sc.compat.mantid.convert_TableWorkspace_to_dataset(cal_ws)
+
+    # Modify units of cal_data
+    cal_data["difc"].unit = sc.units.us/sc.units.angstrom
+    cal_data["difa"].unit = sc.units.us/sc.units.angstrom/sc.units.angstrom
+    cal_data["tzero"].unit = sc.units.us
+
+    # Mask data not used, but is loaded by LoadDiffCal
+    # output.OutputMaskWorkspace)
+
+    # Apply group information to dataset by matching detector id's to group nr
+    group_ws = output.OutputGroupingWorkspace
+    group_map = {}  # dict from detectorID to group number
+    for i in range(group_ws.getNumberHistograms()):
+        group_map[group_ws.getDetector(i).getID()] = group_ws.readY(i)[0]
+
+    # Create list with same ordering as in the cal_data dataset
+    group_list = [group_map[detid] for detid in cal_data["detid"].values]
+
+    cal_data["group"] = sc.Variable([sc.Dim.Row], values=group_list)
+
+    # Delete generated mantid workspaces
+    base_name = mantid_LoadDiffCal_args["WorkspaceName"]
+    mantid.mtd.remove(base_name + "_cal")
+    mantid.mtd.remove(base_name + "_group")
+    mantid.mtd.remove(base_name + "_mask")
+
+    return cal_data


### PR DESCRIPTION
Initial draft of loader for calibration files to be made in task das-122.

diffraction.load.loadCal function uses the Mantid algorithm LoadDiffCal, and returns the relevant information in a scipp dataset. Since the function is so close to its Mantid counterpart, all keyword arguments are kept in the same capitalization as the Mantid arguments.

Units for the DIFA constant (us/AA/AA) was not added as this unit is not yet available in the python 3.6 release of scipp which is necessary for using the Mantid integration.

Documentation is provided in the same format as load from the compat module.