### PR TITLE
get mantid to install and import correctly in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM jupyter/base-notebook
 
 # Avoid using passwords for jupyter notebook
 USER root
+RUN apt-get update
+RUN apt-get install -y freeglut3-dev libglu1-mesa
 RUN sed -i "s/jupyter notebook/jupyter notebook --NotebookApp.token='' --NotebookApp.password=''/" /usr/local/bin/start-notebook.sh
+
 USER $NB_USER
 
 # Remove default "work" directory
@@ -23,7 +26,7 @@ RUN conda install --yes \
       plotly \
       scipp \
       ipywidgets \
-      mantid-framework \
+      mantid-framework=4 \
       python=3.6
 
 # Avoid weird tornado AttributeError


### PR DESCRIPTION
Mantid framework was not installed correctly because it installed an early version (3.12). Have to tell conda to install 4+ version. Mantid-framework also needs OpenGL. Installing GLUT will solve that problem.