### PR TITLE
Adds to_string for ConstProxy and MutableProxy

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -14,9 +14,9 @@
 #include <boost/iterator/transform_iterator.hpp>
 
 #include "scipp/core/except.h"
+#include "scipp/core/proxy_decl.h"
 #include "scipp/core/slice.h"
 #include "scipp/core/variable.h"
-#include "scipp/core/proxy_decl.h"
 
 namespace scipp::core {
 
@@ -24,7 +24,6 @@ class DataArray;
 class Dataset;
 class DatasetConstProxy;
 class DatasetProxy;
-
 
 namespace detail {
 /// Helper for holding data items in Dataset.

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -16,6 +16,7 @@
 #include "scipp/core/except.h"
 #include "scipp/core/slice.h"
 #include "scipp/core/variable.h"
+#include "scipp/core/proxy_decl.h"
 
 namespace scipp::core {
 
@@ -24,26 +25,6 @@ class Dataset;
 class DatasetConstProxy;
 class DatasetProxy;
 
-namespace ProxyId {
-class Attrs;
-class Coords;
-class Labels;
-} // namespace ProxyId
-template <class Id, class Key> class ConstProxy;
-template <class Base> class MutableProxy;
-
-/// Proxy for accessing coordinates of const Dataset and DataConstProxy.
-using CoordsConstProxy = ConstProxy<ProxyId::Coords, Dim>;
-/// Proxy for accessing coordinates of Dataset and DataProxy.
-using CoordsProxy = MutableProxy<CoordsConstProxy>;
-/// Proxy for accessing labels of const Dataset and DataConstProxy.
-using LabelsConstProxy = ConstProxy<ProxyId::Labels, std::string>;
-/// Proxy for accessing labels of Dataset and DataProxy.
-using LabelsProxy = MutableProxy<LabelsConstProxy>;
-/// Proxy for accessing attributes of const Dataset and DataConstProxy.
-using AttrsConstProxy = ConstProxy<ProxyId::Attrs, std::string>;
-/// Proxy for accessing attributes of Dataset and DataProxy.
-using AttrsProxy = MutableProxy<AttrsConstProxy>;
 
 namespace detail {
 /// Helper for holding data items in Dataset.

--- a/core/include/scipp/core/proxy_decl.h
+++ b/core/include/scipp/core/proxy_decl.h
@@ -4,6 +4,9 @@
 /// @author Dimitar Tasev
 #ifndef SCIPP_CORE_PROXY_DECL_H
 #define SCIPP_CORE_PROXY_DECL_H
+
+#include "scipp/units/unit.h"
+
 namespace scipp::core {
 
 namespace ProxyId {

--- a/core/include/scipp/core/proxy_decl.h
+++ b/core/include/scipp/core/proxy_decl.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Dimitar Tasev
+#ifndef SCIPP_CORE_PROXY_DECL_H
+#define SCIPP_CORE_PROXY_DECL_H
+namespace scipp::core {
+
+namespace ProxyId {
+class Attrs;
+class Coords;
+class Labels;
+class Masks;
+} // namespace ProxyId
+template <class Id, class Key> class ConstProxy;
+template <class Base> class MutableProxy;
+
+/// Proxy for accessing coordinates of const Dataset and DataConstProxy.
+using CoordsConstProxy = ConstProxy<ProxyId::Coords, Dim>;
+/// Proxy for accessing coordinates of Dataset and DataProxy.
+using CoordsProxy = MutableProxy<CoordsConstProxy>;
+/// Proxy for accessing labels of const Dataset and DataConstProxy.
+using LabelsConstProxy = ConstProxy<ProxyId::Labels, std::string>;
+/// Proxy for accessing labels of Dataset and DataProxy.
+using LabelsProxy = MutableProxy<LabelsConstProxy>;
+/// Proxy for accessing attributes of const Dataset and DataConstProxy.
+using AttrsConstProxy = ConstProxy<ProxyId::Attrs, std::string>;
+/// Proxy for accessing attributes of Dataset and DataProxy.
+using AttrsProxy = MutableProxy<AttrsConstProxy>;
+/// Proxy for accessing masks of const Dataset and DataConstProxy
+using MasksConstProxy = ConstProxy<ProxyId::Masks, std::string>;
+/// Proxy for accessing masks of Dataset and DataProxy
+using MasksProxy = MutableProxy<MasksConstProxy>;
+
+} // namespace scipp::core
+#endif // SCIPP_CORE_PROXY_DECL_H

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -61,8 +61,8 @@ template <class Id, class Data>
 std::string to_string(const ConstProxy<Id, Data> &proxy) {
   std::stringstream ss;
 
-  for (const auto &[key, item] : proxy) {
-    ss << to_string(proxy[key]);
+  for (const auto & [ key, item ] : proxy) {
+    ss << "<scipp.ConstProxy> (" << key << "):\n" << to_string(item);
   }
   return ss.str();
 }
@@ -70,8 +70,8 @@ std::string to_string(const ConstProxy<Id, Data> &proxy) {
 template <class T> std::string to_string(const MutableProxy<T> &mutableProxy) {
   std::stringstream ss;
 
-  for (const auto &[key, item] : mutableProxy) {
-    ss << to_string(mutableProxy[key]);
+  for (const auto & [ key, item ] : mutableProxy) {
+    ss << "<scipp.MutableProxy> (" << key << "):\n" << to_string(item);
   }
   return ss.str();
 }

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -10,6 +10,7 @@
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 #include "scipp/core/dtype.h"
+#include "scipp/core/proxy_decl.h"
 #include "scipp/units/unit.h"
 
 namespace scipp::core {
@@ -55,6 +56,16 @@ SCIPP_CORE_EXPORT std::string to_string(const DataArray &data);
 SCIPP_CORE_EXPORT std::string to_string(const DataConstProxy &data);
 SCIPP_CORE_EXPORT std::string to_string(const Dataset &dataset);
 SCIPP_CORE_EXPORT std::string to_string(const DatasetConstProxy &dataset);
+
+template <class T>
+std::string to_string(const MutableProxy<T> &mutableProxy) {
+  std::stringstream ss;
+
+  for (const auto &[key, item] : mutableProxy) {
+    ss << to_string(mutableProxy[key]);
+  }
+  return ss.str();
+}
 
 template <class T> std::string array_to_string(const T &arr);
 

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -57,8 +57,17 @@ SCIPP_CORE_EXPORT std::string to_string(const DataConstProxy &data);
 SCIPP_CORE_EXPORT std::string to_string(const Dataset &dataset);
 SCIPP_CORE_EXPORT std::string to_string(const DatasetConstProxy &dataset);
 
-template <class T>
-std::string to_string(const MutableProxy<T> &mutableProxy) {
+template <class Id, class Data>
+std::string to_string(const ConstProxy<Id, Data> &proxy) {
+  std::stringstream ss;
+
+  for (const auto &[key, item] : proxy) {
+    ss << to_string(proxy[key]);
+  }
+  return ss.str();
+}
+
+template <class T> std::string to_string(const MutableProxy<T> &mutableProxy) {
   std::stringstream ss;
 
   for (const auto &[key, item] : mutableProxy) {

--- a/core/test/except_test.cpp
+++ b/core/test/except_test.cpp
@@ -25,23 +25,41 @@ TEST(StringFormattingTest, to_string_Dataset) {
 
 std::tuple<Dataset, Dataset> makeDatasets() {
   Dataset a;
+  a.setCoord(Dim::X, makeVariable<double>({Dim::X, 3}, {1, 2, 3}));
+  a.setCoord(Dim::Y, makeVariable<double>({Dim::Y, 3}, {1, 2, 3}));
+  a.setCoord(Dim::Z, makeVariable<double>({Dim::Z, 3}, {1, 2, 3}));
+  a.setLabels("label_1", makeVariable<int>({Dim::X, 3}, {21, 22, 23}));
+  a.setLabels("label_2", makeVariable<int>({Dim::Y, 3}, {21, 22, 23}));
+  a.setLabels("label_3", makeVariable<int>({Dim::Z, 3}, {21, 22, 23}));
   a.setData("a", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
-  a.setData("b", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  a.setData("b", makeVariable<int>({Dim::Y, 3}, {1, 2, 3}));
+  a.setData("c", makeVariable<int>({Dim::Z, 3}, {1, 2, 3}));
+
   Dataset b;
-  a.setData("b", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  b.setCoord(Dim::X, makeVariable<double>({Dim::X, 3}, {1, 2, 3}));
+  b.setCoord(Dim::Y, makeVariable<double>({Dim::Y, 3}, {1, 2, 3}));
+  b.setCoord(Dim::Z, makeVariable<double>({Dim::Z, 3}, {1, 2, 3}));
+  b.setLabels("label_1", makeVariable<int>({Dim::X, 3}, {21, 22, 23}));
+  b.setLabels("label_2", makeVariable<int>({Dim::Y, 3}, {21, 22, 23}));
+  b.setLabels("label_3", makeVariable<int>({Dim::Z, 3}, {21, 22, 23}));
   b.setData("a", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  b.setData("b", makeVariable<int>({Dim::Y, 3}, {1, 2, 3}));
+  b.setData("c", makeVariable<int>({Dim::Z, 3}, {1, 2, 3}));
+
   return std::make_tuple(a, b);
 }
 
 TEST(StringFormattingTest, to_string_MutableProxy) {
-  auto [a, b] = makeDatasets();
+  auto[a, b] = makeDatasets();
+
   EXPECT_EQ(to_string(a.coords()), to_string(b.coords()));
   EXPECT_EQ(to_string(a.labels()), to_string(b.labels()));
   EXPECT_EQ(to_string(a.attrs()), to_string(b.attrs()));
 }
 
 TEST(StringFormattingTest, to_string_ConstProxy) {
-  const auto [a, b] = makeDatasets();
+  const auto[a, b] = makeDatasets();
+
   EXPECT_EQ(to_string(a.coords()), to_string(b.coords()));
   EXPECT_EQ(to_string(a.labels()), to_string(b.labels()));
   EXPECT_EQ(to_string(a.attrs()), to_string(b.attrs()));

--- a/core/test/except_test.cpp
+++ b/core/test/except_test.cpp
@@ -23,6 +23,30 @@ TEST(StringFormattingTest, to_string_Dataset) {
   EXPECT_EQ(to_string(a), to_string(b));
 }
 
+std::tuple<Dataset, Dataset> makeDatasets() {
+  Dataset a;
+  a.setData("a", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  a.setData("b", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  Dataset b;
+  a.setData("b", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  b.setData("a", makeVariable<int>({Dim::X, 3}, {1, 2, 3}));
+  return std::make_tuple(a, b);
+}
+
+TEST(StringFormattingTest, to_string_MutableProxy) {
+  auto [a, b] = makeDatasets();
+  EXPECT_EQ(to_string(a.coords()), to_string(b.coords()));
+  EXPECT_EQ(to_string(a.labels()), to_string(b.labels()));
+  EXPECT_EQ(to_string(a.attrs()), to_string(b.attrs()));
+}
+
+TEST(StringFormattingTest, to_string_ConstProxy) {
+  const auto [a, b] = makeDatasets();
+  EXPECT_EQ(to_string(a.coords()), to_string(b.coords()));
+  EXPECT_EQ(to_string(a.labels()), to_string(b.labels()));
+  EXPECT_EQ(to_string(a.attrs()), to_string(b.attrs()));
+}
+
 TEST(StringFormattingTest, to_string_sparse_Dataset) {
   Dataset a;
   a.setSparseCoord(


### PR DESCRIPTION
The main purpose of this is to make debugging easier by allowing to `to_string` `dataset.coords/labels/masks/attrs` directly, and printing everything inside