### PR TITLE
Addition of convert_with_calibration function

### DIFF
--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -9,8 +9,10 @@
 #include "scipp/core/counts.h"
 #include "scipp/core/dataset.h"
 #include "scipp/core/transform.h"
+#include "scipp/core/except.h"
 #include "scipp/neutron/beamline.h"
 #include "scipp/neutron/convert.h"
+
 
 using namespace scipp::core;
 
@@ -271,4 +273,43 @@ Dataset convert(Dataset d, const Dim from, const Dim to) {
   // MDZipView<const Coord::TwoTheta>(dataset);
 }
 
+
+//using namespace scipp::core::except::expect;
+
+//namespace scipp::neutron::diffraction {
+namespace diffraction {
+
+Dataset convert_with_calibration(Dataset d, const Dataset &cal){
+  // 1. check cal has the required variables
+  //scipp::core::expect::contains(cal, "tzero");
+  //scipp::core::expect::contains(cal, "difc");
+
+  // 2. Record ToF bin widths
+  const auto oldBinWidths = counts::getBinWidths(d, {Dim::Tof});
+
+  // 3. Transform coordinate
+  d.setCoord(Dim::Tof, (d.coords()[Dim::Tof] - cal["tzero"].data()) / cal["difc"].data());
+
+  // 4. Record DSpacing bin widths
+  const auto newBinWidths = counts::getBinWidths(d, {Dim::Tof});
+
+  // 5. Transform variables
+  for (const auto & [ name, data ] : d) {
+    static_cast<void>(name);
+    if (data.coords()[Dim::Tof].dims().sparse()) {
+      data.coords()[Dim::Tof].assign(
+          data.coords()[Dim::Tof] - cal["tzero"].data());
+      data.coords()[Dim::Tof].assign(
+          data.coords()[Dim::Tof] / cal["difc"].data());
+    } else if (data.unit().isCountDensity()) {
+      counts::fromDensity(data, oldBinWidths);
+      counts::toDensity(data, newBinWidths);
+    }
+  }
+
+  d.rename(Dim::Tof, Dim::DSpacing);
+  return d;
+}
+
+} // namespace scipp::neutron::diffraction
 } // namespace scipp::neutron

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -21,4 +21,10 @@ SCIPP_NEUTRON_EXPORT core::Dataset convert(core::Dataset d, const Dim from,
 
 } // namespace scipp::neutron
 
+namespace scipp::neutron::diffraction {
+
+SCIPP_NEUTRON_EXPORT core::Dataset convert_with_calibration(core::Dataset d, const core::Dataset &cal);
+
+} // namespace scipp::neutron::diffraction
+
 #endif // SCIPP_NEUTRON_CONVERT_H

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -10,11 +10,20 @@
 
 using namespace scipp;
 using namespace scipp::neutron;
+using namespace scipp::neutron::diffraction;
 
 namespace py = pybind11;
 
 void init_neutron(py::module &m) {
   auto neutron = m.def_submodule("neutron");
+  auto diffraction = neutron.def_submodule("diffraction");
+
+  diffraction.def("convert_with_calibration", convert_with_calibration, R"(
+    Calibration of diffraction data using calibration data.
+
+    Inputs a sparse tof variable and a dataset with calibration parameters
+
+    :return: New dataset with converted TOF to d-spacing)");
 
   neutron.def("convert", convert, py::call_guard<py::gil_scoped_release>(),
               R"(


### PR DESCRIPTION
Simple implementation of diffraction converter from time of flight to dspacing using a calibration file. Only the linear terms are currently used, but it can easily be expanded two include the quadratic term in the future.

The convert_with_calibration function is in a new namespace under neutron called diffraction as it is specific to this technique.

The function takes two datasets, one with the data to be used and another with the calibration data for each detector. The Dims for the calibration data and data needs to match, with the exception of the actual Tof dimension.

It is the intention to raise errors when the required fields are not available in the given calibration data, but the necessary exceptions did not work as expected. The calls are commented out.

The function was tested with a modified version of the dream.py code found in scipp/ess and it performed as expected. This code will be uploaded on Jira under das-123.