### PR TITLE
Support unit conversion if there is no dense coord.

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -456,7 +456,7 @@ void Dataset::rename(const Dim from, const Dim to) {
       value.data->rename(from, to);
     if (value.coord)
       value.coord->rename(from, to);
-    for (auto labels : value.labels)
+    for (auto &labels : value.labels)
       labels.second.rename(from, to);
   }
 }

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -436,7 +436,8 @@ void Dataset::rename(const Dim from, const Dim to) {
     map.insert(std::move(node));
   };
   relabel(m_dims);
-  relabel(m_coords);
+  if (coords().contains(from))
+    relabel(m_coords);
   for (auto &item : m_coords)
     item.second.rename(from, to);
   for (auto &item : m_labels)

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -34,12 +34,13 @@ static Dataset convert_with_factor(Dataset &&d, const Dim from, const Dim to,
                                    const Variable &factor) {
   // 1. Transform coordinate
   // Cannot use *= since often a broadcast into Dim::Position is required.
-  d.setCoord(from, d.coords()[from] * factor);
+  if (d.coords().contains(from))
+    d.setCoord(from, d.coords()[from] * factor);
 
   // 2. Transform variables
   for (const auto & [ name, data ] : d) {
     static_cast<void>(name);
-    if (data.coords()[from].dims().sparse()) {
+    if (data.dims().sparse()) {
       data.coords()[from] *= factor;
     } else if (data.unit().isCountDensity()) {
       // Conversion is just a scale factor, so density transform is simple:

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -42,7 +42,8 @@ Dataset makeTofDataForUnitConversion(const bool dense_coord = true) {
   auto eventLists = events.sparseValues<double>();
   eventLists[0] = {1000, 3000, 2000, 4000};
   eventLists[1] = {5000, 6000, 3000};
-  tof.setSparseCoord("events", std::move(events));
+  tof.setSparseCoord("events", events);
+  tof.setSparseLabels("events", "aux", events);
 
   tof.setData("density",
               makeVariable<double>({{Dim::Position, 2}, {Dim::Tof, 3}},
@@ -143,6 +144,15 @@ TEST(Convert, Tof_to_DSpacing) {
   ASSERT_EQ(dspacing.coords()[Dim::Position], tof.coords()[Dim::Position]);
   ASSERT_EQ(dspacing.labels()["component_info"],
             tof.labels()["component_info"]);
+}
+
+TEST(Convert, converts_sparse_labels) {
+  // label "conversion" is name change of dim
+  Dataset tof = makeTofDataForUnitConversion();
+  Dataset dspacing = convert(tof, Dim::Tof, Dim::DSpacing);
+  Dimensions expected({Dim::Position, Dim::DSpacing}, {2, Dimensions::Sparse});
+  EXPECT_EQ(dspacing["events"].coords()[Dim::DSpacing].dims(), expected);
+  EXPECT_EQ(dspacing["events"].labels()["aux"].dims(), expected);
 }
 
 TEST(Convert, Tof_to_DSpacing_no_dense_coord) {

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -12,11 +12,12 @@ using namespace scipp;
 using namespace scipp::core;
 using namespace scipp::neutron;
 
-Dataset makeTofDataForUnitConversion() {
+Dataset makeTofDataForUnitConversion(const bool only_sparse = false) {
   Dataset tof;
 
-  tof.setCoord(Dim::Tof, makeVariable<double>({Dim::Tof, 4}, units::us,
-                                              {4000, 5000, 6100, 7300}));
+  if (!only_sparse)
+    tof.setCoord(Dim::Tof, makeVariable<double>({Dim::Tof, 4}, units::us,
+                                                {4000, 5000, 6100, 7300}));
 
   Dataset components;
   // Source and sample
@@ -142,6 +143,13 @@ TEST(Convert, Tof_to_DSpacing) {
   ASSERT_EQ(dspacing.coords()[Dim::Position], tof.coords()[Dim::Position]);
   ASSERT_EQ(dspacing.labels()["component_info"],
             tof.labels()["component_info"]);
+}
+
+TEST(Convert, Tof_to_DSpacing_no_dense_coord) {
+  const bool only_sparse = true;
+  Dataset tof = makeTofDataForUnitConversion(only_sparse);
+  EXPECT_FALSE(tof.coords().contains(Dim::Tof));
+  EXPECT_NO_THROW(convert(tof, Dim::Tof, Dim::DSpacing));
 }
 
 TEST(Convert, DSpacing_to_Tof) {


### PR DESCRIPTION
One thing led to the next, a chain of bugs was discovered:

- Fix 1: Do not require dense coord in unit conversion, i.e., sparse-only datasets can be converted.
- Fix 2: Without dense coord and data, unit conversion failed to rename dimension labels. This was due to a bug in `Dataset`, failing to record the labels of sparse dimensions.
- Fix 3: The dimensions of sparse labels where not renamed as they should.

Note that Fix 1 currently works only when conversion is done using a simple factor. The other cases will require more checks (since dense coord would be needed for converting count-density data). I suggest this is handled in a planned refactor of this code that will make it more generic.