### PR TITLE
Add benchmarks for coord proxy generation

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -1,457 +1,80 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
-/// @author Simon Heybrock
 #include <benchmark/benchmark.h>
 
 #include <numeric>
-#include <random>
 
-#include "dataset.h"
+#include "scipp/core/dataset.h"
 
+using namespace scipp;
 using namespace scipp::core;
 
-// Dataset::get requires a search based on a tag defined by the type and is thus
-// potentially expensive.
-static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
-  Dataset d;
-  for (int i = 0; i < state.range(0); ++i)
-    d.insert(Data::Value, "name" + std::to_string(i), Dimensions{}, 1);
-  d.insert(Data::Variance, "name", Dimensions{}, 1);
-  for (auto _ : state)
-    d.get(Data::Variance);
-  state.SetItemsProcessed(state.iterations());
+Variable makeCoordData(const Dimensions &dims) {
+  std::vector<double> data(dims.volume());
+  std::iota(data.begin(), data.end(), 0);
+  return makeVariable<double>(dims, data);
 }
-BENCHMARK(BM_Dataset_get_with_many_columns)
-    ->RangeMultiplier(2)
-    ->Range(8, 8 << 10);
 
-// Benchmark demonstrating a potential use of Dataset to replace Histogram. What
-// are the performance implications?
-static void BM_Dataset_as_Histogram(benchmark::State &state) {
-  scipp::index nPoint = state.range(0);
-  Dataset d;
-  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
-  d.insert(Data::Value, "", {Dim::Tof, nPoint}, nPoint);
-  d.insert(Data::Variance, "", {Dim::Tof, nPoint}, nPoint);
-  std::vector<Dataset> histograms;
-  scipp::index nSpec = std::min(1000000l, 10000000 / (nPoint + 1));
-  for (scipp::index i = 0; i < nSpec; ++i) {
-    auto hist(d);
-    // Break sharing
-    hist.get(Data::Value);
-    hist.get(Data::Variance);
-    histograms.push_back(hist);
+struct Generate2D {
+  Dataset operator()(const int size = 100) {
+    Dataset d;
+    d.setCoord(Dim::X, makeCoordData({Dim::X, size}));
+    d.setCoord(Dim::Y, makeCoordData({Dim::Y, size}));
+    return d;
   }
+};
 
+struct Generate6D {
+  Dataset operator()(const int size = 100) {
+    Dataset d;
+    d.setCoord(Dim::X, makeCoordData({Dim::X, size}));
+    d.setCoord(Dim::Y, makeCoordData({Dim::Y, size}));
+    d.setCoord(Dim::Z, makeCoordData({Dim::Z, size}));
+    d.setCoord(Dim::Qx, makeCoordData({Dim::Qx, size}));
+    d.setCoord(Dim::Qy, makeCoordData({Dim::Qy, size}));
+    d.setCoord(Dim::Qz, makeCoordData({Dim::Qz, size}));
+    return d;
+  }
+};
+
+template <class Gen> static void BM_Dataset_coords(benchmark::State &state) {
+  const auto d = Gen()();
   for (auto _ : state) {
-    auto sum = histograms[0];
-    for (scipp::index i = 1; i < nSpec; ++i)
-      sum += histograms[i];
+    d.coords();
   }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 2 *
-                          sizeof(double));
 }
-BENCHMARK(BM_Dataset_as_Histogram)->RangeMultiplier(2)->Range(0, 2 << 14);
+BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate2D);
+BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate6D);
 
-static void BM_Dataset_as_Histogram_with_slice(benchmark::State &state) {
-  Dataset d;
-  d.insert(Coord::Tof, {Dim::Tof, 1000}, 1000);
-  scipp::index nSpec = 10000;
-  Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value, "sample", dims, dims.volume());
-  d.insert(Data::Variance, "sample", dims, dims.volume());
+struct SliceX {
+  auto operator()(const Dataset &d) { return d.slice({Dim::X, 20, 90}); }
+};
 
+struct SliceXY {
+  auto operator()(const Dataset &d) {
+    return d.slice({Dim::X, 20, 90}, {Dim::Y, 30, 60});
+  }
+};
+
+struct SliceXYQz {
+  auto operator()(const Dataset &d) {
+    return d.slice({Dim::X, 20, 90}, {Dim::Y, 30, 60}, {Dim::Qz, 30, 90});
+  }
+};
+
+template <class Gen, class Slice>
+static void BM_Dataset_coords_slice(benchmark::State &state) {
+  const auto d = Gen()();
+  const auto s = Slice()(d);
   for (auto _ : state) {
-    auto sum = d(Dim::Spectrum, 0);
-    for (scipp::index i = 1; i < nSpec; ++i)
-      sum += d(Dim::Spectrum, i);
+    s.coords();
   }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  state.SetBytesProcessed(state.iterations() * nSpec * 1000 * 2 *
-                          sizeof(double));
 }
-BENCHMARK(BM_Dataset_as_Histogram_with_slice);
-
-Dataset makeSingleDataDataset(const scipp::index nSpec,
-                              const scipp::index nPoint) {
-  Dataset d;
-
-  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
-  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
-
-  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
-  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value, "sample", dims, dims.volume());
-  d.insert(Data::Variance, "sample", dims, dims.volume());
-
-  return d;
-}
-
-Dataset makeDataset(const scipp::index nSpec, const scipp::index nPoint) {
-  Dataset d;
-
-  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
-  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
-
-  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
-  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value, "sample", dims, dims.volume());
-  d.insert(Data::Variance, "sample", dims, dims.volume());
-  d.insert(Data::Value, "background", dims, dims.volume());
-  d.insert(Data::Variance, "background", dims, dims.volume());
-
-  return d;
-}
-
-static void BM_Dataset_plus(benchmark::State &state) {
-  scipp::index nSpec = 10000;
-  scipp::index nPoint = state.range(0);
-  auto d = makeDataset(nSpec, nPoint);
-  for (auto _ : state) {
-    d += d;
-  }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
-  // storing 2. That is, this does not take into account intermediate values.
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 6 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_plus)->RangeMultiplier(2)->Range(2 << 9, 2 << 12);
-
-static void BM_Dataset_multiply(benchmark::State &state) {
-  scipp::index nSpec = state.range(0);
-  scipp::index nPoint = 1024;
-  auto d = makeSingleDataDataset(nSpec, nPoint);
-  const auto d2 = makeSingleDataDataset(nSpec, nPoint);
-  for (auto _ : state) {
-    d *= d2;
-  }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
-  // storing 2. That is, this does not take into account intermediate values.
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 6 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_multiply)->RangeMultiplier(2)->Range(2 << 0, 2 << 12);
-BENCHMARK(BM_Dataset_multiply)
-    ->RangeMultiplier(2)
-    ->Range(2 << 0, 2 << 12)
-    ->Threads(4)
-    ->UseRealTime();
-BENCHMARK(BM_Dataset_multiply)
-    ->RangeMultiplier(2)
-    ->Range(2 << 0, 2 << 12)
-    ->Threads(8)
-    ->UseRealTime();
-BENCHMARK(BM_Dataset_multiply)
-    ->RangeMultiplier(2)
-    ->Range(2 << 0, 2 << 12)
-    ->Threads(12)
-    ->UseRealTime();
-BENCHMARK(BM_Dataset_multiply)
-    ->RangeMultiplier(2)
-    ->Range(2 << 0, 2 << 12)
-    ->Threads(24)
-    ->UseRealTime();
-
-Dataset doWork(Dataset d) {
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  d *= d;
-  return d;
-}
-
-static void BM_Dataset_cache_blocking_reference(benchmark::State &state) {
-  scipp::index nSpec = 10000;
-  scipp::index nPoint = state.range(0);
-  auto d = makeDataset(nSpec, nPoint);
-  auto out(d);
-  for (auto _ : state) {
-    d = doWork(std::move(d));
-  }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
-  // storing 2+2. That is, this does not take into account intermediate values.
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_cache_blocking_reference)
-    ->RangeMultiplier(2)
-    ->Range(2 << 9, 2 << 12);
-
-static void BM_Dataset_cache_blocking(benchmark::State &state) {
-  scipp::index nSpec = 10000;
-  scipp::index nPoint = state.range(0);
-  auto d = makeDataset(nSpec, nPoint);
-  for (auto _ : state) {
-    for (scipp::index i = 0; i < nSpec; ++i) {
-      d(Dim::Spectrum, i).assign(doWork(d(Dim::Spectrum, i)));
-    }
-  }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
-  // storing 2+2. That is, this does not take into account intermediate values.
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_cache_blocking)
-    ->RangeMultiplier(2)
-    ->Range(2 << 9, 2 << 14);
-
-static void BM_Dataset_cache_blocking_no_slicing(benchmark::State &state) {
-  scipp::index nSpec = 10000;
-  scipp::index nPoint = state.range(0);
-  const auto d = makeDataset(nSpec, nPoint);
-  std::vector<Dataset> slices;
-  for (scipp::index i = 0; i < nSpec; ++i) {
-    slices.emplace_back(d(Dim::Spectrum, i));
-  }
-
-  for (auto _ : state) {
-    for (scipp::index i = 0; i < nSpec; ++i) {
-      slices[i] = doWork(std::move(slices[i]));
-    }
-  }
-  state.SetItemsProcessed(state.iterations() * nSpec);
-  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
-  // storing 2+2. That is, this does not take into account intermediate values.
-  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_cache_blocking_no_slicing)
-    ->RangeMultiplier(2)
-    ->Range(2 << 9, 2 << 14);
-
-Dataset makeBeamline(const scipp::index nDet) {
-  // TODO The created beamline is currently very incomplete so the full cost
-  // would be higher.
-  Dataset dets;
-
-  dets.insert(Coord::DetectorId, {Dim::Detector, nDet});
-  dets.insert(Coord::Mask, {Dim::Detector, nDet});
-  dets.insert(Coord::Position, {Dim::Detector, nDet});
-  auto ids = dets.get(Coord::DetectorId);
-  std::iota(ids.begin(), ids.end(), 1);
-
-  Dataset d;
-  d.insert(Coord::DetectorInfo, {}, {dets});
-  d.insert(Attr::ExperimentLog, "NeXus logs", {});
-
-  return d;
-}
-
-Dataset makeSpectra(const scipp::index nSpec) {
-  Dataset d;
-
-  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec});
-  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec});
-  auto groups = d.get(Coord::DetectorGrouping);
-  for (scipp::index i = 0; i < groups.size(); ++i)
-    groups[i] = {i};
-  auto nums = d.get(Coord::SpectrumNumber);
-  std::iota(nums.begin(), nums.end(), 1);
-
-  return d;
-}
-
-Dataset makeData(const scipp::index nSpec, const scipp::index nPoint) {
-  Dataset d;
-  d.insert(Coord::Tof, {Dim::Tof, nPoint + 1});
-  auto tofs = d.get(Coord::Tof);
-  std::iota(tofs.begin(), tofs.end(), 0.0);
-  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value, "sample", dims);
-  d.insert(Data::Variance, "sample", dims);
-  return d;
-}
-
-Dataset makeWorkspace2D(const scipp::index nSpec, const scipp::index nPoint) {
-  auto d = makeBeamline(nSpec);
-  d.merge(makeSpectra(nSpec));
-  d.merge(makeData(nSpec, nPoint));
-  return d;
-}
-
-static void BM_Dataset_Workspace2D_create(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nPoint = 2;
-  for (auto _ : state) {
-    auto d = makeWorkspace2D(nSpec, nPoint);
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_Workspace2D_create);
-
-static void BM_Dataset_Workspace2D_copy(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nPoint = 2;
-  auto d = makeWorkspace2D(nSpec, nPoint);
-  for (auto _ : state) {
-    auto copy(d);
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_Workspace2D_copy);
-
-static void BM_Dataset_Workspace2D_copy_and_write(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nPoint = state.range(0);
-  auto d = makeWorkspace2D(nSpec, nPoint);
-  for (auto _ : state) {
-    auto copy(d);
-    copy.get(Data::Value)[0] = 1.0;
-    copy.get(Data::Variance)[0] = 1.0;
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_Workspace2D_copy_and_write)
-    ->RangeMultiplier(2)
-    ->Range(2, 2 << 7);
-
-static void BM_Dataset_Workspace2D_rebin(benchmark::State &state) {
-  scipp::index nSpec = state.range(0) * 1024;
-  scipp::index nPoint = 1024;
-
-  auto newCoord = makeVariable<double>({Dim::Tof, nPoint / 2});
-  double value = 0.0;
-  for (auto &tof : newCoord.span<double>()) {
-    tof = value;
-    value += 3.0;
-  }
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    auto d = makeData(nSpec, nPoint);
-    state.ResumeTiming();
-    auto rebinned = rebin(d, newCoord);
-  }
-  state.SetItemsProcessed(state.iterations());
-  state.SetBytesProcessed(state.iterations() * nSpec * (nPoint + nPoint / 2) *
-                          (1 + 1) * sizeof(double));
-}
-BENCHMARK(BM_Dataset_Workspace2D_rebin)
-    ->RangeMultiplier(2)
-    ->Range(32, 1024)
-    ->UseRealTime();
-
-Dataset makeEventWorkspace(const scipp::index nSpec,
-                           const scipp::index nEvent) {
-  auto d = makeBeamline(nSpec);
-  d.merge(makeSpectra(nSpec));
-
-  d.insert(Coord::Tof, {Dim::Tof, 2});
-
-  d.insert(Data::Events, "events", {Dim::Spectrum, nSpec});
-  std::random_device rd;
-  std::mt19937 mt(rd());
-  std::uniform_int_distribution<int> dist(0, nEvent);
-  Dataset empty;
-  empty.insert(Data::Tof, "", {Dim::Event, 0});
-  empty.insert(Data::PulseTime, "", {Dim::Event, 0});
-  for (auto &eventList : d.get(Data::Events)) {
-    // 1/4 of the event lists is empty
-    scipp::index count = std::max(0l, dist(mt) - nEvent / 4);
-    if (count == 0)
-      eventList = empty;
-    else {
-      eventList.insert(Data::Tof, "", {Dim::Event, count});
-      eventList.insert(Data::PulseTime, "", {Dim::Event, count});
-    }
-  }
-
-  return d;
-}
-
-static void BM_Dataset_EventWorkspace_create(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nEvent = 0;
-  for (auto _ : state) {
-    auto d = makeEventWorkspace(nSpec, nEvent);
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_EventWorkspace_create);
-
-static void BM_Dataset_EventWorkspace_copy(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nEvent = 0;
-  auto d = makeEventWorkspace(nSpec, nEvent);
-  for (auto _ : state) {
-    auto copy(d);
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_EventWorkspace_copy);
-
-static void BM_Dataset_EventWorkspace_copy_and_write(benchmark::State &state) {
-  scipp::index nSpec = 1024 * 1024;
-  scipp::index nEvent = state.range(0);
-  auto d = makeEventWorkspace(nSpec, nEvent);
-  for (auto _ : state) {
-    auto copy(d);
-    auto eventLists = copy.get(Data::Events);
-    static_cast<void>(eventLists);
-  }
-  state.SetItemsProcessed(state.iterations());
-}
-BENCHMARK(BM_Dataset_EventWorkspace_copy_and_write)
-    ->RangeMultiplier(8)
-    ->Range(2, 2 << 10);
-
-static void BM_Dataset_EventWorkspace_plus(benchmark::State &state) {
-  scipp::index nSpec = 128 * 1024;
-  scipp::index nEvent = state.range(0);
-  auto d = makeEventWorkspace(nSpec, nEvent);
-  for (auto _ : state) {
-    auto sum = d + d;
-  }
-
-  scipp::index actualEvents = 0;
-  for (auto &eventList : d.get(Data::Events))
-    actualEvents += eventList.dimensions()[Dim::Event];
-  state.SetItemsProcessed(state.iterations());
-  // 2 for Tof and PulseTime
-  // 1+1+2+2 for loads and save
-  state.SetBytesProcessed(state.iterations() * actualEvents * 2 * 6 *
-                          sizeof(double));
-}
-BENCHMARK(BM_Dataset_EventWorkspace_plus)
-    ->RangeMultiplier(2)
-    ->Range(2, 2 << 12);
-
-static void BM_Dataset_EventWorkspace_grow(benchmark::State &state) {
-  scipp::index nSpec = 128 * 1024;
-  scipp::index nEvent = state.range(0);
-  auto d = makeEventWorkspace(nSpec, nEvent);
-  auto update = makeEventWorkspace(nSpec, 100);
-  for (auto _ : state) {
-    state.PauseTiming();
-    auto sum(d);
-    static_cast<void>(sum.get(Data::Events));
-    state.ResumeTiming();
-    sum += update;
-  }
-
-  scipp::index actualEvents = 0;
-  for (auto &eventList : update.get(Data::Events))
-    actualEvents += eventList.dimensions()[Dim::Event];
-  state.SetItemsProcessed(state.iterations() * actualEvents);
-}
-BENCHMARK(BM_Dataset_EventWorkspace_grow)
-    ->RangeMultiplier(2)
-    ->Range(2, 2 << 13);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D, SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D, SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D, SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D, SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D, SliceXYQz);
 
 BENCHMARK_MAIN();

--- a/benchmark/legacy_dataset_benchmark.cpp
+++ b/benchmark/legacy_dataset_benchmark.cpp
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <benchmark/benchmark.h>
+
+#include <numeric>
+#include <random>
+
+#include "dataset.h"
+
+using namespace scipp::core;
+
+// Dataset::get requires a search based on a tag defined by the type and is thus
+// potentially expensive.
+static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
+  Dataset d;
+  for (int i = 0; i < state.range(0); ++i)
+    d.insert(Data::Value, "name" + std::to_string(i), Dimensions{}, 1);
+  d.insert(Data::Variance, "name", Dimensions{}, 1);
+  for (auto _ : state)
+    d.get(Data::Variance);
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_get_with_many_columns)
+    ->RangeMultiplier(2)
+    ->Range(8, 8 << 10);
+
+// Benchmark demonstrating a potential use of Dataset to replace Histogram. What
+// are the performance implications?
+static void BM_Dataset_as_Histogram(benchmark::State &state) {
+  scipp::index nPoint = state.range(0);
+  Dataset d;
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Value, "", {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Variance, "", {Dim::Tof, nPoint}, nPoint);
+  std::vector<Dataset> histograms;
+  scipp::index nSpec = std::min(1000000l, 10000000 / (nPoint + 1));
+  for (scipp::index i = 0; i < nSpec; ++i) {
+    auto hist(d);
+    // Break sharing
+    hist.get(Data::Value);
+    hist.get(Data::Variance);
+    histograms.push_back(hist);
+  }
+
+  for (auto _ : state) {
+    auto sum = histograms[0];
+    for (scipp::index i = 1; i < nSpec; ++i)
+      sum += histograms[i];
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 2 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_as_Histogram)->RangeMultiplier(2)->Range(0, 2 << 14);
+
+static void BM_Dataset_as_Histogram_with_slice(benchmark::State &state) {
+  Dataset d;
+  d.insert(Coord::Tof, {Dim::Tof, 1000}, 1000);
+  scipp::index nSpec = 10000;
+  Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, nSpec}});
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
+
+  for (auto _ : state) {
+    auto sum = d(Dim::Spectrum, 0);
+    for (scipp::index i = 1; i < nSpec; ++i)
+      sum += d(Dim::Spectrum, i);
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  state.SetBytesProcessed(state.iterations() * nSpec * 1000 * 2 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_as_Histogram_with_slice);
+
+Dataset makeSingleDataDataset(const scipp::index nSpec,
+                              const scipp::index nPoint) {
+  Dataset d;
+
+  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
+
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
+  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
+
+  return d;
+}
+
+Dataset makeDataset(const scipp::index nSpec, const scipp::index nPoint) {
+  Dataset d;
+
+  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
+
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
+  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
+  d.insert(Data::Value, "background", dims, dims.volume());
+  d.insert(Data::Variance, "background", dims, dims.volume());
+
+  return d;
+}
+
+static void BM_Dataset_plus(benchmark::State &state) {
+  scipp::index nSpec = 10000;
+  scipp::index nPoint = state.range(0);
+  auto d = makeDataset(nSpec, nPoint);
+  for (auto _ : state) {
+    d += d;
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
+  // storing 2. That is, this does not take into account intermediate values.
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 6 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_plus)->RangeMultiplier(2)->Range(2 << 9, 2 << 12);
+
+static void BM_Dataset_multiply(benchmark::State &state) {
+  scipp::index nSpec = state.range(0);
+  scipp::index nPoint = 1024;
+  auto d = makeSingleDataDataset(nSpec, nPoint);
+  const auto d2 = makeSingleDataDataset(nSpec, nPoint);
+  for (auto _ : state) {
+    d *= d2;
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
+  // storing 2. That is, this does not take into account intermediate values.
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 6 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_multiply)->RangeMultiplier(2)->Range(2 << 0, 2 << 12);
+BENCHMARK(BM_Dataset_multiply)
+    ->RangeMultiplier(2)
+    ->Range(2 << 0, 2 << 12)
+    ->Threads(4)
+    ->UseRealTime();
+BENCHMARK(BM_Dataset_multiply)
+    ->RangeMultiplier(2)
+    ->Range(2 << 0, 2 << 12)
+    ->Threads(8)
+    ->UseRealTime();
+BENCHMARK(BM_Dataset_multiply)
+    ->RangeMultiplier(2)
+    ->Range(2 << 0, 2 << 12)
+    ->Threads(12)
+    ->UseRealTime();
+BENCHMARK(BM_Dataset_multiply)
+    ->RangeMultiplier(2)
+    ->Range(2 << 0, 2 << 12)
+    ->Threads(24)
+    ->UseRealTime();
+
+Dataset doWork(Dataset d) {
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  d *= d;
+  return d;
+}
+
+static void BM_Dataset_cache_blocking_reference(benchmark::State &state) {
+  scipp::index nSpec = 10000;
+  scipp::index nPoint = state.range(0);
+  auto d = makeDataset(nSpec, nPoint);
+  auto out(d);
+  for (auto _ : state) {
+    d = doWork(std::move(d));
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
+  // storing 2+2. That is, this does not take into account intermediate values.
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_cache_blocking_reference)
+    ->RangeMultiplier(2)
+    ->Range(2 << 9, 2 << 12);
+
+static void BM_Dataset_cache_blocking(benchmark::State &state) {
+  scipp::index nSpec = 10000;
+  scipp::index nPoint = state.range(0);
+  auto d = makeDataset(nSpec, nPoint);
+  for (auto _ : state) {
+    for (scipp::index i = 0; i < nSpec; ++i) {
+      d(Dim::Spectrum, i).assign(doWork(d(Dim::Spectrum, i)));
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
+  // storing 2+2. That is, this does not take into account intermediate values.
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_cache_blocking)
+    ->RangeMultiplier(2)
+    ->Range(2 << 9, 2 << 14);
+
+static void BM_Dataset_cache_blocking_no_slicing(benchmark::State &state) {
+  scipp::index nSpec = 10000;
+  scipp::index nPoint = state.range(0);
+  const auto d = makeDataset(nSpec, nPoint);
+  std::vector<Dataset> slices;
+  for (scipp::index i = 0; i < nSpec; ++i) {
+    slices.emplace_back(d(Dim::Spectrum, i));
+  }
+
+  for (auto _ : state) {
+    for (scipp::index i = 0; i < nSpec; ++i) {
+      slices[i] = doWork(std::move(slices[i]));
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * nSpec);
+  // This is the minimal theoretical data volume to and from RAM, loading 2+2,
+  // storing 2+2. That is, this does not take into account intermediate values.
+  state.SetBytesProcessed(state.iterations() * nSpec * nPoint * 8 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_cache_blocking_no_slicing)
+    ->RangeMultiplier(2)
+    ->Range(2 << 9, 2 << 14);
+
+Dataset makeBeamline(const scipp::index nDet) {
+  // TODO The created beamline is currently very incomplete so the full cost
+  // would be higher.
+  Dataset dets;
+
+  dets.insert(Coord::DetectorId, {Dim::Detector, nDet});
+  dets.insert(Coord::Mask, {Dim::Detector, nDet});
+  dets.insert(Coord::Position, {Dim::Detector, nDet});
+  auto ids = dets.get(Coord::DetectorId);
+  std::iota(ids.begin(), ids.end(), 1);
+
+  Dataset d;
+  d.insert(Coord::DetectorInfo, {}, {dets});
+  d.insert(Attr::ExperimentLog, "NeXus logs", {});
+
+  return d;
+}
+
+Dataset makeSpectra(const scipp::index nSpec) {
+  Dataset d;
+
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec});
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec});
+  auto groups = d.get(Coord::DetectorGrouping);
+  for (scipp::index i = 0; i < groups.size(); ++i)
+    groups[i] = {i};
+  auto nums = d.get(Coord::SpectrumNumber);
+  std::iota(nums.begin(), nums.end(), 1);
+
+  return d;
+}
+
+Dataset makeData(const scipp::index nSpec, const scipp::index nPoint) {
+  Dataset d;
+  d.insert(Coord::Tof, {Dim::Tof, nPoint + 1});
+  auto tofs = d.get(Coord::Tof);
+  std::iota(tofs.begin(), tofs.end(), 0.0);
+  Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
+  d.insert(Data::Value, "sample", dims);
+  d.insert(Data::Variance, "sample", dims);
+  return d;
+}
+
+Dataset makeWorkspace2D(const scipp::index nSpec, const scipp::index nPoint) {
+  auto d = makeBeamline(nSpec);
+  d.merge(makeSpectra(nSpec));
+  d.merge(makeData(nSpec, nPoint));
+  return d;
+}
+
+static void BM_Dataset_Workspace2D_create(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nPoint = 2;
+  for (auto _ : state) {
+    auto d = makeWorkspace2D(nSpec, nPoint);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_Workspace2D_create);
+
+static void BM_Dataset_Workspace2D_copy(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nPoint = 2;
+  auto d = makeWorkspace2D(nSpec, nPoint);
+  for (auto _ : state) {
+    auto copy(d);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_Workspace2D_copy);
+
+static void BM_Dataset_Workspace2D_copy_and_write(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nPoint = state.range(0);
+  auto d = makeWorkspace2D(nSpec, nPoint);
+  for (auto _ : state) {
+    auto copy(d);
+    copy.get(Data::Value)[0] = 1.0;
+    copy.get(Data::Variance)[0] = 1.0;
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_Workspace2D_copy_and_write)
+    ->RangeMultiplier(2)
+    ->Range(2, 2 << 7);
+
+static void BM_Dataset_Workspace2D_rebin(benchmark::State &state) {
+  scipp::index nSpec = state.range(0) * 1024;
+  scipp::index nPoint = 1024;
+
+  auto newCoord = makeVariable<double>({Dim::Tof, nPoint / 2});
+  double value = 0.0;
+  for (auto &tof : newCoord.span<double>()) {
+    tof = value;
+    value += 3.0;
+  }
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto d = makeData(nSpec, nPoint);
+    state.ResumeTiming();
+    auto rebinned = rebin(d, newCoord);
+  }
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(state.iterations() * nSpec * (nPoint + nPoint / 2) *
+                          (1 + 1) * sizeof(double));
+}
+BENCHMARK(BM_Dataset_Workspace2D_rebin)
+    ->RangeMultiplier(2)
+    ->Range(32, 1024)
+    ->UseRealTime();
+
+Dataset makeEventWorkspace(const scipp::index nSpec,
+                           const scipp::index nEvent) {
+  auto d = makeBeamline(nSpec);
+  d.merge(makeSpectra(nSpec));
+
+  d.insert(Coord::Tof, {Dim::Tof, 2});
+
+  d.insert(Data::Events, "events", {Dim::Spectrum, nSpec});
+  std::random_device rd;
+  std::mt19937 mt(rd());
+  std::uniform_int_distribution<int> dist(0, nEvent);
+  Dataset empty;
+  empty.insert(Data::Tof, "", {Dim::Event, 0});
+  empty.insert(Data::PulseTime, "", {Dim::Event, 0});
+  for (auto &eventList : d.get(Data::Events)) {
+    // 1/4 of the event lists is empty
+    scipp::index count = std::max(0l, dist(mt) - nEvent / 4);
+    if (count == 0)
+      eventList = empty;
+    else {
+      eventList.insert(Data::Tof, "", {Dim::Event, count});
+      eventList.insert(Data::PulseTime, "", {Dim::Event, count});
+    }
+  }
+
+  return d;
+}
+
+static void BM_Dataset_EventWorkspace_create(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nEvent = 0;
+  for (auto _ : state) {
+    auto d = makeEventWorkspace(nSpec, nEvent);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_EventWorkspace_create);
+
+static void BM_Dataset_EventWorkspace_copy(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nEvent = 0;
+  auto d = makeEventWorkspace(nSpec, nEvent);
+  for (auto _ : state) {
+    auto copy(d);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_EventWorkspace_copy);
+
+static void BM_Dataset_EventWorkspace_copy_and_write(benchmark::State &state) {
+  scipp::index nSpec = 1024 * 1024;
+  scipp::index nEvent = state.range(0);
+  auto d = makeEventWorkspace(nSpec, nEvent);
+  for (auto _ : state) {
+    auto copy(d);
+    auto eventLists = copy.get(Data::Events);
+    static_cast<void>(eventLists);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_Dataset_EventWorkspace_copy_and_write)
+    ->RangeMultiplier(8)
+    ->Range(2, 2 << 10);
+
+static void BM_Dataset_EventWorkspace_plus(benchmark::State &state) {
+  scipp::index nSpec = 128 * 1024;
+  scipp::index nEvent = state.range(0);
+  auto d = makeEventWorkspace(nSpec, nEvent);
+  for (auto _ : state) {
+    auto sum = d + d;
+  }
+
+  scipp::index actualEvents = 0;
+  for (auto &eventList : d.get(Data::Events))
+    actualEvents += eventList.dimensions()[Dim::Event];
+  state.SetItemsProcessed(state.iterations());
+  // 2 for Tof and PulseTime
+  // 1+1+2+2 for loads and save
+  state.SetBytesProcessed(state.iterations() * actualEvents * 2 * 6 *
+                          sizeof(double));
+}
+BENCHMARK(BM_Dataset_EventWorkspace_plus)
+    ->RangeMultiplier(2)
+    ->Range(2, 2 << 12);
+
+static void BM_Dataset_EventWorkspace_grow(benchmark::State &state) {
+  scipp::index nSpec = 128 * 1024;
+  scipp::index nEvent = state.range(0);
+  auto d = makeEventWorkspace(nSpec, nEvent);
+  auto update = makeEventWorkspace(nSpec, 100);
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto sum(d);
+    static_cast<void>(sum.get(Data::Events));
+    state.ResumeTiming();
+    sum += update;
+  }
+
+  scipp::index actualEvents = 0;
+  for (auto &eventList : update.get(Data::Events))
+    actualEvents += eventList.dimensions()[Dim::Event];
+  state.SetItemsProcessed(state.iterations() * actualEvents);
+}
+BENCHMARK(BM_Dataset_EventWorkspace_grow)
+    ->RangeMultiplier(2)
+    ->Range(2, 2 << 13);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Re #558

Results:
```
---------------------------------------------------------------------------------------------
Benchmark                                                   Time             CPU   Iterations
---------------------------------------------------------------------------------------------
BM_Dataset_coords<Generate2D<6>>                         87.0 ns         87.0 ns      7914380
BM_Dataset_coords<Generate6D<6>>                          223 ns          223 ns      3130547
BM_Dataset_labels<Generate2D<6>>                          108 ns          108 ns      6517941
BM_Dataset_labels<Generate2D<32>>                         122 ns          122 ns      5788129
BM_Dataset_labels<Generate6D<6>>                          278 ns          278 ns      2533791
BM_Dataset_labels<Generate6D<32>>                         318 ns          318 ns      2174452
BM_Dataset_coords_slice<Generate2D<6>, SliceX>           98.9 ns         98.9 ns      7098152
BM_Dataset_coords_slice<Generate2D<6>, SliceXY>           101 ns          101 ns      6994695
BM_Dataset_coords_slice<Generate6D<6>, SliceX>            240 ns          240 ns      2918447
BM_Dataset_coords_slice<Generate6D<6>, SliceXY>           240 ns          240 ns      2926836
BM_Dataset_coords_slice<Generate6D<6>, SliceXYQz>         240 ns          240 ns      2904216
BM_Dataset_labels_slice<Generate2D<6>, SliceX>            122 ns          122 ns      5746194
BM_Dataset_labels_slice<Generate2D<32>, SliceX>           130 ns          130 ns      5420048
BM_Dataset_labels_slice<Generate2D<6>, SliceXY>           120 ns          120 ns      5851345
BM_Dataset_labels_slice<Generate2D<32>, SliceXY>          132 ns          132 ns      5308822
BM_Dataset_labels_slice<Generate6D<6>, SliceX>            287 ns          287 ns      2448160
BM_Dataset_labels_slice<Generate6D<32>, SliceX>           335 ns          335 ns      2088993
BM_Dataset_labels_slice<Generate6D<6>, SliceXY>           289 ns          289 ns      2421085
BM_Dataset_labels_slice<Generate6D<32>, SliceXY>          341 ns          341 ns      2072484
BM_Dataset_labels_slice<Generate6D<6>, SliceXYQz>         286 ns          286 ns      2451902
BM_Dataset_labels_slice<Generate6D<32>, SliceXYQz>        326 ns          326 ns      2100694
```