### PR TITLE
Reduce object size in transform instantiations due to inline lambda.

### DIFF
--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -37,9 +37,20 @@ using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
                std::pair<int64_t, int32_t>, std::pair<int32_t, int64_t>,
                std::pair<double, float>, std::pair<float, double>>()));
 
+static constexpr auto plus_ = [](const auto a_, const auto b_) {
+  return a_ + b_;
+};
+static constexpr auto minus_ = [](const auto a_, const auto b_) {
+  return a_ - b_;
+};
+static constexpr auto times_ = [](const auto a_, const auto b_) {
+  return a_ * b_;
+};
+static constexpr auto divide_ = [](const auto a_, const auto b_) {
+  return a_ / b_;
+};
 template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
-  return transform<arithmetic_and_matrix_type_pairs>(
-      a, b, [](const auto a_, const auto b_) { return a_ + b_; });
+  return transform<arithmetic_and_matrix_type_pairs>(a, b, plus_);
 }
 
 Variable Variable::operator-() const {
@@ -60,8 +71,7 @@ template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
 }
 
 template <class T1, class T2> Variable minus(const T1 &a, const T2 &b) {
-  return transform<arithmetic_and_matrix_type_pairs>(
-      a, b, [](const auto a_, const auto b_) { return a_ - b_; });
+  return transform<arithmetic_and_matrix_type_pairs>(a, b, minus_);
 }
 
 Variable &Variable::operator-=(const Variable &other) & {
@@ -77,8 +87,7 @@ template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
 }
 
 template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
-  return transform<arithmetic_type_pairs>(
-      a, b, [](const auto a_, const auto b_) { return a_ * b_; });
+  return transform<arithmetic_type_pairs>(a, b, times_);
 }
 
 Variable &Variable::operator*=(const Variable &other) & {
@@ -94,8 +103,7 @@ template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
 }
 
 template <class T1, class T2> Variable divide(const T1 &a, const T2 &b) {
-  return transform<arithmetic_type_pairs>(
-      a, b, [](const auto a_, const auto b_) { return a_ / b_; });
+  return transform<arithmetic_type_pairs>(a, b, divide_);
 }
 
 Variable &Variable::operator/=(const Variable &other) & {


### PR DESCRIPTION
GCC's `variable_binary_arithmetic.cpp.o` reduces from 46010992 to 20858736 Byte.