### PR TITLE
Benchmark Dataset item access

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -7,6 +7,11 @@
 
 #include "scipp/core/dataset.h"
 
+// Length of a string that can be stored with SSO
+constexpr auto SHORT_STRING_LENGTH = 6;
+// Length of a string that cannot take advantage of SSO (i.e. must be allocated)
+constexpr auto LONG_STRING_LENGTH = 32;
+
 using namespace scipp;
 using namespace scipp::core;
 
@@ -52,8 +57,8 @@ template <class Gen> static void BM_Dataset_coords(benchmark::State &state) {
     d.coords();
   }
 }
-BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate2D<6>);
-BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate6D<6>);
+BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate2D<SHORT_STRING_LENGTH>);
+BENCHMARK_TEMPLATE(BM_Dataset_coords, Generate6D<SHORT_STRING_LENGTH>);
 
 template <class Gen> static void BM_Dataset_labels(benchmark::State &state) {
   const auto d = Gen()();
@@ -61,10 +66,10 @@ template <class Gen> static void BM_Dataset_labels(benchmark::State &state) {
     d.labels();
   }
 }
-BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate2D<6>);
-BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate2D<32>);
-BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate6D<6>);
-BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate6D<32>);
+BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate2D<SHORT_STRING_LENGTH>);
+BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate2D<LONG_STRING_LENGTH>);
+BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate6D<SHORT_STRING_LENGTH>);
+BENCHMARK_TEMPLATE(BM_Dataset_labels, Generate6D<LONG_STRING_LENGTH>);
 
 struct SliceX {
   auto operator()(const Dataset &d) { return d.slice({Dim::X, 20, 90}); }
@@ -82,6 +87,12 @@ struct SliceXYQz {
   }
 };
 
+struct SliceZXY {
+  auto operator()(const Dataset &d) {
+    return d.slice({Dim::Z, 5, 95}, {Dim::X, 20, 90}, {Dim::Y, 30, 60});
+  }
+};
+
 template <class Gen, class Slice>
 static void BM_Dataset_coords_slice(benchmark::State &state) {
   const auto d = Gen()();
@@ -90,11 +101,16 @@ static void BM_Dataset_coords_slice(benchmark::State &state) {
     s.coords();
   }
 }
-BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D<6>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D<6>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<6>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<6>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<6>, SliceXYQz);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D<SHORT_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate2D<SHORT_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_coords_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceXYQz);
 
 template <class Gen, class Slice>
 static void BM_Dataset_labels_slice(benchmark::State &state) {
@@ -104,15 +120,92 @@ static void BM_Dataset_labels_slice(benchmark::State &state) {
     s.labels();
   }
 }
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<6>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<32>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<6>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<32>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<6>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<32>, SliceX);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<6>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<32>, SliceXY);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<6>, SliceXYQz);
-BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<32>, SliceXYQz);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<SHORT_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<LONG_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<SHORT_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate2D<LONG_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<LONG_STRING_LENGTH>,
+                   SliceX);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<LONG_STRING_LENGTH>,
+                   SliceXY);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<SHORT_STRING_LENGTH>,
+                   SliceXYQz);
+BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<LONG_STRING_LENGTH>,
+                   SliceXYQz);
+
+template <int NameLen> struct GenerateWithDataItems {
+  Dataset operator()(const int itemCount = 5, const int size = 100) {
+    Dataset d;
+    for (auto i = 0; i < itemCount; ++i) {
+      d.setData(std::to_string(i) + std::string(NameLen, 'i'),
+                makeVariable<double>(
+                    {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}}));
+    }
+    return d;
+  }
+};
+
+template <class Gen>
+static void BM_Dataset_item_access(benchmark::State &state) {
+  const auto d = Gen()();
+  const auto name = d.begin()->second.name();
+  for (auto _ : state) {
+    d[name];
+  }
+}
+BENCHMARK_TEMPLATE(BM_Dataset_item_access,
+                   GenerateWithDataItems<SHORT_STRING_LENGTH>);
+BENCHMARK_TEMPLATE(BM_Dataset_item_access,
+                   GenerateWithDataItems<LONG_STRING_LENGTH>);
+
+template <class Gen>
+static void BM_Dataset_iterate_items(benchmark::State &state) {
+  const auto d = Gen()(state.range(0));
+  for (auto _ : state) {
+    for (const auto & [ name, item ] : d) {
+      benchmark::DoNotOptimize(name);
+      benchmark::DoNotOptimize(item);
+    }
+  }
+  state.counters["IterationItemRate"] = benchmark::Counter(
+      state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK_TEMPLATE(BM_Dataset_iterate_items,
+                   GenerateWithDataItems<SHORT_STRING_LENGTH>)
+    ->Range(1 << 2, 1 << 8);
+BENCHMARK_TEMPLATE(BM_Dataset_iterate_items,
+                   GenerateWithDataItems<LONG_STRING_LENGTH>)
+    ->Range(1 << 2, 1 << 8);
+
+template <class Gen, class Slice>
+static void BM_Dataset_iterate_slice_items(benchmark::State &state) {
+  const auto d = Gen()(state.range(0));
+  const auto s = Slice()(d);
+  for (auto _ : state) {
+    for (const auto & [ name, item ] : s) {
+      benchmark::DoNotOptimize(name);
+      benchmark::DoNotOptimize(item);
+    }
+  }
+  state.counters["IterationItemRate"] = benchmark::Counter(
+      state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+}
+BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
+                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX)
+    ->Range(1 << 2, 1 << 8);
+BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
+                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY)
+    ->Range(1 << 2, 1 << 8);
+BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
+                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY)
+    ->Range(1 << 2, 1 << 8);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Re #558

Results:
```
-----------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------------------------
BM_Dataset_item_access<GenerateWithDataItems<SHORT_STRING_LENGTH>>                             17.7 ns         17.7 ns     39788397
BM_Dataset_item_access<GenerateWithDataItems<LONG_STRING_LENGTH>>                              18.8 ns         18.8 ns     36692332
BM_Dataset_iterate_items<GenerateWithDataItems<SHORT_STRING_LENGTH>>/4                         4.61 ns         4.61 ns    151215823 IterationItemRate=867.042M/s
BM_Dataset_iterate_items<GenerateWithDataItems<SHORT_STRING_LENGTH>>/8                         9.31 ns         9.31 ns     75572687 IterationItemRate=859.658M/s
BM_Dataset_iterate_items<GenerateWithDataItems<SHORT_STRING_LENGTH>>/64                        73.8 ns         73.8 ns      9268175 IterationItemRate=866.715M/s
BM_Dataset_iterate_items<GenerateWithDataItems<SHORT_STRING_LENGTH>>/256                        309 ns          309 ns      2337228 IterationItemRate=828.985M/s
BM_Dataset_iterate_items<GenerateWithDataItems<LONG_STRING_LENGTH>>/4                          4.65 ns         4.65 ns    148255730 IterationItemRate=860.119M/s
BM_Dataset_iterate_items<GenerateWithDataItems<LONG_STRING_LENGTH>>/8                          9.31 ns         9.31 ns     76376128 IterationItemRate=859.633M/s
BM_Dataset_iterate_items<GenerateWithDataItems<LONG_STRING_LENGTH>>/64                         75.3 ns         75.3 ns      9156021 IterationItemRate=849.494M/s
BM_Dataset_iterate_items<GenerateWithDataItems<LONG_STRING_LENGTH>>/256                         310 ns          310 ns      2253447 IterationItemRate=825.182M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX>/4            176 ns          176 ns      3906249 IterationItemRate=22.6721M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX>/8            412 ns          412 ns      1810921 IterationItemRate=19.4327M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX>/64          7115 ns         7114 ns        97359 IterationItemRate=8.99601M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX>/256        67941 ns        67938 ns        10229 IterationItemRate=3.76813M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY>/4           184 ns          184 ns      3902626 IterationItemRate=21.7246M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY>/8           394 ns          394 ns      1766088 IterationItemRate=20.2946M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY>/64         7072 ns         7072 ns        99678 IterationItemRate=9.05015M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY>/256       62538 ns        62532 ns        11412 IterationItemRate=4.09394M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY>/4          177 ns          177 ns      3934781 IterationItemRate=22.5931M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY>/8          394 ns          394 ns      1791468 IterationItemRate=20.31M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY>/64        7331 ns         7331 ns        92449 IterationItemRate=8.73048M/s
BM_Dataset_iterate_slice_items<GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY>/256      71309 ns        71304 ns         9947 IterationItemRate=3.59025M/s
```