### PR TITLE
Makes `import scipp as **` to be consistenly `as sc`

### DIFF
--- a/python/src/scipp/plot.py
+++ b/python/src/scipp/plot.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 import numpy as np
-import scipp as sp
+import scipp as sc
 # The need for importing matplotlib.pyplot here is a little strange, but the
 # reason is the following. We want to delay the imports of plot_matplotlib and
 # plot_plotly to inside dispatch_to_backend() in order to hide them from the
@@ -56,12 +56,12 @@ def plot(input_data, collapse=None, backend=None, color=None, **kwargs):
     # tobeplotted is a dict that holds pairs of
     # [number_of_dimensions, DatasetSlice], or
     # [number_of_dimensions, [List of DatasetSlices]] in the case of
-    # 1d sp.Data.
+    # 1d sc.Data.
     # TODO: 0D data is currently ignored -> find a nice way of
     # displaying it?
     tp = type(input_data)
-    if tp is sp.DataProxy or tp is sp.DataArray:
-        ds = sp.Dataset()
+    if tp is sc.DataProxy or tp is sc.DataArray:
+        ds = sc.Dataset()
         ds[input_data.name] = input_data
         input_data = ds
     if tp is not list:
@@ -161,8 +161,8 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, backend=None,
             volume *= size
 
     # Create temporary Dataset
-    ds = sp.Dataset()
-    ds.coords[dim] = sp.Variable([dim], values=coords[dim].values)
+    ds = sc.Dataset()
+    ds.coords[dim] = sc.Variable([dim], values=coords[dim].values)
     # A dictionary to hold the DataProxy objects
     data = dict()
 
@@ -219,7 +219,7 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, backend=None,
         variances = None
         if ds_temp.variances is not None:
             variances = ds_temp.variances
-        ds[key] = sp.Variable([dim], values=ds_temp.values,
+        ds[key] = sc.Variable([dim], values=ds_temp.values,
                               variances=variances)
         data[key] = ds[key]
         color.append(dispatch_to_backend(get_color=True, backend=backend,

--- a/python/src/scipp/tools.py
+++ b/python/src/scipp/tools.py
@@ -4,7 +4,7 @@
 # @author Neil Vaytet
 
 import numpy as np
-import scipp as sp
+import scipp as sc
 
 
 def edges_to_centers(x):
@@ -33,7 +33,7 @@ def axis_label(var, name=None, log=False):
 
     if log:
         label = "log\u2081\u2080(" + label + ")"
-    if var.unit != sp.units.dimensionless:
+    if var.unit != sc.units.dimensionless:
         label += " [{}]".format(var.unit)
     return label
 
@@ -54,7 +54,7 @@ def parse_colorbar(default, cb, plotly=False):
 
 def get_coord_array(coords, labels, axis):
     name = None
-    if isinstance(axis, sp.Dim):
+    if isinstance(axis, sc.Dim):
         var = coords[axis]
     elif isinstance(axis, str):
         var = labels[axis]

--- a/python/tests/compat/mantid_test.py
+++ b/python/tests/compat/mantid_test.py
@@ -2,7 +2,7 @@
 # PYTHONPATH.
 import unittest
 
-import scipp as sp
+import scipp as sc
 import mantid.simpleapi as mantid
 import scipp.compat.mantid as mantidcompat
 # import matplotlib.pyplot as plt
@@ -18,7 +18,7 @@ class TestMantidConversion(unittest.TestCase):
         d = mantidcompat.to_dataset(ws)
         print(d)
         # self.assertEqual(d.dimensions.shape[])
-        # dataset = as_xarray(d[sp.Dim.Position, 1000:2000])
+        # dataset = as_xarray(d[sc.Dim.Position, 1000:2000])
         # dataset['Value'].plot()
         # plt.show()
         # plt.savefig('test.png')
@@ -31,22 +31,22 @@ class TestMantidConversion(unittest.TestCase):
 
         binned_mantid = mantidcompat.to_dataset(ws)
 
-        tof = sp.Variable(binned_mantid[sp.Coord.Tof])
+        tof = sc.Variable(binned_mantid[sc.Coord.Tof])
         d = mantidcompat.to_dataset(eventWS)
-        binned = sp.histogram(d, tof)
+        binned = sc.histogram(d, tof)
 
-        delta = sp.sum(binned_mantid - binned, sp.Dim.Position)
+        delta = sc.sum(binned_mantid - binned, sc.Dim.Position)
         print(delta)
 
         # ds = as_xarray(delta)
         # ds['Value'].plot()
         # plt.savefig('delta.png')
 
-        # ds = as_xarray(sum(binned, sp.Dim.Position))
+        # ds = as_xarray(sum(binned, sc.Dim.Position))
         # ds['Value'].plot()
         # plt.savefig('binned.png')
 
-        # ds = as_xarray(sum(binned_mantid, sp.Dim.Position))
+        # ds = as_xarray(sum(binned_mantid, sc.Dim.Position))
         # ds['Value'].plot()
         # plt.savefig('binned_mantid.png')
 
@@ -56,29 +56,29 @@ class TestMantidConversion(unittest.TestCase):
         eventWS = mantid.LoadEventNexus(filename)
         ws = mantid.Rebin(eventWS, -0.001, PreserveEvents=False)
         tmp = mantidcompat.to_dataset(ws)
-        tof = sp.Variable(tmp[sp.Coord.Tof])
+        tof = sc.Variable(tmp[sc.Coord.Tof])
         ws = mantid.ConvertUnits(InputWorkspace=ws, Target='DeltaE',
                                  EMode='Direct', EFixed=3.3056)
 
         converted_mantid = mantidcompat.to_dataset(ws)
-        converted_mantid[sp.Coord.Ei] = ([], 3.3059)
+        converted_mantid[sc.Coord.Ei] = ([], 3.3059)
 
         d = mantidcompat.to_dataset(eventWS, drop_pulse_times=True)
-        d[sp.Coord.Ei] = ([], 3.3059)
-        d.merge(sp.histogram(d, tof))
-        del(d[sp.Data.Events])
-        converted = sp.convert(d, sp.Dim.Tof, sp.Dim.DeltaE)
+        d[sc.Coord.Ei] = ([], 3.3059)
+        d.merge(sc.histogram(d, tof))
+        del(d[sc.Data.Events])
+        converted = sc.convert(d, sc.Dim.Tof, sc.Dim.DeltaE)
 
-        delta = sp.sum(converted_mantid - converted, sp.Dim.Position)
+        delta = sc.sum(converted_mantid - converted, sc.Dim.Position)
         print(delta)
 
         # ds = as_xarray(delta)
         # ds['Value'].plot()
 
-        # ds = as_xarray(sum(converted, sp.Dim.Position))
+        # ds = as_xarray(sum(converted, sc.Dim.Position))
         # ds['Value'].plot()
 
-        # ds = as_xarray(sum(converted_mantid, sp.Dim.Position))
+        # ds = as_xarray(sum(converted_mantid, sc.Dim.Position))
         # ds['Value'].plot()
         # plt.savefig('converted.png')
 

--- a/python/tests/test_datasetslice.py
+++ b/python/tests/test_datasetslice.py
@@ -4,7 +4,7 @@
 # @author Simon Heybrock
 import unittest
 
-import scipp as sp
+import scipp as sc
 import numpy as np
 import operator
 
@@ -12,19 +12,19 @@ import operator
 class TestDatasetSlice(unittest.TestCase):
 
     def setUp(self):
-        d = sp.Dataset()
-        d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "b"] = ([sp.Dim.X], np.arange(10))
+        d = sc.Dataset()
+        d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "b"] = ([sc.Dim.X], np.arange(10))
         self._d = d
 
     def test_type(self):
         ds_slice = self._d.subset["a"]
-        self.assertEqual(type(ds_slice), sp.DatasetSlice)
+        self.assertEqual(type(ds_slice), sc.DatasetSlice)
 
     def test_extract_slice(self):
         ds_slice = self._d.subset["a"]
-        self.assertEqual(type(ds_slice), sp.DatasetSlice)
+        self.assertEqual(type(ds_slice), sc.DatasetSlice)
         # We should have just one data variable
         self.assertEqual(
             1, len([var for name, tag, var in ds_slice if tag.is_data]))
@@ -34,57 +34,57 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertEqual(2, len(ds_slice))
 
     def test_slice_back_ommit_range(self):
-        sl = self._d[sp.Dim.X, 1:-1][sp.Data.Value, "a"].numpy
+        sl = self._d[sc.Dim.X, 1:-1][sc.Data.Value, "a"].numpy
         ref = np. array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64)
         self.assertEqual(ref.shape, sl.shape)
         self.assertEqual(np.allclose(sl, ref), True)
         # omitting range end
-        sl = self._d[sp.Dim.X, 1:][sp.Data.Value, "b"].numpy
+        sl = self._d[sc.Dim.X, 1:][sc.Data.Value, "b"].numpy
         ref = np. array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.int64)
         self.assertEqual(ref.shape, sl.shape)
         self.assertEqual(np.allclose(sl, ref), True)
         # omitting range begin
-        sl = self._d[sp.Dim.X, :-1][sp.Data.Value, "a"].numpy
+        sl = self._d[sc.Dim.X, :-1][sc.Data.Value, "a"].numpy
         ref = np. array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64)
         self.assertEqual(ref.shape, sl.shape)
         self.assertEqual(np.allclose(sl, ref), True)
         # omitting range both begin and end
-        sl = self._d[sp.Dim.X, :][sp.Data.Value, "b"].numpy
+        sl = self._d[sc.Dim.X, :][sc.Data.Value, "b"].numpy
         ref = np. array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.int64)
         self.assertEqual(ref.shape, sl.shape)
         self.assertEqual(np.allclose(sl, ref), True)
 
     def test_slice_single_index(self):
-        self.assertEqual(self._d[sp.Dim.X, -4][sp.Data.Value, "a"].numpy,
-                         self._d[sp.Dim.X, 6][sp.Data.Value, "a"].numpy)
-        self.assertEqual(self._d[sp.Data.Value, "a"][sp.Dim.X, -3].numpy,
-                         self._d[sp.Data.Value, "a"][sp.Dim.X, 7].numpy)
+        self.assertEqual(self._d[sc.Dim.X, -4][sc.Data.Value, "a"].numpy,
+                         self._d[sc.Dim.X, 6][sc.Data.Value, "a"].numpy)
+        self.assertEqual(self._d[sc.Data.Value, "a"][sc.Dim.X, -3].numpy,
+                         self._d[sc.Data.Value, "a"][sc.Dim.X, 7].numpy)
 
     def test_range_based_slice(self):
         subset = slice(1, 4, 1)
         # Create slice
-        ds_slice = self._d[sp.Dim.X, subset]
+        ds_slice = self._d[sc.Dim.X, subset]
         # Test via variable_slice
-        self.assertEqual(len(ds_slice[sp.Coord.X]), len(
+        self.assertEqual(len(ds_slice[sc.Coord.X]), len(
             range(subset.start, subset.stop, subset.step)))
 
     def test_copy(self):
         import copy
         N = 6
         M = 4
-        d1 = sp.Dataset()
-        d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-        d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+        d1 = sc.Dataset()
+        d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+        d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
         arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
-        d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
-        s1 = d1[sp.Dim.X, 2:]
+        d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
+        s1 = d1[sc.Dim.X, 2:]
         s2 = copy.copy(s1)
         s3 = copy.deepcopy(s2)
         self.assertEqual(s1, s2)
         self.assertEqual(s3, s2)
         s2 *= s2
-        self.assertNotEqual(s1[sp.Data.Value, "A"], s2[sp.Data.Value, "A"])
-        self.assertNotEqual(s3[sp.Data.Value, "A"], s2[sp.Data.Value, "A"])
+        self.assertNotEqual(s1[sc.Data.Value, "A"], s2[sc.Data.Value, "A"])
+        self.assertNotEqual(s3[sc.Data.Value, "A"], s2[sc.Data.Value, "A"])
 
     def _apply_test_op_rhs_ds_slice(
         self,
@@ -96,10 +96,10 @@ class TestDatasetSlice(unittest.TestCase):
             rh_var_name="b"):
         # Assume numpy operations are correct as comparitor
         with np.errstate(invalid='ignore'):
-            op(data, b[sp.Data.Value, rh_var_name].numpy)
+            op(data, b[sc.Data.Value, rh_var_name].numpy)
         op(a, b)
         # Desired nan comparisons
-        np.testing.assert_equal(a[sp.Data.Value, lh_var_name].numpy, data)
+        np.testing.assert_equal(a[sc.Data.Value, lh_var_name].numpy, data)
 
     def _apply_test_op_rhs_variable(
         self,
@@ -113,46 +113,46 @@ class TestDatasetSlice(unittest.TestCase):
         op(data, b.numpy)
         op(a, b)
         # Desired nan comparisons
-        np.testing.assert_equal(a[sp.Data.Value, lh_var_name].numpy, data)
+        np.testing.assert_equal(a[sc.Data.Value, lh_var_name].numpy, data)
 
     def test_binary_slice_rhs_operations(self):
-        d = sp.Dataset()
-        d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-        d[sp.Data.Variance, "a"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-        d[sp.Data.Value, "b"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-        d[sp.Data.Variance, "b"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
+        d = sc.Dataset()
+        d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+        d[sc.Data.Variance, "a"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+        d[sc.Data.Value, "b"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+        d[sc.Data.Variance, "b"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
         a = d.subset["a"]
         b = d.subset["b"]
-        data = np.copy(a[sp.Data.Value, "a"].numpy)
-        variance = np.copy(a[sp.Data.Variance, "a"].numpy)
+        data = np.copy(a[sc.Data.Value, "a"].numpy)
+        variance = np.copy(a[sc.Data.Variance, "a"].numpy)
 
         c = a + b
         # Variables "a" and "b" added despite different names
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data + data))
+            c[sc.Data.Value, "a"].numpy, data + data))
         self.assertTrue(np.array_equal(
-            c[sp.Data.Variance, "a"].numpy, variance + variance))
+            c[sc.Data.Variance, "a"].numpy, variance + variance))
 
         c = a - b
         # Variables "a" and "b" subtracted despite different names
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data - data))
+            c[sc.Data.Value, "a"].numpy, data - data))
         self.assertTrue(np.array_equal(
-            c[sp.Data.Variance, "a"].numpy, variance + variance))
+            c[sc.Data.Variance, "a"].numpy, variance + variance))
 
         c = a * b
         # Variables "a" and "b" multiplied despite different names
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data * data))
+            c[sc.Data.Value, "a"].numpy, data * data))
         self.assertTrue(np.array_equal(
-            c[sp.Data.Variance, "a"].numpy, variance * (data * data) * 2))
+            c[sc.Data.Variance, "a"].numpy, variance * (data * data) * 2))
 
         c = a / b
         # Variables "a" and "b" divided despite different names
         with np.errstate(invalid='ignore'):
-            np.testing.assert_equal(c[sp.Data.Value, "a"].numpy, data / data)
-            np.testing.assert_equal(c[sp.Data.Variance, "a"].numpy,
+            np.testing.assert_equal(c[sc.Data.Value, "a"].numpy, data / data)
+            np.testing.assert_equal(c[sc.Data.Variance, "a"].numpy,
                                     2 * variance / (data * data))
 
         self._apply_test_op_rhs_ds_slice(operator.iadd, a, b, data)
@@ -162,27 +162,27 @@ class TestDatasetSlice(unittest.TestCase):
 
     def test_binary_variable_rhs_operations(self):
         data = np.ones(10, dtype='float64')
-        d = sp.Dataset()
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], data)
-        d[sp.Data.Variance, "a"] = ([sp.Dim.X], data)
-        a = d.subset[sp.Data.Value, "a"]
-        b_var = sp.Variable([sp.Dim.X], data)
+        d = sc.Dataset()
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], data)
+        d[sc.Data.Variance, "a"] = ([sc.Dim.X], data)
+        a = d.subset[sc.Data.Value, "a"]
+        b_var = sc.Variable([sc.Dim.X], data)
 
         c = a + b_var
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data + data))
+            c[sc.Data.Value, "a"].numpy, data + data))
 
         c = a - b_var
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data - data))
+            c[sc.Data.Value, "a"].numpy, data - data))
 
         c = a * b_var
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data * data))
+            c[sc.Data.Value, "a"].numpy, data * data))
 
         c = a / b_var
         with np.errstate(invalid='ignore'):
-            np.testing.assert_equal(c[sp.Data.Value, "a"].numpy, data / data)
+            np.testing.assert_equal(c[sc.Data.Value, "a"].numpy, data / data)
 
         self._apply_test_op_rhs_variable(operator.iadd, a, b_var, data)
         self._apply_test_op_rhs_variable(operator.isub, a, b_var, data)
@@ -190,38 +190,38 @@ class TestDatasetSlice(unittest.TestCase):
         self._apply_test_op_rhs_variable(operator.itruediv, a, b_var, data)
 
     def test_binary_float_operations(self):
-        d = sp.Dataset()
-        d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-        d[sp.Data.Value, "b"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
+        d = sc.Dataset()
+        d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+        d[sc.Data.Value, "b"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
         a = d.subset["a"]
         b = d.subset["b"]
-        data = np.copy(a[sp.Data.Value, "a"].numpy)
+        data = np.copy(a[sc.Data.Value, "a"].numpy)
 
         c = a + 2.0
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data + 2.0))
+            c[sc.Data.Value, "a"].numpy, data + 2.0))
         c = a - b
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data - data))
+            c[sc.Data.Value, "a"].numpy, data - data))
         c = a - 2.0
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data - 2.0))
+            c[sc.Data.Value, "a"].numpy, data - 2.0))
         c = a * 2.0
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data * 2.0))
+            c[sc.Data.Value, "a"].numpy, data * 2.0))
         c = a / 2.0
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data / 2.0))
+            c[sc.Data.Value, "a"].numpy, data / 2.0))
         c = 2.0 + a
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data + 2.0))
+            c[sc.Data.Value, "a"].numpy, data + 2.0))
         c = 2.0 - a
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, 2.0 - data))
+            c[sc.Data.Value, "a"].numpy, 2.0 - data))
         c = 2.0 * a
         self.assertTrue(np.array_equal(
-            c[sp.Data.Value, "a"].numpy, data * 2.0))
+            c[sc.Data.Value, "a"].numpy, data * 2.0))
 
         self._apply_test_op_rhs_ds_slice(operator.iadd, a, b, data)
         self._apply_test_op_rhs_ds_slice(operator.isub, a, b, data)
@@ -229,20 +229,20 @@ class TestDatasetSlice(unittest.TestCase):
         self._apply_test_op_rhs_ds_slice(operator.itruediv, a, b, data)
 
     def test_equal_not_equal(self):
-        d = sp.Dataset()
-        d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
-        d[sp.Data.Value, "b"] = ([sp.Dim.X], np.arange(10, dtype='float64'))
+        d = sc.Dataset()
+        d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
+        d[sc.Data.Value, "b"] = ([sc.Dim.X], np.arange(10, dtype='float64'))
         a = d.subset["a"]
         b = d.subset["b"]
         c = a + b
-        d2 = np.copy(a[sp.Data.Value, "a"].numpy)
-        d2 = d[sp.Dim.X, :]
+        d2 = np.copy(a[sc.Data.Value, "a"].numpy)
+        d2 = d[sc.Dim.X, :]
         a2 = d.subset["a"]
-        d3 = sp.Dataset()
-        d3[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d3[sp.Data.Value, "a"] = (
-            [sp.Dim.X], np.arange(1, 11, dtype='float64'))
+        d3 = sc.Dataset()
+        d3[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d3[sc.Data.Value, "a"] = (
+            [sc.Dim.X], np.arange(1, 11, dtype='float64'))
         a3 = d3.subset["a"]
         self.assertEqual(d, d2)
         self.assertEqual(d2, d)
@@ -253,34 +253,34 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertNotEqual(a, a3)
 
     def test_binary_ops_with_variable(self):
-        d = sp.Dataset()
-        d[sp.Coord.X] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Value, "a"] = ([sp.Dim.X], np.arange(10))
-        d[sp.Data.Variance, "a"] = ([sp.Dim.X], np.arange(10))
+        d = sc.Dataset()
+        d[sc.Coord.X] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Value, "a"] = ([sc.Dim.X], np.arange(10))
+        d[sc.Data.Variance, "a"] = ([sc.Dim.X], np.arange(10))
 
-        d += sp.Variable(2)
+        d += sc.Variable(2)
 
     def test_correct_temporaries(self):
         N = 6
         M = 4
-        d1 = sp.Dataset()
-        d1[sp.Coord.X] = ([sp.Dim.X], np.arange(N + 1).astype(np.float64))
-        d1[sp.Coord.Y] = ([sp.Dim.Y], np.arange(M + 1).astype(np.float64))
+        d1 = sc.Dataset()
+        d1[sc.Coord.X] = ([sc.Dim.X], np.arange(N + 1).astype(np.float64))
+        d1[sc.Coord.Y] = ([sc.Dim.Y], np.arange(M + 1).astype(np.float64))
         arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
-        d1[sp.Data.Value, "A"] = ([sp.Dim.X, sp.Dim.Y], arr1)
-        d1 = d1[sp.Dim.X, 1:2]
-        self.assertEqual(list(d1[sp.Data.Value, "A"].data), [
+        d1[sc.Data.Value, "A"] = ([sc.Dim.X, sc.Dim.Y], arr1)
+        d1 = d1[sc.Dim.X, 1:2]
+        self.assertEqual(list(d1[sc.Data.Value, "A"].data), [
                          5.0, 6.0, 7.0, 8.0])
 
     def test_set_dataset_slice_items(self):
         d = self._d.copy()
-        d[sp.Data.Value, "a"][sp.Dim.X, 0:2] += \
-            d[sp.Data.Value, "b"][sp.Dim.X, 1:3]
-        self.assertEqual(list(d[sp.Data.Value, "a"].data), [
+        d[sc.Data.Value, "a"][sc.Dim.X, 0:2] += \
+            d[sc.Data.Value, "b"][sc.Dim.X, 1:3]
+        self.assertEqual(list(d[sc.Data.Value, "a"].data), [
                          1, 3, 2, 3, 4, 5, 6, 7, 8, 9])
-        d[sp.Data.Value, "a"][sp.Dim.X, 6] += \
-            d[sp.Data.Value, "b"][sp.Dim.X, 8]
-        self.assertEqual(list(d[sp.Data.Value, "a"].data), [
+        d[sc.Data.Value, "a"][sc.Dim.X, 6] += \
+            d[sc.Data.Value, "b"][sc.Dim.X, 8]
+        self.assertEqual(list(d[sc.Data.Value, "a"].data), [
                          1, 3, 2, 3, 4, 5, 14, 7, 8, 9])
 
 

--- a/python/tests/test_dtype.py
+++ b/python/tests/test_dtype.py
@@ -5,12 +5,12 @@
 import pytest
 
 import numpy as np
-import scipp as sp
+import scipp as sc
 
 
 def test_dtype():
-    assert sp.dtype.int32 == sp.dtype.int32
-    assert sp.dtype.int32 != sp.dtype.int64
+    assert sc.dtype.int32 == sc.dtype.int32
+    assert sc.dtype.int32 != sc.dtype.int64
 
 
 @pytest.mark.skip(reason="Unfortunately the scipp dtype is currently not \
@@ -18,4 +18,4 @@ def test_dtype():
         strings which numpy cannot handle, so we cannot simply use \
         numpy.dtype.")
 def test_numpy_comparison():
-    assert sp.dtype.int32 == np.dtype(np.int32)
+    assert sc.dtype.int32 == np.dtype(np.int32)

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Neil Vaytet
-import scipp as sp
+import scipp as sc
 import numpy as np
 import io
 from contextlib import redirect_stdout
@@ -15,7 +15,7 @@ import pytest
 
 def do_plot(d, **kwargs):
     with io.StringIO() as buf, redirect_stdout(buf):
-        sp.plot(d, **kwargs)
+        sc.plot(d, **kwargs)
     return
 
 
@@ -29,104 +29,104 @@ def make_2d_dataset(variances=False):
     c = M / 2.0
     r = np.sqrt(((x - c) / b)**2 + ((y - c) / b)**2)
     a = np.sin(r)
-    d1 = sp.Dataset(
+    d1 = sc.Dataset(
         coords={
-            sp.Dim.X: sp.Variable([sp.Dim.X], values=xx, unit=sp.units.m),
-            sp.Dim.Y: sp.Variable([sp.Dim.Y], values=yy, unit=sp.units.m)
+            sc.Dim.X: sc.Variable([sc.Dim.X], values=xx, unit=sc.units.m),
+            sc.Dim.Y: sc.Variable([sc.Dim.Y], values=yy, unit=sc.units.m)
         })
     params = {"values": a}
     if variances:
         params["variances"] = np.random.rand(M, N) + (x == y)
-    d1["Sample"] = sp.Variable([sp.Dim.Y, sp.Dim.X],
-                               unit=sp.units.counts,
+    d1["Sample"] = sc.Variable([sc.Dim.Y, sc.Dim.X],
+                               unit=sc.units.counts,
                                **params)
     return d1
 
 
 def do_test_plot_1d(**kwargs):
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N).astype(np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
-                               unit=sp.units.counts)
+                               unit=sc.units.counts)
     do_plot(d1, **kwargs)
 
 
 def do_test_plot_1d_with_variances():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N).astype(np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N),
-                               unit=sp.units.counts)
+                               unit=sc.units.counts)
     do_plot(d1)
 
 
 def do_test_plot_1d_bin_edges():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N + 1).astype(
                                             np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
-                               unit=sp.units.counts)
+                               unit=sc.units.counts)
     do_plot(d1)
 
 
 def do_test_plot_1d_bin_edges_with_variances():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N + 1).astype(
                                             np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N),
-                               unit=sp.units.counts)
+                               unit=sc.units.counts)
     do_plot(d1)
 
 
 def do_test_plot_1d_two_entries():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     N = 100
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N).astype(np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
-                               unit=sp.units.counts)
-    d1["Background"] = sp.Variable([sp.Dim.Tof],
+                               unit=sc.units.counts)
+    d1["Background"] = sc.Variable([sc.Dim.Tof],
                                    values=2.0 * np.random.rand(N),
-                                   unit=sp.units.counts)
+                                   unit=sc.units.counts)
     do_plot(d1)
 
 
 def do_test_plot_1d_list_of_datasets():
     N = 100
-    d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1 = sc.Dataset()
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N).astype(np.float64),
-                                        unit=sp.units.us)
-    d1["Sample"] = sp.Variable([sp.Dim.Tof], values=10.0 * np.random.rand(N))
-    d1["Background"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof], values=10.0 * np.random.rand(N))
+    d1["Background"] = sc.Variable([sc.Dim.Tof],
                                    values=2.0 * np.random.rand(N))
-    d2 = sp.Dataset()
-    d2.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d2 = sc.Dataset()
+    d2.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N).astype(np.float64),
-                                        unit=sp.units.us)
-    d2["Sample"] = sp.Variable([sp.Dim.Tof],
+                                        unit=sc.units.us)
+    d2["Sample"] = sc.Variable([sc.Dim.Tof],
                                values=10.0 * np.random.rand(N),
                                variances=np.random.rand(N))
-    d2["Background"] = sp.Variable([sp.Dim.Tof],
+    d2["Background"] = sc.Variable([sc.Dim.Tof],
                                    values=2.0 * np.random.rand(N),
                                    variances=np.random.rand(N))
     do_plot([d1, d2])
@@ -139,7 +139,7 @@ def do_test_plot_2d_image():
 
 def do_test_plot_2d_image_with_axes():
     d1 = make_2d_dataset()
-    do_plot(d1, axes=[sp.Dim.X, sp.Dim.Y])
+    do_plot(d1, axes=[sc.Dim.X, sc.Dim.Y])
 
 
 def do_test_plot_2d_image_with_variances():
@@ -160,89 +160,89 @@ def do_test_plot_2d_image_with_variances_with_filename(fname):
 def do_test_plot_collapse():
     N = 100
     M = 5
-    d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1 = sc.Dataset()
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N + 1).astype(
                                             np.float64),
-                                        unit=sp.units.us)
-    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                        unit=sc.units.us)
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
                                       values=np.arange(M).astype(np.float64),
-                                      unit=sp.units.m)
-    d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
+                                      unit=sc.units.m)
+    d1["Sample"] = sc.Variable([sc.Dim.X, sc.Dim.Tof],
                                values=10.0 * np.random.rand(M, N),
                                variances=np.random.rand(M, N))
-    do_plot(d1, collapse=sp.Dim.Tof)
+    do_plot(d1, collapse=sc.Dim.Tof)
 
 
 def do_test_plot_waterfall():
     N = 100
     M = 5
-    d1 = sp.Dataset()
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1 = sc.Dataset()
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         values=np.arange(N + 1).astype(
                                             np.float64),
-                                        unit=sp.units.us)
-    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+                                        unit=sc.units.us)
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
                                       values=np.arange(M).astype(np.float64),
-                                      unit=sp.units.m)
-    d1["Sample"] = sp.Variable([sp.Dim.X, sp.Dim.Tof],
+                                      unit=sc.units.m)
+    d1["Sample"] = sc.Variable([sc.Dim.X, sc.Dim.Tof],
                                values=10.0 * np.random.rand(M, N),
                                variances=np.random.rand(M, N))
-    do_plot(d1, waterfall=sp.Dim.X)
+    do_plot(d1, waterfall=sc.Dim.X)
 
 
 def do_test_plot_sliceviewer():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
                                       np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
                                       np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
                                       np.arange(n3).astype(np.float64))
-    d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
                                    n3, n2, n1).astype(np.float64))
     do_plot(d1)
 
 
 def do_test_plot_sliceviewer_with_two_sliders():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     n1 = 20
     n2 = 30
     n3 = 40
     n4 = 50
-    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
                                       np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
                                       np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
                                       np.arange(n3).astype(np.float64))
-    d1.coords[sp.Dim.Tof] = sp.Variable([sp.Dim.Tof],
+    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
                                         np.arange(n4).astype(np.float64))
-    d1["Sample"] = sp.Variable([sp.Dim.Tof, sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+    d1["Sample"] = sc.Variable([sc.Dim.Tof, sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
                                values=np.arange(n1 * n2 * n3 * n4).reshape(
                                    n4, n3, n2, n1).astype(np.float64))
     do_plot(d1)
 
 
 def do_test_plot_sliceviewer_with_axes():
-    d1 = sp.Dataset()
+    d1 = sc.Dataset()
     n1 = 20
     n2 = 30
     n3 = 40
-    d1.coords[sp.Dim.X] = sp.Variable([sp.Dim.X],
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
                                       np.arange(n1).astype(np.float64))
-    d1.coords[sp.Dim.Y] = sp.Variable([sp.Dim.Y],
+    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
                                       np.arange(n2).astype(np.float64))
-    d1.coords[sp.Dim.Z] = sp.Variable([sp.Dim.Z],
+    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
                                       np.arange(n3).astype(np.float64))
-    d1["Sample"] = sp.Variable([sp.Dim.Z, sp.Dim.Y, sp.Dim.X],
+    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
                                values=np.arange(n1 * n2 * n3).reshape(
                                    n3, n2, n1).astype(np.float64))
-    do_plot(d1, axes=[sp.Dim.Y, sp.Dim.X, sp.Dim.Z])
+    do_plot(d1, axes=[sc.Dim.Y, sc.Dim.X, sc.Dim.Z])
 
 
 # Using plotly backend =======================================================
@@ -322,62 +322,62 @@ def test_plot_sliceviewer_with_axes():
 # Using matplotlib backend ====================================================
 
 def test_plot_1d_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d()
 
 
 def test_plot_1d_with_variances_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d_with_variances()
 
 
 def test_plot_1d_bin_edges_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d_bin_edges()
 
 
 def test_plot_1d_bin_edges_with_variances_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d_bin_edges_with_variances()
 
 
 def test_plot_1d_two_entries_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d_bin_edges_with_variances()
 
 
 def test_plot_1d_list_of_datasets_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_1d_list_of_datasets()
 
 
 def test_plot_2d_image_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_2d_image()
 
 
 def test_plot_2d_image_with_axes_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_2d_image_with_axes()
 
 
 def test_plot_2d_image_with_variances_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_2d_image_with_variances()
 
 
 def test_plot_2d_image_with_filename_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_2d_image_with_filename("image.pdf")
 
 
 def test_plot_2d_image_with_variances_with_filename_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_2d_image_with_variances_with_filename("val_and_var.pdf")
 
 
 def test_plot_collapse_mpl():
-    sp.plot_config.backend = "matplotlib"
+    sc.plot_config.backend = "matplotlib"
     do_test_plot_collapse()
 
 

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -3,91 +3,91 @@
 # @file
 # @author Neil Vaytet
 import numpy as np
-import scipp as sp
+import scipp as sc
 from scipp import Dim
 
 
 def test_dataset_with_1d_data():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
                                     values=np.arange(N).astype(np.float64))
-    d['Counts'] = sp.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
-    sp.table(d)
+    d['Counts'] = sc.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
+    sc.table(d)
 
 
 def test_dataset_with_1d_data_with_bin_edges():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Row] = sp.Variable([Dim.Row],
+    d.coords[Dim.Row] = sc.Variable([Dim.Row],
                                     values=np.arange(N + 1).astype(np.float64))
-    d['Counts'] = sp.Variable([Dim.Row], values=10.0 * np.random.rand(N))
-    sp.table(d)
+    d['Counts'] = sc.Variable([Dim.Row], values=10.0 * np.random.rand(N))
+    sc.table(d)
 
 
 def test_dataset_with_1d_data_with_variances():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
                                     values=np.arange(N).astype(np.float64))
-    d['Counts'] = sp.Variable([Dim.Tof],
+    d['Counts'] = sc.Variable([Dim.Tof],
                               values=10.0 * np.random.rand(N),
                               variances=np.random.rand(N))
-    sp.table(d)
+    sc.table(d)
 
 
 def test_dataset_with_1d_data_with_coord_variances():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
                                     values=np.arange(N).astype(np.float64),
                                     variances=0.1 * np.random.rand(N))
-    d['Counts'] = sp.Variable([Dim.Tof],
+    d['Counts'] = sc.Variable([Dim.Tof],
                               values=10.0 * np.random.rand(N),
                               variances=np.random.rand(N))
-    sp.table(d)
+    sc.table(d)
 
 
 def test_dataset_with_1d_data_with_units():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
                                     values=np.arange(N).astype(np.float64),
-                                    unit=sp.units.us,
+                                    unit=sc.units.us,
                                     variances=0.1 * np.random.rand(N))
-    d['Sample'] = sp.Variable([Dim.Tof],
+    d['Sample'] = sc.Variable([Dim.Tof],
                               values=10.0 * np.random.rand(N),
-                              unit=sp.units.m,
+                              unit=sc.units.m,
                               variances=np.random.rand(N))
-    sp.table(d)
+    sc.table(d)
 
 
 def test_dataset_with_0d_data():
-    d = sp.Dataset()
-    d['Scalar'] = sp.Variable(1.2)
-    sp.table(d)
+    d = sc.Dataset()
+    d['Scalar'] = sc.Variable(1.2)
+    sc.table(d)
 
 
 def test_dataset_with_everything():
-    d = sp.Dataset()
+    d = sc.Dataset()
     N = 10
-    d.coords[Dim.Tof] = sp.Variable([Dim.Tof],
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
                                     values=np.arange(N).astype(np.float64),
-                                    unit=sp.units.us,
+                                    unit=sc.units.us,
                                     variances=0.1 * np.random.rand(N))
-    d['Counts'] = sp.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
-    d['Sample'] = sp.Variable([Dim.Tof],
+    d['Counts'] = sc.Variable([Dim.Tof], values=10.0 * np.random.rand(N))
+    d['Sample'] = sc.Variable([Dim.Tof],
                               values=10.0 * np.random.rand(N),
-                              unit=sp.units.m,
+                              unit=sc.units.m,
                               variances=np.random.rand(N))
-    d['Scalar'] = sp.Variable(1.2)
-    sp.table(d)
+    d['Scalar'] = sc.Variable(1.2)
+    sc.table(d)
 
 
 def test_variable():
     N = 10
-    v = sp.Variable([Dim.Tof],
+    v = sc.Variable([Dim.Tof],
                     values=np.arange(N).astype(np.float64),
-                    unit=sp.units.us,
+                    unit=sc.units.us,
                     variances=0.1 * np.random.rand(N))
-    sp.table(v)
+    sc.table(v)

--- a/python/tests/test_units.py
+++ b/python/tests/test_units.py
@@ -4,36 +4,36 @@
 # @author Simon Heybrock
 import unittest
 
-import scipp as sp
+import scipp as sc
 import numpy as np
 
 
 class TestUnits(unittest.TestCase):
     def test_create_unit(self):
-        u = sp.units.angstrom
+        u = sc.units.angstrom
         self.assertEqual(repr(u), "\u212B")
 
     def test_variable_unit_repr(self):
-        var1 = sp.Variable([sp.Dim.X], values=np.arange(4))
-        u = sp.units.angstrom
+        var1 = sc.Variable([sc.Dim.X], values=np.arange(4))
+        u = sc.units.angstrom
         var1.unit = u
         self.assertEqual(repr(var1.unit), "\u212B")
-        var1.unit = sp.units.m * sp.units.m
+        var1.unit = sc.units.m * sc.units.m
         self.assertEqual(repr(var1.unit), "m^2")
-        var1.unit = sp.units.counts / sp.units.us
+        var1.unit = sc.units.counts / sc.units.us
         self.assertEqual(repr(var1.unit), "counts \u03BCs^-1")
         with self.assertRaisesRegex(RuntimeError, r"Unsupported unit as "
                                     r"result of division: \(counts\) / \(m\)"):
-            var1.unit = sp.units.counts / sp.units.m
-        var1.unit = sp.units.m / sp.units.m * sp.units.counts
+            var1.unit = sc.units.counts / sc.units.m
+        var1.unit = sc.units.m / sc.units.m * sc.units.counts
         self.assertEqual(repr(var1.unit), "counts")
-        # The statement below fails because (sp.units.counts * sp.units.m) is
+        # The statement below fails because (sc.units.counts * sc.units.m) is
         # performed first and is not part of the currently supported set of
-        # intermediate sp.units.
+        # intermediate sc.units.
         with self.assertRaisesRegex(RuntimeError, r"Unsupported unit as "
                                     r"result of multiplication: "
                                     r"\(counts\) \* \(m\)"):
-            var1.unit = sp.units.counts * sp.units.m / sp.units.m
+            var1.unit = sc.units.counts * sc.units.m / sc.units.m
 
 
 if __name__ == '__main__':

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -4,164 +4,164 @@
 # @author Simon Heybrock
 import pytest
 
-import scipp as sp
+import scipp as sc
 from scipp import Dim
 import numpy as np
 
 
 def make_variables():
     data = np.arange(1, 4, dtype=float)
-    a = sp.Variable([sp.Dim.X], data)
-    b = sp.Variable([sp.Dim.X], data)
-    a_slice = a[sp.Dim.X, :]
-    b_slice = b[sp.Dim.X, :]
+    a = sc.Variable([sc.Dim.X], data)
+    b = sc.Variable([sc.Dim.X], data)
+    a_slice = a[sc.Dim.X, :]
+    b_slice = b[sc.Dim.X, :]
     return a, b, a_slice, b_slice, data
 
 
 def test_create_default():
-    var = sp.Variable()
+    var = sc.Variable()
     assert var.dims == []
     assert var.sparse_dim is None
-    assert var.dtype == sp.dtype.double
-    assert var.unit == sp.units.dimensionless
+    assert var.dtype == sc.dtype.double
+    assert var.unit == sc.units.dimensionless
     assert var.value == 0.0
 
 
 def test_create_default_dtype():
-    var = sp.Variable([sp.Dim.X], [4])
-    assert var.dtype == sp.dtype.double
+    var = sc.Variable([sc.Dim.X], [4])
+    assert var.dtype == sc.dtype.double
 
 
 def test_create_with_dtype():
-    var = sp.Variable(dims=[Dim.X], shape=[2], dtype=sp.dtype.float)
-    assert var.dtype == sp.dtype.float
+    var = sc.Variable(dims=[Dim.X], shape=[2], dtype=sc.dtype.float)
+    assert var.dtype == sc.dtype.float
 
 
 def test_create_with_numpy_dtype():
-    var = sp.Variable(dims=[Dim.X], shape=[2], dtype=np.dtype(np.float32))
-    assert var.dtype == sp.dtype.float
+    var = sc.Variable(dims=[Dim.X], shape=[2], dtype=np.dtype(np.float32))
+    assert var.dtype == sc.dtype.float
 
 
 def test_create_with_variances():
-    assert sp.Variable(dims=[Dim.X], shape=[2]).variances is None
-    assert sp.Variable(dims=[Dim.X], shape=[2],
+    assert sc.Variable(dims=[Dim.X], shape=[2]).variances is None
+    assert sc.Variable(dims=[Dim.X], shape=[2],
                        variances=False).variances is None
-    assert sp.Variable(dims=[Dim.X], shape=[2],
+    assert sc.Variable(dims=[Dim.X], shape=[2],
                        variances=True).variances is not None
 
 
 def test_create_with_shape_and_variances():
     # If no values are given, variances must be Bool, cannot pass array.
     with pytest.raises(TypeError):
-        sp.Variable(dims=[Dim.X], shape=[2], variances=np.arange(2))
+        sc.Variable(dims=[Dim.X], shape=[2], variances=np.arange(2))
 
 
 def test_create_sparse():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
-    assert var.dtype == sp.dtype.double
-    assert var.sparse_dim == sp.Dim.Y
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
+    assert var.dtype == sc.dtype.double
+    assert var.sparse_dim == sc.Dim.Y
     assert len(var.values) == 4
     for vals in var.values:
         assert len(vals) == 0
 
 
 def test_create_from_numpy_1d():
-    var = sp.Variable([sp.Dim.X], np.arange(4.0))
-    assert var.dtype == sp.dtype.double
+    var = sc.Variable([sc.Dim.X], np.arange(4.0))
+    assert var.dtype == sc.dtype.double
     np.testing.assert_array_equal(var.values, np.arange(4))
 
 
 def test_create_from_numpy_1d_bool():
-    var = sp.Variable(dims=[sp.Dim.X], values=np.array([True, False, True]))
-    assert var.dtype == sp.dtype.bool
+    var = sc.Variable(dims=[sc.Dim.X], values=np.array([True, False, True]))
+    assert var.dtype == sc.dtype.bool
     np.testing.assert_array_equal(var.values, np.array([True, False, True]))
 
 
 def test_create_with_variances_from_numpy_1d():
-    var = sp.Variable([sp.Dim.X],
+    var = sc.Variable([sc.Dim.X],
                       values=np.arange(4.0),
                       variances=np.arange(4.0, 8.0))
-    assert var.dtype == sp.dtype.double
+    assert var.dtype == sc.dtype.double
     np.testing.assert_array_equal(var.values, np.arange(4))
     np.testing.assert_array_equal(var.variances, np.arange(4, 8))
 
 
 def test_create_scalar():
-    var = sp.Variable(1.2)
+    var = sc.Variable(1.2)
     assert var.value == 1.2
     assert var.dims == []
-    assert var.dtype == sp.dtype.double
-    assert var.unit == sp.units.dimensionless
+    assert var.dtype == sc.dtype.double
+    assert var.unit == sc.units.dimensionless
 
 
 def test_create_scalar_Dataset():
-    dataset = sp.Dataset({'a': sp.Variable([sp.Dim.X], np.arange(4.0))})
-    var = sp.Variable(dataset)
+    dataset = sc.Dataset({'a': sc.Variable([sc.Dim.X], np.arange(4.0))})
+    var = sc.Variable(dataset)
     assert var.value == dataset
     assert var.dims == []
-    assert var.dtype == sp.dtype.Dataset
-    assert var.unit == sp.units.dimensionless
+    assert var.dtype == sc.dtype.Dataset
+    assert var.unit == sc.units.dimensionless
 
 
 def test_create_scalar_quantity():
-    var = sp.Variable(1.2, unit=sp.units.m)
+    var = sc.Variable(1.2, unit=sc.units.m)
     assert var.value == 1.2
     assert var.dims == []
-    assert var.dtype == sp.dtype.double
-    assert var.unit == sp.units.m
+    assert var.dtype == sc.dtype.double
+    assert var.unit == sc.units.m
 
 
 def test_create_via_unit():
-    expected = sp.Variable(1.2, unit=sp.units.m)
-    var = 1.2 * sp.units.m
+    expected = sc.Variable(1.2, unit=sc.units.m)
+    var = 1.2 * sc.units.m
     assert var == expected
 
 
 def test_create_1D_string():
-    var = sp.Variable(dims=[Dim.Row], values=['a', 'bb'], unit=sp.units.m)
+    var = sc.Variable(dims=[Dim.Row], values=['a', 'bb'], unit=sc.units.m)
     assert len(var.values) == 2
     assert var.values[0] == 'a'
     assert var.values[1] == 'bb'
     assert var.dims == [Dim.Row]
-    assert var.dtype == sp.dtype.string
-    assert var.unit == sp.units.m
+    assert var.dtype == sc.dtype.string
+    assert var.unit == sc.units.m
 
 
 def test_create_1D_vector_3_double():
-    var = sp.Variable(dims=[Dim.X],
+    var = sc.Variable(dims=[Dim.X],
                       values=[[1, 2, 3], [4, 5, 6]],
-                      unit=sp.units.m)
+                      unit=sc.units.m)
     assert len(var.values) == 2
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
     assert var.dims == [Dim.X]
-    assert var.dtype == sp.dtype.vector_3_double
-    assert var.unit == sp.units.m
+    assert var.dtype == sc.dtype.vector_3_double
+    assert var.unit == sc.units.m
 
 
 def test_create_2D_inner_size_3():
-    var = sp.Variable(dims=[Dim.X, Dim.Y],
+    var = sc.Variable(dims=[Dim.X, Dim.Y],
                       values=np.arange(6.0).reshape(2, 3),
-                      unit=sp.units.m)
+                      unit=sc.units.m)
     assert var.shape == [2, 3]
     np.testing.assert_array_equal(var.values[0], [0, 1, 2])
     np.testing.assert_array_equal(var.values[1], [3, 4, 5])
     assert var.dims == [Dim.X, Dim.Y]
-    assert var.dtype == sp.dtype.double
-    assert var.unit == sp.units.m
+    assert var.dtype == sc.dtype.double
+    assert var.unit == sc.units.m
 
 
 def test_operation_with_scalar_quantity():
-    reference = sp.Variable([sp.Dim.X], np.arange(4.0) * 1.5)
-    reference.unit = sp.units.kg
+    reference = sc.Variable([sc.Dim.X], np.arange(4.0) * 1.5)
+    reference.unit = sc.units.kg
 
-    var = sp.Variable([sp.Dim.X], np.arange(4.0))
-    var *= sp.Variable(1.5, unit=sp.units.kg)
+    var = sc.Variable([sc.Dim.X], np.arange(4.0))
+    var *= sc.Variable(1.5, unit=sc.units.kg)
     assert var == reference
 
 
 def test_0D_scalar_access():
-    var = sp.Variable()
+    var = sc.Variable()
     assert var.value == 0.0
     var.value = 1.2
     assert var.value == 1.2
@@ -170,14 +170,14 @@ def test_0D_scalar_access():
 
 
 def test_0D_scalar_string():
-    var = sp.Variable(value='a')
+    var = sc.Variable(value='a')
     assert var.value == 'a'
     var.value = 'b'
-    assert var == sp.Variable(value='b')
+    assert var == sc.Variable(value='b')
 
 
 def test_1D_scalar_access_fail():
-    var = sp.Variable([Dim.X], (1, ))
+    var = sc.Variable([Dim.X], (1, ))
     with pytest.raises(RuntimeError):
         assert var.value == 0.0
     with pytest.raises(RuntimeError):
@@ -185,7 +185,7 @@ def test_1D_scalar_access_fail():
 
 
 def test_1D_access():
-    var = sp.Variable([Dim.X], (2, ))
+    var = sc.Variable([Dim.X], (2, ))
     assert len(var.values) == 2
     assert var.values.shape == (2, )
     var.values[1] = 1.2
@@ -193,44 +193,44 @@ def test_1D_access():
 
 
 def test_1D_set_from_list():
-    var = sp.Variable([Dim.X], (2, ))
+    var = sc.Variable([Dim.X], (2, ))
     var.values = [1.0, 2.0]
-    assert var == sp.Variable([Dim.X], values=[1.0, 2.0])
+    assert var == sc.Variable([Dim.X], values=[1.0, 2.0])
 
 
 def test_1D_string():
-    var = sp.Variable([Dim.X], values=['a', 'b'])
+    var = sc.Variable([Dim.X], values=['a', 'b'])
     assert len(var.values) == 2
     assert var.values[0] == 'a'
     assert var.values[1] == 'b'
     var.values = ['c', 'd']
-    assert var == sp.Variable([Dim.X], values=['c', 'd'])
+    assert var == sc.Variable([Dim.X], values=['c', 'd'])
 
 
 def test_1D_converting():
-    var = sp.Variable([Dim.X], values=[1, 2])
+    var = sc.Variable([Dim.X], values=[1, 2])
     var.values = [3.3, 4.6]
     # floats get truncated
-    assert var == sp.Variable([Dim.X], values=[3, 4])
+    assert var == sc.Variable([Dim.X], values=[3, 4])
 
 
 def test_1D_dataset():
-    var = sp.Variable([Dim.X], shape=(2, ), dtype=sp.dtype.Dataset)
-    d1 = sp.Dataset({'a': 1.5 * sp.units.m})
-    d2 = sp.Dataset({'a': 2.5 * sp.units.m})
+    var = sc.Variable([Dim.X], shape=(2, ), dtype=sc.dtype.Dataset)
+    d1 = sc.Dataset({'a': 1.5 * sc.units.m})
+    d2 = sc.Dataset({'a': 2.5 * sc.units.m})
     var.values = [d1, d2]
     assert var.values[0] == d1
     assert var.values[1] == d2
 
 
 def test_1D_access_bad_shape_fail():
-    var = sp.Variable([Dim.X], (2, ))
+    var = sc.Variable([Dim.X], (2, ))
     with pytest.raises(RuntimeError):
         var.values = np.arange(3)
 
 
 def test_2D_access():
-    var = sp.Variable([Dim.X, Dim.Y], (2, 3))
+    var = sc.Variable([Dim.X, Dim.Y], (2, 3))
     assert var.values.shape == (2, 3)
     assert len(var.values) == 2
     assert len(var.values[0]) == 3
@@ -242,13 +242,13 @@ def test_2D_access():
 
 
 def test_2D_access_bad_shape_fail():
-    var = sp.Variable([Dim.X, Dim.Y], (2, 3))
+    var = sc.Variable([Dim.X, Dim.Y], (2, 3))
     with pytest.raises(RuntimeError):
         var.values = np.ones(shape=(3, 2))
 
 
 def test_2D_access_variances():
-    var = sp.Variable([Dim.X, Dim.Y], (2, 3), variances=True)
+    var = sc.Variable([Dim.X, Dim.Y], (2, 3), variances=True)
     assert var.values.shape == (2, 3)
     assert var.variances.shape == (2, 3)
     var.values[1] = 1.2
@@ -258,7 +258,7 @@ def test_2D_access_variances():
 
 
 def test_sparse_slice():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
     vals0 = var[Dim.X, 0].values
     assert len(vals0) == 0
     vals0.append(1.2)
@@ -266,67 +266,67 @@ def test_sparse_slice():
 
 
 def test_sparse_setitem():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
 
 
 def test_sparse_setitem_sparse_fail():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
     with pytest.raises(RuntimeError):
         var.values = np.arange(3)
 
 
 def test_sparse_setitem_shape_fail():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse])
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
     with pytest.raises(RuntimeError):
         var[Dim.X, 0].values = np.ones(shape=(3, 2))
 
 
 def test_sparse_setitem_float():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse],
-                      dtype=sp.dtype.float)
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse],
+                      dtype=sc.dtype.float)
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
 
 
 def test_sparse_setitem_int64_t():
-    var = sp.Variable([sp.Dim.X, sp.Dim.Y], [4, sp.Dimensions.Sparse],
-                      dtype=sp.dtype.int64)
+    var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse],
+                      dtype=sc.dtype.int64)
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
 
 
 def test_create_dtype():
-    var = sp.Variable([Dim.X], values=np.arange(4))
-    assert var.dtype == sp.dtype.int64
-    var = sp.Variable([Dim.X], values=np.arange(4).astype(np.int32))
-    assert var.dtype == sp.dtype.int32
-    var = sp.Variable([Dim.X], values=np.arange(4).astype(np.float64))
-    assert var.dtype == sp.dtype.double
-    var = sp.Variable([Dim.X], values=np.arange(4).astype(np.float32))
-    assert var.dtype == sp.dtype.float
-    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.float64))
-    assert var.dtype == sp.dtype.double
-    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.float32))
-    assert var.dtype == sp.dtype.float
-    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.int64))
-    assert var.dtype == sp.dtype.int64
-    var = sp.Variable([Dim.X], (4, ), dtype=np.dtype(np.int32))
-    assert var.dtype == sp.dtype.int32
+    var = sc.Variable([Dim.X], values=np.arange(4))
+    assert var.dtype == sc.dtype.int64
+    var = sc.Variable([Dim.X], values=np.arange(4).astype(np.int32))
+    assert var.dtype == sc.dtype.int32
+    var = sc.Variable([Dim.X], values=np.arange(4).astype(np.float64))
+    assert var.dtype == sc.dtype.double
+    var = sc.Variable([Dim.X], values=np.arange(4).astype(np.float32))
+    assert var.dtype == sc.dtype.float
+    var = sc.Variable([Dim.X], (4, ), dtype=np.dtype(np.float64))
+    assert var.dtype == sc.dtype.double
+    var = sc.Variable([Dim.X], (4, ), dtype=np.dtype(np.float32))
+    assert var.dtype == sc.dtype.float
+    var = sc.Variable([Dim.X], (4, ), dtype=np.dtype(np.int64))
+    assert var.dtype == sc.dtype.int64
+    var = sc.Variable([Dim.X], (4, ), dtype=np.dtype(np.int32))
+    assert var.dtype == sc.dtype.int32
 
 
 def test_get_slice():
-    var = sp.Variable([Dim.X, Dim.Y], values=np.arange(0, 8).reshape(2, 4))
+    var = sc.Variable([Dim.X, Dim.Y], values=np.arange(0, 8).reshape(2, 4))
     var_slice = var[Dim.X, 1:2]
-    assert var_slice == sp.Variable([Dim.X, Dim.Y],
+    assert var_slice == sc.Variable([Dim.X, Dim.Y],
                                     values=np.arange(4, 8).reshape(1, 4))
 
 
 def test_slicing():
-    var = sp.Variable([sp.Dim.X], values=np.arange(0, 3))
-    var_slice = var[(sp.Dim.X, slice(0, 2))]
-    assert isinstance(var_slice, sp.VariableProxy)
+    var = sc.Variable([sc.Dim.X], values=np.arange(0, 3))
+    var_slice = var[(sc.Dim.X, slice(0, 2))]
+    assert isinstance(var_slice, sc.VariableProxy)
     assert len(var_slice.values) == 2
     assert np.array_equal(var_slice.values, np.array([0, 1]))
 
@@ -394,7 +394,7 @@ def test_binary_divide():
 
 
 def test_in_place_binary_with_scalar():
-    v = sp.Variable([Dim.X], values=[10])
+    v = sc.Variable([Dim.X], values=[10])
     copy = v.copy()
 
     v += 2
@@ -424,74 +424,74 @@ def test_binary_not_equal():
 
 
 def test_abs():
-    var = sp.Variable([Dim.X], values=np.array([0.1, -0.2]), unit=sp.units.m)
-    expected = sp.Variable([Dim.X],
+    var = sc.Variable([Dim.X], values=np.array([0.1, -0.2]), unit=sc.units.m)
+    expected = sc.Variable([Dim.X],
                            values=np.array([0.1, 0.2]),
-                           unit=sp.units.m)
-    assert sp.abs(var) == expected
+                           unit=sc.units.m)
+    assert sc.abs(var) == expected
 
 
 def test_dot():
-    a = sp.Variable(dims=[Dim.X],
+    a = sc.Variable(dims=[Dim.X],
                     values=[[1, 0, 0], [0, 1, 0]],
-                    unit=sp.units.m)
-    b = sp.Variable(dims=[Dim.X],
+                    unit=sc.units.m)
+    b = sc.Variable(dims=[Dim.X],
                     values=[[1, 0, 0], [1, 0, 0]],
-                    unit=sp.units.m)
-    expected = sp.Variable([Dim.X],
+                    unit=sc.units.m)
+    expected = sc.Variable([Dim.X],
                            values=np.array([1.0, 0.0]),
-                           unit=sp.units.m**2)
-    assert sp.dot(a, b) == expected
+                           unit=sc.units.m**2)
+    assert sc.dot(a, b) == expected
 
 
 def test_concatenate():
-    var = sp.Variable([Dim.X], values=np.array([0.1, 0.2]), unit=sp.units.m)
-    expected = sp.Variable([sp.Dim.X],
+    var = sc.Variable([Dim.X], values=np.array([0.1, 0.2]), unit=sc.units.m)
+    expected = sc.Variable([sc.Dim.X],
                            values=np.array([0.1, 0.2, 0.1, 0.2]),
-                           unit=sp.units.m)
-    assert sp.concatenate(var, var, Dim.X) == expected
+                           unit=sc.units.m)
+    assert sc.concatenate(var, var, Dim.X) == expected
 
 
 def test_mean():
-    var = sp.Variable([Dim.X, Dim.Y],
+    var = sc.Variable([Dim.X, Dim.Y],
                       values=np.array([[0.1, 0.3], [0.2, 0.6]]),
-                      unit=sp.units.m)
-    expected = sp.Variable([Dim.X],
+                      unit=sc.units.m)
+    expected = sc.Variable([Dim.X],
                            values=np.array([0.2, 0.4]),
-                           unit=sp.units.m)
-    assert sp.mean(var, Dim.Y) == expected
+                           unit=sc.units.m)
+    assert sc.mean(var, Dim.Y) == expected
 
 
 def test_norm():
-    var = sp.Variable(dims=[Dim.X],
+    var = sc.Variable(dims=[Dim.X],
                       values=[[1, 0, 0], [3, 4, 0]],
-                      unit=sp.units.m)
-    expected = sp.Variable([Dim.X],
+                      unit=sc.units.m)
+    expected = sc.Variable([Dim.X],
                            values=np.array([1.0, 5.0]),
-                           unit=sp.units.m)
-    assert sp.norm(var) == expected
+                           unit=sc.units.m)
+    assert sc.norm(var) == expected
 
 
 def test_sqrt():
-    var = sp.Variable([Dim.X], values=np.array([4.0, 9.0]), unit=sp.units.m**2)
-    expected = sp.Variable([Dim.X],
+    var = sc.Variable([Dim.X], values=np.array([4.0, 9.0]), unit=sc.units.m**2)
+    expected = sc.Variable([Dim.X],
                            values=np.array([2.0, 3.0]),
-                           unit=sp.units.m)
-    assert sp.sqrt(var) == expected
+                           unit=sc.units.m)
+    assert sc.sqrt(var) == expected
 
 
 def test_sum():
-    var = sp.Variable([Dim.X, Dim.Y],
+    var = sc.Variable([Dim.X, Dim.Y],
                       values=np.array([[0.1, 0.3], [0.2, 0.6]]),
-                      unit=sp.units.m)
-    expected = sp.Variable([Dim.X],
+                      unit=sc.units.m)
+    expected = sc.Variable([Dim.X],
                            values=np.array([0.4, 0.8]),
-                           unit=sp.units.m)
-    assert sp.sum(var, Dim.Y) == expected
+                           unit=sc.units.m)
+    assert sc.sum(var, Dim.Y) == expected
 
 
 def test_variance_acess():
-    v = sp.Variable()
+    v = sc.Variable()
     assert v.variance is None
     assert v.variances is None
 
@@ -499,8 +499,8 @@ def test_variance_acess():
 def test_set_variance():
     values = np.random.rand(2, 3)
     variances = np.random.rand(2, 3)
-    var = sp.Variable(dims=[Dim.X, Dim.Y], values=values)
-    expected = sp.Variable(dims=[Dim.X, Dim.Y],
+    var = sc.Variable(dims=[Dim.X, Dim.Y], values=values)
+    expected = sc.Variable(dims=[Dim.X, Dim.Y],
                            values=values,
                            variances=variances)
 
@@ -516,8 +516,8 @@ def test_set_variance():
 def test_copy_variance():
     values = np.random.rand(2, 3)
     variances = np.random.rand(2, 3)
-    var = sp.Variable(dims=[Dim.X, Dim.Y], values=values)
-    expected = sp.Variable(dims=[Dim.X, Dim.Y],
+    var = sc.Variable(dims=[Dim.X, Dim.Y], values=values)
+    expected = sc.Variable(dims=[Dim.X, Dim.Y],
                            values=values,
                            variances=variances)
 
@@ -534,8 +534,8 @@ def test_set_variance_convert_dtype():
     values = np.random.rand(2, 3)
     variances = np.arange(6).reshape(2, 3)
     assert variances.dtype == np.int
-    var = sp.Variable(dims=[Dim.X, Dim.Y], values=values)
-    expected = sp.Variable(dims=[Dim.X, Dim.Y],
+    var = sc.Variable(dims=[Dim.X, Dim.Y], values=values)
+    expected = sc.Variable(dims=[Dim.X, Dim.Y],
                            values=values,
                            variances=variances)
 
@@ -549,41 +549,41 @@ def test_set_variance_convert_dtype():
 
 
 def test_sum_mean():
-    var = sp.Variable([Dim.X], values=np.ones(5).astype(np.int64))
-    assert sp.sum(var, Dim.X) == sp.Variable(5)
-    var = sp.Variable([Dim.X], values=np.arange(6).astype(np.int64))
-    assert sp.mean(var, Dim.X) == sp.Variable(2.5)
+    var = sc.Variable([Dim.X], values=np.ones(5).astype(np.int64))
+    assert sc.sum(var, Dim.X) == sc.Variable(5)
+    var = sc.Variable([Dim.X], values=np.arange(6).astype(np.int64))
+    assert sc.mean(var, Dim.X) == sc.Variable(2.5)
 
 
 def test_make_variable_from_unit_scalar_mult_div():
-    var = sp.Variable()
-    var.unit = sp.units.m
-    assert var == 0.0 * sp.units.m
-    var.unit = sp.units.m**(-1)
-    assert var == 0.0 / sp.units.m
+    var = sc.Variable()
+    var.unit = sc.units.m
+    assert var == 0.0 * sc.units.m
+    var.unit = sc.units.m**(-1)
+    assert var == 0.0 / sc.units.m
 
-    var = sp.Variable(np.float32())
-    var.unit = sp.units.m
-    assert var == np.float32(0.0) * sp.units.m
-    var.unit = sp.units.m**(-1)
-    assert var == np.float32(0.0) / sp.units.m
+    var = sc.Variable(np.float32())
+    var.unit = sc.units.m
+    assert var == np.float32(0.0) * sc.units.m
+    var.unit = sc.units.m**(-1)
+    assert var == np.float32(0.0) / sc.units.m
 
 
 def test_construct_0d_numpy():
-    v = sp.Variable([sp.Dim.X], values=np.array([0]), dtype=np.float32)
-    var = sp.Variable(v[sp.Dim.X, 0])
-    assert var == sp.Variable(np.float32())
+    v = sc.Variable([sc.Dim.X], values=np.array([0]), dtype=np.float32)
+    var = sc.Variable(v[sc.Dim.X, 0])
+    assert var == sc.Variable(np.float32())
 
 
 def test_construct_0d_native_python_types():
-    assert sp.Variable(2).dtype == sp.dtype.int64
-    assert sp.Variable(2.0).dtype == sp.dtype.double
-    assert sp.Variable(True).dtype == sp.dtype.bool
+    assert sc.Variable(2).dtype == sc.dtype.int64
+    assert sc.Variable(2.0).dtype == sc.dtype.double
+    assert sc.Variable(True).dtype == sc.dtype.bool
 
 
 def test_rename_dims():
     values = np.arange(6).reshape(2, 3)
-    xy = sp.Variable(dims=[Dim.X, Dim.Y], values=values)
-    zy = sp.Variable(dims=[Dim.Z, Dim.Y], values=values)
+    xy = sc.Variable(dims=[Dim.X, Dim.Y], values=values)
+    zy = sc.Variable(dims=[Dim.Z, Dim.Y], values=values)
     xy.rename_dims({Dim.X: Dim.Z})
     assert xy == zy

--- a/python/tests/test_variable_proxy.py
+++ b/python/tests/test_variable_proxy.py
@@ -2,16 +2,16 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
-import scipp as sp
+import scipp as sc
 from scipp import Dim
 import numpy as np
 import operator
 
 
 def test_type():
-    variable_slice = sp.Variable(
+    variable_slice = sc.Variable(
         [Dim.X], np.arange(1, 10, dtype=float))[Dim.X, :]
-    assert type(variable_slice) == sp.VariableProxy
+    assert type(variable_slice) == sc.VariableProxy
 
 
 def apply_test_op(op, a, b, data):
@@ -22,14 +22,14 @@ def apply_test_op(op, a, b, data):
 
 
 def test_binary_operations():
-    _a = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
-    _b = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
+    _a = sc.Variable([Dim.X], np.arange(1, 10, dtype=float))
+    _b = sc.Variable([Dim.X], np.arange(1, 10, dtype=float))
     a = _a[Dim.X, :]
     b = _b[Dim.X, :]
 
     data = np.copy(a.values)
     c = a + b
-    assert type(c) == sp.Variable
+    assert type(c) == sc.Variable
     assert np.array_equal(c.values, data + data)
     c = a - b
     assert np.array_equal(c.values, data - data)
@@ -45,7 +45,7 @@ def test_binary_operations():
 
 
 def test_binary_float_operations():
-    _a = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
+    _a = sc.Variable([Dim.X], np.arange(1, 10, dtype=float))
     a = _a[Dim.X, :]
     data = np.copy(a.values)
     c = a + 2.0
@@ -65,8 +65,8 @@ def test_binary_float_operations():
 
 
 def test_equal_not_equal():
-    _a = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
-    _b = sp.Variable([Dim.X], np.arange(1, 10, dtype=float))
+    _a = sc.Variable([Dim.X], np.arange(1, 10, dtype=float))
+    _b = sc.Variable([Dim.X], np.arange(1, 10, dtype=float))
     a = _a[Dim.X, :]
     b = _b[Dim.X, :]
     c = a + 2.0
@@ -77,8 +77,8 @@ def test_equal_not_equal():
 
 
 def test_correct_temporaries():
-    v = sp.Variable([Dim.X], values=np.arange(100.0))
-    b = sp.sqrt(v)[Dim.X, 0:10]
+    v = sc.Variable([Dim.X], values=np.arange(100.0))
+    b = sc.sqrt(v)[Dim.X, 0:10]
     assert len(b.values) == 10
     b = b[Dim.X, 2:5]
     assert len(b.values) == 3


### PR DESCRIPTION
The `sc` alias is used in the jupyter notebook tutorials, and most of the tests.
This PR makes it so it is used in ALL of the tests and Python files.