### PR TITLE
Update of Python table implementation

### DIFF
--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -80,6 +80,24 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
   c.def("__contains__", &T::contains);
   c.def("copy", [](const T &self) { return Dataset(self); },
         "Return a (deep) copy.");
+  c.def_property_readonly("dims",
+                          [](const T &self) {
+                            std::unordered_map<Dim, scipp::index> dims;
+                            for (const auto dim : self.dimensions()) {
+                              dims[dim.first] = dim.second;
+                            }
+                            return dims;
+                          },
+                          R"(Dict of dimensions.)",
+                          py::return_value_policy::move,
+                          py::keep_alive<0, 1>());
+  // c.def_property_readonly(
+  //     "dims",
+  //     py::cpp_function([](T &self) { return self.dimensions(); },
+  //                      py::return_value_policy::move, py::keep_alive<0,
+  //                      1>()),
+  //     R"(
+  //     Dict of dimensions.)");
 }
 
 template <class T, class... Ignored>

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -38,11 +38,14 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
     # Declare table
     html = "<table style='border-collapse: collapse;'>"
     dims = dataset.dims
-    size = None
+    coord_dim = size = coord = None
+    # size = None
     if len(dims) > 0:
         # Get first key in dict
         coord_dim = next(iter(dims))
         size = dims[coord_dim]
+        if len(dataset.coords) > 0:
+            coord = dataset.coords[coord_dim]
     # for key, val in dataset:
     #     print("shape", val.shape, len(val.shape))
     #     if len(val.shape) > 0:
@@ -57,7 +60,7 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
         # if coord_dim is not None:
         if len(dataset.coords) > 0:
             # coord_dim = next(iter(dataset.dims))
-            coord = dataset.coords[coord_dim]
+            # coord = dataset.coords[coord_dim]
             html += "<th {} colspan='{}'>Coord: {}</th>".format(
                 cstyle.replace("style='", "style='text-align: center;"),
                 1 + (coord.variances is not None), axis_label(coord))
@@ -106,7 +109,7 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
                     if is_hist:
                         text = '[{}; {}]'.format(
                             text, value_to_string(coord.variances[i + 1]))
-                    html += "< {}td>{}</td>".format(bstyle, text)
+                    html += "<td {}>{}</td>".format(bstyle, text)
             for key, val in dataset:
                 html += "<td {}>{}</td>".format(bstyle,
                                                 value_to_string(val.values[i]))
@@ -190,8 +193,8 @@ def table(dataset):
             #         tabledict["1D Variables"][key] = sc.Dataset(**temp_dict)
             #     else:
             #         tabledict["1D Variables"][key][name] = var
-            # else:
-            #     tabledict["0D Variables"][name] = var
+            elif len(var.dims) == 0:
+                tabledict["0D Variables"][name] = var
         # print("==================")
         # print(tabledict["1D Variables"])
         # print("==================")
@@ -245,6 +248,7 @@ def table(dataset):
 
     elif (tp is sc.DataArray) or (tp is sc.DataProxy) or (
             tp is sc.Variable) or (tp is sc.VariableProxy):
+        print(tp)
         try:
             key = dataset.name
         except AttributeError:
@@ -254,12 +258,13 @@ def table(dataset):
             if len(dataset.coords) > 0:
                 coord_def = dataset.dims[0]
     else:
-        tabledict["default"][""] = sc.Variable([sc.Dim.X], values=dataset)
+        tabledict["default"][""] = sc.Variable([sc.Dim.Row], values=dataset)
         headers = False
 
     subtitle = "<h6 style='font-weight: normal; color: grey'>"
     output = ""
     if len(tabledict["default"]) > 0:
+        print(tabledict["default"])
         output += table_from_dataset(tabledict["default"],
                                      # coord_dim=coord_def,
                                      headers=headers)

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -21,18 +21,10 @@ def value_to_string(val, precision=3):
 
 
 def table_from_dataset(dataset, is_hist=False, headers=True):
-    # border style
+
     bstyle = "style='border: 1px solid black;"
     cstyle = bstyle + "background-color: #adf3e0;'"
     lstyle = bstyle + "background-color: #d9c0fa;'"
-    # cstyle = [
-    #     bstyle + "background-color: #adf3e0;'",
-    #     bstyle + "background-color: #b9ffec;'"
-    # ]
-    # lstyle = [
-    #     bstyle + "background-color: #d9c0fa;'",
-    #     bstyle + "background-color: #ecdeff;'"
-    # ]
     bstyle += "'"
     estyle = "style='border: 0px solid white;background-color: #ffffff;'"
 
@@ -40,7 +32,6 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
     html = "<table style='border-collapse: collapse;'>"
     dims = dataset.dims
     dataset_dim = size = coord = None
-    # size = None
     if len(dims) > 0:
         # Get first key in dict
         dataset_dim = next(iter(dims))
@@ -49,22 +40,10 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
             coord = dataset.coords[dataset_dim]
             if is_hist:
                 size += 1
-    # for key, val in dataset:
-    #     print("shape", val.shape, len(val.shape))
-    #     if len(val.shape) > 0:
-    #         size = val.shape[0]
-    #     else:
-    #         size = None
-    # # Get first key in dict
-    # dataset_dim = next(iter(dataset.dims))
-    # Table headers
-    print(size, is_hist)
+
     if headers:
         html += "<tr>"
-        # if dataset_dim is not None:
         if coord is not None:
-            # dataset_dim = next(iter(dataset.dims))
-            # coord = dataset.coords[dataset_dim]
             html += "<th {} colspan='{}'>Coord: {}</th>".format(
                 cstyle.replace("style='", "style='text-align: center;"),
                 1 + (coord.variances is not None), axis_label(coord))
@@ -73,7 +52,6 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
                 bstyle.replace("style='", "style='text-align: center;"),
                 1 + (val.variances is not None), axis_label(val, name=key))
         for key, lab in dataset.labels:
-            print(lab.dims,dataset_dim)
             if lab.dims[0] == dataset_dim:
                 html += "<th {}>{}</th>".format(
                     lstyle.replace("style='", "style='text-align: center;"),
@@ -100,35 +78,16 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
                                                 value_to_string(val.variance))
         html += "</tr>"
     else:
-        # if is_hist:
-        #     td_open = "<td rowspan='2' "
-        # else:
-        #     td_open = "<td "
         for i in range(size):
             html += '<tr style="font-weight:normal">'
+            # Add coordinates
             if coord is not None:
                 text = value_to_string(coord.values[i])
-                # if is_hist:
-                #     text = '[{}; {}]'.format(
-                #         text, value_to_string(coord.values[i + 1]))
                 html += "<td rowspan='2' {}>{}</td>".format(bstyle, text)
                 if coord.variances is not None:
                     text = value_to_string(coord.variances[i])
-                    # if is_hist:
-                    #     text = '[{}; {}]'.format(
-                    #         text, value_to_string(coord.variances[i + 1]))
                     html += "<td rowspan='2' {}>{}</td>".format(bstyle, text)
-            # Check for bin edges
-            # if i == 0:
-            #     for key, val in dataset:
-            #         if len(val.values) == len(coord.values) - 1:
-            #             html += <>
-            #         html += "<td {}>{}</td>".format(bstyle,
-            #                                         value_to_string(val.values[i]))
-            #         if val.variances is not None:
-            #             html += "<td {}>{}</td>".format(
-            #                 bstyle, value_to_string(val.variances[i]))
-
+            # Add data fields
             for key, val in dataset:
                 header_line_for_bin_edges = False
                 if coord is not None:
@@ -145,6 +104,7 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
                     if val.variances is not None:
                         html += "<td rowspan='2' {}>{}</td>".format(
                             bstyle, value_to_string(val.variances[i]))
+            # Add labels
             for key, lab in dataset.labels:
                 if lab.dims[0] == dataset_dim:
                     header_line_for_bin_edges = False
@@ -162,12 +122,9 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
                         if lab.variances is not None:
                             html += "<td rowspan='2' {}>{}</td>".format(
                                 bstyle, value_to_string(lab.variances[i]))
-
-
-
-                    # if i == 0 and len(val.values) == len(coord.values) - 1:
-                    # html += "<td {}>{}</td>".format(bstyle, lab.values[i])
             html += "</tr><tr>"
+            # If there are bin edges, we need to add trailing cells for data
+            # and labels
             if coord is not None:
                 for key, val in dataset:
                     if len(val.values) == len(coord.values) - 1:
@@ -201,11 +158,8 @@ def table_from_dataset(dataset, is_hist=False, headers=True):
 
 
 def table(dataset):
-    from IPython.display import display, HTML
 
-    # title = "<h3>{}</h3>".format(
-    #     str(type(dataset)).replace("<class 'scipp._scipp.",
-    #                                "").replace("'>", ""))
+    from IPython.display import display, HTML
 
     tabledict = {
         "default": sc.Dataset(),
@@ -220,28 +174,16 @@ def table(dataset):
     hist_tag = ":hist"
 
     tp = type(dataset)
+
     if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
+
         # First add one entry per dimension
         for dim in dataset.dims:
             key = str(dim)
-            # Create two separate entries to accomodate for potential bin-edge
-            # coordinates
-            # for i, suffix in enumerate(["", hist_tag]):
-            #     new_key = "{}{}".format(key, suffix)
-            #     tabledict["1D Variables"][new_key] = sc.Dataset()
-            #     is_empty[new_key] = True
-            #     is_histogram[new_key] = i > 0
             tabledict["1D Variables"][key] = sc.Dataset()
             is_empty[key] = True
             is_histogram[key] = False
 
-        # # Next add only the 1D coordinates
-        # for dim, var in dataset.coords:
-        #     if len(var.dims) == 1:
-        #         # dim = coord.dims[0]
-        #         key = str(dim)
-        #         tabledict["1D Variables"][key].coords[dim] = var
-        #         is_empty[key] = False
         # Next add the variables
         for name, var in dataset:
             if len(var.dims) == 1:
@@ -249,50 +191,22 @@ def table(dataset):
                 key = str(dim)
                 if len(var.coords) > 0:
                     if len(var.coords[dim].values) == len(var.values) + 1:
-                        # key = "{}{}".format(key, hist_tag)
                         is_histogram[key] = True
                     tabledict["1D Variables"][key].coords[dim] = var.coords[dim]
-                    # else:
-                    #     new_key = key
-
                 tabledict["1D Variables"][key][name] = var.data
                 is_empty[key] = False
 
-            #     if key not in tabledict["1D Variables"].keys():
-            #         temp_dict = {"data": {name: dataset[name].data}}
-            #         if len(var.coords) > 0:
-            #             coord_1d[key] = var.dims[0]
-            #             temp_dict["coords"] = {
-            #                 var.dims[0]: var.coords[var.dims[0]]
-            #             }
-            #             if len(var.coords[var.dims[0]].values) == \
-            #                len(var.values) + 1:
-            #                 is_histogram[key] = True
-            #             else:
-            #                 is_histogram[key] = False
-            #         else:
-            #             coord_1d[key] = None
-            #         tabledict["1D Variables"][key] = sc.Dataset(**temp_dict)
-            #     else:
-            #         tabledict["1D Variables"][key][name] = var
             elif len(var.dims) == 0:
                 tabledict["0D Variables"][name] = var
-        # print("==================")
-        # print(tabledict["1D Variables"])
-        # print("==================")
+
         # Next add only the 1D coordinates
         for dim, var in dataset.coords:
             if len(var.dims) == 1:
-                # dim = coord.dims[0]
                 key = str(dim)
-                # print(key)
-                # # print(dim not in tabledict["1D Variables"][key].coords)
-                # if dim not in tabledict["1D Variables"][key].coords and \
-                #     dim not in tabledict["1D Variables"]["{}{}".format(
-                #         key, hist_tag)].coords:
                 if dim not in tabledict["1D Variables"][key].coords:
                     tabledict["1D Variables"][key].coords[dim] = var
                     is_empty[key] = False
+
         # Next add the labels
         for name, lab in dataset.labels:
             if len(lab.dims) == 1:
@@ -300,36 +214,15 @@ def table(dataset):
                 key = str(dim)
                 if len(dataset.coords) > 0:
                     if len(dataset.coords[dim].values) == len(lab.values) + 1:
-                        # key = "{}{}".format(key, hist_tag)
                         is_histogram[key] = True
                     tabledict["1D Variables"][key].coords[dim] = dataset.coords[dim]
-                # # hist_key = "hist:{}".format(key)
-                # # print(lab)
-                # # print(is_empty[key], is_empty[hist_key])
-                # if is_empty[key] and (not is_empty[hist_key]):
-                #     new_key = hist_key
-                # else:
-                #     new_key = key
-                # # print(new_key)
                 tabledict["1D Variables"][key].labels[name] = lab
                 is_empty[key] = False
 
         # Now purge out the empty entries
         for key, val in is_empty.items():
             if val:
-                # print("deleting entry", key)
                 del(tabledict["1D Variables"][key])
-
-        # # for key in tabledict["1D Variables"].keys():
-        # #     print(key)
-        # #     if is_empty[key]:
-        # #         print("deleting entry", key)
-        # #         del(tabledict["1D Variables"][key])
-        # print("++++++++++++++++")
-        # print(tabledict["1D Variables"])
-        # print("++++++++++++++++")
-
-
 
     elif (tp is sc.DataArray) or (tp is sc.DataProxy):
         key = dataset.name
@@ -337,16 +230,14 @@ def table(dataset):
         if len(dataset.coords) > 0:
             dim = dataset.dims[0]
             tabledict["default"][key].coords[dim] = dataset.coords[dim]
-                # coord_def = dataset.dims[0]
     elif (tp is sc.Variable) or (tp is sc.VariableProxy):
-        key = ""
+        key = str(dataset.dims[0])
         tabledict["default"][key] = dataset
     else:
         tabledict["default"][""] = sc.Variable([sc.Dim.Row], values=dataset)
         headers = False
 
     subtitle = "<tr><td style='font-weight:normal;color:grey;font-style:italic;background-color:#ffffff;text-align:left;font-size:1.2em;padding: 1px;'>&nbsp;{}</td></tr>"
-    # title = str(type(dataset))
     whitetd = "<tr><td style='background-color:#ffffff;'>"
     title = str(type(dataset)).replace("<class 'scipp._scipp.core.",
                                        "").replace("'>", "")
@@ -355,56 +246,21 @@ def table(dataset):
     output += "{}</td></tr>".format(title)
 
     if len(tabledict["default"]) > 0:
-        # print(tabledict["default"])
         output += whitetd
-        # output += "text-align:center;background-color:#ffffff;'>"
-        output += table_from_dataset(tabledict["default"],
-                                     # coord_dim=coord_def,
-                                     headers=headers)
+        output += table_from_dataset(tabledict["default"], headers=headers)
         output += "</td></tr>"
     if len(tabledict["0D Variables"]) > 0:
         output += subtitle.format("0D Variables")
-         # "<tr><td {}>0D Variables</td></tr>".format(subtitle)
         output += whitetd
-        # output += subtitle + "0D Variables</h6>"
         output += table_from_dataset(tabledict["0D Variables"])
         output += "</td></tr>"
     if len(tabledict["1D Variables"].keys()) > 0:
-        # output += "<tr><td {}>1D Variables</td></tr>".format(subtitle)
         output += subtitle.format("1D Variables")
         output += whitetd
-        # oldkey = None
         for key, val in sorted(tabledict["1D Variables"].items()):
-            # # Here we place the bin-edge and non-bin-edge tables with the same
-            # # dimensions on the same row
-            # raw_key = key.replace(hist_tag, "")
-            # if raw_key in tabledict["1D Variables"].keys() and \
-            #     "{}{}".format(raw_key, hist_tag) in tabledict["1D Variables"].keys():
-            #     outer_table = True
-            # else:
-            #     outer_table = False
-            # print("=========")
-            # print(key, val)
-            # if outer_table:
-            #     if key.count(hist_tag) < 1:
-            #         output += "<table><tr>"
-            #     output += "<td style='border: 0px solid white;"
-            #     output += "background-color: #ffffff;"
-            #     output += "vertical-align:top;'>"
-            # print(val.dims.keys()[0])
-            # print(next(iter(val.dims)))
-            output += table_from_dataset(val,
-                                         # coord_dim=coord_1d[key],
-                                         is_hist=is_histogram[key])
-            # if outer_table:
-            #     output += "</td>"
-            #     if key.count(hist_tag) > 0:
-            #         output += "</tr></table>"
-            # oldkey = key.replace(hist_tag, "")
+            output += table_from_dataset(val, is_hist=is_histogram[key])
         output += "</td></tr>"
     output += "</table>"
-
-    # print(output)
 
     display(HTML(output))
 


### PR DESCRIPTION
- Added missing labels in table
- Border around contents of a Dataset
- Coordinates alone now render a table
- Entries that correspond to bin centers are now offset by half a row with respect to the coordinates

Demo:
```Python
import scipp as sc
import numpy as np
from scipp import Dim

d = sc.Dataset()
d.coords[Dim.Position] = sc.Variable([Dim.Position], values=np.arange(10.0), variances=np.random.rand(10))
d.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(11))
d.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(12))
d.labels["two_theta"] = sc.Variable([Dim.Position], values=np.arange(9))
d['sample'] = sc.Variable([Dim.Position], values=np.arange(10))
d['sample2'] = sc.Variable([Dim.Position], values=np.arange(9.0), variances=np.random.rand(9))
d['Xaa'] = sc.Variable([Dim.X], values=np.arange(10))
d['scalar'] = sc.Variable(1.5)
d['scalarAndVar'] = sc.Variable(21.5, variance=0.56)
sc.table(d)
```
![Screenshot at 2019-10-09 16-01-35](https://user-images.githubusercontent.com/39047984/66488386-1c35ae80-eaae-11e9-8321-2669d7951c45.png)

Please test for any bugs.

Fixes #545 #583 