### PR TITLE
Store PyObject in scalar variables

### DIFF
--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -10,6 +10,10 @@
 
 #include "scipp/core/bool.h"
 
+namespace pybind11 {
+class object;
+}
+
 namespace scipp::core {
 
 class DataArray;
@@ -39,8 +43,10 @@ enum class DType {
   DataArray,
   Dataset,
   EigenVector3d,
+  PyObject,
   Unknown
 };
+
 template <class T> constexpr DType dtype = DType::Unknown;
 template <> constexpr DType dtype<double> = DType::Double;
 template <> constexpr DType dtype<float> = DType::Float;
@@ -59,6 +65,7 @@ constexpr DType dtype<sparse_container<int32_t>> = DType::SparseInt32;
 template <> constexpr DType dtype<DataArray> = DType::DataArray;
 template <> constexpr DType dtype<Dataset> = DType::Dataset;
 template <> constexpr DType dtype<Eigen::Vector3d> = DType::EigenVector3d;
+template <> constexpr DType dtype<pybind11::object> = DType::PyObject;
 
 bool isInt(DType tp);
 bool isFloatingPoint(DType tp);

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -96,6 +96,8 @@ std::string to_string(const DType dtype) {
     return "sparse_int32";
   case DType::EigenVector3d:
     return "vector_3_double";
+  case DType::PyObject:
+    return "PyObject";
   case DType::Unknown:
     return "unknown";
   default:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,6 +11,7 @@ pybind11_add_module(_scipp
                     sparse_container.cpp
                     units_neutron.cpp
                     variable.cpp
+                    variable_instantiate_py_object.cpp
                     variable_view.cpp)
 target_link_libraries(_scipp LINK_PRIVATE scipp-core scipp-neutron)
 

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -156,6 +156,8 @@ template <class... Ts> class as_VariableViewImpl {
       return {Getter::template get<Dataset>(proxy)};
     case dtype<Eigen::Vector3d>:
       return {Getter::template get<Eigen::Vector3d>(proxy)};
+    case dtype<py::object>:
+      return {Getter::template get<py::object>(proxy)};
     default:
       throw std::runtime_error("not implemented for this type.");
     }
@@ -232,10 +234,15 @@ template <class... Ts> class as_VariableViewImpl {
             //    slicing a 1-D array).
             // 2. For 1-D sparse data, where the individual item is then a
             //    vector-like object.
-            if (dims.shape().size() == 0)
-              return py::cast(data[0], py::return_value_policy::reference);
-            else
+            if (dims.shape().size() == 0) {
+              if constexpr (std::is_same_v<std::decay_t<decltype(data[0])>,
+                                           py::object>)
+                return data[0];
+              else
+                return py::cast(data[0], py::return_value_policy::reference);
+            } else {
               return py::cast(data);
+            }
           },
           get<Getter>(proxy));
     }
@@ -275,9 +282,13 @@ public:
     expect::equals(Dimensions(), view.dims());
     return std::visit(
         [&obj](const auto &data) {
-          // Passing `obj` as parent so py::keep_alive works.
-          return py::cast(data[0], py::return_value_policy::reference_internal,
-                          obj);
+          if constexpr (std::is_same_v<std::decay_t<decltype(data[0])>,
+                                       py::object>)
+            return data[0];
+          else
+            // Passing `obj` as parent so py::keep_alive works.
+            return py::cast(data[0],
+                            py::return_value_policy::reference_internal, obj);
         },
         get<get_values>(view));
   }
@@ -290,9 +301,13 @@ public:
     expect::equals(Dimensions(), view.dims());
     return std::visit(
         [&obj](const auto &data) {
-          // Passing `obj` as parent so py::keep_alive works.
-          return py::cast(data[0], py::return_value_policy::reference_internal,
-                          obj);
+          if constexpr (std::is_same_v<std::decay_t<decltype(data[0])>,
+                                       py::object>)
+            return data[0];
+          else
+            // Passing `obj` as parent so py::keep_alive works.
+            return py::cast(data[0],
+                            py::return_value_policy::reference_internal, obj);
         },
         get<get_variances>(view));
   }
@@ -326,7 +341,7 @@ using as_VariableView =
     as_VariableViewImpl<double, float, int64_t, int32_t, bool, std::string,
                         sparse_container<double>, sparse_container<float>,
                         sparse_container<int64_t>, DataArray, Dataset,
-                        Eigen::Vector3d>;
+                        Eigen::Vector3d, py::object>;
 
 template <class T, class... Ignored>
 void bind_data_properties(pybind11::class_<T, Ignored...> &c) {

--- a/python/tests/test_neutron_convert.py
+++ b/python/tests/test_neutron_convert.py
@@ -54,10 +54,14 @@ def test_neutron_convert():
 def test_neutron_beamline():
     d = make_dataset_with_beamline()
 
-    assert sc.neutron.source_position(d) == sc.Variable(value=[0, 0, -10],
-                                                        unit=sc.units.m)
-    assert sc.neutron.sample_position(d) == sc.Variable(value=[0, 0, 0],
-                                                        unit=sc.units.m)
+    assert sc.neutron.source_position(d) == sc.Variable(
+        value=np.array([0, 0, -10]),
+        dtype=sc.dtype.vector_3_double,
+        unit=sc.units.m)
+    assert sc.neutron.sample_position(d) == sc.Variable(
+        value=np.array([0, 0, 0]),
+        dtype=sc.dtype.vector_3_double,
+        unit=sc.units.m)
     assert sc.neutron.l1(d) == 10.0 * sc.units.m
     assert sc.neutron.l2(d) == sc.Variable(dims=[Dim.Position],
                                            values=np.ones(4),

--- a/python/tests/test_variable_py_object.py
+++ b/python/tests/test_variable_py_object.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+import numpy as np
+
+
+def test_scalar_Variable_py_object_dict():
+    var = sc.Variable(value={'a': 1, 'b': 2})
+    assert var.dtype == sc.dtype.PyObject
+    assert var.value == {'a': 1, 'b': 2}
+    var.value['a'] = 3
+    var.value['c'] = 4
+    assert var.value == {'a': 3, 'b': 2, 'c': 4}
+
+
+def test_scalar_Variable_py_object_list():
+    var = sc.Variable(value=[1, 2, 3])
+    assert var.dtype == sc.dtype.PyObject
+    assert var.value == [1, 2, 3]
+    var.value[0] = 2
+    assert var.value == [2, 2, 3]
+
+
+def test_scalar_Variable_py_object_change():
+    var = sc.Variable(value=[1, 2, 3])
+    assert var.dtype == sc.dtype.PyObject
+    assert var.value == [1, 2, 3]
+    # Value assignment cannot change dtype, so the result is still PyObject,
+    # contrary to creating a variable directly from and integer.
+    var.value = 1
+    assert var.dtype == sc.dtype.PyObject
+    assert var.value == 1

--- a/python/tests/test_variable_py_object.py
+++ b/python/tests/test_variable_py_object.py
@@ -32,3 +32,11 @@ def test_scalar_Variable_py_object_change():
     var.value = 1
     assert var.dtype == sc.dtype.PyObject
     assert var.value == 1
+
+
+def test_scalar_Variable_py_object_shallow_copy():
+    var = sc.Variable(value=[1,2,3])
+    copy = var.copy()
+    copy.value[0] = 666
+    assert copy.value == [666, 2, 3]
+    assert var.value == [666, 2, 3]

--- a/python/tests/test_variable_py_object.py
+++ b/python/tests/test_variable_py_object.py
@@ -3,7 +3,6 @@
 # @file
 # @author Simon Heybrock
 import scipp as sc
-import numpy as np
 
 
 def test_scalar_Variable_py_object_dict():

--- a/python/tests/test_variable_py_object.py
+++ b/python/tests/test_variable_py_object.py
@@ -35,7 +35,7 @@ def test_scalar_Variable_py_object_change():
 
 
 def test_scalar_Variable_py_object_shallow_copy():
-    var = sc.Variable(value=[1,2,3])
+    var = sc.Variable(value=[1, 2, 3])
     copy = var.copy()
     copy.value[0] = 666
     assert copy.value == [666, 2, 3]

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -191,6 +191,7 @@ void init_variable(py::module &m) {
   bind_init_0D<bool>(variable);
   bind_init_0D<int64_t>(variable);
   bind_init_0D<double>(variable);
+  bind_init_0D<py::object>(variable);
   //------------------------------------
 
   py::class_<VariableConstProxy>(m, "VariableConstProxy")

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -81,16 +81,22 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
                                                        variances);
 }
 
+template <class T>
+auto do_init_0D(const T &value, const std::optional<T> &variance,
+                const units::Unit &unit) {
+  Variable var;
+  if (variance)
+    var = makeVariable<T>(value, *variance);
+  else
+    var = makeVariable<T>(value);
+  var.setUnit(unit);
+  return var;
+}
+
 template <class T> void bind_init_0D(py::class_<Variable> &c) {
   c.def(py::init([](const T &value, const std::optional<T> &variance,
                     const units::Unit &unit) {
-          Variable var;
-          if (variance)
-            var = makeVariable<T>(value, *variance);
-          else
-            var = makeVariable<T>(value);
-          var.setUnit(unit);
-          return var;
+          return do_init_0D(value, variance, unit);
         }),
         py::arg("value"), py::arg("variance") = std::nullopt,
         py::arg("unit") = units::Unit(units::dimensionless));
@@ -106,6 +112,12 @@ void bind_init_0D(py::class_<Variable> &c) {
 
             return py::cast<Variable>(
                 pyMakeVariable0D(py::array(b), v, unit, dtype));
+          } else if (info.ndim == 1 &&
+                     scipp_dtype(dtype) == core::dtype<Eigen::Vector3d>) {
+            return do_init_0D<Eigen::Vector3d>(
+                b.cast<Eigen::Vector3d>(),
+                v ? std::optional(v->cast<Eigen::Vector3d>()) : std::nullopt,
+                unit);
           } else {
             throw scipp::except::VariableError(
                 "Wrong overload for making 0D variable.");
@@ -165,14 +177,6 @@ void init_variable(py::module &m) {
       .def("__deepcopy__",
            [](Variable &self, py::dict) { return Variable(self); })
       .def_property_readonly("dtype", &Variable::dtype)
-      .def(py::self + double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self - double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self * double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self / double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self += double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self -= double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self *= double(), py::call_guard<py::gil_scoped_release>())
-      .def(py::self /= double(), py::call_guard<py::gil_scoped_release>())
       .def("__radd__", [](Variable &a, double &b) { return a + b; },
            py::is_operator())
       .def("__rsub__", [](Variable &a, double &b) { return b - a; },

--- a/python/variable_instantiate_py_object.cpp
+++ b/python/variable_instantiate_py_object.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/variable.tcc"
+
+#include "pybind11.h"
+
+namespace py = pybind11;
+
+namespace scipp::core {
+
+INSTANTIATE_VARIABLE(py::object)
+
+} // namespace scipp::core


### PR DESCRIPTION
Add support for starting arbitrary Python objects in (scalar) variables. Nothing prevents us from supporting this also when creating 1-D or higher variables, but this is not required right now so bindings were not added.

This feature can be useful in parrticular when storing specific data from Mantid workspaces such as `Sample` or `Run`, without the need to add instantiations and bindings for each new type.

Remarks:
- Changes for creating `Vector3d` were required. `[1,2,3]` is now stored as `PyObject` (a Python list) instead of magically converting to `Vector3d`. A numpy array and an explicit `dtype` must be used now to create a `Vector3d`.
- This change has consequences on copying (see one of the tests). We get the "normal" Python behavior (shallow copies). A decision on how to handle this must be made, I opened #604 for this.
- This change made it clear that adding support for a new `dtype` is too cumbersome. Part of the problem is that it requires changes in `core` (to add new enum values). This could maybe be solved by switching `dtype` to be a `constexpr` class holding an integer ID. However, this would still require assinging ID ranges to potentially multiple higher-level libraries (0-999 is for core, 1000-1999 for neutron, ...) and remains error prone, I think. Next time we add a new type we should also look into requiring fewer changes in the Python bindings for every new type.

  That being said, it may be that the addition of support for `PyObject` drastically reduces the need for new custom dtypes, so this discussion may turn out to be irrelevant.