### PR TITLE
Faster 2d image plot

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ nose
 ipywidgets
 plotly
 pytest
+Pillow

--- a/python/src/scipp/plot_plotly.py
+++ b/python/src/scipp/plot_plotly.py
@@ -268,6 +268,10 @@ class Slicer2d:
             # Add coordinate name and unit
             self.vbox.append(widgets.HBox([self.slider[key], self.lab[key],
                                            self.buttons[key]]))
+        if self.ndim == 2:
+            for key in self.slider.keys():
+                self.slider[key].layout.display = 'none'
+                self.lab[key].value = key
 
         # Initialise Figure and VBox objects
         self.fig = None

--- a/python/src/scipp/plot_plotly.py
+++ b/python/src/scipp/plot_plotly.py
@@ -733,7 +733,7 @@ class Slicer3d:
             ax_dim = self.buttons[key].value.lower()
             xy = getattr(self.fig.data[slice_indices[ax_dim]], ax_dim)
             for i in range(1 + self.show_variances):
-                k = slice_indices[ax_dim]+(3*(i>0))
+                k = slice_indices[ax_dim] + (3 * (i > 0))
                 setattr(self.fig.data[k], ax_dim, xy / xy * loc)
                 self.fig.data[k].surfacecolor = \
                     self.check_transpose(vslice, variances=(i > 0))

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -280,6 +280,16 @@ def do_test_plot_sliceviewer_with_3d_projection_with_variances():
     do_plot(d1, projection="3d", show_variances=True)
 
 
+def do_test_plot_2d_image_rasterized():
+    d1 = make_2d_dataset()
+    do_plot(d1, rasterize=True)
+
+
+def do_test_plot_2d_image_with_variances_rasterized():
+    d1 = make_2d_dataset(variances=True)
+    do_plot(d1, rasterize=True)
+
+
 # Using plotly backend =======================================================
 
 
@@ -353,6 +363,14 @@ def test_plot_sliceviewer_with_3d_projection():
 
 def test_plot_sliceviewer_with_3d_projection_with_variances():
     do_test_plot_sliceviewer_with_3d_projection_with_variances()
+
+
+def test_plot_2d_image_rasterized():
+    do_test_plot_2d_image_rasterized()
+
+
+def test_plot_2d_image_with_variances_rasterized():
+    do_test_plot_2d_image_with_variances_rasterized()
 
 
 # Using matplotlib backend ====================================================


### PR DESCRIPTION
These changes make the generation and interaction of large 2D images much faster.
It it displaying the data as a background image, instead of drawing 1 square per pixel on the web canvas.
Some tricks are involved to get the `plotly` auto-scale features to work properly.

Displaying a 2000x1000 image:
```Python
N = 2000
M = 1000
xx = np.arange(N, dtype=np.float64)
yy = np.arange(M, dtype=np.float64)
x, y = np.meshgrid(xx, yy)
b = N/1000.0
c = M/100.0
r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2)
a = np.sin(r)
d1 = sc.Dataset()
d1.coords[Dim.X] = sc.Variable([Dim.X], values=xx, unit=sc.units.m)
d1.coords[Dim.Y] = sc.Variable([Dim.Y], values=yy, unit=sc.units.m)
d1['Signal'] = sc.Variable([Dim.Y, Dim.X], values=a, unit=sc.units.counts)
```
No rasterization: ~18s render time
```Python
sc.plot(d1, rasterize=False)
```
With rasterization: ~2s render time
```Python
sc.plot(d1, rasterize=True)
```

By default, `rasterize='auto'`, meaning if the image has more than 100,000 pixels, it will switch to rasterize automatically.
![Screenshot at 2019-10-11 14-26-02](https://user-images.githubusercontent.com/39047984/66651342-13221a00-ec33-11e9-880f-ffbb0f822e74.png)

**Additional fixes:**
- Hide sliders if there are only 2 dimensions
- Correct colormap for 3d projection