### PR TITLE
Copy benchmarks

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -7,7 +7,7 @@ mkdir -p build
 mkdir -p install
 cd build
 cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
-make -j2 install all-tests
+make -j2 install all-tests all-benchmarks
 
 # Units tests
 ./units/test/scipp-units-test

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,22 +1,31 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+
+add_custom_target(all-benchmarks)
+
 add_executable(transform_benchmark EXCLUDE_FROM_ALL transform_benchmark.cpp)
+add_dependencies(all-benchmarks transform_benchmark)
 target_link_libraries(transform_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(variable_benchmark EXCLUDE_FROM_ALL variable_benchmark.cpp)
+add_dependencies(all-benchmarks variable_benchmark)
 target_link_libraries(variable_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(dataset_benchmark EXCLUDE_FROM_ALL dataset_benchmark.cpp)
+add_dependencies(all-benchmarks dataset_benchmark)
 target_link_libraries(dataset_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(legacy_histogram_benchmark EXCLUDE_FROM_ALL legacy_histogram_benchmark.cpp)
+# add_dependencies(all-benchmarks legacy_histogram_benchmark)
 target_link_libraries(legacy_histogram_benchmark
                       LINK_PRIVATE
                       scipp-core
                       benchmark)
 
-                    add_executable(multi_index_benchmark EXCLUDE_FROM_ALL multi_index_benchmark.cpp)
+add_executable(multi_index_benchmark EXCLUDE_FROM_ALL multi_index_benchmark.cpp)
+# add_dependencies(all-benchmarks multi_index_benchmark)
 target_link_libraries(multi_index_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(variable_view_benchmark EXCLUDE_FROM_ALL variable_view_benchmark.cpp)
+# add_dependencies(all-benchmarks variable_view_benchmark)
 target_link_libraries(variable_view_benchmark LINK_PRIVATE scipp-core benchmark)

--- a/benchmark/common.h
+++ b/benchmark/common.h
@@ -5,41 +5,48 @@
 #include "../core/test/make_sparse.h"
 
 template <typename T> struct GenerateSparse {
-  Variable operator()(int size) {
+  auto operator()(int length) {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> dis(0, 100);
 
-    auto a = make_sparse_variable<T>(size);
+    auto a = make_sparse_variable<T>(length);
+    unsigned long long size(0);
 
     /* Generate a random amount of sparse data for each point */
     auto vals = a.template sparseValues<T>();
-    for (scipp::index i = 0; i < size; ++i)
-      vals[i] = scipp::core::sparse_container<T>(dis(gen), i);
+    for (scipp::index i = 0; i < length; ++i) {
+      const auto l = dis(gen);
+      size += l;
+      vals[i] = scipp::core::sparse_container<T>(l, i);
+    }
 
-    return a;
+    return std::make_tuple(a, sizeof(T) * size);
   }
 };
 
 template <int NameLen> struct Generate3DWithDataItems {
-  auto operator()(const int itemCount = 5, const int size = 100) {
+  auto operator()(const int itemCount = 5, const int length = 100) {
     Dataset d;
     for (auto i = 0; i < itemCount; ++i) {
       d.setData(std::to_string(i) + std::string(NameLen, 'i'),
                 makeVariable<double>(
-                    {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}}));
+                    {{Dim::X, length}, {Dim::Y, length}, {Dim::Z, length}}));
     }
-    return d;
+    return std::make_tuple(d, sizeof(double) * itemCount * std::pow(length, 3));
   }
 };
 
 template <int NameLen> struct GenerateWithSparseDataItems {
-  Dataset operator()(const int itemCount = 5, const int size = 100) {
+  auto operator()(const int itemCount = 5, const int length = 100) {
     Dataset d;
     GenerateSparse<double> gen;
+    unsigned long long size(0);
     for (auto i = 0; i < itemCount; ++i) {
-      d.setData(std::to_string(i) + std::string(NameLen, 'i'), gen(size));
+      const auto [data, s] = gen(length);
+      size += s;
+      d.setData(std::to_string(i) + std::string(NameLen, 'i'), data);
     }
-    return d;
+    return std::make_tuple(d, size);
   }
 };

--- a/benchmark/common.h
+++ b/benchmark/common.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <random>
+
+#include "../core/test/make_sparse.h"
+
+template <typename T> struct GenerateSparse {
+  Variable operator()(int size) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, 100);
+
+    auto a = make_sparse_variable<T>(size);
+
+    /* Generate a random amount of sparse data for each point */
+    auto vals = a.template sparseValues<T>();
+    for (scipp::index i = 0; i < size; ++i)
+      vals[i] = scipp::core::sparse_container<T>(dis(gen), i);
+
+    return a;
+  }
+};

--- a/benchmark/common.h
+++ b/benchmark/common.h
@@ -20,3 +20,26 @@ template <typename T> struct GenerateSparse {
     return a;
   }
 };
+
+template <int NameLen> struct Generate3DWithDataItems {
+  auto operator()(const int itemCount = 5, const int size = 100) {
+    Dataset d;
+    for (auto i = 0; i < itemCount; ++i) {
+      d.setData(std::to_string(i) + std::string(NameLen, 'i'),
+                makeVariable<double>(
+                    {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}}));
+    }
+    return d;
+  }
+};
+
+template <int NameLen> struct GenerateWithSparseDataItems {
+  Dataset operator()(const int itemCount = 5, const int size = 100) {
+    Dataset d;
+    GenerateSparse<double> gen;
+    for (auto i = 0; i < itemCount; ++i) {
+      d.setData(std::to_string(i) + std::string(NameLen, 'i'), gen(size));
+    }
+    return d;
+  }
+};

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -210,7 +210,8 @@ template <class Gen> static void BM_Dataset_copy(benchmark::State &state) {
   for (auto _ : state) {
     Dataset copy(d);
   }
-  state.counters["Bandwidth"] =
+  state.counters["SizeBytes"] = size;
+  state.counters["BandwidthBytes"] =
       benchmark::Counter(size, benchmark::Counter::kIsIterationInvariantRate,
                          benchmark::Counter::OneK::kIs1024);
 }

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -5,6 +5,8 @@
 
 #include <numeric>
 
+#include "common.h"
+
 #include "scipp/core/dataset.h"
 
 // Length of a string that can be stored with SSO
@@ -153,6 +155,17 @@ template <int NameLen> struct GenerateWithDataItems {
   }
 };
 
+template <int NameLen> struct GenerateWithSparseDataItems {
+  Dataset operator()(const int itemCount = 5, const int size = 100) {
+    Dataset d;
+    GenerateSparse<double> gen;
+    for (auto i = 0; i < itemCount; ++i) {
+      d.setData(std::to_string(i) + std::string(NameLen, 'i'), gen(size));
+    }
+    return d;
+  }
+};
+
 template <class Gen>
 static void BM_Dataset_item_access(benchmark::State &state) {
   const auto d = Gen()();
@@ -222,6 +235,12 @@ static void Args_Dataset_copy(benchmark::internal::Benchmark *b) {
 BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<SHORT_STRING_LENGTH>)
     ->Apply(Args_Dataset_copy);
 BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<LONG_STRING_LENGTH>)
+    ->Apply(Args_Dataset_copy);
+BENCHMARK_TEMPLATE(BM_Dataset_copy,
+                   GenerateWithSparseDataItems<SHORT_STRING_LENGTH>)
+    ->Apply(Args_Dataset_copy);
+BENCHMARK_TEMPLATE(BM_Dataset_copy,
+                   GenerateWithSparseDataItems<LONG_STRING_LENGTH>)
     ->Apply(Args_Dataset_copy);
 
 BENCHMARK_MAIN();

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -170,7 +170,7 @@ template <class Gen>
 static void BM_Dataset_iterate_items(benchmark::State &state) {
   const auto d = Gen()(state.range(0));
   for (auto _ : state) {
-    for (const auto & [ name, item ] : d) {
+    for (const auto &[name, item] : d) {
       benchmark::DoNotOptimize(name);
       benchmark::DoNotOptimize(item);
     }
@@ -190,7 +190,7 @@ static void BM_Dataset_iterate_slice_items(benchmark::State &state) {
   const auto d = Gen()(state.range(0));
   const auto s = Slice()(d);
   for (auto _ : state) {
-    for (const auto & [ name, item ] : s) {
+    for (const auto &[name, item] : s) {
       benchmark::DoNotOptimize(name);
       benchmark::DoNotOptimize(item);
     }
@@ -207,5 +207,21 @@ BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
                    GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY)
     ->Range(1 << 2, 1 << 8);
+
+template <class Gen> static void BM_Dataset_copy(benchmark::State &state) {
+  const auto d = Gen()(state.range(0), state.range(1));
+  for (auto _ : state) {
+    Dataset copy(d);
+  }
+}
+static void Args_Dataset_copy(benchmark::internal::Benchmark *b) {
+  b->RangeMultiplier(2)
+      ->Ranges({{1, 16}, {32, 64}})
+      ->Unit(benchmark::kMicrosecond);
+}
+BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<SHORT_STRING_LENGTH>)
+    ->Apply(Args_Dataset_copy);
+BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<LONG_STRING_LENGTH>)
+    ->Apply(Args_Dataset_copy);
 
 BENCHMARK_MAIN();

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -143,29 +143,6 @@ BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<SHORT_STRING_LENGTH>,
 BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<LONG_STRING_LENGTH>,
                    SliceXYQz);
 
-template <int NameLen> struct GenerateWithDataItems {
-  Dataset operator()(const int itemCount = 5, const int size = 100) {
-    Dataset d;
-    for (auto i = 0; i < itemCount; ++i) {
-      d.setData(std::to_string(i) + std::string(NameLen, 'i'),
-                makeVariable<double>(
-                    {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}}));
-    }
-    return d;
-  }
-};
-
-template <int NameLen> struct GenerateWithSparseDataItems {
-  Dataset operator()(const int itemCount = 5, const int size = 100) {
-    Dataset d;
-    GenerateSparse<double> gen;
-    for (auto i = 0; i < itemCount; ++i) {
-      d.setData(std::to_string(i) + std::string(NameLen, 'i'), gen(size));
-    }
-    return d;
-  }
-};
-
 template <class Gen>
 static void BM_Dataset_item_access(benchmark::State &state) {
   const auto d = Gen()();
@@ -175,13 +152,14 @@ static void BM_Dataset_item_access(benchmark::State &state) {
   }
 }
 BENCHMARK_TEMPLATE(BM_Dataset_item_access,
-                   GenerateWithDataItems<SHORT_STRING_LENGTH>);
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>);
 BENCHMARK_TEMPLATE(BM_Dataset_item_access,
-                   GenerateWithDataItems<LONG_STRING_LENGTH>);
+                   Generate3DWithDataItems<LONG_STRING_LENGTH>);
 
 template <class Gen>
 static void BM_Dataset_iterate_items(benchmark::State &state) {
-  const auto d = Gen()(state.range(0));
+  const auto itemCount = state.range(0);
+  const auto d = Gen()(itemCount);
   for (auto _ : state) {
     for (const auto &[name, item] : d) {
       benchmark::DoNotOptimize(name);
@@ -189,18 +167,19 @@ static void BM_Dataset_iterate_items(benchmark::State &state) {
     }
   }
   state.counters["IterationItemRate"] = benchmark::Counter(
-      state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+      itemCount, benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_items,
-                   GenerateWithDataItems<SHORT_STRING_LENGTH>)
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>)
     ->Range(1 << 2, 1 << 8);
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_items,
-                   GenerateWithDataItems<LONG_STRING_LENGTH>)
+                   Generate3DWithDataItems<LONG_STRING_LENGTH>)
     ->Range(1 << 2, 1 << 8);
 
 template <class Gen, class Slice>
 static void BM_Dataset_iterate_slice_items(benchmark::State &state) {
-  const auto d = Gen()(state.range(0));
+  const auto itemCount = state.range(0);
+  const auto d = Gen()(itemCount);
   const auto s = Slice()(d);
   for (auto _ : state) {
     for (const auto &[name, item] : s) {
@@ -209,32 +188,36 @@ static void BM_Dataset_iterate_slice_items(benchmark::State &state) {
     }
   }
   state.counters["IterationItemRate"] = benchmark::Counter(
-      state.range(0), benchmark::Counter::kIsIterationInvariantRate);
+      itemCount, benchmark::Counter::kIsIterationInvariantRate);
 }
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
-                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceX)
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>, SliceX)
     ->Range(1 << 2, 1 << 8);
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
-                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceXY)
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>, SliceXY)
     ->Range(1 << 2, 1 << 8);
 BENCHMARK_TEMPLATE(BM_Dataset_iterate_slice_items,
-                   GenerateWithDataItems<SHORT_STRING_LENGTH>, SliceZXY)
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>, SliceZXY)
     ->Range(1 << 2, 1 << 8);
 
 template <class Gen> static void BM_Dataset_copy(benchmark::State &state) {
-  const auto d = Gen()(state.range(0), state.range(1));
+  const auto itemCount = state.range(0);
+  const auto itemLength = state.range(1);
+  const auto d = Gen()(itemCount, itemLength);
   for (auto _ : state) {
     Dataset copy(d);
   }
 }
 static void Args_Dataset_copy(benchmark::internal::Benchmark *b) {
   b->RangeMultiplier(2)
-      ->Ranges({{1, 16}, {32, 64}})
+      ->Ranges({/* Item count */ {1, 16},
+                /* Axis length */ {32, 64}})
       ->Unit(benchmark::kMicrosecond);
 }
-BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<SHORT_STRING_LENGTH>)
+BENCHMARK_TEMPLATE(BM_Dataset_copy,
+                   Generate3DWithDataItems<SHORT_STRING_LENGTH>)
     ->Apply(Args_Dataset_copy);
-BENCHMARK_TEMPLATE(BM_Dataset_copy, GenerateWithDataItems<LONG_STRING_LENGTH>)
+BENCHMARK_TEMPLATE(BM_Dataset_copy, Generate3DWithDataItems<LONG_STRING_LENGTH>)
     ->Apply(Args_Dataset_copy);
 BENCHMARK_TEMPLATE(BM_Dataset_copy,
                    GenerateWithSparseDataItems<SHORT_STRING_LENGTH>)

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -4,49 +4,125 @@
 /// @author Simon Heybrock
 #include <benchmark/benchmark.h>
 
-#include "variable.h"
+#include "scipp/core/variable.h"
 
 using namespace scipp::core;
+using namespace scipp;
 
-static void BM_Variable_copy(benchmark::State &state) {
-  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+template <typename T> struct Generate1D {
+  Variable operator()(int size) { return makeVariable<T>({Dim::X, size}); }
+};
 
+template <typename T> struct Generate2D {
+  Variable operator()(int size) {
+    return makeVariable<T>({{Dim::X, size}, {Dim::Y, size}});
+  }
+};
+
+template <typename T> struct Generate3D {
+  Variable operator()(int size) {
+    return makeVariable<T>({{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}});
+  }
+};
+
+template <typename T> struct Generate4D {
+  Variable operator()(int size) {
+    return makeVariable<T>(
+        {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}, {Dim::Qx, size}});
+  }
+};
+
+template <typename T> struct Generate5D {
+  Variable operator()(int size) {
+    return makeVariable<T>({{Dim::X, size},
+                            {Dim::Y, size},
+                            {Dim::Z, size},
+                            {Dim::Qx, size},
+                            {Dim::Qy, size}});
+  }
+};
+
+template <typename T> struct Generate6D {
+  Variable operator()(int size) {
+    return makeVariable<T>({{Dim::X, size},
+                            {Dim::Y, size},
+                            {Dim::Z, size},
+                            {Dim::Qx, size},
+                            {Dim::Qy, size},
+                            {Dim::Qz, size}});
+  }
+};
+
+template <class Gen> static void BM_Variable_copy(benchmark::State &state) {
+  auto var = Gen()(state.range(0));
   for (auto _ : state) {
     Variable copy(var);
   }
 }
-BENCHMARK(BM_Variable_copy);
-
-static void BM_Variable_trivial_slice(benchmark::State &state) {
-  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
-
-  for (auto _ : state) {
-    ConstVariableSlice view(var);
-    Variable copy(view);
-  }
+static void Args_Variable_copy(benchmark::internal::Benchmark *b) {
+  b->Arg(10)->Arg(20);
 }
-BENCHMARK(BM_Variable_trivial_slice);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate1D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate2D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate3D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate4D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate5D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate6D<float>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate1D<double>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate2D<double>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate3D<double>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate4D<double>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate5D<double>)
+    ->Apply(Args_Variable_copy);
+BENCHMARK_TEMPLATE(BM_Variable_copy, Generate6D<double>)
+    ->Apply(Args_Variable_copy);
 
-// The following two benchmarks "prove" that operator+ with a VariableSlice is
-// not unintentionally converting the second argument to a temporary Variable.
-static void BM_Variable_binary_with_Variable(benchmark::State &state) {
-  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
-  Variable a = var(Dim::Z, 0, 8);
+/* static void BM_Variable_trivial_slice(benchmark::State &state) { */
+/*   auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X,
+ * 30}}); */
 
-  for (auto _ : state) {
-    Variable b = var(Dim::Z, 1, 9);
-    auto sum = a + b;
-  }
-}
-static void BM_Variable_binary_with_VariableSlice(benchmark::State &state) {
-  auto b = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
-  Variable a = b(Dim::Z, 0, 8);
+/*   for (auto _ : state) { */
+/*     ConstVariableSlice view(var); */
+/*     Variable copy(view); */
+/*   } */
+/* } */
+/* BENCHMARK(BM_Variable_trivial_slice); */
 
-  for (auto _ : state) {
-    auto sum = a + b(Dim::Z, 1, 9);
-  }
-}
-BENCHMARK(BM_Variable_binary_with_Variable);
-BENCHMARK(BM_Variable_binary_with_VariableSlice);
+/* // The following two benchmarks "prove" that operator+ with a VariableSlice
+ * is */
+/* // not unintentionally converting the second argument to a temporary
+ * Variable. */
+/* static void BM_Variable_binary_with_Variable(benchmark::State &state) { */
+/*   auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X,
+ * 30}}); */
+/*   Variable a = var(Dim::Z, 0, 8); */
+
+/*   for (auto _ : state) { */
+/*     Variable b = var(Dim::Z, 1, 9); */
+/*     auto sum = a + b; */
+/*   } */
+/* } */
+/* static void BM_Variable_binary_with_VariableSlice(benchmark::State &state) {
+ */
+/*   auto b = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+ */
+/*   Variable a = b(Dim::Z, 0, 8); */
+
+/*   for (auto _ : state) { */
+/*     auto sum = a + b(Dim::Z, 1, 9); */
+/*   } */
+/* } */
+/* BENCHMARK(BM_Variable_binary_with_Variable); */
+/* BENCHMARK(BM_Variable_binary_with_VariableSlice); */
 
 BENCHMARK_MAIN();

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -73,7 +73,8 @@ template <class Gen> static void BM_Variable_copy(benchmark::State &state) {
   for (auto _ : state) {
     Variable copy(var);
   }
-  state.counters["Bandwidth"] =
+  state.counters["SizeBytes"] = size;
+  state.counters["BandwidthBytes"] =
       benchmark::Counter(size, benchmark::Counter::kIsIterationInvariantRate,
                          benchmark::Counter::OneK::kIs1024);
 }

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -56,7 +56,8 @@ template <typename T> struct Generate6D {
 };
 
 template <class Gen> static void BM_Variable_copy(benchmark::State &state) {
-  auto var = Gen()(state.range(0));
+  const auto axisLength = state.range(0);
+  auto var = Gen()(axisLength);
   for (auto _ : state) {
     Variable copy(var);
   }

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -4,11 +4,9 @@
 /// @author Simon Heybrock
 #include <benchmark/benchmark.h>
 
+#include "common.h"
+
 #include "scipp/core/variable.h"
-
-#include "../core/test/make_sparse.h"
-
-#include <random>
 
 using namespace scipp::core;
 using namespace scipp;
@@ -54,23 +52,6 @@ template <typename T> struct Generate6D {
                             {Dim::Qx, size},
                             {Dim::Qy, size},
                             {Dim::Qz, size}});
-  }
-};
-
-template <typename T> struct GenerateSparse {
-  Variable operator()(int size) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, 100);
-
-    auto a = make_sparse_variable<T>(size);
-
-    /* Generate a random amount of sparse data for each point */
-    auto vals = a.template sparseValues<T>();
-    for (scipp::index i = 0; i < size; ++i)
-      vals[i] = scipp::core::sparse_container<T>(dis(gen), i);
-
-    return a;
   }
 };
 

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -113,42 +113,36 @@ BENCHMARK_TEMPLATE(BM_Variable_copy, GenerateSparse<float>)
 BENCHMARK_TEMPLATE(BM_Variable_copy, GenerateSparse<double>)
     ->Apply(Args_Variable_copy_sparse);
 
-/* static void BM_Variable_trivial_slice(benchmark::State &state) { */
-/*   auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X,
- * 30}}); */
+static void BM_Variable_trivial_slice(benchmark::State &state) {
+  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
 
-/*   for (auto _ : state) { */
-/*     ConstVariableSlice view(var); */
-/*     Variable copy(view); */
-/*   } */
-/* } */
-/* BENCHMARK(BM_Variable_trivial_slice); */
+  for (auto _ : state) {
+    VariableProxy view(var);
+    Variable copy(view);
+  }
+}
+BENCHMARK(BM_Variable_trivial_slice);
 
-/* // The following two benchmarks "prove" that operator+ with a VariableSlice
- * is */
-/* // not unintentionally converting the second argument to a temporary
- * Variable. */
-/* static void BM_Variable_binary_with_Variable(benchmark::State &state) { */
-/*   auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X,
- * 30}}); */
-/*   Variable a = var(Dim::Z, 0, 8); */
+// The following two benchmarks "prove" that operator+ with a VariableProxy is
+// not unintentionally converting the second argument to a temporary Variable.
+static void BM_Variable_binary_with_Variable(benchmark::State &state) {
+  auto var = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable a(var.slice({Dim::Z, 0, 8}));
 
-/*   for (auto _ : state) { */
-/*     Variable b = var(Dim::Z, 1, 9); */
-/*     auto sum = a + b; */
-/*   } */
-/* } */
-/* static void BM_Variable_binary_with_VariableSlice(benchmark::State &state) {
- */
-/*   auto b = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
- */
-/*   Variable a = b(Dim::Z, 0, 8); */
+  for (auto _ : state) {
+    Variable b(var.slice({Dim::Z, 1, 9}));
+    auto sum = a + b;
+  }
+}
+static void BM_Variable_binary_with_VariableProxy(benchmark::State &state) {
+  auto b = makeVariable<double>({{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable a(b.slice({Dim::Z, 0, 8}));
 
-/*   for (auto _ : state) { */
-/*     auto sum = a + b(Dim::Z, 1, 9); */
-/*   } */
-/* } */
-/* BENCHMARK(BM_Variable_binary_with_Variable); */
-/* BENCHMARK(BM_Variable_binary_with_VariableSlice); */
+  for (auto _ : state) {
+    auto sum = a + b.slice({Dim::Z, 1, 9});
+  }
+}
+BENCHMARK(BM_Variable_binary_with_Variable);
+BENCHMARK(BM_Variable_binary_with_VariableProxy);
 
 BENCHMARK_MAIN();

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -12,55 +12,70 @@ using namespace scipp::core;
 using namespace scipp;
 
 template <typename T> struct Generate1D {
-  Variable operator()(int size) { return makeVariable<T>({Dim::X, size}); }
+  auto operator()(int length) {
+    return std::make_tuple(makeVariable<T>({Dim::X, length}),
+                           sizeof(T) * length);
+  }
 };
 
 template <typename T> struct Generate2D {
-  Variable operator()(int size) {
-    return makeVariable<T>({{Dim::X, size}, {Dim::Y, size}});
+  auto operator()(int length) {
+    return std::make_tuple(
+        makeVariable<T>({{Dim::X, length}, {Dim::Y, length}}),
+        sizeof(T) * std::pow(length, 2));
   }
 };
 
 template <typename T> struct Generate3D {
-  Variable operator()(int size) {
-    return makeVariable<T>({{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}});
+  auto operator()(int length) {
+    return std::make_tuple(
+        makeVariable<T>({{Dim::X, length}, {Dim::Y, length}, {Dim::Z, length}}),
+        sizeof(T) * std::pow(length, 3));
   }
 };
 
 template <typename T> struct Generate4D {
-  Variable operator()(int size) {
-    return makeVariable<T>(
-        {{Dim::X, size}, {Dim::Y, size}, {Dim::Z, size}, {Dim::Qx, size}});
+  auto operator()(int length) {
+    return std::make_tuple(makeVariable<T>({{Dim::X, length},
+                                            {Dim::Y, length},
+                                            {Dim::Z, length},
+                                            {Dim::Qx, length}}),
+                           sizeof(T) * std::pow(length, 4));
   }
 };
 
 template <typename T> struct Generate5D {
-  Variable operator()(int size) {
-    return makeVariable<T>({{Dim::X, size},
-                            {Dim::Y, size},
-                            {Dim::Z, size},
-                            {Dim::Qx, size},
-                            {Dim::Qy, size}});
+  auto operator()(int length) {
+    return std::make_tuple(makeVariable<T>({{Dim::X, length},
+                                            {Dim::Y, length},
+                                            {Dim::Z, length},
+                                            {Dim::Qx, length},
+                                            {Dim::Qy, length}}),
+                           sizeof(T) * std::pow(length, 5));
   }
 };
 
 template <typename T> struct Generate6D {
-  Variable operator()(int size) {
-    return makeVariable<T>({{Dim::X, size},
-                            {Dim::Y, size},
-                            {Dim::Z, size},
-                            {Dim::Qx, size},
-                            {Dim::Qy, size},
-                            {Dim::Qz, size}});
+  auto operator()(int length) {
+    return std::make_tuple(makeVariable<T>({{Dim::X, length},
+                                            {Dim::Y, length},
+                                            {Dim::Z, length},
+                                            {Dim::Qx, length},
+                                            {Dim::Qy, length},
+                                            {Dim::Qz, length}}),
+                           sizeof(T) * std::pow(length, 6));
   }
 };
 
 template <class Gen> static void BM_Variable_copy(benchmark::State &state) {
   const auto axisLength = state.range(0);
-  auto var = Gen()(axisLength);
+  auto [var, size] = Gen()(axisLength);
   for (auto _ : state) {
     Variable copy(var);
   }
+  state.counters["Bandwidth"] =
+      benchmark::Counter(size, benchmark::Counter::kIsIterationInvariantRate,
+                         benchmark::Counter::OneK::kIs1024);
 }
 static void Args_Variable_copy(benchmark::internal::Benchmark *b) {
   b->Arg(10)->Arg(20);

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -981,12 +981,12 @@ TEST(DatasetSetData, labels) {
 }
 
 TEST(DatasetInPlaceStrongExceptionGuarantee, sparse) {
-  auto good = make_sparse_variable_with_variance();
-  set_sparse_values(good, {{1, 2, 3}, {4}});
-  set_sparse_variances(good, {{5, 6, 7}, {8}});
-  auto bad = make_sparse_variable_with_variance();
-  set_sparse_values(bad, {{0.1, 0.2, 0.3}, {0.4}});
-  set_sparse_variances(bad, {{0.5, 0.6}, {0.8}});
+  auto good = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(good, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(good, {{5, 6, 7}, {8}});
+  auto bad = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(bad, {{0.1, 0.2, 0.3}, {0.4}});
+  set_sparse_variances<double>(bad, {{0.5, 0.6}, {0.8}});
   DataArray good_array(good, {}, {});
 
   // We have no control over the iteration order in the implementation of binary

--- a/core/test/make_sparse.h
+++ b/core/test/make_sparse.h
@@ -10,14 +10,15 @@
 using namespace scipp;
 using namespace scipp::core;
 
-template <typename T> inline auto make_sparse_variable_with_variance() {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+template <typename T>
+inline auto make_sparse_variable_with_variance(int length = 2) {
+  Dimensions dims({Dim::Y, Dim::X}, {length, Dimensions::Sparse});
   return makeVariable<T>(dims, {sparse_container<T>(), sparse_container<T>()},
                          {sparse_container<T>(), sparse_container<T>()});
 }
 
-template <typename T> inline auto make_sparse_variable() {
-  Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+template <typename T> inline auto make_sparse_variable(int length = 2) {
+  Dimensions dims({Dim::Y, Dim::X}, {length, Dimensions::Sparse});
   return makeVariable<T>(dims);
 }
 

--- a/core/test/make_sparse.h
+++ b/core/test/make_sparse.h
@@ -10,30 +10,29 @@
 using namespace scipp;
 using namespace scipp::core;
 
-inline auto make_sparse_variable_with_variance() {
+template <typename T> inline auto make_sparse_variable_with_variance() {
   Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  return makeVariable<double>(
-      dims, {sparse_container<double>(), sparse_container<double>()},
-      {sparse_container<double>(), sparse_container<double>()});
+  return makeVariable<T>(dims, {sparse_container<T>(), sparse_container<T>()},
+                         {sparse_container<T>(), sparse_container<T>()});
 }
 
-inline auto make_sparse_variable() {
+template <typename T> inline auto make_sparse_variable() {
   Dimensions dims({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  return makeVariable<double>(dims);
+  return makeVariable<T>(dims);
 }
 
-inline void
-set_sparse_values(Variable &var,
-                  const std::vector<sparse_container<double>> &data) {
-  auto vals = var.sparseValues<double>();
+template <typename T>
+inline void set_sparse_values(Variable &var,
+                              const std::vector<sparse_container<T>> &data) {
+  auto vals = var.sparseValues<T>();
   for (scipp::index i = 0; i < scipp::size(data); ++i)
     vals[i] = data[i];
 }
 
-inline void
-set_sparse_variances(Variable &var,
-                     const std::vector<sparse_container<double>> &data) {
-  auto vals = var.sparseVariances<double>();
+template <typename T>
+inline void set_sparse_variances(Variable &var,
+                                 const std::vector<sparse_container<T>> &data) {
+  auto vals = var.sparseVariances<T>();
   for (scipp::index i = 0; i < scipp::size(data); ++i)
     vals[i] = data[i];
 }

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -583,12 +583,12 @@ TEST_F(TransformTest_sparse_binary_values_variances_size_fail,
 }
 
 TEST_F(TransformBinaryTest, sparse_val_var_with_sparse_val_var) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
-  auto b = make_sparse_variable_with_variance();
-  set_sparse_values(b, {{0.1, 0.2, 0.3}, {0.4}});
-  set_sparse_variances(b, {{0.5, 0.6, 0.7}, {0.8}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
+  auto b = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(b, {{0.1, 0.2, 0.3}, {0.4}});
+  set_sparse_variances<double>(b, {{0.5, 0.6, 0.7}, {0.8}});
 
   const auto ab = transform<pair_self_t<double>>(a, b, op);
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
@@ -612,11 +612,11 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_sparse_val_var) {
 }
 
 TEST_F(TransformBinaryTest, sparse_val_var_with_sparse_val) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
-  auto b = make_sparse_variable();
-  set_sparse_values(b, {{0.1, 0.2, 0.3}, {0.4}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
+  auto b = make_sparse_variable<double>();
+  set_sparse_values<double>(b, {{0.1, 0.2, 0.3}, {0.4}});
 
   const auto ab = transform<pair_self_t<double>>(a, b, op);
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
@@ -638,9 +638,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_sparse_val) {
 }
 
 TEST_F(TransformBinaryTest, sparse_val_var_with_val_var) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
   auto b = makeVariable<double>({Dim::Y, 2}, {1.5, 1.6}, {1.7, 1.8});
 
   const auto ab = transform<pair_self_t<double>>(a, b, op);
@@ -663,9 +663,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val_var) {
 }
 
 TEST_F(TransformBinaryTest, sparse_val_var_with_val) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
   auto b = makeVariable<double>({Dim::Y, 2}, {1.5, 1.6});
 
   const auto ab = transform<pair_self_t<double>>(a, b, op);
@@ -688,9 +688,9 @@ TEST_F(TransformBinaryTest, sparse_val_var_with_val) {
 }
 
 TEST_F(TransformBinaryTest, broadcast_sparse_val_var_with_val) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
   const auto b = makeVariable<float>({Dim::Z, 2}, {1.5, 1.6});
 
   const auto ab = transform<pair_custom_t<std::pair<double, float>>>(a, b, op);
@@ -724,9 +724,9 @@ TEST_F(TransformBinaryTest, broadcast_sparse_val_var_with_val) {
 // integrations, but may be unexpected. Should we fail and support this as a
 // separate operation instead?
 TEST_F(TransformBinaryTest, DISABLED_broadcast_sparse_val_var_with_val) {
-  auto a = make_sparse_variable_with_variance();
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  auto a = make_sparse_variable_with_variance<double>();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
   const auto b = makeVariable<float>({Dim::Z, 2}, {1.5, 1.6});
 
   EXPECT_THROW((transform_in_place<pair_custom_t<std::pair<double, float>>>(
@@ -812,10 +812,10 @@ TEST_F(TransformInPlaceDryRunTest, variances_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, sparse_variance_length_fail) {
-  auto a = make_sparse_variable_with_variance();
+  auto a = make_sparse_variable_with_variance<double>();
   a.setUnit(units::m);
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8, 9}});
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8, 9}});
   const auto original(a);
 
   EXPECT_THROW(dry_run::transform_in_place<double>(a, unary),
@@ -827,14 +827,14 @@ TEST_F(TransformInPlaceDryRunTest, sparse_variance_length_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, sparse_length_fail) {
-  auto a = make_sparse_variable_with_variance();
+  auto a = make_sparse_variable_with_variance<double>();
   a.setUnit(units::m);
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
-  auto b = make_sparse_variable_with_variance();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
+  auto b = make_sparse_variable_with_variance<double>();
   b.setUnit(units::m);
-  set_sparse_values(b, {{1, 2, 3}, {4, 5}});
-  set_sparse_variances(b, {{5, 6, 7}, {8, 9}});
+  set_sparse_values<double>(b, {{1, 2, 3}, {4, 5}});
+  set_sparse_variances<double>(b, {{5, 6, 7}, {8, 9}});
   const auto original(a);
 
   EXPECT_THROW(dry_run::transform_in_place<pair_self_t<double>>(a, b, binary),
@@ -843,12 +843,12 @@ TEST_F(TransformInPlaceDryRunTest, sparse_length_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, sparse_no_variances_length_fail) {
-  auto a = make_sparse_variable();
+  auto a = make_sparse_variable<double>();
   a.setUnit(units::m);
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  auto b = make_sparse_variable();
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  auto b = make_sparse_variable<double>();
   b.setUnit(units::m);
-  set_sparse_values(b, {{1, 2, 3}, {4, 5}});
+  set_sparse_values<double>(b, {{1, 2, 3}, {4, 5}});
   const auto original(a);
 
   EXPECT_THROW(dry_run::transform_in_place<pair_self_t<double>>(a, b, binary),
@@ -857,10 +857,10 @@ TEST_F(TransformInPlaceDryRunTest, sparse_no_variances_length_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, unchanged_if_success) {
-  auto a = make_sparse_variable_with_variance();
+  auto a = make_sparse_variable_with_variance<double>();
   a.setUnit(units::m);
-  set_sparse_values(a, {{1, 2, 3}, {4}});
-  set_sparse_variances(a, {{5, 6, 7}, {8}});
+  set_sparse_values<double>(a, {{1, 2, 3}, {4}});
+  set_sparse_variances<double>(a, {{5, 6, 7}, {8}});
   const auto original(a);
 
   dry_run::transform_in_place<double>(a, unary);


### PR DESCRIPTION
Benchmarks `Variable` and `Dataset` copies with both dense and sparse data.

Results (`Variable`):
```
------------------------------------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations BandwidthBytes  SizeBytes
------------------------------------------------------------------------------------------------------------------
BM_Variable_copy<Generate1D<float>>/10              73.3 ns         73.3 ns      9005505     520.509M/s         40
BM_Variable_copy<Generate1D<float>>/20              77.4 ns         77.4 ns      9313154      985.42M/s         80
BM_Variable_copy<Generate2D<float>>/10               105 ns          105 ns      6661767     3.53712G/s        400
BM_Variable_copy<Generate2D<float>>/20               171 ns          171 ns      4150415     8.68897G/s       1.6k
BM_Variable_copy<Generate3D<float>>/10               202 ns          202 ns      3527298     18.4439G/s         4k
BM_Variable_copy<Generate3D<float>>/20               870 ns          870 ns       811032     34.2402G/s        32k
BM_Variable_copy<Generate4D<float>>/10              1046 ns         1046 ns       652018     35.6179G/s        40k
BM_Variable_copy<Generate4D<float>>/20             29896 ns        29895 ns        23246     19.9383G/s       640k
BM_Variable_copy<Generate5D<float>>/10             10057 ns        10057 ns        70051     37.0408G/s       400k
BM_Variable_copy<Generate5D<float>>/20           1228633 ns      1228542 ns          552     9.70332G/s      12.8M
BM_Variable_copy<Generate6D<float>>/10            289482 ns       289466 ns         2415     12.8695G/s         4M
BM_Variable_copy<Generate6D<float>>/20          97787835 ns     97785264 ns            7     2.43819G/s       256M
BM_Variable_copy<Generate1D<double>>/10             88.2 ns         88.2 ns      7997994     864.616M/s         80
BM_Variable_copy<Generate1D<double>>/20             96.1 ns         96.1 ns      7200129     1.54987G/s        160
BM_Variable_copy<Generate2D<double>>/10              112 ns          112 ns      6200390     6.64884G/s        800
BM_Variable_copy<Generate2D<double>>/20              193 ns          193 ns      3628487     15.4686G/s       3.2k
BM_Variable_copy<Generate3D<double>>/10              258 ns          258 ns      2722866     28.8617G/s         8k
BM_Variable_copy<Generate3D<double>>/20             1603 ns         1603 ns       445278     37.1877G/s        64k
BM_Variable_copy<Generate4D<double>>/10             1989 ns         1988 ns       343701     37.4686G/s        80k
BM_Variable_copy<Generate4D<double>>/20            92380 ns        92375 ns         7557     12.9049G/s      1.28M
BM_Variable_copy<Generate5D<double>>/10            51485 ns        51484 ns        13603     14.4716G/s       800k
BM_Variable_copy<Generate5D<double>>/20          3142477 ns      3142387 ns          221     7.58718G/s      25.6M
BM_Variable_copy<Generate6D<double>>/10           631654 ns       631574 ns         1117     11.7968G/s         8M
BM_Variable_copy<Generate6D<double>>/20        194878068 ns    194867848 ns            4     2.44698G/s       512M
BM_Variable_copy<GenerateSparse<float>>/32           606 ns          606 ns      1256251     11.4231G/s     7.428k
BM_Variable_copy<GenerateSparse<float>>/64          1152 ns         1152 ns       595443     10.1796G/s    12.596k
BM_Variable_copy<GenerateSparse<float>>/512        14521 ns        14521 ns        47358     6.54028G/s   101.972k
BM_Variable_copy<GenerateSparse<float>>/4096      174683 ns       174675 ns         3996     4.40645G/s   826.456k
BM_Variable_copy<GenerateSparse<double>>/32          780 ns          780 ns       838308     13.0017G/s    10.888k
BM_Variable_copy<GenerateSparse<double>>/64         1539 ns         1539 ns       470092     15.2366G/s    25.184k
BM_Variable_copy<GenerateSparse<double>>/512       14715 ns        14715 ns        46345     12.8889G/s    203.64k
BM_Variable_copy<GenerateSparse<double>>/4096     234548 ns       234532 ns         3003      6.4551G/s   1.62557M
```

Results (`Dataset`):
```
--------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                        Time             CPU   Iterations BandwidthBytes  SizeBytes
--------------------------------------------------------------------------------------------------------------------------------------------
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/1/32            6.55 us         6.55 us       100897     37.2676G/s   262.144k
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/2/32            19.3 us         19.3 us        37262     25.2896G/s   524.288k
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/4/32            77.2 us         77.2 us         9062     12.6427G/s   1048.58k
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/8/32             155 us          155 us         4520     12.6018G/s   2.09715M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/16/32            312 us          312 us         2234     12.5234G/s    4.1943M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/1/64             153 us          153 us         4470     12.7422G/s   2.09715M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/2/64             308 us          308 us         2280     12.6942G/s    4.1943M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/4/64             694 us          694 us          992     11.2538G/s   8.38861M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/8/64            1858 us         1858 us          377     8.41139G/s   16.7772M
BM_Dataset_copy<Generate3DWithDataItems<SHORT_STRING_LENGTH>>/16/64           4209 us         4209 us          166     7.42408G/s   33.5544M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/1/32             6.21 us         6.21 us       111263     39.2863G/s   262.144k
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/2/32             20.0 us         20.0 us        39428     24.3774G/s   524.288k
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/4/32             75.2 us         75.2 us         9140     12.9795G/s   1048.58k
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/8/32              155 us          155 us         4522     12.5951G/s   2.09715M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/16/32             313 us          313 us         2239     12.4911G/s    4.1943M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/1/64              153 us          153 us         4565     12.7515G/s   2.09715M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/2/64              311 us          311 us         2272     12.5416G/s    4.1943M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/4/64              733 us          733 us          958     10.6615G/s   8.38861M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/8/64             2018 us         2018 us          315     7.74227G/s   16.7772M
BM_Dataset_copy<Generate3DWithDataItems<LONG_STRING_LENGTH>>/16/64            4379 us         4378 us          132      7.1374G/s   33.5544M
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/1/32       0.935 us        0.935 us       789780     14.3071G/s    14.368k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/2/32        1.79 us         1.79 us       434549     13.0405G/s    25.104k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/4/32        3.53 us         3.53 us       208091     13.5014G/s    51.168k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/8/32        7.66 us         7.66 us        90974     12.5657G/s   103.296k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/16/32       19.8 us         19.8 us        35005     10.1364G/s   215.496k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/1/64        1.63 us         1.63 us       428293     14.1828G/s    24.784k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/2/64        3.22 us         3.22 us       220866     14.8269G/s    51.272k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/4/64        6.79 us         6.79 us       102806     14.9947G/s   109.328k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/8/64        18.4 us         18.4 us        40236     11.2426G/s   221.544k
BM_Dataset_copy<GenerateWithSparseDataItems<SHORT_STRING_LENGTH>>/16/64       53.1 us         53.1 us        12961     7.23408G/s   412.544k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/1/32        0.860 us        0.860 us       829059     11.3501G/s     10.48k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/2/32         1.80 us         1.80 us       364890     13.1841G/s    25.496k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/4/32         3.68 us         3.68 us       195660     13.0674G/s    51.584k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/8/32         7.37 us         7.37 us        90022     13.0224G/s   103.104k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/16/32        21.3 us         21.3 us        33466     8.95178G/s    204.88k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/1/64         1.64 us         1.64 us       434563     14.1228G/s     24.88k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/2/64         3.24 us         3.24 us       210599     14.6324G/s     50.84k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/4/64         6.70 us         6.70 us       104037     14.1219G/s   101.624k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/8/64         17.5 us         17.5 us        37975     10.8926G/s   204.096k
BM_Dataset_copy<GenerateWithSparseDataItems<LONG_STRING_LENGTH>>/16/64        53.5 us         53.5 us        13126     7.25173G/s   416.272k
```

Re #558.