### PR TITLE
Use Dim.Spectrum instead of Dim.Position when converting workspace

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -889,14 +889,14 @@ SCIPP_CORE_EXPORT Variable concatenate(const VariableConstProxy &a1,
 SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
 SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim);
-SCIPP_CORE_EXPORT Variable norm(const Variable &var);
+SCIPP_CORE_EXPORT Variable norm(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT Variable permute(const Variable &var, const Dim dim,
                                    const std::vector<scipp::index> &indices);
 SCIPP_CORE_EXPORT Variable rebin(const VariableConstProxy &var, const Dim dim,
                                  const VariableConstProxy &oldCoord,
                                  const VariableConstProxy &newCoord);
 SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
-SCIPP_CORE_EXPORT Variable sqrt(const Variable &var);
+SCIPP_CORE_EXPORT Variable sqrt(const VariableConstProxy &var);
 
 SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var, const Dim dim);
 SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -165,13 +165,13 @@ Variable abs(const Variable &var) {
   return transform<double, float>(var, [](const auto x) { return abs(x); });
 }
 
-Variable norm(const Variable &var) {
+Variable norm(const VariableConstProxy &var) {
   return transform<Eigen::Vector3d>(
       var, overloaded{[](const auto &x) { return x.norm(); },
                       [](const units::Unit &x) { return x; }});
 }
 
-Variable sqrt(const Variable &var) {
+Variable sqrt(const VariableConstProxy &var) {
   using std::sqrt;
   return transform<double, float>(var, [](const auto x) { return sqrt(x); });
 }

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -74,16 +74,16 @@
     "\n",
     "### Dimensions and coordinates\n",
     "\n",
-    "#### Position\n",
+    "#### Spectrum\n",
     "\n",
     "In most Mantid workspaces each spectrum corresponds to data measured at a detector pixel, i.e., at a specific position or region in space.\n",
-    "Therefore we use `Dim.Position` for the \"spectrum\" dimension.\n",
+    "If that is the case, scipp used `Dim.Spectrum` for this dimension.\n",
     "\n",
-    "Note that this deliberately avoids a more generic `Dim.Spectrum` since that hides the true meaning and is ambigous.\n",
-    "For example, after converting data to `Q` we want to avoid having \"compatible\" dimensions of a data and would use `Dim.Q`.\n",
+    "Note that using the generic `Dim.Spectrum` should be avoided in other cases.\n",
+    "For example, after converting data to `Q` we need to avoid having \"compatible\" dimensions of a data and would use `Dim.Q`.\n",
     "The double meaning of what a \"spectrum\" actually is in Mantid is thus avoided.\n",
     "\n",
-    "The position dimensions comes with a coordinate:"
+    "The spectrum dimension comes with a coordinate:"
    ]
   },
   {
@@ -92,16 +92,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.coords[Dim.Position]"
+    "d.coords[Dim.Spectrum]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The position coordinate stores the positions of all spectra.\n",
-    "Each position is a 3-component vector (X, Y, Z).\n",
-    "\n",
     "#### Time-of-flight\n",
     "\n",
     "In contrast to a `EventWorkspace` in Mantid, a dataset does not necessarily come with a time-of-flight (TOF) coordinate (bin edges) on top of the TOF values for the events.\n",
@@ -114,11 +111,12 @@
     "Labels or coords (and not attributes) are used to ensure that information is compatible in operations involving multiple data arrays or dataset.\n",
     "\n",
     "This actually happended internally when we first loaded the files for sample and vanadium and inserted them into the same dataset:\n",
-    "If the files had had different spectrum positions or spectrum numbers the insertion of the `'vanadium'` data would have failed due to incompatible coordinates or labels.\n",
+    "If the files had had different spectrum numbers or spectrum positions the insertion of the `'vanadium'` data would have failed due to incompatible coordinates or labels.\n",
     "\n",
-    "#### Spectrum numbers\n",
+    "#### Position\n",
     "\n",
-    "Spectrum numbers are an auxiliary coordinate for `Dim.Position`, in other words they can be used to \"label\" the position coordinate, e.g., in an a plot:"
+    "Positions are an auxiliary coordinate for `Dim.Spectrum`, in other words they could be used to \"label\" the spectrum coordinate, e.g., in an a plot.\n",
+    "The main purpose of storing postions as labels instead of, e.g., attributes is to ensure that operations between data with mismatching detector positions fail and thus prevent mistakes."
    ]
   },
   {
@@ -127,7 +125,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.labels['spectrum_number']"
+    "d.labels['position']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The position coordinate stores the positions of all spectra.\n",
+    "Each position is a 3-component vector (X, Y, Z)."
    ]
   },
   {
@@ -213,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.show(d[Dim.Position, 10:20])"
+    "sc.show(d[Dim.Spectrum, 10:20])"
    ]
   },
   {
@@ -226,8 +232,8 @@
     "  Therefore, there is a time-of-flight for *every pixel*, for *every event*, and for *every data item* (`'vanadium'` and `'sample'`).\n",
     "  This **sparse coordinate** has the following properties:\n",
     "  - The sparse coord for `Dim.Tof` is associated with a data item and is not global for the dataset.\n",
-    "  - The sparse coord for `Dim.Tof` depends on `Dim.Position`.\n",
-    "  - The sparse coord for `Dim.Tof` has a different length at each position.\n",
+    "  - The sparse coord for `Dim.Tof` depends on `Dim.Spectrum`.\n",
+    "  - The sparse coord for `Dim.Tof` has a different length for each spectrum.\n",
     "- Extra information such as pulse times are stored as sparse labels.\n",
     "  What was said above for sparse coords also applies to sparse labels.\n",
     "  The length at each position matches the corresponding length of the sparse coordinate.\n",
@@ -244,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d['sample'].coords[sc.Dim.Tof][sc.Dim.Position, 10].values"
+    "d['sample'].coords[sc.Dim.Tof][sc.Dim.Spectrum, 10].values"
    ]
   },
   {
@@ -275,7 +281,7 @@
    },
    "outputs": [],
    "source": [
-    "sc.plot(d['sample'], axes=['spectrum_number', Dim.Tof])"
+    "sc.plot(d['sample'])"
    ]
   },
   {
@@ -378,7 +384,7 @@
    "outputs": [],
    "source": [
     "sample_over_beam = d['sample'] / sc.rebin(d.labels['beam'].value, Dim.Tof, d.coords[Dim.Tof])\n",
-    "sc.plot(sample_over_beam, axes=['spectrum_number', Dim.Tof])"
+    "sc.plot(sample_over_beam)"
    ]
   },
   {
@@ -413,7 +419,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(temp_scan[Dim.Position, 20:], axes=[Dim.Tof, Dim.Temperature, 'spectrum_number'])"
+    "sc.plot(temp_scan[Dim.Spectrum, 20:], axes=[Dim.Tof, Dim.Temperature, Dim.Spectrum])"
    ]
   },
   {
@@ -422,7 +428,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(temp_scan[Dim.Position, 500], collapse=Dim.Tof)"
+    "sc.plot(temp_scan[Dim.Spectrum, 500], collapse=Dim.Tof)"
    ]
   },
   {
@@ -452,7 +458,7 @@
    "outputs": [],
    "source": [
     "# Plotting cannot handle ragged coordinates at this point, rebin to edges of first spectrum\n",
-    "d = sc.rebin(d, Dim.DSpacing, d.coords[Dim.DSpacing][Dim.Position, 0])"
+    "d = sc.rebin(d, Dim.DSpacing, d.coords[Dim.DSpacing][Dim.Spectrum, 0])"
    ]
   },
   {
@@ -463,7 +469,7 @@
    },
    "outputs": [],
    "source": [
-    "sc.plot(d, axes=['spectrum_number', Dim.DSpacing])"
+    "sc.plot(d)"
    ]
   },
   {
@@ -479,7 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summed = sc.sum(d, Dim.Position)\n",
+    "summed = sc.sum(d, Dim.Spectrum)\n",
     "sc.plot(summed)"
    ]
   },
@@ -512,8 +518,8 @@
     "Each of the approaches has its advantages and drawbacks.\n",
     "\n",
     "Here we recommend option 1, which in itself can be implemented in one of two ways:\n",
-    "- Concatenate along a new dimension (`Dim.Bank` and `Coord.Bank` is not supported currently, use, e.g., `Dim.Row` instead).\n",
-    "- Concatenate along the existing dimension `Dim.Position`.\n",
+    "- Concatenate along a new dimension (`Dim.Bank` is not supported currently, use, e.g., `Dim.Row` instead).\n",
+    "- Concatenate along the existing dimension `Dim.Spectrum`.\n",
     "\n",
     "*Note: You will likely experience some small problems with plotting, in particular issues with multi-dimensional coordinates in the first case (we suggest to slice manually until this is supported), and large gaps in the second case (can be avoided by adding a helper-coordinate).*\n",
     "\n",

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -14,6 +14,10 @@ auto component_positions(const Dataset &d) {
   return d.labels()["component_info"].values<Dataset>()[0]["position"].data();
 }
 
+VariableConstProxy position(const core::Dataset &d) {
+  return d.labels()["position"];
+}
+
 Variable source_position(const Dataset &d) {
   // TODO Need a better mechanism to identify source and sample.
   return Variable(component_positions(d).slice({Dim::Row, 0}));
@@ -27,9 +31,7 @@ Variable l1(const Dataset &d) {
   return norm(sample_position(d) - source_position(d));
 }
 
-Variable l2(const Dataset &d) {
-  return norm(d.coords()[Dim::Position] - sample_position(d));
-}
+Variable l2(const Dataset &d) { return norm(position(d) - sample_position(d)); }
 
 Variable scattering_angle(const Dataset &d) { return 0.5 * two_theta(d); }
 
@@ -37,7 +39,7 @@ Variable two_theta(const Dataset &d) {
   auto beam = sample_position(d) - source_position(d);
   const auto l1 = norm(beam);
   beam /= l1;
-  auto scattered = d.coords()[Dim::Position] - sample_position(d);
+  auto scattered = position - sample_position(d);
   const auto l2 = norm(scattered);
   scattered /= l2;
 

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -15,7 +15,10 @@ auto component_positions(const Dataset &d) {
 }
 
 VariableConstProxy position(const core::Dataset &d) {
-  return d.labels()["position"];
+  if (d.coords().contains(Dim::Position))
+    return d.coords()[Dim::Position];
+  else
+    return d.labels()["position"];
 }
 
 Variable source_position(const Dataset &d) {

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -39,7 +39,7 @@ Variable two_theta(const Dataset &d) {
   auto beam = sample_position(d) - source_position(d);
   const auto l1 = norm(beam);
   beam /= l1;
-  auto scattered = position - sample_position(d);
+  auto scattered = position(d) - sample_position(d);
   const auto l2 = norm(scattered);
   scattered /= l2;
 

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -33,7 +33,7 @@ const auto tofToEnergyPhysicalConstants =
 static Dataset convert_with_factor(Dataset &&d, const Dim from, const Dim to,
                                    const Variable &factor) {
   // 1. Transform coordinate
-  // Cannot use *= since often a broadcast into Dim::Position is required.
+  // Cannot use *= since often a broadcast into Dim::Spectrum is required.
   if (d.coords().contains(from))
     d.setCoord(from, d.coords()[from] * factor);
 
@@ -58,7 +58,7 @@ auto tofToDSpacing(const Dataset &d) {
   auto beam = samplePos - sourcePos;
   const auto l1 = norm(beam);
   beam /= l1;
-  auto scattered = d.coords()[Dim::Position] - samplePos;
+  auto scattered = neutron::position(d) - samplePos;
   const auto l2 = norm(scattered);
   scattered /= l2;
 
@@ -83,7 +83,7 @@ static auto tofToWavelength(const Dataset &d) {
 auto tofToEnergyConversionFactor(const Dataset &d) {
   const auto &samplePos = sample_position(d);
   const auto l1 = neutron::l1(d);
-  const auto specPos = d.coords()[Dim::Position];
+  const auto specPos = neutron::position(d);
 
   // l_total = l1 + l2
   auto conversionFactor(norm(specPos - samplePos) + l1);

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -13,10 +13,12 @@
 namespace scipp::core {
 class Dataset;
 class Variable;
+class VariableConstProxy;
 } // namespace scipp::core
 
 namespace scipp::neutron {
 
+SCIPP_NEUTRON_EXPORT core::VariableConstProxy position(const core::Dataset &d);
 SCIPP_NEUTRON_EXPORT core::Variable source_position(const core::Dataset &d);
 SCIPP_NEUTRON_EXPORT core::Variable sample_position(const core::Dataset &d);
 SCIPP_NEUTRON_EXPORT core::Variable l1(const core::Dataset &d);

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -25,10 +25,10 @@ Dataset makeDatasetWithBeamline() {
   beamline.setLabels("component_info", makeVariable<Dataset>(components));
   // TODO Need fuzzy comparison for variables to write a convenient test with
   // detectors away from the axes.
-  beamline.setCoord(Dim::Position, makeVariable<Eigen::Vector3d>(
-                                       {Dim::Position, 2}, units::m,
-                                       {Eigen::Vector3d{1.0, 0.0, 0.01},
-                                        Eigen::Vector3d{0.0, 1.0, 0.01}}));
+  beamline.setLabels("position", makeVariable<Eigen::Vector3d>(
+                                     {Dim::Spectrum, 2}, units::m,
+                                     {Eigen::Vector3d{1.0, 0.0, 0.01},
+                                      Eigen::Vector3d{0.0, 1.0, 0.01}}));
   return beamline;
 }
 
@@ -47,14 +47,14 @@ TEST_F(BeamlineTest, basics) {
 
 TEST_F(BeamlineTest, l2) {
   ASSERT_EQ(l2(dataset),
-            makeVariable<double>({Dim::Position, 2}, units::m, {1.0, 1.0}));
+            makeVariable<double>({Dim::Spectrum, 2}, units::m, {1.0, 1.0}));
 }
 
 template <class T> constexpr T pi = T(3.1415926535897932385L);
 
 TEST_F(BeamlineTest, scattering_angle) {
   ASSERT_EQ(two_theta(dataset),
-            makeVariable<double>({Dim::Position, 2}, units::rad,
+            makeVariable<double>({Dim::Spectrum, 2}, units::rad,
                                  {pi<double> / 2, pi<double> / 2}));
   ASSERT_EQ(scattering_angle(dataset), 0.5 * two_theta(dataset));
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -315,7 +315,7 @@ void init_variable(py::module &m) {
         :seealso: :py:class:`scipp.sum`
         :return: New variable containing the mean.
         :rtype: Variable)");
-  m.def("norm", py::overload_cast<const Variable &>(&norm),
+  m.def("norm", py::overload_cast<const VariableConstProxy &>(&norm),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise norm.
 
@@ -341,7 +341,7 @@ void init_variable(py::module &m) {
         py::call_guard<py::gil_scoped_release>(),
         "Split a Variable along a given Dimension.");
 
-  m.def("sqrt", [](const Variable &self) { return sqrt(self); },
+  m.def("sqrt", [](const VariableConstProxy &self) { return sqrt(self); },
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise square-root.
 

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -143,9 +143,9 @@ public:
   using Unit_impl<Unit>::Unit_impl;
 };
 
-SCIPP_UNITS_DECLARE_DIMENSIONS(DSpacing, Energy, EnergyTransfer, Position, Q,
-                               Qx, Qy, Qz, Row, Spectrum, Temperature, Time,
-                               Tof, Wavelength, X, Y, Z)
+SCIPP_UNITS_DECLARE_DIMENSIONS(Detector, DSpacing, Energy, EnergyTransfer,
+                               Position, Q, Qx, Qy, Qz, Row, Spectrum,
+                               Temperature, Time, Tof, Wavelength, X, Y, Z)
 
 } // namespace neutron
 


### PR DESCRIPTION
A while ago (still during prototyping) I had made the choice to avoid `Dim.Spectrum` and use `Dim.Position` instead. The argument was that Mantid uses "spectrum" for everything, even if it is not, e.g., `Q` or `2-theta`.

However, there are more things to consider:

- While the argument still applies for `Dim.Q` and others, for the raw input data `Dim.Spectrum` appears to be more convenient and easier to understand than `Dim.Position`.
- People are used to "spectrum" from Mantid.
- We need to handle detector grouping. The most natural dimension for detectors is `Dim.Detector`. This gives the following options:
  1. Use `Dim.Detector` before and after grouping (avoiding "spectrum"). This gives a double meaning to the dimension. The advantage is that users do not need to know about the difference between detetors and groups of detectors. The disadvantage is confusion (and maybe increased risk for errors?) from the double meaning.
  2. Use `Dim.Position` before and after grouping (avoiding "spectrum"). This gives a double meaning to the dimension. Advantages and disadvantages as above. Addional advantage: `Dim.Position` gives a clear meaning.
  3. Use `Dim.Detector` and `Dim.Position`. This feels inconsistent.
  4. Use `Dim.Detector` and `Dim.Position`. More consistent and in-line with Mantid.
- Plotting would usually use spectrum numbers as labels, if the coordinate is the position we always must specify this by hand. 
- Inconsistency between storing positions and other geometry information. Compare:
  ```python
  pos = data.coords[Dim.Position]
  rot = data.labels['rotation']
  ```
  with
  ```python
  pos = data.labels['position']
  rot = data.labels['rotation']
  ```

While I am still not convinced that there is an absolute obious choice, I think at least for now using `Dim.Spectrum` has overall the advantage.

Note that I changed the code in `neutron` such that, e.g., `convert` does not rely on this and can handle positions as coords or labels. So the only convention we are actually enforcing is what the converter from Mantid does.