### PR TITLE
Added psutil to docs build environment

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - plotly
   - plotly-orca
   - ipywidgets
+  - psutil

--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -19,7 +19,8 @@
     "import numpy as np\n",
     "import scipp as sc\n",
     "from scipp import Dim\n",
-    "from scipp.plot import plot"
+    "from scipp.plot import plot\n",
+    "sc.plot.config.backend = 'static'"
    ]
   },
   {


### PR DESCRIPTION
The use of static image export for `plotly` graphs introduced the need for `psutil` to be installed: see e.g. https://readthedocs.org/projects/scipp/builds/9812274/

Also added `'static'` backend to `quick-start` notebook.