### PR TITLE
Fix plotting with labels

### DIFF
--- a/docs/user-guide/plotting.ipynb
+++ b/docs/user-guide/plotting.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot.config.backend = \"static\""
+    "# sc.plot.config.backend = \"static\""
    ]
   },
   {
@@ -140,6 +140,42 @@
    "outputs": [],
    "source": [
     "plot(d, color=['red', '#30D5F9'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Logarithmic scales\n",
+    "\n",
+    "Logarithmic axes are supported as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(d, logx=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(d, logy=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(d, logxy=True)"
    ]
   },
   {

--- a/docs/user-guide/plotting.ipynb
+++ b/docs/user-guide/plotting.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sc.plot.config.backend = \"static\""
+    "sc.plot.config.backend = \"static\""
    ]
   },
   {
@@ -262,6 +262,61 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Custom labels along x axis\n",
+    "\n",
+    "Sometimes one wishes to have `labels` along the X axis instead of the coordinate. This can be achieved via the `axes` keyword argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1 = sc.Dataset()\n",
+    "N = 100\n",
+    "d1.coords[Dim.Tof] = sc.Variable([Dim.Tof],\n",
+    "                                 values=np.arange(N).astype(np.float64),\n",
+    "                                 unit=sc.units.us)\n",
+    "d1[\"Sample\"] = sc.Variable([Dim.Tof],\n",
+    "                           values=10.0 * np.random.rand(N),\n",
+    "                           unit=sc.units.counts)\n",
+    "d1.labels[\"somelabels\"] = sc.Variable([sc.Dim.Tof],\n",
+    "                                      values=np.linspace(101., 105., N),\n",
+    "                                      unit=sc.units.s)\n",
+    "plot(d1, axes=\"somelabels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If one has multiple entries in a `Dataset`, the labels corresponding to each dimension need to be specified in a dictionary-like fashion:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "M = 50\n",
+    "d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],\n",
+    "                                  values=np.arange(M).astype(np.float64),\n",
+    "                                  unit=sc.units.m)\n",
+    "d1[\"Sample2\"] = sc.Variable([sc.Dim.X],\n",
+    "                            values=10.0 * np.random.rand(M),\n",
+    "                            unit=sc.units.counts)\n",
+    "d1.labels[\"Xlabels\"] = sc.Variable([sc.Dim.X],\n",
+    "                                   values=np.linspace(151., 155., M),\n",
+    "                                   unit=sc.units.s)\n",
+    "plot(d1, axes={Dim.X: \"Xlabels\", Dim.Tof: \"somelabels\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Plotting 2-D data\n",
     "\n",
     "### 2-D data as an image\n",
@@ -416,6 +471,27 @@
    "source": [
     "plot(d1, show_variances=True,\n",
     "     cb={\"min\": 0, \"max\": 0.5, \"min_var\": -0.01, \"max_var\": 0.01})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using labels along some axis\n",
+    "\n",
+    "Just like in the 1d plots, we can use labels along a chosen dimension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d1.labels[\"somelabels\"] = sc.Variable([sc.Dim.X],\n",
+    "                                      values=np.linspace(101., 105., N),\n",
+    "                                      unit=sc.units.s)\n",
+    "plot(d1, axes=[Dim.Y, \"somelabels\"])"
    ]
   },
   {

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -50,25 +50,31 @@ def plot(input_data, collapse=None, backend=None, color=None, **kwargs):
             elif ndims > 1:
                 tobeplotted[name] = [ndims, ds[name]]
 
+    # Prepare color containers
+    auto_color = False
+    if color is None:
+        auto_color = True
+    elif not isinstance(color, list):
+        color = [color]
+
     # Plot all the subsets
     color_count = 0
     output = dict()
     for key, val in tobeplotted.items():
         if val[0] == 1:
-            if color is None:
+            if auto_color:
                 color = []
                 for l in val[1].keys():
                     color.append(get_color(index=color_count))
                     color_count += 1
-            elif not isinstance(color, list):
-                color = [color]
             name = None
         else:
             color = None
             name = key
         if collapse is not None:
             output[key] = plot_collapse(input_data=val[1], dim=collapse,
-                                        name=name, backend=backend, **kwargs)
+                                        name=name, backend=backend,
+                                        color=color, **kwargs)
         else:
             output[key] = dispatch(input_data=val[1], ndim=val[0], name=name,
                                    backend=backend, color=color, **kwargs)

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -4,7 +4,7 @@
 
 # Scipp imports
 from . import config
-from .tools import edges_to_centers, axis_label, render_plot
+from .tools import edges_to_centers, axis_label, render_plot, axis_to_dim_label
 
 # Other imports
 import numpy as np
@@ -12,7 +12,7 @@ import plotly.graph_objs as go
 
 
 def plot_1d(input_data, backend=None, logx=False, logy=False, logxy=False,
-            color=None, filename=None):
+            color=None, filename=None, axes=None):
     """
     Plot a 1D spectrum.
 
@@ -26,9 +26,17 @@ def plot_1d(input_data, backend=None, logx=False, logy=False, logxy=False,
 
     data = []
     for i, (name, var) in enumerate(input_data.items()):
-        xcoord = var.coords[var.dims[0]]
+        if axes is None:
+            axes = {var.dims[0] : var.dims[0]}
+        elif isinstance(axes, str):
+            axes = {var.dims[0] : axes}
+        dim, lab = axis_to_dim_label(var, axes[var.dims[0]])
+        if lab is not None:
+            xcoord = var.labels[lab]
+        else:
+            xcoord = var.coords[dim]
         x = xcoord.values
-        xlab = axis_label(xcoord)
+        xlab = axis_label(var=xcoord, name=lab)
         y = var.values
         ylab = axis_label(var=var, name=name)
 

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -4,7 +4,7 @@
 
 # Scipp imports
 from . import config
-from .tools import edges_to_centers, axis_label, render_plot, get_1d_axes
+from .tools import edges_to_centers, render_plot, get_1d_axes
 
 # Other imports
 import numpy as np

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -4,7 +4,7 @@
 
 # Scipp imports
 from . import config
-from .tools import edges_to_centers, axis_label, render_plot, axis_to_dim_label
+from .tools import edges_to_centers, axis_label, render_plot, get_1d_axes
 
 # Other imports
 import numpy as np
@@ -26,19 +26,8 @@ def plot_1d(input_data, backend=None, logx=False, logy=False, logxy=False,
 
     data = []
     for i, (name, var) in enumerate(input_data.items()):
-        if axes is None:
-            axes = {var.dims[0] : var.dims[0]}
-        elif isinstance(axes, str):
-            axes = {var.dims[0] : axes}
-        dim, lab = axis_to_dim_label(var, axes[var.dims[0]])
-        if lab is not None:
-            xcoord = var.labels[lab]
-        else:
-            xcoord = var.coords[dim]
-        x = xcoord.values
-        xlab = axis_label(var=xcoord, name=lab)
-        y = var.values
-        ylab = axis_label(var=var, name=name)
+
+        xlab, ylab, x, y = get_1d_axes(var, axes, name)
 
         nx = x.shape[0]
         ny = y.shape[0]

--- a/python/src/scipp/plot/plot_collapse.py
+++ b/python/src/scipp/plot/plot_collapse.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 def plot_collapse(input_data, dim=None, name=None, filename=None, backend=None,
-                  **kwargs):
+                  color=None, **kwargs):
     """
     Collapse higher dimensions into a 1D plot.
     """
@@ -77,9 +77,13 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, backend=None,
     slice_list = np.reshape(
         np.transpose(slice_list), (volume, len(slice_dims), 2))
 
+    auto_color = False
+    if color is None:
+        color = []
+        auto_color = True
+
     # Extract each entry from the slice_list, make temporary dataset and add to
     # input dictionary for plot_1d
-    color = []
     for i, line in enumerate(slice_list):
         ds_temp = input_data
         key = ""
@@ -93,7 +97,8 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, backend=None,
         ds[key] = sc.core.Variable([dim], values=ds_temp.values,
                                    variances=variances)
         data[key] = ds[key]
-        color.append(get_color(index=i))
+        if auto_color:
+            color.append(get_color(index=i))
 
     # Send the newly created dictionary of DataProxy to the plot_1d function
     return dispatch(input_data=data, ndim=1, backend=backend, color=color,

--- a/python/src/scipp/plot/plot_matplotlib.py
+++ b/python/src/scipp/plot/plot_matplotlib.py
@@ -84,7 +84,6 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
         axes = input_data.dims
 
     # Get coordinates axes and dimensions
-    coords = input_data.coords
     zdims = input_data.dims
     nz = input_data.shape
 

--- a/python/src/scipp/plot/plot_matplotlib.py
+++ b/python/src/scipp/plot/plot_matplotlib.py
@@ -6,7 +6,7 @@
 # Scipp imports
 from . import config
 from .tools import edges_to_centers, centers_to_edges, axis_label, \
-                   parse_colorbar
+                   parse_colorbar, get_1d_axes, axis_to_dim_label
 
 # Other imports
 import numpy as np
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 
 
 def plot_1d(input_data, logx=False, logy=False, logxy=False,
-            color=None, filename=None, title=None, mpl_axes=None):
+            color=None, filename=None, title=None, axes=None, mpl_axes=None):
     """
     Plot a 1D spectrum.
     Input is a dictionary containing a list of DataProxy.
@@ -32,11 +32,8 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False,
            "errorbar": {}}
 
     for i, (name, var) in enumerate(input_data.items()):
-        xcoord = var.coords[var.dims[0]]
-        x = xcoord.values
-        xlab = axis_label(xcoord)
-        y = var.values
-        ylab = axis_label(var=var, name=name)
+
+        xlab, ylab, x, y = get_1d_axes(var, axes, name)
 
         # Check for bin edges
         if x.shape[0] == y.shape[0] + 1:
@@ -59,6 +56,10 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False,
     ax.legend()
     if title is not None:
         ax.set_title(title)
+    if logx or logxy:
+        ax.set_xscale("log")
+    if logy or logxy:
+        ax.set_yscale("log")
 
     out["ax"] = ax
     if fig is not None:
@@ -87,8 +88,8 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
     zdims = input_data.dims
     nz = input_data.shape
 
-    xcoord = coords[axes[-1]]
-    ycoord = coords[axes[-2]]
+    dimx, labx, xcoord = axis_to_dim_label(input_data, axes[-1])
+    dimy, laby, ycoord = axis_to_dim_label(input_data, axes[-2])
     xy = [xcoord.values, ycoord.values]
 
     # Check for bin edges
@@ -121,8 +122,8 @@ def plot_2d(input_data, name=None, axes=None, contours=False, cb=None,
     else:
         fig, ax = plt.subplots(1, 1)
 
-    ax.set_xlabel(axis_label(xcoord))
-    ax.set_ylabel(axis_label(ycoord))
+    ax.set_xlabel(axis_label(xcoord, name=labx))
+    ax.set_ylabel(axis_label(ycoord, name=laby))
 
     if variances:
         z = input_data.variances

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -106,7 +106,10 @@ def axis_to_dim_label(dataset, axis):
         lab = None
         var = dataset.coords[dim]
     elif isinstance(axis, str):
-        dim = dataset.labels[axis].dims[0]
+        # By convention, the last dim of the labels is the inner dimension,
+        # but note that for now two-dimensional labels are not supported in
+        # the plotting.
+        dim = dataset.labels[axis].dims[-1]
         lab = axis
         var = dataset.labels[lab]
     else:

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -121,9 +121,9 @@ def get_1d_axes(var, axes, name):
     Utility to simplify getting 1d axes labels and coordinate arrays
     """
     if axes is None:
-        axes = {var.dims[0] : var.dims[0]}
+        axes = {var.dims[0]: var.dims[0]}
     elif isinstance(axes, str):
-        axes = {var.dims[0] : axes}
+        axes = {var.dims[0]: axes}
     dim, lab, xcoord = axis_to_dim_label(var, axes[var.dims[0]])
     x = xcoord.values
     xlab = axis_label(var=xcoord, name=lab)

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -5,6 +5,8 @@
 # Scipp imports
 from . import config
 from .._scipp.core.units import dimensionless
+from .._scipp.core import Dim
+
 
 # Other imports
 import numpy as np
@@ -93,3 +95,128 @@ def parse_colorbar(default, cb, plotly=False):
     if plotly:
         cbar["name"] = cbar["name"].capitalize()
     return cbar
+
+
+def axis_to_dim_label(dataset, axis):
+    """
+    Get dimensions and label (if present) from requested axis
+    """
+
+    if isinstance(axis, Dim):
+        dim = axis
+        lab = None
+    elif isinstance(axis, str):
+        dim = dataset.labels[axis].dims[0]
+        lab = axis
+    else:
+        raise RuntimeError("Unsupported axis found in 'axes': {}. This must "
+                           "be either a Scipp dimension "
+                           "or a string.".format(axis))
+    return dim, lab
+
+
+class Slicer:
+
+    def __init__(self, input_data, axes, value_name, cb, show_variances,
+                 button_options):
+
+        import ipywidgets as widgets
+
+        self.input_data = input_data
+        self.show_variances = ((self.input_data.variances is not None) and
+                               show_variances)
+        self.cb = cb
+        self.value_name = value_name
+
+        # Get the dimensions of the image to be displayed
+        self.coords = self.input_data.coords
+        self.labels = self.input_data.labels
+        self.shapes = dict(zip(self.input_data.dims, self.input_data.shape))
+
+        # Size of the slider coordinate arrays
+        self.slider_nx = dict()
+        # Save dimensions tags for sliders, e.g. Dim.X
+        self.slider_dims = []
+        # Store coordinates of dimensions that will be in sliders
+        self.slider_x = dict()
+        # Store labels for sliders if any
+        self.slider_labels = dict()
+        # Protect against duplicate entries in axes
+        if len(axes) != len(set(axes)):
+            raise RuntimeError("Duplicate entry in axes: {}".format(axes))
+        # Iterate through axes and collect dimensions
+        for ax in axes:
+            dim, lab = axis_to_dim_label(self.input_data, ax)
+            if (lab is not None) and (dim in axes):
+                raise RuntimeError("The dimension of the labels cannot also "
+                                   "be specified as another axis.")
+            self.slider_dims.append(dim)
+            self.slider_labels[str(dim)] = lab
+        self.ndim = len(self.slider_dims)
+        for dim in self.slider_dims:
+            key = str(dim)
+            self.slider_nx[key] = self.shapes[dim]
+            if self.slider_labels[key] is not None:
+                self.slider_x[key] = self.labels[self.slider_labels[key]]
+            else:
+                self.slider_x[key] = self.coords[dim]
+        self.nslices = len(self.slider_dims)
+
+        # Initialise list for VBox container
+        self.vbox = []
+
+        # Initialise slider and label containers
+        self.lab = dict()
+        self.slider = dict()
+        self.buttons = dict()
+        # Default starting index for slider
+        indx = 0
+
+        # Now begin loop to construct sliders
+        button_values = [None] * (self.ndim - len(button_options)) + \
+            button_options[::-1]
+        for i, dim in enumerate(self.slider_dims):
+            key = str(dim)
+            # If this is a 3d projection, place slices half-way
+            if len(button_options) == 3:
+                indx = (self.slider_nx[key] - 1) // 2
+            if self.slider_labels[key] is not None:
+                descr = self.slider_labels[key]
+            else:
+                descr = key
+            # Add an IntSlider to slide along the z dimension of the array
+            self.slider[key] = widgets.IntSlider(
+                value=indx,
+                min=0,
+                max=self.slider_nx[key] - 1,
+                step=1,
+                description=descr,
+                continuous_update=True,
+                readout=False, disabled=((i >= self.ndim-2) and
+                                         len(button_options) == 2)
+            )
+            labvalue = str(self.slider_x[key].values[indx])
+            if self.ndim == 2:
+                self.slider[key].layout.display = 'none'
+                labvalue = descr
+            print(labvalue, descr, self.slider_labels[key])
+            # Add a label widget to display the value of the z coordinate
+            self.lab[key] = widgets.Label(value=labvalue)
+            # Add one set of buttons per dimension
+            self.buttons[key] = widgets.ToggleButtons(
+                options=button_options, description='',
+                value=button_values[i],
+                disabled=False,
+                button_style='')
+            setattr(self.buttons[key], "dim_str", key)
+            setattr(self.buttons[key], "dim", dim)
+            setattr(self.buttons[key], "old_value", self.buttons[key].value)
+            setattr(self.slider[key], "dim_str", key)
+            setattr(self.slider[key], "dim", dim)
+            self.buttons[key].on_msg(self.update_buttons)
+            # Add an observer to the slider
+            self.slider[key].observe(self.update_slice, names="value")
+            # Add coordinate name and unit
+            self.vbox.append(widgets.HBox([self.slider[key], self.lab[key],
+                                           self.buttons[key]]))
+        return

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -6,6 +6,7 @@ import scipp as sc
 import numpy as np
 import io
 from contextlib import redirect_stdout
+import pytest
 
 # TODO: For now we are just checking that the plot does not throw any errors.
 # In the future it would be nice to check the output by either comparing
@@ -27,7 +28,24 @@ def do_plot(d, test_plotly_backend=True, test_mpl_backend=False, **kwargs):
     return
 
 
-def make_2d_dataset(variances=False, binedges=False):
+def make_1d_dataset(variances=False, binedges=False, labels=False):
+    N = 100
+    d1 = sc.Dataset()
+    d1.coords[sc.Dim.Tof] = sc.Variable(
+        [sc.Dim.Tof], values=np.arange(N + binedges).astype(np.float64),
+        unit=sc.units.us)
+    d1["Sample"] = sc.Variable([sc.Dim.Tof],
+                               values=10.0 * np.random.rand(N),
+                               unit=sc.units.counts)
+    if variances:
+        d1["Sample"].variances = np.random.rand(N)
+    if labels:
+        d1.labels["somelabels"] = sc.Variable(
+            [sc.Dim.Tof], values=np.linspace(101., 105., N), unit=sc.units.s)
+    return d1
+
+
+def make_2d_dataset(variances=False, binedges=False, labels=False):
     N = 100
     M = 50
     xx = np.arange(N, dtype=np.float64)
@@ -51,95 +69,95 @@ def make_2d_dataset(variances=False, binedges=False):
     d1["Sample"] = sc.Variable([sc.Dim.Y, sc.Dim.X],
                                unit=sc.units.counts,
                                **params)
+    if labels:
+        d1.labels["somelabels"] = sc.Variable(
+            [sc.Dim.X], values=np.linspace(101., 105., N), unit=sc.units.s)
+    return d1
+
+
+def make_3d_dataset(variances=False, binedges=False, labels=False):
+    n1 = 20
+    n2 = 30
+    n3 = 40
+    d1 = sc.Dataset()
+    d1.coords[sc.Dim.X] = sc.Variable(
+        [sc.Dim.X], np.arange(n1 + binedges).astype(np.float64))
+    d1.coords[sc.Dim.Y] = sc.Variable(
+        [sc.Dim.Y], np.arange(n2 + binedges).astype(np.float64))
+    d1.coords[sc.Dim.Z] = sc.Variable(
+        [sc.Dim.Z], np.arange(n3 + binedges).astype(np.float64))
+    a = np.arange(n1 * n2 * n3).reshape(n3, n2, n1).astype(np.float64)
+    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X], values=a)
+    if variances:
+        d1["Sample"].variances = np.random.normal(a * 0.1, 0.05)
+    if labels:
+        d1.labels["somelabels"] = sc.Variable(
+            [sc.Dim.Y], values=np.linspace(101., 105., n2), unit=sc.units.s)
     return d1
 
 
 def test_plot_1d():
-    d1 = sc.Dataset()
-    N = 100
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N).astype(np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               unit=sc.units.counts)
+    d1 = make_1d_dataset()
     do_plot(d1, test_mpl_backend=True)
 
 
 def test_plot_1d_with_variances():
-    d1 = sc.Dataset()
-    N = 100
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N).astype(np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               variances=np.random.rand(N),
-                               unit=sc.units.counts)
+    d1 = make_1d_dataset(variances=True)
     do_plot(d1, test_mpl_backend=True)
 
 
 def test_plot_1d_bin_edges():
-    d1 = sc.Dataset()
-    N = 100
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N + 1).astype(
-                                            np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               unit=sc.units.counts)
+    d1 = make_1d_dataset(binedges=True)
     do_plot(d1, test_mpl_backend=True)
 
 
+def test_plot_1d_with_labels():
+    d1 = make_1d_dataset(labels=True)
+    do_plot(d1, axes="somelabels", test_mpl_backend=False)
+
+
+def test_plot_1d_log_axes():
+    d1 = make_1d_dataset()
+    do_plot(d1, logx=True, test_mpl_backend=True)
+    do_plot(d1, logy=True, test_mpl_backend=True)
+    do_plot(d1, logxy=True, test_mpl_backend=True)
+
+
 def test_plot_1d_bin_edges_with_variances():
-    d1 = sc.Dataset()
-    N = 100
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N + 1).astype(
-                                            np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               variances=np.random.rand(N),
-                               unit=sc.units.counts)
+    d1 = make_1d_dataset(variances=True, binedges=True)
     do_plot(d1, test_mpl_backend=True)
 
 
 def test_plot_1d_two_entries():
-    d1 = sc.Dataset()
-    N = 100
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N).astype(np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               unit=sc.units.counts)
+    d1 = make_1d_dataset()
     d1["Background"] = sc.Variable([sc.Dim.Tof],
-                                   values=2.0 * np.random.rand(N),
+                                   values=2.0 * np.random.rand(100),
                                    unit=sc.units.counts)
     do_plot(d1, test_mpl_backend=True)
 
 
-def test_plot_1d_list_of_datasets():
+def test_plot_1d_three_entries_with_labels():
     N = 100
-    d1 = sc.Dataset()
-    d1.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N).astype(np.float64),
-                                        unit=sc.units.us)
-    d1["Sample"] = sc.Variable([sc.Dim.Tof], values=10.0 * np.random.rand(N))
+    d1 = make_1d_dataset(labels=True)
     d1["Background"] = sc.Variable([sc.Dim.Tof],
-                                   values=2.0 * np.random.rand(N))
-    d2 = sc.Dataset()
-    d2.coords[sc.Dim.Tof] = sc.Variable([sc.Dim.Tof],
-                                        values=np.arange(N).astype(np.float64),
-                                        unit=sc.units.us)
-    d2["Sample"] = sc.Variable([sc.Dim.Tof],
-                               values=10.0 * np.random.rand(N),
-                               variances=np.random.rand(N))
-    d2["Background"] = sc.Variable([sc.Dim.Tof],
                                    values=2.0 * np.random.rand(N),
-                                   variances=np.random.rand(N))
+                                   unit=sc.units.counts)
+    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
+                                      values=np.arange(N).astype(np.float64),
+                                      unit=sc.units.m)
+    d1["Sample2"] = sc.Variable([sc.Dim.X],
+                                values=10.0 * np.random.rand(N),
+                                unit=sc.units.counts)
+    d1.labels["Xlabels"] = sc.Variable([sc.Dim.X],
+                                       values=np.linspace(151., 155., N),
+                                       unit=sc.units.s)
+    do_plot(d1, axes={sc.Dim.X: "Xlabels", sc.Dim.Tof: "somelabels"},
+            test_mpl_backend=False)
+
+
+def test_plot_1d_list_of_datasets():
+    d1 = make_1d_dataset(binedges=True)
+    d2 = make_1d_dataset(binedges=True, variances=True)
     do_plot([d1, d2], test_mpl_backend=True)
 
 
@@ -151,6 +169,11 @@ def test_plot_2d_image():
 def test_plot_2d_image_with_axes():
     d1 = make_2d_dataset()
     do_plot(d1, axes=[sc.Dim.X, sc.Dim.Y], test_mpl_backend=True)
+
+
+def test_plot_2d_image_with_labels():
+    d1 = make_2d_dataset(labels=True)
+    do_plot(d1, axes=[sc.Dim.Y, "somelabels"], test_mpl_backend=True)
 
 
 def test_plot_2d_image_with_variances():
@@ -197,37 +220,12 @@ def test_plot_collapse():
 
 
 def test_plot_sliceviewer():
-    d1 = sc.Dataset()
-    n1 = 20
-    n2 = 30
-    n3 = 40
-    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
-                                      np.arange(n1).astype(np.float64))
-    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
-                                      np.arange(n2).astype(np.float64))
-    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
-                                      np.arange(n3).astype(np.float64))
-    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
-                               values=np.arange(n1 * n2 * n3).reshape(
-                                   n3, n2, n1).astype(np.float64))
+    d1 = make_3d_dataset()
     do_plot(d1)
 
 
 def test_plot_sliceviewer_with_variances():
-    d1 = sc.Dataset()
-    n1 = 20
-    n2 = 30
-    n3 = 40
-    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
-                                      np.arange(n1).astype(np.float64))
-    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
-                                      np.arange(n2).astype(np.float64))
-    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
-                                      np.arange(n3).astype(np.float64))
-    a = np.arange(n1 * n2 * n3).reshape(n3, n2, n1).astype(np.float64)
-    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
-                               values=a,
-                               variances=np.random.rand(n3, n2, n1) * a * 0.1)
+    d1 = make_3d_dataset(variances=True)
     do_plot(d1, show_variances=True)
 
 
@@ -252,55 +250,35 @@ def test_plot_sliceviewer_with_two_sliders():
 
 
 def test_plot_sliceviewer_with_axes():
-    d1 = sc.Dataset()
-    n1 = 20
-    n2 = 30
-    n3 = 40
-    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
-                                      np.arange(n1).astype(np.float64))
-    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
-                                      np.arange(n2).astype(np.float64))
-    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
-                                      np.arange(n3).astype(np.float64))
-    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
-                               values=np.arange(n1 * n2 * n3).reshape(
-                                   n3, n2, n1).astype(np.float64))
+    d1 = make_3d_dataset()
     do_plot(d1, axes=[sc.Dim.Y, sc.Dim.X, sc.Dim.Z])
 
 
+def test_plot_sliceviewer_with_labels():
+    d1 = make_3d_dataset(labels=True)
+    do_plot(d1, axes=[sc.Dim.X, sc.Dim.Z, "somelabels"])
+
+
+def test_plot_sliceviewer_with_labels_bad_dimension():
+    d1 = make_3d_dataset(labels=True)
+    with pytest.raises(Exception) as e:
+        do_plot(d1, axes=[sc.Dim.Y, sc.Dim.Z, "somelabels"])
+    assert str(e.value) == ("The dimension of the labels cannot also be "
+                            "specified as another axis.")
+
 def test_plot_sliceviewer_with_3d_projection():
-    d1 = sc.Dataset()
-    n1 = 20
-    n2 = 30
-    n3 = 40
-    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
-                                      np.arange(n1).astype(np.float64))
-    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
-                                      np.arange(n2).astype(np.float64))
-    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
-                                      np.arange(n3).astype(np.float64))
-    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
-                               values=np.arange(n1 * n2 * n3).reshape(
-                                   n3, n2, n1).astype(np.float64))
+    d1 = make_3d_dataset()
     do_plot(d1, projection="3d")
 
 
 def test_plot_sliceviewer_with_3d_projection_with_variances():
-    d1 = sc.Dataset()
-    n1 = 20
-    n2 = 30
-    n3 = 40
-    d1.coords[sc.Dim.X] = sc.Variable([sc.Dim.X],
-                                      np.arange(n1).astype(np.float64))
-    d1.coords[sc.Dim.Y] = sc.Variable([sc.Dim.Y],
-                                      np.arange(n2).astype(np.float64))
-    d1.coords[sc.Dim.Z] = sc.Variable([sc.Dim.Z],
-                                      np.arange(n3).astype(np.float64))
-    a = np.arange(n1 * n2 * n3).reshape(n3, n2, n1).astype(np.float64)
-    d1["Sample"] = sc.Variable([sc.Dim.Z, sc.Dim.Y, sc.Dim.X],
-                               values=a,
-                               variances=np.random.rand(n3, n2, n1) * a * 0.1)
+    d1 = make_3d_dataset(variances=True)
     do_plot(d1, projection="3d", show_variances=True)
+
+
+def test_plot_sliceviewer_with_3d_projection_with_labels():
+    d1 = make_3d_dataset(labels=True)
+    do_plot(d1, projection="3d", axes=[sc.Dim.X, sc.Dim.Z, "somelabels"])
 
 
 def test_plot_2d_image_rasterized():
@@ -311,3 +289,8 @@ def test_plot_2d_image_rasterized():
 def test_plot_2d_image_with_variances_rasterized():
     d1 = make_2d_dataset(variances=True)
     do_plot(d1, show_variances=True, rasterize=True)
+
+
+def test_plot_sliceviewer_rasterized():
+    d1 = make_3d_dataset()
+    do_plot(d1, rasterize=True)

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -113,7 +113,7 @@ def test_plot_1d_bin_edges():
 
 def test_plot_1d_with_labels():
     d1 = make_1d_dataset(labels=True)
-    do_plot(d1, axes="somelabels", test_mpl_backend=False)
+    do_plot(d1, axes="somelabels", test_mpl_backend=True)
 
 
 def test_plot_1d_log_axes():
@@ -152,7 +152,7 @@ def test_plot_1d_three_entries_with_labels():
                                        values=np.linspace(151., 155., N),
                                        unit=sc.units.s)
     do_plot(d1, axes={sc.Dim.X: "Xlabels", sc.Dim.Tof: "somelabels"},
-            test_mpl_backend=False)
+            test_mpl_backend=True)
 
 
 def test_plot_1d_list_of_datasets():


### PR DESCRIPTION
Plotting with labels was broken since the update to the plotting in #566 .
This PR brings this functionality back.

Addtional notes:
- You can also use labels in 1d plots (see examples in plotting notebook)
- Some refactor of common code between `Slicer2d` and `Slicer3d`
- Colors were fixed in 1D plots with multiple entries in a `Dataset`
- Improved the plotting tests

You should now be able to do:
```Python
N = 100
M = 50
xx = np.arange(N, dtype=np.float64)
yy = np.arange(M, dtype=np.float64)
x, y = np.meshgrid(xx, yy)
b = N/20.0
c = M/2.0
r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2)
a = np.sin(r)
d1 = sc.Dataset()
d1.coords[Dim.X] = sc.Variable([Dim.X], values=xx, unit=sc.units.m)
d1.coords[Dim.Y] = sc.Variable([Dim.Y], values=yy, unit=sc.units.m)
d1['Signal'] = sc.Variable([Dim.Y, Dim.X], values=a, unit=sc.units.counts)
d1.labels['somelabels'] = sc.Variable([Dim.X], values=np.linspace(101., 105., N), unit=sc.units.s)
plot(d1, axes=[Dim.Y, "somelabels"])
```

Fixes #623 