### PR TITLE
Get the docs building again

### DIFF
--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -20,7 +20,8 @@
     "import scipp as sc\n",
     "from scipp import Dim\n",
     "from scipp.plot import plot\n",
-    "sc.plot.config.backend = 'static'"
+    "sc.plot.config.backend = 'matplotlib:quiet'\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -186,6 +187,13 @@
     "dataset['b'] *= dataset['scalar']\n",
     "print(dataset)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -37,7 +37,8 @@
    "source": [
     "import numpy as np\n",
     "import scipp as sc\n",
-    "from scipp import Dim # scipp.Dim is used frequently can import it directly for convience"
+    "from scipp import Dim # scipp.Dim is used frequently can import it directly for convience\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -249,8 +250,9 @@
    "source": [
     "from scipp.plot import plot\n",
     "\n",
-    "# Remove the line below to get interactive plots (currently not available on readthedocs)\n",
-    "sc.plot.config.backend = \"static\"\n",
+    "# Remove the line below, or switch to \"interactive\", to get interactive plots\n",
+    "# (currently not available on readthedocs)\n",
+    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
     "\n",
     "plot(d)"
    ]

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -20,7 +20,8 @@
     "import numpy as np\n",
     "import scipp as sc\n",
     "from scipp import Dim\n",
-    "from scipp.plot import plot"
+    "from scipp.plot import plot\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -39,8 +40,10 @@
    "source": [
     "d = sc.Dataset(\n",
     "    {\n",
-    "    'alice': sc.Variable([Dim.Z, Dim.Y, Dim.X], values=np.random.rand(10, 10, 10), variances=0.1*np.random.rand(10, 10, 10)),\n",
-    "    'bob': sc.Variable([Dim.X, Dim.Z], values=np.arange(0.0, 10.0, 0.1).reshape(10, 10), variances=0.1*np.random.rand(10, 10))\n",
+    "    'alice': sc.Variable([Dim.Z, Dim.Y, Dim.X], values=np.random.rand(10, 10, 10),\n",
+    "                         variances=0.1*np.random.rand(10, 10, 10)),\n",
+    "    'bob': sc.Variable([Dim.X, Dim.Z], values=np.arange(0.0, 10.0, 0.1).reshape(10, 10),\n",
+    "                       variances=0.1*np.random.rand(10, 10))\n",
     "    },\n",
     "    coords={\n",
     "        Dim.X: sc.Variable([sc.Dim.X], values=np.arange(11.0), unit=sc.units.m),\n",
@@ -96,8 +99,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Remove the line below to get interactive plots (currently not available on readthedocs)\n",
-    "sc.plot.config.backend = \"static\"\n",
+    "# Remove the line below, or switch to \"interactive\", to get interactive plots\n",
+    "# (currently not available on readthedocs)\n",
+    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
     "\n",
     "plot(d[\"bob\"])"
    ]
@@ -122,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plotting a 3-dimensional data cube will show a 2D image with a slider to navigate through the third dimension (note that the sliders only appear in the Jupyter notebook, and not in the documentation pages):"
+    "Plotting a 3-dimensional data cube will show a 2D image with a slider to navigate through the third dimension (note that these interactive plots are only available via the default `'interactive'` backend that uses `plotly` and currently only render inside Jupyter notebooks, and not in the documentation pages):"
    ]
   },
   {
@@ -131,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(d[\"alice\"])"
+    "plot(d[\"alice\"], backend=\"interactive\")"
    ]
   },
   {
@@ -263,7 +267,7 @@
     "offset = d.copy()\n",
     "offset.coords[Dim.X] += sc.Variable(8.0, unit=sc.units.m)\n",
     "combined = sc.concatenate(d, offset, Dim.X)\n",
-    "plot(combined['alice'])"
+    "plot(combined['alice'], backend=\"interactive\")"
    ]
   },
   {

--- a/docs/user-guide/plotting.ipynb
+++ b/docs/user-guide/plotting.ipynb
@@ -24,9 +24,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are currently two different backends for plotting. The default (`'interactive'`) renders interactive plots for Jupyter notebooks, while the second (`'static'`) generates static png exports of the figures.\n",
+    "There are currently three different backends for plotting. The default (`'interactive'`) renders interactive plots for Jupyter notebooks, while the second (`'static'`) generates static png exports of the figures.\n",
+    "The third (`'matplotlib'`) returns a dict of `matplotlib` objects that can then be used in highly customized figures. There is an additional `'matplotlib:quiet'` backend which does not return the objects dict, but is used to simply render the basic `matplotlib` figures in the Jupyter notebook.\n",
     "\n",
-    "Here we switch to the `static` backend, as `plotly` interactive figures currently do not work when embedded in the documentation pages on `Read the Docs`."
+    "Here we switch to the `matplotlib` backend, as `plotly` (interactive and static) figures currently do not work when embedded in the documentation pages on `Read the Docs`."
    ]
   },
   {
@@ -35,7 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot.config.backend = \"static\""
+    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -104,7 +106,7 @@
    "outputs": [],
    "source": [
     "d['Background'] = sc.Variable([Dim.Tof], values=5.0*np.random.rand(N),\n",
-    "                              unit=sc.units.m)\n",
+    "                              unit=sc.units.counts)\n",
     "plot(d)"
    ]
   },
@@ -236,7 +238,7 @@
    "source": [
     "### Multiple datasets\n",
     "\n",
-    "`scipp.plot` also suports multiple 1-D datasets:"
+    "`scipp.plot` also suports multiple 1-D datasets (note that the data entries are grouped onto the same graph if they have the same dimension and unit):"
    ]
   },
   {
@@ -251,10 +253,10 @@
     "                                    values=np.arange(N).astype(np.float64),\n",
     "                                    unit=sc.units.us)\n",
     "other['OtherSample'] = sc.Variable([Dim.Tof], values=10.0*np.random.rand(N),\n",
-    "                                   unit=sc.units.counts)\n",
+    "                                   unit=sc.units.s)\n",
     "other['OtherNoise'] = sc.Variable([Dim.Tof], values=10.0*np.random.rand(N-1),\n",
     "                                  variances=3.0*np.random.rand(N-1),\n",
-    "                                  unit=sc.units.counts)\n",
+    "                                  unit=sc.units.s)\n",
     "plot([d, other])"
    ]
   },
@@ -577,7 +579,7 @@
     "\n",
     "Data with 3 or more dimensions are currently represented by a 2-D image, accompanied by sliders to navigate the extra dimensions (one slider per dimension above 2).\n",
     "\n",
-    "**Note:** the sliders do not show on the documentation pages, they appear only inside the Jupyter notebook."
+    "**Note:** plots for more than 2 dimensions do not show on the documentation pages, they appear only inside the Jupyter notebook."
    ]
   },
   {
@@ -607,7 +609,7 @@
     "d3.coords[Dim.Qx] = sc.Variable([Dim.Qx], values=qq)\n",
     "d3['Some3Ddata'] = sc.Variable([Dim.X, Dim.Y, Dim.Z, Dim.Qx], values=a,\n",
     "                               variances=np.random.normal(a * 0.1, 0.05))\n",
-    "plot(d3)"
+    "plot(d3, backend=\"interactive\")"
    ]
   },
   {
@@ -624,7 +626,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(d3, axes=[Dim.Z, Dim.Qx, Dim.Y, Dim.X])"
+    "plot(d3, axes=[Dim.Z, Dim.Qx, Dim.Y, Dim.X], backend=\"interactive\")"
    ]
   },
   {
@@ -640,7 +642,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(d3, projection=\"3d\")"
+    "plot(d3, projection=\"3d\", backend=\"interactive\")"
    ]
   },
   {
@@ -656,7 +658,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(d3, projection=\"3d\", show_variances=True)"
+    "plot(d3, projection=\"3d\", show_variances=True, backend=\"interactive\")"
    ]
   },
   {
@@ -899,7 +901,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out2['140668957391536_Dim.Tof'][\"line\"][\"Sample\"][0].set_linestyle('None')\n",
+    "out2['Dim.Tof.counts'][\"line\"][\"Sample\"][0].set_linestyle('None')\n",
     "figs"
    ]
   },

--- a/python/src/scipp/plot/config.py
+++ b/python/src/scipp/plot/config.py
@@ -4,8 +4,8 @@
 # @author Neil Vaytet
 
 
-# The plotting backend: possible choices are "interactive", "static" and
-# "matplotlib"
+# The plotting backend: possible choices are "interactive", "static",
+# "matplotlib", and "matplotlib:quiet"
 backend = "interactive"
 
 # The list of default line colors

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -14,7 +14,7 @@ def dispatch(input_data, ndim=0, name=None, backend=None, collapse=None,
         raise RuntimeError("Invalid number of dimensions for "
                            "plotting: {}".format(ndim))
 
-    if backend == "matplotlib":
+    if backend == "matplotlib" or backend == "matplotlib:quiet":
 
         from .plot_matplotlib import plot_1d, plot_2d
         if ndim == 1:

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -3,6 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
+from . import config
 from .._scipp import core as sc
 
 
@@ -15,6 +16,9 @@ def plot(input_data, collapse=None, backend=None, color=None, **kwargs):
     from .tools import get_color
     from .plot_collapse import plot_collapse
     from .dispatch import dispatch
+
+    if backend is None:
+        backend = config.backend
 
     # Create a list of variables which will then be dispatched to the plot_auto
     # function.
@@ -40,9 +44,9 @@ def plot(input_data, collapse=None, backend=None, color=None, **kwargs):
             coords = var.coords
             ndims = len(coords)
             if ndims == 1:
-                # Make a unique key from the dataset id in case there are more
-                # than one dataset with 1D variables with the same coordinates
-                key = "{}_{}".format(str(id(ds)), str(var.dims[0]))
+                # Construct a key from the dimension and the unit, to group
+                # compatible data together.
+                key = "{}.{}".format(str(var.dims[0]), str(var.unit))
                 if key in tobeplotted.keys():
                     tobeplotted[key][1][name] = ds[name]
                 else:

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -36,7 +36,7 @@ def plot_1d(input_data, backend=None, logx=False, logy=False, logxy=False,
             histogram = True
 
         # Define trace
-        trace = dict(x=x, y=y, name=ylab, type="scattergl")
+        trace = dict(x=x, y=y, name=name, type="scattergl")
         if histogram:
             trace["line"] = {"shape": "hv"}
             trace["y"] = np.concatenate((trace["y"], [0.0]))
@@ -64,7 +64,7 @@ def plot_1d(input_data, backend=None, logx=False, logy=False, logxy=False,
 
     layout = dict(
         xaxis=dict(title=xlab),
-        yaxis=dict(),
+        yaxis=dict(title=ylab),
         showlegend=True,
         legend=dict(x=0.0, y=1.15, orientation="h"),
         height=config.height

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -23,9 +23,6 @@ def render_plot(static_fig=None, interactive_fig=None, backend=None,
     import IPython.display as disp
     from plotly.io import write_html, write_image, to_image
 
-    if backend is None:
-        backend = config.backend
-
     if filename is not None:
         if filename.endswith(".html"):
             write_html(fig=static_fig, file=filename, auto_open=False)
@@ -65,21 +62,23 @@ def centers_to_edges(x):
     return np.concatenate([[2.0 * x[0] - e[0]], e, [2.0 * x[-1] - e[-1]]])
 
 
-def axis_label(var, name=None, log=False, replace_dim=True):
+def axis_label(var=None, name=None, log=False, replace_dim=True):
     """
     Make an axis label with "Name [unit]"
     """
+    label = ""
     if name is not None:
         label = name
-    else:
+    elif var is not None:
         label = str(var.dims[0])
         if replace_dim:
             label = label.replace("Dim.", "")
 
     if log:
         label = "log\u2081\u2080(" + label + ")"
-    if var.unit != dimensionless:
-        label += " [{}]".format(var.unit)
+    if var is not None:
+        if var.unit != dimensionless:
+            label += " [{}]".format(var.unit)
     return label
 
 
@@ -131,7 +130,7 @@ def get_1d_axes(var, axes, name):
     x = xcoord.values
     xlab = axis_label(var=xcoord, name=lab)
     y = var.values
-    ylab = axis_label(var=var, name=name)
+    ylab = axis_label(var=var, name="")
     return xlab, ylab, x, y
 
 


### PR DESCRIPTION
This PR switches the plotting in the docs notebooks back to using `matplotlib`.

Since #614 , the `'matplotlib'` backend actually returns a dict of mpl objects that can be used for advanced figure composing. The output of this in Jupyter was both printing the dict, and showing the figures (Jupyter seems smart enough to detect figures in the output and display them inline).

Since the output was a little noisy (the dict of mpl object could be rather confusing), I introduced here the `'matplotlib:quiet'` backend, where the dict is no longer returned. The figures are captured by Jupyter and shown in the notebook, at least on my machine:
```
Ubuntu 18.04
jupyter                   1.0.0                      py_2    conda-forge
jupyter_client            5.3.1                      py_0    conda-forge
jupyter_console           6.0.0                      py_0    conda-forge
jupyter_core              4.4.0                      py_0    conda-forge
```

Other fixes:
- axes in 2D images did not have the right extents in `matplotlib`
- automatic transposing of 2D images in `matplotlib` was broken since #626 
- fixes #484 by grouping 1D variables according to dimension and unit

fixes #627 
