### PR TITLE
Master Only Appveyor Build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 os: Visual Studio 2019
 branches:
   only:
-  - visual_studio_build # TODO change to master 
+  - master
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Currently pointing only at feature branch.

We'll later look to upgrade the settings to not restrict branches. But lets work for a while with Master only builds.