### PR TITLE
Disable LTO in (non-conda) CI builds.

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -6,7 +6,7 @@ set -xe
 mkdir -p build
 mkdir -p install
 cd build
-cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DDYNAMIC_LIB=ON -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
+cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
 make -j2 install all-tests all-benchmarks
 
 # C++ tests

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -6,7 +6,7 @@ set -xe
 mkdir -p build
 mkdir -p install
 cd build
-cmake -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
+cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DDYNAMIC_LIB=ON -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
 make -j2 install all-tests all-benchmarks
 
 # Units tests

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -9,13 +9,10 @@ cd build
 cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DDYNAMIC_LIB=ON -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
 make -j2 install all-tests all-benchmarks
 
-# Units tests
+# C++ tests
+./common/test/scipp-common-test
 ./units/test/scipp-units-test
-
-# Core tests
 ./core/test/scipp-core-test
-
-# Neutron tests
 ./neutron/test/scipp-neutron-test
 
 # Python tests


### PR DESCRIPTION
Hopefully this makes CI builds a bit faster. I thought we had this enabled already but apparently not (or it got lost at some point?).