### PR TITLE
Uniform color scheme for table and show

### DIFF
--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -20,7 +20,7 @@
     "import scipp as sc\n",
     "from scipp import Dim\n",
     "from scipp.plot import plot\n",
-    "sc.plot.config.backend = 'matplotlib:quiet'\n",
+    "sc.config.plot.backend = 'matplotlib:quiet'\n",
     "%matplotlib inline"
    ]
   },
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "import numpy as np\n",
     "import scipp as sc\n",
-    "from scipp import Dim # scipp.Dim is used frequently can import it directly for convience\n",
+    "from scipp import Dim # scipp.Dim is used frequently can import it directly for convenience\n",
     "%matplotlib inline"
    ]
   },
@@ -72,7 +72,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
     "\n",
     "# Remove the line below, or switch to \"interactive\", to get interactive plots\n",
     "# (currently not available on readthedocs)\n",
-    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
+    "sc.config.plot.backend = \"matplotlib:quiet\"\n",
     "\n",
     "plot(d)"
    ]
@@ -729,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
   "nbsphinx": {
    "allow_errors": true

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "# Remove the line below, or switch to \"interactive\", to get interactive plots\n",
     "# (currently not available on readthedocs)\n",
-    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
+    "sc.config.plot.backend = \"matplotlib:quiet\"\n",
     "\n",
     "plot(d[\"bob\"])"
    ]
@@ -464,7 +464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
   "nbsphinx": {
    "allow_errors": true

--- a/docs/user-guide/plotting.ipynb
+++ b/docs/user-guide/plotting.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot.config.backend = \"matplotlib:quiet\"\n",
+    "sc.config.plot.backend = \"matplotlib:quiet\"\n",
     "%matplotlib inline"
    ]
   },
@@ -535,7 +535,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot.config.rasterize_threshold = 120000"
+    "sc.config.plot.rasterize_threshold = 120000"
    ]
   },
   {

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -12,3 +12,4 @@ from .show import show
 from .table import table
 from . import plot
 from .extend_units import *
+from . import config

--- a/python/src/scipp/config.py
+++ b/python/src/scipp/config.py
@@ -4,32 +4,46 @@
 # @author Neil Vaytet
 
 
-# The plotting backend: possible choices are "interactive", "static",
-# "matplotlib", and "matplotlib:quiet"
-backend = "interactive"
+class _Plot:
 
-# The list of default line colors
-color_list = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-              '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+    def __init__(self):
 
-# The colorbar properties
-cb = {"name": "viridis", "log": False, "min": None, "max": None,
-      "min_var": None, "max_var": None}
+        # The plotting backend: possible choices are "interactive", "static",
+        # "matplotlib", and "matplotlib:quiet"
+        self.backend = "interactive"
 
-# The default image height (in pixels)
-height = 600
+        # The list of default line colors
+        self.color_list = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728",
+                           "#9467bd", "#8c564b", "#e377c2", "#7f7f7f",
+                           "#bcbd22", "#17becf"]
 
-# The default image width (in pixels)
-width = 950
+        # The colorbar properties
+        self.cb = {"name": "viridis", "log": False, "min": None, "max": None,
+                   "min_var": None, "max_var": None}
 
-# The size threshold above which an image will automatically be rasterized
-rasterize_threshold = 100000
+        # The default image height (in pixels)
+        self.height = 600
 
-# The colors for each dataset member used in table and show functions
-member_colors = {
-    'coord': ['dde9af', 'bcd35f', '89a02c'],
-    'data': ['ffe680', 'ffd42a', 'd4aa00'],
-    'labels': ['afdde9', '5fbcd3', '2c89a0'],
-    'attr': ['ff8080', 'ff2a2a', 'd40000'],
-    'inactive': ['cccccc', '888888', '444444']
-}
+        # The default image width (in pixels)
+        self.width = 950
+
+        # The size threshold above which an image will automatically be rasterized
+        self.rasterize_threshold = 100000
+
+
+class _Colors:
+
+    def __init__(self):
+
+        # The colors for each dataset member used in table and show functions
+        self.scheme = {
+            "coord": ["#dde9af", "#bcd35f", "#89a02c"],
+            "data": ["#ffe680", "#ffd42a", "#d4aa00"],
+            "labels": ["#afdde9", "#5fbcd3", "#2c89a0"],
+            "attr": ["#ff8080", "#ff2a2a", "#d40000"],
+            "inactive": ["#cccccc", "#888888", "#444444"]
+        }
+
+
+plot = _Plot()
+colors = _Colors()

--- a/python/src/scipp/config.py
+++ b/python/src/scipp/config.py
@@ -24,3 +24,12 @@ width = 950
 
 # The size threshold above which an image will automatically be rasterized
 rasterize_threshold = 100000
+
+# The colors for each dataset member used in table and show functions
+member_colors = {
+    'coord': ['dde9af', 'bcd35f', '89a02c'],
+    'data': ['ffe680', 'ffd42a', 'd4aa00'],
+    'labels': ['afdde9', '5fbcd3', '2c89a0'],
+    'attr': ['ff8080', 'ff2a2a', 'd40000'],
+    'inactive': ['cccccc', '888888', '444444']
+}

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -6,4 +6,3 @@
 # flake8: noqa
 
 from .plot import plot
-from . import config

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -37,7 +37,7 @@ def dispatch(input_data, ndim=0, name=None, backend=None, collapse=None,
                                "interactive backend instead by setting "
                                "scipp.plot.config.backend = 'interactive'.")
 
-    else:
+    elif backend == "interactive" or backend == "static":
 
         # Delayed imports
         from .plot_1d import plot_1d
@@ -59,5 +59,11 @@ def dispatch(input_data, ndim=0, name=None, backend=None, collapse=None,
         else:
             raise RuntimeError("Wrong projection type. Expected either '2d' "
                                "or '3d', got {}.".format(projection))
+
+    else:
+        raise RuntimeError("Unknown backend {}. Currently supported "
+                           "backends are 'interactive', 'static', "
+                           "'matplotlib' and "
+                           "'matplotlib:quiet'".format(backend))
 
     return

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -35,7 +35,7 @@ def dispatch(input_data, ndim=0, name=None, backend=None, collapse=None,
                                "1D or 2D dataset by slicing your object. "
                                "Alternatively, try using the plotly "
                                "interactive backend instead by setting "
-                               "scipp.plot.config.backend = 'interactive'.")
+                               "scipp.config.plot.backend = 'interactive'.")
 
     elif backend == "interactive" or backend == "static":
 

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .._scipp import core as sc
 
 

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .render import render_plot
 from .tools import edges_to_centers, get_1d_axes
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .render import render_plot
 from .slicer import Slicer
 from .tools import axis_label, parse_colorbar

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .plot_2d import Slicer2d
 from .render import render_plot
 from .slicer import Slicer

--- a/python/src/scipp/plot/plot_sparse.py
+++ b/python/src/scipp/plot/plot_sparse.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .render import render_plot
 from .sparse import visit_sparse_data
 from .tools import axis_label, parse_colorbar

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 # Scipp imports
-from . import config
+from ..config import plot as config
 from .._scipp.core import Dim
 from .._scipp.core.units import dimensionless
 

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -5,14 +5,15 @@ from math import ceil
 
 import numpy as np
 from ._scipp import core as sc
+from .config import member_colors
 
-_colors = {
-    'coord': ['dde9af', 'bcd35f', '89a02c'],
-    'data': ['ffe680', 'ffd42a', 'd4aa00'],
-    'labels': ['afdde9', '5fbcd3', '2c89a0'],
-    'attr': ['ff8080', 'ff2a2a', 'd40000'],
-    'inactive': ['cccccc', '888888', '444444']
-}
+# _colors = {
+#     'coord': ['dde9af', 'bcd35f', '89a02c'],
+#     'data': ['ffe680', 'ffd42a', 'd4aa00'],
+#     'labels': ['afdde9', '5fbcd3', '2c89a0'],
+#     'attr': ['ff8080', 'ff2a2a', 'd40000'],
+#     'inactive': ['cccccc', '888888', '444444']
+# }
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.
@@ -236,13 +237,14 @@ class VariableDrawer():
             if self._variable.sparse_dim is not None:
                 for name, label in self._variable.labels:
                     if label.sparse_dim is not None:
-                        items.append((name, label.values, _colors['labels']))
+                        items.append((name, label.values,
+                                      member_colors['labels']))
                 sparse_dim = self._variable.sparse_dim
                 for dim, coord in self._variable.coords:
                     if dim == sparse_dim:
                         items.append((str(sparse_dim),
                                       self._variable.coords[sparse_dim].values,
-                                      _colors['coord']))
+                                      member_colors['coord']))
 
         for i, (name, data, color) in enumerate(items):
             svg += '<g>'
@@ -272,7 +274,7 @@ class VariableDrawer():
             '<svg width={}em viewBox="0 0 {} {}">{}</svg>'.format(
                 _svg_width, max(_cubes_in_full_width,
                                 self.size()[0]),
-                self.size()[1], self.draw(color=_colors['data'])))
+                self.size()[1], self.draw(color=member_colors['data'])))
 
 
 class DatasetDrawer():
@@ -328,12 +330,12 @@ class DatasetDrawer():
         area_xy = []
         area_0d = []
         if is_data_array(self._dataset):
-            area_xy.append(('', self._dataset, _colors['data']))
+            area_xy.append(('', self._dataset, member_colors['data']))
         else:
             # Render highest-dimension items last so coords are optically
             # aligned
             for name, data in dataset:
-                item = (name, data, _colors['data'])
+                item = (name, data, member_colors['data'])
                 if data.dims != dims:
                     if len(data.dims) == 0:
                         area_0d.append(item)
@@ -351,7 +353,7 @@ class DatasetDrawer():
         for dim, coord in dataset.coords:
             if coord.sparse_dim is not None:
                 continue
-            item = (dim, coord, _colors['coord'])
+            item = (dim, coord, member_colors['coord'])
             if len(coord.dims) == 0:
                 area_0d.append(item)
             elif coord.dims[-1] == dims[-1]:
@@ -364,7 +366,7 @@ class DatasetDrawer():
         for name, labels in dataset.labels:
             if labels.sparse_dim is not None:
                 continue
-            item = (name, labels, _colors['labels'])
+            item = (name, labels, member_colors['labels'])
             if len(labels.dims) == 0:
                 area_0d.append(item)
             elif labels.dims[-1] == dims[-1]:
@@ -377,7 +379,7 @@ class DatasetDrawer():
         for name, attr in dataset.attrs:
             if attr.sparse_dim is not None:
                 continue
-            item = (name, attr, _colors['attr'])
+            item = (name, attr, member_colors['attr'])
             if len(attr.dims) == 0:
                 area_0d.append(item)
             elif attr.dims[-1] == dims[-1]:

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -5,15 +5,7 @@ from math import ceil
 
 import numpy as np
 from ._scipp import core as sc
-from .config import member_colors
-
-# _colors = {
-#     'coord': ['dde9af', 'bcd35f', '89a02c'],
-#     'data': ['ffe680', 'ffd42a', 'd4aa00'],
-#     'labels': ['afdde9', '5fbcd3', '2c89a0'],
-#     'attr': ['ff8080', 'ff2a2a', 'd40000'],
-#     'inactive': ['cccccc', '888888', '444444']
-# }
+from .config import colors
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.
@@ -48,15 +40,15 @@ class VariableDrawer():
     def _draw_box(self, origin_x, origin_y, color, xlen=1):
         return " ".join([
             '<rect',
-            'style="fill:#{};fill-opacity:1;stroke:#000;stroke-width:0.05"',
+            'style="fill:{};fill-opacity:1;stroke:#000;stroke-width:0.05"',
             'id="rect"',
             'width="xlen" height="1" x="origin_x" y="origin_y"/>',
             '<path',
-            'style="fill:#{};stroke:#000;stroke-width:0.05;stroke-linejoin:round"',  # noqa #501
+            'style="fill:{};stroke:#000;stroke-width:0.05;stroke-linejoin:round"',  # noqa #501
             'd="m origin_x origin_y l 0.3 -0.3 h xlen l -0.3 0.3 z"',
             'id="path1" />',
             '<path',
-            'style="fill:#{};stroke:#000;stroke-width:0.05;stroke-linejoin:round"',  # noqa #501
+            'style="fill:{};stroke:#000;stroke-width:0.05;stroke-linejoin:round"',  # noqa #501
             'd="m origin_x origin_y m xlen 0 l 0.3 -0.3 v 1 l -0.3 0.3 z"',
             'id="path2" />'
         ]).format(*color).replace("origin_x", str(origin_x)).replace(
@@ -238,13 +230,13 @@ class VariableDrawer():
                 for name, label in self._variable.labels:
                     if label.sparse_dim is not None:
                         items.append((name, label.values,
-                                      member_colors['labels']))
+                                      colors.scheme['labels']))
                 sparse_dim = self._variable.sparse_dim
                 for dim, coord in self._variable.coords:
                     if dim == sparse_dim:
                         items.append((str(sparse_dim),
                                       self._variable.coords[sparse_dim].values,
-                                      member_colors['coord']))
+                                      colors.scheme['coord']))
 
         for i, (name, data, color) in enumerate(items):
             svg += '<g>'
@@ -274,7 +266,7 @@ class VariableDrawer():
             '<svg width={}em viewBox="0 0 {} {}">{}</svg>'.format(
                 _svg_width, max(_cubes_in_full_width,
                                 self.size()[0]),
-                self.size()[1], self.draw(color=member_colors['data'])))
+                self.size()[1], self.draw(color=colors.scheme['data'])))
 
 
 class DatasetDrawer():
@@ -330,12 +322,12 @@ class DatasetDrawer():
         area_xy = []
         area_0d = []
         if is_data_array(self._dataset):
-            area_xy.append(('', self._dataset, member_colors['data']))
+            area_xy.append(('', self._dataset, colors.scheme['data']))
         else:
             # Render highest-dimension items last so coords are optically
             # aligned
             for name, data in dataset:
-                item = (name, data, member_colors['data'])
+                item = (name, data, colors.scheme['data'])
                 if data.dims != dims:
                     if len(data.dims) == 0:
                         area_0d.append(item)
@@ -353,7 +345,7 @@ class DatasetDrawer():
         for dim, coord in dataset.coords:
             if coord.sparse_dim is not None:
                 continue
-            item = (dim, coord, member_colors['coord'])
+            item = (dim, coord, colors.scheme['coord'])
             if len(coord.dims) == 0:
                 area_0d.append(item)
             elif coord.dims[-1] == dims[-1]:
@@ -366,7 +358,7 @@ class DatasetDrawer():
         for name, labels in dataset.labels:
             if labels.sparse_dim is not None:
                 continue
-            item = (name, labels, member_colors['labels'])
+            item = (name, labels, colors.scheme['labels'])
             if len(labels.dims) == 0:
                 area_0d.append(item)
             elif labels.dims[-1] == dims[-1]:
@@ -379,7 +371,7 @@ class DatasetDrawer():
         for name, attr in dataset.attrs:
             if attr.sparse_dim is not None:
                 continue
-            item = (name, attr, member_colors['attr'])
+            item = (name, attr, colors.scheme['attr'])
             if len(attr.dims) == 0:
                 area_0d.append(item)
             elif attr.dims[-1] == dims[-1]:

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -3,6 +3,7 @@
 # @file
 # @author Igor Gudich & Neil Vaytet
 
+from .config import member_colors
 from ._scipp import core as sc
 
 

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -3,7 +3,7 @@
 # @file
 # @author Igor Gudich & Neil Vaytet
 
-from .config import member_colors
+from .config import colors
 from ._scipp import core as sc
 
 
@@ -39,8 +39,12 @@ def title_to_string(var, name=None, replace_dim=True):
 def table_from_dataset(dataset, is_hist=False, headers=2):
 
     bstyle = "style='border: 1px solid black;"
-    cstyle = bstyle + "background-color: #adf3e0;text-align: center;'"
-    lstyle = bstyle + "background-color: #d9c0fa;text-align: center;'"
+    cstyle = bstyle + "background-color: {};text-align: center;'".format(
+        colors.scheme["coord"][0])
+    lstyle = bstyle + "background-color: {};text-align: center;'".format(
+        colors.scheme["labels"][0])
+    dstyle = bstyle + "background-color: {};text-align: center;'".format(
+        colors.scheme["data"][0])
     mstyle = bstyle + "text-align: center;'"
     bstyle += "'"
     estyle = "style='border: 0px solid white;background-color: #ffffff;'"
@@ -75,7 +79,7 @@ def table_from_dataset(dataset, is_hist=False, headers=2):
             html += "<th {} colspan='{}'>Labels</th>".format(lstyle,
                                                              colsp_labs)
         if colsp_data > 0:
-            html += "<th {} colspan='{}'>Data</th>".format(mstyle,
+            html += "<th {} colspan='{}'>Data</th>".format(dstyle,
                                                            colsp_data)
         html += "</tr>"
 


### PR DESCRIPTION
Fixes #636 

**Additional notes:**
- Moved the `config` out of the plot module to make it global, and the color scheme for table and show is now stored in there