### PR TITLE
Use masks in Sum and Mean operations

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -36,6 +36,10 @@ add_executable(dataset_benchmark EXCLUDE_FROM_ALL dataset_benchmark.cpp)
 add_dependencies(all-benchmarks dataset_benchmark)
 target_link_libraries(dataset_benchmark LINK_PRIVATE scipp-core benchmark)
 
+add_executable(dataset_operations_benchmark EXCLUDE_FROM_ALL dataset_operations_benchmark.cpp)
+add_dependencies(all-benchmarks dataset_operations_benchmark)
+target_link_libraries(dataset_operations_benchmark LINK_PRIVATE scipp-core benchmark)
+
 add_executable(legacy_histogram_benchmark EXCLUDE_FROM_ALL
                legacy_histogram_benchmark.cpp)
 # add_dependencies(all-benchmarks legacy_histogram_benchmark)

--- a/benchmark/dataset_operations_benchmark.cpp
+++ b/benchmark/dataset_operations_benchmark.cpp
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+#include <benchmark/benchmark.h>
+
+#include <numeric>
+
+#include "common.h"
+
+#include "boost/preprocessor.hpp"
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+enum BoolsGeneratorType { ALTERNATING, FALSE, TRUE };
+
+template <BoolsGeneratorType type = BoolsGeneratorType::ALTERNATING>
+std::vector<bool> makeBools(const scipp::index size) {
+  std::vector<bool> data(size);
+  for (scipp::index i = 0; i < size; ++i)
+    if constexpr (type == BoolsGeneratorType::ALTERNATING) {
+      data[i] = i % 2;
+    } else if constexpr (type == BoolsGeneratorType::FALSE) {
+      data[i] = false;
+    } else {
+      data[i] = true;
+    }
+  return data;
+}
+
+template <typename DType> Variable makeData(const Dimensions &dims) {
+  std::vector<DType> data(dims.volume());
+  std::iota(data.begin(), data.end(), static_cast<DType>(0));
+  return makeVariable<DType>(dims, data);
+}
+struct Generate {
+  Dataset operator()(const int axisLength, const int num_masks = 0) {
+    Dataset d;
+    d.setData("a", makeData<double>({Dim::X, axisLength}));
+    for (int i = 0; i < num_masks; ++i) {
+      d.setMask(std::string(1, ('a' + i)),
+                makeVariable<bool>(
+                    {Dim::X, axisLength},
+                    makeBools<BoolsGeneratorType::ALTERNATING>(axisLength)));
+    }
+    return d;
+  }
+};
+
+struct Generate_2D_data {
+  Dataset operator()(const int axisLength, const int num_masks = 0) {
+    Dataset d;
+    d.setData("a",
+              makeData<double>({{Dim::X, axisLength}, {Dim::Y, axisLength}}));
+    for (int i = 0; i < num_masks; ++i) {
+      d.setMask(std::string(1, ('a' + i)),
+                makeVariable<bool>({{Dim::X, axisLength}, {Dim::Y, axisLength}},
+                                   makeBools<BoolsGeneratorType::ALTERNATING>(
+                                       axisLength * axisLength)));
+    }
+    return d;
+  }
+};
+
+struct Generate_3D_data {
+  Dataset operator()(const int axisLength, const int num_masks = 0) {
+    Dataset d;
+    d.setData("a", makeData<double>({{Dim::X, axisLength},
+                                     {Dim::Y, axisLength},
+                                     {Dim::Z, axisLength}}));
+    for (int i = 0; i < num_masks; ++i) {
+      d.setMask(std::string(1, ('a' + i)),
+                makeVariable<bool>({{Dim::X, axisLength},
+                                    {Dim::Y, axisLength},
+                                    {Dim::Z, axisLength}},
+                                   makeBools<BoolsGeneratorType::ALTERNATING>(
+                                       axisLength * axisLength * axisLength)));
+    }
+    return d;
+  }
+};
+
+template <class Gen> static void BM_Dataset_sum(benchmark::State &state) {
+  const auto itemCount = state.range(0);
+  const auto maskCount = state.range(1);
+  const auto d = Gen()(itemCount, maskCount);
+  for (auto _ : state) {
+    const auto result = sum(d, Dim::X);
+    benchmark::DoNotOptimize(result);
+    benchmark::ClobberMemory();
+  }
+}
+
+// -------------------------------------------------
+// No masks
+// -------------------------------------------------
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {2 << 12, 2 << 15},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate_2D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate_3D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {16, 128},
+              /* Masks count */ {0, 0}});
+
+// -------------------------------------------------
+// With Masks
+// -------------------------------------------------
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {1, 8}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {2 << 12, 2 << 15},
+              /* Masks count */ {1, 2}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate_2D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {1, 8}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_sum, Generate_3D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {16, 128},
+              /* Masks count */ {1, 8}});
+
+template <class Gen> static void BM_Dataset_mean(benchmark::State &state) {
+  const auto itemCount = state.range(0);
+  const auto d = Gen()(itemCount);
+  for (auto _ : state) {
+    const auto result = mean(d, Dim::X);
+    benchmark::DoNotOptimize(result);
+    benchmark::ClobberMemory();
+  }
+}
+
+// -------------------------------------------------
+// No masks
+// -------------------------------------------------
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {2 << 12, 2 << 15},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate_2D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {0, 0}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate_3D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {16, 128},
+              /* Masks count */ {0, 0}});
+
+// -------------------------------------------------
+// With Masks
+// -------------------------------------------------
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {1, 8}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {2 << 12, 2 << 15},
+              /* Masks count */ {1, 2}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate_2D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {256, 2048},
+              /* Masks count */ {1, 8}});
+
+BENCHMARK_TEMPLATE(BM_Dataset_mean, Generate_3D_data)
+    ->RangeMultiplier(2)
+    ->Ranges({/* Item count */ {16, 128},
+              /* Masks count */ {1, 8}});
+
+BENCHMARK_MAIN();

--- a/core/dataset_operations.cpp
+++ b/core/dataset_operations.cpp
@@ -179,7 +179,7 @@ Dataset concatenate(const DatasetConstProxy &a, const DatasetConstProxy &b,
 
 DataArray sum(const DataConstProxy &a, const Dim dim) {
   return apply_to_data_and_drop_dim(a, [](auto &&... _) { return sum(_...); },
-                                    dim);
+                                    dim, a.masks());
 }
 
 Dataset sum(const DatasetConstProxy &d, const Dim dim) {
@@ -192,7 +192,7 @@ Dataset sum(const DatasetConstProxy &d, const Dim dim) {
 
 DataArray mean(const DataConstProxy &a, const Dim dim) {
   return apply_to_data_and_drop_dim(a, [](auto &&... _) { return mean(_...); },
-                                    dim);
+                                    dim, a.masks());
 }
 
 Dataset mean(const DatasetConstProxy &d, const Dim dim) {

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -518,7 +518,7 @@ template <class... Ts> overloaded_sparse(Ts...)->overloaded_sparse<Ts...>;
 template <class... TypePairs, class Op>
 static constexpr auto type_pairs(Op) noexcept {
   if constexpr (sizeof...(TypePairs) == 0)
-    return typename Op::types{};
+    return underlying_type_t<typename Op::types>{};
   else
     return std::tuple_cat(TypePairs{}...);
 }

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -13,9 +13,17 @@ template <class... Ts> struct pair_self {
   using type = std::tuple<std::pair<Ts, Ts>...>;
 };
 template <class... Ts> struct pair_custom { using type = std::tuple<Ts...>; };
+template <class... Ts> struct pair_ {
+  template <class RHS> struct with {
+    using type = decltype(std::tuple_cat(std::tuple<std::pair<Ts, RHS>>{}...));
+  };
+};
 
 template <class... Ts> using pair_self_t = typename pair_self<Ts...>::type;
 template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
+template <class RHS>
+using pair_numerical_with_t =
+    typename pair_<double, float, int64_t, int32_t>::with<RHS>::type;
 
 } // namespace scipp::core
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -970,6 +970,9 @@ SCIPP_CORE_EXPORT Variable asin(const Variable &var);
 SCIPP_CORE_EXPORT Variable acos(const Variable &var);
 SCIPP_CORE_EXPORT Variable atan(const Variable &var);
 
+// Merges all masks contained in the MasksConstProxy into a single Variable
+SCIPP_CORE_EXPORT Variable masks_merge(const MasksConstProxy &masks, const Dimensions dims);
+
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT void reserve(const VariableProxy &sparse,

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -942,8 +942,6 @@ SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
 SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
-                                const VariableConstProxy &masks_sums);
-SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
                                 const MasksConstProxy &masks);
 SCIPP_CORE_EXPORT Variable norm(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT Variable permute(const Variable &var, const Dim dim,
@@ -970,9 +968,7 @@ SCIPP_CORE_EXPORT Variable asin(const Variable &var);
 SCIPP_CORE_EXPORT Variable acos(const Variable &var);
 SCIPP_CORE_EXPORT Variable atan(const Variable &var);
 
-// Merges all masks contained in the MasksConstProxy into a single Variable
-SCIPP_CORE_EXPORT Variable masks_merge(const MasksConstProxy &masks,
-                                       const Dimensions dims);
+SCIPP_CORE_EXPORT Variable masks_merge(const MasksConstProxy &masks);
 
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstProxy &var);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -971,7 +971,8 @@ SCIPP_CORE_EXPORT Variable acos(const Variable &var);
 SCIPP_CORE_EXPORT Variable atan(const Variable &var);
 
 // Merges all masks contained in the MasksConstProxy into a single Variable
-SCIPP_CORE_EXPORT Variable masks_merge(const MasksConstProxy &masks, const Dimensions dims);
+SCIPP_CORE_EXPORT Variable masks_merge(const MasksConstProxy &masks,
+                                       const Dimensions dims);
 
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstProxy &var);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -305,6 +305,7 @@ public:
   }
 
   explicit operator bool() const noexcept { return m_object.operator bool(); }
+  Variable operator~() const;
 
   units::Unit unit() const { return m_unit; }
   void setUnit(const units::Unit &unit) { m_unit = unit; }
@@ -607,6 +608,8 @@ public:
   explicit operator bool() const noexcept {
     return m_variable->operator bool();
   }
+
+  auto operator~() const { return m_variable->operator~(); }
 
   VariableConstProxy slice(const Slice slice) const {
     return VariableConstProxy(*this, slice.dim(), slice.begin(), slice.end());
@@ -938,6 +941,10 @@ SCIPP_CORE_EXPORT Variable concatenate(const VariableConstProxy &a1,
 SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
 SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim);
+SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
+                                const scipp::index num_masks);
+SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
+                                const MasksConstProxy &masks);
 SCIPP_CORE_EXPORT Variable norm(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT Variable permute(const Variable &var, const Dim dim,
                                    const std::vector<scipp::index> &indices);
@@ -950,6 +957,9 @@ SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
 SCIPP_CORE_EXPORT Variable sqrt(const VariableConstProxy &var);
 
 SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var, const Dim dim);
+SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var, const Dim dim,
+                               const MasksConstProxy &masks);
+
 SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 
 // Trigonometrics

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -942,7 +942,7 @@ SCIPP_CORE_EXPORT Variable dot(const Variable &a, const Variable &b);
 SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
-                                const scipp::index num_masks);
+                                const VariableConstProxy &masks_sums);
 SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var, const Dim dim,
                                 const MasksConstProxy &masks);
 SCIPP_CORE_EXPORT Variable norm(const VariableConstProxy &var);

--- a/core/operators.h
+++ b/core/operators.h
@@ -42,6 +42,10 @@ struct times_equals {
       pair_self_t<double, float, int32_t, int64_t>{},
       pair_custom_t<std::pair<double, float>, std::pair<float, double>,
                     std::pair<int64_t, int32_t>,
+                    std::pair<double, Bool>,
+                    std::pair<float, Bool>,
+                    std::pair<int64_t, Bool>,
+                    std::pair<int32_t, Bool>,
                     std::pair<Eigen::Vector3d, double>>{}));
 };
 struct divide_equals {

--- a/core/operators.h
+++ b/core/operators.h
@@ -42,10 +42,10 @@ struct times_equals {
       pair_self_t<double, float, int32_t, int64_t>{},
       pair_custom_t<std::pair<double, float>, std::pair<float, double>,
                     std::pair<int64_t, int32_t>,
-                    std::pair<double, Bool>,
-                    std::pair<float, Bool>,
-                    std::pair<int64_t, Bool>,
-                    std::pair<int32_t, Bool>,
+                    std::pair<double, bool>,
+                    std::pair<float, bool>,
+                    std::pair<int64_t, bool>,
+                    std::pair<int32_t, bool>,
                     std::pair<Eigen::Vector3d, double>>{}));
 };
 struct divide_equals {

--- a/core/operators.h
+++ b/core/operators.h
@@ -41,10 +41,8 @@ struct times_equals {
   using types = decltype(std::tuple_cat(
       pair_self_t<double, float, int32_t, int64_t>{},
       pair_custom_t<std::pair<double, float>, std::pair<float, double>,
-                    std::pair<int64_t, int32_t>,
-                    std::pair<double, bool>,
-                    std::pair<float, bool>,
-                    std::pair<int64_t, bool>,
+                    std::pair<int64_t, int32_t>, std::pair<double, bool>,
+                    std::pair<float, bool>, std::pair<int64_t, bool>,
                     std::pair<int32_t, bool>,
                     std::pair<Eigen::Vector3d, double>>{}));
 };

--- a/core/operators.h
+++ b/core/operators.h
@@ -41,10 +41,9 @@ struct times_equals {
   using types = decltype(std::tuple_cat(
       pair_self_t<double, float, int32_t, int64_t>{},
       pair_custom_t<std::pair<double, float>, std::pair<float, double>,
-                    std::pair<int64_t, int32_t>, std::pair<double, bool>,
-                    std::pair<float, bool>, std::pair<int64_t, bool>,
-                    std::pair<int32_t, bool>,
-                    std::pair<Eigen::Vector3d, double>>{}));
+                    std::pair<int64_t, int32_t>,
+                    std::pair<Eigen::Vector3d, double>>{},
+      pair_numerical_with_t<bool>{}));
 };
 struct divide_equals {
   template <class A, class B>

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                data_proxy_test.cpp
                dataset_comparison_test.cpp
                dataset_binary_arithmetic_test.cpp
+               dataset_operations_test.cpp
                dataset_proxy_test.cpp
                dataset_test_common.cpp
                dataset_test.cpp

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -67,5 +67,41 @@ TYPED_TEST(DatasetShapeChangingOpTest, mean_fully_masked) {
     EXPECT_TRUE(std::isnan(result["data_x"].values<TypeParam>()[0]));
   else
     EXPECT_TRUE(std::isnan(result["data_x"].values<double>()[0]));
+}
 
+TEST(DatasetOperationsTest, mean_two_dims) {
+  Dataset ds;
+  // the negative values should have been masked out
+  ds.setData("data_xy", makeVariable<int64_t>(
+                            {{Dim::X, 5}, {Dim::Y, 2}},
+                            {-999, -999, 3, -999, 5, 6, -999, 10, 10, -999}));
+
+  ds.setMask("mask_xy", makeVariable<bool>({{Dim::X, 5}, {Dim::Y, 2}},
+                                           {true, true, false, true, false,
+                                            false, true, false, false, true}));
+
+  const Dataset result = mean(ds, Dim::X);
+
+  ASSERT_EQ(result["data_xy"].data(),
+            makeVariable<double>({Dim::Y, 2}, {6, 8}));
+}
+
+TEST(DatasetOperationsTest, mean_three_dims) {
+  Dataset ds;
+  // the negative values should have been masked out
+  ds.setData("data_xy", makeVariable<int64_t>(
+                            {{Dim::Z, 2}, {Dim::X, 5}, {Dim::Y, 2}},
+                            {-999, -999, 3, -999, 5, 6, -999, 10, 10, -999,
+                             -999, -999, 3, -999, 5, 6, -999, 10, 10, -999}));
+
+  ds.setMask("mask_xy",
+             makeVariable<bool>({{Dim::Z, 2}, {Dim::X, 5}, {Dim::Y, 2}},
+                                {true,  true,  false, true,  false, false, true,
+                                 false, false, true,  true,  true,  false, true,
+                                 false, false, true,  false, false, true}));
+
+  const Dataset result = mean(ds, Dim::X);
+
+  ASSERT_EQ(result["data_xy"].data(),
+            makeVariable<double>({{Dim::Z, 2}, {Dim::Y, 2}}, {6, 8, 6, 8}));
 }

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -56,3 +56,16 @@ TYPED_TEST(DatasetShapeChangingOpTest, mean_masked) {
   else // non floating point gets the result as a double
     ASSERT_EQ(result["data_x"].data(), makeVariable<double>({2}));
 }
+
+TYPED_TEST(DatasetShapeChangingOpTest, mean_fully_masked) {
+  this->ds.setMask(
+      "full_mask",
+      makeVariable<bool>({Dim::X, 5}, makeBools<BoolsGeneratorType::TRUE>(5)));
+  const Dataset result = mean(this->ds, Dim::X);
+
+  if constexpr (std::is_floating_point_v<TypeParam>)
+    EXPECT_TRUE(std::isnan(result["data_x"].values<TypeParam>()[0]));
+  else
+    EXPECT_TRUE(std::isnan(result["data_x"].values<double>()[0]));
+
+}

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include "test_macros.h"
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include "dataset_test_common.h"
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(DatasetOperationsTest, sum) {
+  auto ds = make_1_values_and_variances<float>(
+      "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+  EXPECT_EQ(core::sum(ds, Dim::X)["a"].data(), makeVariable<float>(6, 45));
+  EXPECT_EQ(core::sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
+            makeVariable<float>(3, 27));
+  EXPECT_THROW(core::sum(make_sparse_2d({1, 2, 3, 4}, {0, 0}), Dim::X),
+               except::DimensionError);
+}
+
+TEST(DatasetOperationsTest, mean) {
+  auto ds = make_1_values_and_variances<float>(
+      "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+  EXPECT_EQ(core::mean(ds, Dim::X)["a"].data(), makeVariable<float>(2, 5.0));
+  EXPECT_EQ(core::mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
+            makeVariable<float>(1.5, 6.75));
+}
+
+template <typename T>
+class DatasetShapeChangingOpTest : public ::testing::Test {
+public:
+  void SetUp() {
+    ds.setData("data_x", makeVariable<T>({Dim::X, 5}, {1, 5, 4, 5, 1}));
+    ds.setMask("masks_x", makeVariable<bool>(
+                              {Dim::X, 5}, {false, true, false, true, false}));
+  }
+  Dataset ds;
+};
+
+using DataTypes = ::testing::Types<double, float, int64_t, int32_t>;
+TYPED_TEST_SUITE(DatasetShapeChangingOpTest, DataTypes);
+
+TYPED_TEST(DatasetShapeChangingOpTest, sum_masked) {
+  const auto result = sum(this->ds, Dim::X);
+
+  ASSERT_EQ(result["data_x"].data(), makeVariable<TypeParam>({6}));
+}
+
+TYPED_TEST(DatasetShapeChangingOpTest, mean_masked) {
+  const auto result = mean(this->ds, Dim::X);
+
+  if constexpr (std::is_floating_point_v<TypeParam>)
+    ASSERT_EQ(result["data_x"].data(), makeVariable<TypeParam>({2}));
+  else // non floating point gets the result as a double
+    ASSERT_EQ(result["data_x"].data(), makeVariable<double>({2}));
+}

--- a/core/test/dataset_test_common.h
+++ b/core/test/dataset_test_common.h
@@ -13,7 +13,7 @@
 using namespace scipp;
 using namespace scipp::core;
 
-enum BoolsGeneratorType { ALTERNATING, FALSE, TRUE };
+enum BoolsGeneratorType { ALTERNATING, FALSE, TRUE, EVERY_THIRD };
 
 template <BoolsGeneratorType type = BoolsGeneratorType::ALTERNATING>
 std::vector<bool> makeBools(const scipp::index size) {
@@ -21,6 +21,8 @@ std::vector<bool> makeBools(const scipp::index size) {
   for (scipp::index i = 0; i < size; ++i)
     if constexpr (type == BoolsGeneratorType::ALTERNATING) {
       data[i] = i % 2;
+    } else if constexpr (type == BoolsGeneratorType::EVERY_THIRD) {
+      data[i] = i % 3 == 0;
     } else if constexpr (type == BoolsGeneratorType::FALSE) {
       data[i] = false;
     } else {

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -31,8 +31,11 @@ template <class... Ts> struct pair_product {
 template <class... Ts>
 using pair_product_t = typename pair_product<Ts...>::type;
 
-using arithmetic_type_pairs =
-    pair_product_t<float, double, int32_t, int64_t, bool>;
+using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
+
+using arithmetic_type_pairs_with_bool =
+    decltype(std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                            std::declval<pair_numerical_with_t<bool>>()));
 
 using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
     std::declval<arithmetic_type_pairs>(),
@@ -104,7 +107,7 @@ template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
 }
 
 template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
-  return transform<arithmetic_type_pairs>(a, b, times_);
+  return transform<arithmetic_type_pairs_with_bool>(a, b, times_);
 }
 
 Variable &Variable::operator*=(const Variable &other) & {

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -31,7 +31,7 @@ template <class... Ts> struct pair_product {
 template <class... Ts>
 using pair_product_t = typename pair_product<Ts...>::type;
 
-using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
+using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t, bool>;
 
 using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
     std::declval<arithmetic_type_pairs>(),
@@ -295,6 +295,15 @@ Variable operator/(const double a, const VariableConstProxy &b_proxy) {
   return b;
 }
 
+Variable Variable::operator~() const {
+  return transform<bool>(
+      *this, overloaded{[](const auto &current) { return !current; },
+                        [](const units::Unit &unit) -> units::Unit {
+                          expect::equals(unit, units::dimensionless);
+                          return unit;
+                        }});
+}
+
 struct MakeVariableWithType {
   template <class T> struct Maker {
     static Variable apply(const VariableConstProxy &parent) {
@@ -321,5 +330,4 @@ Variable astype(const VariableConstProxy &var, DType type) {
   return type == var.dtype() ? Variable(var)
                              : MakeVariableWithType::make(var, type);
 }
-
 } // namespace scipp::core

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -31,7 +31,8 @@ template <class... Ts> struct pair_product {
 template <class... Ts>
 using pair_product_t = typename pair_product<Ts...>::type;
 
-using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t, bool>;
+using arithmetic_type_pairs =
+    pair_product_t<float, double, int32_t, int64_t, bool>;
 
 using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
     std::declval<arithmetic_type_pairs>(),

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -331,9 +331,9 @@ Variable copy(const VariableConstProxy &var) { return Variable(var); }
 
 Variable masks_merge(const MasksConstProxy &masks, const Dimensions dims) {
   auto mask_union = makeVariable<bool>(dims);
-    for (const auto &mask : masks) {
-      mask_union |= mask.second;
-    }
-    return mask_union;
+  for (const auto &mask : masks) {
+    mask_union |= mask.second;
+  }
+  return mask_union;
 }
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -226,11 +226,8 @@ Variable sum(const VariableConstProxy &var, const Dim dim,
   if (masks.empty()) {
     return sum(var, dim);
   } else {
-    auto maskUnion = makeVariable<bool>(var.dims());
-    for (const auto &mask : masks) {
-      maskUnion |= mask.second;
-    }
-    return sum(var * ~maskUnion, dim);
+    const auto mask_union = masks_merge(masks, var.dims());
+    return sum(var * ~mask_union, dim);
   }
 }
 
@@ -258,14 +255,9 @@ Variable mean(const VariableConstProxy &var, const Dim dim,
   if (masks.empty()) {
     return mean(var, dim);
   } else {
-    auto masks_union = makeVariable<bool>(var.dims());
-    for (const auto &mask : masks) {
-      masks_union |= mask.second;
-    }
-
-    const auto masks_sum = sum(masks_union, dim);
-
-    return mean(var * ~masks_union, dim, masks_sum);
+    const auto mask_union = masks_merge(masks, var.dims());
+    const auto masks_sum = sum(mask_union, dim);
+    return mean(var * ~mask_union, dim, masks_sum);
   }
 }
 
@@ -337,4 +329,11 @@ Variable reverse(Variable var, const Dim dim) {
 /// Return a deep copy of a Variable or of a VariableProxy.
 Variable copy(const VariableConstProxy &var) { return Variable(var); }
 
+Variable masks_merge(const MasksConstProxy &masks, const Dimensions dims) {
+  auto mask_union = makeVariable<bool>(dims);
+    for (const auto &mask : masks) {
+      mask_union |= mask.second;
+    }
+    return mask_union;
+}
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -226,13 +226,9 @@ Variable sum(const VariableConstProxy &var, const Dim dim,
   if (masks.empty()) {
     return sum(var, dim);
   } else {
-    const auto mask_union = masks_merge(masks, var.dims());
+    const auto mask_union = masks_merge(masks);
     return sum(var * ~mask_union, dim);
   }
-}
-
-Variable mean(const VariableConstProxy &var, const Dim dim) {
-  return mean(var, dim, makeVariable<int64_t>(0));
 }
 
 Variable mean(const VariableConstProxy &var, const Dim dim,
@@ -250,12 +246,16 @@ Variable mean(const VariableConstProxy &var, const Dim dim,
   return summed;
 }
 
+Variable mean(const VariableConstProxy &var, const Dim dim) {
+  return mean(var, dim, makeVariable<int64_t>(0));
+}
+
 Variable mean(const VariableConstProxy &var, const Dim dim,
               const MasksConstProxy &masks) {
   if (masks.empty()) {
     return mean(var, dim);
   } else {
-    const auto mask_union = masks_merge(masks, var.dims());
+    const auto mask_union = masks_merge(masks);
     const auto masks_sum = sum(mask_union, dim);
     return mean(var * ~mask_union, dim, masks_sum);
   }
@@ -329,10 +329,11 @@ Variable reverse(Variable var, const Dim dim) {
 /// Return a deep copy of a Variable or of a VariableProxy.
 Variable copy(const VariableConstProxy &var) { return Variable(var); }
 
-Variable masks_merge(const MasksConstProxy &masks, const Dimensions dims) {
-  auto mask_union = makeVariable<bool>(dims);
+/// Merges all masks contained in the MasksConstProxy into a single Variable
+Variable masks_merge(const MasksConstProxy &masks) {
+  auto mask_union = makeVariable<bool>(false);
   for (const auto &mask : masks) {
-    mask_union |= mask.second;
+    mask_union = mask_union | mask.second;
   }
   return mask_union;
 }

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -372,7 +372,8 @@ def test_sum_masked():
             'a': sc.Variable([Dim.X], values=np.array([1, 5, 4, 5, 1]))
         },
         masks={
-            "m1": sc.Variable([Dim.X], values=np.array([False, True, False, True, False]))
+            "m1": sc.Variable([Dim.X], values=np.array([
+                False, True, False, True, False]))
         })
 
     d_ref = sc.Dataset(
@@ -389,7 +390,8 @@ def test_mean_masked():
             'a': sc.Variable([Dim.X], values=np.array([1, 5, 4, 5, 1]))
         },
         masks={
-            "m1": sc.Variable([Dim.X], values=np.array([False, True, False, True, False]))
+            "m1": sc.Variable([Dim.X], values=np.array([
+                False, True, False, True, False]))
         })
     d_ref = sc.Dataset(
         {

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -366,6 +366,38 @@ def test_sum_mean():
     assert sc.mean(d, Dim.Y)["b"].value == 1.0
 
 
+def test_sum_masked():
+    d = sc.Dataset(
+        {
+            'a': sc.Variable([Dim.X], values=np.array([1, 5, 4, 5, 1]))
+        },
+        masks={
+            "m1": sc.Variable([Dim.X], values=np.array([False, True, False, True, False]))
+        })
+
+    d_ref = sc.Dataset(
+        {
+            'a': sc.Variable(6)
+        })
+
+    assert sc.sum(d, Dim.X)["a"] == d_ref["a"]
+
+
+def test_mean_masked():
+    d = sc.Dataset(
+        {
+            'a': sc.Variable([Dim.X], values=np.array([1, 5, 4, 5, 1]))
+        },
+        masks={
+            "m1": sc.Variable([Dim.X], values=np.array([False, True, False, True, False]))
+        })
+    d_ref = sc.Dataset(
+        {
+            'a': sc.Variable(2.0)
+        })
+    assert sc.mean(d, Dim.X)["a"] == d_ref["a"]
+
+
 def test_variable_histogram():
     var = sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, sc.Dimensions.Sparse])
     var[Dim.X, 0].values = np.arange(3)


### PR DESCRIPTION
Makes Dataset `sum` and `mean` operations account for masks. `operator~` was added for Variable that inverts a Variable with `bool`s. C++ and Python tests have been added for cases with masks.

The current implementation does a union of _all_ masks in the Dataset, then multiples the data, before applying the actual sum/mean operation: all data that should be masked gets multiplied by `false`, i.e. 0).

The Python interface for Variable `sum` and `mean` is not changed, it can't do the sum or mean for a Variable and a mask. It has to be in a Dataset

As part of this a benchmark for dataset_operation was added in `dataset_operations_benchmark` that currently covers `sum/mean` with/without masks
