### PR TITLE
convert_with_calibration bugfix

### DIFF
--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -12,8 +12,14 @@ using namespace scipp::core;
 namespace scipp::neutron::diffraction {
 
 Dataset convert_with_calibration(Dataset d, Dataset cal) {
-  // 1. Record ToF bin widths
-  const auto oldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+
+  std::vector<Variable> oldBinWidths;
+  std::vector<Variable> newBinWidths;
+
+  if (d.coords().contains(Dim::Tof)) {
+      // 1. Record ToF bin widths
+      oldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+  }
 
   // 2. There may be a grouping of detectors, in which case we need to apply it
   // to the cal information first.
@@ -40,12 +46,15 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
                                  ". Missing detector information?");
   }
 
-  // 3. Transform coordinate
-  d.setCoord(Dim::Tof,
-             (d.coords()[Dim::Tof] - cal["tzero"].data()) / cal["difc"].data());
+  if (d.coords().contains(Dim::Tof)) {
+      // 3. Transform coordinate
+      d.setCoord(Dim::Tof,
+                 (d.coords()[Dim::Tof] - cal["tzero"].data())
+                 / cal["difc"].data());
 
-  // 4. Record DSpacing bin widths
-  const auto newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+      // 4. Record DSpacing bin widths
+      newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+  }
 
   // 5. Transform variables
   for (const auto &[name, data] : d) {

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -48,9 +48,8 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
 
   if (d.coords().contains(Dim::Tof)) {
     // 3. Transform coordinate
-    d.setCoord(Dim::Tof,
-               (d.coords()[Dim::Tof] - cal["tzero"].data())
-               / cal["difc"].data());
+    d.setCoord(Dim::Tof, (d.coords()[Dim::Tof] - cal["tzero"].data()) /
+                             cal["difc"].data());
 
     // 4. Record DSpacing bin widths
     newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -17,8 +17,8 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
   std::vector<Variable> newBinWidths;
 
   if (d.coords().contains(Dim::Tof)) {
-      // 1. Record ToF bin widths
-      oldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+    // 1. Record ToF bin widths
+    OldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
   }
 
   // 2. There may be a grouping of detectors, in which case we need to apply it
@@ -47,13 +47,13 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
   }
 
   if (d.coords().contains(Dim::Tof)) {
-      // 3. Transform coordinate
-      d.setCoord(Dim::Tof,
-                 (d.coords()[Dim::Tof] - cal["tzero"].data())
-                 / cal["difc"].data());
+    // 3. Transform coordinate
+    d.setCoord(Dim::Tof,
+               (d.coords()[Dim::Tof] - cal["tzero"].data())
+               / cal["difc"].data());
 
-      // 4. Record DSpacing bin widths
-      newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+    // 4. Record DSpacing bin widths
+    newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
   }
 
   // 5. Transform variables

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -18,7 +18,7 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
 
   if (d.coords().contains(Dim::Tof)) {
     // 1. Record ToF bin widths
-    OldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
+    oldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
   }
 
   // 2. There may be a grouping of detectors, in which case we need to apply it


### PR DESCRIPTION
Fixed a bug in convert_with_calibration that caused the function to fail if no dense data with Dim.Tof is present in the Dataset.