### PR TITLE
neutron.convert for DataArray

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -1114,9 +1114,9 @@ public:
   }
 
   /// Iterable const view for generic code supporting Dataset and DataArray.
-  DatasetConstProxy iter() const noexcept { return m_holder; }
+  DatasetConstProxy iterable_view() const noexcept { return m_holder; }
   /// Iterable view for generic code supporting Dataset and DataArray.
-  DatasetProxy iter() noexcept { return m_holder; }
+  DatasetProxy iterable_view() noexcept { return m_holder; }
 
 private:
   DataConstProxy get() const;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -262,6 +262,7 @@ public:
   using mapped_type = DataArray;
   using value_type = std::pair<const std::string &, DataConstProxy>;
   using const_view_type = DatasetConstProxy;
+  using view_type = DatasetProxy;
 
   Dataset() = default;
   explicit Dataset(const DatasetConstProxy &proxy);
@@ -952,6 +953,7 @@ SCIPP_CORE_EXPORT Dataset copy(const DatasetConstProxy &dataset);
 class SCIPP_CORE_EXPORT DataArray {
 public:
   using const_view_type = DataConstProxy;
+  using view_type = DataProxy;
 
   DataArray() = default;
   explicit DataArray(const DataConstProxy &proxy);

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -1111,6 +1111,11 @@ public:
     return copy(get().slice(slice1, slice2, slice3));
   }
 
+  /// Iterable const view for generic code supporting Dataset and DataArray.
+  DatasetConstProxy iter() const noexcept { return m_holder; }
+  /// Iterable view for generic code supporting Dataset and DataArray.
+  DatasetProxy iter() noexcept { return m_holder; }
+
 private:
   DataConstProxy get() const;
   DataProxy get();

--- a/core/include/scipp/core/dataset_util.h
+++ b/core/include/scipp/core/dataset_util.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_DATASET_UTIL_H
+#define SCIPP_CORE_DATASET_UTIL_H
+
+#include "scipp/core/dataset.h"
+
+namespace scipp::core {
+
+/// Iteration helper for generic code supporting data array and dataset.
+///
+/// Example:
+///     for (const auto &[name, data] : iter(dataarray_or_dataset)) {}
+template <class T> static decltype(auto) iter(T &d) {
+  if constexpr (std::is_same_v<T, Dataset>)
+    return d;
+  else
+    return d.iter();
+}
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_DATASET_UTIL_H

--- a/core/include/scipp/core/dataset_util.h
+++ b/core/include/scipp/core/dataset_util.h
@@ -17,7 +17,7 @@ template <class T> static decltype(auto) iter(T &d) {
   if constexpr (std::is_same_v<T, Dataset>)
     return d;
   else
-    return d.iter();
+    return d.iterable_view();
 }
 } // namespace scipp::core
 

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -7,6 +7,7 @@
 #include <boost/units/systems/si/codata/universal_constants.hpp>
 
 #include "scipp/core/dataset.h"
+#include "scipp/core/dataset_util.h"
 #include "scipp/core/transform.h"
 #include "scipp/neutron/beamline.h"
 #include "scipp/neutron/convert.h"
@@ -28,13 +29,6 @@ const auto m_to_angstrom =
 const auto tofToEnergyPhysicalConstants =
     0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
     (tof_to_s * tof_to_s);
-
-template <class T> static decltype(auto) iter(T &d) {
-  if constexpr (std::is_same_v<T, Dataset>)
-    return d;
-  else
-    return d.iter();
-}
 
 template <class T>
 static T convert_with_factor(T &&d, const Dim from, const Dim to,
@@ -252,11 +246,11 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
 }
 
 DataArray convert(DataArray d, const Dim from, const Dim to) {
-  return convert_impl(d, from, to);
+  return convert_impl(std::move(d), from, to);
 }
 
 Dataset convert(Dataset d, const Dim from, const Dim to) {
-  return convert_impl(d, from, to);
+  return convert_impl(std::move(d), from, to);
 }
 
 } // namespace scipp::neutron

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -253,22 +253,12 @@ DataArray convert(const DataConstProxy &d, const Dim from, const Dim to) {
   return convert(DataArray(d), from, to);
 }
 
-DataProxy convert(const DataConstProxy &d, const Dim from, const Dim to,
-                  const DataProxy &out) {
-  return out;
-}
-
 Dataset convert(Dataset d, const Dim from, const Dim to) {
   return convert_impl(std::move(d), from, to);
 }
 
 Dataset convert(const DatasetConstProxy &d, const Dim from, const Dim to) {
   return convert(Dataset(d), from, to);
-}
-
-DatasetProxy convert(const DatasetConstProxy &d, const Dim from, const Dim to,
-                     const DatasetProxy &out) {
-  return out;
 }
 
 } // namespace scipp::neutron

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -249,8 +249,26 @@ DataArray convert(DataArray d, const Dim from, const Dim to) {
   return convert_impl(std::move(d), from, to);
 }
 
+DataArray convert(const DataConstProxy &d, const Dim from, const Dim to) {
+  return convert(DataArray(d), from, to);
+}
+
+DataProxy convert(const DataConstProxy &d, const Dim from, const Dim to,
+                  const DataProxy &out) {
+  return out;
+}
+
 Dataset convert(Dataset d, const Dim from, const Dim to) {
   return convert_impl(std::move(d), from, to);
+}
+
+Dataset convert(const DatasetConstProxy &d, const Dim from, const Dim to) {
+  return convert(Dataset(d), from, to);
+}
+
+DatasetProxy convert(const DatasetConstProxy &d, const Dim from, const Dim to,
+                     const DatasetProxy &out) {
+  return out;
 }
 
 } // namespace scipp::neutron

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -29,8 +29,16 @@ const auto tofToEnergyPhysicalConstants =
     0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
     (tof_to_s * tof_to_s);
 
-static Dataset convert_with_factor(Dataset &&d, const Dim from, const Dim to,
-                                   const Variable &factor) {
+template <class T> static decltype(auto) iter(T &d) {
+  if constexpr (std::is_same_v<T, Dataset>)
+    return d;
+  else
+    return d.iter();
+}
+
+template <class T>
+static T convert_with_factor(T &&d, const Dim from, const Dim to,
+                             const Variable &factor) {
   // 1. Transform coordinate
   // Cannot use *= since often a broadcast into Dim::Spectrum is required.
   if (d.coords().contains(from)) {
@@ -39,7 +47,7 @@ static Dataset convert_with_factor(Dataset &&d, const Dim from, const Dim to,
   }
 
   // 2. Transform sparse coordinates
-  for (const auto &[name, data] : d) {
+  for (const auto &[name, data] : iter(d)) {
     static_cast<void>(name);
     if (data.dims().sparse()) {
       data.coords()[from] *= factor;
@@ -49,7 +57,7 @@ static Dataset convert_with_factor(Dataset &&d, const Dim from, const Dim to,
   return std::move(d);
 }
 
-auto tofToDSpacing(const Dataset &d) {
+template <class T> auto tofToDSpacing(const T &d) {
   const auto &sourcePos = source_position(d);
   const auto &samplePos = sample_position(d);
 
@@ -71,14 +79,14 @@ auto tofToDSpacing(const Dataset &d) {
   return reciprocal(conversionFactor);
 }
 
-static auto tofToWavelength(const Dataset &d) {
+template <class T> static auto tofToWavelength(const T &d) {
   const auto l = l1(d) + l2(d);
   return (tof_to_s * m_to_angstrom * boost::units::si::constants::codata::h /
           boost::units::si::constants::codata::m_n) /
          std::move(l);
 }
 
-auto tofToEnergyConversionFactor(const Dataset &d) {
+template <class T> auto tofToEnergyConversionFactor(const T &d) {
   const auto &samplePos = sample_position(d);
   const auto l1 = neutron::l1(d);
   const auto specPos = neutron::position(d);
@@ -93,7 +101,7 @@ auto tofToEnergyConversionFactor(const Dataset &d) {
   return conversionFactor;
 }
 
-Dataset tofToEnergy(Dataset &&d) {
+template <class T> T tofToEnergy(T &&d) {
   // 1. Compute conversion factor
   const auto conversionFactor = tofToEnergyConversionFactor(d);
 
@@ -105,7 +113,7 @@ Dataset tofToEnergy(Dataset &&d) {
   }
 
   // 3. Transform sparse coordinates
-  for (const auto &[name, data] : d) {
+  for (const auto &[name, data] : iter(d)) {
     static_cast<void>(name);
     if (data.coords()[Dim::Tof].dims().sparse()) {
       transform_in_place<pair_self_t<double, float>>(
@@ -120,7 +128,7 @@ Dataset tofToEnergy(Dataset &&d) {
   return std::move(d);
 }
 
-Dataset energyToTof(Dataset &&d) {
+template <class T> T energyToTof(T &&d) {
   // 1. Compute conversion factor
   const auto conversionFactor = tofToEnergyConversionFactor(d);
 
@@ -132,7 +140,7 @@ Dataset energyToTof(Dataset &&d) {
   }
 
   // 3. Transform sparse coordinates
-  for (const auto &[name, data] : d) {
+  for (const auto &[name, data] : iter(d)) {
     static_cast<void>(name);
     if (data.coords()[Dim::Energy].dims().sparse()) {
       transform_in_place<pair_self_t<double, float>>(
@@ -219,8 +227,8 @@ Dataset tofToDeltaE(const Dataset &d) {
 }
 */
 
-Dataset convert(Dataset d, const Dim from, const Dim to) {
-  for (const auto &item : d)
+template <class T> T convert_impl(T d, const Dim from, const Dim to) {
+  for (const auto &item : iter(d))
     if (item.second.hasData())
       expect::notCountDensity(item.second.unit());
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
@@ -241,6 +249,14 @@ Dataset convert(Dataset d, const Dim from, const Dim to) {
     return energyToTof(std::move(d));
   throw std::runtime_error(
       "Conversion between requested dimensions not implemented yet.");
+}
+
+DataArray convert(DataArray d, const Dim from, const Dim to) {
+  return convert_impl(d, from, to);
+}
+
+Dataset convert(Dataset d, const Dim from, const Dim to) {
+  return convert_impl(d, from, to);
 }
 
 } // namespace scipp::neutron

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -4,6 +4,7 @@
 /// @author Mads Bertelsen
 #include "scipp/neutron/diffraction/convert_with_calibration.h"
 #include "scipp/core/counts.h"
+#include "scipp/core/dataset_util.h"
 #include "scipp/core/except.h"
 #include "scipp/core/groupby.h"
 
@@ -11,33 +12,36 @@ using namespace scipp::core;
 
 namespace scipp::neutron::diffraction {
 
-Dataset convert_with_calibration(Dataset d, Dataset cal) {
+template <class T> bool has_dim(const T &d, const Dim dim) {
+  if constexpr (std::is_same_v<T, Dataset>)
+    return d.dimensions().count(dim) == 1;
+  else
+    return d.dims().contains(dim);
+}
 
-  std::vector<Variable> oldBinWidths;
-  std::vector<Variable> newBinWidths;
+template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
+  for (const auto &item : iter(d))
+    if (item.second.hasData())
+      expect::notCountDensity(item.second.unit());
 
-  if (d.coords().contains(Dim::Tof)) {
-    // 1. Record ToF bin widths
-    oldBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
-  }
-
-  // 2. There may be a grouping of detectors, in which case we need to apply it
+  // 1. There may be a grouping of detectors, in which case we need to apply it
   // to the cal information first.
   if (d.labels().contains("detector_info")) {
-    // 2a. Merge cal with detector_info, which contains information on how `d`
+    // 1a. Merge cal with detector_info, which contains information on how `d`
     // groups its detectors. At the same time, the coord comparison in `merge`
     // ensures that detector IDs of `d` match those of `cal` .
-    const auto &detector_info = d.labels()["detector_info"].value<Dataset>();
+    const auto &detector_info =
+        d.labels()["detector_info"].template value<Dataset>();
     cal = merge(detector_info, cal);
 
-    // 2b. Translate detector-based calibration information into coordinates of
+    // 1b. Translate detector-based calibration information into coordinates of
     // data.
     // We are hard-coding some information here: the existence of "spectra",
     // since we require labels named "spectrum" and a corresponding dimension.
     // Given that this in in a branch that is access only if "detector_info" is
     // present this should probably be ok.
     cal = groupby(cal, "spectrum", Dim::Spectrum).mean(Dim::Detector);
-  } else if (d.dimensions().count(cal["tzero"].dims().inner()) != 1) {
+  } else if (!has_dim(d, cal["tzero"].dims().inner())) {
     throw except::DimensionError("Calibration depends on dimension " +
                                  to_string(cal["tzero"].dims().inner()) +
                                  " that is not present in the converted "
@@ -46,31 +50,33 @@ Dataset convert_with_calibration(Dataset d, Dataset cal) {
                                  ". Missing detector information?");
   }
 
+  // 2. Transform coordinate
   if (d.coords().contains(Dim::Tof)) {
-    // 3. Transform coordinate
     d.setCoord(Dim::Tof, (d.coords()[Dim::Tof] - cal["tzero"].data()) /
                              cal["difc"].data());
-
-    // 4. Record DSpacing bin widths
-    newBinWidths = counts::getBinWidths(d.coords(), {Dim::Tof});
   }
 
-  // 5. Transform variables
-  for (const auto &[name, data] : d) {
+  // 3. Transform sparse coordinates
+  for (const auto &[name, data] : iter(d)) {
     static_cast<void>(name);
     if (data.coords()[Dim::Tof].dims().sparse()) {
       data.coords()[Dim::Tof].assign(data.coords()[Dim::Tof] -
                                      cal["tzero"].data());
       data.coords()[Dim::Tof].assign(data.coords()[Dim::Tof] /
                                      cal["difc"].data());
-    } else if (data.unit().isCountDensity()) {
-      counts::fromDensity(data, oldBinWidths);
-      counts::toDensity(data, newBinWidths);
     }
   }
 
   d.rename(Dim::Tof, Dim::DSpacing);
   return d;
+}
+
+DataArray convert_with_calibration(DataArray d, Dataset cal) {
+  return convert_with_calibration_impl(std::move(d), std::move(cal));
+}
+
+Dataset convert_with_calibration(Dataset d, Dataset cal) {
+  return convert_with_calibration_impl(std::move(d), std::move(cal));
 }
 
 } // namespace scipp::neutron::diffraction

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -15,8 +15,18 @@ namespace scipp::neutron {
 
 SCIPP_NEUTRON_EXPORT core::DataArray convert(core::DataArray d, const Dim from,
                                              const Dim to);
+SCIPP_NEUTRON_EXPORT core::DataArray convert(const core::DataConstProxy &d,
+                                             const Dim from, const Dim to);
+SCIPP_NEUTRON_EXPORT core::DataProxy convert(const core::DataConstProxy &d,
+                                             const Dim from, const Dim to,
+                                             const core::DataProxy &out);
 SCIPP_NEUTRON_EXPORT core::Dataset convert(core::Dataset d, const Dim from,
                                            const Dim to);
+SCIPP_NEUTRON_EXPORT core::Dataset convert(const core::DatasetConstProxy &d,
+                                           const Dim from, const Dim to);
+SCIPP_NEUTRON_EXPORT core::DatasetProxy
+convert(const core::DatasetConstProxy &d, const Dim from, const Dim to,
+        const core::DatasetProxy &out);
 
 } // namespace scipp::neutron
 

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -13,6 +13,8 @@
 
 namespace scipp::neutron {
 
+SCIPP_NEUTRON_EXPORT core::DataArray convert(core::DataArray d, const Dim from,
+                                             const Dim to);
 SCIPP_NEUTRON_EXPORT core::Dataset convert(core::Dataset d, const Dim from,
                                            const Dim to);
 

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -17,16 +17,10 @@ SCIPP_NEUTRON_EXPORT core::DataArray convert(core::DataArray d, const Dim from,
                                              const Dim to);
 SCIPP_NEUTRON_EXPORT core::DataArray convert(const core::DataConstProxy &d,
                                              const Dim from, const Dim to);
-SCIPP_NEUTRON_EXPORT core::DataProxy convert(const core::DataConstProxy &d,
-                                             const Dim from, const Dim to,
-                                             const core::DataProxy &out);
 SCIPP_NEUTRON_EXPORT core::Dataset convert(core::Dataset d, const Dim from,
                                            const Dim to);
 SCIPP_NEUTRON_EXPORT core::Dataset convert(const core::DatasetConstProxy &d,
                                            const Dim from, const Dim to);
-SCIPP_NEUTRON_EXPORT core::DatasetProxy
-convert(const core::DatasetConstProxy &d, const Dim from, const Dim to,
-        const core::DatasetProxy &out);
 
 } // namespace scipp::neutron
 

--- a/neutron/include/scipp/neutron/diffraction/convert_with_calibration.h
+++ b/neutron/include/scipp/neutron/diffraction/convert_with_calibration.h
@@ -10,6 +10,8 @@
 
 namespace scipp::neutron::diffraction {
 
+SCIPP_NEUTRON_EXPORT core::DataArray
+convert_with_calibration(core::DataArray d, core::Dataset cal);
 SCIPP_NEUTRON_EXPORT core::Dataset convert_with_calibration(core::Dataset d,
                                                             core::Dataset cal);
 

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -54,6 +54,31 @@ Variable makeCountDensityData(const units::Unit &unit) {
                               {1, 2, 3, 4, 5, 6});
 }
 
+// Tests for DataArray (or its view) as input, comparing against conversion of
+// Dataset.
+TEST(ConvertDataArray, from_tof) {
+  Dataset tof = makeTofDataForUnitConversion();
+  for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
+    const auto expected = convert(tof, Dim::Tof, dim);
+    Dataset result;
+    for (const auto &[name, data] : tof)
+      result.setData(name, convert(data, Dim::Tof, dim));
+    EXPECT_EQ(result, expected);
+  }
+}
+
+TEST(ConvertDataArray, to_tof) {
+  Dataset tof = makeTofDataForUnitConversion();
+  for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
+    const auto input = convert(tof, Dim::Tof, dim);
+    const auto expected = convert(input, dim, Dim::Tof);
+    Dataset result;
+    for (const auto &[name, data] : input)
+      result.setData(name, convert(data, dim, Dim::Tof));
+    EXPECT_EQ(result, expected);
+  }
+}
+
 TEST(Convert, fail_count_density) {
   const Dataset tof = makeTofDataForUnitConversion();
   for (const Dim dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -61,6 +61,8 @@ template <class T> void bind_beamline(py::module &m) {
 }
 
 template <class T> void bind_convert(py::module &m) {
+  using ConstView = const typename T::const_view_type &;
+  using View = const typename T::view_type &;
   const char *doc = R"(
     Convert dimension (unit) into another.
 
@@ -71,8 +73,12 @@ template <class T> void bind_convert(py::module &m) {
     :param to: Dimension to convert into
     :return: New data array or dataset with converted dimension (dimension labels, coordinate values, and units)
     :rtype: DataArray or Dataset)";
-  m.def("convert", py::overload_cast<T, const Dim, const Dim>(convert),
+  m.def("convert", py::overload_cast<ConstView, const Dim, const Dim>(convert),
         py::arg("data"), py::arg("from"), py::arg("to"),
+        py::call_guard<py::gil_scoped_release>(), doc);
+  m.def("convert",
+        py::overload_cast<ConstView, const Dim, const Dim, View>(convert),
+        py::arg("data"), py::arg("from"), py::arg("to"), py::arg("out"),
         py::call_guard<py::gil_scoped_release>(), doc);
 }
 

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -76,24 +76,36 @@ template <class T> void bind_convert(py::module &m) {
         py::call_guard<py::gil_scoped_release>(), doc);
 }
 
-void init_neutron(py::module &m) {
-  auto neutron = m.def_submodule("neutron");
-  auto diffraction = m.def_submodule("neutron_diffraction");
-
-  diffraction.def("convert_with_calibration",
-                  diffraction::convert_with_calibration, py::arg("data"),
-                  py::arg("calibration"), R"(
+template <class T> void bind_convert_with_calibration(py::module &m) {
+  m.def("convert_with_calibration",
+        py::overload_cast<T, core::Dataset>(
+            diffraction::convert_with_calibration),
+        py::arg("data"), py::arg("calibration"), R"(
     Convert unit of powder-diffraction data based on calibration.
 
     :param data: Input data with time-of-flight dimension (Dim.Tof)
     :param calibration: Table of calibration constants
-    :return: New dataset with time-of-flight converted to d-spacing (Dim.DSpacing)
-    :rtype: Dataset
+    :return: New data array or dataset with time-of-flight converted to d-spacing (Dim.DSpacing)
+    :rtype: DataArray or Dataset
 
     .. seealso:: Use :py:func:`scipp.neutron.convert` for unit conversion based on beamline-geometry information instead of calibration information.)");
+}
+
+void bind_diffraction(py::module &m) {
+  auto diffraction = m.def_submodule("neutron_diffraction");
+  bind_convert_with_calibration<core::DataArray>(diffraction);
+  bind_convert_with_calibration<core::Dataset>(diffraction);
+}
+
+void init_neutron(py::module &m) {
+  auto neutron = m.def_submodule("neutron");
 
   bind_convert<core::DataArray>(neutron);
   bind_convert<core::Dataset>(neutron);
   bind_beamline<core::DataArray>(neutron);
   bind_beamline<core::Dataset>(neutron);
+
+  // This is deliberately `m` and not `neutron` due to how nested imports work
+  // in Python in combination with mixed C++/Python modules.
+  bind_diffraction(m);
 }

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -76,10 +76,6 @@ template <class T> void bind_convert(py::module &m) {
   m.def("convert", py::overload_cast<ConstView, const Dim, const Dim>(convert),
         py::arg("data"), py::arg("from"), py::arg("to"),
         py::call_guard<py::gil_scoped_release>(), doc);
-  m.def("convert",
-        py::overload_cast<ConstView, const Dim, const Dim, View>(convert),
-        py::arg("data"), py::arg("from"), py::arg("to"), py::arg("out"),
-        py::call_guard<py::gil_scoped_release>(), doc);
 }
 
 template <class T> void bind_convert_with_calibration(py::module &m) {

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -60,7 +60,7 @@ template <class T> void bind_beamline(py::module &m) {
     :rtype: Variable)");
 }
 
-void bind_convert(py::module &m) {
+template <class T> void bind_convert(py::module &m) {
   const char *doc = R"(
     Convert dimension (unit) into another.
 
@@ -69,9 +69,10 @@ void bind_convert(py::module &m) {
     :param data: Input data with time-of-flight dimension (Dim.Tof)
     :param from: Dimension to convert from
     :param to: Dimension to convert into
-    :return: New dataset with converted dimension (dimension labels, coordinate values, and units)
-    :rtype: Dataset)";
-  m.def("convert", convert, py::arg("data"), py::arg("from"), py::arg("to"),
+    :return: New data array or dataset with converted dimension (dimension labels, coordinate values, and units)
+    :rtype: DataArray or Dataset)";
+  m.def("convert", py::overload_cast<T, const Dim, const Dim>(convert),
+        py::arg("data"), py::arg("from"), py::arg("to"),
         py::call_guard<py::gil_scoped_release>(), doc);
 }
 
@@ -91,7 +92,8 @@ void init_neutron(py::module &m) {
 
     .. seealso:: Use :py:func:`scipp.neutron.convert` for unit conversion based on beamline-geometry information instead of calibration information.)");
 
-  bind_convert(neutron);
+  bind_convert<core::DataArray>(neutron);
+  bind_convert<core::Dataset>(neutron);
   bind_beamline<core::DataArray>(neutron);
   bind_beamline<core::Dataset>(neutron);
 }


### PR DESCRIPTION
Fixes #655.

- `neutron.convert` for `DataArray`.
- Bring recent changes in `neutron.convert` also into its sibling `neutron.diffraction.convert_with_calibration`.