### PR TITLE
Improves masks (Variable of bools) representation, display masks in `table` and `show`

### DIFF
--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -47,6 +47,7 @@ SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const Dataset &dataset);
 
+SCIPP_CORE_EXPORT std::string to_string(const bool b);
 SCIPP_CORE_EXPORT std::string to_string(const DType dtype);
 SCIPP_CORE_EXPORT std::string to_string(const Dimensions &dims);
 SCIPP_CORE_EXPORT std::string to_string(const Slice &slice);

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -68,6 +68,8 @@ std::string to_string(const Dimensions &dims) {
   return s;
 }
 
+std::string to_string(const bool b) { return b ? "True" : "False"; }
+
 std::string to_string(const DType dtype) {
   switch (dtype) {
   case DType::String:

--- a/python/src/scipp/config.py
+++ b/python/src/scipp/config.py
@@ -41,7 +41,9 @@ class _Colors:
             "data": ["#ffe680", "#ffd42a", "#d4aa00"],
             "labels": ["#afdde9", "#5fbcd3", "#2c89a0"],
             "attr": ["#ff8080", "#ff2a2a", "#d40000"],
-            "inactive": ["#cccccc", "#888888", "#444444"]
+            "inactive": ["#cccccc", "#888888", "#444444"],
+            # TODO sort out the color
+            "masks": ["#ffaaff", "#5fbcd3", "#2c89a0"]
         }
 
 

--- a/python/src/scipp/config.py
+++ b/python/src/scipp/config.py
@@ -42,8 +42,7 @@ class _Colors:
             "labels": ["#afdde9", "#5fbcd3", "#2c89a0"],
             "attr": ["#ff8080", "#ff2a2a", "#d40000"],
             "inactive": ["#cccccc", "#888888", "#444444"],
-            # TODO sort out the color
-            "masks": ["#ffaaff", "#5fbcd3", "#2c89a0"]
+            "masks": ["#ffb3ff", "#ff80ff", "#cc00cc"]
         }
 
 

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -231,6 +231,10 @@ class VariableDrawer():
                     if label.sparse_dim is not None:
                         items.append((name, label.values,
                                       colors.scheme['labels']))
+                for name, mask in self._variable.masks:
+                    if label.sparse_dim is not None:
+                        items.append((name, mask.values,
+                                      colors.scheme['masks']))
                 sparse_dim = self._variable.sparse_dim
                 for dim, coord in self._variable.coords:
                     if dim == sparse_dim:
@@ -364,6 +368,19 @@ class DatasetDrawer():
             elif labels.dims[-1] == dims[-1]:
                 area_x.append(item)
             elif labels.dims[-1] == dims[-2]:
+                area_y.append(item)
+            else:
+                area_z.append(item)
+
+        for name, masks in dataset.masks:
+            if masks.sparse_dim is not None:
+                continue
+            item = (name, masks, colors.scheme['masks'])
+            if len(masks.dims) == 0:
+                area_0d.append(item)
+            elif masks.dims[-1] == dims[-1]:
+                area_x.append(item)
+            elif masks.dims[-1] == dims[-2]:
                 area_y.append(item)
             else:
                 area_z.append(item)

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -36,18 +36,127 @@ def title_to_string(var, name=None, replace_dim=True):
     return text
 
 
-def table_from_dataset(dataset, is_hist=False, headers=2):
+def _make_table_section_name_header(name, section, style):
+    """
+    Adds a first row of the table that contains the names of the sections
+    being displayed in the table. This is usually the first row and will
+    contain Data, Labels, Masks, etc.
+    """
+    col_separators = 0
+    for key, sec in section:
+        col_separators += 1 + (sec.variances is not None)
+    if col_separators > 0:
+        return "<th {} colspan='{}'>{}</th>".format(
+            style, col_separators, name)
+    else:
+        return ""
 
-    bstyle = "style='border: 1px solid black;"
-    cstyle = bstyle + "background-color: {};text-align: center;'".format(
+
+def _make_table_sections(dataset, coord, base_style):
+    coord_style = "{} background-color: {};text-align: center;'".format(
+        base_style,
         colors.scheme["coord"][0])
-    lstyle = bstyle + "background-color: {};text-align: center;'".format(
+    label_style = "{} background-color: {};text-align: center;'".format(
+        base_style,
         colors.scheme["labels"][0])
-    dstyle = bstyle + "background-color: {};text-align: center;'".format(
+    mask_style = "{} background-color: {};text-align: center;'".format(
+        base_style,
+        colors.scheme["masks"][0])
+    data_style = "{} background-color: {};text-align: center;'".format(
+        base_style,
         colors.scheme["data"][0])
-    mstyle = bstyle + "text-align: center;'"
-    bstyle += "'"
-    estyle = "style='border: 0px solid white;background-color: #ffffff;'"
+
+    colsp_coord = 0
+    if coord is not None:
+        colsp_coord = 1 + (coord.variances is not None)
+    html = ["<tr>"]
+
+    if colsp_coord > 0:
+        html.append("<th {} colspan='{}'>Coordinate</th>".format(coord_style,
+                                                                 colsp_coord))
+    html.append(_make_table_section_name_header(
+        "Labels", dataset.labels, label_style))
+    html.append(_make_table_section_name_header(
+        "Masks", dataset.masks, mask_style))
+    html.append(_make_table_section_name_header(
+        "Data", dataset, data_style))
+
+    html.append("</tr>")
+
+    return "".join(html)
+
+
+def _make_table_unit_headers(section, text_style):
+    """
+    Adds a row containing the unit of the section
+    """
+    html = []
+    for key, val in section:
+        html.append("<th {} colspan='{}'>{}</th>".format(
+            text_style, 1 + (val.variances is not None),
+            title_to_string(val, name=key)))
+    return "".join(html)
+
+
+def _make_table_subsections(section, text_style):
+    """
+    Adds Value | Variance columns for the section.
+    """
+    html = []
+
+    for key, val in section:
+        html.append("<th {}>Values</th>".format(text_style))
+        if val.variances is not None:
+            html.append("<th {}>Variances</th>".format(text_style))
+
+    return "".join(html)
+
+
+def _make_value_rows(section, coord, index, base_style, edge_style):
+    html = []
+    for key, val in section:
+        header_line_for_bin_edges = False
+        if coord is not None:
+            if len(val.values) == len(coord.values) - 1:
+                header_line_for_bin_edges = True
+        if header_line_for_bin_edges:
+            if index == 0:
+                html.append("<td {}></td>".format(edge_style))
+                if val.variances is not None:
+                    html.append("<td {}></td>".format(edge_style))
+        else:
+            html.append("<td rowspan='2' {}>{}</td>".format(
+                base_style, value_to_string(val.values[index])))
+            if val.variances is not None:
+                html.append("<td rowspan='2' {}>{}</td>".format(
+                    base_style, value_to_string(val.variances[index])))
+
+    return "".join(html)
+
+
+def _make_trailing_cells(section, coord, index, size, base_style, edge_style):
+    html = []
+    for key, val in section:
+        if len(val.values) == len(coord.values) - 1:
+            if index == size - 1:
+                html.append("<td {}></td>".format(edge_style))
+                if val.variances is not None:
+                    html.append("<td {}></td>".format(edge_style))
+            else:
+                html.append("<td rowspan='2' {}>{}</td>".format(
+                    base_style, value_to_string(val.values[index])))
+                if val.variances is not None:
+                    html.append("<td rowspan='2' {}>{}</td>".format(
+                        base_style, value_to_string(val.variances[index])))
+
+    return "".join(html)
+
+
+def table_from_dataset(dataset, is_hist=False, headers=2):
+    base_style = "style='border: 1px solid black;"
+
+    mstyle = base_style + "text-align: center;'"
+    edge_style = "style='border: 0px solid white;background-color: #ffffff;'"
 
     # Declare table
     html = "<table style='border-collapse: collapse;'>"
@@ -62,135 +171,72 @@ def table_from_dataset(dataset, is_hist=False, headers=2):
                 size += 1
 
     if headers > 1:
-        colsp_coord = 0
-        if coord is not None:
-            colsp_coord = 1 + (coord.variances is not None)
-        colsp_labs = 0
-        for key, lab in dataset.labels:
-            colsp_labs += 1 + (lab.variances is not None)
-        colsp_data = 0
-        for key, val in dataset:
-            colsp_data += 1 + (val.variances is not None)
-        html += "<tr>"
-        if colsp_coord > 0:
-            html += "<th {} colspan='{}'>Coordinate</th>".format(cstyle,
-                                                                 colsp_coord)
-        if colsp_labs > 0:
-            html += "<th {} colspan='{}'>Labels</th>".format(lstyle,
-                                                             colsp_labs)
-        if colsp_data > 0:
-            html += "<th {} colspan='{}'>Data</th>".format(dstyle,
-                                                           colsp_data)
-        html += "</tr>"
+        html += _make_table_sections(dataset, coord, base_style)
 
     if headers > 0:
         html += "<tr>"
+
         if coord is not None:
             html += "<th {} colspan='{}'>{}</th>".format(
                 mstyle, 1 + (coord.variances is not None),
                 title_to_string(coord, replace_dim=False))
-        for key, lab in dataset.labels:
-            html += "<th {} colspan='{}'>{}</th>".format(
-                mstyle, 1 + (lab.variances is not None),
-                title_to_string(lab, name=key))
-        for key, val in dataset:
-            html += "<th {} colspan='{}'>{}</th>".format(
-                mstyle, 1 + (val.variances is not None),
-                title_to_string(val, name=key))
+
+        html += _make_table_unit_headers(dataset.labels, mstyle)
+        html += _make_table_unit_headers(dataset.masks, mstyle)
+        html += _make_table_unit_headers(dataset, mstyle)
+
         html += "</tr><tr>"
+
         if coord is not None:
             html += "<th {}>Values</th>".format(mstyle)
             if coord.variances is not None:
                 html += "<th {}>Variances</th>".format(mstyle)
-        for key, lab in dataset.labels:
-            html += "<th {}>Values</th>".format(mstyle)
-            if lab.variances is not None:
-                html += "<th {}>Variances</th>".format(mstyle)
-        for key, val in dataset:
-            html += "<th {}>Values</th>".format(mstyle)
-            if val.variances is not None:
-                html += "<th {}>Variances</th>".format(mstyle)
+        html += _make_table_subsections(dataset.labels, mstyle)
+        html += _make_table_subsections(dataset.masks, mstyle)
+        html += _make_table_subsections(dataset, mstyle)
         html += "</tr>"
-    if size is None:
+
+    # the base style still does not have a closing quote, so we add it here
+    base_style += "'"
+
+    if size is None:  # handle 0D variable
         html += "<tr>"
         for key, val in dataset:
-            html += "<td {}>{}</td>".format(bstyle, value_to_string(val.value))
+            html += "<td {}>{}</td>".format(base_style,
+                                            value_to_string(val.value))
             if val.variances is not None:
-                html += "<td {}>{}</td>".format(bstyle,
+                html += "<td {}>{}</td>".format(base_style,
                                                 value_to_string(val.variance))
         html += "</tr>"
     else:
         for i in range(size):
-            html += '<tr style="font-weight:normal">'
+            html += '<tr>'
             # Add coordinates
             if coord is not None:
                 text = value_to_string(coord.values[i])
-                html += "<td rowspan='2' {}>{}</td>".format(bstyle, text)
+                html += "<td rowspan='2' {}>{}</td>".format(base_style, text)
                 if coord.variances is not None:
                     text = value_to_string(coord.variances[i])
-                    html += "<td rowspan='2' {}>{}</td>".format(bstyle, text)
-            # Add labels
-            for key, lab in dataset.labels:
-                header_line_for_bin_edges = False
-                if coord is not None:
-                    if len(lab.values) == len(coord.values) - 1:
-                        header_line_for_bin_edges = True
-                if header_line_for_bin_edges:
-                    if i == 0:
-                        html += "<td {}></td>".format(estyle)
-                        if lab.variances is not None:
-                            html += "<td {}></td>".format(estyle)
-                else:
                     html += "<td rowspan='2' {}>{}</td>".format(
-                        bstyle, value_to_string(lab.values[i]))
-                    if lab.variances is not None:
-                        html += "<td rowspan='2' {}>{}</td>".format(
-                            bstyle, value_to_string(lab.variances[i]))
-            # Add data fields
-            for key, val in dataset:
-                header_line_for_bin_edges = False
-                if coord is not None:
-                    if len(val.values) == len(coord.values) - 1:
-                        header_line_for_bin_edges = True
-                if header_line_for_bin_edges:
-                    if i == 0:
-                        html += "<td {}></td>".format(estyle)
-                        if val.variances is not None:
-                            html += "<td {}></td>".format(estyle)
-                else:
-                    html += "<td rowspan='2' {}>{}</td>".format(
-                        bstyle, value_to_string(val.values[i]))
-                    if val.variances is not None:
-                        html += "<td rowspan='2' {}>{}</td>".format(
-                            bstyle, value_to_string(val.variances[i]))
+                        base_style, text)
+
+            html += _make_value_rows(
+                dataset.labels, coord, i, base_style, edge_style)
+            html += _make_value_rows(
+                dataset.masks, coord, i, base_style, edge_style)
+            html += _make_value_rows(
+                dataset, coord, i, base_style, edge_style)
+
             html += "</tr><tr>"
             # If there are bin edges, we need to add trailing cells for data
             # and labels
             if coord is not None:
-                for key, lab in dataset.labels:
-                    if len(lab.values) == len(coord.values) - 1:
-                        if i == size - 1:
-                            html += "<td {}></td>".format(estyle)
-                            if lab.variances is not None:
-                                html += "<td {}></td>".format(estyle)
-                        else:
-                            html += "<td rowspan='2' {}>{}</td>".format(
-                                bstyle, value_to_string(lab.values[i]))
-                            if lab.variances is not None:
-                                html += "<td rowspan='2' {}>{}</td>".format(
-                                    bstyle, value_to_string(lab.variances[i]))
-                for key, val in dataset:
-                    if len(val.values) == len(coord.values) - 1:
-                        if i == size - 1:
-                            html += "<td {}></td>".format(estyle)
-                            if val.variances is not None:
-                                html += "<td {}></td>".format(estyle)
-                        else:
-                            html += "<td rowspan='2' {}>{}</td>".format(
-                                bstyle, value_to_string(val.values[i]))
-                            if val.variances is not None:
-                                html += "<td rowspan='2' {}>{}</td>".format(
-                                    bstyle, value_to_string(val.variances[i]))
+                html += _make_trailing_cells(
+                    dataset.labels, coord, i, size, base_style, edge_style)
+                html += _make_trailing_cells(
+                    dataset.masks, coord, i, size, base_style, edge_style)
+                html += _make_trailing_cells(
+                    dataset, coord, i, size, base_style, edge_style)
             html += "</tr>"
 
     html += "</table>"
@@ -260,6 +306,19 @@ def table(dataset):
                 tabledict["1D Variables"][key].labels[name] = lab
                 is_empty[key] = False
 
+        # Next add the masks
+        for name, mask in dataset.masks:
+            if len(mask.dims) == 1:
+                dim = mask.dims[0]
+                key = str(dim)
+                if len(dataset.coords) > 0:
+                    if len(dataset.coords[dim].values) == len(mask.values) + 1:
+                        is_histogram[key] = True
+                    tabledict["1D Variables"][key].coords[dim] = \
+                        dataset.coords[dim]
+                tabledict["1D Variables"][key].masks[name] = mask
+                is_empty[key] = False
+
         # Now purge out the empty entries
         for key, val in is_empty.items():
             if val:
@@ -312,5 +371,3 @@ def table(dataset):
     output += "</table>"
 
     display(HTML(output))
-
-    return

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -113,3 +113,34 @@ def test_dataset_with_labels():
                               variances=np.random.rand(N))
     d.labels["Normalized"] = sc.Variable([Dim.Tof], values=np.arange(N))
     sc.table(d)
+
+
+def test_dataset_with_masks():
+    d = sc.Dataset()
+    N = 10
+    d.coords[Dim.Tof] = sc.Variable([Dim.Tof],
+                                    values=np.arange(N).astype(np.float64),
+                                    variances=0.1 * np.random.rand(N))
+    d['Counts'] = sc.Variable([Dim.Tof],
+                              values=10.0 * np.random.rand(N),
+                              variances=np.random.rand(N))
+    d.labels["Normalized"] = sc.Variable([Dim.Tof], values=np.arange(N))
+
+    d.masks["Mask"] = sc.Variable([Dim.Tof], values=np.zeros(N, dtype=np.bool))
+
+    sc.table(d)
+
+
+def test_dataset_histogram_with_masks():
+    N = 10
+
+    d = sc.Dataset(
+        {"Counts": sc.Variable([Dim.X],
+                               values=10.0 * np.random.rand(N),
+                               variances=np.random.rand(N))},
+        {Dim.X: sc.Variable([Dim.X], values=np.arange(N+1))})
+    d.labels["Normalized"] = sc.Variable([Dim.X], values=np.arange(N))
+
+    d.masks["Mask"] = sc.Variable([Dim.X], values=np.zeros(N, dtype=np.bool))
+
+    sc.table(d)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -687,3 +687,8 @@ def test_rename_dims():
 def test_create_1d_with_strings():
     v = sc.Variable([Dim.X], values=["aaa", "ff", "bb"])
     assert np.all(v.values == np.array(["aaa", "ff", "bb"]))
+
+
+def test_bool_variable_repr():
+    a = sc.Variable([Dim.X], values=np.array([False, True, True, False, True]))
+    assert [expected in repr(a) for expected in ["True", "False", "..."]]


### PR DESCRIPTION
- Variables of bools now display their actual values in their representation
  - Follows Python's bool capitalisation, i.e. `True`, `False`
  - Adds new `to_string(Bool)` overload, @SimonHeybrock do we want to avoid `Bool` here? Just `bool` does not resolve properly.
- Some refactoring in `table.py`. Stopped further refactoring as I wasn't sure if it was a prototype (and might be rewritten). (I'm happy to further refactor it, if desired)
- Added masks column in `scipp.table`
- Renders masks in `scipp.show`
- Added colours for masks. Subject to discussion. I didn't know if there is an expected mask colour from another package, and soft-ish pink looked nice.