### PR TITLE
Support attributes for items of Dataset

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -270,7 +270,9 @@ void Dataset::setAttr(const std::string &attrName, Variable attr) {
 void Dataset::setAttr(const std::string &name, const std::string &attrName,
                       Variable attr) {
   expect::contains(*this, name);
-  setDims(attr.dims());
+  if (!operator[](name).dims().contains(attr.dims()))
+    throw except::DimensionError(
+        "Attribute dimensions must match and not exceed dimensions of data.");
   m_data[name].attrs.insert_or_assign(attrName, std::move(attr));
 }
 

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -383,23 +383,27 @@ void Dataset::setSparseLabels(const std::string &name,
 }
 
 /// Removes the coordinate for the given dimension.
-void Dataset::eraseCoord(const Dim dim) {
-  erase_from_map(&Dataset::m_coords, dim);
-}
+void Dataset::eraseCoord(const Dim dim) { erase_from_map(m_coords, dim); }
 
 /// Removes the labels for the given label name.
 void Dataset::eraseLabels(const std::string &labelName) {
-  erase_from_map(&Dataset::m_labels, labelName);
+  erase_from_map(m_labels, labelName);
 }
 
 /// Removes an attribute for the given attribute name.
 void Dataset::eraseAttr(const std::string &attrName) {
-  erase_from_map(&Dataset::m_attrs, attrName);
+  erase_from_map(m_attrs, attrName);
+}
+
+/// Removes attribute with given attribute name from the given item.
+void Dataset::eraseAttr(const std::string &name, const std::string &attrName) {
+  expect::contains(*this, name);
+  erase_from_map(m_data[name].attrs, attrName);
 }
 
 /// Removes an attribute for the given attribute name.
 void Dataset::eraseMask(const std::string &maskName) {
-  erase_from_map(&Dataset::m_masks, maskName);
+  erase_from_map(m_masks, maskName);
 }
 
 /// Remove the sparse coordinate with given name.

--- a/core/dataset_operations_common.h
+++ b/core/dataset_operations_common.h
@@ -17,17 +17,17 @@ DataArray apply_and_drop_dim_impl(const DataConstProxy &a, Func func,
 
   std::map<std::string, Variable> labels;
   for (auto &&[name, label] : a.labels())
-    if (label.dims().inner() != dim)
+    if (!label.dims().contains(dim))
       labels.emplace(name, label);
 
   std::map<std::string, Variable> attrs;
   for (auto &&[name, attr] : a.attrs())
-    if (attr.dims().inner() != dim)
+    if (!attr.dims().contains(dim))
       attrs.emplace(name, attr);
 
   std::map<std::string, Variable> masks;
   for (auto &&[name, mask] : a.masks())
-    if (mask.dims().inner() != dim)
+    if (!mask.dims().contains(dim))
       masks.emplace(name, mask);
 
   if constexpr (ApplyToData)
@@ -60,10 +60,14 @@ DataArray apply_to_items(const DataConstProxy &d, Func func, Args &&... args) {
 }
 
 template <class Func, class... Args>
-Dataset apply_to_items(const DatasetConstProxy &d, Func func, Args &&... args) {
+Dataset apply_to_items(const DatasetConstProxy &d, Func func, const Dim dim,
+                       Args &&... args) {
   Dataset result;
   for (const auto &[name, data] : d)
-    result.setData(name, func(data, std::forward<Args>(args)...));
+    result.setData(name, func(data, dim, std::forward<Args>(args)...));
+  for (auto &&[name, attr] : d.attrs())
+    if (!attr.dims().contains(dim))
+      result.setAttr(name, attr);
   return result;
 }
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -993,8 +993,8 @@ public:
       else
         m_holder.setLabels(std::string(label_name), std::move(l));
 
-    for (auto &&[attr_name, m] : masks)
-      m_holder.setMask(std::string(attr_name), std::move(m));
+    for (auto &&[mask_name, m] : masks)
+      m_holder.setMask(std::string(mask_name), std::move(m));
 
     for (auto &&[attr_name, a] : attrs)
       m_holder.setAttr(name, std::string(attr_name), std::move(a));

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -35,6 +35,8 @@ struct DatasetData {
   std::optional<Variable> coord;
   /// Potential labels for the sparse dimension.
   std::unordered_map<std::string, Variable> labels;
+  /// Attributes for data.
+  std::unordered_map<std::string, Variable> attrs;
 };
 
 using dataset_item_map = std::unordered_map<std::string, DatasetData>;
@@ -355,6 +357,8 @@ public:
   void setLabels(const std::string &labelName, Variable labels);
   void setMask(const std::string &masksName, Variable masks);
   void setAttr(const std::string &attrName, Variable attr);
+  void setAttr(const std::string &name, const std::string &attrName,
+               Variable attr);
   void setData(const std::string &name, Variable data);
   void setData(const std::string &name, const DataConstProxy &data);
   void setSparseCoord(const std::string &name, Variable coord);
@@ -373,6 +377,10 @@ public:
   }
   void setAttr(const std::string &attrName, const VariableConstProxy &attr) {
     setAttr(attrName, Variable(attr));
+  }
+  void setAttr(const std::string &name, const std::string &attrName,
+               const VariableConstProxy &attr) {
+    setAttr(name, attrName, Variable(attr));
   }
   void setData(const std::string &name, const VariableConstProxy &data) {
     setData(name, Variable(data));
@@ -688,8 +696,12 @@ public:
         m_parent->setLabels(key, var);
       if constexpr (std::is_same_v<Base, MasksConstProxy>)
         m_parent->setMask(key, var);
-      if constexpr (std::is_same_v<Base, AttrsConstProxy>)
-        m_parent->setAttr(key, var);
+      if constexpr (std::is_same_v<Base, AttrsConstProxy>) {
+        if (m_name)
+          m_parent->setAttr(*m_name, key, var);
+        else
+          m_parent->setAttr(key, var);
+      }
     }
     // TODO rebuild *this?!
   }
@@ -981,7 +993,7 @@ public:
       m_holder.setMask(std::string(attr_name), std::move(m));
 
     for (auto &&[attr_name, a] : attrs)
-      m_holder.setAttr(std::string(attr_name), std::move(a));
+      m_holder.setAttr(name, std::string(attr_name), std::move(a));
 
     if (m_holder.size() != 1)
       throw std::runtime_error(

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -711,7 +711,7 @@ public:
       throw std::runtime_error(
           "Cannot remove coord/labels/attr field from a slice.");
 
-    bool sparse = m_name; // Does proxy points on sparse data or not
+    bool sparse = m_name; // Does proxy point on sparse data or not
     if (sparse)
       sparse &= (*m_parent)[*m_name].dims().sparse();
 

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -397,6 +397,7 @@ public:
   void eraseCoord(const Dim dim);
   void eraseLabels(const std::string &labelName);
   void eraseAttr(const std::string &attrName);
+  void eraseAttr(const std::string &name, const std::string &attrName);
   void eraseMask(const std::string &maskName);
   void eraseSparseCoord(const std::string &name);
   void eraseSparseLabels(const std::string &name, const std::string &labelName);
@@ -475,9 +476,8 @@ private:
   void rebuildDims();
 
   template <class Key, class Val>
-  void erase_from_map(std::unordered_map<Key, Val> Dataset::*map,
-                      const Key &key) {
-    (this->*map).erase(key);
+  void erase_from_map(std::unordered_map<Key, Val> &map, const Key &key) {
+    map.erase(key);
     rebuildDims();
   }
 
@@ -720,8 +720,12 @@ public:
         m_parent->eraseCoord(key);
       if constexpr (std::is_same_v<Base, LabelsConstProxy>)
         m_parent->eraseLabels(key);
-      if constexpr (std::is_same_v<Base, AttrsConstProxy>)
-        m_parent->eraseAttr(key);
+      if constexpr (std::is_same_v<Base, AttrsConstProxy>) {
+        if (m_name)
+          m_parent->eraseAttr(*m_name, key);
+        else
+          m_parent->eraseAttr(key);
+      }
       if constexpr (std::is_same_v<Base, MasksConstProxy>)
         m_parent->eraseMask(key);
     } else {

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(TARGET_NAME "scipp-core-test")
 add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
+               attributes_test.cpp
                concatenate_test.cpp
                coords_proxy_test.cpp
                counts_test.cpp

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -7,56 +7,111 @@
 using namespace scipp;
 using namespace scipp::core;
   // to test:
-  // - insert erase dataset
-  // - insert data with attr
-  // - insert erase item attr
   // - operations with dataset and item attrs (sum, or directly apply_to_items?)
   // - binary in-place operations preserving dataset and item attrs
-  // - slicing
 
 class AttributesTest : public ::testing::Test {
 protected:
-  const Variable scalar = makeVariable<double>(1.0);
-  const Variable var1d = makeVariable<double>({Dim::X, 2}, {2.0, 3.0});
+  const Variable scalar = makeVariable<double>(1);
+  const Variable varX = makeVariable<double>({Dim::X, 2}, {2, 3});
+  const Variable varZX =
+      makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, {4, 5, 6, 7});
 };
 
 TEST_F(AttributesTest, dataset_attrs) {
   Dataset d;
   d.setAttr("scalar", scalar);
-  d.setAttr("1d", var1d);
+  d.setAttr("x", varX);
   ASSERT_EQ(d.attrs().size(), 2);
   ASSERT_TRUE(d.attrs().contains("scalar"));
-  ASSERT_TRUE(d.attrs().contains("1d"));
+  ASSERT_TRUE(d.attrs().contains("x"));
   ASSERT_EQ(d.dimensions(),
             (std::unordered_map<Dim, scipp::index>{{Dim::X, 2}}));
   d.eraseAttr("scalar");
-  d.eraseAttr("1d");
+  d.eraseAttr("x");
   ASSERT_EQ(d.attrs().size(), 0);
   ASSERT_EQ(d.dimensions(), (std::unordered_map<Dim, scipp::index>{}));
 }
 
 TEST_F(AttributesTest, dataset_item_attrs) {
   Dataset d;
-  d.setData("a", var1d);
+  d.setData("a", varX);
   d["a"].attrs().set("scalar", scalar);
-  d["a"].attrs().set("1d", var1d);
+  d["a"].attrs().set("x", varX);
   d.attrs().set("dataset_attr", scalar);
 
   ASSERT_FALSE(d.attrs().contains("scalar"));
-  ASSERT_FALSE(d.attrs().contains("1d"));
+  ASSERT_FALSE(d.attrs().contains("x"));
 
   ASSERT_EQ(d["a"].attrs().size(), 2);
   ASSERT_TRUE(d["a"].attrs().contains("scalar"));
-  ASSERT_TRUE(d["a"].attrs().contains("1d"));
+  ASSERT_TRUE(d["a"].attrs().contains("x"));
   ASSERT_FALSE(d["a"].attrs().contains("dataset_attr"));
 
   d["a"].attrs().erase("scalar");
-  d["a"].attrs().erase("1d");
+  d["a"].attrs().erase("x");
   ASSERT_EQ(d["a"].attrs().size(), 0);
 }
 
 TEST_F(AttributesTest, dataset_item_attrs_dimensions_exceeding_data) {
   Dataset d;
   d.setData("scalar", scalar);
-  EXPECT_THROW(d["scalar"].attrs().set("1d", var1d), except::DimensionError);
+  EXPECT_THROW(d["scalar"].attrs().set("x", varX), except::DimensionError);
+}
+
+TEST_F(AttributesTest, slice_dataset_item_attrs) {
+  Dataset d;
+  d.setData("a", varZX);
+  d["a"].attrs().set("scalar", scalar);
+  d["a"].attrs().set("x", varX);
+
+  // Same behavior as coord slicing:
+  // - Lower-dimensional attrs are not hidden by slicing.
+  // - Non-range slice hides attribute.
+  // The alternative would be to handle attributes like data, but at least for
+  // now coord-like handling appears to make more sense.
+  ASSERT_TRUE(d["a"].slice({Dim::X, 0}).attrs().contains("scalar"));
+  ASSERT_FALSE(d["a"].slice({Dim::X, 0}).attrs().contains("x"));
+  ASSERT_TRUE(d["a"].slice({Dim::X, 0, 1}).attrs().contains("scalar"));
+  ASSERT_TRUE(d["a"].slice({Dim::X, 0, 1}).attrs().contains("x"));
+  ASSERT_TRUE(d["a"].slice({Dim::Y, 0}).attrs().contains("scalar"));
+  ASSERT_TRUE(d["a"].slice({Dim::Y, 0}).attrs().contains("x"));
+  ASSERT_TRUE(d["a"].slice({Dim::Y, 0, 1}).attrs().contains("scalar"));
+  ASSERT_TRUE(d["a"].slice({Dim::Y, 0, 1}).attrs().contains("x"));
+}
+
+TEST_F(AttributesTest, binary_ops_in_place) {
+  Dataset d1;
+  d1.setData("a", varX);
+  d1["a"].attrs().set("a_attr", scalar);
+  d1.attrs().set("dataset_attr", scalar);
+
+  Dataset d2;
+  d2.setData("a", varX);
+  d2["a"].attrs().set("a_attr", varX);
+  d2.attrs().set("dataset_attr", varX);
+
+  auto result(d1);
+  result += d2;
+  ASSERT_TRUE(result.attrs().contains("dataset_attr"));
+  EXPECT_EQ(result.attrs()["dataset_attr"], scalar);
+  ASSERT_TRUE(result["a"].attrs().contains("a_attr"));
+  EXPECT_EQ(result["a"].attrs()["a_attr"], scalar);
+}
+
+TEST_F(AttributesTest, reduction_ops) {
+  Dataset d;
+  d.setData("a", varX);
+  d["a"].attrs().set("a_attr", scalar);
+  d["a"].attrs().set("a_attr_x", varX);
+  d.attrs().set("dataset_attr", scalar);
+  d.attrs().set("dataset_attr_x", varX);
+
+  const auto result = sum(d, Dim::X);
+  ASSERT_TRUE(result.attrs().contains("dataset_attr"));
+  ASSERT_FALSE(result.attrs().contains("dataset_attr_x"));
+  EXPECT_EQ(result.attrs()["dataset_attr"], scalar);
+  ASSERT_TRUE(result["a"].attrs().contains("a_attr"));
+  ASSERT_FALSE(result["a"].attrs().contains("a_attr_x"));
+  EXPECT_EQ(result["a"].attrs()["a_attr"], scalar);
 }

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+  // to test:
+  // - insert erase dataset
+  // - insert data with attr
+  // - insert erase item attr
+  // - operations with dataset and item attrs (sum, or directly apply_to_items?)
+  // - binary in-place operations preserving dataset and item attrs
+  // - slicing
+
+class AttributesTest : public ::testing::Test {
+protected:
+  const Variable scalar = makeVariable<double>(1.0);
+  const Variable var1d = makeVariable<double>({Dim::X, 2}, {2.0, 3.0});
+};
+
+TEST_F(AttributesTest, dataset_attrs) {
+  Dataset d;
+  d.setAttr("scalar", scalar);
+  d.setAttr("1d", var1d);
+  ASSERT_EQ(d.attrs().size(), 2);
+  ASSERT_TRUE(d.attrs().contains("scalar"));
+  ASSERT_TRUE(d.attrs().contains("1d"));
+  ASSERT_EQ(d.dimensions(),
+            (std::unordered_map<Dim, scipp::index>{{Dim::X, 2}}));
+  d.eraseAttr("scalar");
+  d.eraseAttr("1d");
+  ASSERT_EQ(d.attrs().size(), 0);
+  ASSERT_EQ(d.dimensions(), (std::unordered_map<Dim, scipp::index>{}));
+}
+
+TEST_F(AttributesTest, dataset_item_attrs) {
+  Dataset d;
+  d.setData("a", var1d);
+  d["a"].attrs().set("scalar", scalar);
+  d["a"].attrs().set("1d", var1d);
+  d.attrs().set("dataset_attr", scalar);
+
+  ASSERT_FALSE(d.attrs().contains("scalar"));
+  ASSERT_FALSE(d.attrs().contains("1d"));
+
+  ASSERT_EQ(d["a"].attrs().size(), 2);
+  ASSERT_TRUE(d["a"].attrs().contains("scalar"));
+  ASSERT_TRUE(d["a"].attrs().contains("1d"));
+  ASSERT_FALSE(d["a"].attrs().contains("dataset_attr"));
+
+  d["a"].attrs().erase("scalar");
+  d["a"].attrs().erase("1d");
+  ASSERT_EQ(d["a"].attrs().size(), 0);
+}
+
+TEST_F(AttributesTest, dataset_item_attrs_dimensions_exceeding_data) {
+  Dataset d;
+  d.setData("scalar", scalar);
+  EXPECT_THROW(d["scalar"].attrs().set("1d", var1d), except::DimensionError);
+}

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -85,7 +85,7 @@ TEST_F(AttributesTest, binary_ops) {
 
   for (const auto &result : {d + d, d - d, d * d, d / d}) {
     EXPECT_TRUE(result.attrs().empty());
-    EXPECT_TRUE(result['a'].attrs().empty());
+    EXPECT_TRUE(result["a"].attrs().empty());
   }
 }
 

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -26,18 +26,22 @@ protected:
     dataset.setLabels("labels", makeVariable<int>({Dim::X, 4}));
     dataset.setMask("mask", makeVariable<bool>({Dim::X, 4}));
 
-    dataset.setAttr("attr", makeVariable<int>({}));
+    dataset.setAttr("global_attr", makeVariable<int>({}));
 
     dataset.setData("val_and_var",
                     makeVariable<double>({{Dim::Y, 3}, {Dim::X, 4}},
                                          std::vector<double>(12),
                                          std::vector<double>(12)));
+    dataset.setAttr("val_and_var", "attr", makeVariable<int>({}));
 
     dataset.setData("val", makeVariable<double>({Dim::X, 4}));
+    dataset.setAttr("val", "attr", makeVariable<int>({}));
 
     dataset.setSparseCoord("sparse_coord", sparse_variable);
+    dataset.setAttr("sparse_coord", "attr", makeVariable<int>({}));
     dataset.setData("sparse_coord_and_val", sparse_variable);
     dataset.setSparseCoord("sparse_coord_and_val", sparse_variable);
+    dataset.setAttr("sparse_coord_and_val", "attr", makeVariable<int>({}));
   }
   void expect_eq(const DataConstProxy &a, const DataConstProxy &b) const {
     EXPECT_TRUE(a == b);
@@ -96,8 +100,8 @@ auto make_1_attr(const std::string &name, const Dimensions &dims,
                  const units::Unit unit,
                  const std::initializer_list<T2> &data) {
   Dataset d;
-  d.setAttr(name, makeVariable<T>(dims, unit, data));
   d.setData("", makeVariable<T>(dims));
+  d.setAttr("", name, makeVariable<T>(dims, unit, data));
   return DataArray(d[""]);
 }
 
@@ -248,9 +252,10 @@ TEST_F(DataArray_comparison_operators, extra_mask) {
 
 TEST_F(DataArray_comparison_operators, extra_attr) {
   auto extra = dataset;
-  extra.setAttr("extra", makeVariable<double>(0.0));
-  for (const auto [name, a] : extra)
+  for (const auto [name, a] : extra) {
+    extra.setAttr(name, "extra", makeVariable<double>(0.0));
     expect_ne(a, dataset[name]);
+  }
 }
 
 TEST_F(DataArray_comparison_operators, extra_variance) {

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -29,9 +29,7 @@ TEST(DataArrayTest, sum_dataset_columns_via_DataArray) {
 
   dataset["data_zyx"] += dataset["data_xyz"];
 
-  // Direction compare fails since binary operation do not propagate attributes.
-  EXPECT_NE(sum, dataset["data_zyx"]);
-
-  dataset.setData("sum", sum);
-  EXPECT_EQ(dataset["sum"], dataset["data_zyx"]);
+  // This would fail if the data items had attributes, since += preserves them
+  // but + does not.
+  EXPECT_EQ(sum, dataset["data_zyx"]);
 }

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -16,7 +16,7 @@ static auto make_dataset_for_groupby_test() {
   d.setData("b", makeVariable<double>({Dim::X, 3}, units::s, {0.1, 0.2, 0.3}));
   d.setData("c", makeVariable<double>({{Dim::Z, 2}, {Dim::X, 3}}, units::s,
                                       {1, 2, 3, 4, 5, 6}));
-  d.setAttr("scalar", makeVariable<double>(1.2));
+  d.setAttr("a", "scalar", makeVariable<double>(1.2));
   d.setLabels("labels1",
               makeVariable<double>({Dim::X, 3}, units::m, {1, 2, 3}));
   d.setLabels("labels2",
@@ -56,7 +56,7 @@ TEST(GroupbyTest, dataset_1d_and_2d) {
                                              {(0.1 + 0.2) / 2.0, 0.3}));
   expected.setData("c", makeVariable<double>({{Dim::Z, 2}, {Dim::Y, 2}},
                                              units::s, {1.5, 3.0, 4.5, 6.0}));
-  expected.setAttr("scalar", makeVariable<double>(1.2));
+  expected.setAttr("a", "scalar", makeVariable<double>(1.2));
   expected.setCoord(Dim::Y,
                     makeVariable<double>({Dim::Y, 2}, units::m, {1, 3}));
 
@@ -72,7 +72,7 @@ static auto make_dataset_for_bin_test() {
                                       {0.1, 0.2, 0.3, 0.4, 0.5}));
   d.setData("b", makeVariable<double>({{Dim::Y, 2}, {Dim::X, 5}}, units::s,
                                       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
-  d.setAttr("scalar", makeVariable<double>(1.2));
+  d.setAttr("a", "scalar", makeVariable<double>(1.2));
   d.setLabels("labels1",
               makeVariable<double>({Dim::X, 5}, units::m, {1, 2, 3, 4, 5}));
   d.setLabels("labels2", makeVariable<double>({Dim::X, 5}, units::m,
@@ -91,7 +91,7 @@ TEST(GroupbyTest, bins) {
       "a", makeVariable<double>({Dim::Z, 3}, units::s, {0.0, 0.8, 0.3}));
   expected.setData("b", makeVariable<double>({{Dim::Y, 2}, {Dim::Z, 3}},
                                              units::s, {0, 8, 3, 0, 23, 8}));
-  expected.setAttr("scalar", makeVariable<double>(1.2));
+  expected.setAttr("a", "scalar", makeVariable<double>(1.2));
 
   EXPECT_EQ(groupby(d, "labels2", bins).sum(Dim::X), expected);
   EXPECT_EQ(groupby(d["a"], "labels2", bins).sum(Dim::X), expected["a"]);
@@ -132,7 +132,7 @@ TEST(GroupbyTest, two_bin) {
   auto group0 =
       concatenate(d.slice({Dim::X, 0, 2}), d.slice({Dim::X, 4, 5}), Dim::X);
   // concatenate does currently not preserve attributes
-  group0.setAttr("scalar", d.attrs()["scalar"]);
+  group0.setAttr("a", "scalar", d["a"].attrs()["scalar"]);
   EXPECT_EQ(groups.sum(Dim::X).slice({Dim::Z, 0}), sum(group0, Dim::X));
   EXPECT_EQ(groups.mean(Dim::X).slice({Dim::Z, 0}), mean(group0, Dim::X));
 


### PR DESCRIPTION
Fixes #666.

This implementation does *not* map dataset attributes into the attribute dict of its items. This is unlike coords, labels, or masks. There are two reasons:
- Complications and ambiguities when implementing operations on dataset, which are based on applying the operation to all items --- if the operation preserves attributes then the dataset attribute that was mapped into the input items attr dicts would get copied as new attribute for each item of the output.
- Danger of unwillingly changing dataset attributes when modifying item attributes, since with the existing syntax there is no way of distinguishing item attributes from dataset attributes:
  ```python
  d['a'].attrs['facility'] = 'xxx' # is this changing an attribute of `d`?
  ```