### PR TITLE
ExternalProject errors will now fail the CMake Configure

### DIFF
--- a/CMake/Eigen.cmake
+++ b/CMake/Eigen.cmake
@@ -3,7 +3,17 @@ configure_file(${CMAKE_SOURCE_DIR}/CMake/Eigen.in
   ${CMAKE_BINARY_DIR}/Eigen-download/CMakeLists.txt)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download )
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download
+  RESULTS_VARIABLE result)
+
+if(result)
+  message(FATAL_ERROR "CMake step for Eigen failed: ${result}")
+endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download )
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download
+  RESULTS_VARIABLE result)
+
+if(result)
+  message(FATAL_ERROR "Build step for Eigen failed: ${result}")
+endif()

--- a/CMake/Eigen.cmake
+++ b/CMake/Eigen.cmake
@@ -1,18 +1,18 @@
 # Download and unpack Eigen at configure time
 configure_file(${CMAKE_SOURCE_DIR}/CMake/Eigen.in
-  ${CMAKE_BINARY_DIR}/Eigen-download/CMakeLists.txt)
+               ${CMAKE_BINARY_DIR}/Eigen-download/CMakeLists.txt)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download
-  RESULTS_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download RESULTS_VARIABLE result)
 
 if(result)
   message(FATAL_ERROR "CMake step for Eigen failed: ${result}")
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download
-  RESULTS_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Eigen-download RESULTS_VARIABLE result)
 
 if(result)
   message(FATAL_ERROR "Build step for Eigen failed: ${result}")

--- a/CMake/GTest.cmake
+++ b/CMake/GTest.cmake
@@ -1,55 +1,59 @@
-# Prevent overriding the parent project's compiler/linker
-# settings on Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Prevent overriding the parent project's compiler/linker settings on Windows
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
 
 # Download and unpack googletest at configure time
 configure_file(${CMAKE_SOURCE_DIR}/CMake/GTest.in
                ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE result
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
 if(result)
   message(FATAL_ERROR "CMake step for googletest failed: ${result}")
 endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .  
-                RESULT_VARIABLE result
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
 if(result)
   message(FATAL_ERROR "Build step for googletest failed: ${result}")
 endif()
 
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src ${CMAKE_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
 
 # Hide targets from "all" and put them in the UnitTests folder in MSVS
-foreach( target_var gmock gtest gmock_main gtest_main )
-  set_target_properties( ${target_var}
-					   PROPERTIES EXCLUDE_FROM_ALL TRUE
-					   FOLDER "googletest" )
+foreach(target_var gmock gtest gmock_main gtest_main)
+  set_target_properties(${target_var} PROPERTIES EXCLUDE_FROM_ALL TRUE FOLDER
+                                                 "googletest")
 endforeach()
 
-set( GMOCK_LIB gmock )
-set( GMOCK_LIB_DEBUG gmock )
-set( GMOCK_LIBRARIES optimized ${GMOCK_LIB} debug ${GMOCK_LIB_DEBUG} )
-set( GTEST_LIB gtest )
-set( GTEST_LIB_DEBUG gtest )
-set( GTEST_LIBRARIES optimized ${GTEST_LIB} debug ${GTEST_LIB_DEBUG} )
+set(GMOCK_LIB gmock)
+set(GMOCK_LIB_DEBUG gmock)
+set(GMOCK_LIBRARIES optimized ${GMOCK_LIB} debug ${GMOCK_LIB_DEBUG})
+set(GTEST_LIB gtest)
+set(GTEST_LIB_DEBUG gtest)
+set(GTEST_LIBRARIES optimized ${GTEST_LIB} debug ${GTEST_LIB_DEBUG})
 
-find_path ( GMOCK_INCLUDE_DIR gmock/gmock.h
-		  PATHS ${CMAKE_BINARY_DIR}/googletest-src/googlemock/include
-		  NO_DEFAULT_PATH )
-find_path ( GTEST_INCLUDE_DIR gtest/gtest.h
-		  PATHS ${CMAKE_BINARY_DIR}/googletest-src/googletest/include
-		  NO_DEFAULT_PATH )
+find_path(
+  GMOCK_INCLUDE_DIR gmock/gmock.h
+  PATHS ${CMAKE_BINARY_DIR}/googletest-src/googlemock/include
+  NO_DEFAULT_PATH)
+find_path(
+  GTEST_INCLUDE_DIR gtest/gtest.h
+  PATHS ${CMAKE_BINARY_DIR}/googletest-src/googletest/include
+  NO_DEFAULT_PATH)
 
+# handle the QUIETLY and REQUIRED arguments and set GMOCK_FOUND to TRUE if all
+# listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMOCK DEFAULT_MSG GMOCK_INCLUDE_DIR
+                                  GMOCK_LIBRARIES)
+find_package_handle_standard_args(GTEST DEFAULT_MSG GTEST_INCLUDE_DIR
+                                  GTEST_LIBRARIES)
 
-# handle the QUIETLY and REQUIRED arguments and set GMOCK_FOUND to TRUE if
-# all listed variables are TRUE
-include ( FindPackageHandleStandardArgs )
-find_package_handle_standard_args( GMOCK DEFAULT_MSG GMOCK_INCLUDE_DIR
-GMOCK_LIBRARIES )
-find_package_handle_standard_args( GTEST DEFAULT_MSG GTEST_INCLUDE_DIR
-GTEST_LIBRARIES )
-
-mark_as_advanced ( GMOCK_INCLUDE_DIR GMOCK_LIB GMOCK_LIB_DEBUG )
-mark_as_advanced ( GTEST_INCLUDE_DIR GTEST_LIB GTEST_LIB_DEBUG )
+mark_as_advanced(GMOCK_INCLUDE_DIR GMOCK_LIB GMOCK_LIB_DEBUG)
+mark_as_advanced(GTEST_INCLUDE_DIR GTEST_LIB GTEST_LIB_DEBUG)
 include(GoogleTest)

--- a/CMake/GoogleBenchmark.cmake
+++ b/CMake/GoogleBenchmark.cmake
@@ -6,10 +6,19 @@ configure_file(${CMAKE_SOURCE_DIR}/CMake/GoogleBenchmark.in
                ${CMAKE_BINARY_DIR}/googlebenchmark-download/CMakeLists.txt)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download )
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
+                  RESULTS_VARIABLE result)
+
+if(result)
+    message(FATAL_ERROR "CMake step for GoogleBenchmark failed: ${result}")
+endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download )
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
+                  RESULTS_VARIABLE result)
+if(result)
+    message(FATAL_ERROR "Build step for GoogleBenchmark failed: ${result}")
+endif()
 
 add_subdirectory(${CMAKE_BINARY_DIR}/googlebenchmark-src
                  ${CMAKE_BINARY_DIR}/googlebenchmark-build)

--- a/CMake/GoogleBenchmark.cmake
+++ b/CMake/GoogleBenchmark.cmake
@@ -1,23 +1,27 @@
 # Download and unpack googlebenchmark at configure time
 
-set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_TESTING
+    OFF
+    CACHE BOOL "" FORCE)
 
 configure_file(${CMAKE_SOURCE_DIR}/CMake/GoogleBenchmark.in
                ${CMAKE_BINARY_DIR}/googlebenchmark-download/CMakeLists.txt)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
-                  RESULTS_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
+                    RESULTS_VARIABLE result)
 
 if(result)
-    message(FATAL_ERROR "CMake step for GoogleBenchmark failed: ${result}")
+  message(FATAL_ERROR "CMake step for GoogleBenchmark failed: ${result}")
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
-                  RESULTS_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googlebenchmark-download
+                    RESULTS_VARIABLE result)
 if(result)
-    message(FATAL_ERROR "Build step for GoogleBenchmark failed: ${result}")
+  message(FATAL_ERROR "Build step for GoogleBenchmark failed: ${result}")
 endif()
 
 add_subdirectory(${CMAKE_BINARY_DIR}/googlebenchmark-src

--- a/CMake/boost.cmake
+++ b/CMake/boost.cmake
@@ -7,20 +7,22 @@ configure_file(${CMAKE_SOURCE_DIR}/CMake/boost.in
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                RESULT_VARIABLE result
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download)
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+                RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "CMake step for boost failed: ${result}")
 endif()
+
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                RESULT_VARIABLE result
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download)
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+                RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "Build step for boost failed: ${result}")
 endif()
+
 execute_process(COMMAND ${CMAKE_COMMAND} --install .
-                RESULT_VARIABLE result
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download)
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+                RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "Install step for boost failed: ${result}")
 endif()

--- a/CMake/boost.cmake
+++ b/CMake/boost.cmake
@@ -2,30 +2,36 @@
 configure_file(${CMAKE_SOURCE_DIR}/CMake/boost.in
                ${CMAKE_BINARY_DIR}/boost-download/CMakeLists.txt)
 
-# Prevent overriding the parent project's compiler/linker
-# settings on Windows
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Prevent overriding the parent project's compiler/linker settings on Windows
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
-                RESULT_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+  RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "CMake step for boost failed: ${result}")
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
-                RESULT_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+  RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "Build step for boost failed: ${result}")
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --install .
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
-                RESULT_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --install .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost-download
+  RESULT_VARIABLE result)
 if(result)
   message(FATAL_ERROR "Install step for boost failed: ${result}")
 endif()
 
-set(BOOST_INCLUDEDIR "${CMAKE_BINARY_DIR}/boost/include" CACHE PATH "Path to boost")
+set(BOOST_INCLUDEDIR
+    "${CMAKE_BINARY_DIR}/boost/include"
+    CACHE PATH "Path to boost")
 set(BOOST_NO_SYSTEM_PATHS ON)

--- a/CMake/pybind11.cmake
+++ b/CMake/pybind11.cmake
@@ -3,10 +3,18 @@ configure_file(${CMAKE_SOURCE_DIR}/CMake/pybind11.in
                ${CMAKE_BINARY_DIR}/pybind11-download/CMakeLists.txt)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download )
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
+                  RESULT_VARIABLE result)
+if(result)
+    message(FATAL_ERROR "CMake step for pybind11 failed: ${result}")
+endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download )
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
+                  RESULT_VARIABLE result)
+if(result)
+    message(FATAL_ERROR "Build step for pybind11 failed: ${result}")
+endif()
 
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 add_subdirectory(${CMAKE_BINARY_DIR}/pybind11-src

--- a/CMake/pybind11.cmake
+++ b/CMake/pybind11.cmake
@@ -2,18 +2,20 @@
 configure_file(${CMAKE_SOURCE_DIR}/CMake/pybind11.in
                ${CMAKE_BINARY_DIR}/pybind11-download/CMakeLists.txt)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
-                  RESULT_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
+  RESULT_VARIABLE result)
 if(result)
-    message(FATAL_ERROR "CMake step for pybind11 failed: ${result}")
+  message(FATAL_ERROR "CMake step for pybind11 failed: ${result}")
 endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
-                  RESULT_VARIABLE result)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pybind11-download
+  RESULT_VARIABLE result)
 if(result)
-    message(FATAL_ERROR "Build step for pybind11 failed: ${result}")
+  message(FATAL_ERROR "Build step for pybind11 failed: ${result}")
 endif()
 
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)


### PR DESCRIPTION
- Added missing exit code checks on multiple external project calls.
- Formats all the CMake files with [cmake_format](https://github.com/cheshirekow/cmake_format). This is in a separate commit that doesn't do anything else, to avoid hidden changes

Fixes #257, although not in quite the required way (printing the error). Instead the configuration is failed immediately after the failed step. I think this makes more sense.