### PR TITLE
Fix position of [[nodiscard]] and remove braces on primitives to fix clang warning

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -967,8 +967,8 @@ SCIPP_CORE_EXPORT Variable rebin(const VariableConstProxy &var, const Dim dim,
 SCIPP_CORE_EXPORT Variable resize(const VariableConstProxy &var, const Dim dim,
                                   const scipp::index size);
 SCIPP_CORE_EXPORT Variable reverse(Variable var, const Dim dim);
-SCIPP_CORE_EXPORT[[nodiscard]] Variable sqrt(const VariableConstProxy &var);
-SCIPP_CORE_EXPORT[[nodiscard]] Variable sqrt(Variable &&var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable sqrt(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable sqrt(Variable &&var);
 SCIPP_CORE_EXPORT VariableProxy sqrt(const VariableConstProxy &var,
                                      const VariableProxy &out);
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -203,7 +203,7 @@ void bind_init_list(py::class_<Variable> &c) {
           if (scipp_dtype(dtype) == core::dtype<Eigen::Vector3d>) {
             auto val = values.cast<std::vector<Eigen::Vector3d>>();
             Variable var;
-            Dimensions dims({label[0]}, {scipp::size(val)});
+            Dimensions dims(label[0], scipp::size(val));
             if (variances)
               var = makeVariable<Eigen::Vector3d>(
                   dims, val, variances->cast<std::vector<Eigen::Vector3d>>());


### PR DESCRIPTION
Fixes my local clang `all` build, and removes the warnings for having braces around primitive values in constructor