### PR TITLE
Reduce compile times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 
 # Optimization flags
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --param inline-unit-growth=100")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --param inline-unit-growth=50")
 endif()
 
 # Get version from git-describe

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -37,7 +37,9 @@ set(SRC_FILES
     variable_binary_arithmetic.cpp
     variable_instantiate_basic.cpp
     variable_instantiate_dataset.cpp
+    variable_logical_operations.cpp
     variable_operations.cpp
+    variable_type_conversion.cpp
     view_index.cpp)
 
 set(LINK_TYPE "STATIC")

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -660,20 +660,15 @@ template <bool dry_run> struct in_place {
         } else {
           do_transform_in_place(*a, as_view{*b, dimsA}, op);
         }
-      } else if (dimsA.contains(dimsB)) {
-        auto a_view = as_view{*a, dimsA};
-        if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-          do_transform_in_place(a_view, *b, op);
-        } else {
-          do_transform_in_place(a_view, as_view{*b, dimsA}, op);
-        }
       } else {
-        // LHS has fewer dimensions than RHS, e.g., for computing sum. Use view.
-        auto a_view = as_view{*a, dimsB};
+        // If LHS has fewer dimensions than RHS, e.g., for computing sum the
+        // view for iteration is based on dimsB.
+        const auto viewDims = dimsA.contains(dimsB) ? dimsA : dimsB;
+        auto a_view = as_view{*a, viewDims};
         if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
           do_transform_in_place(a_view, *b, op);
         } else {
-          do_transform_in_place(a_view, as_view{*b, dimsB}, op);
+          do_transform_in_place(a_view, as_view{*b, viewDims}, op);
         }
       }
     }

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -14,26 +14,22 @@ template <class... Ts> struct pair_self {
 };
 template <class... Ts> struct pair_custom { using type = std::tuple<Ts...>; };
 template <class... Ts> struct pair_ {
-  template <class RHS> struct with {
-    using type = decltype(std::tuple_cat(std::tuple<std::pair<Ts, RHS>>{}...));
-  };
+  template <class RHS> using type = std::tuple<std::pair<Ts, RHS>...>;
 };
 
 template <class... Ts> using pair_self_t = typename pair_self<Ts...>::type;
 template <class... Ts> using pair_custom_t = typename pair_custom<Ts...>::type;
 template <class RHS>
 using pair_numerical_with_t =
-    typename pair_<double, float, int64_t, int32_t>::with<RHS>::type;
+    typename pair_<double, float, int64_t, int32_t>::type<RHS>;
 
 template <class... Ts> struct pair_product {
-  template <class T> struct pair_with {
-    using type = decltype(std::tuple_cat(std::tuple<std::pair<T, Ts>>{}...));
-  };
-  using type = decltype(std::tuple_cat(typename pair_with<Ts>::type{}...));
+  template <class T> using type = std::tuple<std::pair<T, Ts>...>;
 };
 
 template <class... Ts>
-using pair_product_t = typename pair_product<Ts...>::type;
+using pair_product_t = decltype(
+    std::tuple_cat(typename pair_product<Ts...>::template type<Ts>{}...));
 
 using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
 

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -25,6 +25,41 @@ template <class RHS>
 using pair_numerical_with_t =
     typename pair_<double, float, int64_t, int32_t>::with<RHS>::type;
 
+template <class... Ts> struct pair_product {
+  template <class T> struct pair_with {
+    using type = decltype(std::tuple_cat(std::tuple<std::pair<T, Ts>>{}...));
+  };
+  using type = decltype(std::tuple_cat(typename pair_with<Ts>::type{}...));
+};
+
+template <class... Ts>
+using pair_product_t = typename pair_product<Ts...>::type;
+
+using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
+
+using arithmetic_type_pairs_with_bool =
+    decltype(std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                            std::declval<pair_numerical_with_t<bool>>()));
+
+using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
+    std::declval<arithmetic_type_pairs>(),
+    std::tuple<std::pair<Eigen::Vector3d, Eigen::Vector3d>,
+               std::pair<int64_t, int32_t>, std::pair<int32_t, int64_t>,
+               std::pair<double, float>, std::pair<float, double>>()));
+
+static constexpr auto dimensionless_unit_check =
+    [](units::Unit &varUnit, const units::Unit &otherUnit) {
+      expect::equals(varUnit, units::dimensionless);
+      expect::equals(otherUnit, units::dimensionless);
+    };
+
+static constexpr auto dimensionless_unit_check_return =
+    [](const units::Unit &aUnit, const units::Unit &bUnit) {
+      expect::equals(aUnit, units::dimensionless);
+      expect::equals(bUnit, units::dimensionless);
+      return aUnit;
+    };
+
 } // namespace scipp::core
 
 #endif // SCIPP_CORE_TRANSFORM_COMMON_H

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -360,27 +360,22 @@ public:
   Variable reshape(const Dimensions &dims) &&;
   void rename(const Dim from, const Dim to);
 
-  bool operator==(const Variable &other) const;
   bool operator==(const VariableConstProxy &other) const;
-  bool operator!=(const Variable &other) const;
   bool operator!=(const VariableConstProxy &other) const;
   Variable operator-() const;
 
-  Variable &operator+=(const Variable &other) &;
   Variable &operator+=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator+=(const T v) & {
     return *this += makeVariable<T>(v);
   }
 
-  Variable &operator-=(const Variable &other) &;
   Variable &operator-=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator-=(const T v) & {
     return *this -= makeVariable<T>(v);
   }
 
-  Variable &operator*=(const Variable &other) &;
   Variable &operator*=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator*=(const T v) & {
@@ -392,7 +387,6 @@ public:
     return *this *= quantity.value();
   }
 
-  Variable &operator/=(const Variable &other) &;
   Variable &operator/=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator/=(const T v) & {
@@ -404,13 +398,8 @@ public:
     return *this /= quantity.value();
   }
 
-  Variable &operator|=(const Variable &other) &;
   Variable &operator|=(const VariableConstProxy &other) &;
-
-  Variable &operator&=(const Variable &other) &;
   Variable &operator&=(const VariableConstProxy &other) &;
-
-  Variable &operator^=(const Variable &other) &;
   Variable &operator^=(const VariableConstProxy &other) &;
 
   const VariableConcept &data() const && = delete;
@@ -681,9 +670,7 @@ public:
     return variances<T>()[0];
   }
 
-  bool operator==(const Variable &other) const;
   bool operator==(const VariableConstProxy &other) const;
-  bool operator!=(const Variable &other) const;
   bool operator!=(const VariableConstProxy &other) const;
   Variable operator-() const;
 
@@ -779,41 +766,32 @@ public:
   // (would this suffer from the same issue?).
   template <class T> VariableProxy assign(const T &other) const;
 
-  VariableProxy operator+=(const Variable &other) const;
   VariableProxy operator+=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator+=(const T v) const {
     return *this += makeVariable<T>(v);
   }
 
-  VariableProxy operator-=(const Variable &other) const;
   VariableProxy operator-=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator-=(const T v) const {
     return *this -= makeVariable<T>(v);
   }
 
-  VariableProxy operator*=(const Variable &other) const;
   VariableProxy operator*=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator*=(const T v) const {
     return *this *= makeVariable<T>(v);
   }
 
-  VariableProxy operator/=(const Variable &other) const;
   VariableProxy operator/=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator/=(const T v) const {
     return *this /= makeVariable<T>(v);
   }
 
-  VariableProxy operator|=(const Variable &other) const;
   VariableProxy operator|=(const VariableConstProxy &other) const;
-
-  VariableProxy operator&=(const Variable &other) const;
   VariableProxy operator&=(const VariableConstProxy &other) const;
-
-  VariableProxy operator^=(const Variable &other) const;
   VariableProxy operator^=(const VariableConstProxy &other) const;
 
   template <class T> void setVariances(Vector<T> &&v) const;
@@ -831,39 +809,6 @@ private:
   Variable *m_mutableVariable;
 };
 
-SCIPP_CORE_EXPORT Variable operator+(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator-(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator*(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator/(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator|(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator&(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator^(const Variable &a, const Variable &b);
-SCIPP_CORE_EXPORT Variable operator+(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator-(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator*(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator/(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator|(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator&(const Variable &a,
-                                     const VariableConstProxy &b);
-SCIPP_CORE_EXPORT Variable operator+(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator-(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator*(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator/(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator|(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator&(const VariableConstProxy &a,
-                                     const Variable &b);
-SCIPP_CORE_EXPORT Variable operator^(const VariableConstProxy &a,
-                                     const Variable &b);
 SCIPP_CORE_EXPORT Variable operator+(const VariableConstProxy &a,
                                      const VariableConstProxy &b);
 SCIPP_CORE_EXPORT Variable operator-(const VariableConstProxy &a,

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -52,16 +52,8 @@ template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
   return a.data() == b.data();
 }
 
-bool Variable::operator==(const Variable &other) const {
-  return equals(*this, other);
-}
-
 bool Variable::operator==(const VariableConstProxy &other) const {
   return equals(*this, other);
-}
-
-bool Variable::operator!=(const Variable &other) const {
-  return !(*this == other);
 }
 
 bool Variable::operator!=(const VariableConstProxy &other) const {
@@ -82,18 +74,12 @@ VariableProxy::assign(const VariableConstProxy &) const;
 template SCIPP_CORE_EXPORT VariableProxy
 VariableProxy::assign(const VariableProxy &) const;
 
-bool VariableConstProxy::operator==(const Variable &other) const {
+bool VariableConstProxy::operator==(const VariableConstProxy &other) const {
   // Always use deep comparison (pointer comparison does not make sense since we
   // may be looking at a different section).
   return equals(*this, other);
 }
-bool VariableConstProxy::operator==(const VariableConstProxy &other) const {
-  return equals(*this, other);
-}
 
-bool VariableConstProxy::operator!=(const Variable &other) const {
-  return !(*this == other);
-}
 bool VariableConstProxy::operator!=(const VariableConstProxy &other) const {
   return !(*this == other);
 }

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -4,9 +4,7 @@
 /// @author Simon Heybrock
 #include <cmath>
 
-#include "scipp/core/dataset.h"
 #include "scipp/core/except.h"
-#include "scipp/core/tag_util.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
 
@@ -21,28 +19,6 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   return variable;
 }
 
-template <class... Ts> struct pair_product {
-  template <class T> struct pair_with {
-    using type = decltype(std::tuple_cat(std::tuple<std::pair<T, Ts>>{}...));
-  };
-  using type = decltype(std::tuple_cat(typename pair_with<Ts>::type{}...));
-};
-
-template <class... Ts>
-using pair_product_t = typename pair_product<Ts...>::type;
-
-using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
-
-using arithmetic_type_pairs_with_bool =
-    decltype(std::tuple_cat(std::declval<arithmetic_type_pairs>(),
-                            std::declval<pair_numerical_with_t<bool>>()));
-
-using arithmetic_and_matrix_type_pairs = decltype(std::tuple_cat(
-    std::declval<arithmetic_type_pairs>(),
-    std::tuple<std::pair<Eigen::Vector3d, Eigen::Vector3d>,
-               std::pair<int64_t, int32_t>, std::pair<int32_t, int64_t>,
-               std::pair<double, float>, std::pair<float, double>>()));
-
 static constexpr auto plus_ = [](const auto a_, const auto b_) {
   return a_ + b_;
 };
@@ -55,43 +31,6 @@ static constexpr auto times_ = [](const auto a_, const auto b_) {
 static constexpr auto divide_ = [](const auto a_, const auto b_) {
   return a_ / b_;
 };
-
-static constexpr auto dimensionless_unit_check =
-    [](units::Unit &varUnit, const units::Unit &otherUnit) {
-      expect::equals(varUnit, units::dimensionless);
-      expect::equals(otherUnit, units::dimensionless);
-    };
-
-static constexpr auto dimensionless_unit_check_return =
-    [](const units::Unit &aUnit, const units::Unit &bUnit) {
-      expect::equals(aUnit, units::dimensionless);
-      expect::equals(bUnit, units::dimensionless);
-      return aUnit;
-    };
-
-static constexpr auto or_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ | other_; },
-    dimensionless_unit_check_return};
-
-static constexpr auto or_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ |= other_; },
-               dimensionless_unit_check};
-
-static constexpr auto and_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ & other_; },
-    dimensionless_unit_check_return};
-
-static constexpr auto and_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ &= other_; },
-               dimensionless_unit_check};
-
-static constexpr auto xor_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ ^ other_; },
-    dimensionless_unit_check_return};
-
-static constexpr auto xor_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ ^= other_; },
-               dimensionless_unit_check};
 
 template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
   return transform<arithmetic_and_matrix_type_pairs>(a, b, plus_);
@@ -171,54 +110,6 @@ Variable &Variable::operator/=(const VariableConstProxy &other) & {
   return divide_equals(*this, other);
 }
 
-template <class T1, class T2> T1 &or_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<bool>>(variable, other, or_equals_);
-  return variable;
-}
-
-template <class T1, class T2> Variable or_op(const T1 &a, const T2 &b) {
-  return transform<pair_self_t<bool>>(a, b, or_op_);
-}
-
-template <class T1, class T2> T1 &and_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<bool>>(variable, other, and_equals_);
-  return variable;
-}
-
-template <class T1, class T2> Variable and_op(const T1 &a, const T2 &b) {
-  return transform<pair_self_t<bool>>(a, b, and_op_);
-}
-
-template <class T1, class T2> T1 &xor_equals(T1 &variable, const T2 &other) {
-  transform_in_place<pair_self_t<bool>>(variable, other, xor_equals_);
-  return variable;
-}
-
-template <class T1, class T2> Variable xor_op(const T1 &a, const T2 &b) {
-  return transform<pair_self_t<bool>>(a, b, xor_op_);
-}
-
-Variable &Variable::operator|=(const Variable &other) & {
-  return or_equals(*this, other);
-}
-Variable &Variable::operator|=(const VariableConstProxy &other) & {
-  return or_equals(*this, other);
-}
-
-Variable &Variable::operator&=(const Variable &other) & {
-  return and_equals(*this, other);
-}
-Variable &Variable::operator&=(const VariableConstProxy &other) & {
-  return and_equals(*this, other);
-}
-
-Variable &Variable::operator^=(const Variable &other) & {
-  return xor_equals(*this, other);
-}
-Variable &Variable::operator^=(const VariableConstProxy &other) & {
-  return xor_equals(*this, other);
-}
-
 VariableProxy VariableProxy::operator+=(const Variable &other) const {
   return plus_equals(*this, other);
 }
@@ -247,27 +138,6 @@ VariableProxy VariableProxy::operator/=(const VariableConstProxy &other) const {
   return divide_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator|=(const Variable &other) const {
-  return or_equals(*this, other);
-}
-VariableProxy VariableProxy::operator|=(const VariableConstProxy &other) const {
-  return or_equals(*this, other);
-}
-
-VariableProxy VariableProxy::operator&=(const Variable &other) const {
-  return and_equals(*this, other);
-}
-VariableProxy VariableProxy::operator&=(const VariableConstProxy &other) const {
-  return and_equals(*this, other);
-}
-
-VariableProxy VariableProxy::operator^=(const Variable &other) const {
-  return xor_equals(*this, other);
-}
-VariableProxy VariableProxy::operator^=(const VariableConstProxy &other) const {
-  return xor_equals(*this, other);
-}
-
 Variable VariableConstProxy::operator-() const {
   Variable copy(*this);
   return -copy;
@@ -278,13 +148,6 @@ Variable operator-(const Variable &a, const Variable &b) { return minus(a, b); }
 Variable operator*(const Variable &a, const Variable &b) { return times(a, b); }
 Variable operator/(const Variable &a, const Variable &b) {
   return divide(a, b);
-}
-Variable operator|(const Variable &a, const Variable &b) { return or_op(a, b); }
-Variable operator&(const Variable &a, const Variable &b) {
-  return and_op(a, b);
-}
-Variable operator^(const Variable &a, const Variable &b) {
-  return xor_op(a, b);
 }
 Variable operator+(const Variable &a, const VariableConstProxy &b) {
   return plus(a, b);
@@ -298,15 +161,6 @@ Variable operator*(const Variable &a, const VariableConstProxy &b) {
 Variable operator/(const Variable &a, const VariableConstProxy &b) {
   return divide(a, b);
 }
-Variable operator|(const Variable &a, const VariableConstProxy &b) {
-  return or_op(a, b);
-}
-Variable operator&(const Variable &a, const VariableConstProxy &b) {
-  return and_op(a, b);
-}
-Variable operator^(const Variable &a, const VariableConstProxy &b) {
-  return xor_op(a, b);
-}
 Variable operator+(const VariableConstProxy &a, const Variable &b) {
   return plus(a, b);
 }
@@ -319,15 +173,6 @@ Variable operator*(const VariableConstProxy &a, const Variable &b) {
 Variable operator/(const VariableConstProxy &a, const Variable &b) {
   return divide(a, b);
 }
-Variable operator|(const VariableConstProxy &a, const Variable &b) {
-  return or_op(a, b);
-}
-Variable operator&(const VariableConstProxy &a, const Variable &b) {
-  return and_op(a, b);
-}
-Variable operator^(const VariableConstProxy &a, const Variable &b) {
-  return xor_op(a, b);
-}
 Variable operator+(const VariableConstProxy &a, const VariableConstProxy &b) {
   return plus(a, b);
 }
@@ -339,15 +184,6 @@ Variable operator*(const VariableConstProxy &a, const VariableConstProxy &b) {
 }
 Variable operator/(const VariableConstProxy &a, const VariableConstProxy &b) {
   return divide(a, b);
-}
-Variable operator|(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return or_op(a, b);
-}
-Variable operator&(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return and_op(a, b);
-}
-Variable operator^(const VariableConstProxy &a, const VariableConstProxy &b) {
-  return xor_op(a, b);
 }
 Variable operator+(const VariableConstProxy &a_, const double b) {
   Variable a(a_);
@@ -391,39 +227,4 @@ Variable operator/(const double a, const VariableConstProxy &b_proxy) {
   return b;
 }
 
-Variable Variable::operator~() const {
-  return transform<bool>(
-      *this, overloaded{[](const auto &current) { return !current; },
-                        [](const units::Unit &unit) -> units::Unit {
-                          expect::equals(unit, units::dimensionless);
-                          return unit;
-                        }});
-}
-
-struct MakeVariableWithType {
-  template <class T> struct Maker {
-    static Variable apply(const VariableConstProxy &parent) {
-      return transform<double, float, int64_t, int32_t, bool>(
-          parent, overloaded{[](const units::Unit &x) { return x; },
-                             [](const auto &x) {
-                               if constexpr (detail::is_ValueAndVariance_v<
-                                                 std::decay_t<decltype(x)>>)
-                                 return detail::ValueAndVariance<T>{
-                                     static_cast<T>(x.value),
-                                     static_cast<T>(x.variance)};
-                               else
-                                 return static_cast<T>(x);
-                             }});
-    }
-  };
-  static Variable make(const VariableConstProxy &var, DType type) {
-    return CallDType<double, float, int64_t, int32_t, bool>::apply<Maker>(type,
-                                                                          var);
-  }
-};
-
-Variable astype(const VariableConstProxy &var, DType type) {
-  return type == var.dtype() ? Variable(var)
-                             : MakeVariableWithType::make(var, type);
-}
 } // namespace scipp::core

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -55,9 +55,6 @@ Variable Variable::operator-() const {
       *this, [](const auto a) { return -a; });
 }
 
-Variable &Variable::operator+=(const Variable &other) & {
-  return plus_equals(*this, other);
-}
 Variable &Variable::operator+=(const VariableConstProxy &other) & {
   return plus_equals(*this, other);
 }
@@ -71,9 +68,6 @@ template <class T1, class T2> Variable minus(const T1 &a, const T2 &b) {
   return transform<arithmetic_and_matrix_type_pairs>(a, b, minus_);
 }
 
-Variable &Variable::operator-=(const Variable &other) & {
-  return minus_equals(*this, other);
-}
 Variable &Variable::operator-=(const VariableConstProxy &other) & {
   return minus_equals(*this, other);
 }
@@ -87,9 +81,6 @@ template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
   return transform<arithmetic_type_pairs_with_bool>(a, b, times_);
 }
 
-Variable &Variable::operator*=(const Variable &other) & {
-  return times_equals(*this, other);
-}
 Variable &Variable::operator*=(const VariableConstProxy &other) & {
   return times_equals(*this, other);
 }
@@ -103,37 +94,22 @@ template <class T1, class T2> Variable divide(const T1 &a, const T2 &b) {
   return transform<arithmetic_type_pairs>(a, b, divide_);
 }
 
-Variable &Variable::operator/=(const Variable &other) & {
-  return divide_equals(*this, other);
-}
 Variable &Variable::operator/=(const VariableConstProxy &other) & {
   return divide_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator+=(const Variable &other) const {
-  return plus_equals(*this, other);
-}
 VariableProxy VariableProxy::operator+=(const VariableConstProxy &other) const {
   return plus_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator-=(const Variable &other) const {
-  return minus_equals(*this, other);
-}
 VariableProxy VariableProxy::operator-=(const VariableConstProxy &other) const {
   return minus_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator*=(const Variable &other) const {
-  return times_equals(*this, other);
-}
 VariableProxy VariableProxy::operator*=(const VariableConstProxy &other) const {
   return times_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator/=(const Variable &other) const {
-  return divide_equals(*this, other);
-}
 VariableProxy VariableProxy::operator/=(const VariableConstProxy &other) const {
   return divide_equals(*this, other);
 }
@@ -143,36 +119,6 @@ Variable VariableConstProxy::operator-() const {
   return -copy;
 }
 
-Variable operator+(const Variable &a, const Variable &b) { return plus(a, b); }
-Variable operator-(const Variable &a, const Variable &b) { return minus(a, b); }
-Variable operator*(const Variable &a, const Variable &b) { return times(a, b); }
-Variable operator/(const Variable &a, const Variable &b) {
-  return divide(a, b);
-}
-Variable operator+(const Variable &a, const VariableConstProxy &b) {
-  return plus(a, b);
-}
-Variable operator-(const Variable &a, const VariableConstProxy &b) {
-  return minus(a, b);
-}
-Variable operator*(const Variable &a, const VariableConstProxy &b) {
-  return times(a, b);
-}
-Variable operator/(const Variable &a, const VariableConstProxy &b) {
-  return divide(a, b);
-}
-Variable operator+(const VariableConstProxy &a, const Variable &b) {
-  return plus(a, b);
-}
-Variable operator-(const VariableConstProxy &a, const Variable &b) {
-  return minus(a, b);
-}
-Variable operator*(const VariableConstProxy &a, const Variable &b) {
-  return times(a, b);
-}
-Variable operator/(const VariableConstProxy &a, const Variable &b) {
-  return divide(a, b);
-}
 Variable operator+(const VariableConstProxy &a, const VariableConstProxy &b) {
   return plus(a, b);
 }

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -56,7 +56,8 @@ Variable Variable::operator-() const {
 }
 
 Variable &Variable::operator+=(const VariableConstProxy &other) & {
-  return plus_equals(*this, other);
+  VariableProxy(*this) += other;
+  return *this;
 }
 
 template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
@@ -69,7 +70,8 @@ template <class T1, class T2> Variable minus(const T1 &a, const T2 &b) {
 }
 
 Variable &Variable::operator-=(const VariableConstProxy &other) & {
-  return minus_equals(*this, other);
+  VariableProxy(*this) -= other;
+  return *this;
 }
 
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
@@ -82,7 +84,8 @@ template <class T1, class T2> Variable times(const T1 &a, const T2 &b) {
 }
 
 Variable &Variable::operator*=(const VariableConstProxy &other) & {
-  return times_equals(*this, other);
+  VariableProxy(*this) *= other;
+  return *this;
 }
 
 template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
@@ -95,7 +98,8 @@ template <class T1, class T2> Variable divide(const T1 &a, const T2 &b) {
 }
 
 Variable &Variable::operator/=(const VariableConstProxy &other) & {
-  return divide_equals(*this, other);
+  VariableProxy(*this) /= other;
+  return *this;
 }
 
 VariableProxy VariableProxy::operator+=(const VariableConstProxy &other) const {

--- a/core/variable_logical_operations.cpp
+++ b/core/variable_logical_operations.cpp
@@ -64,15 +64,18 @@ template <class T1, class T2> Variable xor_op(const T1 &a, const T2 &b) {
 }
 
 Variable &Variable::operator|=(const VariableConstProxy &other) & {
-  return or_equals(*this, other);
+  VariableProxy(*this) |= other;
+  return *this;
 }
 
 Variable &Variable::operator&=(const VariableConstProxy &other) & {
-  return and_equals(*this, other);
+  VariableProxy(*this) &= other;
+  return *this;
 }
 
 Variable &Variable::operator^=(const VariableConstProxy &other) & {
-  return xor_equals(*this, other);
+  VariableProxy(*this) ^= other;
+  return *this;
 }
 
 VariableProxy VariableProxy::operator|=(const VariableConstProxy &other) const {

--- a/core/variable_logical_operations.cpp
+++ b/core/variable_logical_operations.cpp
@@ -63,73 +63,30 @@ template <class T1, class T2> Variable xor_op(const T1 &a, const T2 &b) {
   return transform<pair_self_t<bool>>(a, b, xor_op_);
 }
 
-Variable &Variable::operator|=(const Variable &other) & {
-  return or_equals(*this, other);
-}
 Variable &Variable::operator|=(const VariableConstProxy &other) & {
   return or_equals(*this, other);
 }
 
-Variable &Variable::operator&=(const Variable &other) & {
-  return and_equals(*this, other);
-}
 Variable &Variable::operator&=(const VariableConstProxy &other) & {
   return and_equals(*this, other);
 }
 
-Variable &Variable::operator^=(const Variable &other) & {
-  return xor_equals(*this, other);
-}
 Variable &Variable::operator^=(const VariableConstProxy &other) & {
   return xor_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator|=(const Variable &other) const {
-  return or_equals(*this, other);
-}
 VariableProxy VariableProxy::operator|=(const VariableConstProxy &other) const {
   return or_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator&=(const Variable &other) const {
-  return and_equals(*this, other);
-}
 VariableProxy VariableProxy::operator&=(const VariableConstProxy &other) const {
   return and_equals(*this, other);
 }
 
-VariableProxy VariableProxy::operator^=(const Variable &other) const {
-  return xor_equals(*this, other);
-}
 VariableProxy VariableProxy::operator^=(const VariableConstProxy &other) const {
   return xor_equals(*this, other);
 }
 
-Variable operator|(const Variable &a, const Variable &b) { return or_op(a, b); }
-Variable operator&(const Variable &a, const Variable &b) {
-  return and_op(a, b);
-}
-Variable operator^(const Variable &a, const Variable &b) {
-  return xor_op(a, b);
-}
-Variable operator|(const Variable &a, const VariableConstProxy &b) {
-  return or_op(a, b);
-}
-Variable operator&(const Variable &a, const VariableConstProxy &b) {
-  return and_op(a, b);
-}
-Variable operator^(const Variable &a, const VariableConstProxy &b) {
-  return xor_op(a, b);
-}
-Variable operator|(const VariableConstProxy &a, const Variable &b) {
-  return or_op(a, b);
-}
-Variable operator&(const VariableConstProxy &a, const Variable &b) {
-  return and_op(a, b);
-}
-Variable operator^(const VariableConstProxy &a, const Variable &b) {
-  return xor_op(a, b);
-}
 Variable operator|(const VariableConstProxy &a, const VariableConstProxy &b) {
   return or_op(a, b);
 }

--- a/core/variable_logical_operations.cpp
+++ b/core/variable_logical_operations.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <cmath>
+
+#include "scipp/core/except.h"
+#include "scipp/core/transform.h"
+#include "scipp/core/variable.h"
+
+#include "operators.h"
+
+namespace scipp::core {
+
+static constexpr auto or_op_ = overloaded{
+    [](const auto &var_, const auto &other_) -> bool { return var_ | other_; },
+    dimensionless_unit_check_return};
+
+static constexpr auto or_equals_ =
+    overloaded{[](auto &var_, const auto &other_) { var_ |= other_; },
+               dimensionless_unit_check};
+
+static constexpr auto and_op_ = overloaded{
+    [](const auto &var_, const auto &other_) -> bool { return var_ & other_; },
+    dimensionless_unit_check_return};
+
+static constexpr auto and_equals_ =
+    overloaded{[](auto &var_, const auto &other_) { var_ &= other_; },
+               dimensionless_unit_check};
+
+static constexpr auto xor_op_ = overloaded{
+    [](const auto &var_, const auto &other_) -> bool { return var_ ^ other_; },
+    dimensionless_unit_check_return};
+
+static constexpr auto xor_equals_ =
+    overloaded{[](auto &var_, const auto &other_) { var_ ^= other_; },
+               dimensionless_unit_check};
+
+template <class T1, class T2> T1 &or_equals(T1 &variable, const T2 &other) {
+  transform_in_place<pair_self_t<bool>>(variable, other, or_equals_);
+  return variable;
+}
+
+template <class T1, class T2> Variable or_op(const T1 &a, const T2 &b) {
+  return transform<pair_self_t<bool>>(a, b, or_op_);
+}
+
+template <class T1, class T2> T1 &and_equals(T1 &variable, const T2 &other) {
+  transform_in_place<pair_self_t<bool>>(variable, other, and_equals_);
+  return variable;
+}
+
+template <class T1, class T2> Variable and_op(const T1 &a, const T2 &b) {
+  return transform<pair_self_t<bool>>(a, b, and_op_);
+}
+
+template <class T1, class T2> T1 &xor_equals(T1 &variable, const T2 &other) {
+  transform_in_place<pair_self_t<bool>>(variable, other, xor_equals_);
+  return variable;
+}
+
+template <class T1, class T2> Variable xor_op(const T1 &a, const T2 &b) {
+  return transform<pair_self_t<bool>>(a, b, xor_op_);
+}
+
+Variable &Variable::operator|=(const Variable &other) & {
+  return or_equals(*this, other);
+}
+Variable &Variable::operator|=(const VariableConstProxy &other) & {
+  return or_equals(*this, other);
+}
+
+Variable &Variable::operator&=(const Variable &other) & {
+  return and_equals(*this, other);
+}
+Variable &Variable::operator&=(const VariableConstProxy &other) & {
+  return and_equals(*this, other);
+}
+
+Variable &Variable::operator^=(const Variable &other) & {
+  return xor_equals(*this, other);
+}
+Variable &Variable::operator^=(const VariableConstProxy &other) & {
+  return xor_equals(*this, other);
+}
+
+VariableProxy VariableProxy::operator|=(const Variable &other) const {
+  return or_equals(*this, other);
+}
+VariableProxy VariableProxy::operator|=(const VariableConstProxy &other) const {
+  return or_equals(*this, other);
+}
+
+VariableProxy VariableProxy::operator&=(const Variable &other) const {
+  return and_equals(*this, other);
+}
+VariableProxy VariableProxy::operator&=(const VariableConstProxy &other) const {
+  return and_equals(*this, other);
+}
+
+VariableProxy VariableProxy::operator^=(const Variable &other) const {
+  return xor_equals(*this, other);
+}
+VariableProxy VariableProxy::operator^=(const VariableConstProxy &other) const {
+  return xor_equals(*this, other);
+}
+
+Variable operator|(const Variable &a, const Variable &b) { return or_op(a, b); }
+Variable operator&(const Variable &a, const Variable &b) {
+  return and_op(a, b);
+}
+Variable operator^(const Variable &a, const Variable &b) {
+  return xor_op(a, b);
+}
+Variable operator|(const Variable &a, const VariableConstProxy &b) {
+  return or_op(a, b);
+}
+Variable operator&(const Variable &a, const VariableConstProxy &b) {
+  return and_op(a, b);
+}
+Variable operator^(const Variable &a, const VariableConstProxy &b) {
+  return xor_op(a, b);
+}
+Variable operator|(const VariableConstProxy &a, const Variable &b) {
+  return or_op(a, b);
+}
+Variable operator&(const VariableConstProxy &a, const Variable &b) {
+  return and_op(a, b);
+}
+Variable operator^(const VariableConstProxy &a, const Variable &b) {
+  return xor_op(a, b);
+}
+Variable operator|(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return or_op(a, b);
+}
+Variable operator&(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return and_op(a, b);
+}
+Variable operator^(const VariableConstProxy &a, const VariableConstProxy &b) {
+  return xor_op(a, b);
+}
+
+Variable Variable::operator~() const {
+  return transform<bool>(
+      *this, overloaded{[](const auto &current) { return !current; },
+                        [](const units::Unit &unit) -> units::Unit {
+                          expect::equals(unit, units::dimensionless);
+                          return unit;
+                        }});
+}
+
+} // namespace scipp::core

--- a/core/variable_type_conversion.cpp
+++ b/core/variable_type_conversion.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Igor Gudich
+#include <cmath>
+
+#include "scipp/core/dataset.h"
+#include "scipp/core/except.h"
+#include "scipp/core/tag_util.h"
+#include "scipp/core/transform.h"
+#include "scipp/core/variable.h"
+
+#include "operators.h"
+
+namespace scipp::core {
+
+struct MakeVariableWithType {
+  template <class T> struct Maker {
+    static Variable apply(const VariableConstProxy &parent) {
+      return transform<double, float, int64_t, int32_t, bool>(
+          parent, overloaded{[](const units::Unit &x) { return x; },
+                             [](const auto &x) {
+                               if constexpr (detail::is_ValueAndVariance_v<
+                                                 std::decay_t<decltype(x)>>)
+                                 return detail::ValueAndVariance<T>{
+                                     static_cast<T>(x.value),
+                                     static_cast<T>(x.variance)};
+                               else
+                                 return static_cast<T>(x);
+                             }});
+    }
+  };
+  static Variable make(const VariableConstProxy &var, DType type) {
+    return CallDType<double, float, int64_t, int32_t, bool>::apply<Maker>(type,
+                                                                          var);
+  }
+};
+
+Variable astype(const VariableConstProxy &var, DType type) {
+  return type == var.dtype() ? Variable(var)
+                             : MakeVariableWithType::make(var, type);
+}
+} // namespace scipp::core


### PR DESCRIPTION
An attempt to reduce the compile times, which have recently become unacceptably large. Not sure it is helping much for CI, but locally a saw a slight improvement.

- Split some object files (could probably do more here).
- Remove overloads -> Just use proxy-based implementation.
- Irrelevant(?) template changes in `transform.h`.
- GCC inlining flag adapted.
- Tweak recursive call to avoid redundant instantiations.