### PR TITLE
Read masks from Workspace2D

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -147,42 +147,44 @@ def convert_Workspace2D_to_dataset(ws):
                                                  len(ws.readY(0))),
                                           unit=sc.units.counts,
                                           variances=True),
-                         coords={
-                             dim: coord,
-                             sc.Dim.Spectrum: num
-    },
-        labels={"position": pos,
-                             "component_info": comp_info,
-                             "detector_info": det_info
-                },
-        attrs={"run": make_run(ws),
-                             "sample": make_sample(ws)
-               })
+                         coords={dim: coord,
+                                 sc.Dim.Spectrum: num
+                                 },
+                         labels={"position": pos,
+                                 "component_info": comp_info,
+                                 "detector_info": det_info
+                                 },
+                         attrs={"run": make_run(ws),
+                                "sample": make_sample(ws)
+                                }
+                         )
 
+    spectrum_masks = None
     if ws.detectorInfo().hasMaskedDetectors():
-        array.masks["spectrum"] = sc.Variable([sc.Dim.Spectrum],
-                                              shape=(ws.getNumberHistograms(),),
-                                              dtype=sc.dtype.bool)
+        array.masks["spectrum"] = sc.Variable(
+            [sc.Dim.Spectrum],
+            shape=(ws.getNumberHistograms(),),
+            dtype=sc.dtype.bool)
         spectrum_masks = array.masks["spectrum"]
 
-    if common_bins and ws.hasMaskedBins(0):
+    if ws.hasAnyMaskedBins():
+        array.masks["bin"] = make_bin_masks(common_bins, dim,
+                                            ws.blocksize(),
+                                            ws.getNumberHistograms())
         bin_masks = array.masks["bin"]
-        array.masks["bin"] = make_bin_masks(common_bins, dim,
-                                            ws.blocksize(),
-                                            ws.getNumberHistograms())
-
-        set_common_bins_masks(bin_masks, dim, ws.maskedBinsIndices(0))
-    elif not common_bins:
-        array.masks["bin"] = make_bin_masks(common_bins, dim,
-                                            ws.blocksize(),
-                                            ws.getNumberHistograms())
+        # set all the bin masks now - they're all the same
+        if common_bins:
+            set_common_bins_masks(bin_masks, dim, ws.maskedBinsIndices(0))
 
     data = array.data
     spectrum_info = ws.spectrumInfo()
     for i in range(ws.getNumberHistograms()):
         data[sc.Dim.Spectrum, i].values = ws.readY(i)
         data[sc.Dim.Spectrum, i].variances = np.power(ws.readE(i), 2)
-        spectrum_masks[sc.Dim.Spectrum, i].value = spectrum_info.isMasked(i)
+
+        if spectrum_masks:
+            spectrum_masks[sc.Dim.Spectrum,
+                           i].value = spectrum_info.isMasked(i)
 
         if not common_bins and ws.hasMaskedBins(i):
             set_bin_masks(bin_masks, dim, i, ws.maskedBinsIndices(i))

--- a/python/tests/compat/mantid_data_helper.py
+++ b/python/tests/compat/mantid_data_helper.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @author Dimitar Tasev
 
 import os
 import urllib

--- a/python/tests/compat/mantid_data_helper.py
+++ b/python/tests/compat/mantid_data_helper.py
@@ -1,0 +1,32 @@
+
+import os
+import urllib
+
+
+class MantidDataHelper:
+    # Valid only for Linux. Windows is as C:\MantidExternalData
+    DATA_DIR = os.path.abspath(os.path.expanduser("~/MantidExternalData"))
+    DATA_LOCATION = "{data_dir}/{algorithm}/{hash}"
+    DATA_FILES = {
+        "CNCS_51936_event.nxs": {
+            "hash": "5ba401e489260a44374b5be12b780911",
+            "algorithm": "MD5"}
+    }
+    REMOTE_URL = "http://mantidweb.nd.rl.ac.uk/externaldata/isis-readonly/"\
+        "{algorithm}/{hash}"
+
+    @classmethod
+    def find_file(cls, name):
+        data_file = cls.DATA_FILES[name]
+
+        data_location = cls.DATA_LOCATION.format(
+            data_dir=cls.DATA_DIR,
+            algorithm=data_file["algorithm"],
+            hash=data_file["hash"])
+
+        if not os.path.isfile(data_location):
+            data_location, http_response = urllib.request.urlretrieve(
+                cls.REMOTE_URL.format(algorithm=data_file["algorithm"],
+                                      hash=data_file["hash"]), data_location)
+
+        return data_location

--- a/python/tests/compat/mantid_test.py
+++ b/python/tests/compat/mantid_test.py
@@ -16,6 +16,8 @@ class TestMantidConversion(unittest.TestCase):
     def setUpClass(cls):
         # This is from the Mantid system-test data
         filename = "CNCS_51936_event.nxs"
+        # This needs OutputWorkspace specified, as it doesn't
+        # pick up the name from the class variable name
         cls.base_event_ws = mantid.LoadEventNexus(
             MantidDataHelper.find_file(filename),
             OutputWorkspace="test_ws{}".format(__file__))

--- a/python/tests/compat/mantid_test.py
+++ b/python/tests/compat/mantid_test.py
@@ -8,12 +8,20 @@ from mantid.api import EventType
 import scipp.compat.mantid as mantidcompat
 import numpy as np
 
+from mantid_data_helper import MantidDataHelper
+
 
 class TestMantidConversion(unittest.TestCase):
-    def test_Workspace2D(self):
+    @classmethod
+    def setUpClass(cls):
         # This is from the Mantid system-test data
         filename = "CNCS_51936_event.nxs"
-        eventWS = mantid.LoadEventNexus(filename)
+        cls.base_event_ws = mantid.LoadEventNexus(
+            MantidDataHelper.find_file(filename),
+            OutputWorkspace="test_ws{}".format(__file__))
+
+    def test_Workspace2D(self):
+        eventWS = mantid.CloneWorkspace(self.base_event_ws)
         ws = mantid.Rebin(eventWS, 10000, PreserveEvents=False)
         d = mantidcompat.convert_Workspace2D_to_dataset(ws)
         self.assertEqual(
@@ -22,9 +30,7 @@ class TestMantidConversion(unittest.TestCase):
         )
 
     def test_EventWorkspace(self):
-        # This is from the Mantid system-test data
-        filename = "CNCS_51936_event.nxs"
-        eventWS = mantid.LoadEventNexus(filename)
+        eventWS = mantid.CloneWorkspace(self.base_event_ws)
         ws = mantid.Rebin(eventWS, 10000)
 
         binned_mantid = mantidcompat.convert_Workspace2D_to_dataset(ws)
@@ -39,9 +45,7 @@ class TestMantidConversion(unittest.TestCase):
         self.assertLess(np.abs(delta.value), 1e-5)
 
     def test_unit_conversion(self):
-        # This is from the Mantid system-test data
-        filename = "CNCS_51936_event.nxs"
-        eventWS = mantid.LoadEventNexus(filename)
+        eventWS = mantid.CloneWorkspace(self.base_event_ws)
         ws = mantid.Rebin(eventWS, 10000, PreserveEvents=False)
         tmp = mantidcompat.convert_Workspace2D_to_dataset(ws)
         target_tof = tmp.coords[sc.Dim.Tof]
@@ -65,6 +69,67 @@ class TestMantidConversion(unittest.TestCase):
                     converted.coords[sc.Dim.Wavelength].values,
                 )))
         # delta = sc.sum(converted_mantid - converted, sc.Dim.Spectrum)
+
+    @staticmethod
+    def _mask_bins_and_spectra(ws, xmin, xmax, num_spectra):
+        masked_ws = mantid.MaskBins(ws, XMin=xmin, XMax=xmax)
+
+        # mask the first 3 spectra
+        for i in range(num_spectra):
+            masked_ws.spectrumInfo().setMasked(i, True)
+
+        return masked_ws
+
+    def test_Workspace2D_common_bins_masks(self):
+        eventWS = mantid.CloneWorkspace(self.base_event_ws)
+        ws = mantid.Rebin(eventWS, 10000, PreserveEvents=False)
+        ws_x = ws.readX(0)
+
+        # mask the first 3 bins, range is taken as [XMin, XMax)
+        masked_ws = self._mask_bins_and_spectra(ws,
+                                                xmin=ws_x[0],
+                                                xmax=ws_x[3],
+                                                num_spectra=3)
+
+        self.assertTrue(masked_ws.isCommonBins())
+
+        ds = mantidcompat.convert_Workspace2D_to_dataset(masked_ws)
+
+        np.testing.assert_array_equal(
+            ds.masks["bin"].values[0:3],
+            [True, True, True])
+
+        np.testing.assert_array_equal(
+            ds.masks["spectrum"].values[0:3],
+            [True, True, True])
+
+    def test_Workspace2D_not_common_bins_masks(self):
+        eventWS = mantid.CloneWorkspace(self.base_event_ws)
+        ws = mantid.Rebin(eventWS, 10000, PreserveEvents=False)
+        ws = mantid.ConvertUnits(ws, "Wavelength",
+                                 EMode="Direct",
+                                 EFixed=0.1231)
+
+        # these X values will mask different number of bins
+        masked_ws = self._mask_bins_and_spectra(ws, -214, -192, num_spectra=3)
+
+        self.assertFalse(masked_ws.isCommonBins())
+
+        ds = mantidcompat.convert_Workspace2D_to_dataset(masked_ws)
+
+        # bin with 3 masks
+        np.testing.assert_array_equal(
+            ds.masks["bin"].values[0],
+            [True, True, False, False, False])
+
+        # bin with only 2
+        np.testing.assert_array_equal(
+            ds.masks["bin"].values[31],
+            [True, True, True, False, False])
+
+        np.testing.assert_array_equal(
+            ds.masks["spectrum"].values[0:3],
+            [True, True, True])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Reads bin and spectrum masks from Workspace2D only
- Adds `mantid_data_helper.py` to retrieve the data file needed by the test, so that it can run and pass again. I haven't enabled the test so I don't think it will run on the build servers in this state
- Adds 2 new tests for converting Ws2D with masks, having common and not common bins

Fixes #616.