### PR TITLE
Improve clarity of Python docstrings

### DIFF
--- a/python/counts.cpp
+++ b/python/counts.cpp
@@ -16,18 +16,25 @@ void init_counts(py::module &m) {
         [](const DatasetConstProxy &d, const Dim dim) {
           return counts::toDensity(Dataset(d), dim);
         },
+        py::arg("x"), py::arg("dim"),
         R"(
         Converts counts to count density on a given dimension.
 
+        :param x: Data as counts.
+        :param dim: Dimension on which to convert.
         :return: Data as count density.
         :rtype: Dataset)");
+
   m.def("counts_to_density",
         [](const DataConstProxy &d, const Dim dim) {
           return counts::toDensity(DataArray(d), dim);
         },
+        py::arg("x"), py::arg("dim"),
         R"(
         Converts counts to count density on a given dimension.
 
+        :param x: Data as counts.
+        :param dim: Dimension on which to convert.
         :return: Data as count density.
         :rtype: DataArray)");
 
@@ -35,18 +42,25 @@ void init_counts(py::module &m) {
         [](const DatasetConstProxy &d, const Dim dim) {
           return counts::fromDensity(Dataset(d), dim);
         },
+        py::arg("x"), py::arg("dim"),
         R"(
         Converts count density to counts on a given dimension.
 
+        :param x: Data as count density.
+        :param dim: Dimension on which to convert.
         :return: Data as counts.
         :rtype: Dataset)");
+
   m.def("density_to_counts",
         [](const DataConstProxy &d, const Dim dim) {
           return counts::fromDensity(DataArray(d), dim);
         },
+        py::arg("x"), py::arg("dim"),
         R"(
         Converts count density to counts on a given dimension.
 
+        :param x: Data as count density.
+        :param dim: Dimension on which to convert.
         :return: Data as counts.
         :rtype: DataArray)");
 }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -268,7 +268,7 @@ void init_dataset(py::module &m) {
 
         :param x: First DataProxy.
         :param y: Second DataProxy.
-        :param dim: Dimensions along which to concatenate.
+        :param dim: Dimension along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New data array containing all data, coords, labels, and masks of the input arrays.
         :rtype: DataArray)");
@@ -285,7 +285,7 @@ void init_dataset(py::module &m) {
 
         :param x: First Dataset.
         :param y: Second Dataset.
-        :param dim: Dimensions along which to concatenate.
+        :param dim: Dimension along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New dataset.
         :rtype: Dataset)");

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -266,8 +266,8 @@ void init_dataset(py::module &m) {
         Concatenates the data, coords, labels and masks of the data array.
         Coords, labels and masks for any but the given dimension are required to match and are copied to the output without changes.
 
-        :param x: First DataProxy.
-        :param y: Second DataProxy.
+        :param x: First DataArray.
+        :param y: Second DataArray.
         :param dim: Dimension along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New data array containing all data, coords, labels, and masks of the input arrays.
@@ -295,7 +295,7 @@ void init_dataset(py::module &m) {
           return core::histogram(ds, bins);
         },
         py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-        R"(Returns a new DataArray with values in bins for for sparse dims.
+        R"(Returns a new DataArray with values in bins for sparse dims.
 
         :param x: Data to histogram.
         :param bins: Bin edges.
@@ -307,7 +307,7 @@ void init_dataset(py::module &m) {
           return core::histogram(ds, bins);
         },
         py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-        R"(Returns a new DataArray with values in bins for for sparse dims.
+        R"(Returns a new DataArray with values in bins for sparse dims.
 
         :param x: Data to histogram.
         :param bins: Bin edges.
@@ -319,7 +319,7 @@ void init_dataset(py::module &m) {
           return core::histogram(ds, bins);
         },
         py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-        R"(Returns a new Dataset with values in bins for for sparse dims.
+        R"(Returns a new Dataset with values in bins for sparse dims.
 
         :param x: Data to histogram.
         :param bins: Bin edges.
@@ -331,7 +331,7 @@ void init_dataset(py::module &m) {
           return core::histogram(ds, bins);
         },
         py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-        R"(Returns a new Dataset with values in bins for for sparse dims.
+        R"(Returns a new Dataset with values in bins for sparse dims.
 
         :param x: Data to histogram.
         :param bins: Bin edges.

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -259,12 +259,16 @@ void init_dataset(py::module &m) {
   m.def("concatenate",
         py::overload_cast<const DataConstProxy &, const DataConstProxy &,
                           const Dim>(&concatenate),
+        py::arg("x"), py::arg("y"), py::arg("dim"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Concatenate input data array along the given dimension.
 
         Concatenates the data, coords, labels and masks of the data array.
         Coords, labels and masks for any but the given dimension are required to match and are copied to the output without changes.
 
+        :param x: First DataProxy.
+        :param y: Second DataProxy.
+        :param dim: Dimensions along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New data array containing all data, coords, labels, and masks of the input arrays.
         :rtype: DataArray)");
@@ -272,12 +276,16 @@ void init_dataset(py::module &m) {
   m.def("concatenate",
         py::overload_cast<const DatasetConstProxy &, const DatasetConstProxy &,
                           const Dim>(&concatenate),
+        py::arg("x"), py::arg("y"), py::arg("dim"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Concatenate input datasets along the given dimension.
 
         Concatenate all cooresponding items in the input datasets.
         The output contains only items that are present in both inputs.
 
+        :param x: First Dataset.
+        :param y: Second Dataset.
+        :param dim: Dimensions along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New dataset.
         :rtype: Dataset)");
@@ -286,76 +294,111 @@ void init_dataset(py::module &m) {
         [](const DataConstProxy &ds, const Variable &bins) {
           return core::histogram(ds, bins);
         },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable with values in bins for for sparse dims");
+        py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
+        R"(Returns a new DataArray with values in bins for for sparse dims.
+
+        :param x: Data to histogram.
+        :param bins: Bin edges.
+        :return: Histogramed data.
+        :rtype: DataArray)");
 
   m.def("histogram",
         [](const DataConstProxy &ds, const VariableConstProxy &bins) {
           return core::histogram(ds, bins);
         },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Variable with values in bins for sparse dims");
+        py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
+        R"(Returns a new DataArray with values in bins for for sparse dims.
+
+        :param x: Data to histogram.
+        :param bins: Bin edges.
+        :return: Histogramed data.
+        :rtype: DataArray)");
 
   m.def("histogram",
         [](const Dataset &ds, const VariableConstProxy &bins) {
           return core::histogram(ds, bins);
         },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Dataset with histograms for sparse dims");
+        py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
+        R"(Returns a new Dataset with values in bins for for sparse dims.
+
+        :param x: Data to histogram.
+        :param bins: Bin edges.
+        :return: Histogramed data.
+        :rtype: Dataset)");
 
   m.def("histogram",
         [](const Dataset &ds, const Variable &bins) {
           return core::histogram(ds, bins);
         },
-        py::call_guard<py::gil_scoped_release>(),
-        "Returns a new Dataset with histograms for sparse dims");
+        py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
+        R"(Returns a new Dataset with values in bins for for sparse dims.
+
+        :param x: Data to histogram.
+        :param bins: Bin edges.
+        :return: Histogramed data.
+        :rtype: Dataset)");
 
   m.def("merge",
         [](const DatasetConstProxy &lhs, const DatasetConstProxy &rhs) {
           return core::merge(lhs, rhs);
         },
+        py::arg("lhs"), py::arg("rhs"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Union of two datasets.
 
+        :param lhs: First Dataset.
+        :param rhs: Second Dataset.
         :raises: If there are conflicting items with different content.
         :return: A new dataset that contains the union of all data items, coords, labels, masks and attributes.
         :rtype: Dataset)");
 
   m.def("sum", py::overload_cast<const DataConstProxy &, const Dim>(&sum),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise sum over the specified dimension.
 
+        :param x: Data to sum.
+        :param dim: Dimension over which to sum.
         :raises: If the dimension does not exist, or if the dtype cannot be summed, e.g., if it is a string
         :seealso: :py:class:`scipp.mean`
         :return: New data array containing the sum.
         :rtype: DataArray)");
 
   m.def("sum", py::overload_cast<const DatasetConstProxy &, const Dim>(&sum),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise sum over the specified dimension.
 
+        :param x: Data to sum.
+        :param dim: Dimension over which to sum.
         :raises: If the dimension does not exist, or if the dtype cannot be summed, e.g., if it is a string
         :seealso: :py:class:`scipp.mean`
         :return: New dataset containing the sum for each data item.
         :rtype: Dataset)");
 
   m.def("mean", py::overload_cast<const DataConstProxy &, const Dim>(&mean),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise mean over the specified dimension, if variances are present, the new variance is computated as standard-deviation of the mean.
 
         See the documentation for the mean of a Variable for details in the computation of the ouput variance.
 
+        :param x: Data to calculate mean of.
+        :param dim: Dimension over which to calculate mean.
         :raises: If the dimension does not exist, or if the dtype cannot be summed, e.g., if it is a string
         :seealso: :py:class:`scipp.mean`
         :return: New data array containing the mean for each data item.
         :rtype: DataArray)");
 
   m.def("mean", py::overload_cast<const DatasetConstProxy &, const Dim>(&mean),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise mean over the specified dimension, if variances are present, the new variance is computated as standard-deviation of the mean.
 
         See the documentation for the mean of a Variable for details in the computation of the ouput variance.
 
+        :param x: Data to calculate mean of.
+        :param dim: Dimension over which to calculate mean.
         :raises: If the dimension does not exist, or if the dtype cannot be summed, e.g., if it is a string
         :seealso: :py:class:`scipp.mean`
         :return: New dataset containing the mean for each data item.
@@ -364,18 +407,27 @@ void init_dataset(py::module &m) {
   m.def("rebin",
         py::overload_cast<const DataConstProxy &, const Dim,
                           const VariableConstProxy &>(&rebin),
+        py::arg("x"), py::arg("dim"), py::arg("bins"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Rebin a dimension of a data array.
 
+        :param x: Data to rebin.
+        :param dim: Dimension to rebin over.
+        :param bins: New bin edges.
         :raises: If data cannot be rebinned, e.g., if the unit is not counts, or the existing coordinate is not a bin-edge coordinate.
         :return: A new data array with data rebinned according to the new coordinate.
         :rtype: DataArray)");
+
   m.def("rebin",
         py::overload_cast<const DatasetConstProxy &, const Dim,
                           const VariableConstProxy &>(&rebin),
+        py::arg("x"), py::arg("dim"), py::arg("bins"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Rebin a dimension of a dataset.
 
+        :param x: Data to rebin.
+        :param dim: Dimension to rebin over.
+        :param bins: New bin edges.
         :raises: If data cannot be rebinned, e.g., if the unit is not counts, or the existing coordinate is not a bin-edge coordinate.
         :return: A new dataset with data rebinned according to the new coordinate.
         :rtype: Dataset)");
@@ -383,25 +435,26 @@ void init_dataset(py::module &m) {
   m.def("sort",
         py::overload_cast<const DataConstProxy &, const VariableConstProxy &>(
             &sort),
-        py::arg("data"), py::arg("key"),
-        py::call_guard<py::gil_scoped_release>(),
+        py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
         R"(Sort data array along a dimension by a sort key.
 
         :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
         :return: New sorted data array.
         :rtype: DataArray)");
+
   m.def(
       "sort", py::overload_cast<const DataConstProxy &, const Dim &>(&sort),
-      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
       R"(Sort data array along a dimension by the coordinate values for that dimension.
 
       :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
       :return: New sorted data array.
       :rtype: DataArray)");
+
   m.def(
       "sort",
       py::overload_cast<const DataConstProxy &, const std::string &>(&sort),
-      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
       R"(Sort data array along a dimension by the label values for the given key.
 
       :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
@@ -412,24 +465,26 @@ void init_dataset(py::module &m) {
       "sort",
       py::overload_cast<const DatasetConstProxy &, const VariableConstProxy &>(
           &sort),
-      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
       R"(Sort dataset along a dimension by a sort key.
 
         :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
         :return: New sorted dataset.
         :rtype: Dataset)");
+
   m.def(
       "sort", py::overload_cast<const DatasetConstProxy &, const Dim &>(&sort),
-      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
       R"(Sort dataset along a dimension by the coordinate values for that dimension.
 
       :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.
       :return: New sorted dataset.
       :rtype: Dataset)");
+
   m.def(
       "sort",
       py::overload_cast<const DatasetConstProxy &, const std::string &>(&sort),
-      py::arg("data"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("key"), py::call_guard<py::gil_scoped_release>(),
       R"(Sort dataset along a dimension by the label values for the given key.
 
       :raises: If the key is invalid, e.g., if it has not exactly one dimension, or if its dtype is not sortable.

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -329,15 +329,18 @@ void init_variable(py::module &m) {
           Dimensions dims(labels, shape.cast<std::vector<scipp::index>>());
           return self.reshape(dims);
         },
-        py::arg("variable"), py::arg("dims"), py::arg("shape"),
+        py::arg("x"), py::arg("dims"), py::arg("shape"),
         R"(
         Reshape a variable.
 
+        :param x: Data to reshape.
+        :param dims: List of new dimensions.
+        :param shape: New extents in each dimension.
         :raises: If the volume of the old shape is not equal to the volume of the new shape.
         :return: New variable with requested dimension labels and shape.
         :rtype: Variable)");
 
-  m.def("abs", [](const Variable &self) { return abs(self); },
+  m.def("abs", [](const Variable &self) { return abs(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise absolute value.
 
@@ -345,16 +348,20 @@ void init_variable(py::module &m) {
         :seealso: :py:class:`scipp.norm` for vector-like dtype
         :return: Copy of the input with values replaced by the absolute values
         :rtype: Variable)");
+
   m.def("dot", py::overload_cast<const Variable &, const Variable &>(&dot),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise dot-product.
 
         :raises: If the dtype is not a vector such as :py:class:`scipp.dtype.vector_3_double`
         :return: New variable with scalar elements based on the two inputs.
         :rtype: Variable)");
+
   m.def("concatenate",
         py::overload_cast<const VariableConstProxy &,
                           const VariableConstProxy &, const Dim>(&concatenate),
+        py::arg("x"), py::arg("y"), py::arg("dim"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Concatenate input variables along the given dimension.
 
@@ -362,11 +369,16 @@ void init_variable(py::module &m) {
         - Along an existing dimension, yielding a new dimension extent given by the sum of the input's extents.
         - Along a new dimension that is not contained in either of the inputs, yielding an output with one extra dimensions.
 
+        :param x: First Variable.
+        :param y: Second Variable.
+        :param dim: Dimensions along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New variable containing all elements of the input variables.
         :rtype: Variable)");
+
   m.def("filter",
         py::overload_cast<const Variable &, const Variable &>(&filter),
+        py::arg("x"), py::arg("filter"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Selects elements for a Variable using a filter (mask).
 
@@ -377,8 +389,10 @@ void init_variable(py::module &m) {
         :raises: If the filter variable is not 1 dimensional.
         :return: New variable containing the data selected by the filter
         :rtype: Variable)");
+
   m.def("mean", py::overload_cast<const VariableConstProxy &, const Dim>(&mean),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise mean over the specified dimension, if variances are present, the new variance is computated as standard-deviation of the mean.
 
         If the input has variances, the variances stored in the ouput are based on the "standard deviation of the mean", i.e., :math:`\sigma_{mean} = \sigma / \sqrt{N}`.
@@ -390,8 +404,9 @@ void init_variable(py::module &m) {
         :seealso: :py:class:`scipp.sum`
         :return: New variable containing the mean.
         :rtype: Variable)");
+
   m.def("norm", py::overload_cast<const VariableConstProxy &>(&norm),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise norm.
 
         :raises: If the dtype has no norm, i.e., if it is not a vector
@@ -417,7 +432,7 @@ void init_variable(py::module &m) {
         "Split a Variable along a given Dimension.");
 
   m.def("sqrt", [](const VariableConstProxy &self) { return sqrt(self); },
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise square-root.
 
         :raises: If the dtype has no square-root, e.g., if it is a string
@@ -437,15 +452,18 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("sum", py::overload_cast<const VariableConstProxy &, const Dim>(&sum),
-        py::call_guard<py::gil_scoped_release>(), R"(
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
         Element-wise sum over the specified dimension.
 
+        :param x: Data to sum.
+        :param dim: Dimension over which to sum.
         :raises: If the dimension does not exist, or if the dtype cannot be summed, e.g., if it is a string
         :seealso: :py:class:`scipp.mean`
         :return: New variable containing the sum.
         :rtype: Variable)");
 
-  m.def("sin", [](const Variable &self) { return sin(self); },
+  m.def("sin", [](const Variable &self) { return sin(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise sin.
 
@@ -453,7 +471,7 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the sin.
         :rtype: Variable)");
 
-  m.def("cos", [](const Variable &self) { return cos(self); },
+  m.def("cos", [](const Variable &self) { return cos(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise cos.
 
@@ -461,7 +479,7 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the cos.
         :rtype: Variable)");
 
-  m.def("tan", [](const Variable &self) { return tan(self); },
+  m.def("tan", [](const Variable &self) { return tan(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise tan.
 
@@ -469,7 +487,7 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the tan.
         :rtype: Variable)");
 
-  m.def("asin", [](const Variable &self) { return asin(self); },
+  m.def("asin", [](const Variable &self) { return asin(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise asin.
 
@@ -477,7 +495,7 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the asin. Output unit is rad.
         :rtype: Variable)");
 
-  m.def("acos", [](const Variable &self) { return acos(self); },
+  m.def("acos", [](const Variable &self) { return acos(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise acos.
 
@@ -485,7 +503,7 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the acos. Output unit is rad.
         :rtype: Variable)");
 
-  m.def("atan", [](const Variable &self) { return atan(self); },
+  m.def("atan", [](const Variable &self) { return atan(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise atan.
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -371,7 +371,7 @@ void init_variable(py::module &m) {
 
         :param x: First Variable.
         :param y: Second Variable.
-        :param dim: Dimensions along which to concatenate.
+        :param dim: Dimension along which to concatenate.
         :raises: If the dtype or unit does not match, or if the dimensions and shapes are incompatible.
         :return: New variable containing all elements of the input variables.
         :rtype: Variable)");


### PR DESCRIPTION
This should cover all the missing arguments and descriptions.

I used `x` and `y` for  general data names (apart from `merge` where left and right hand side actually have meaning), feel free to suggest better names.

Fixes #652