### PR TITLE
Volume rendering

### DIFF
--- a/docs/user-guide/plotting.ipynb
+++ b/docs/user-guide/plotting.ipynb
@@ -647,6 +647,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Plotting in 3 dimensions\n",
     "It is also possible to use a 3d projection:"
    ]
   },
@@ -679,7 +680,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " ## LAMP's Superplot\n",
+    "### Volume rendering\n",
+    "It is also possible to create a volume rendering of a dataset with 3 or more dimensions by using the `\"volume\"` projection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(d3, projection=\"volume\", backend=\"interactive\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LAMP's Superplot\n",
     "Finally, a `1d` projection is also available for multidimensional data, with the possibility to keep/remove lines that are plotted, a behaviour we copied from LAMP's [Superplot](https://github.com/mantidproject/documents/blob/master/Requirements/Visualisation_and_Analysis/superplot.md) which was very popular in the neutron physics community."
    ]
   },
@@ -690,6 +708,24 @@
    "outputs": [],
    "source": [
     "plot(d3, projection=\"1d\", backend=\"interactive\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convenience Methods\n",
+    "A small number of convenience methods are included in the `plot` module which provide shortcuts to the different projections. These are `image`, `threeslice`, `volume`, and `superplot`, and are used in the following way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipp import plot as pl\n",
+    "pl.threeslice(d3)"
    ]
   },
   {

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -6,3 +6,16 @@
 # flake8: noqa
 
 from .plot import plot
+
+
+def superplot(dataset, **kwargs):
+    return plot(dataset, projection="1d", **kwargs)
+
+def image(dataset, **kwargs):
+    return plot(dataset, projection="2d", **kwargs)
+
+def threeslice(dataset, **kwargs):
+    return plot(dataset, projection="3d", **kwargs)
+
+def volume(dataset, **kwargs):
+    return plot(dataset, projection="volume", **kwargs)

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -51,18 +51,19 @@ def dispatch(input_data, ndim=0, name=None, backend=None, collapse=None,
                 projection = "{}d".format(ndim)
             else:
                 projection = "2d"
+        projection = projection.lower()
 
         if sparse_dim is not None and bins is None:
             plot_sparse(input_data, ndim=ndim, sparse_dim=sparse_dim,
                         backend=backend, color=color, **kwargs)
-        elif projection.lower() == "1d":
+        elif projection == "1d":
             plot_1d(input_data, backend=backend, color=color, **kwargs)
-        elif projection.lower() == "2d":
+        elif projection == "2d":
             plot_2d(input_data, name=name, ndim=ndim, backend=backend,
                     **kwargs)
-        elif projection.lower() == "3d":
+        elif projection == "3d" or projection == "volume":
             plot_3d(input_data, name=name, ndim=ndim, backend=backend,
-                    **kwargs)
+                    volume=(projection == "volume"), **kwargs)
         else:
             raise RuntimeError("Wrong projection type. Expected either '2d' "
                                "or '3d', got {}.".format(projection))

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -137,6 +137,7 @@ class Slicer3d(Slicer):
                         isomax=val["cmax"],
                         opacity=0.1, # needs to be small to see through all surfaces
                         surface_count=volume_sampling, # needs to be a large number for good volume rendering
+                        colorscale=self.cb["name"]
                         ))
                 else:
                     for j in range(3):
@@ -174,6 +175,7 @@ class Slicer3d(Slicer):
                     isomax=params["values"]["cmax"],
                     opacity=0.1, # needs to be small to see through all surfaces
                     surface_count=volume_sampling, # needs to be a large number for good volume rendering
+                    colorscale=self.cb["name"]
                     )]
             else:
                 data = [go.Surface(cmin=params["values"]["cmin"],
@@ -302,7 +304,12 @@ class Slicer3d(Slicer):
             print("button_dims", button_dims)
             print("cubedims", self.cube.dims)
             # self.fig.data[0].value = self.check_transpose(self.cube).flatten()
-            self.fig.data[0].value = self.cube.values.T.flatten()
+            transpose = [str(dim) for dim in self.cube.dims] != [button_dims["x"], button_dims["y"], button_dims["z"]]
+            print("transpose", transpose)
+            values = self.cube.values
+            if transpose:
+                values = values.T
+            self.fig.data[0].value = values.flatten()
             print("value", np.shape(self.check_transpose(self.cube)))
             print("cube", np.shape(self.cube.values))
             print("cube.T", np.shape(self.cube.values.T))
@@ -311,7 +318,10 @@ class Slicer3d(Slicer):
                 self.fig.data[1].x = xyz_arrays[0].flatten()
                 self.fig.data[1].y = xyz_arrays[1].flatten()
                 self.fig.data[1].z = xyz_arrays[2].flatten()
-                self.fig.data[1].value = self.cube.variances.T.flatten()
+                variances = self.cube.variances
+                if transpose:
+                    variances = variances.T
+                self.fig.data[1].value = variances.flatten()
                 
 
         else:

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -83,7 +83,6 @@ class Slicer3d(Slicer):
                          button_options=['X', 'Y', 'Z'], volume=volume)
 
         self.cube = None
-        self.slice_indices = {"x": 0, "y": 1, "z": 2}
         self.volume = volume
 
         # Initialise Figure and VBox objects
@@ -224,9 +223,6 @@ class Slicer3d(Slicer):
                 ax_dim = button.value
                 if ax_dim is not None:
                     ax_dim = ax_dim.lower()
-                    # for j in range(1 + self.show_variances):
-                    #     k = self.slice_indices[ax_dim] + (4 * self.volume) * j
-                    #     self.fig.data[k].visible = True
                 self.fig.update_traces(visible=True)
                 self.showhide[key].value = (button.value is not None)
                 self.showhide[key].disabled = (button.value is None)
@@ -240,9 +236,6 @@ class Slicer3d(Slicer):
             scatter_x, scatter_y, scatter_z = self.get_outline_as_scatter()
             self.fig.update_traces(x=scatter_x, y=scatter_y, z=scatter_z,
                                    selector={"name": "scatter"})
-            # self.fig.data[3].update(x=scatter_x, y=scatter_y, z=scatter_z)
-            # if self.show_variances:
-            #     self.fig.data[7].update(x=scatter_x, y=scatter_y, z=scatter_z)
         self.update_axes()
 
         return
@@ -341,13 +334,6 @@ class Slicer3d(Slicer):
                     self.fig.update_traces(
                         **args, selector={"name": "slice_{}".format(key)})
 
-                    # for j in range(1 + self.show_variances):
-                    #     k = i + 4 * j
-                    #     setattr(self.fig.data[k], key,
-                    #             np.ones_like(xx) * val["loc"])
-                    #     setattr(self.fig.data[k], permutations[key][0], xx)
-                    #     setattr(self.fig.data[k], permutations[key][1], yy)
-
                 self.fig.update_traces(
                     surfacecolor=self.check_transpose(val["slice"]),
                     selector={"name": "slice_{}".format(key),
@@ -359,12 +345,6 @@ class Slicer3d(Slicer):
                         selector={"name": "slice_{}".format(key),
                                   "meta": "variances"})
 
-                # self.fig.data[i].surfacecolor = self.check_transpose(
-                #     val["slice"])
-                # if self.show_variances:
-                #     self.fig.data[i+4].surfacecolor = self.check_transpose(
-                #         val["slice"], variances=True)
-
         return
 
     # Define function to update slices
@@ -374,6 +354,7 @@ class Slicer3d(Slicer):
         else:
             # Update only one slice
             # The dimensions to be sliced have been saved in slider_dims
+            slice_indices = {"x": 0, "y": 1, "z": 2}
             key = change["owner"].dim_str
             self.lab[key].value = self.make_slider_label(
                     self.slider_x[key], change["new"])
@@ -382,7 +363,7 @@ class Slicer3d(Slicer):
             # Now move slice
             ax_dim = self.buttons[key].value.lower()
             xy = {ax_dim: np.ones_like(
-                self.fig.data[self.slice_indices[ax_dim]][ax_dim]) * \
+                self.fig.data[slice_indices[ax_dim]][ax_dim]) * \
                     self.slider_x[key].values[change["new"]]}
 
             self.fig.update_traces(

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -117,9 +117,9 @@ class Slicer3d(Slicer):
 
         # Make a generic volume trace
         if self.volume:
-            vol_trace = go.Volume(x=[0], y=[0], z=[0], value=[0],
-                        opacity=0.1, surface_count=volume_sampling,
-                        colorscale=self.cb["name"], showscale=True)
+            vol_trace = go.Volume(x=[0], y=[0], z=[0], value=[0], opacity=0.1,
+                                  surface_count=volume_sampling,
+                                  colorscale=self.cb["name"], showscale=True)
 
         xyz = "xyz"
         if self.show_variances:
@@ -363,7 +363,7 @@ class Slicer3d(Slicer):
             # Now move slice
             ax_dim = self.buttons[key].value.lower()
             xy = {ax_dim: np.ones_like(
-                self.fig.data[slice_indices[ax_dim]][ax_dim]) * \
+                self.fig.data[slice_indices[ax_dim]][ax_dim]) *
                     self.slider_x[key].values[change["new"]]}
 
             self.fig.update_traces(

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -173,6 +173,7 @@ class Slicer3d(Slicer):
                 vol_trace["isomin"] = params["values"]["cmin"]
                 vol_trace["isomax"] = params["values"]["cmax"]
                 vol_trace["meta"] = "values"
+                vol_trace["colorbar"] = colorbars[0]
                 data = [vol_trace]
             else:
                 data = [go.Surface(cmin=params["values"]["cmin"],

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -9,7 +9,7 @@ from .._scipp.core.units import dimensionless
 class Slicer:
 
     def __init__(self, input_data=None, axes=None, value_name=None, cb=None,
-                 show_variances=False, button_options=None):
+                 show_variances=False, button_options=None, volume=False):
 
         import ipywidgets as widgets
 
@@ -68,13 +68,14 @@ class Slicer:
         for i, dim in enumerate(self.slider_dims):
             key = str(dim)
             # If this is a 3d projection, place slices half-way
-            if len(button_options) == 3:
+            if len(button_options) == 3 and (not volume):
                 indx = (self.slider_nx[key] - 1) // 2
             if self.slider_labels[key] is not None:
                 descr = self.slider_labels[key]
             else:
                 descr = key
             # Add an IntSlider to slide along the z dimension of the array
+            print("slider keys", key)
             self.slider[key] = widgets.IntSlider(
                 value=indx,
                 min=0,
@@ -84,7 +85,7 @@ class Slicer:
                 continuous_update=True,
                 readout=False,
                 disabled=((i >= self.ndim-len(button_options)) and
-                          len(button_options) < 3))
+                          ((len(button_options) < 3) or volume)))
             labvalue = self.make_slider_label(self.slider_x[key], indx)
             if self.ndim == len(button_options):
                 self.slider[key].layout.display = 'none'
@@ -113,7 +114,7 @@ class Slicer:
                 self.buttons[key].layout.display = 'none'
                 self.lab[key].layout.display = 'none'
 
-            if len(button_options) == 3:
+            if (len(button_options) == 3) and (not volume):
                 self.showhide[key] = widgets.Button(
                     description="hide",
                     disabled=(button_values[i] is None),
@@ -132,7 +133,7 @@ class Slicer:
             self.slider[key].observe(self.update_slice, names="value")
             # Add the row of slider + buttons
             row = [self.slider[key], self.lab[key], self.buttons[key]]
-            if len(button_options) == 3:
+            if (len(button_options) == 3) and (not volume):
                 row += [widgets.HTML(value="&nbsp;&nbsp;&nbsp;&nbsp;"),
                         self.showhide[key]]
             self.vbox.append(widgets.HBox(row))

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -75,7 +75,6 @@ class Slicer:
             else:
                 descr = key
             # Add an IntSlider to slide along the z dimension of the array
-            print("slider keys", key)
             self.slider[key] = widgets.IntSlider(
                 value=indx,
                 min=0,
@@ -90,7 +89,6 @@ class Slicer:
             if self.ndim == len(button_options):
                 self.slider[key].layout.display = 'none'
                 labvalue = descr
-            print(labvalue)
             # Add a label widget to display the value of the z coordinate
             self.lab[key] = widgets.Label(value=labvalue)
             # Add one set of buttons per dimension

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -90,6 +90,7 @@ class Slicer:
             if self.ndim == len(button_options):
                 self.slider[key].layout.display = 'none'
                 labvalue = descr
+            print(labvalue)
             # Add a label widget to display the value of the z coordinate
             self.lab[key] = widgets.Label(value=labvalue)
             # Add one set of buttons per dimension

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -264,6 +264,20 @@ def test_plot_sliceviewer_with_1d_projection():
     do_plot(d, projection="1d")
 
 
+def test_plot_volume():
+    d = make_dense_dataset(ndim=3)
+    do_plot(d, projection="volume")
+
+
+def test_plot_convenience_methods():
+    d = make_dense_dataset(ndim=3)
+    with io.StringIO() as buf, redirect_stdout(buf):
+        sc.plot.image(d)
+        sc.plot.threeslice(d)
+        sc.plot.volume(d)
+        sc.plot.superplot(d)
+
+
 def test_plot_2d_image_rasterized():
     d = make_dense_dataset(ndim=2)
     do_plot(d, rasterize=True)


### PR DESCRIPTION
Some quick changes to `plot_3d` allow to display a volume rendering of 3D data.

Example:
```Python
import numpy as np
import scipp as sc
from scipp import Dim
from scipp.plot import plot
N = 50
M = 40
L = 30
xx = np.arange(N, dtype=np.float64)
yy = np.arange(M, dtype=np.float64)
zz = np.arange(L, dtype=np.float64)
x, y, z = np.meshgrid(xx, yy, zz, indexing='ij')
b = N/20.0
c = M/2.0
d = L/2.0
r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2 + ((z-d)/b)**2)
a = np.sin(r)
d3 = sc.Dataset()
d3.coords[Dim.X] = sc.Variable([Dim.X], values=xx, unit=sc.units.m)
d3.coords[Dim.Y] = sc.Variable([Dim.Y], values=yy, unit=sc.units.s)
d3.coords[Dim.Z] = sc.Variable([Dim.Z], values=zz, unit=sc.units.kg)
d3['Some3Ddata'] = sc.Variable([Dim.X, Dim.Y, Dim.Z], values=a)
plot(d3, projection="volume")
```
![Screenshot at 2019-11-20 13-56-47](https://user-images.githubusercontent.com/39047984/69240991-01bb1e80-0b9e-11ea-8ec3-b439c227bb21.png)

**Additional note:**
Some convenient functions were added to the `plot` module, enabling us to do:
```Python
from scipp import plot as pl
...
pl.threeslice(d) # equivalent to pl.plot(d, projection="3d")
pl.image(d) # equivalent to pl.plot(d, projection="2d")
pl.superplot(d) # equivalent to pl.plot(d, projection="1d")
pl.volume(d) # equivalent to pl.plot(d, projection="volume")
```
Is there a better name than `superplot`?