### PR TITLE
Histogram with weights

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -73,8 +73,9 @@ Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,
                 if (bin >= 0.0 && bin < nbin) {
                   if constexpr (have_variance) {
                     const auto [val, var] =
-                        op(1.0, ValueAndVariance{weights.value[bin],
-                                                 weights.variance[bin]});
+                        op(ValueAndVariance(1.0, 1.0),
+                           ValueAndVariance{weights.value[bin],
+                                            weights.variance[bin]});
                     out_vals.emplace_back(val);
                     out_vars.emplace_back(var);
                   } else {
@@ -82,7 +83,8 @@ Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,
                   }
                 } else {
                   if constexpr (have_variance) {
-                    const auto [val, var] = op(1.0, ValueAndVariance{0.0, 0.0});
+                    const auto [val, var] = op(ValueAndVariance(1.0, 1.0),
+                                               ValueAndVariance{0.0, 0.0});
                     out_vals.emplace_back(val);
                     out_vars.emplace_back(var);
                   } else {

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -64,7 +64,7 @@ Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,
             if (have_variance)
               out_vars.reserve(sparse.size());
             if (scipp::numeric::is_linspace(edges)) {
-              auto len = scipp::size(sparse) - 1;
+              auto len = scipp::size(edges) - 1;
               const auto offset = edges.front();
               const auto nbin = static_cast<decltype(offset)>(len);
               const auto scale = nbin / (edges.back() - edges.front());

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -43,7 +43,6 @@ constexpr static auto divide = [](const auto &a, const auto &b) {
 constexpr static auto apply_op_sparse_dense = [](auto op, const auto &coord,
                                                  const auto &edges,
                                                  const auto &weights) {
-  expect::histogram::sorted_edges(edges);
   using W = std::decay_t<decltype(weights)>;
   constexpr bool have_variance = is_ValueAndVariance_v<W>;
   using ElemT = typename core::detail::element_type_t<W>::value_type;
@@ -71,7 +70,8 @@ constexpr static auto apply_op_sparse_dense = [](auto op, const auto &coord,
       }
     }
   } else {
-    throw std::runtime_error("Only equal-sized bins supported.");
+    expect::histogram::sorted_edges(edges);
+    throw std::runtime_error("Non-constant bin width not supported yet.");
   }
   if constexpr (have_variance) {
     return std::pair(std::move(out_vals), std::move(out_vars));

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -55,10 +55,11 @@ auto apply_op_sparse_dense(Op op, const Coord &coord, const Edges &edges,
   if (scipp::numeric::is_linspace(edges)) {
     const auto [offset, nbin, scale] = linear_edge_params(edges);
     for (const auto c : coord) {
+      constexpr auto event_weight = 1.0;
       const auto bin = (c - offset) * scale;
       if constexpr (have_variance) {
         const auto [val, var] =
-            op(ValueAndVariance<ElemT>(1.0, Variance),
+            op(ValueAndVariance<ElemT>(event_weight, Variance),
                bin >= 0.0 && bin < nbin
                    ? ValueAndVariance{weights.value[bin], weights.variance[bin]}
                    : ValueAndVariance<ElemT>{0.0, 0.0});
@@ -66,7 +67,7 @@ auto apply_op_sparse_dense(Op op, const Coord &coord, const Edges &edges,
         out_vars.emplace_back(var);
       } else {
         out_vals.emplace_back(
-            op(1.0, bin >= 0.0 && bin < nbin ? weights[bin] : 0.0));
+            op(event_weight, bin >= 0.0 && bin < nbin ? weights[bin] : 0.0));
       }
     }
   } else {

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -180,8 +180,14 @@ auto sparse_dense_op(Op op, const DataConstProxy &a, const DataConstProxy &b) {
     auto out =
         sparse_dense_op_impl(op, a.coords()[dim], b.coords()[dim], b.data());
     if (a.hasData()) {
+      throw std::runtime_error("Operation between sparse data with values and "
+                               "histogram not implemented yet");
       // Undo implicit factor of counts added by sparse_dense_op_impl
       out.setUnit(out.unit() / units::Unit(units::counts));
+      // TODO This does not work, because the implicit "1" used by
+      // sparse_dense_op_impl for the uncertainties breaks the chaining of
+      // operations. Is there a better way apart from having a completely
+      // separate implementation?
       out *= a.data();
     }
     return out;

--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -18,9 +18,7 @@ static constexpr auto make_histogram = [](auto &data, const auto &events,
   if (scipp::numeric::is_linspace(edges)) {
     // Special implementation for linear bins. Gives a 1x to 20x speedup
     // for few and many events per histogram, respectively.
-    const double offset = edges.front();
-    const double nbin = static_cast<double>(scipp::size(data.value));
-    const double scale = nbin / (edges.back() - edges.front());
+    const auto [offset, nbin, scale] = linear_edge_params(edges);
     for (const auto &e : events) {
       const double bin = (e - offset) * scale;
       if (bin >= 0.0 && bin < nbin)
@@ -40,9 +38,7 @@ static constexpr auto make_histogram_from_weighted =
     [](auto &data, const auto &events, const auto &weights, const auto &edges) {
       expect::histogram::sorted_edges(edges);
       if (scipp::numeric::is_linspace(edges)) {
-        const double offset = edges.front();
-        const double nbin = static_cast<double>(scipp::size(data.value));
-        const double scale = nbin / (edges.back() - edges.front());
+        const auto [offset, nbin, scale] = linear_edge_params(edges);
         for (scipp::index i = 0; i < scipp::size(events); ++i) {
           const auto x = events[i];
           const double bin = (x - offset) * scale;

--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -14,7 +14,6 @@ namespace scipp::core {
 
 static constexpr auto make_histogram = [](auto &data, const auto &events,
                                           const auto &edges) {
-  expect::histogram::sorted_edges(edges);
   if (scipp::numeric::is_linspace(edges)) {
     // Special implementation for linear bins. Gives a 1x to 20x speedup
     // for few and many events per histogram, respectively.
@@ -25,6 +24,7 @@ static constexpr auto make_histogram = [](auto &data, const auto &events,
         ++data.value[static_cast<scipp::index>(bin)];
     }
   } else {
+    expect::histogram::sorted_edges(edges);
     for (const auto &e : events) {
       auto it = std::upper_bound(edges.begin(), edges.end(), e);
       if (it != edges.end() && it != edges.begin())
@@ -36,7 +36,6 @@ static constexpr auto make_histogram = [](auto &data, const auto &events,
 
 static constexpr auto make_histogram_from_weighted =
     [](auto &data, const auto &events, const auto &weights, const auto &edges) {
-      expect::histogram::sorted_edges(edges);
       if (scipp::numeric::is_linspace(edges)) {
         const auto [offset, nbin, scale] = linear_edge_params(edges);
         for (scipp::index i = 0; i < scipp::size(events); ++i) {
@@ -51,6 +50,7 @@ static constexpr auto make_histogram_from_weighted =
           }
         }
       } else {
+        expect::histogram::sorted_edges(edges);
         for (scipp::index i = 0; i < scipp::size(events); ++i) {
           const auto x = events[i];
           auto it = std::upper_bound(edges.begin(), edges.end(), x);

--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -153,6 +153,7 @@ Dataset histogram(const Dataset &dataset, const Dim &dim) {
   return histogram(dataset, bins);
 }
 
+/// Return true if the data array respresents a histogram for given dim.
 bool is_histogram(const DataConstProxy &a, const Dim dim) {
   const auto dims = a.dims();
   const auto coords = a.coords();

--- a/core/include/scipp/core/histogram.h
+++ b/core/include/scipp/core/histogram.h
@@ -13,6 +13,15 @@ namespace scipp::core {
 
 SCIPP_CORE_EXPORT bool is_histogram(const DataConstProxy &a, const Dim dim);
 
+/// Return params for computing bin index for linear edges (constant bin width).
+constexpr static auto linear_edge_params = [](const auto &edges) {
+  auto len = scipp::size(edges) - 1;
+  const auto offset = edges.front();
+  const auto nbin = static_cast<decltype(offset)>(len);
+  const auto scale = nbin / (edges.back() - edges.front());
+  return std::array{offset, nbin, scale};
+};
+
 namespace expect::histogram {
 template <class T> void sorted_edges(const T &edges) {
   if (!std::is_sorted(edges.begin(), edges.end()))

--- a/core/include/scipp/core/histogram.h
+++ b/core/include/scipp/core/histogram.h
@@ -17,6 +17,9 @@ SCIPP_CORE_EXPORT bool is_histogram(const DataConstProxy &a, const Dim dim);
 constexpr static auto linear_edge_params = [](const auto &edges) {
   auto len = scipp::size(edges) - 1;
   const auto offset = edges.front();
+  static_assert(
+      std::is_floating_point_v<decltype(offset)>,
+      "linear_bin_edges is not implement to support integer-valued bin-edges");
   const auto nbin = static_cast<decltype(offset)>(len);
   const auto scale = nbin / (edges.back() - edges.front());
   return std::array{offset, nbin, scale};

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -492,73 +492,65 @@ template <bool dry_run> struct in_place {
       call_in_place(op, indices, arg, other...);
   }
 
-  /// Helper for in-place transform implementation, performing branching between
-  /// output with and without variances.
-  template <class T1, class Op>
-  static void do_transform_in_place(T1 &a, Op op) {
+  /// Recursion endpoint for do_transform_in_place.
+  ///
+  /// Calls transform_in_place_impl unless the output has no variance even
+  /// though it should.
+  template <class Op, class Tuple>
+  static void do_transform_in_place(Op op, Tuple &&processed) {
     using namespace detail;
-    auto a_val = a.values();
-    if (a.hasVariances()) {
-      if constexpr (canHaveVariances<typename T1::value_type>()) {
-        auto a_var = a.variances();
-        transform_in_place_impl(op, ValuesAndVariances{a_val, a_var});
-      }
-    } else {
-      transform_in_place_impl(op, a_val);
-    }
+    std::apply(
+        [&](auto &&arg, auto &&... args) {
+          if constexpr (is_ValuesAndVariances_v<std::decay_t<decltype(arg)>> ||
+                        !(is_ValuesAndVariances_v<
+                              std::decay_t<decltype(args)>> ||
+                          ...) ||
+                        std::is_base_of_v<
+                            transform_flags::expect_no_variance_arg_t<0>, Op>) {
+            transform_in_place_impl(op, std::forward<decltype(arg)>(arg),
+                                    std::forward<decltype(args)>(args)...);
+          } else {
+            throw except::VariancesError(
+                "Output has no variance but at least one input does.");
+          }
+        },
+        std::forward<Tuple>(processed));
   }
 
   /// Helper for in-place transform implementation, performing branching between
   /// output with and without variances as well as handling other operands with
   /// and without variances.
-  template <class T1, class T2, class Op>
-  static void do_transform_in_place(T1 &a, const T2 &b, Op op) {
+  template <class Op, class Tuple, class Arg, class... Args>
+  static void do_transform_in_place(Op op, Tuple &&processed, Arg &arg,
+                                    const Args &... args) {
     using namespace detail;
-    auto a_val = a.values();
-    auto b_val = b.values();
-    if (a.hasVariances()) {
-      if constexpr (std::is_base_of_v<
-                        transform_flags::expect_no_variance_arg_t<0>, Op>) {
-        throw except::VariancesError(
-            "Variances in first argument not supported.");
-
-      } else {
-        if constexpr (canHaveVariances<typename T1::value_type>() &&
-                      canHaveVariances<typename T2::value_type>()) {
-          auto a_var = a.variances();
-          if (b.hasVariances()) {
-            if constexpr (std::is_base_of_v<
-                              transform_flags::expect_no_variance_arg_t<1>,
-                              Op>) {
-              throw except::VariancesError(
-                  "Variances in second argument not supported.");
-            } else {
-              auto b_var = b.variances();
-              transform_in_place_impl(op, ValuesAndVariances{a_val, a_var},
-                                      ValuesAndVariances{b_val, b_var});
-            }
-          } else {
-            transform_in_place_impl(op, ValuesAndVariances{a_val, a_var},
-                                    b_val);
-          }
-        }
-      }
-    } else if (b.hasVariances()) {
-      if constexpr (std::is_base_of_v<
-                        transform_flags::expect_no_variance_arg_t<1>, Op>) {
-        throw except::VariancesError(
-            "Variances in second argument not supported.");
-      } else if constexpr (std::is_base_of_v<
-                               transform_flags::expect_no_variance_arg_t<0>,
-                               Op>) {
-        auto b_var = b.variances();
-        transform_in_place_impl(op, a_val, ValuesAndVariances{b_val, b_var});
-      } else {
-        throw std::runtime_error(
-            "RHS in operation has variances but LHS does not.");
+    auto vals = arg.values();
+    if (arg.hasVariances()) {
+      if constexpr (std::is_base_of_v<transform_flags::expect_no_variance_arg_t<
+                                          std::tuple_size_v<Tuple>>,
+                                      Op>) {
+        throw except::VariancesError("Variances in argument " +
+                                     std::to_string(std::tuple_size_v<Tuple>) +
+                                     " not supported.");
+      } else if constexpr (canHaveVariances<typename Arg::value_type>()) {
+        auto vars = arg.variances();
+        do_transform_in_place(
+            op,
+            std::tuple_cat(processed,
+                           std::tuple(ValuesAndVariances{vals, vars})),
+            args...);
       }
     } else {
-      transform_in_place_impl(op, a_val, b_val);
+      if constexpr (std::is_base_of_v<transform_flags::expect_variance_arg_t<
+                                          std::tuple_size_v<Tuple>>,
+                                      Op>) {
+        throw except::VariancesError("Argument " +
+                                     std::to_string(std::tuple_size_v<Tuple>) +
+                                     " must have variances.");
+      } else {
+        do_transform_in_place(op, std::tuple_cat(processed, std::tuple(vals)),
+                              args...);
+      }
     }
   }
 
@@ -589,9 +581,9 @@ template <bool dry_run> struct in_place {
       using namespace detail;
       auto view = as_view{*handle, handle->dims()};
       if (handle->isContiguous())
-        do_transform_in_place(*handle, op);
+        do_transform_in_place(op, std::tuple<>{}, *handle);
       else
-        do_transform_in_place(view, op);
+        do_transform_in_place(op, std::tuple<>{}, view);
     }
 
     template <class A, class B> void operator()(A &&a, B &&b) const {
@@ -614,9 +606,9 @@ template <bool dry_run> struct in_place {
 
       if (a->isContiguous() && dimsA.contains(dimsB)) {
         if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-          do_transform_in_place(*a, *b, op);
+          do_transform_in_place(op, std::tuple<>{}, *a, *b);
         } else {
-          do_transform_in_place(*a, as_view{*b, dimsA}, op);
+          do_transform_in_place(op, std::tuple<>{}, *a, as_view{*b, dimsA});
         }
       } else {
         // If LHS has fewer dimensions than RHS, e.g., for computing sum the
@@ -624,11 +616,21 @@ template <bool dry_run> struct in_place {
         const auto viewDims = dimsA.contains(dimsB) ? dimsA : dimsB;
         auto a_view = as_view{*a, viewDims};
         if (b->isContiguous() && dimsA.isContiguousIn(dimsB)) {
-          do_transform_in_place(a_view, *b, op);
+          do_transform_in_place(op, std::tuple<>{}, a_view, *b);
         } else {
-          do_transform_in_place(a_view, as_view{*b, viewDims}, op);
+          do_transform_in_place(op, std::tuple<>{}, a_view,
+                                as_view{*b, viewDims});
         }
       }
+    }
+
+    template <class T, class... Ts>
+    void operator()(T &&out, Ts &&... handles) const {
+      using namespace detail;
+      const auto dims = merge(out->dims(), handles->dims()...);
+      auto out_view = as_view{*out, dims};
+      do_transform_in_place(op, std::tuple<>{}, out_view,
+                            as_view{*handles, dims}...);
     }
   };
   // gcc cannot deal with deduction guide for nested class => helper function.
@@ -649,6 +651,9 @@ template <bool dry_run> struct in_place {
       if constexpr ((is_any_sparse<Ts>::value || ...)) {
         visit_impl<Ts...>::apply(makeTransformInPlace(op), var.dataHandle(),
                                  other.dataHandle()...);
+      } else if constexpr (sizeof...(Other) > 1) {
+        static_assert("Transform with more than 2 arguments not implemented "
+                      "yet for element-wise operation.");
       } else {
         // Note that if only one of the inputs is sparse it must be the one
         // being transformed in-place, so there are only three cases here.
@@ -700,6 +705,14 @@ void transform_in_place(Var &&var, Op op) {
 template <class... TypePairs, class Var, class Op>
 void transform_in_place(Var &&var, const VariableConstProxy &other, Op op) {
   in_place<false>::transform<TypePairs...>(op, std::forward<Var>(var), other);
+}
+
+/// Transform the data elements of a variable in-place.
+template <class... TypePairs, class Var, class Op>
+void transform_in_place(Var &&var, const VariableConstProxy &var1,
+                        const VariableConstProxy &var2, Op op) {
+  in_place<false>::transform<TypePairs...>(op, std::forward<Var>(var), var1,
+                                           var2);
 }
 
 /// Accumulate data elements of a variable in-place.

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -547,7 +547,8 @@ template <bool dry_run> struct in_place {
         throw except::VariancesError(
             "Variances in second argument not supported.");
       } else if constexpr (std::is_base_of_v<
-                               transform_flags::no_variance_output_t, Op>) {
+                               transform_flags::expect_no_variance_arg_t<0>,
+                               Op>) {
         auto b_var = b.variances();
         transform_in_place_impl(op, a_val, ValuesAndVariances{b_val, b_var});
       } else {

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -223,6 +223,7 @@ struct element_type<ValuesAndVariances<const sparse_container<T>>> {
 /// This helper allows the use of a common transform implementation when mixing
 /// sparse and non-sparse data.
 template <class T> struct broadcast {
+  using value_type = std::remove_const_t<T>;
   constexpr auto operator[](const scipp::index) const noexcept { return value; }
   constexpr auto data() const noexcept { return *this; }
   T value;
@@ -472,7 +473,8 @@ template <bool dry_run> struct in_place {
     // For sparse data we can fail for any subitem if the sizes to not match. To
     // avoid partially modifying (and thus corrupting) data in an in-place
     // operation we need to do the checks before any modification happens.
-    if constexpr (is_sparse_v<typename std::decay_t<T>::value_type>) {
+    if constexpr (is_sparse_v<typename std::decay_t<T>::value_type> ||
+                  (is_sparse_v<typename std::decay_t<Ts>::value_type> || ...)) {
       for (auto i = indices; std::get<0>(i) != end; iter::increment(i)) {
         call_in_place(
             [](auto &&... args) {

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -67,6 +67,9 @@ template <int N> static constexpr auto expect_no_variance_arg = []() {};
 template <int N>
 using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 
+template <int N> static constexpr auto expect_variance_arg = []() {};
+template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
+
 } // namespace transform_flags
 
 } // namespace scipp::core

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -62,10 +62,7 @@ static constexpr auto dimensionless_unit_check_return =
 
 namespace transform_flags {
 /// Add this to overloaded operator to indicate that the operation does not
-/// produce output with variances, even if the inputs contain variances.
-static constexpr auto no_variance_output = []() {};
-using no_variance_output_t = decltype(no_variance_output);
-
+/// support variances in the specified argument.
 template <int N> static constexpr auto expect_no_variance_arg = []() {};
 template <int N>
 using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -60,6 +60,9 @@ static constexpr auto dimensionless_unit_check_return =
       return aUnit;
     };
 
+/// Flags for transform, added as overloads to the operator. These are never
+/// actually called since flag presence is checked via the base class of the
+/// operator.
 namespace transform_flags {
 /// Add this to overloaded operator to indicate that the operation does not
 /// support variances in the specified argument.
@@ -67,6 +70,8 @@ template <int N> static constexpr auto expect_no_variance_arg = []() {};
 template <int N>
 using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 
+/// Add this to overloaded operator to indicate that the operation requires
+/// variances in the specified argument.
 template <int N> static constexpr auto expect_variance_arg = []() {};
 template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
 

--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_TRANSFORM_RESIZE_H
+#define SCIPP_CORE_TRANSFORM_RESIZE_H
+
+#include "scipp/core/subspan_view.h"
+#include "scipp/core/transform.h"
+
+namespace scipp::core {
+
+template <class Types, class Op>
+[[nodiscard]] Variable transform_subspan(const Dim dim, const scipp::index size,
+                                         VariableConstProxy var1,
+                                         VariableConstProxy var2, Op op) {
+  auto dims1 = var1.dims();
+  auto dims2 = var2.dims();
+  dims1.erase(dim);
+  dims2.erase(dim);
+  auto dims = merge(dims1, dims2);
+  dims.addInner(dim, size);
+
+  // This will cause failure below unless the output type (first type in inner
+  // tuple) is the same in all inner tuples.
+  using OutT =
+      typename std::tuple_element_t<0,
+                                    std::tuple_element_t<0, Types>>::value_type;
+  Variable out =
+      std::is_base_of_v<transform_flags::expect_variance_arg_t<0>, Op>
+          ? makeVariableWithVariances<OutT>(dims)
+          : makeVariable<OutT>(dims);
+
+  Variable var1_subspans;
+  Variable var2_subspans;
+  if (!var1.dims().sparse()) {
+    var1_subspans = subspan_view(var1, dim);
+    var1 = VariableConstProxy(var1_subspans);
+  }
+  if (!var2.dims().sparse()) {
+    var2_subspans = subspan_view(var2, dim);
+    var2 = VariableConstProxy(var2_subspans);
+  }
+
+  out.setUnit(op(var1.unit(), var2.unit()));
+  in_place<false>::transform_data(Types{}, op, subspan_view(out, dim), var1,
+                                  var2);
+  return out;
+}
+
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_TRANSFORM_RESIZE_H

--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -2,14 +2,34 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef SCIPP_CORE_TRANSFORM_RESIZE_H
-#define SCIPP_CORE_TRANSFORM_RESIZE_H
+#ifndef SCIPP_CORE_TRANSFORM_SUBSPAN_H
+#define SCIPP_CORE_TRANSFORM_SUBSPAN_H
 
 #include "scipp/core/subspan_view.h"
 #include "scipp/core/transform.h"
 
 namespace scipp::core {
 
+/// Non-element-wise transform.
+///
+/// This is a specialized version of transform, handling the case of inputs (and
+/// output) that differ along one of their dimensions. Applications are mixing
+/// of sparse and dense data, as well as operations that change the length of a
+/// dimension (such as rebin). The syntax for the user-provided operator is
+/// special and differs from that of `transform` and `transform_in_place`, and
+/// also the tuple of supported type combinations is special:
+/// 1. The overload for the transform of the unit is as for `transform`, i.e.,
+///    returns the new unit.
+/// 2. The overload handling the data has one extra argument. This additional
+///    (first) argument is the "out" argument, as used in `transform_in_place`.
+/// 3. The tuple of supported type combinations must include the type of the out
+///    argument as the first type in the inner tuples. Currently all supported
+///    combinations must have the same output type.
+/// 4. The output type and the type of non-sparse inputs that depend on `dim`
+///    must be specified as `span<T>`. The user-provided lambda is called with a
+///    span of values for these arguments.
+/// 5. Use the flag transform_flags::expect_variance_arg<0> to control whether
+///    the output should have variances or not.
 template <class Types, class Op>
 [[nodiscard]] Variable transform_subspan(const Dim dim, const scipp::index size,
                                          VariableConstProxy var1,
@@ -50,4 +70,4 @@ template <class Types, class Op>
 
 } // namespace scipp::core
 
-#endif // SCIPP_CORE_TRANSFORM_RESIZE_H
+#endif // SCIPP_CORE_TRANSFORM_SUBSPAN_H

--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -85,6 +85,15 @@ template <class Types, class Op>
       return transform_subspan_impl<Types>(dim, size, op, var1, var2);
     }
 
+template <class Types, class Op>
+[[nodiscard]] Variable
+    transform_subspan(const Dim dim, const scipp::index size,
+                      const VariableConstProxy &var1,
+                      const VariableConstProxy &var2,
+                      const VariableConstProxy &var3, Op op) {
+      return transform_subspan_impl<Types>(dim, size, op, var1, var2, var3);
+    }
+
 } // namespace scipp::core
 
 #endif // SCIPP_CORE_TRANSFORM_SUBSPAN_H

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -139,3 +139,32 @@ TEST(DataArraySparseArithmeticTest, sparse_over_histogram) {
                      expected.slice({Dim::X, 0, 3}).variances<double>()));
   EXPECT_TRUE(std::isnan(out_vars[1][3]));
 }
+
+TEST(DataArraySparseArithmeticTest, consistency_with_histogram) {
+  // Apart from uncertainties, the order of operations does not matter. We can
+  // either first multiply and then histogram, or first histogram and then
+  // multiply.
+  const auto sparse = make_sparse();
+  auto edges = makeVariable<double>({Dim::X, 4}, units::us, {1, 2, 3, 4});
+  auto data =
+      makeVariable<double>({Dim::X, 3}, {2.0, 3.0, 4.0}, {0.3, 0.4, 0.5});
+
+  auto hist = DataArray(data, {{Dim::X, edges}});
+  auto bins = hist.coords()[Dim::X];
+  auto ab = histogram(sparse * hist, bins);
+  auto ba = histogram(sparse, bins) * hist;
+
+  // Case 1: 1 event per bin => uncertainties are the same
+  EXPECT_EQ(ab, ba);
+
+  hist = make_histogram();
+  bins = hist.coords()[Dim::X];
+  ab = histogram(sparse * hist, bins);
+  ba = histogram(sparse, bins) * hist;
+
+  // Case 2: Multiple events per bin => uncertainties differ, set to 0 before
+  // comparison.
+  ab.setVariances(Vector<double>(4));
+  ba.setVariances(Vector<double>(4));
+  EXPECT_EQ(ab, ba);
+}

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -87,9 +87,7 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram) {
   }
 }
 
-// TODO Disabled since implementation not available yet.
-TEST(DataArraySparseArithmeticTest,
-     DISABLED_sparse_with_values_times_histogram) {
+TEST(DataArraySparseArithmeticTest, sparse_with_values_times_histogram) {
   auto sparse = make_sparse();
   const auto hist = make_histogram();
   Variable data(sparse.coords()[Dim::X]);

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -87,7 +87,9 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram) {
   }
 }
 
-TEST(DataArraySparseArithmeticTest, sparse_with_values_times_histogram) {
+// TODO Disabled since implementation not available yet.
+TEST(DataArraySparseArithmeticTest,
+     DISABLED_sparse_with_values_times_histogram) {
   auto sparse = make_sparse();
   const auto hist = make_histogram();
   Variable data(sparse.coords()[Dim::X]);

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -151,8 +151,7 @@ Variable counts(const VariableConstProxy &var) {
       pair_custom_t<std::pair<scipp::index, sparse_container<double>>>>(
       counts, var,
       overloaded{[](scipp::index &c, const auto &sparse) { c = sparse.size(); },
-                 transform_flags::expect_no_variance_arg<0>,
-                 transform_flags::no_variance_output});
+                 transform_flags::expect_no_variance_arg<0>});
   return counts;
 }
 


### PR DESCRIPTION

- Fixes #662.
- Fix some bugs in operations between sparse data and histogram.
- Refactor histogram code to be more generic.
- Add support for weights (sparse data with values) in histogram.

The refactor causes a moderate performance decrease (my guess is because the bin edge are not checked multiple times, or due to allocation when creating the `subspan` variable). This could be avoided in principle, but I suggest to postpone this, since it would add more code.