### PR TITLE
TypeError can take Variables to show specific types in error message

### DIFF
--- a/core/include/scipp/core/apply.h
+++ b/core/include/scipp/core/apply.h
@@ -18,7 +18,8 @@ void apply_in_place(Op op, Var &&var, const Vars &... vars) {
     scipp::core::visit_impl<Ts...>::apply(op, var.dataHandle(),
                                           vars.dataHandle()...);
   } catch (const std::bad_variant_access &) {
-    throw except::TypeError("");
+    throw except::TypeError("Cannot apply operation to item dtypes: ", var,
+                            vars...);
   }
 }
 

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef EXCEPT_H
-#define EXCEPT_H
+#ifndef SCIPP_CORE_EXCEPT_H
+#define SCIPP_CORE_EXCEPT_H
 
 #include <stdexcept>
 #include <string>
@@ -33,6 +33,10 @@ namespace scipp::except {
 
 struct SCIPP_CORE_EXPORT TypeError : public std::runtime_error {
   using std::runtime_error::runtime_error;
+
+  template <class... Vars>
+  TypeError(const std::string &msg, const Vars &... vars)
+      : std::runtime_error(msg + ((to_string(vars.dtype()) + ' ') + ...)) {}
 };
 
 using DataArrayError = Error<core::DataArray>;
@@ -164,4 +168,4 @@ template <class T> void hasVariances(const T &variable) {
 
 } // namespace scipp::core::expect
 
-#endif // EXCEPT_H
+#endif // SCIPP_CORE_EXCEPT_H

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -661,10 +661,8 @@ template <bool dry_run> struct in_place {
                    var.dataHandle(), other.dataHandle()...);
       }
     } catch (const std::bad_variant_access &) {
-      throw except::TypeError("Cannot apply operation to item dtypes " +
-                              [](auto &&... v) {
-                                return ((to_string(v.dtype()) + ' ') + ...);
-                              }(var, other...));
+      throw except::TypeError("Cannot apply operation to item dtypes ", var,
+                              other...);
     }
   }
   template <class... Ts, class Op, class Var, class... Other>
@@ -753,8 +751,7 @@ Variable transform(std::tuple<Ts...> &&, Op op, const Vars &... vars) {
                        vars.dataHandle()...);
     }
   } catch (const std::bad_variant_access &) {
-    throw except::TypeError("Cannot apply operation to item dtypes " +
-                            ((to_string(vars.dtype()) + ' ') + ...));
+    throw except::TypeError("Cannot apply operation to item dtypes ", vars...);
   }
   out.setUnit(unit);
   return out;


### PR DESCRIPTION
Adds 2 constructors to TypeError that take a Variable arg pack, or a single Variable and a Variable arg pack. The types are then appended to the error message