### PR TITLE
to_string now shows data attributes

### DIFF
--- a/core/string.cpp
+++ b/core/string.cpp
@@ -209,6 +209,12 @@ auto format_data_proxy(const Key &name, const DataConstProxy &data,
                                std::string(label_name),
                            labels, datasetDims);
     }
+
+  if (!data.attrs().empty()) {
+    s << tab << "Attributes:\n";
+    for (const auto &[attr_name, var] : data.attrs())
+      s << tab << tab << format_variable(attr_name, var, datasetDims);
+  }
   return s.str();
 }
 


### PR DESCRIPTION
`to_string` will now show attributes attached to data.

```
Dataset ds;
ds.setData("a", makeVariable<double>({Dim::X, 2}, {0.1, 0.2}));
ds.setAttr("a", "scalar", makeVariable<double>(1.2));

std::cout << to_string(ds);
```
will now show the "scalar" attribute.
```
<scipp.Dataset>
Dimensions: {{Dim.X, 2}}
Data:
    a                         double     [dimensionless]  (Dim.X)  [0.100000, 0.200000]
    Attributes:
            scalar                    double     [dimensionless]  ()  [1.200000]
    b                         double     [dimensionless]  (Dim.X)  [1.000000, 2.000000]
    c                         double     [dimensionless]  (Dim.X)  [5.000000, 6.000000]  [1.000000, 1.000000]
```
Previously the "scalar" attribute was hidden, which is an issue for debugging - `EXPECT_EQ` would fail on seemingly the same datasets.

Note the formatting is not ideal. I'm open to suggestions on making it more readable.