### PR TITLE
Adjusted Eigen source URL

### DIFF
--- a/CMake/Eigen.in
+++ b/CMake/Eigen.in
@@ -4,8 +4,8 @@ project(Eigen-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(Eigen
-  URL               https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
-  URL_HASH          MD5=f2a417d083fe8ca4b8ed2bc613d20f07
+  URL               https://github.com/eigenteam/eigen-git-mirror/archive/3.3.7.tar.gz
+  URL_HASH          MD5=77a2c934eaf35943c43ee600a83b72df
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/Eigen-src"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""


### PR DESCRIPTION
Similar change to https://github.com/mantidproject/mantid/pull/27545/files

Apparently this is not the final URL of the migration. So this will break soon too, but it will fix the cmake configure until then