### PR TITLE
Support a wider range of Mantid units

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -19,12 +19,12 @@ def make_sample(ws):
     return sc.Variable(value=deepcopy(ws.sample()))
 
 
-def make_bin_masks(common_bins, dim, num_bins, num_spectra):
+def make_bin_masks(common_bins, spec_dim, dim, num_bins, num_spectra):
     if common_bins:
         return sc.Variable([dim], shape=(num_bins,),
                            dtype=sc.dtype.bool)
     else:
-        return sc.Variable([sc.Dim.Spectrum, dim],
+        return sc.Variable([spec_dim, dim],
                            shape=(num_spectra, num_bins),
                            dtype=sc.dtype.bool)
 
@@ -82,10 +82,30 @@ def make_detector_info(ws):
                                         labels={'spectrum': spectrum}))
 
 
-def init_pos_spectrum_no(ws):
+def validate_and_get_unit(unit):
+    known_units = {
+        "DeltaE": [sc.Dim.EnergyTransfer, sc.units.meV],
+        "TOF": [sc.Dim.Tof, sc.units.us],
+        "Wavelength": [sc.Dim.Wavelength, sc.units.angstrom],
+        "Energy": [sc.Dim.Energy, sc.units.meV],
+        "dSpacing": [sc.Dim.DSpacing, sc.units.angstrom],
+        "MomentumTransfer": [sc.Dim.Q, sc.units.dimensionless / sc.units.angstrom],
+        "QSquared": [sc.Dim.QSquared, sc.units.dimensionless / (sc.units.angstrom * sc.units.angstrom)],
+        "Label": [sc.Dim.Spectrum, sc.units.dimensionless],
+    }
+
+    if unit not in known_units.keys():
+        raise RuntimeError("X-axis unit not currently supported."
+                           "Possible values are: {}, "
+                           "got '{}'. ".format(
+                               [k for k in known_units.keys()], unit))
+    else:
+        return known_units[unit]
+
+
+def init_pos(ws):
     nHist = ws.getNumberHistograms()
     pos = np.zeros([nHist, 3])
-    num = np.zeros([nHist], dtype=np.int32)
 
     spec_info = ws.spectrumInfo()
     for i in range(nHist):
@@ -94,11 +114,14 @@ def init_pos_spectrum_no(ws):
             pos[i, :] = [p.X(), p.Y(), p.Z()]
         else:
             pos[i, :] = [np.nan, np.nan, np.nan]
-        num[i] = ws.getSpectrum(i).getSpectrumNo()
-    pos = sc.Variable([sc.Dim.Spectrum], values=pos, unit=sc.units.m,
-                      dtype=sc.dtype.vector_3_double)
-    num = sc.Variable([sc.Dim.Spectrum], values=num)
-    return pos, num
+    return sc.Variable([sc.Dim.Spectrum], values=pos, unit=sc.units.m,
+                       dtype=sc.dtype.vector_3_double)
+
+
+def init_spec_axis(ws):
+    axis = ws.getAxis(1)
+    dim, unit = validate_and_get_unit(axis.getUnit().unitID())
+    return dim, sc.Variable([dim], values=axis.extractValues(), unit=unit)
 
 
 def set_common_bins_masks(bin_masks, dim, masked_bins):
@@ -115,40 +138,27 @@ def convert_Workspace2D_to_dataarray(ws):
     common_bins = ws.isCommonBins()
     comp_info = make_component_info(ws)
     det_info = make_detector_info(ws)
-    pos, num = init_pos_spectrum_no(ws)
-
-    # TODO More cases?
-    allowed_units = {
-        "DeltaE": [sc.Dim.EnergyTransfer, sc.units.meV],
-        "TOF": [sc.Dim.Tof, sc.units.us],
-        "Wavelength": [sc.Dim.Wavelength, sc.units.angstrom]
-    }
-    xunit = ws.getAxis(0).getUnit().unitID()
-    if xunit not in allowed_units.keys():
-        raise RuntimeError("X-axis unit not currently supported for "
-                           "Workspace2D. Possible values are: {}, "
-                           "got '{}'. ".format(
-                               [k for k in allowed_units.keys()], xunit))
-    else:
-        [dim, unit] = allowed_units[xunit]
+    pos = init_pos(ws)
+    dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit().unitID())
+    spec_dim, spec_coord = init_spec_axis(ws)
 
     if common_bins:
         coord = sc.Variable([dim], values=ws.readX(0), unit=unit)
     else:
-        coord = sc.Variable([sc.Dim.Spectrum, dim],
+        coord = sc.Variable([spec_dim, dim],
                             shape=(ws.getNumberHistograms(), len(ws.readX(0))),
                             unit=unit)
         for i in range(ws.getNumberHistograms()):
-            coord[sc.Dim.Spectrum, i].values = ws.readX(i)
+            coord[spec_dim, i].values = ws.readX(i)
 
     # TODO Use unit information in workspace, if available.
-    array = sc.DataArray(data=sc.Variable([sc.Dim.Spectrum, dim],
+    array = sc.DataArray(data=sc.Variable([spec_dim, dim],
                                           shape=(ws.getNumberHistograms(),
                                                  len(ws.readY(0))),
                                           unit=sc.units.counts,
                                           variances=True),
                          coords={dim: coord,
-                                 sc.Dim.Spectrum: num
+                                 spec_dim: spec_coord
                                  },
                          labels={"position": pos,
                                  "component_info": comp_info,
@@ -162,13 +172,13 @@ def convert_Workspace2D_to_dataarray(ws):
     spectrum_masks = None
     if ws.detectorInfo().hasMaskedDetectors():
         array.masks["spectrum"] = sc.Variable(
-            [sc.Dim.Spectrum],
+            [spec_dim],
             shape=(ws.getNumberHistograms(),),
             dtype=sc.dtype.bool)
         spectrum_masks = array.masks["spectrum"]
 
     if ws.hasAnyMaskedBins():
-        array.masks["bin"] = make_bin_masks(common_bins, dim,
+        array.masks["bin"] = make_bin_masks(common_bins, spec_dim, dim,
                                             ws.blocksize(),
                                             ws.getNumberHistograms())
         bin_masks = array.masks["bin"]
@@ -179,11 +189,11 @@ def convert_Workspace2D_to_dataarray(ws):
     data = array.data
     spectrum_info = ws.spectrumInfo()
     for i in range(ws.getNumberHistograms()):
-        data[sc.Dim.Spectrum, i].values = ws.readY(i)
-        data[sc.Dim.Spectrum, i].variances = np.power(ws.readE(i), 2)
+        data[spec_dim, i].values = ws.readY(i)
+        data[spec_dim, i].variances = np.power(ws.readE(i), 2)
 
         if spectrum_masks:
-            spectrum_masks[sc.Dim.Spectrum,
+            spectrum_masks[spec_dim,
                            i].value = spectrum_info.isMasked(i)
 
         if not common_bins and ws.hasMaskedBins(i):
@@ -194,27 +204,19 @@ def convert_Workspace2D_to_dataarray(ws):
 
 def convertEventWorkspace_to_dataarray(ws, load_pulse_times):
     from mantid.api import EventType
-    allowed_units = {"TOF": [sc.Dim.Tof, sc.units.us]}
-    xunit = ws.getAxis(0).getUnit().unitID()
-    if xunit not in allowed_units.keys():
-        raise RuntimeError("X-axis unit not currently supported for "
-                           "EventWorkspace. Possible values are: {}, "
-                           "got '{}'. ".format(
-                               [k for k in allowed_units.keys()], xunit))
-    else:
-        [dim, unit] = allowed_units[xunit]
 
+    dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit().unitID())
+    spec_dim, spec_coord = init_spec_axis(ws)
     nHist = ws.getNumberHistograms()
     comp_info = make_component_info(ws)
     det_info = make_detector_info(ws)
-    pos, num = init_pos_spectrum_no(ws)
+    pos = init_pos(ws)
 
-    # TODO Use unit information in workspace, if available.
-    coord = sc.Variable([sc.Dim.Spectrum, dim],
+    coord = sc.Variable([spec_dim, dim],
                         shape=[nHist, sc.Dimensions.Sparse],
                         unit=unit)
     if load_pulse_times:
-        labs = sc.Variable([sc.Dim.Spectrum, dim],
+        labs = sc.Variable([spec_dim, dim],
                            shape=[nHist, sc.Dimensions.Sparse])
 
     # Check for weighted events
@@ -222,27 +224,27 @@ def convertEventWorkspace_to_dataarray(ws, load_pulse_times):
     contains_weighted_events = ((evtp == EventType.WEIGHTED)
                                 or (evtp == EventType.WEIGHTED_NOTIME))
     if contains_weighted_events:
-        weights = sc.Variable([sc.Dim.Spectrum, dim],
+        weights = sc.Variable([spec_dim, dim],
                               shape=[nHist, sc.Dimensions.Sparse])
 
     for i in range(nHist):
         sp = ws.getSpectrum(i)
-        coord[sc.Dim.Spectrum, i].values = sp.getTofs()
+        coord[spec_dim, i].values = sp.getTofs()
         if load_pulse_times:
             # Pulse times have a Mantid-specific format so the conversion is
             # very slow.
             # TODO: Find a more efficient way to do this.
             pt = sp.getPulseTimes()
-            labs[sc.Dim.Spectrum, i].values = np.asarray(
+            labs[spec_dim, i].values = np.asarray(
                 [p.totalNanoseconds() for p in pt])
         if contains_weighted_events:
-            weights[sc.Dim.Spectrum, i].values = sp.getWeights()
-            weights[sc.Dim.Spectrum, i].variances = sp.getWeightErrors()
+            weights[spec_dim, i].values = sp.getWeights()
+            weights[spec_dim, i].variances = sp.getWeightErrors()
 
     coords_labs_data = {
         "coords": {
             dim: coord,
-            sc.Dim.Spectrum: num
+            spec_dim: spec_coord
         },
         "labels": {
             "position": pos,
@@ -388,7 +390,7 @@ def load(filename="",
                               RewriteSpectraMap=True)
 
     dataset = None
-    if data_ws.id() == 'Workspace2D':
+    if data_ws.id() == 'Workspace2D' or data_ws.id() == 'RebinnedOutput':
         has_monitors = False
         for spec in data_ws.spectrumInfo():
             has_monitors |= spec.isMonitor

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -19,12 +19,12 @@ def make_sample(ws):
     return sc.Variable(value=deepcopy(ws.sample()))
 
 
-def make_bin_masks(common_bins, spec_dim, dim, num_bins, num_spectra):
+def make_bin_masks(common_bins, dim, num_bins, num_spectra):
     if common_bins:
         return sc.Variable([dim], shape=(num_bins,),
                            dtype=sc.dtype.bool)
     else:
-        return sc.Variable([spec_dim, dim],
+        return sc.Variable([sc.Dim.Spectrum, dim],
                            shape=(num_spectra, num_bins),
                            dtype=sc.dtype.bool)
 
@@ -82,6 +82,35 @@ def make_detector_info(ws):
                                         labels={'spectrum': spectrum}))
 
 
+def init_pos_spectrum_no(ws):
+    nHist = ws.getNumberHistograms()
+    pos = np.zeros([nHist, 3])
+    num = np.zeros([nHist], dtype=np.int32)
+
+    spec_info = ws.spectrumInfo()
+    for i in range(nHist):
+        if spec_info.hasDetectors(i):
+            p = spec_info.position(i)
+            pos[i, :] = [p.X(), p.Y(), p.Z()]
+        else:
+            pos[i, :] = [np.nan, np.nan, np.nan]
+        num[i] = ws.getSpectrum(i).getSpectrumNo()
+    pos = sc.Variable([sc.Dim.Spectrum], values=pos, unit=sc.units.m,
+                      dtype=sc.dtype.vector_3_double)
+    num = sc.Variable([sc.Dim.Spectrum], values=num)
+    return pos, num
+
+
+def set_common_bins_masks(bin_masks, dim, masked_bins):
+    for masked_bin in masked_bins:
+        bin_masks[dim, masked_bin].value = True
+
+
+def set_bin_masks(bin_masks, dim, index, masked_bins):
+    for masked_bin in masked_bins:
+        bin_masks[sc.Dim.Spectrum, index][dim, masked_bin].value = True
+
+
 def validate_and_get_unit(unit):
     known_units = {
         "DeltaE": [sc.Dim.EnergyTransfer, sc.units.meV],
@@ -103,44 +132,14 @@ def validate_and_get_unit(unit):
         return known_units[unit]
 
 
-def init_pos(ws):
-    nHist = ws.getNumberHistograms()
-    pos = np.zeros([nHist, 3])
-
-    spec_info = ws.spectrumInfo()
-    for i in range(nHist):
-        if spec_info.hasDetectors(i):
-            p = spec_info.position(i)
-            pos[i, :] = [p.X(), p.Y(), p.Z()]
-        else:
-            pos[i, :] = [np.nan, np.nan, np.nan]
-    return sc.Variable([sc.Dim.Spectrum], values=pos, unit=sc.units.m,
-                       dtype=sc.dtype.vector_3_double)
-
-
-def init_spec_axis(ws):
-    axis = ws.getAxis(1)
-    dim, unit = validate_and_get_unit(axis.getUnit().unitID())
-    return dim, sc.Variable([dim], values=axis.extractValues(), unit=unit)
-
-
-def set_common_bins_masks(bin_masks, dim, masked_bins):
-    for masked_bin in masked_bins:
-        bin_masks[dim, masked_bin].value = True
-
-
-def set_bin_masks(bin_masks, dim, index, masked_bins):
-    for masked_bin in masked_bins:
-        bin_masks[sc.Dim.Spectrum, index][dim, masked_bin].value = True
-
-
 def convert_Workspace2D_to_dataarray(ws):
     common_bins = ws.isCommonBins()
     comp_info = make_component_info(ws)
     det_info = make_detector_info(ws)
-    pos = init_pos(ws)
+    pos, num = init_pos_spectrum_no(ws)
+
     dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit().unitID())
-    spec_dim, spec_coord = init_spec_axis(ws)
+    spec_dim, _ = validate_and_get_unit(ws.getAxis(1).getUnit().unitID())
 
     if common_bins:
         coord = sc.Variable([dim], values=ws.readX(0), unit=unit)
@@ -149,7 +148,7 @@ def convert_Workspace2D_to_dataarray(ws):
                             shape=(ws.getNumberHistograms(), len(ws.readX(0))),
                             unit=unit)
         for i in range(ws.getNumberHistograms()):
-            coord[spec_dim, i].values = ws.readX(i)
+            coord[sc.Dim.Spectrum, i].values = ws.readX(i)
 
     # TODO Use unit information in workspace, if available.
     array = sc.DataArray(data=sc.Variable([spec_dim, dim],
@@ -158,7 +157,7 @@ def convert_Workspace2D_to_dataarray(ws):
                                           unit=sc.units.counts,
                                           variances=True),
                          coords={dim: coord,
-                                 spec_dim: spec_coord
+                                 spec_dim: num
                                  },
                          labels={"position": pos,
                                  "component_info": comp_info,
@@ -172,13 +171,13 @@ def convert_Workspace2D_to_dataarray(ws):
     spectrum_masks = None
     if ws.detectorInfo().hasMaskedDetectors():
         array.masks["spectrum"] = sc.Variable(
-            [spec_dim],
+            [sc.Dim.Spectrum],
             shape=(ws.getNumberHistograms(),),
             dtype=sc.dtype.bool)
         spectrum_masks = array.masks["spectrum"]
 
     if ws.hasAnyMaskedBins():
-        array.masks["bin"] = make_bin_masks(common_bins, spec_dim, dim,
+        array.masks["bin"] = make_bin_masks(common_bins, dim,
                                             ws.blocksize(),
                                             ws.getNumberHistograms())
         bin_masks = array.masks["bin"]
@@ -189,11 +188,11 @@ def convert_Workspace2D_to_dataarray(ws):
     data = array.data
     spectrum_info = ws.spectrumInfo()
     for i in range(ws.getNumberHistograms()):
-        data[spec_dim, i].values = ws.readY(i)
-        data[spec_dim, i].variances = np.power(ws.readE(i), 2)
+        data[sc.Dim.Spectrum, i].values = ws.readY(i)
+        data[sc.Dim.Spectrum, i].variances = np.power(ws.readE(i), 2)
 
         if spectrum_masks:
-            spectrum_masks[spec_dim,
+            spectrum_masks[sc.Dim.Spectrum,
                            i].value = spectrum_info.isMasked(i)
 
         if not common_bins and ws.hasMaskedBins(i):
@@ -206,17 +205,18 @@ def convertEventWorkspace_to_dataarray(ws, load_pulse_times):
     from mantid.api import EventType
 
     dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit().unitID())
-    spec_dim, spec_coord = init_spec_axis(ws)
+    spec_dim, _ = validate_and_get_unit(ws.getAxis(1).getUnit().unitID())
+
     nHist = ws.getNumberHistograms()
     comp_info = make_component_info(ws)
     det_info = make_detector_info(ws)
-    pos = init_pos(ws)
+    pos, num = init_pos_spectrum_no(ws)
 
     coord = sc.Variable([spec_dim, dim],
                         shape=[nHist, sc.Dimensions.Sparse],
                         unit=unit)
     if load_pulse_times:
-        labs = sc.Variable([spec_dim, dim],
+        labs = sc.Variable([sc.Dim.Spectrum, dim],
                            shape=[nHist, sc.Dimensions.Sparse])
 
     # Check for weighted events
@@ -224,27 +224,27 @@ def convertEventWorkspace_to_dataarray(ws, load_pulse_times):
     contains_weighted_events = ((evtp == EventType.WEIGHTED)
                                 or (evtp == EventType.WEIGHTED_NOTIME))
     if contains_weighted_events:
-        weights = sc.Variable([spec_dim, dim],
+        weights = sc.Variable([sc.Dim.Spectrum, dim],
                               shape=[nHist, sc.Dimensions.Sparse])
 
     for i in range(nHist):
         sp = ws.getSpectrum(i)
-        coord[spec_dim, i].values = sp.getTofs()
+        coord[sc.Dim.Spectrum, i].values = sp.getTofs()
         if load_pulse_times:
             # Pulse times have a Mantid-specific format so the conversion is
             # very slow.
             # TODO: Find a more efficient way to do this.
             pt = sp.getPulseTimes()
-            labs[spec_dim, i].values = np.asarray(
+            labs[sc.Dim.Spectrum, i].values = np.asarray(
                 [p.totalNanoseconds() for p in pt])
         if contains_weighted_events:
-            weights[spec_dim, i].values = sp.getWeights()
-            weights[spec_dim, i].variances = sp.getWeightErrors()
+            weights[sc.Dim.Spectrum, i].values = sp.getWeights()
+            weights[sc.Dim.Spectrum, i].variances = sp.getWeightErrors()
 
     coords_labs_data = {
         "coords": {
             dim: coord,
-            spec_dim: spec_coord
+            sc.Dim.Spectrum: num
         },
         "labels": {
             "position": pos,
@@ -390,7 +390,7 @@ def load(filename="",
                               RewriteSpectraMap=True)
 
     dataset = None
-    if data_ws.id() == 'Workspace2D' or data_ws.id() == 'RebinnedOutput':
+    if data_ws.id() == 'Workspace2D':
         has_monitors = False
         for spec in data_ws.spectrumInfo():
             has_monitors |= spec.isMonitor

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -97,7 +97,7 @@ def validate_and_get_unit(unit):
     }
 
     if unit not in known_units.keys():
-        raise RuntimeError("X-axis unit not currently supported."
+        raise RuntimeError("Axis unit not currently supported."
                            "Possible values are: {}, "
                            "got '{}'. ".format(
                                [k for k in known_units.keys()], unit))

--- a/python/tests/compat/mantid_data_helper.py
+++ b/python/tests/compat/mantid_data_helper.py
@@ -14,6 +14,9 @@ class MantidDataHelper:
         "CNCS_51936_event.nxs": {
             "hash": "5ba401e489260a44374b5be12b780911",
             "algorithm": "MD5"},
+        "iris26176_graphite002_sqw.nxs": {
+            "hash": "7ea63f9137602b7e9b604fe30f0c6ec2",
+            "algorithm": "MD5"},
         "WISH00016748.raw": {
             "hash": "37ecc6f99662b57e405ed967bdc068af",
             "algorithm": "MD5"},

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -172,6 +172,12 @@ class TestMantidConversion(unittest.TestCase):
         assert isinstance(monitors, sc.DataArray)
         assert monitors.shape == [2, 200001]
 
+    def test_Workspace2D_with_specific_axis_units(self):
+        filename = MantidDataHelper.find_file("iris26176_graphite002_sqw.nxs")
+        ds = mantidcompat.load(filename)
+        assert ds.shape == [23, 200]
+        assert ds.dims == [sc.Dim.Q, sc.Dim.EnergyTransfer]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -144,9 +144,9 @@ public:
 };
 
 SCIPP_UNITS_DECLARE_DIMENSIONS(Detector, DSpacing, Energy, EnergyTransfer,
-                               Position, Q, Qx, Qy, Qz, Row, ScatteringAngle,
-                               Spectrum, Temperature, Time, Tof, Wavelength, X,
-                               Y, Z)
+                               Position, Q, QSquared, Qx, Qy, Qz, Row,
+                               ScatteringAngle, Spectrum, Temperature, Time,
+                               Tof, Wavelength, X, Y, Z)
 
 } // namespace neutron
 
@@ -160,7 +160,9 @@ template <> struct supported_units<neutron::Unit> {
           meV *us *us *dimensionless, kg *m / s, m / s, c, c *m, meV / c,
           dimensionless / c, K, us / angstrom, us / (angstrom * angstrom),
           us / (m * angstrom), angstrom / us, (m * angstrom) / us, us *us,
-          dimensionless / (us * us), dimensionless / meV)));
+          dimensionless / (us * us), dimensionless / meV,
+          dimensionless / angstrom, angstrom *angstrom,
+          dimensionless / (angstrom * angstrom))));
 };
 template <> struct counts_unit<neutron::Unit> {
   using type = decltype(counts);


### PR DESCRIPTION
Supports (almost) the full range of Mantid units for X and spectrum axes.

Unfortunately the same cannot easily be done for the Y axis as Mantid is somewhat inconsistent with Y units (e.g. after rebinning the Y axis is intensity/undefined rather than counts).