### PR TITLE
Refactoring 6

### DIFF
--- a/benchmark/dataset_operations_benchmark.cpp
+++ b/benchmark/dataset_operations_benchmark.cpp
@@ -40,10 +40,10 @@ struct Generate {
     Dataset d;
     d.setData("a", makeData<double>({Dim::X, axisLength}));
     for (int i = 0; i < num_masks; ++i) {
+      auto bools = makeBools<BoolsGeneratorType::ALTERNATING>(axisLength);
       d.setMask(std::string(1, ('a' + i)),
-                makeVariable<bool>({Dim::X, axisLength},
-                                   makeBools<BoolsGeneratorType::ALTERNATING>(
-                                       axisLength)) /*LABEL_1*/);
+                createVariable<bool>(Dims{Dim::X}, Shape{axisLength},
+                                     Values(bools.begin(), bools.end())));
     }
     return d;
   }
@@ -54,11 +54,13 @@ struct Generate_2D_data {
     Dataset d;
     d.setData("a",
               makeData<double>({{Dim::X, axisLength}, {Dim::Y, axisLength}}));
+    auto bools =
+        makeBools<BoolsGeneratorType::ALTERNATING>(axisLength * axisLength);
     for (int i = 0; i < num_masks; ++i) {
       d.setMask(std::string(1, ('a' + i)),
-                makeVariable<bool>({{Dim::X, axisLength}, {Dim::Y, axisLength}},
-                                   makeBools<BoolsGeneratorType::ALTERNATING>(
-                                       axisLength * axisLength)) /*LABEL_1*/);
+                createVariable<bool>(Dims{Dim::X, Dim::Y},
+                                     Shape{axisLength, axisLength},
+                                     Values(bools.begin(), bools.end())));
     }
     return d;
   }
@@ -70,14 +72,13 @@ struct Generate_3D_data {
     d.setData("a", makeData<double>({{Dim::X, axisLength},
                                      {Dim::Y, axisLength},
                                      {Dim::Z, axisLength}}));
+    auto bools = makeBools<BoolsGeneratorType::ALTERNATING>(
+        axisLength * axisLength * axisLength);
     for (int i = 0; i < num_masks; ++i) {
       d.setMask(std::string(1, ('a' + i)),
-                makeVariable<bool>(
-                    {{Dim::X, axisLength},
-                     {Dim::Y, axisLength},
-                     {Dim::Z, axisLength}},
-                    makeBools<BoolsGeneratorType::ALTERNATING>(
-                        axisLength * axisLength * axisLength)) /*LABEL_1*/);
+                createVariable<bool>(Dims{Dim::X, Dim::Y, Dim::Z},
+                                     Shape{axisLength, axisLength, axisLength},
+                                     Values(bools.begin(), bools.end())));
     }
     return d;
   }

--- a/benchmark/groupby_benchmark.cpp
+++ b/benchmark/groupby_benchmark.cpp
@@ -12,7 +12,8 @@ using namespace scipp::core;
 
 auto make_2d_sparse_coord_only(const scipp::index size,
                                const scipp::index count) {
-  auto var = makeVariable<double>({Dim::X, Dim::Y}, {size, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                    Shape{size, Dimensions::Sparse});
   auto vals = var.sparseValues<double>();
   for (scipp::index i = 0; i < size; ++i)
     vals[i].resize(count);

--- a/benchmark/histogram_benchmark.cpp
+++ b/benchmark/histogram_benchmark.cpp
@@ -14,7 +14,8 @@ using namespace scipp::core;
 
 auto make_2d_sparse_coord_only(const scipp::index size,
                                const scipp::index count) {
-  auto var = makeVariable<double>({Dim::X, Dim::Y}, {size, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                    Shape{size, Dimensions::Sparse});
   auto vals = var.sparseValues<double>();
   Random rand(0.0, 1000.0);
   for (scipp::index i = 0; i < size; ++i) {

--- a/benchmark/neutron_convert_benchmark.cpp
+++ b/benchmark/neutron_convert_benchmark.cpp
@@ -19,7 +19,8 @@ auto make_beamline(const scipp::index size) {
                          Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
                          Values{Eigen::Vector3d{0.0, 0.0, -10.0},
                                 Eigen::Vector3d{0.0, 0.0, 0.0}}));
-  beamline.setLabels("component_info", makeVariable<Dataset>(components));
+  beamline.setLabels("component_info",
+                     createVariable<Dataset>(Values{components}));
   beamline.setLabels(
       "position", createVariable<Eigen::Vector3d>(
                       Dims{Dim::Spectrum}, Shape{size}, units::Unit(units::m)));
@@ -28,8 +29,8 @@ auto make_beamline(const scipp::index size) {
 
 auto make_sparse_coord_only(const scipp::index size, const scipp::index count) {
   auto out = make_beamline(size);
-  auto var = makeVariable<double>({Dim::Spectrum, Dim::Tof},
-                                  {size, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Spectrum, Dim::Tof},
+                                    Shape{size, Dimensions::Sparse});
   auto vals = var.sparseValues<double>();
   for (scipp::index i = 0; i < size; ++i)
     vals[i].resize(count, 5000.0);

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -41,7 +41,7 @@ template <class T> T GroupBy<T>::flatten(const Dim reductionDim) const {
       flatten_impl(out_.coords()[sparseDim], array.coords()[sparseDim]);
       if (in.hasData())
         flatten_impl(out_.data(), array.data());
-      for (auto &&[label_name, label] : out_.labels()) {
+      for (auto && [ label_name, label ] : out_.labels()) {
         if (label.dims().sparse())
           flatten_impl(label, array.labels()[label_name]);
       }
@@ -51,7 +51,7 @@ template <class T> T GroupBy<T>::flatten(const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto &[name, item] : m_data)
+      for (const auto & [ name, item ] : m_data)
         apply(out_slice[name], item, group);
     } else {
       apply(out_slice, m_data, group);
@@ -86,7 +86,7 @@ template <class T> T GroupBy<T>::sum(const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto &[name, item] : m_data) {
+      for (const auto & [ name, item ] : m_data) {
         const auto out_data = out_slice[name].data();
         sum_impl(out_data, item, groups()[group], reductionDim);
       }
@@ -125,7 +125,7 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
 
   // 3. sum/N -> mean
   if constexpr (std::is_same_v<T, Dataset>) {
-    for (const auto &[name, item] : out) {
+    for (const auto & [ name, item ] : out) {
       if (isInt(item.data().dtype()))
         out.setData(name, item.data() * scale);
       else
@@ -172,7 +172,8 @@ template <class T> struct MakeGroups {
       keys.push_back(item.first);
       groups.emplace_back(std::move(item.second));
     }
-    auto keys_ = makeVariable<T>(dims, std::move(keys)) /*LABEL_1*/;
+    auto keys_ =
+        createVariable<T>(Dimensions{dims}, Values(keys.begin(), keys.end()));
     keys_.setUnit(key.unit());
     return GroupByGrouping{std::move(keys_), std::move(groups)};
   }

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -172,8 +172,7 @@ template <class T> struct MakeGroups {
       keys.push_back(item.first);
       groups.emplace_back(std::move(item.second));
     }
-    auto keys_ =
-        createVariable<T>(Dimensions{dims}, Values(keys.begin(), keys.end()));
+    auto keys_ = createVariable<T>(Dimensions{dims}, Values(std::move(keys)));
     keys_.setUnit(key.unit());
     return GroupByGrouping{std::move(keys_), std::move(groups)};
   }

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -41,7 +41,7 @@ template <class T> T GroupBy<T>::flatten(const Dim reductionDim) const {
       flatten_impl(out_.coords()[sparseDim], array.coords()[sparseDim]);
       if (in.hasData())
         flatten_impl(out_.data(), array.data());
-      for (auto && [ label_name, label ] : out_.labels()) {
+      for (auto &&[label_name, label] : out_.labels()) {
         if (label.dims().sparse())
           flatten_impl(label, array.labels()[label_name]);
       }
@@ -51,7 +51,7 @@ template <class T> T GroupBy<T>::flatten(const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto & [ name, item ] : m_data)
+      for (const auto &[name, item] : m_data)
         apply(out_slice[name], item, group);
     } else {
       apply(out_slice, m_data, group);
@@ -86,7 +86,7 @@ template <class T> T GroupBy<T>::sum(const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto & [ name, item ] : m_data) {
+      for (const auto &[name, item] : m_data) {
         const auto out_data = out_slice[name].data();
         sum_impl(out_data, item, groups()[group], reductionDim);
       }
@@ -125,7 +125,7 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
 
   // 3. sum/N -> mean
   if constexpr (std::is_same_v<T, Dataset>) {
-    for (const auto & [ name, item ] : out) {
+    for (const auto &[name, item] : out) {
       if (isInt(item.data().dtype()))
         out.setData(name, item.data() * scale);
       else

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -208,25 +208,25 @@ public:
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataProxy operator+=(const T value) const {
-    return *this += makeVariable<T>(value);
+    return *this += createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataProxy operator-=(const T value) const {
-    return *this -= makeVariable<T>(value);
+    return *this -= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataProxy operator*=(const T value) const {
-    return *this *= makeVariable<T>(value);
+    return *this *= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataProxy operator/=(const T value) const {
-    return *this /= makeVariable<T>(value);
+    return *this /= createVariable<T>(Values{value});
   }
 
 private:
@@ -1068,25 +1068,25 @@ public:
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataArray &operator+=(const T value) {
-    return *this += makeVariable<T>(value);
+    return *this += createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataArray &operator-=(const T value) {
-    return *this -= makeVariable<T>(value);
+    return *this -= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataArray &operator*=(const T value) {
-    return *this *= makeVariable<T>(value);
+    return *this *= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DataArray &operator/=(const T value) {
-    return *this /= makeVariable<T>(value);
+    return *this /= createVariable<T>(Values{value});
   }
 
   void setData(Variable data) { m_holder.setData(name(), std::move(data)); }

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -443,25 +443,25 @@ public:
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   Dataset &operator+=(const T value) {
-    return *this += makeVariable<T>(value);
+    return *this += createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   Dataset &operator-=(const T value) {
-    return *this -= makeVariable<T>(value);
+    return *this -= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   Dataset &operator*=(const T value) {
-    return *this *= makeVariable<T>(value);
+    return *this *= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   Dataset &operator/=(const T value) {
-    return *this /= makeVariable<T>(value);
+    return *this /= createVariable<T>(Values{value});
   }
 
   std::unordered_map<Dim, scipp::index> dimensions() const;
@@ -935,25 +935,25 @@ public:
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DatasetProxy operator+=(const T value) const {
-    return *this += makeVariable<T>(value);
+    return *this += createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DatasetProxy operator-=(const T value) const {
-    return *this -= makeVariable<T>(value);
+    return *this -= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DatasetProxy operator*=(const T value) const {
-    return *this *= makeVariable<T>(value);
+    return *this *= createVariable<T>(Values{value});
   }
 
   template <typename T,
             typename = std::enable_if_t<!is_container_or_proxy<T>()>>
   DatasetProxy operator/=(const T value) const {
-    return *this /= makeVariable<T>(value);
+    return *this /= createVariable<T>(Values{value});
   }
 
   DatasetProxy assign(const DatasetConstProxy &other) const;
@@ -1266,36 +1266,36 @@ SCIPP_CORE_EXPORT Dataset operator/(const VariableConstProxy &lhs,
 
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator+(const T value, const DatasetConstProxy &a) {
-  return makeVariable<T>(value) + a;
+  return createVariable<T>(Values{value}) + a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator-(const T value, const DatasetConstProxy &a) {
-  return makeVariable<T>(value) - a;
+  return createVariable<T>(Values{value}) - a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator*(const T value, const DatasetConstProxy &a) {
-  return makeVariable<T>(value) * a;
+  return createVariable<T>(Values{value}) * a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator/(const T value, const DatasetConstProxy &a) {
-  return makeVariable<T>(value) / a;
+  return createVariable<T>(Values{value}) / a;
 }
 
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator+(const DatasetConstProxy &a, const T value) {
-  return a + makeVariable<T>(value);
+  return a + createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator-(const DatasetConstProxy &a, const T value) {
-  return a - makeVariable<T>(value);
+  return a - createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator*(const DatasetConstProxy &a, const T value) {
-  return a * makeVariable<T>(value);
+  return a * createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Dataset operator/(const DatasetConstProxy &a, const T value) {
-  return a / makeVariable<T>(value);
+  return a / createVariable<T>(Values{value});
 }
 
 SCIPP_CORE_EXPORT DataArray histogram(const DataConstProxy &sparse,

--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -47,7 +47,7 @@ template <class Types, class Op, class... Var>
   Variable out =
       std::is_base_of_v<transform_flags::expect_variance_arg_t<0>, Op>
           ? makeVariableWithVariances<OutT>(dims)
-          : makeVariable<OutT>(dims);
+          : createVariable<OutT>(Dimensions{dims});
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -281,6 +281,7 @@ struct default_init<Eigen::Matrix<T, Rows, Cols>> {
 };
 } // namespace detail
 
+template <class T, class... Ts> Variable createVariable(Ts &&... ts);
 template <class T> Variable makeVariable(T value);
 
 /// Variable is a type-erased handle to any data structure representing a
@@ -404,19 +405,19 @@ public:
   Variable &operator+=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator+=(const T v) & {
-    return *this += makeVariable<T>(v);
+    return *this += createVariable<T>(Values{v});
   }
 
   Variable &operator-=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator-=(const T v) & {
-    return *this -= makeVariable<T>(v);
+    return *this -= createVariable<T>(Values{v});
   }
 
   Variable &operator*=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator*=(const T v) & {
-    return *this *= makeVariable<T>(v);
+    return *this *= createVariable<T>(Values{v});
   }
   template <class T>
   Variable &operator*=(const boost::units::quantity<T> &quantity) & {
@@ -427,7 +428,7 @@ public:
   Variable &operator/=(const VariableConstProxy &other) &;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   Variable &operator/=(const T v) & {
-    return *this /= makeVariable<T>(v);
+    return *this /= createVariable<T>(Values{v});
   }
   template <class T>
   Variable &operator/=(const boost::units::quantity<T> &quantity) & {
@@ -821,25 +822,25 @@ public:
   VariableProxy operator+=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator+=(const T v) const {
-    return *this += makeVariable<T>(v);
+    return *this += createVariable<T>(Values{v});
   }
 
   VariableProxy operator-=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator-=(const T v) const {
-    return *this -= makeVariable<T>(v);
+    return *this -= createVariable<T>(Values{v});
   }
 
   VariableProxy operator*=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator*=(const T v) const {
-    return *this *= makeVariable<T>(v);
+    return *this *= createVariable<T>(Values{v});
   }
 
   VariableProxy operator/=(const VariableConstProxy &other) const;
   template <typename T, typename = std::enable_if_t<!is_variable_or_proxy<T>()>>
   VariableProxy operator/=(const T v) const {
-    return *this /= makeVariable<T>(v);
+    return *this /= createVariable<T>(Values{v});
   }
 
   VariableProxy operator|=(const VariableConstProxy &other) const;
@@ -880,35 +881,35 @@ SCIPP_CORE_EXPORT Variable operator^(const VariableConstProxy &a,
 // anyway so this is a convenient way to avoid defining more overloads.
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator+(const T value, const VariableConstProxy &a) {
-  return makeVariable<T>(value) + a;
+  return createVariable<T>(Values{value}) + a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator-(const T value, const VariableConstProxy &a) {
-  return makeVariable<T>(value) - a;
+  return createVariable<T>(Values{value}) - a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator*(const T value, const VariableConstProxy &a) {
-  return makeVariable<T>(value) * a;
+  return createVariable<T>(Values{value}) * a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator/(const T value, const VariableConstProxy &a) {
-  return makeVariable<T>(value) / a;
+  return createVariable<T>(Values{value}) / a;
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator+(const VariableConstProxy &a, const T value) {
-  return a + makeVariable<T>(value);
+  return a + createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator-(const VariableConstProxy &a, const T value) {
-  return a - makeVariable<T>(value);
+  return a - createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator*(const VariableConstProxy &a, const T value) {
-  return a * makeVariable<T>(value);
+  return a * createVariable<T>(Values{value});
 }
 template <typename T, typename = std::enable_if_t<!is_container_or_proxy<T>()>>
 Variable operator/(const VariableConstProxy &a, const T value) {
-  return a / makeVariable<T>(value);
+  return a / createVariable<T>(Values{value});
 }
 
 template <class T>

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -282,7 +282,6 @@ struct default_init<Eigen::Matrix<T, Rows, Cols>> {
 } // namespace detail
 
 template <class T, class... Ts> Variable createVariable(Ts &&... ts);
-template <class T> Variable makeVariable(T value);
 
 /// Variable is a type-erased handle to any data structure representing a
 /// multi-dimensional array. It has a name, a unit, and a set of named
@@ -556,21 +555,6 @@ makeVariableWithVariances(const Dimensions &dimensions,
     return Variable(units::dimensionless, dimensions,
                     Vector<T>(dimensions.volume(), init),
                     Vector<T>(dimensions.volume(), init));
-}
-
-template <class T>
-Variable makeVariable(const std::initializer_list<Dim> &dims,
-                      const std::initializer_list<scipp::index> &shape) {
-  return createVariable<T>(Dimensions(dims, shape));
-}
-
-template <class T> Variable makeVariable(T value) {
-  return Variable(units::dimensionless, Dimensions{}, Vector<T>(1, value));
-}
-
-template <class T> Variable makeVariable(T value, T variance) {
-  return Variable(units::dimensionless, Dimensions{}, Vector<T>(1, value),
-                  Vector<T>(1, variance));
 }
 
 template <class T>

--- a/core/include/scipp/core/variable_keyword_arg_constructor.h
+++ b/core/include/scipp/core/variable_keyword_arg_constructor.h
@@ -56,7 +56,7 @@ struct ValuesTag {};
 struct VariancesTag {};
 
 template <class... Ts> auto makeArgsTuple(Ts &&... ts) {
-  return std::make_tuple<std::remove_reference_t<Ts>...>(
+  return std::tuple<std::decay_t<Ts>...>(
       std::forward<Ts>(ts)...);
 }
 

--- a/core/include/scipp/core/variable_keyword_arg_constructor.h
+++ b/core/include/scipp/core/variable_keyword_arg_constructor.h
@@ -56,8 +56,7 @@ struct ValuesTag {};
 struct VariancesTag {};
 
 template <class... Ts> auto makeArgsTuple(Ts &&... ts) {
-  return std::tuple<std::decay_t<Ts>...>(
-      std::forward<Ts>(ts)...);
+  return std::tuple<std::decay_t<Ts>...>(std::forward<Ts>(ts)...);
 }
 
 template <class T> auto makeArgsTuple(std::initializer_list<T> init) {

--- a/core/subspan_view.cpp
+++ b/core/subspan_view.cpp
@@ -46,10 +46,17 @@ template <class T, class Var> Variable subspan_view(Var &var, const Dim dim) {
   std::conditional_t<std::is_const_v<T>, const Var, Var> &var_ref = var;
   using MaybeConstT =
       std::conditional_t<std::is_const_v<Var>, std::add_const_t<T>, T>;
-  return makeVariable<span<MaybeConstT>>(
-      dims, var.unit(), values_view(var_ref),
-      var.hasVariances() ? variances_view(var_ref)
-                         : std::vector<span<MaybeConstT>>{}) /*LABEL_1*/;
+  auto valuesView = values_view(var_ref);
+  if (var.hasVariances()) {
+    auto variancesView = variances_view(var_ref);
+    return createVariable<span<MaybeConstT>>(
+        Dimensions{dims}, var.unit(),
+        Values(valuesView.begin(), valuesView.end()),
+        Variances(variancesView.begin(), variancesView.end()));
+  } else
+    return createVariable<span<MaybeConstT>>(
+        Dimensions{dims}, var.unit(),
+        Values(valuesView.begin(), valuesView.end()));
 }
 
 template <class... Ts, class... Args>

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -9,7 +9,7 @@ using namespace scipp::core;
 
 class AttributesTest : public ::testing::Test {
 protected:
-  const Variable scalar = makeVariable<double>(1);
+  const Variable scalar = createVariable<double>(Values{1});
   const Variable varX =
       createVariable<double>(Dims{Dim::X}, Shape{2}, Values{2, 3});
   const Variable varZX = createVariable<double>(

--- a/core/test/comparison_test.cpp
+++ b/core/test/comparison_test.cpp
@@ -42,20 +42,20 @@ TEST(ComparisonTest, variable_not_equal_outside_tolerance) {
 }
 
 TEST(ComparisonTest, variable_variances_equal) {
-  const auto a = makeVariable<double>(10.0, 1.0);
-  const auto b = makeVariable<double>(10.0, 1.0);
+  const auto a = createVariable<double>(Values{10.0}, Variances{1.0});
+  const auto b = createVariable<double>(Values{10.0}, Variances{1.0});
   EXPECT_TRUE(is_approx(a, b, 0.1));
 }
 
 TEST(ComparisonTest, variable_variances_not_equal_outside_tolerance) {
-  const auto a = makeVariable<double>(10.0, 1.0);
-  const auto b = makeVariable<double>(10.0, 0.5);
+  const auto a = createVariable<double>(Values{10.0}, Variances{1.0});
+  const auto b = createVariable<double>(Values{10.0}, Variances{0.5});
   EXPECT_FALSE(is_approx(a, b, 0.1));
 }
 
 TEST(ComparisonTest, variable_variances_missing_in_one_operand) {
-  const auto a = makeVariable<double>(10.0);
-  const auto b = makeVariable<double>(10.0, 1.0);
+  const auto a = createVariable<double>(Values{10.0});
+  const auto b = createVariable<double>(Values{10.0}, Variances{1.0});
   EXPECT_FALSE(is_approx(a, b, 0.1));
 }
 

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -30,8 +30,7 @@ protected:
 
     dataset.setData("val_and_var",
                     createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
-                                           Values(std::vector<double>(12)),
-                                           Variances(std::vector<double>(12))));
+                                           Values(12), Variances(12)));
     dataset.setAttr("val_and_var", "attr", createVariable<int>(Values{int{}}));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
@@ -268,10 +267,8 @@ TEST_F(DataArray_comparison_operators, extra_attr) {
 
 TEST_F(DataArray_comparison_operators, extra_variance) {
   auto extra = dataset;
-  extra.setData("val",
-                createVariable<double>(Dimensions{Dim::X, 4},
-                                       Values(std::vector<double>(4)),
-                                       Variances(std::vector<double>(4))));
+  extra.setData("val", createVariable<double>(Dimensions{Dim::X, 4}, Values(4),
+                                              Variances(4)));
   expect_ne(extra["val"], dataset["val"]);
 }
 

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -28,10 +28,12 @@ protected:
 
     dataset.setAttr("global_attr", makeVariable<int>({}));
 
-    dataset.setData("val_and_var",
-                    makeVariable<double>({{Dim::Y, 3}, {Dim::X, 4}},
-                                         std::vector<double>(12),
-                                         std::vector<double>(12)) /*LABEL_1*/);
+    auto vector = std::vector<double>(12);
+    dataset.setData(
+        "val_and_var",
+        createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
+                               Values(vector.begin(), vector.end()),
+                               Variances(vector.begin(), vector.end())));
     dataset.setAttr("val_and_var", "attr", makeVariable<int>({}));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
@@ -267,9 +269,11 @@ TEST_F(DataArray_comparison_operators, extra_attr) {
 
 TEST_F(DataArray_comparison_operators, extra_variance) {
   auto extra = dataset;
-  extra.setData("val",
-                makeVariable<double>({Dim::X, 4}, std::vector<double>(4),
-                                     std::vector<double>(4)) /*LABEL_1*/);
+  auto vector = std::vector<double>(4);
+  extra.setData(
+      "val", createVariable<double>(Dimensions{Dim::X, 4},
+                                    Values(vector.begin(), vector.end()),
+                                    Variances(vector.begin(), vector.end())));
   expect_ne(extra["val"], dataset["val"]);
 }
 

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -28,12 +28,10 @@ protected:
 
     dataset.setAttr("global_attr", createVariable<int>(Values{int{}}));
 
-    auto vector = std::vector<double>(12);
-    dataset.setData(
-        "val_and_var",
-        createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
-                               Values(vector.begin(), vector.end()),
-                               Variances(vector.begin(), vector.end())));
+    dataset.setData("val_and_var",
+                    createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
+                                           Values(std::vector<double>(12)),
+                                           Variances(std::vector<double>(12))));
     dataset.setAttr("val_and_var", "attr", createVariable<int>(Values{int{}}));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
@@ -270,11 +268,10 @@ TEST_F(DataArray_comparison_operators, extra_attr) {
 
 TEST_F(DataArray_comparison_operators, extra_variance) {
   auto extra = dataset;
-  auto vector = std::vector<double>(4);
-  extra.setData(
-      "val", createVariable<double>(Dimensions{Dim::X, 4},
-                                    Values(vector.begin(), vector.end()),
-                                    Variances(vector.begin(), vector.end())));
+  extra.setData("val",
+                createVariable<double>(Dimensions{Dim::X, 4},
+                                       Values(std::vector<double>(4)),
+                                       Variances(std::vector<double>(4))));
   expect_ne(extra["val"], dataset["val"]);
 }
 

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -18,15 +18,15 @@ using namespace scipp::core;
 class DataArray_comparison_operators : public ::testing::Test {
 protected:
   DataArray_comparison_operators()
-      : sparse_variable(makeVariable<double>({Dim::Y, Dim::Z, Dim::X},
-                                             {3, 2, Dimensions::Sparse})) {
+      : sparse_variable(createVariable<double>(
+            Dims{Dim::Y, Dim::Z, Dim::X}, Shape{3l, 2l, Dimensions::Sparse})) {
     dataset.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{4}));
     dataset.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{3}));
 
     dataset.setLabels("labels", createVariable<int>(Dims{Dim::X}, Shape{4}));
     dataset.setMask("mask", createVariable<bool>(Dims{Dim::X}, Shape{4}));
 
-    dataset.setAttr("global_attr", makeVariable<int>({}));
+    dataset.setAttr("global_attr", createVariable<int>(Values{int{}}));
 
     auto vector = std::vector<double>(12);
     dataset.setData(
@@ -34,16 +34,17 @@ protected:
         createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
                                Values(vector.begin(), vector.end()),
                                Variances(vector.begin(), vector.end())));
-    dataset.setAttr("val_and_var", "attr", makeVariable<int>({}));
+    dataset.setAttr("val_and_var", "attr", createVariable<int>(Values{int{}}));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
-    dataset.setAttr("val", "attr", makeVariable<int>({}));
+    dataset.setAttr("val", "attr", createVariable<int>(Values{int{}}));
 
     dataset.setSparseCoord("sparse_coord", sparse_variable);
-    dataset.setAttr("sparse_coord", "attr", makeVariable<int>({}));
+    dataset.setAttr("sparse_coord", "attr", createVariable<int>(Values{int{}}));
     dataset.setData("sparse_coord_and_val", sparse_variable);
     dataset.setSparseCoord("sparse_coord_and_val", sparse_variable);
-    dataset.setAttr("sparse_coord_and_val", "attr", makeVariable<int>({}));
+    dataset.setAttr("sparse_coord_and_val", "attr",
+                    createVariable<int>(Values{int{}}));
   }
   void expect_eq(const DataConstProxy &a, const DataConstProxy &b) const {
     EXPECT_TRUE(a == b);
@@ -240,21 +241,21 @@ TEST_F(DataArray_comparison_operators, copy) {
 
 TEST_F(DataArray_comparison_operators, extra_coord) {
   auto extra = dataset;
-  extra.setCoord(Dim::Z, makeVariable<double>(0.0));
+  extra.setCoord(Dim::Z, createVariable<double>(Values{0.0}));
   for (const auto [name, a] : extra)
     expect_ne(a, dataset[name]);
 }
 
 TEST_F(DataArray_comparison_operators, extra_labels) {
   auto extra = dataset;
-  extra.setLabels("extra", makeVariable<double>(0.0));
+  extra.setLabels("extra", createVariable<double>(Values{0.0}));
   for (const auto [name, a] : extra)
     expect_ne(a, dataset[name]);
 }
 
 TEST_F(DataArray_comparison_operators, extra_mask) {
   auto extra = dataset;
-  extra.setMask("extra", makeVariable<bool>(false));
+  extra.setMask("extra", createVariable<bool>(Values{false}));
   for (const auto [name, a] : extra)
     expect_ne(a, dataset[name]);
 }
@@ -262,7 +263,7 @@ TEST_F(DataArray_comparison_operators, extra_mask) {
 TEST_F(DataArray_comparison_operators, extra_attr) {
   auto extra = dataset;
   for (const auto [name, a] : extra) {
-    extra.setAttr(name, "extra", makeVariable<double>(0.0));
+    extra.setAttr(name, "extra", createVariable<double>(Values{0.0}));
     expect_ne(a, dataset[name]);
   }
 }

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -35,7 +35,8 @@ TEST(DataArrayTest, sum_dataset_columns_via_DataArray) {
 }
 
 auto make_sparse() {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{2l, Dimensions::Sparse});
   var.setUnit(units::us);
   auto vals = var.sparseValues<double>();
   vals[0] = {1.1, 2.2, 3.3};

--- a/core/test/data_proxy_test.cpp
+++ b/core/test/data_proxy_test.cpp
@@ -24,7 +24,7 @@ using DataProxyTypes = ::testing::Types<DataProxy, DataConstProxy>;
 TYPED_TEST_SUITE(DataProxyTest, DataProxyTypes);
 
 TYPED_TEST(DataProxyTest, name_ignored_in_comparison) {
-  const auto var = makeVariable<double>(1.0);
+  const auto var = createVariable<double>(Values{1.0});
   Dataset d;
   d.setData("a", var);
   d.setData("b", var);
@@ -36,17 +36,18 @@ TYPED_TEST(DataProxyTest, sparse_sparseDim) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
 
-  d.setData("dense", makeVariable<double>({}));
+  d.setData("dense", createVariable<double>(Values{double{}}));
   ASSERT_FALSE(d_ref["dense"].dims().sparse());
   ASSERT_EQ(d_ref["dense"].dims().sparseDim(), Dim::Invalid);
 
   d.setData("sparse_data",
-            makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+            createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse}));
   ASSERT_TRUE(d_ref["sparse_data"].dims().sparse());
   ASSERT_EQ(d_ref["sparse_data"].dims().sparseDim(), Dim::X);
 
-  d.setSparseCoord("sparse_coord",
-                   makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+  d.setSparseCoord(
+      "sparse_coord",
+      createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse}));
   ASSERT_TRUE(d_ref["sparse_coord"].dims().sparse());
   ASSERT_EQ(d_ref["sparse_coord"].dims().sparseDim(), Dim::X);
 }
@@ -54,8 +55,8 @@ TYPED_TEST(DataProxyTest, sparse_sparseDim) {
 TYPED_TEST(DataProxyTest, dims) {
   Dataset d;
   const auto dense = createVariable<double>(Dims{Dim::X, Dim::Y}, Shape{1, 2});
-  const auto sparse = makeVariable<double>({Dim::X, Dim::Y, Dim::Z},
-                                           {1, 2, Dimensions::Sparse});
+  const auto sparse = createVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z},
+                                             Shape{1l, 2l, Dimensions::Sparse});
   typename TestFixture::dataset_type &d_ref(d);
 
   d.setData("dense", dense);
@@ -87,15 +88,15 @@ TYPED_TEST(DataProxyTest, unit) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
 
-  d.setData("dense", makeVariable<double>({}));
+  d.setData("dense", createVariable<double>(Values{double{}}));
   EXPECT_EQ(d_ref["dense"].unit(), units::dimensionless);
 }
 
 TYPED_TEST(DataProxyTest, unit_access_fails_without_values) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
-  d.setSparseCoord("sparse",
-                   makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+  d.setSparseCoord("sparse", createVariable<double>(Dims{Dim::X},
+                                                    Shape{Dimensions::Sparse}));
   EXPECT_THROW(d_ref["sparse"].unit(), except::SparseDataError);
 }
 
@@ -113,8 +114,8 @@ TYPED_TEST(DataProxyTest, coords) {
 TYPED_TEST(DataProxyTest, coords_sparse) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
-  const auto var =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                          Shape{3l, Dimensions::Sparse});
   d.setSparseCoord("a", var);
 
   ASSERT_NO_THROW(d_ref["a"].coords());
@@ -131,8 +132,8 @@ TYPED_TEST(DataProxyTest, coords_sparse_shadow) {
       createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto y =
       createVariable<double>(Dims{Dim::Y}, Shape{3}, Values{4, 5, 6});
-  const auto sparse =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto sparse = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                             Shape{3l, Dimensions::Sparse});
   d.setCoord(Dim::X, x);
   d.setCoord(Dim::Y, y);
   d.setSparseCoord("a", sparse);
@@ -154,8 +155,8 @@ TYPED_TEST(DataProxyTest, coords_sparse_shadow_even_if_no_coord) {
       createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto y =
       createVariable<double>(Dims{Dim::Y}, Shape{3}, Values{4, 5, 6});
-  const auto sparse =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto sparse = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                             Shape{3l, Dimensions::Sparse});
   d.setCoord(Dim::X, x);
   d.setCoord(Dim::Y, y);
   d.setData("a", sparse);
@@ -234,8 +235,8 @@ TYPED_TEST(DataProxyTest, hasData_hasVariances) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
 
-  d.setData("a", makeVariable<double>({}));
-  d.setData("b", makeVariable<double>(1, 1));
+  d.setData("a", createVariable<double>(Values{double{}}));
+  d.setData("b", createVariable<double>(Values{1}, Variances{1}));
 
   ASSERT_TRUE(d_ref["a"].hasData());
   ASSERT_FALSE(d_ref["a"].hasVariances());
@@ -261,7 +262,8 @@ TYPED_TEST(DataProxyTest, values_variances) {
 TYPED_TEST(DataProxyTest, sparse_with_no_data) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
-  d.setSparseCoord("a", makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+  d.setSparseCoord(
+      "a", createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse}));
 
   EXPECT_ANY_THROW(d_ref["a"].data());
   ASSERT_FALSE(d_ref["a"].hasData());

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -56,52 +56,38 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
 
   const auto coordX = rand(lx);
   const auto coordY = rand(ly);
-  const auto valY = rand(ly);
-  const auto boolsY = makeBools(ly);
-  const auto labelT = createVariable<double>(Dimensions{Dim::Y, ly},
-                                             Values(valY.begin(), valY.end()));
-  const auto masks = createVariable<bool>(Dimensions{Dim::Y, ly},
-                                          Values(boolsY.begin(), boolsY.end()));
+  const auto labelT =
+      createVariable<double>(Dimensions{Dim::Y, ly}, Values(rand(ly)));
+  const auto masks =
+      createVariable<bool>(Dimensions{Dim::Y, ly}, Values(makeBools(ly)));
 
   Dataset a;
   {
-    a.setCoord(Dim::X,
-               createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                      Values(coordX.begin(), coordX.end())));
-    a.setCoord(Dim::Y,
-               createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                      Values(coordY.begin(), coordY.end())));
+    a.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
+                                              Values(std::vector(coordX))));
+    a.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
+                                              Values(std::vector(coordY))));
 
     a.setLabels("t", labelT);
     a.setMask("mask", masks);
-
-    const auto valX = rand(lx);
-    const auto valY = rand(ly);
-
     a.setData("data_a",
-              createVariable<double>(Dimensions{Dim::X, lx},
-                                     Values(valX.begin(), valX.end())));
+              createVariable<double>(Dimensions{Dim::X, lx}, Values(rand(lx))));
     a.setData("data_b",
-              createVariable<double>(Dimensions{Dim::Y, ly},
-                                     Values(valY.begin(), valY.end())));
+              createVariable<double>(Dimensions{Dim::Y, ly}, Values(rand(ly))));
   }
 
   Dataset b;
   {
-    b.setCoord(Dim::X,
-               createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                      Values(coordX.begin(), coordX.end())));
-    b.setCoord(Dim::Y,
-               createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                      Values(coordY.begin(), coordY.end())));
+    b.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
+                                              Values(std::vector(coordX))));
+    b.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
+                                              Values(std::vector(coordY))));
 
     b.setLabels("t", labelT);
     b.setMask("mask", masks);
 
-    const auto valY = rand(ly);
     b.setData("data_a",
-              createVariable<double>(Dimensions{Dim::Y, ly},
-                                     Values(valY.begin(), valY.end())));
+              createVariable<double>(Dimensions{Dim::Y, ly}, Values(rand(ly))));
   }
 
   return std::make_tuple(a, b);
@@ -412,10 +398,9 @@ TYPED_TEST(DatasetBinaryEqualsOpTest,
 TYPED_TEST(DatasetBinaryEqualsOpTest, masks_propagate) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
-  auto boolsX = makeBools<BoolsGeneratorType::TRUE>(datasetFactory.lx);
-  const auto expectedMasks =
-      createVariable<bool>(Dimensions{Dim::X, datasetFactory.lx},
-                           Values(boolsX.begin(), boolsX.end()));
+  const auto expectedMasks = createVariable<bool>(
+      Dimensions{Dim::X, datasetFactory.lx},
+      Values(makeBools<BoolsGeneratorType::TRUE>(datasetFactory.lx)));
 
   b.setMask("masks_x", expectedMasks);
 
@@ -429,9 +414,8 @@ TYPED_TEST_SUITE(DatasetMaskSlicingBinaryOpTest, Binary);
 TYPED_TEST(DatasetMaskSlicingBinaryOpTest, binary_op_on_sliced_masks) {
   auto a = make_1d_masked();
 
-  auto bools = makeBools<BoolsGeneratorType::TRUE>(3);
   const auto expectedMasks = createVariable<bool>(
-      Dimensions{Dim::X, 3}, Values(bools.begin(), bools.end()));
+      Dimensions{Dim::X, 3}, Values(makeBools<BoolsGeneratorType::TRUE>(3)));
 
   // these are conveniently 0 1 0 and 1 0 1
   const auto slice1 = a.slice({Dim::X, 0, 3});
@@ -929,10 +913,9 @@ TYPED_TEST(DatasetBinaryOpTest, masks_propagate) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
 
-  auto boolsX = makeBools<BoolsGeneratorType::TRUE>(datasetFactory.lx);
-  const auto expectedMasks =
-      createVariable<bool>(Dimensions{Dim::X, datasetFactory.lx},
-                           Values(boolsX.begin(), boolsX.end()));
+  const auto expectedMasks = createVariable<bool>(
+      Dimensions{Dim::X, datasetFactory.lx},
+      Values(makeBools<BoolsGeneratorType::TRUE>(datasetFactory.lx)));
 
   b.setMask("masks_x", expectedMasks);
 

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -429,8 +429,9 @@ TYPED_TEST_SUITE(DatasetMaskSlicingBinaryOpTest, Binary);
 TYPED_TEST(DatasetMaskSlicingBinaryOpTest, binary_op_on_sliced_masks) {
   auto a = make_1d_masked();
 
-  const auto expectedMasks = makeVariable<bool>(
-      {Dim::X, 3}, makeBools<BoolsGeneratorType::TRUE>(3)) /*LABEL_1*/;
+  auto bools = makeBools<BoolsGeneratorType::TRUE>(3);
+  const auto expectedMasks = createVariable<bool>(
+      Dimensions{Dim::X, 3}, Values(bools.begin(), bools.end()));
 
   // these are conveniently 0 1 0 and 1 0 1
   const auto slice1 = a.slice({Dim::X, 0, 3});

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -64,9 +64,9 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
   Dataset a;
   {
     a.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                              Values(std::vector(coordX))));
+                                              Values(coordX)));
     a.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                              Values(std::vector(coordY))));
+                                              Values(coordY)));
 
     a.setLabels("t", labelT);
     a.setMask("mask", masks);
@@ -79,9 +79,9 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
   Dataset b;
   {
     b.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                              Values(std::vector(coordX))));
+                                              Values(coordX)));
     b.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                              Values(std::vector(coordY))));
+                                              Values(coordY)));
 
     b.setLabels("t", labelT);
     b.setMask("mask", masks);

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -302,7 +302,7 @@ TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_coord_mismatch) {
 
 TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
   auto a = datasetFactory.make();
-  a.setData("extra", makeVariable<double>({}));
+  a.setData("extra", createVariable<double>(Values{double{}}));
   auto b = datasetFactory.make();
   auto reference(a);
 
@@ -319,7 +319,7 @@ TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
 TYPED_TEST(DatasetBinaryEqualsOpTest, rhs_Dataset_with_extra_items) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
-  b.setData("extra", makeVariable<double>({}));
+  b.setData("extra", createVariable<double>(Values{double{}}));
 
   ASSERT_ANY_THROW(TestFixture::op(a, b));
 }
@@ -539,7 +539,7 @@ TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_coord_mismatch) {
 
 TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
   auto a = datasetFactory.make();
-  a.setData("extra", makeVariable<double>({}));
+  a.setData("extra", createVariable<double>(Values{double{}}));
   auto b = datasetFactory.make();
   auto reference(a);
 
@@ -556,7 +556,7 @@ TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_with_missing_items) {
 TYPED_TEST(DatasetProxyBinaryEqualsOpTest, rhs_Dataset_with_extra_items) {
   auto a = datasetFactory.make();
   auto b = datasetFactory.make();
-  b.setData("extra", makeVariable<double>({}));
+  b.setData("extra", createVariable<double>(Values{double{}}));
 
   ASSERT_ANY_THROW(TestFixture::op(DatasetProxy(a), b));
 }
@@ -674,7 +674,7 @@ TYPED_TEST(DatasetBinaryOpTest, broadcast) {
   const auto x =
       createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto y = createVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 2});
-  const auto c = makeVariable<double>(2.0);
+  const auto c = createVariable<double>(Values{2.0});
   Dataset a;
   Dataset b;
   a.setCoord(Dim::X, x);
@@ -767,7 +767,7 @@ TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense_fail) {
 
 TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense) {
   Dataset dense;
-  dense.setData("a", makeVariable<double>(2.0));
+  dense.setData("a", createVariable<double>(Values{2.0}));
   const auto sparse =
       make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0}, "a");
 
@@ -781,7 +781,7 @@ TYPED_TEST(DatasetBinaryOpTest, sparse_with_dense) {
 
 TYPED_TEST(DatasetBinaryOpTest, dense_with_sparse) {
   Dataset dense;
-  dense.setData("a", makeVariable<double>(2.0));
+  dense.setData("a", createVariable<double>(Values{2.0}));
   const auto sparse =
       make_sparse_with_coords_and_labels({1.1, 2.2}, {1.0, 2.0}, "a");
 
@@ -961,7 +961,7 @@ Dataset non_trivial_2d_sparse(std::string_view name) {
 TEST(DatasetSetData, sparse_to_sparse) {
   auto base = non_trivial_2d_sparse("base");
   auto other = non_trivial_2d_sparse("other");
-  other["other"] *= makeVariable<double>(2);
+  other["other"] *= createVariable<double>(Values{2});
   base.setData("other", other["other"]);
   EXPECT_EQ(other["other"], base["other"]);
 }

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -63,10 +63,10 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
 
   Dataset a;
   {
-    a.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                              Values(coordX)));
-    a.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                              Values(coordY)));
+    a.setCoord(Dim::X,
+               createVariable<double>(Dims{Dim::X}, Shape{lx}, Values(coordX)));
+    a.setCoord(Dim::Y,
+               createVariable<double>(Dims{Dim::Y}, Shape{ly}, Values(coordY)));
 
     a.setLabels("t", labelT);
     a.setMask("mask", masks);
@@ -78,10 +78,10 @@ std::tuple<Dataset, Dataset> generateBinaryOpTestCase() {
 
   Dataset b;
   {
-    b.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{lx},
-                                              Values(coordX)));
-    b.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{ly},
-                                              Values(coordY)));
+    b.setCoord(Dim::X,
+               createVariable<double>(Dims{Dim::X}, Shape{lx}, Values(coordX)));
+    b.setCoord(Dim::Y,
+               createVariable<double>(Dims{Dim::Y}, Shape{ly}, Values(coordY)));
 
     b.setLabels("t", labelT);
     b.setMask("mask", masks);

--- a/core/test/dataset_comparison_test.cpp
+++ b/core/test/dataset_comparison_test.cpp
@@ -46,8 +46,7 @@ protected:
 
     dataset.setData("val_and_var",
                     createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
-                                           Values(std::vector<double>(12)),
-                                           Variances(std::vector<double>(12))));
+                                           Values(12), Variances(12)));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
 
@@ -181,10 +180,8 @@ TEST_F(Dataset_comparison_operators, extra_data) {
 
 TEST_F(Dataset_comparison_operators, extra_variance) {
   auto extra = dataset;
-  extra.setData("val",
-                createVariable<double>(Dimensions{Dim::X, 4},
-                                       Values(std::vector<double>(4)),
-                                       Variances(std::vector<double>(4))));
+  extra.setData("val", createVariable<double>(Dimensions{Dim::X, 4}, Values(4),
+                                              Variances(4)));
   expect_ne(extra, dataset);
 }
 

--- a/core/test/dataset_comparison_test.cpp
+++ b/core/test/dataset_comparison_test.cpp
@@ -44,12 +44,10 @@ protected:
 
     dataset.setAttr("attr", createVariable<int>(Values{int{}}));
 
-    auto vector = std::vector<double>(12);
-    dataset.setData(
-        "val_and_var",
-        createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
-                               Values(vector.begin(), vector.end()),
-                               Variances(vector.begin(), vector.end())));
+    dataset.setData("val_and_var",
+                    createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
+                                           Values(std::vector<double>(12)),
+                                           Variances(std::vector<double>(12))));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
 
@@ -183,11 +181,10 @@ TEST_F(Dataset_comparison_operators, extra_data) {
 
 TEST_F(Dataset_comparison_operators, extra_variance) {
   auto extra = dataset;
-  auto vector = std::vector<double>(4);
-  extra.setData(
-      "val", createVariable<double>(Dimensions{Dim::X, 4},
-                                    Values(vector.begin(), vector.end()),
-                                    Variances(vector.begin(), vector.end())));
+  extra.setData("val",
+                createVariable<double>(Dimensions{Dim::X, 4},
+                                       Values(std::vector<double>(4)),
+                                       Variances(std::vector<double>(4))));
   expect_ne(extra, dataset);
 }
 

--- a/core/test/dataset_comparison_test.cpp
+++ b/core/test/dataset_comparison_test.cpp
@@ -35,14 +35,14 @@ private:
 
 protected:
   Dataset_comparison_operators()
-      : sparse_variable(makeVariable<double>({Dim::Y, Dim::Z, Dim::X},
-                                             {3, 2, Dimensions::Sparse})) {
+      : sparse_variable(createVariable<double>(
+            Dims{Dim::Y, Dim::Z, Dim::X}, Shape{3l, 2l, Dimensions::Sparse})) {
     dataset.setCoord(Dim::X, createVariable<double>(Dims{Dim::X}, Shape{4}));
     dataset.setCoord(Dim::Y, createVariable<double>(Dims{Dim::Y}, Shape{3}));
 
     dataset.setLabels("labels", createVariable<int>(Dims{Dim::X}, Shape{4}));
 
-    dataset.setAttr("attr", makeVariable<int>({}));
+    dataset.setAttr("attr", createVariable<int>(Values{int{}}));
 
     auto vector = std::vector<double>(12);
     dataset.setData(

--- a/core/test/dataset_comparison_test.cpp
+++ b/core/test/dataset_comparison_test.cpp
@@ -44,10 +44,12 @@ protected:
 
     dataset.setAttr("attr", makeVariable<int>({}));
 
-    dataset.setData("val_and_var",
-                    makeVariable<double>({{Dim::Y, 3}, {Dim::X, 4}},
-                                         std::vector<double>(12),
-                                         std::vector<double>(12)) /*LABEL_1*/);
+    auto vector = std::vector<double>(12);
+    dataset.setData(
+        "val_and_var",
+        createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
+                               Values(vector.begin(), vector.end()),
+                               Variances(vector.begin(), vector.end())));
 
     dataset.setData("val", createVariable<double>(Dims{Dim::X}, Shape{4}));
 
@@ -181,9 +183,11 @@ TEST_F(Dataset_comparison_operators, extra_data) {
 
 TEST_F(Dataset_comparison_operators, extra_variance) {
   auto extra = dataset;
-  extra.setData("val",
-                makeVariable<double>({Dim::X, 4}, std::vector<double>(4),
-                                     std::vector<double>(4)) /*LABEL_1*/);
+  auto vector = std::vector<double>(4);
+  extra.setData(
+      "val", createVariable<double>(Dimensions{Dim::X, 4},
+                                    Values(vector.begin(), vector.end()),
+                                    Variances(vector.begin(), vector.end())));
   expect_ne(extra, dataset);
 }
 

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -121,20 +121,26 @@ TEST(DatasetOperationsTest, mean_three_dims) {
 
 TEST(DatasetOperationsTest, rebin) {
   Dataset ds;
-  ds.setCoord(Dim::X, makeVariable<double>({Dim::X, 6}, {1, 2, 3, 4, 5, 6}));
-  ds.setData("data_x", makeVariable<double>({Dim::X, 5}, {1, 2, 3, 4, 5}));
+  ds.setCoord(Dim::X, createVariable<double>(Dimensions{Dim::X, 6},
+                                             Values{1, 2, 3, 4, 5, 6}));
+  ds.setData("data_x", createVariable<double>(Dimensions{Dim::X, 5},
+                                              Values{1, 2, 3, 4, 5}));
 
-  ds.setMask("mask_x", makeVariable<bool>({Dim::X, 5},
-                                          {false, false, true, false, false}));
-  ds.setMask("mask_y", makeVariable<bool>({Dim::Y, 5},
-                                          {false, false, true, false, false}));
+  ds.setMask("mask_x",
+             createVariable<bool>(Dimensions{Dim::X, 5},
+                                  Values{false, false, true, false, false}));
+  ds.setMask("mask_y",
+             createVariable<bool>(Dimensions{Dim::Y, 5},
+                                  Values{false, false, true, false, false}));
 
-  const auto edges = makeVariable<double>({Dim::X, 3}, {1, 3, 5});
+  const auto edges =
+      createVariable<double>(Dimensions{Dim::X, 3}, Values{1, 3, 5});
   const Dataset result = rebin(ds, Dim::X, edges);
 
-  ASSERT_EQ(result["data_x"].data(), makeVariable<double>({Dim::X, 2}, {3, 7}));
+  ASSERT_EQ(result["data_x"].data(),
+            createVariable<double>(Dimensions{Dim::X, 2}, Values{3, 7}));
   ASSERT_EQ(result["data_x"].masks()["mask_x"],
-            makeVariable<bool>({Dim::X, 2}, {false, true}));
+            createVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true}));
   // the Y masks should not have been touched
   ASSERT_EQ(ds.masks().size(), 2);
   ASSERT_EQ(ds.masks()["mask_y"].dims(), Dimensions(Dim::Y, 5));

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -65,10 +65,10 @@ TYPED_TEST(DatasetShapeChangingOpTest, mean_masked) {
 }
 
 TYPED_TEST(DatasetShapeChangingOpTest, mean_fully_masked) {
-  auto bools = makeBools<BoolsGeneratorType::TRUE>(5);
-  this->ds.setMask("full_mask",
-                   createVariable<bool>(Dimensions{Dim::X, 5},
-                                        Values(bools.begin(), bools.end())));
+  this->ds.setMask(
+      "full_mask",
+      createVariable<bool>(Dimensions{Dim::X, 5},
+                           Values(makeBools<BoolsGeneratorType::TRUE>(5))));
   const Dataset result = mean(this->ds, Dim::X);
 
   if constexpr (std::is_floating_point_v<TypeParam>)

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -60,10 +60,10 @@ TYPED_TEST(DatasetShapeChangingOpTest, mean_masked) {
 }
 
 TYPED_TEST(DatasetShapeChangingOpTest, mean_fully_masked) {
-  this->ds.setMask(
-      "full_mask",
-      makeVariable<bool>({Dim::X, 5},
-                         makeBools<BoolsGeneratorType::TRUE>(5)) /*LABEL_1*/);
+  auto bools = makeBools<BoolsGeneratorType::TRUE>(5);
+  this->ds.setMask("full_mask",
+                   createVariable<bool>(Dimensions{Dim::X, 5},
+                                        Values(bools.begin(), bools.end())));
   const Dataset result = mean(this->ds, Dim::X);
 
   if constexpr (std::is_floating_point_v<TypeParam>)

--- a/core/test/dataset_operations_test.cpp
+++ b/core/test/dataset_operations_test.cpp
@@ -13,9 +13,10 @@ using namespace scipp::core;
 TEST(DatasetOperationsTest, sum) {
   auto ds = make_1_values_and_variances<float>(
       "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
-  EXPECT_EQ(core::sum(ds, Dim::X)["a"].data(), makeVariable<float>(6, 45));
+  EXPECT_EQ(core::sum(ds, Dim::X)["a"].data(),
+            createVariable<float>(Values{6}, Variances{45}));
   EXPECT_EQ(core::sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(3, 27));
+            createVariable<float>(Values{3}, Variances{27}));
   EXPECT_THROW(core::sum(make_sparse_2d({1, 2, 3, 4}, {0, 0}), Dim::X),
                except::DimensionError);
 }
@@ -23,9 +24,10 @@ TEST(DatasetOperationsTest, sum) {
 TEST(DatasetOperationsTest, mean) {
   auto ds = make_1_values_and_variances<float>(
       "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
-  EXPECT_EQ(core::mean(ds, Dim::X)["a"].data(), makeVariable<float>(2, 5.0));
+  EXPECT_EQ(core::mean(ds, Dim::X)["a"].data(),
+            createVariable<float>(Values{2}, Variances{5.0}));
   EXPECT_EQ(core::mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(1.5, 6.75));
+            createVariable<float>(Values{1.5}, Variances{6.75}));
 }
 
 template <typename T>
@@ -47,16 +49,19 @@ TYPED_TEST_SUITE(DatasetShapeChangingOpTest, DataTypes);
 TYPED_TEST(DatasetShapeChangingOpTest, sum_masked) {
   const auto result = sum(this->ds, Dim::X);
 
-  ASSERT_EQ(result["data_x"].data(), makeVariable<TypeParam>({6}));
+  ASSERT_EQ(result["data_x"].data(),
+            createVariable<TypeParam>(Values{TypeParam{6}}));
 }
 
 TYPED_TEST(DatasetShapeChangingOpTest, mean_masked) {
   const auto result = mean(this->ds, Dim::X);
 
   if constexpr (std::is_floating_point_v<TypeParam>)
-    ASSERT_EQ(result["data_x"].data(), makeVariable<TypeParam>({2}));
+    ASSERT_EQ(result["data_x"].data(),
+              createVariable<TypeParam>(Values{TypeParam{2}}));
   else // non floating point gets the result as a double
-    ASSERT_EQ(result["data_x"].data(), makeVariable<double>({2}));
+    ASSERT_EQ(result["data_x"].data(),
+              createVariable<double>(Values{double{2}}));
 }
 
 TYPED_TEST(DatasetShapeChangingOpTest, mean_fully_masked) {

--- a/core/test/dataset_proxy_test.cpp
+++ b/core/test/dataset_proxy_test.cpp
@@ -53,9 +53,9 @@ TYPED_TEST(DatasetProxyTest, bad_item_access) {
 
 TYPED_TEST(DatasetProxyTest, name) {
   Dataset d;
-  d.setData("a", makeVariable<double>({}));
-  d.setData("b", makeVariable<float>({}));
-  d.setData("c", makeVariable<int64_t>({}));
+  d.setData("a", createVariable<double>(Values{double{}}));
+  d.setData("b", createVariable<float>(Values{float{}}));
+  d.setData("c", createVariable<int64_t>(Values{int64_t{}}));
   auto &&proxy = TestFixture::access(d);
 
   for (const auto &name : {"a", "b", "c"})
@@ -66,9 +66,9 @@ TYPED_TEST(DatasetProxyTest, name) {
 
 TYPED_TEST(DatasetProxyTest, find_and_contains) {
   Dataset d;
-  d.setData("a", makeVariable<double>({}));
-  d.setData("b", makeVariable<float>({}));
-  d.setData("c", makeVariable<int64_t>({}));
+  d.setData("a", createVariable<double>(Values{double{}}));
+  d.setData("b", createVariable<float>(Values{float{}}));
+  d.setData("c", createVariable<int64_t>(Values{int64_t{}}));
   auto &&proxy = TestFixture::access(d);
 
   EXPECT_EQ(proxy.find("not a thing"), proxy.end());
@@ -108,7 +108,7 @@ TYPED_TEST(DatasetProxyTest, iterators_empty_dataset) {
 
 TYPED_TEST(DatasetProxyTest, iterators_only_coords) {
   Dataset d;
-  d.setCoord(Dim::X, makeVariable<double>({}));
+  d.setCoord(Dim::X, createVariable<double>(Values{double{}}));
   auto &&proxy = TestFixture::access(d);
   ASSERT_NO_THROW(proxy.begin());
   ASSERT_NO_THROW(proxy.end());
@@ -117,7 +117,7 @@ TYPED_TEST(DatasetProxyTest, iterators_only_coords) {
 
 TYPED_TEST(DatasetProxyTest, iterators_only_labels) {
   Dataset d;
-  d.setLabels("a", makeVariable<double>({}));
+  d.setLabels("a", createVariable<double>(Values{double{}}));
   auto &&proxy = TestFixture::access(d);
   ASSERT_NO_THROW(proxy.begin());
   ASSERT_NO_THROW(proxy.end());
@@ -126,7 +126,7 @@ TYPED_TEST(DatasetProxyTest, iterators_only_labels) {
 
 TYPED_TEST(DatasetProxyTest, iterators_only_attrs) {
   Dataset d;
-  d.setAttr("a", makeVariable<double>({}));
+  d.setAttr("a", createVariable<double>(Values{double{}}));
   auto &&proxy = TestFixture::access(d);
   ASSERT_NO_THROW(proxy.begin());
   ASSERT_NO_THROW(proxy.end());
@@ -135,9 +135,9 @@ TYPED_TEST(DatasetProxyTest, iterators_only_attrs) {
 
 TYPED_TEST(DatasetProxyTest, iterators) {
   Dataset d;
-  d.setData("a", makeVariable<double>({}));
-  d.setData("b", makeVariable<float>({}));
-  d.setData("c", makeVariable<int64_t>({}));
+  d.setData("a", createVariable<double>(Values{double{}}));
+  d.setData("b", createVariable<float>(Values{float{}}));
+  d.setData("c", createVariable<int64_t>(Values{int64_t{}}));
   auto &&proxy = TestFixture::access(d);
 
   ASSERT_NO_THROW(proxy.begin());

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -173,7 +173,7 @@ TEST(DatasetTest, setLabels_with_name_matching_data_name) {
   // It is possible to set labels with a name matching data. However, there is
   // no special meaning attached to this. In particular it is *not* linking the
   // labels to that data item.
-  ASSERT_NO_THROW(d.setLabels("a", makeVariable<double>({})));
+  ASSERT_NO_THROW(d.setLabels("a", createVariable<double>(Values{double{}})));
   ASSERT_EQ(d.size(), 2);
   ASSERT_EQ(d.labels().size(), 1);
   ASSERT_EQ(d["a"].labels().size(), 1);
@@ -189,8 +189,8 @@ TEST(DatasetTest, setSparseCoord_not_sparse_fail) {
 
 TEST(DatasetTest, setSparseCoord) {
   Dataset d;
-  const auto var =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                          Shape{3l, Dimensions::Sparse});
 
   ASSERT_NO_THROW(d.setSparseCoord("a", var));
   ASSERT_EQ(d.size(), 1);
@@ -199,7 +199,8 @@ TEST(DatasetTest, setSparseCoord) {
 
 TEST(DatasetTest, setSparseLabels_missing_values_or_coord) {
   Dataset d;
-  const auto sparse = makeVariable<double>({Dim::X}, {Dimensions::Sparse});
+  const auto sparse =
+      createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse});
 
   ASSERT_ANY_THROW(d.setSparseLabels("a", "x", sparse));
   d.setSparseCoord("a", sparse);
@@ -208,8 +209,9 @@ TEST(DatasetTest, setSparseLabels_missing_values_or_coord) {
 
 TEST(DatasetTest, setSparseLabels_not_sparse_fail) {
   Dataset d;
-  const auto dense = makeVariable<double>({});
-  const auto sparse = makeVariable<double>({Dim::X}, {Dimensions::Sparse});
+  const auto dense = createVariable<double>(Values{double{}});
+  const auto sparse =
+      createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse});
 
   d.setSparseCoord("a", sparse);
   ASSERT_ANY_THROW(d.setSparseLabels("a", "x", dense));
@@ -217,7 +219,8 @@ TEST(DatasetTest, setSparseLabels_not_sparse_fail) {
 
 TEST(DatasetTest, setSparseLabels) {
   Dataset d;
-  const auto sparse = makeVariable<double>({Dim::X}, {Dimensions::Sparse});
+  const auto sparse =
+      createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse});
   d.setSparseCoord("a", sparse);
 
   ASSERT_NO_THROW(d.setSparseLabels("a", "x", sparse));
@@ -239,9 +242,10 @@ TEST(DatasetTest, const_iterators_return_types) {
 }
 
 TEST(DatasetTest, set_dense_data_with_sparse_coord) {
-  auto sparse_variable =
-      makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
-  auto dense_variable = makeVariable<double>({Dim::Y, Dim::X}, {2, 2});
+  auto sparse_variable = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                                Shape{2l, Dimensions::Sparse});
+  auto dense_variable =
+      createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2l, 2l});
 
   Dataset a;
   a.setData("sparse_coord_and_val", dense_variable);
@@ -340,13 +344,15 @@ TEST(DataProxyTest, set_variances) {
 TEST(DatasetTest, sum_and_mean) {
   auto ds = make_1_values_and_variances<float>(
       "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
-  EXPECT_EQ(core::sum(ds, Dim::X)["a"].data(), makeVariable<float>(6, 45));
+  EXPECT_EQ(core::sum(ds, Dim::X)["a"].data(),
+            createVariable<float>(Values{6}, Variances{45}));
   EXPECT_EQ(core::sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(3, 27));
+            createVariable<float>(Values{3}, Variances{27}));
 
-  EXPECT_EQ(core::mean(ds, Dim::X)["a"].data(), makeVariable<float>(2, 5.0));
+  EXPECT_EQ(core::mean(ds, Dim::X)["a"].data(),
+            createVariable<float>(Values{2}, Variances{5.0}));
   EXPECT_EQ(core::mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(1.5, 6.75));
+            createVariable<float>(Values{1.5}, Variances{6.75}));
 
   EXPECT_THROW(core::sum(make_sparse_2d({1, 2, 3, 4}, {0, 0}), Dim::X),
                except::DimensionError);
@@ -367,15 +373,16 @@ TEST(DatasetTest, erase_coord) {
   ds.setCoord(Dim::X, coord);
   EXPECT_EQ(ref, ds);
 
-  const auto var =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                          Shape{3l, Dimensions::Sparse});
   ds.setSparseCoord("newCoord", var);
   EXPECT_TRUE(ds["newCoord"].coords().contains(Dim::X));
   ds.eraseSparseCoord("newCoord");
   EXPECT_EQ(ref, ds);
 
   ds.setSparseCoord("newCoord", var);
-  ds.setData("newCoord", makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+  ds.setData("newCoord",
+             createVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse}));
   EXPECT_TRUE(ds["newCoord"].coords().contains(Dim::X));
   EXPECT_THROW(ds["newCoord"].coords().erase(Dim::Z), except::SparseDataError);
   ds["newCoord"].coords().erase(Dim::X);
@@ -397,8 +404,8 @@ TEST(DatasetTest, erase_labels) {
   ds.setLabels("labels_x", labels);
   EXPECT_EQ(ref, ds);
 
-  const auto var =
-      makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                          Shape{3l, Dimensions::Sparse});
   ds.setSparseCoord("newCoord", var);
   ds.setSparseLabels("newCoord", "labels_sparse", var);
   EXPECT_TRUE(ds["newCoord"].labels().contains("labels_sparse"));

--- a/core/test/dataset_test_common.cpp
+++ b/core/test/dataset_test_common.cpp
@@ -15,34 +15,23 @@ DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
                                    const scipp::index ly_,
                                    const scipp::index lz_)
     : lx(lx_), ly(ly_), lz(lz_) {
-  auto vX = rand(lx);
-  auto vY = rand(ly);
-  auto vXYZ = rand(lx * ly * lz);
   base.setCoord(Dim::Time, createVariable<double>(Values{rand(1).front()}));
-  base.setCoord(Dim::X, createVariable<double>(Dimensions{Dim::X, lx},
-                                               Values(vX.begin(), vX.end())));
-  base.setCoord(Dim::Y, createVariable<double>(Dimensions{Dim::Y, ly},
-                                               Values(vY.begin(), vY.end())));
+  base.setCoord(
+      Dim::X, createVariable<double>(Dimensions{Dim::X, lx}, Values(rand(lx))));
+  base.setCoord(
+      Dim::Y, createVariable<double>(Dimensions{Dim::Y, ly}, Values(rand(ly))));
   base.setCoord(Dim::Z,
                 createVariable<double>(
                     Dimensions{{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
-                    Values(vXYZ.begin(), vXYZ.end())));
+                    Values(rand(lx * ly * lz))));
 
-  vX = rand(lx);
-  vY = rand(ly);
-  auto vZ = rand(lz);
-  auto vXY = rand(lx * ly);
-  vXYZ = rand(lx * ly * lz);
-
-  base.setLabels("labels_x",
-                 createVariable<double>(Dimensions{Dim::X, lx},
-                                        Values(vX.begin(), vX.end())));
+  base.setLabels("labels_x", createVariable<double>(Dimensions{Dim::X, lx},
+                                                    Values(rand(lx))));
   base.setLabels("labels_xy",
                  createVariable<double>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
-                                        Values(vXY.begin(), vXY.end())));
-  base.setLabels("labels_z",
-                 createVariable<double>(Dimensions{Dim::Z, lz},
-                                        Values(vZ.begin(), vZ.end())));
+                                        Values(rand(lx * ly))));
+  base.setLabels("labels_z", createVariable<double>(Dimensions{Dim::Z, lz},
+                                                    Values(rand(lz))));
 
   auto bX = makeBools<BoolsGeneratorType::ALTERNATING>(lx);
   auto bXY = makeBools<BoolsGeneratorType::ALTERNATING>(lx * ly);
@@ -55,45 +44,34 @@ DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
   base.setMask("masks_z", createVariable<bool>(Dimensions{Dim::Z, lz},
                                                Values(bZ.begin(), bZ.end())));
 
-  vX = rand(lx);
   base.setAttr("attr_scalar", createVariable<double>(Values{rand(1).front()}));
   base.setAttr("attr_x", createVariable<double>(Dimensions{Dim::X, lx},
-                                                Values(vX.begin(), vX.end())));
+                                                Values(rand(lx))));
 }
 
 Dataset DatasetFactory3D::make() {
   Dataset dataset(base);
-  auto vX = rand(lx);
-  auto dvalX = rand(lx);
-  auto dvarX = rand(lx);
-  auto dvalXY = rand(lx * ly);
-  auto dvarXY = rand(lx * ly);
-  auto dvalXYZ = rand(lx * ly * lz);
-  auto dvalZYX = rand(lx * ly * lz);
-  auto dvarZYX = rand(lx * ly * lz);
-  dataset.setData("values_x",
-                  createVariable<double>(Dimensions{Dim::X, lx},
-                                         Values(vX.begin(), vX.end())));
-  dataset.setData(
-      "data_x", createVariable<double>(Dimensions{Dim::X, lx},
-                                       Values(dvalX.begin(), dvalX.end()),
-                                       Variances(dvarX.begin(), dvarX.end())));
+  dataset.setData("values_x", createVariable<double>(Dimensions{Dim::X, lx},
+                                                     Values(rand(lx))));
+  dataset.setData("data_x", createVariable<double>(Dimensions{Dim::X, lx},
+                                                   Values(rand(lx)),
+                                                   Variances(rand(lx))));
 
-  dataset.setData("data_xy", createVariable<double>(
-                                 Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
-                                 Values(dvalXY.begin(), dvalXY.end()),
-                                 Variances(dvarXY.begin(), dvarXY.end())));
+  dataset.setData("data_xy",
+                  createVariable<double>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+                                         Values(rand(lx * ly)),
+                                         Variances(rand(lx * ly))));
 
   dataset.setData("data_zyx",
                   createVariable<double>(
                       Dimensions{{Dim::Z, lz}, {Dim::Y, ly}, {Dim::X, lx}},
-                      Values(dvalZYX.begin(), dvalZYX.end()),
-                      Variances(dvarZYX.begin(), dvarZYX.end())));
+                      Values(rand(lx * ly * lz)),
+                      Variances(rand(lx * ly * lz))));
 
   dataset.setData("data_xyz",
                   createVariable<double>(
                       Dimensions{{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
-                      Values(dvalXYZ.begin(), dvalXYZ.end())));
+                      Values(rand(lx * ly * lz))));
 
   dataset.setData("data_scalar",
                   createVariable<double>(Values{rand(1).front()}));
@@ -150,14 +128,12 @@ Dataset make_sparse_2d(std::initializer_list<double> values, std::string key) {
 
 Dataset make_1d_masked() {
   Random random;
-  auto vect = random(10);
-  auto bools = makeBools<BoolsGeneratorType::ALTERNATING>(10);
   Dataset ds;
-  ds.setData("data_x",
-             createVariable<double>(Dimensions{Dim::X, 10},
-                                    Values(vect.begin(), vect.end())));
+  ds.setData("data_x", createVariable<double>(Dimensions{Dim::X, 10},
+                                              Values(random(10))));
   ds.setMask("masks_x",
-             createVariable<bool>(Dimensions{Dim::X, 10},
-                                  Values(bools.begin(), bools.end())));
+             createVariable<bool>(
+                 Dimensions{Dim::X, 10},
+                 Values(makeBools<BoolsGeneratorType::ALTERNATING>(10))));
   return ds;
 }

--- a/core/test/dataset_test_common.cpp
+++ b/core/test/dataset_test_common.cpp
@@ -95,7 +95,8 @@ Dataset DatasetFactory3D::make() {
                       Dimensions{{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
                       Values(dvalXYZ.begin(), dvalXYZ.end())));
 
-  dataset.setData("data_scalar", makeVariable<double>(rand(1).front()));
+  dataset.setData("data_scalar",
+                  createVariable<double>(Values{rand(1).front()}));
 
   return dataset;
 }
@@ -139,7 +140,8 @@ Dataset make_sparse_with_coords_and_labels(
 
 Dataset make_sparse_2d(std::initializer_list<double> values, std::string key) {
   Dataset ds;
-  auto var = makeVariable<double>({Dim::X, Dim::Y}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                    Shape{2l, Dimensions::Sparse});
   var.sparseValues<double>()[0] = values;
   var.sparseValues<double>()[1] = values;
   ds.setData(key, var);

--- a/core/test/dataset_test_common.cpp
+++ b/core/test/dataset_test_common.cpp
@@ -6,9 +6,7 @@
 
 Variable makeRandom(const Dimensions &dims) {
   Random rand;
-  auto vect = rand(dims.volume());
-  return createVariable<double>(Dimensions{dims},
-                                Values(vect.begin(), vect.end()));
+  return createVariable<double>(Dimensions{dims}, Values(rand(dims.volume())));
 }
 
 DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
@@ -33,16 +31,19 @@ DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
   base.setLabels("labels_z", createVariable<double>(Dimensions{Dim::Z, lz},
                                                     Values(rand(lz))));
 
-  auto bX = makeBools<BoolsGeneratorType::ALTERNATING>(lx);
-  auto bXY = makeBools<BoolsGeneratorType::ALTERNATING>(lx * ly);
-  auto bZ = makeBools<BoolsGeneratorType::ALTERNATING>(lz);
-  base.setMask("masks_x", createVariable<bool>(Dimensions{Dim::X, lx},
-                                               Values(bX.begin(), bX.end())));
-  base.setMask("masks_xy",
-               createVariable<bool>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
-                                    Values(bXY.begin(), bXY.end())));
-  base.setMask("masks_z", createVariable<bool>(Dimensions{Dim::Z, lz},
-                                               Values(bZ.begin(), bZ.end())));
+  base.setMask("masks_x",
+               createVariable<bool>(
+                   Dimensions{Dim::X, lx},
+                   Values(makeBools<BoolsGeneratorType::ALTERNATING>(lx))));
+  base.setMask(
+      "masks_xy",
+      createVariable<bool>(
+          Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+          Values(makeBools<BoolsGeneratorType::ALTERNATING>(lx * ly))));
+  base.setMask("masks_z",
+               createVariable<bool>(
+                   Dimensions{Dim::Z, lz},
+                   Values(makeBools<BoolsGeneratorType::ALTERNATING>(lz))));
 
   base.setAttr("attr_scalar", createVariable<double>(Values{rand(1).front()}));
   base.setAttr("attr_x", createVariable<double>(Dimensions{Dim::X, lx},

--- a/core/test/dataset_test_common.cpp
+++ b/core/test/dataset_test_common.cpp
@@ -6,65 +6,94 @@
 
 Variable makeRandom(const Dimensions &dims) {
   Random rand;
-  return makeVariable<double>(dims, rand(dims.volume())) /*LABEL_1*/;
+  auto vect = rand(dims.volume());
+  return createVariable<double>(Dimensions{dims},
+                                Values(vect.begin(), vect.end()));
 }
 
 DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
                                    const scipp::index ly_,
                                    const scipp::index lz_)
     : lx(lx_), ly(ly_), lz(lz_) {
-  base.setCoord(Dim::Time, makeVariable<double>(rand(1).front()));
-  base.setCoord(Dim::X,
-                makeVariable<double>({Dim::X, lx}, rand(lx)) /*LABEL_1*/);
-  base.setCoord(Dim::Y,
-                makeVariable<double>({Dim::Y, ly}, rand(ly)) /*LABEL_1*/);
+  auto vX = rand(lx);
+  auto vY = rand(ly);
+  auto vXYZ = rand(lx * ly * lz);
+  base.setCoord(Dim::Time, createVariable<double>(Values{rand(1).front()}));
+  base.setCoord(Dim::X, createVariable<double>(Dimensions{Dim::X, lx},
+                                               Values(vX.begin(), vX.end())));
+  base.setCoord(Dim::Y, createVariable<double>(Dimensions{Dim::Y, ly},
+                                               Values(vY.begin(), vY.end())));
   base.setCoord(Dim::Z,
-                makeVariable<double>({{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
-                                     rand(lx * ly * lz)) /*LABEL_1*/);
+                createVariable<double>(
+                    Dimensions{{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
+                    Values(vXYZ.begin(), vXYZ.end())));
+
+  vX = rand(lx);
+  vY = rand(ly);
+  auto vZ = rand(lz);
+  auto vXY = rand(lx * ly);
+  vXYZ = rand(lx * ly * lz);
 
   base.setLabels("labels_x",
-                 makeVariable<double>({Dim::X, lx}, rand(lx)) /*LABEL_1*/);
-  base.setLabels("labels_xy", makeVariable<double>({{Dim::X, lx}, {Dim::Y, ly}},
-                                                   rand(lx * ly)) /*LABEL_1*/);
+                 createVariable<double>(Dimensions{Dim::X, lx},
+                                        Values(vX.begin(), vX.end())));
+  base.setLabels("labels_xy",
+                 createVariable<double>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+                                        Values(vXY.begin(), vXY.end())));
   base.setLabels("labels_z",
-                 makeVariable<double>({Dim::Z, lz}, rand(lz)) /*LABEL_1*/);
-  base.setMask("masks_x",
-               makeVariable<bool>(
-                   {Dim::X, lx},
-                   makeBools<BoolsGeneratorType::ALTERNATING>(lx)) /*LABEL_1*/);
-  base.setMask("masks_xy",
-               makeVariable<bool>({{Dim::X, lx}, {Dim::Y, ly}},
-                                  makeBools<BoolsGeneratorType::ALTERNATING>(
-                                      lx * ly)) /*LABEL_1*/);
-  base.setMask("masks_z",
-               makeVariable<bool>(
-                   {Dim::Z, lz},
-                   makeBools<BoolsGeneratorType::ALTERNATING>(lz)) /*LABEL_1*/);
+                 createVariable<double>(Dimensions{Dim::Z, lz},
+                                        Values(vZ.begin(), vZ.end())));
 
-  base.setAttr("attr_scalar", makeVariable<double>(rand(1).front()));
-  base.setAttr("attr_x",
-               makeVariable<double>({Dim::X, lx}, rand(lx)) /*LABEL_1*/);
+  auto bX = makeBools<BoolsGeneratorType::ALTERNATING>(lx);
+  auto bXY = makeBools<BoolsGeneratorType::ALTERNATING>(lx * ly);
+  auto bZ = makeBools<BoolsGeneratorType::ALTERNATING>(lz);
+  base.setMask("masks_x", createVariable<bool>(Dimensions{Dim::X, lx},
+                                               Values(bX.begin(), bX.end())));
+  base.setMask("masks_xy",
+               createVariable<bool>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+                                    Values(bXY.begin(), bXY.end())));
+  base.setMask("masks_z", createVariable<bool>(Dimensions{Dim::Z, lz},
+                                               Values(bZ.begin(), bZ.end())));
+
+  vX = rand(lx);
+  base.setAttr("attr_scalar", createVariable<double>(Values{rand(1).front()}));
+  base.setAttr("attr_x", createVariable<double>(Dimensions{Dim::X, lx},
+                                                Values(vX.begin(), vX.end())));
 }
 
 Dataset DatasetFactory3D::make() {
   Dataset dataset(base);
+  auto vX = rand(lx);
+  auto dvalX = rand(lx);
+  auto dvarX = rand(lx);
+  auto dvalXY = rand(lx * ly);
+  auto dvarXY = rand(lx * ly);
+  auto dvalXYZ = rand(lx * ly * lz);
+  auto dvalZYX = rand(lx * ly * lz);
+  auto dvarZYX = rand(lx * ly * lz);
   dataset.setData("values_x",
-                  makeVariable<double>({Dim::X, lx}, rand(lx)) /*LABEL_1*/);
-  dataset.setData("data_x", makeVariable<double>({Dim::X, lx}, rand(lx),
-                                                 rand(lx)) /*LABEL_1*/);
-
-  dataset.setData("data_xy", makeVariable<double>({{Dim::X, lx}, {Dim::Y, ly}},
-                                                  rand(lx * ly),
-                                                  rand(lx * ly)) /*LABEL_1*/);
-
+                  createVariable<double>(Dimensions{Dim::X, lx},
+                                         Values(vX.begin(), vX.end())));
   dataset.setData(
-      "data_zyx",
-      makeVariable<double>({{Dim::Z, lz}, {Dim::Y, ly}, {Dim::X, lx}},
-                           rand(lx * ly * lz), rand(lx * ly * lz)) /*LABEL_1*/);
+      "data_x", createVariable<double>(Dimensions{Dim::X, lx},
+                                       Values(dvalX.begin(), dvalX.end()),
+                                       Variances(dvarX.begin(), dvarX.end())));
 
-  dataset.setData("data_xyz", makeVariable<double>(
-                                  {{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
-                                  rand(lx * ly * lz)) /*LABEL_1*/);
+  dataset.setData("data_xy", createVariable<double>(
+                                 Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+                                 Values(dvalXY.begin(), dvalXY.end()),
+                                 Variances(dvarXY.begin(), dvarXY.end())));
+
+  dataset.setData("data_zyx",
+                  createVariable<double>(
+                      Dimensions{{Dim::Z, lz}, {Dim::Y, ly}, {Dim::X, lx}},
+                      Values(dvalZYX.begin(), dvalZYX.end()),
+                      Variances(dvarZYX.begin(), dvarZYX.end())));
+
+  dataset.setData("data_xyz",
+                  createVariable<double>(
+                      Dimensions{{Dim::X, lx}, {Dim::Y, ly}, {Dim::Z, lz}},
+                      Values(dvalXYZ.begin(), dvalXYZ.end())));
 
   dataset.setData("data_scalar", makeVariable<double>(rand(1).front()));
 
@@ -119,13 +148,14 @@ Dataset make_sparse_2d(std::initializer_list<double> values, std::string key) {
 
 Dataset make_1d_masked() {
   Random random;
-
+  auto vect = random(10);
+  auto bools = makeBools<BoolsGeneratorType::ALTERNATING>(10);
   Dataset ds;
   ds.setData("data_x",
-             makeVariable<double>({Dim::X, 10}, random(10)) /*LABEL_1*/);
+             createVariable<double>(Dimensions{Dim::X, 10},
+                                    Values(vect.begin(), vect.end())));
   ds.setMask("masks_x",
-             makeVariable<bool>(
-                 {Dim::X, 10},
-                 makeBools<BoolsGeneratorType::ALTERNATING>(10)) /*LABEL_1*/);
+             createVariable<bool>(Dimensions{Dim::X, 10},
+                                  Values(bools.begin(), bools.end())));
   return ds;
 }

--- a/core/test/except_test.cpp
+++ b/core/test/except_test.cpp
@@ -13,12 +13,12 @@ using namespace scipp::core;
 
 TEST(StringFormattingTest, to_string_Dataset) {
   Dataset a;
-  a.setData("a", makeVariable<double>({}));
-  a.setData("b", makeVariable<double>({}));
+  a.setData("a", createVariable<double>(Values{double{}}));
+  a.setData("b", createVariable<double>(Values{double{}}));
   // Create new dataset with same variables but different order
   Dataset b;
-  b.setData("b", makeVariable<double>({}));
-  b.setData("a", makeVariable<double>({}));
+  b.setData("b", createVariable<double>(Values{double{}}));
+  b.setData("a", createVariable<double>(Values{double{}}));
   // string representations should be the same
   EXPECT_EQ(to_string(a), to_string(b));
 }
@@ -79,8 +79,8 @@ TEST(StringFormattingTest, to_string_ConstProxy) {
 
 TEST(StringFormattingTest, to_string_sparse_Dataset) {
   Dataset a;
-  a.setSparseCoord(
-      "a", makeVariable<double>({Dim::Y, Dim::X}, {4, Dimensions::Sparse}));
+  a.setSparseCoord("a", createVariable<double>(Dims{Dim::Y, Dim::X},
+                                               Shape{4l, Dimensions::Sparse}));
   ASSERT_NO_THROW(to_string(a));
 }
 

--- a/core/test/histogram_test.cpp
+++ b/core/test/histogram_test.cpp
@@ -47,7 +47,8 @@ TEST(HistogramTest, is_histogram) {
 
 Dataset make_2d_sparse_coord_only(const std::string &name) {
   Dataset sparse;
-  auto var = makeVariable<double>({Dim::X, Dim::Y}, {3, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
+                                    Shape{3l, Dimensions::Sparse});
   var.sparseValues<double>()[0] = {1.5, 2.5, 3.5, 4.5, 5.5};
   var.sparseValues<double>()[1] = {3.5, 4.5, 5.5, 6.5, 7.5};
   var.sparseValues<double>()[2] = {-1, 0, 0, 1, 1, 2, 2, 2, 4, 4, 4, 6};
@@ -65,8 +66,8 @@ TEST(HistogramTest, fail_edges_not_sorted) {
 
 auto make_single_sparse() {
   Dataset sparse;
-  sparse.setSparseCoord("sparse",
-                        makeVariable<double>({Dim::X}, {Dimensions::Sparse}));
+  sparse.setSparseCoord("sparse", createVariable<double>(
+                                      Dims{Dim::X}, Shape{Dimensions::Sparse}));
   sparse["sparse"].coords()[Dim::X].sparseValues<double>()[0] = {0, 1, 1, 2, 3};
   return sparse;
 }

--- a/core/test/mean_test.cpp
+++ b/core/test/mean_test.cpp
@@ -113,7 +113,7 @@ TEST(MeanTest, variances_as_standard_deviation_of_the_mean) {
 TEST(MeanTest, dataset_mean_fails) {
   Dataset d;
   d.setData("a", createVariable<double>(Dims{Dim::X}, Shape{2}));
-  d.setData("b", makeVariable<double>(1.0));
+  d.setData("b", createVariable<double>(Values{1.0}));
   // "b" does not depend on X, so this fails. This could change in the future if
   // we find a clear definition of the functions behavior in this case.
   EXPECT_THROW(mean(d, Dim::X), except::DimensionError);

--- a/core/test/mean_test.cpp
+++ b/core/test/mean_test.cpp
@@ -41,13 +41,17 @@ TEST(MeanTest, basic) {
 }
 
 TEST(MeanTest, masked_data_array) {
-  const auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m,
-                                        {1.0, 2.0, 3.0, 4.0});
-  const auto mask = makeVariable<bool>({Dim::X, 2}, {false, true});
+  const auto var =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
+                             units::Unit(units::m), Values{1.0, 2.0, 3.0, 4.0});
+  const auto mask =
+      createVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
-  const auto meanX = makeVariable<double>({Dim::Y, 2}, units::m, {1.0, 3.0});
-  const auto meanY = makeVariable<double>({Dim::X, 2}, units::m, {2.0, 3.0});
+  const auto meanX = createVariable<double>(
+      Dimensions{Dim::Y, 2}, units::Unit(units::m), Values{1.0, 3.0});
+  const auto meanY = createVariable<double>(
+      Dimensions{Dim::X, 2}, units::Unit(units::m), Values{2.0, 3.0});
   EXPECT_EQ(mean(a, Dim::X).data(), meanX);
   EXPECT_EQ(mean(a, Dim::Y).data(), meanY);
   EXPECT_FALSE(mean(a, Dim::X).masks().contains("mask"));
@@ -55,15 +59,20 @@ TEST(MeanTest, masked_data_array) {
 }
 
 TEST(MeanTest, masked_data_array_two_masks) {
-  const auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m,
-                                        {1.0, 2.0, 3.0, 4.0});
-  const auto maskX = makeVariable<bool>({Dim::X, 2}, {false, true});
-  const auto maskY = makeVariable<bool>({Dim::Y, 2}, {false, true});
+  const auto var =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
+                             units::Unit(units::m), Values{1.0, 2.0, 3.0, 4.0});
+  const auto maskX =
+      createVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
+  const auto maskY =
+      createVariable<bool>(Dimensions{Dim::Y, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("x", maskX);
   a.masks().set("y", maskY);
-  const auto meanX = makeVariable<double>({Dim::Y, 2}, units::m, {1.0, 3.0});
-  const auto meanY = makeVariable<double>({Dim::X, 2}, units::m, {1.0, 2.0});
+  const auto meanX = createVariable<double>(
+      Dimensions{Dim::Y, 2}, units::Unit(units::m), Values{1.0, 3.0});
+  const auto meanY = createVariable<double>(
+      Dimensions{Dim::X, 2}, units::Unit(units::m), Values{1.0, 2.0});
   EXPECT_EQ(mean(a, Dim::X).data(), meanX);
   EXPECT_EQ(mean(a, Dim::Y).data(), meanY);
   EXPECT_FALSE(mean(a, Dim::X).masks().contains("x"));

--- a/core/test/merge_test.cpp
+++ b/core/test/merge_test.cpp
@@ -21,8 +21,8 @@ TEST(MergeTest, simple) {
               createVariable<int>(Dims{Dim::Y}, Shape{3}, Values{9, 8, 7}));
   a.setMask("masks_1", createVariable<bool>(Dims{Dim::X}, Shape{3},
                                             Values{false, true, false}));
-  a.setAttr("attr_1", makeVariable<int>(42));
-  a.setAttr("attr_2", makeVariable<int>(495));
+  a.setAttr("attr_1", createVariable<int>(Values{42}));
+  a.setAttr("attr_2", createVariable<int>(Values{495}));
 
   Dataset b;
   b.setCoord(Dim::X,
@@ -33,7 +33,7 @@ TEST(MergeTest, simple) {
               createVariable<int>(Dims{Dim::X}, Shape{3}, Values{9, 8, 9}));
   b.setMask("masks_2", createVariable<bool>(Dims{Dim::X}, Shape{3},
                                             Values{false, true, false}));
-  b.setAttr("attr_2", makeVariable<int>(495));
+  b.setAttr("attr_2", createVariable<int>(Values{495}));
 
   const auto d = merge(a, b);
 
@@ -91,14 +91,16 @@ TEST(MergeTest, non_matching_dense_data) {
 TEST(MergeTest, non_matching_sparse_data) {
   Dataset a;
   {
-    auto data = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto data = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                    Shape{1l, Dimensions::Sparse});
     data.sparseValues<int>()[0] = {2, 3};
     a.setData("sparse", data);
   }
 
   Dataset b;
   {
-    auto data = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto data = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                    Shape{1l, Dimensions::Sparse});
     data.sparseValues<int>()[0] = {1, 2};
     b.setData("sparse", data);
   }
@@ -119,14 +121,16 @@ TEST(MergeTest, non_matching_dense_coords) {
 TEST(MergeTest, non_matching_sparse_coords) {
   Dataset a;
   {
-    auto coord = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto coord = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                     Shape{1l, Dimensions::Sparse});
     coord.sparseValues<int>()[0] = {2, 3};
     a.setSparseCoord("sparse", coord);
   }
 
   Dataset b;
   {
-    auto coord = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto coord = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                     Shape{1l, Dimensions::Sparse});
     coord.sparseValues<int>()[0] = {1, 2};
     b.setSparseCoord("sparse", coord);
   }
@@ -145,12 +149,14 @@ TEST(MergeTest, non_matching_dense_labels) {
 }
 
 TEST(MergeTest, non_matching_sparse_labels) {
-  auto coord = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+  auto coord =
+      createVariable<int>(Dims{Dim::X, Dim::Y}, Shape{1l, Dimensions::Sparse});
   coord.sparseValues<int>()[0] = {1, 2};
 
   Dataset a;
   {
-    auto label = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto label = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                     Shape{1l, Dimensions::Sparse});
     label.sparseValues<int>()[0] = {2, 3};
     a.setSparseCoord("sparse", coord);
     a.setSparseLabels("sparse", "l", label);
@@ -158,7 +164,8 @@ TEST(MergeTest, non_matching_sparse_labels) {
 
   Dataset b;
   {
-    auto label = makeVariable<int>({Dim::X, Dim::Y}, {1, Dimensions::Sparse});
+    auto label = createVariable<int>(Dims{Dim::X, Dim::Y},
+                                     Shape{1l, Dimensions::Sparse});
     label.sparseValues<int>()[0] = {1, 2};
     b.setSparseCoord("sparse", coord);
     b.setSparseLabels("sparse", "l", label);

--- a/core/test/rebin_test.cpp
+++ b/core/test/rebin_test.cpp
@@ -112,19 +112,20 @@ TEST_F(RebinTest, keeps_unrelated_labels_but_drops_others) {
 
 class RebinMask1DTest : public ::testing::Test {
 protected:
-  Variable x =
-      makeVariable<double>({Dim::X, 11}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+  Variable x = createVariable<double>(
+      Dimensions{Dim::X, 11}, Values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
 
-  Variable mask =
-      makeVariable<bool>({Dim::X, 10}, {false, false, true, false, false, false,
-                                        false, false, false, false});
+  Variable mask = createVariable<bool>(
+      Dimensions{Dim::X, 10}, Values{false, false, true, false, false, false,
+                                     false, false, false, false});
 };
 
 TEST_F(RebinMask1DTest, mask_1d) {
 
-  const auto edges = makeVariable<double>({Dim::X, 5}, {1, 3, 5, 7, 10});
-  const auto expected =
-      makeVariable<bool>({Dim::X, 4}, {false, true, false, false});
+  const auto edges =
+      createVariable<double>(Dimensions{Dim::X, 5}, Values{1, 3, 5, 7, 10});
+  const auto expected = createVariable<bool>(Dimensions{Dim::X, 4},
+                                             Values{false, true, false, false});
 
   const auto result = rebin(mask, Dim::X, x, edges);
 
@@ -132,10 +133,10 @@ TEST_F(RebinMask1DTest, mask_1d) {
 }
 
 TEST_F(RebinMask1DTest, mask_weights_1d) {
-  const auto edges =
-      makeVariable<double>({Dim::X, 5}, {1.0, 3.5, 5.5, 7.0, 10.0});
-  const auto expected =
-      makeVariable<bool>({Dim::X, 4}, {true, true, false, false});
+  const auto edges = createVariable<double>(Dimensions{Dim::X, 5},
+                                            Values{1.0, 3.5, 5.5, 7.0, 10.0});
+  const auto expected = createVariable<bool>(Dimensions{Dim::X, 4},
+                                             Values{true, true, false, false});
 
   const auto result = rebin(mask, Dim::X, x, edges);
 
@@ -144,20 +145,22 @@ TEST_F(RebinMask1DTest, mask_weights_1d) {
 
 class RebinMask2DTest : public ::testing::Test {
 protected:
-  Variable x = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 6}},
-                                    {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
+  Variable x =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 6}},
+                             Values{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
 
-  Variable mask = makeVariable<bool>(
-      {{Dim::Y, 2}, {Dim::X, 5}},
-      {false, true, false, false, true, false, false, true, false, false});
+  Variable mask =
+      createVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 5}},
+                           Values{false, true, false, false, true, false, false,
+                                  true, false, false});
 };
 
 TEST_F(RebinMask2DTest, mask_weights_2d) {
-  const auto edges =
-      makeVariable<double>({Dim::X, 5}, {1.0, 3.0, 4.0, 5.5, 6.0});
-  const auto expected =
-      makeVariable<bool>({{Dim::Y, 2}, {Dim::X, 4}},
-                         {true, false, true, true, false, true, false, false});
+  const auto edges = createVariable<double>(Dimensions{Dim::X, 5},
+                                            Values{1.0, 3.0, 4.0, 5.5, 6.0});
+  const auto expected = createVariable<bool>(
+      Dimensions{{Dim::Y, 2}, {Dim::X, 4}},
+      Values{true, false, true, true, false, true, false, false});
 
   const auto result = rebin(mask, Dim::X, x, edges);
 

--- a/core/test/sort_test.cpp
+++ b/core/test/sort_test.cpp
@@ -49,7 +49,7 @@ TEST(SortTest, dataset_1d) {
   d.setData("b", createVariable<double>(Dims{Dim::X}, Shape{3},
                                         units::Unit(units::s),
                                         Values{0.1, 0.2, 0.3}));
-  d.setData("scalar", makeVariable<double>(1.2));
+  d.setData("scalar", createVariable<double>(Values{1.2}));
   d.setCoord(Dim::X,
              createVariable<double>(Dims{Dim::X}, Shape{3},
                                     units::Unit(units::m), Values{1, 2, 3}));

--- a/core/test/sparse_counts_test.cpp
+++ b/core/test/sparse_counts_test.cpp
@@ -8,8 +8,8 @@ using namespace scipp;
 using namespace scipp::core;
 
 static auto make_sparse() {
-  auto var = makeVariable<double>({Dim::Z, Dim::Y, Dim::X},
-                                  {3, 2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Z, Dim::Y, Dim::X},
+                                    Shape{3l, 2l, Dimensions::Sparse});
   scipp::index count = 0;
   for (auto &v : var.sparseValues<double>())
     v.resize(count++);
@@ -29,7 +29,7 @@ static auto make_sparse_with_variances() {
 }
 
 TEST(SparseCountsTest, fail_dense) {
-  auto bad = makeVariable<double>(1.0);
+  auto bad = createVariable<double>(Values{1.0});
   EXPECT_ANY_THROW(sparse::counts(bad));
 }
 

--- a/core/test/sparse_data_operations_consistency_test.cpp
+++ b/core/test/sparse_data_operations_consistency_test.cpp
@@ -8,7 +8,8 @@ using namespace scipp;
 using namespace scipp::core;
 
 static auto make_sparse() {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{2, Dimensions::Sparse});
   var.setUnit(units::us);
   auto vals = var.sparseValues<double>();
   vals[0] = {1.1, 2.2, 3.3};
@@ -21,9 +22,11 @@ static auto make_sparse_array_coord_only() {
 }
 
 static auto make_histogram() {
-  auto edges = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 3}}, units::us,
-                                    {0, 2, 4, 1, 3, 5});
-  auto data = makeVariable<double>({Dim::X, 2}, {2.0, 3.0}, {0.3, 0.4});
+  auto edges =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 3}},
+                             units::Unit(units::us), Values{0, 2, 4, 1, 3, 5});
+  auto data = createVariable<double>(Dimensions{Dim::X, 2}, Values{2.0, 3.0},
+                                     Variances{0.3, 0.4});
 
   return DataArray(data, {{Dim::X, edges}});
 }
@@ -33,9 +36,10 @@ TEST(SparseDataOperationsConsistencyTest, multiply) {
   // either first multiply and then histogram, or first histogram and then
   // multiply.
   const auto sparse = make_sparse_array_coord_only();
-  auto edges = makeVariable<double>({Dim::X, 4}, units::us, {1, 2, 3, 4});
-  auto data =
-      makeVariable<double>({Dim::X, 3}, {2.0, 3.0, 4.0}, {0.3, 0.4, 0.5});
+  auto edges = createVariable<double>(
+      Dimensions{Dim::X, 4}, units::Unit(units::us), Values{1, 2, 3, 4});
+  auto data = createVariable<double>(
+      Dimensions{Dim::X, 3}, Values{2.0, 3.0, 4.0}, Variances{0.3, 0.4, 0.5});
 
   auto hist = DataArray(data, {{Dim::X, edges}});
   auto ab = histogram(sparse * hist, edges);
@@ -58,15 +62,18 @@ TEST(SparseDataOperationsConsistencyTest, multiply) {
 
 TEST(SparseDataOperationsConsistencyTest, flatten_sum) {
   const auto sparse = make_sparse_array_coord_only();
-  auto edges = makeVariable<double>({Dim::X, 3}, units::us, {1, 3, 6});
+  auto edges = createVariable<double>(Dimensions{Dim::X, 3},
+                                      units::Unit(units::us), Values{1, 3, 6});
   EXPECT_EQ(sum(histogram(sparse, edges), Dim::Y),
             histogram(flatten(sparse, Dim::Y), edges));
 }
 
 TEST(SparseDataOperationsConsistencyTest, flatten_multiply_sum) {
   const auto sparse = make_sparse_array_coord_only();
-  auto edges = makeVariable<double>({Dim::X, 3}, units::us, {1, 3, 5});
-  auto data = makeVariable<double>({Dim::X, 2}, {2.0, 3.0}, {0.3, 0.4});
+  auto edges = createVariable<double>(Dimensions{Dim::X, 3},
+                                      units::Unit(units::us), Values{1, 3, 5});
+  auto data = createVariable<double>(Dimensions{Dim::X, 2}, Values{2.0, 3.0},
+                                     Variances{0.3, 0.4});
   auto hist = DataArray(data, {{Dim::X, edges}});
 
   auto hfm = histogram(flatten(hist * sparse, Dim::Y), edges);

--- a/core/test/subspan_view_test.cpp
+++ b/core/test/subspan_view_test.cpp
@@ -20,7 +20,8 @@ protected:
 };
 
 TEST_F(SubspanViewTest, fail_sparse) {
-  auto sparse = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto sparse = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                       Shape{2l, Dimensions::Sparse});
   EXPECT_THROW(subspan_view(sparse, Dim::X), except::DimensionError);
   EXPECT_THROW(subspan_view(sparse, Dim::Y), except::DimensionError);
 }

--- a/core/test/sum_test.cpp
+++ b/core/test/sum_test.cpp
@@ -9,13 +9,17 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(SumTest, masked_data_array) {
-  const auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m,
-                                        {1.0, 2.0, 3.0, 4.0});
-  const auto mask = makeVariable<bool>({Dim::X, 2}, {false, true});
+  const auto var =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
+                             units::Unit(units::m), Values{1.0, 2.0, 3.0, 4.0});
+  const auto mask =
+      createVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
-  const auto sumX = makeVariable<double>({Dim::Y, 2}, units::m, {1.0, 3.0});
-  const auto sumY = makeVariable<double>({Dim::X, 2}, units::m, {4.0, 6.0});
+  const auto sumX = createVariable<double>(
+      Dimensions{Dim::Y, 2}, units::Unit(units::m), Values{1.0, 3.0});
+  const auto sumY = createVariable<double>(
+      Dimensions{Dim::X, 2}, units::Unit(units::m), Values{4.0, 6.0});
   EXPECT_EQ(sum(a, Dim::X).data(), sumX);
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
   EXPECT_FALSE(sum(a, Dim::X).masks().contains("mask"));
@@ -23,15 +27,20 @@ TEST(SumTest, masked_data_array) {
 }
 
 TEST(SumTest, masked_data_array_two_masks) {
-  const auto var = makeVariable<double>({{Dim::Y, 2}, {Dim::X, 2}}, units::m,
-                                        {1.0, 2.0, 3.0, 4.0});
-  const auto maskX = makeVariable<bool>({Dim::X, 2}, {false, true});
-  const auto maskY = makeVariable<bool>({Dim::Y, 2}, {false, true});
+  const auto var =
+      createVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
+                             units::Unit(units::m), Values{1.0, 2.0, 3.0, 4.0});
+  const auto maskX =
+      createVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
+  const auto maskY =
+      createVariable<bool>(Dimensions{Dim::Y, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("x", maskX);
   a.masks().set("y", maskY);
-  const auto sumX = makeVariable<double>({Dim::Y, 2}, units::m, {1.0, 3.0});
-  const auto sumY = makeVariable<double>({Dim::X, 2}, units::m, {1.0, 2.0});
+  const auto sumX = createVariable<double>(
+      Dimensions{Dim::Y, 2}, units::Unit(units::m), Values{1.0, 3.0});
+  const auto sumY = createVariable<double>(
+      Dimensions{Dim::X, 2}, units::Unit(units::m), Values{1.0, 2.0});
   EXPECT_EQ(sum(a, Dim::X).data(), sumX);
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
   EXPECT_FALSE(sum(a, Dim::X).masks().contains("x"));

--- a/core/test/transform_sparse_and_dense_test.cpp
+++ b/core/test/transform_sparse_and_dense_test.cpp
@@ -17,7 +17,8 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(TransformSparseAndDenseTest, two_args) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{2l, Dimensions::Sparse});
   auto vals = var.sparseValues<double>();
   vals[0] = {1, 2, 3};
   vals[1] = {4};
@@ -40,7 +41,8 @@ TEST(TransformSparseAndDenseTest, two_args) {
 }
 
 TEST(TransformSparseAndDenseTest, three_args) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{2l, Dimensions::Sparse});
   auto vals = var.sparseValues<double>();
   vals[0] = {1, 2, 3};
   vals[1] = {4};

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -9,8 +9,12 @@
 
 using namespace scipp;
 using namespace scipp::core;
+
 TEST(CreateVariableTest, from_single_value) {
   auto var = createVariable<float>(Values{0}, Variances{1});
+  EXPECT_EQ(var.dtype(), dtype<float>);
+  EXPECT_EQ(var.value<float>(), 0.0f);
+  EXPECT_EQ(var.variance<float>(), 1.0f);
 }
 
 TEST(CreateVariableTest, construct_sparse) {

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -17,6 +17,12 @@ TEST(CreateVariableTest, from_single_value) {
   EXPECT_EQ(var.variance<float>(), 1.0f);
 }
 
+TEST(CreateVariableTest, from_vector) {
+  EXPECT_EQ(createVariable<double>(Dims{Dim::X}, Shape{3},
+                                   Values(std::vector<int>{1, 2, 3})),
+            createVariable<double>(Dims{Dim::X}, Shape{3}, Values({1, 2, 3})));
+}
+
 TEST(CreateVariableTest, construct_sparse) {
   auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
                                     Shape{2, Dimensions::Sparse});

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -21,6 +21,10 @@ TEST(CreateVariableTest, from_vector) {
   EXPECT_EQ(createVariable<double>(Dims{Dim::X}, Shape{3},
                                    Values(std::vector<int>{1, 2, 3})),
             createVariable<double>(Dims{Dim::X}, Shape{3}, Values({1, 2, 3})));
+
+  const std::vector<double> v{1, 2, 3};
+  auto varRef = createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1,2,3});
+  auto var = createVariable<double> (Dims{Dim::X}, Shape{3}, Values(v));
 }
 
 TEST(CreateVariableTest, construct_sparse) {

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -23,8 +23,8 @@ TEST(CreateVariableTest, from_vector) {
             createVariable<double>(Dims{Dim::X}, Shape{3}, Values({1, 2, 3})));
 
   const std::vector<double> v{1, 2, 3};
-  auto varRef = createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1,2,3});
-  auto var = createVariable<double> (Dims{Dim::X}, Shape{3}, Values(v));
+  auto varRef = createVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
+  auto var = createVariable<double>(Dims{Dim::X}, Shape{3}, Values(v));
 }
 
 TEST(CreateVariableTest, construct_sparse) {

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -9,6 +9,10 @@
 
 using namespace scipp;
 using namespace scipp::core;
+TEST(CreateVariableTest, from_single_value) {
+  auto var = createVariable<float>(Values{0}, Variances{1});
+}
+
 TEST(CreateVariableTest, construct_sparse) {
   auto var = createVariable<double>(Dims{Dim::X, Dim::Y},
                                     Shape{2, Dimensions::Sparse});

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -73,7 +73,7 @@ TEST(Variable, operator_plus_equal) {
 TEST(Variable, operator_plus_equal_automatic_broadcast_of_rhs) {
   auto a = createVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.1, 2.2});
 
-  auto fewer_dimensions = makeVariable<double>(1.0);
+  auto fewer_dimensions = createVariable<double>(Values{1.0});
 
   ASSERT_NO_THROW(a += fewer_dimensions);
   EXPECT_EQ(a.values<double>()[0], 2.1);
@@ -197,7 +197,8 @@ TEST(Variable, operator_plus_eigen_type) {
 }
 
 TEST(SparseVariable, operator_plus) {
-  auto sparse = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto sparse = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                       Shape{2l, Dimensions::Sparse});
   auto sparse_ = sparse.sparseValues<double>();
   sparse_[0] = {1, 2, 3};
   sparse_[1] = {4};
@@ -331,7 +332,7 @@ TEST(Variable, operator_times_can_broadcast) {
 
 TEST(Variable, operator_divide_equal) {
   auto a = createVariable<double>(Dims{Dim::X}, Shape{2}, Values{2.0, 3.0});
-  auto b = makeVariable<double>(2.0);
+  auto b = createVariable<double>(Values{2.0});
   b.setUnit(units::m);
 
   EXPECT_NO_THROW(a /= b);
@@ -381,10 +382,10 @@ TEST(Variable, operator_divide_scalar_float) {
 }
 
 TEST(Variable, operator_allowed_types) {
-  auto i32 = makeVariable<int32_t>(10);
-  auto i64 = makeVariable<int64_t>(10);
-  auto f = makeVariable<float>(0.5f);
-  auto d = makeVariable<double>(0.5);
+  auto i32 = createVariable<int32_t>(Values{10});
+  auto i64 = createVariable<int64_t>(Values{10});
+  auto f = createVariable<float>(Values{0.5f});
+  auto d = createVariable<double>(Values{0.5});
 
   /* Can operate on higher precision from lower precision */
   EXPECT_NO_THROW(i64 += i32);
@@ -492,11 +493,13 @@ TEST(SparseVariable, concatenate) {
 }
 
 TEST(SparseVariable, concatenate_along_sparse_dimension) {
-  auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                  Shape{2l, Dimensions::Sparse});
   auto a_ = a.sparseValues<double>();
   a_[0] = {1, 2, 3};
   a_[1] = {1, 2};
-  auto b = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto b = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                  Shape{2l, Dimensions::Sparse});
   auto b_ = b.sparseValues<double>();
   b_[0] = {1, 3};
   b_[1] = {};
@@ -571,7 +574,8 @@ TEST(Variable, sum) {
 TEST(VariableConstProxy, sum) {
   const auto var =
       createVariable<float>(Dims{Dim::X}, Shape{4}, Values{1.0, 2.0, 3.0, 4.0});
-  EXPECT_EQ(sum(var.slice({Dim::X, 0, 2}), Dim::X), makeVariable<float>(3));
+  EXPECT_EQ(sum(var.slice({Dim::X, 0, 2}), Dim::X),
+            createVariable<float>(Values{3}));
 }
 
 TEST(Variable, abs) {
@@ -1150,10 +1154,10 @@ TYPED_TEST_CASE(ReciprocalTest, test_types);
 
 TYPED_TEST(ReciprocalTest, variable_reciprocal) {
   using T = TypeParam;
-  auto var1 = makeVariable<T>(2);
-  auto var2 = makeVariable<T>(0.5);
+  auto var1 = createVariable<T>(Values{2});
+  auto var2 = createVariable<T>(Values{0.5});
   ASSERT_EQ(reciprocal(var1), var2);
-  var1 = makeVariable<T>(2, 1);
-  var2 = makeVariable<T>(0.5, 0.0625);
+  var1 = createVariable<T>(Values{2}, Variances{1});
+  var2 = createVariable<T>(Values{0.5}, Variances{0.0625});
   ASSERT_EQ(reciprocal(var1), var2);
 }

--- a/core/test/variable_scalar_accessors_test.cpp
+++ b/core/test/variable_scalar_accessors_test.cpp
@@ -27,7 +27,7 @@ TYPED_TEST_SUITE(Variable_scalar_accessors_mutate, VariableTypesMutable);
 TYPED_TEST_SUITE(Variable_scalar_accessors, VariableTypes);
 
 TYPED_TEST(Variable_scalar_accessors_mutate, value_dim_0) {
-  auto v_ = makeVariable<double>(1.1);
+  auto v_ = createVariable<double>(Values{1.1});
   auto &&v = TestFixture::access(v_);
   ASSERT_THROW(v.template value<float>(), except::TypeError);
   ASSERT_THROW(v.template variance<double>(), except::VariancesError);
@@ -37,7 +37,7 @@ TYPED_TEST(Variable_scalar_accessors_mutate, value_dim_0) {
 }
 
 TYPED_TEST(Variable_scalar_accessors_mutate, variance_dim_0) {
-  auto v_ = makeVariable<double>(1.1, 2.2);
+  auto v_ = createVariable<double>(Values{1.1}, Variances{2.2});
   auto &&v = TestFixture::access(v_);
   ASSERT_THROW(v.template variance<float>(), except::TypeError);
   EXPECT_EQ(v.template variance<double>(), 2.2);
@@ -46,7 +46,7 @@ TYPED_TEST(Variable_scalar_accessors_mutate, variance_dim_0) {
 }
 
 TYPED_TEST(Variable_scalar_accessors, value_dim_0) {
-  auto v_ = makeVariable<double>(1.1);
+  auto v_ = createVariable<double>(Values{1.1});
   auto &&v = TestFixture::access(v_);
   ASSERT_THROW(v.template value<float>(), except::TypeError);
   ASSERT_THROW(v.template variance<double>(), except::VariancesError);
@@ -54,7 +54,7 @@ TYPED_TEST(Variable_scalar_accessors, value_dim_0) {
 }
 
 TYPED_TEST(Variable_scalar_accessors, variance_dim_0) {
-  auto v_ = makeVariable<double>(1.1, 2.2);
+  auto v_ = createVariable<double>(Values{1.1}, Variances{2.2});
   auto &&v = TestFixture::access(v_);
   ASSERT_THROW(v.template variance<float>(), except::TypeError);
   EXPECT_EQ(v.template variance<double>(), 2.2);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -40,8 +40,8 @@ TEST(Variable, move) {
 }
 
 TEST(Variable, makeVariable_custom_type) {
-  auto doubles = makeVariable<double>({});
-  auto floats = makeVariable<float>({});
+  auto doubles = createVariable<double>(Values{double{}});
+  auto floats = createVariable<float>(Values{float{}});
 
   ASSERT_NO_THROW(doubles.values<double>());
   ASSERT_NO_THROW(floats.values<float>());
@@ -66,8 +66,8 @@ TEST(Variable, makeVariable_custom_type_initializer_list) {
 }
 
 TEST(Variable, dtype) {
-  auto doubles = makeVariable<double>({});
-  auto floats = makeVariable<float>({});
+  auto doubles = createVariable<double>(Values{double{}});
+  auto floats = createVariable<float>(Values{float{}});
   EXPECT_EQ(doubles.dtype(), dtype<double>);
   EXPECT_NE(doubles.dtype(), dtype<float>);
   EXPECT_NE(floats.dtype(), dtype<double>);
@@ -121,10 +121,10 @@ protected:
 };
 
 TEST_F(Variable_comparison_operators, values_0d) {
-  const auto base = makeVariable<double>(1.1);
+  const auto base = createVariable<double>(Values{1.1});
   expect_eq(base, base);
-  expect_eq(base, makeVariable<double>(1.1));
-  expect_ne(base, makeVariable<double>(1.2));
+  expect_eq(base, createVariable<double>(Values{1.1}));
+  expect_ne(base, createVariable<double>(Values{1.2}));
 }
 
 TEST_F(Variable_comparison_operators, values_1d) {
@@ -148,11 +148,11 @@ TEST_F(Variable_comparison_operators, values_2d) {
 }
 
 TEST_F(Variable_comparison_operators, variances_0d) {
-  const auto base = makeVariable<double>(1.1, 0.1);
+  const auto base = createVariable<double>(Values{1.1}, Variances{0.1});
   expect_eq(base, base);
-  expect_eq(base, makeVariable<double>(1.1, 0.1));
-  expect_ne(base, makeVariable<double>(1.1));
-  expect_ne(base, makeVariable<double>(1.1, 0.2));
+  expect_eq(base, createVariable<double>(Values{1.1}, Variances{0.1}));
+  expect_ne(base, createVariable<double>(Values{1.1}));
+  expect_ne(base, createVariable<double>(Values{1.1}, Variances{0.2}));
 }
 
 TEST_F(Variable_comparison_operators, variances_1d) {
@@ -184,7 +184,7 @@ TEST_F(Variable_comparison_operators, variances_2d) {
 }
 
 TEST_F(Variable_comparison_operators, dimension_mismatch) {
-  expect_ne(makeVariable<double>(1.1),
+  expect_ne(createVariable<double>(Values{1.1}),
             createVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.1}));
   expect_ne(createVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.1}),
             createVariable<double>(Dims{Dim::Y}, Shape{1}, Values{1.1}));
@@ -211,26 +211,30 @@ TEST_F(Variable_comparison_operators, unit) {
 }
 
 TEST_F(Variable_comparison_operators, dtype) {
-  const auto base = makeVariable<double>(1.0);
-  expect_ne(base, makeVariable<float>(1.0));
+  const auto base = createVariable<double>(Values{1.0});
+  expect_ne(base, createVariable<float>(Values{1.0}));
 }
 
 TEST_F(Variable_comparison_operators, dense_sparse) {
-  auto dense = makeVariable<double>({Dim::Y, Dim::X}, {2, 0});
-  auto sparse = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto dense = createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2l, 0l});
+  auto sparse = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                       Shape{2l, Dimensions::Sparse});
   expect_ne(dense, sparse);
 }
 
 TEST_F(Variable_comparison_operators, sparse) {
-  auto a = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                  Shape{2l, Dimensions::Sparse});
   auto a_ = a.sparseValues<double>();
   a_[0] = {1, 2, 3};
   a_[1] = {1, 2};
-  auto b = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto b = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                  Shape{2l, Dimensions::Sparse});
   auto b_ = b.sparseValues<double>();
   b_[0] = {1, 2, 3};
   b_[1] = {1, 2};
-  auto c = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto c = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                  Shape{2l, Dimensions::Sparse});
   auto c_ = c.sparseValues<double>();
   c_[0] = {1, 3};
   c_[1] = {};
@@ -264,8 +268,8 @@ TEST_F(Variable_comparison_operators, sparse_variances) {
   c_vars[0] = {1, 3};
   c_vars[1] = {};
 
-  auto a_no_vars =
-      makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto a_no_vars = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                          Shape{2l, Dimensions::Sparse});
   auto a_no_vars_ = a_no_vars.sparseValues<double>();
   a_no_vars_[0] = {1, 2, 3};
   a_no_vars_[1] = {1, 2};
@@ -337,8 +341,9 @@ TEST(Variable, assign_slice_unit_checks) {
 }
 
 TEST(Variable, assign_slice_variance_checks) {
-  const auto parent_vals = makeVariable<double>(1.0);
-  const auto parent_vals_vars = makeVariable<double>(1.0, 2.0);
+  const auto parent_vals = createVariable<double>(Values{1.0});
+  const auto parent_vals_vars =
+      createVariable<double>(Values{1.0}, Variances{2.0});
   auto vals = createVariable<double>(Dims{Dim::X}, Shape{4});
   auto vals_vars = makeVariableWithVariances<double>({Dim::X, 4});
 
@@ -911,8 +916,8 @@ TEST(Variable, access_typed_view_edges) {
 }
 
 TEST(SparseVariable, create) {
-  const auto var =
-      makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                          Shape{2l, Dimensions::Sparse});
   EXPECT_TRUE(var.dims().sparse());
   EXPECT_EQ(var.dims().sparseDim(), Dim::X);
   // Should we return the full volume here, i.e., accumulate the extents of all
@@ -921,8 +926,8 @@ TEST(SparseVariable, create) {
 }
 
 TEST(SparseVariable, dtype) {
-  const auto var =
-      makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                          Shape{2l, Dimensions::Sparse});
   // It is not clear that this is the best way of handling things.
   // Variable::dtype() makes sense like this, but it is not so clear for
   // VariableConcept::dtype().
@@ -938,8 +943,8 @@ TEST(SparseVariable, non_sparse_access_fail) {
 }
 
 TEST(SparseVariable, DISABLED_low_level_access) {
-  const auto var =
-      makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  const auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                          Shape{2l, Dimensions::Sparse});
   // Need to decide whether we allow this direct access or not.
   ASSERT_THROW((var.values<sparse_container<double>>()), except::TypeError);
 }
@@ -960,7 +965,8 @@ TEST(SparseVariable, access) {
 }
 
 TEST(SparseVariable, resize_sparse) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{2l, Dimensions::Sparse});
   auto data = var.sparseValues<double>();
   data[1] = {1, 2, 3};
 }
@@ -981,7 +987,8 @@ TEST(SparseVariable, move) {
 }
 
 TEST(SparseVariable, slice) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {4, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{4l, Dimensions::Sparse});
   auto data = var.sparseValues<double>();
   data[0] = {1, 2, 3};
   data[1] = {1, 2};
@@ -997,7 +1004,8 @@ TEST(SparseVariable, slice) {
 }
 
 TEST(SparseVariable, slice_fail) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {4, Dimensions::Sparse});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X},
+                                    Shape{4l, Dimensions::Sparse});
   auto data = var.sparseValues<double>();
   data[0] = {1, 2, 3};
   data[1] = {1, 2};
@@ -1008,22 +1016,23 @@ TEST(SparseVariable, slice_fail) {
 }
 
 TEST(VariableTest, create_with_variance) {
-  ASSERT_NO_THROW(makeVariable<double>(1.0, 0.1));
+  ASSERT_NO_THROW(createVariable<double>(Values{1.0}, Variances{0.1}));
   ASSERT_NO_THROW(createVariable<double>(Dims(), Shape(), units::Unit(units::m),
                                          Values{1.0}, Variances{0.1}));
 }
 
 TEST(VariableTest, hasVariances) {
-  ASSERT_FALSE(makeVariable<double>({}).hasVariances());
-  ASSERT_FALSE(makeVariable<double>(1.0).hasVariances());
-  ASSERT_TRUE(makeVariable<double>(1.0, 0.1).hasVariances());
+  ASSERT_FALSE(createVariable<double>(Values{double{}}).hasVariances());
+  ASSERT_FALSE(createVariable<double>(Values{1.0}).hasVariances());
+  ASSERT_TRUE(
+      createVariable<double>(Values{1.0}, Variances{0.1}).hasVariances());
   ASSERT_TRUE(createVariable<double>(Dims(), Shape(), units::Unit(units::m),
                                      Values{1.0}, Variances{0.1})
                   .hasVariances());
 }
 
 TEST(VariableTest, values_variances) {
-  const auto var = makeVariable<double>(1.0, 0.1);
+  const auto var = createVariable<double>(Values{1.0}, Variances{0.1});
   ASSERT_NO_THROW(var.values<double>());
   ASSERT_NO_THROW(var.variances<double>());
   ASSERT_TRUE(equals(var.values<double>(), {1.0}));
@@ -1075,7 +1084,7 @@ TEST(VariableTest, variances_unsupported_type_fail) {
 }
 
 TEST(VariableTest, construct_proxy_dims) {
-  auto var = makeVariable<double>({Dim::Y, Dim::X}, {2, 3});
+  auto var = createVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2l, 3l});
   Variable vv(var.slice({Dim::X, 0, 2}));
   ASSERT_NO_THROW(Variable(var.slice({Dim::X, 0, 2}), Dimensions(Dim::Y, 2)));
 }
@@ -1100,11 +1109,11 @@ TYPED_TEST_CASE(AsTypeTest, type_pairs);
 TYPED_TEST(AsTypeTest, variable_astype) {
   using T1 = typename TypeParam::first_type;
   using T2 = typename TypeParam::second_type;
-  auto var1 = makeVariable<T1>(1, 1);
-  auto var2 = makeVariable<T2>(1, 1);
+  auto var1 = createVariable<T1>(Values{1}, Variances{1});
+  auto var2 = createVariable<T2>(Values{1}, Variances{1});
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
-  var1 = makeVariable<T1>(1);
-  var2 = makeVariable<T2>(1);
+  var1 = createVariable<T1>(Values{1});
+  var2 = createVariable<T2>(Values{1});
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
   var1 = createVariable<T1>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
                             Values{1.0, 2.0, 3.0});

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -239,7 +239,8 @@ Variable mean(const VariableConstProxy &var, const Dim dim,
   expect::notSparse(var);
   auto summed = sum(var, dim);
 
-  auto scale = 1.0 / (makeVariable<double>(var.dims()[dim]) - masks_sum);
+  auto scale =
+      1.0 / (createVariable<double>(Values{var.dims()[dim]}) - masks_sum);
 
   if (isInt(var.dtype()))
     summed = summed * scale;
@@ -249,7 +250,7 @@ Variable mean(const VariableConstProxy &var, const Dim dim,
 }
 
 Variable mean(const VariableConstProxy &var, const Dim dim) {
-  return mean(var, dim, makeVariable<int64_t>(0));
+  return mean(var, dim, createVariable<int64_t>(Values{0}));
 }
 
 Variable mean(const VariableConstProxy &var, const Dim dim,
@@ -348,7 +349,7 @@ Variable copy(const VariableConstProxy &var) { return Variable(var); }
 
 /// Merges all masks contained in the MasksConstProxy into a single Variable
 Variable masks_merge(const MasksConstProxy &masks, const Dim dim) {
-  auto mask_union = makeVariable<bool>(false);
+  auto mask_union = createVariable<bool>(Values{false});
   for (const auto &mask : masks) {
     if (mask.second.dims().contains(dim)) {
       mask_union = mask_union | mask.second;

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -23,7 +23,8 @@ Dataset makeDatasetWithBeamline() {
                      createVariable<Eigen::Vector3d>(
                          Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
                          Values{source_pos, sample_pos}));
-  beamline.setLabels("component_info", makeVariable<Dataset>(components));
+  beamline.setLabels("component_info",
+                     createVariable<Dataset>(Values{components}));
   // TODO Need fuzzy comparison for variables to write a convenient test with
   // detectors away from the axes.
   beamline.setLabels("position",

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -27,7 +27,7 @@ Dataset makeTofDataForUnitConversion(const bool dense_coord = true) {
                          Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
                          Values{Eigen::Vector3d{0.0, 0.0, -10.0},
                                 Eigen::Vector3d{0.0, 0.0, 0.0}}));
-  tof.setLabels("component_info", makeVariable<Dataset>(components));
+  tof.setLabels("component_info", createVariable<Dataset>(Values{components}));
   tof.setLabels("position",
                 createVariable<Eigen::Vector3d>(
                     Dims{Dim::Spectrum}, Shape{2}, units::Unit(units::m),
@@ -39,8 +39,8 @@ Dataset makeTofDataForUnitConversion(const bool dense_coord = true) {
                                      Values{1, 2, 3, 4, 5, 6}));
   tof["counts"].data().setUnit(units::counts);
 
-  auto events =
-      makeVariable<double>({Dim::Spectrum, Dim::Tof}, {2, Dimensions::Sparse});
+  auto events = createVariable<double>(Dims{Dim::Spectrum, Dim::Tof},
+                                       Shape{2l, Dimensions::Sparse});
   events.setUnit(units::us);
   auto eventLists = events.sparseValues<double>();
   eventLists[0] = {1000, 3000, 2000, 4000};

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -209,12 +209,11 @@ void bind_init_list(py::class_<Variable> &c) {
               variable = createVariable<Eigen::Vector3d>(
                   Dims{label[0]}, Shape{scipp::size(val)},
                   Values(val.begin(), val.end()),
-                  Variances(var.begin(), var.end()));
+                  Variances(var.begin(), var.end()), units::Unit(unit));
             } else
               variable = createVariable<Eigen::Vector3d>(
                   Dims{label[0]}, Shape{scipp::size(val)},
-                  Values(val.begin(), val.end()));
-            variable.setUnit(unit);
+                  Values(val.begin(), val.end()), units::Unit(unit));
             return variable;
           }
 
@@ -277,8 +276,7 @@ void init_variable(py::module &m) {
   py::class_<VariableConstProxy>(m, "VariableConstProxy")
       .def(py::init<const Variable &>());
   py::class_<VariableProxy, VariableConstProxy> variableProxy(
-      m, "VariableProxy", py::buffer_protocol(),
-      R"(
+      m, "VariableProxy", py::buffer_protocol(), R"(
         Proxy for Variable, representing a sliced or transposed view onto a variable;
         Mostly equivalent to Variable, see there for details.)");
   variableProxy.def_buffer(&make_py_buffer_info);
@@ -338,8 +336,7 @@ void init_variable(py::module &m) {
           Dimensions dims(labels, shape.cast<std::vector<scipp::index>>());
           return self.reshape(dims);
         },
-        py::arg("x"), py::arg("dims"), py::arg("shape"),
-        R"(
+        py::arg("x"), py::arg("dims"), py::arg("shape"), R"(
         Reshape a variable.
 
         :param x: Data to reshape.
@@ -350,8 +347,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("abs", [](const Variable &self) { return abs(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise absolute value.
 
         :raises: If the dtype has no absolute value, e.g., if it is a string
@@ -372,8 +368,7 @@ void init_variable(py::module &m) {
         py::overload_cast<const VariableConstProxy &,
                           const VariableConstProxy &, const Dim>(&concatenate),
         py::arg("x"), py::arg("y"), py::arg("dim"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Concatenate input variables along the given dimension.
 
         Concatenation can happen in two ways:
@@ -387,10 +382,10 @@ void init_variable(py::module &m) {
         :return: New variable containing all elements of the input variables.
         :rtype: Variable)");
 
-  m.def(
-      "filter", py::overload_cast<const Variable &, const Variable &>(&filter),
-      py::arg("x"), py::arg("filter"), py::call_guard<py::gil_scoped_release>(),
-      R"(
+  m.def("filter",
+        py::overload_cast<const Variable &, const Variable &>(&filter),
+        py::arg("x"), py::arg("filter"),
+        py::call_guard<py::gil_scoped_release>(), R"(
         Selects elements for a Variable using a filter (mask).
 
         The filter variable must be 1D and of bool type.
@@ -417,8 +412,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("norm", py::overload_cast<const VariableConstProxy &>(&norm),
-        py::arg("x"), py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise norm.
 
         :raises: If the dtype has no norm, i.e., if it is not a vector
@@ -444,8 +438,7 @@ void init_variable(py::module &m) {
         "Split a Variable along a given Dimension.");
 
   m.def("sqrt", [](const VariableConstProxy &self) { return sqrt(self); },
-        py::arg("x"), py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise square-root.
 
         :raises: If the dtype has no square-root, e.g., if it is a string
@@ -477,8 +470,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("sin", [](const Variable &self) { return sin(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise sin.
 
         :raises: If the unit is not a plane-angle unit, or if the dtype has no sin, e.g., if it is an integer
@@ -486,8 +478,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("cos", [](const Variable &self) { return cos(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise cos.
 
         :raises: If the unit is not a plane-angle unit, or if the dtype has no cos, e.g., if it is an integer
@@ -495,8 +486,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("tan", [](const Variable &self) { return tan(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise tan.
 
         :raises: If the unit is not a plane-angle unit, or if the dtype has no tan, e.g., if it is an integer
@@ -504,8 +494,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("asin", [](const Variable &self) { return asin(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise asin.
 
         :raises: If the unit is dimensionless, or if the dtype has no asin, e.g., if it is an integer
@@ -513,8 +502,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("acos", [](const Variable &self) { return acos(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise acos.
 
         :raises: If the unit is dimensionless, or if the dtype has no acos, e.g., if it is an integer
@@ -522,8 +510,7 @@ void init_variable(py::module &m) {
         :rtype: Variable)");
 
   m.def("atan", [](const Variable &self) { return atan(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(),
-        R"(
+        py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise atan.
 
         :raises: If the unit is dimensionless, or if the dtype has no atan, e.g., if it is an integer

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -66,8 +66,9 @@ template <class ST> struct MakeODFromNativePythonTypes {
   template <class T> struct Maker {
     static Variable apply(const units::Unit unit, const ST &value,
                           const std::optional<ST> &variance) {
-      auto var = variance ? makeVariable<T>(T(value), T(variance.value()))
-                          : makeVariable<T>(T(value));
+      auto var = variance ? createVariable<T>(Values{T(value)},
+                                              Variances{T(variance.value())})
+                          : createVariable<T>(Values{T(value)});
       var.setUnit(unit);
       return var;
     }
@@ -98,9 +99,9 @@ auto do_init_0D(const T &value, const std::optional<T> &variance,
                 const units::Unit &unit) {
   Variable var;
   if (variance)
-    var = makeVariable<T>(value, *variance);
+    var = createVariable<T>(Values{value}, Variances{*variance});
   else
-    var = makeVariable<T>(value);
+    var = createVariable<T>(Values{value});
   var.setUnit(unit);
   return var;
 }


### PR DESCRIPTION
Manual fixes for using `makeVariable` in merged external branches. Skipping refactoring_4 and 5, because the code is in incompilable stage reasoned by external branches merging.