### PR TITLE
Consistent header guards

### DIFF
--- a/common/include/scipp/common/index.h
+++ b/common/include/scipp/common/index.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef INDEX_H
-#define INDEX_H
+#ifndef SCIPP_COMMON_INDEX_H
+#define SCIPP_COMMON_INDEX_H
 #include <cstddef>
 
 namespace scipp {
@@ -23,4 +23,4 @@ template <class T> index size(const T &container) {
 }
 } // namespace scipp
 
-#endif // INDEX_H
+#endif // SCIPP_COMMON_INDEX_H

--- a/common/include/scipp/common/span.h
+++ b/common/include/scipp/common/span.h
@@ -2,10 +2,10 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef SPAN_H
-#define SPAN_H
+#ifndef SCIPP_COMMON_SPAN_H
+#define SCIPP_COMMON_SPAN_H
 
 #define TCB_SPAN_NAMESPACE_NAME scipp
 #include "tcb/span.hpp"
 
-#endif // SPAN_H
+#endif // SCIPP_COMMON_SPAN_H

--- a/core/include/scipp/core/aligned_allocator.h
+++ b/core/include/scipp/core/aligned_allocator.h
@@ -5,8 +5,8 @@
 
 // from https://stackoverflow.com/a/12942652/1458281
 
-#ifndef ALIGNED_ALLOCATOR_H
-#define ALIGNED_ALLOCATOR_H
+#ifndef SCIPP_CORE_ALIGNED_ALLOCATOR_H
+#define SCIPP_CORE_ALIGNED_ALLOCATOR_H
 
 #include <cassert>
 
@@ -195,4 +195,4 @@ inline bool operator!=(const AlignedAllocator<T, TAlign> &,
 }
 
 } // namespace scipp::core
-#endif // ALIGNED_ALLOCATOR_H
+#endif // SCIPP_CORE_ALIGNED_ALLOCATOR_H

--- a/core/include/scipp/core/apply.h
+++ b/core/include/scipp/core/apply.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef APPLY_H
-#define APPLY_H
+#ifndef SCIPP_CORE_APPLY_H
+#define SCIPP_CORE_APPLY_H
 
 #include "scipp/core/except.h"
 #include "scipp/core/variable.h"
@@ -25,4 +25,4 @@ void apply_in_place(Op op, Var &&var, const Vars &... vars) {
 
 } // namespace scipp::core
 
-#endif // APPLY_H
+#endif // SCIPP_CORE_APPLY_H

--- a/core/include/scipp/core/dataset_index.h
+++ b/core/include/scipp/core/dataset_index.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef DATASET_INDEX_H
-#define DATASET_INDEX_H
+#ifndef SCIPP_CORE_DATASET_INDEX_H
+#define SCIPP_CORE_DATASET_INDEX_H
 
 #include <unordered_map>
 
@@ -33,4 +33,4 @@ private:
 
 } // namespace scipp::core
 
-#endif // DATASET_INDEX_H
+#endif // SCIPP_CORE_DATASET_INDEX_H

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef DIMENSIONS_H
-#define DIMENSIONS_H
+#ifndef SCIPP_CORE_DIMENSIONS_H
+#define SCIPP_CORE_DIMENSIONS_H
 
 #include <limits>
 #include <memory>
@@ -167,4 +167,4 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
 
 } // namespace scipp::core
 
-#endif // DIMENSIONS_H
+#endif // SCIPP_CORE_DIMENSIONS_H

--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef DTYPE_H
-#define DTYPE_H
+#ifndef SCIPP_CORE_DTYPE_H
+#define SCIPP_CORE_DTYPE_H
 
 #include <Eigen/Dense>
 #include <boost/container/small_vector.hpp>
@@ -70,4 +70,4 @@ bool isBool(DType tp);
 
 } // namespace scipp::core
 
-#endif // DTYPE_H
+#endif // SCIPP_CORE_DTYPE_H

--- a/core/include/scipp/core/memory_pool.h
+++ b/core/include/scipp/core/memory_pool.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef MEMORY_POOL_H
-#define MEMORY_POOL_H
+#ifndef SCIPP_CORE_MEMORY_POOL_H
+#define SCIPP_CORE_MEMORY_POOL_H
 
 #include <array>
 #include <map>
@@ -98,4 +98,4 @@ inline MemoryPool &instance() {
 
 } // namespace scipp::core
 
-#endif // MEMORY_POOL_H
+#endif // SCIPP_CORE_MEMORY_POOL_H

--- a/core/include/scipp/core/slice.h
+++ b/core/include/scipp/core/slice.h
@@ -6,8 +6,8 @@
 #include "scipp/common/index.h"
 #include "scipp/units/unit.h"
 
-#ifndef SLICE_H
-#define SLICE_H
+#ifndef SCIPP_CORE_SLICE_H
+#define SCIPP_CORE_SLICE_H
 
 namespace scipp {
 namespace core {
@@ -36,4 +36,4 @@ private:
 } // namespace core
 } // namespace scipp
 
-#endif // SLICE_H
+#endif // SCIPP_CORE_SLICE_H

--- a/core/include/scipp/core/tag_util.h
+++ b/core/include/scipp/core/tag_util.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef TAG_UTIL_H
-#define TAG_UTIL_H
+#ifndef SCIPP_CORE_TAG_UTIL_H
+#define SCIPP_CORE_TAG_UTIL_H
 
 namespace scipp::core {
 
@@ -48,4 +48,4 @@ struct CallDTypeWithSparse : public CallDType<Ts..., sparse_container<Ts>...> {
 
 } // namespace scipp::core
 
-#endif // TAG_UTIL_H
+#endif // SCIPP_CORE_TAG_UTIL_H

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -20,8 +20,8 @@
 ///    client-provided overload will match.
 ///
 /// @author Simon Heybrock
-#ifndef TRANSFORM_H
-#define TRANSFORM_H
+#ifndef SCIPP_CORE_TRANSFORM_H
+#define SCIPP_CORE_TRANSFORM_H
 
 #include "scipp/common/overloaded.h"
 #include "scipp/core/except.h"
@@ -800,4 +800,4 @@ template <class... TypeTuples, class Op>
 
 } // namespace scipp::core
 
-#endif // TRANSFORM_H
+#endif // SCIPP_CORE_TRANSFORM_H

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
-#ifndef VALUE_AND_VARIANCE_H
-#define VALUE_AND_VARIANCE_H
+#ifndef SCIPP_CORE_VALUE_AND_VARIANCE_H
+#define SCIPP_CORE_VALUE_AND_VARIANCE_H
 
 #include "scipp/core/variable.h"
 
@@ -152,4 +152,4 @@ inline constexpr bool is_ValueAndVariance_v = is_ValueAndVariance<T>::value;
 
 } // namespace scipp::core
 
-#endif // VALUE_AND_VARIANCE_H
+#endif // SCIPP_CORE_VALUE_AND_VARIANCE_H

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef VARIABLE_H
-#define VARIABLE_H
+#ifndef SCIPP_CORE_VARIABLE_H
+#define SCIPP_CORE_VARIABLE_H
 
 #include <optional>
 #include <string>
@@ -1081,4 +1081,4 @@ SCIPP_CORE_EXPORT void reserve(const VariableProxy &sparse,
 
 } // namespace scipp::core
 
-#endif // VARIABLE_H
+#endif // SCIPP_CORE_VARIABLE_H

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef VARIABLE_VIEW_H
-#define VARIABLE_VIEW_H
+#ifndef SCIPP_CORE_VARIABLE_VIEW_H
+#define SCIPP_CORE_VARIABLE_VIEW_H
 
 #include <algorithm>
 
@@ -191,4 +191,4 @@ inline constexpr bool is_VariableView_v = is_VariableView<T>::value;
 
 } // namespace scipp::core
 
-#endif // VARIABLE_VIEW_H
+#endif // SCIPP_CORE_VARIABLE_VIEW_H

--- a/core/include/scipp/core/vector.h
+++ b/core/include/scipp/core/vector.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef VECTOR_H
-#define VECTOR_H
+#ifndef SCIPP_CORE_VECTOR_H
+#define SCIPP_CORE_VECTOR_H
 
 #include "scipp/core/element_array.h"
 
@@ -11,4 +11,4 @@ namespace scipp::core {
 template <class T> using Vector = detail::element_array<T>;
 }
 
-#endif // VECTOR_H
+#endif // SCIPP_CORE_VECTOR_H

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Neil Vaytet
-#ifndef VIEW_INDEX_H
-#define VIEW_INDEX_H
+#ifndef SCIPP_CORE_VIEW_INDEX_H
+#define SCIPP_CORE_VIEW_INDEX_H
 
 #include "scipp-core_export.h"
 #include "scipp/core/dimensions.h"
@@ -112,4 +112,4 @@ private:
 
 } // namespace scipp::core
 
-#endif // VIEW_INDEX_H
+#endif // SCIPP_CORE_VIEW_INDEX_H

--- a/core/include/scipp/core/visit.h
+++ b/core/include/scipp/core/visit.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef VISIT_H
-#define VISIT_H
+#ifndef SCIPP_CORE_VISIT_H
+#define SCIPP_CORE_VISIT_H
 
 #include <memory>
 #include <tuple>
@@ -100,4 +100,4 @@ template <class... Ts> auto visit(const std::tuple<Ts...> &) {
 
 } // namespace scipp::core
 
-#endif // VISIT_H
+#endif // SCIPP_CORE_VISIT_H

--- a/test/test_macros.h
+++ b/test/test_macros.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef TEST_MACROS_H
-#define TEST_MACROS_H
+#ifndef SCIPP_TEST_MACROS_H
+#define SCIPP_TEST_MACROS_H
 
 #include <algorithm>
 #include <cmath>
@@ -56,4 +56,4 @@ bool equals(const T1 &a, const T2 &b, const Tol tolerance) {
 #define ASSERT_NO_THROW_NODISCARD(expr) ASSERT_NO_THROW((void)expr)
 #define ASSERT_THROW_NODISCARD(expr, type) ASSERT_THROW((void)expr, type)
 
-#endif // TEST_MACROS_H
+#endif // SCIPP_TEST_MACROS_H

--- a/test/test_operations.h
+++ b/test/test_operations.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 /// @file
-#ifndef TEST_OPERATIONS_H
-#define TEST_OPERATIONS_H
+#ifndef SCIPP_TEST_OPERATIONS_H
+#define SCIPP_TEST_OPERATIONS_H
 
 #include <gtest/gtest.h>
 
@@ -57,4 +57,4 @@ using Binary = ::testing::Types<plus, minus, times, divide>;
 using BinaryEquals =
     ::testing::Types<plus_equals, minus_equals, times_equals, divide_equals>;
 
-#endif // TEST_OPERATIONS_H
+#endif // SCIPP_TEST_OPERATIONS_H


### PR DESCRIPTION
Makes all header guards in format of `SCIPP_<TARGET>_<FILE_NAME_IN_UPPERCASE>_H` 

Closes #650