### PR TITLE
Only PR builds to run travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,19 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: NOT type = cron
+      if: branch = master AND NOT type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - compiler: clang
       name: "clang"
-      if: NOT type = cron
+      if: NOT branch = master AND type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - os: osx
       name: "apple clang"
-      if: NOT type = cron
+      if: NOT branch = master AND type = pull_request
       osx_image: xcode10.2
       before_install: brew install ccache ninja
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,19 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: NOT branch = master AND type = pull_request
+      if: type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - compiler: clang
       name: "clang"
-      if: NOT branch = master AND type = pull_request
+      if: type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - os: osx
       name: "apple clang"
-      if: NOT branch = master AND type = pull_request
+      if: type = pull_request
       osx_image: xcode10.2
       before_install: brew install ccache ninja
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: branch = master AND type = pull_request
+      if: NOT branch = master AND type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: branch = master AND NOT type = pull_request
+      if: branch = master AND type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Build scipp and test ONLY if not deploying, i.e. not master and a pull_request event
-if [[$TRAVIS_PULL_REQUEST_BRANCH -ne 'master'] && [$TRAVIS_EVENT_TYPE -eq 'pull_request']]
+if [[$TRAVIS_EVENT_TYPE -eq 'pull_request']]
 then
     mkdir -p build
     mkdir -p install

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -2,27 +2,21 @@
 
 set -xe
 
-# Build scipp and test ONLY if not deploying, i.e. not master and a pull_request event
-if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]   ; then
-   if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "master" ]   ; then
-        mkdir -p build
-        mkdir -p install
-        cd build
-        cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
-        make -j2 install all-tests all-benchmarks
-        # C++ tests
-        ./common/test/scipp-common-test
-        ./units/test/scipp-units-test
-        ./core/test/scipp-core-test
-        ./neutron/test/scipp-neutron-test
-        
-        # Python tests
-        python3 -m pip install --user -r ../python/requirements.txt
-        export PYTHONPATH=$PYTHONPATH:../install
-        cd ../python
-        python3 -m pytest
-	exit 0
-    fi
-fi
-echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
-echo 'build type' $TRAVIS_EVENT_TYPE 
+# Build scipp
+mkdir -p build
+mkdir -p install
+cd build
+cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
+make -j2 install all-tests all-benchmarks
+
+# C++ tests
+./common/test/scipp-common-test
+./units/test/scipp-units-test
+./core/test/scipp-core-test
+./neutron/test/scipp-neutron-test
+
+# Python tests
+python3 -m pip install --user -r ../python/requirements.txt
+export PYTHONPATH=$PYTHONPATH:../install
+cd ../python
+python3 -m pytest

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Build scipp and test ONLY if not deploying, i.e. not master and a pull_request event
-if [[$TRAVIS_BRANCH -ne 'master'] && [$TRAVIS_EVENT_TYPE -eq 'pull_request']]
+if [[$TRAVIS_PULL_REQUEST_BRANCH -ne 'master'] && [$TRAVIS_EVENT_TYPE -eq 'pull_request']]
 then
     mkdir -p build
     mkdir -p install
@@ -22,6 +22,6 @@ then
     cd ../python
     python3 -m pytest
 else
-    echo 'build and test step skipped on' $TRAVIS_BRANCH
+    echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
 fi
 

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -23,5 +23,5 @@ then
     python3 -m pytest
 else
     echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
-fi
+    echo 'build type' $TRAVIS_EVENT_TYPE 
 

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -21,6 +21,7 @@ if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]   ; then
         export PYTHONPATH=$PYTHONPATH:../install
         cd ../python
         python3 -m pytest
+	exit 0
     fi
 fi
 echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -2,21 +2,26 @@
 
 set -xe
 
-# Build scipp
-mkdir -p build
-mkdir -p install
-cd build
-cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
-make -j2 install all-tests all-benchmarks
+# Build scipp and test ONLY if not deploying, i.e. not master and a pull_request event
+if [[$TRAVIS_BRANCH -ne 'master'] && [$TRAVIS_EVENT_TYPE -eq 'pull_request']]
+then
+    mkdir -p build
+    mkdir -p install
+    cd build
+    cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
+    make -j2 install all-tests all-benchmarks
+    # C++ tests
+    ./common/test/scipp-common-test
+    ./units/test/scipp-units-test
+    ./core/test/scipp-core-test
+    ./neutron/test/scipp-neutron-test
+    
+    # Python tests
+    python3 -m pip install --user -r ../python/requirements.txt
+    export PYTHONPATH=$PYTHONPATH:../install
+    cd ../python
+    python3 -m pytest
+else
+    echo 'build and test step skipped on' $TRAVIS_BRANCH
+fi
 
-# C++ tests
-./common/test/scipp-common-test
-./units/test/scipp-units-test
-./core/test/scipp-core-test
-./neutron/test/scipp-neutron-test
-
-# Python tests
-python3 -m pip install --user -r ../python/requirements.txt
-export PYTHONPATH=$PYTHONPATH:../install
-cd ../python
-python3 -m pytest

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -24,4 +24,4 @@ then
 else
     echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
     echo 'build type' $TRAVIS_EVENT_TYPE 
-
+fi

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -3,25 +3,25 @@
 set -xe
 
 # Build scipp and test ONLY if not deploying, i.e. not master and a pull_request event
-if [[$TRAVIS_EVENT_TYPE -eq 'pull_request']]
-then
-    mkdir -p build
-    mkdir -p install
-    cd build
-    cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
-    make -j2 install all-tests all-benchmarks
-    # C++ tests
-    ./common/test/scipp-common-test
-    ./units/test/scipp-units-test
-    ./core/test/scipp-core-test
-    ./neutron/test/scipp-neutron-test
-    
-    # Python tests
-    python3 -m pip install --user -r ../python/requirements.txt
-    export PYTHONPATH=$PYTHONPATH:../install
-    cd ../python
-    python3 -m pytest
-else
-    echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
-    echo 'build type' $TRAVIS_EVENT_TYPE 
+if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]   ; then
+   if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "master" ]   ; then
+        mkdir -p build
+        mkdir -p install
+        cd build
+        cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} $@ -DCMAKE_INSTALL_PREFIX=../install ..
+        make -j2 install all-tests all-benchmarks
+        # C++ tests
+        ./common/test/scipp-common-test
+        ./units/test/scipp-units-test
+        ./core/test/scipp-core-test
+        ./neutron/test/scipp-neutron-test
+        
+        # Python tests
+        python3 -m pip install --user -r ../python/requirements.txt
+        export PYTHONPATH=$PYTHONPATH:../install
+        cd ../python
+        python3 -m pytest
+    fi
 fi
+echo 'build and test step skipped on' $TRAVIS_PULL_REQUEST_BRANCH
+echo 'build type' $TRAVIS_EVENT_TYPE 


### PR DESCRIPTION
Should save time for master builds and will mirror the current Appveyor settings.

Only PRs will run build test executables and run them.