### PR TITLE
Fix exception and lifetime issues with values and variances properties.

### DIFF
--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -76,18 +76,6 @@ def test_lifetime_coord_values():
     assert np.array_equal(values, var.values)
 
 
-def test_lifetime_xxx():
-    var = sc.Variable([Dim.X], values=['ab', 'c'])
-    #var = sc.Variable([Dim.X], values=np.arange(12).astype()
-    #vals = sc.sum(var, Dim.Y).values
-    vals = var.copy().values
-    import gc
-    gc.collect()
-    assert vals[0] == 'ab'
-    #assert var.value['a'].values[-1] == 9
-    #assert var.copy().values['a'].values[-1] == 9
-
-
 def test_lifetime_scalar_py_object():
     var = sc.Variable(value=[1] * 100000)
     assert var.dtype == sc.dtype.PyObject

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -74,3 +74,46 @@ def test_lifetime_coord_values():
     values = d.coords[Dim.X].values
     d += d
     assert np.array_equal(values, var.values)
+
+
+def test_lifetime_xxx():
+    var = sc.Variable([Dim.X], values=['ab', 'c'])
+    #var = sc.Variable([Dim.X], values=np.arange(12).astype()
+    #vals = sc.sum(var, Dim.Y).values
+    vals = var.copy().values
+    import gc
+    gc.collect()
+    assert vals[0] == 'ab'
+    #assert var.value['a'].values[-1] == 9
+    #assert var.copy().values['a'].values[-1] == 9
+
+
+def test_lifetime_scalar_py_object():
+    var = sc.Variable(value=[1] * 100000)
+    assert var.dtype == sc.dtype.PyObject
+    val = var.copy().value
+    import gc
+    gc.collect()
+    var.copy()  # do something allocating memory to trigger potential segfault
+    assert val[-1] == 1
+
+
+def test_lifetime_scalar():
+    elem = sc.Variable([Dim.X], values=np.arange(100000))
+    var = sc.Variable(value=elem)
+    assert var.values == elem
+    vals = var.copy().values
+    import gc
+    gc.collect()
+    var.copy()  # do something allocating memory to trigger potential segfault
+    assert var.values == elem
+
+
+def test_lifetime_string_array():
+    var = sc.Variable([Dim.X], values=['ab', 'c'] * 100000)
+    assert var.values[100000] == 'ab'
+    vals = var.copy().values
+    import gc
+    gc.collect()
+    var.copy()  # do something allocating memory to trigger potential segfault
+    assert vals[100000] == 'ab'

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -94,7 +94,7 @@ def test_lifetime_scalar():
     import gc
     gc.collect()
     var.copy()  # do something allocating memory to trigger potential segfault
-    assert var.values == elem
+    assert vals == elem
 
 
 def test_lifetime_string_array():

--- a/python/tests/test_variable_scalar.py
+++ b/python/tests/test_variable_scalar.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+
+
+def test_scalar_Variable_values_property_int():
+    var = sc.Variable(value=1, variance=2)
+    assert var.dtype == sc.dtype.int64
+    assert var.values == 1
+    assert var.variances == 2
+
+
+def test_scalar_Variable_values_property_string():
+    var = sc.Variable(value='abc')
+    assert var.dtype == sc.dtype.string
+    assert var.values == 'abc'
+
+
+def test_scalar_Variable_values_property_PyObject():
+    var = sc.Variable(value=[1, 2])
+    assert var.dtype == sc.dtype.PyObject
+    assert var.values == [1, 2]


### PR DESCRIPTION
Fix #748.

It is unclear why the previous implementation did not work. Wait remains to be done (not just for these changes, but most of the Python bindings) is to check whether there are any memory leaks, since the keep-alive policies are quite intricate.