### PR TITLE
Return none in dtype and unit for sparse array w/o data.

### DIFF
--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -52,7 +52,7 @@ def _format_non_sparse(var, has_variances):
 
 
 def _format_sparse(var, has_variances):
-    if var.data is None:
+    if hasattr(var, "data") and var.data is None:
         return "no data in sparse array"
     s = []
     size = var.shape[0]

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -52,6 +52,8 @@ def _format_non_sparse(var, has_variances):
 
 
 def _format_sparse(var, has_variances):
+    if var.data is None:
+        return "no data in sparse array"
     s = []
     size = var.shape[0]
 


### PR DESCRIPTION
Fixes #745. See title, this is now consistent with the behavior of other properties (in particular `data`).

The only remaining fix that actually touches `to_html` is to avoid attempts to format `None` data.