### PR TITLE
to_html for variables and data arrays

### DIFF
--- a/python/src/scipp/table_html/__init__.py
+++ b/python/src/scipp/table_html/__init__.py
@@ -2,10 +2,16 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Dimitar Tasev
-from scipp.table_html.formatting_html import dataset_repr
+from .._scipp import core as sc
+from .formatting_html import dataset_repr, variable_repr
 
 
-def to_html(dataset):
+def to_html(container):
     from IPython.display import display, HTML
 
-    display(HTML(dataset_repr(dataset)))
+    if isinstance(container, sc.Variable) or isinstance(
+            container, sc.VariableProxy):
+        rep = variable_repr(container)
+    else:
+        rep = dataset_repr(container)
+    display(HTML(rep))

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -388,7 +388,7 @@ def dataset_repr(ds):
         dim_section(ds),
         coord_section(ds.coords),
         label_section(ds.labels),
-        data_section(ds),
+        data_section(ds if hasattr(ds, '__len__') else [('', ds)]),
         mask_section(ds.masks),
         attr_section(ds.attrs),
     ]

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -9,7 +9,7 @@ from functools import partial, reduce
 from html import escape
 import numpy as np
 
-import scipp as sc
+from .._scipp import core as sc
 
 CSS_FILE_PATH = f"{os.path.dirname(__file__)}/style.css"
 with open(CSS_FILE_PATH, 'r') as f:
@@ -295,7 +295,8 @@ def _mapping_section(mapping, name, details_func, max_items_collapse,
 
 
 def dim_section(dataset):
-    dim_list = format_dims(dataset.dims, dataset.shape, dataset.coords)
+    coords = dataset.coords if hasattr(dataset, "coords") else []
+    dim_list = format_dims(dataset.dims, dataset.shape, coords)
 
     return collapsible_section(
         "Dimensions", inline_details=dim_list, enabled=False, collapsed=True
@@ -353,7 +354,6 @@ data_section = partial(
     max_items_collapse=15,
 )
 
-
 attr_section = partial(
     _mapping_section,
     name="Attributes",
@@ -391,6 +391,19 @@ def dataset_repr(ds):
         data_section(ds),
         mask_section(ds.masks),
         attr_section(ds.attrs),
+    ]
+
+    return _obj_repr(header_components, sections)
+
+
+def variable_repr(var):
+    obj_type = "scipp.{}".format(type(var).__name__)
+
+    header_components = [f"<div class='xr-obj-type'>{escape(obj_type)}</div>"]
+
+    sections = [
+        dim_section(var),
+        data_section([('', var)]),
     ]
 
     return _obj_repr(header_components, sections)

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -21,6 +21,10 @@ with open(ICONS_SVG_PATH, 'r') as f:
     ICONS_SVG = "".join(f.readlines())
 
 
+def _is_dataset(x):
+    return isinstance(x, sc.Dataset) or isinstance(x, sc.DataProxy)
+
+
 def _format_array(data, size):
     i = 0
     s = []
@@ -240,8 +244,10 @@ def summarize_variable(name, var, is_index=False, is_attr=None):
 
 
 def summarize_vars(dataset):
+    hide_attrs = not _is_dataset(dataset)
     vars_li = "".join(
-        f"<li class='xr-var-item'>{summarize_variable(name, values)}</li>"
+        "<li class='xr-var-item'>{}</li>".format(
+            summarize_variable(name, values, is_attr=hide_attrs))
         for name, values in dataset
     )
 


### PR DESCRIPTION
- Use relative imports within module.
- Add `to_html` for variables. Could probably do a lot better (no need for the "Data" section thing, and the indent), but this was a quick addition to get something working.