### PR TITLE
to_html improvements

### DIFF
--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -262,10 +262,13 @@ def collapsible_section(name, inline_details="", details="", n_items=None,
     tip = " title='Expand/collapse section'" if enabled else ""
 
     if add_value_variance_labels:
-        val_var_html = f"<div class='sc-section-header \
-                            sc-section-header-values'>Values</div>\
-                         <div class='sc-section-header \
-                            sc-section-header-variances'>Variances</div>"
+        val_var_html = "<div class='sc-section-header "\
+            "sc-section-header-values'>"\
+            "<span class='sc-section-header-text'>Values</span>"\
+            "</div><div class='sc-section-header "\
+            "sc-section-header-variances'>"\
+            "<span class='sc-section-header-text'>Variances</span>"\
+            "</div>"
     else:
         val_var_html = ""
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -412,7 +412,7 @@ def dataset_repr(ds):
         add_value_variance_labels = False
 
     sections.append(data_section(
-        ds if hasattr(ds, '__len__') else [('', ds)]),
+        ds if hasattr(ds, '__len__') else [('', ds)],
         add_value_variance_labels=add_value_variance_labels))
     add_value_variance_labels = False
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -144,7 +144,7 @@ def summarize_attrs_simple(attrs):
 def summarize_attrs(attrs):
     attrs_li = "".join(
         f"<li class='xr-var-item'>\
-            {summarize_variable(name, values, is_attr=True)}</li>"
+            {summarize_variable(name, values, has_attrs=False)}</li>"
         for name, values in attrs
     )
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
@@ -174,7 +174,7 @@ def summarize_coords(coords):
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
-def summarize_variable(name, var, is_index=False, is_attr=None):
+def summarize_variable(name, var, is_index=False, has_attrs=False):
     """
     :param name:
     :param var:
@@ -182,9 +182,8 @@ def summarize_variable(name, var, is_index=False, is_attr=None):
                      coordinates that represent the indices of
                      a dimension that the data contains
 
-    :param is_attr: If the variable is for an attribute, then this
-                    hides the show/hide attributes button.
-
+    :param has_attrs: If the variable is for a section that cannot contain
+                      attributes, then this hides the show/hide button.
     """
     cssclass_idx = " class='xr-has-index'" if is_index else ""
     dims_text = ', '.join(escape(f'{str(dim)} [sparse]'
@@ -227,7 +226,7 @@ def summarize_variable(name, var, is_index=False, is_attr=None):
             xr-preview'>{variances_preview}</div>",
         f"<input id='{attrs_id}' class='xr-var-attrs-in' ",
         f"type='checkbox' {disabled}>",
-        f"<label for='{attrs_id}' class='{'xr-hide-icon' if is_attr else '1'}'"
+        f"<label for='{attrs_id}' class='{'xr-hide-icon' if not has_attrs else ''}'"
         " title='Show/Hide attributes'>",
         f"{attrs_icon}</label>",
         f"<input id='{data_id}' class='xr-var-data-in' type='checkbox'>",
@@ -239,9 +238,10 @@ def summarize_variable(name, var, is_index=False, is_attr=None):
     return "".join(html)
 
 
-def summarize_vars(dataset):
+def summarize_data(dataset):
     vars_li = "".join(
-        f"<li class='xr-var-item'>{summarize_variable(name, values)}</li>"
+        "<li class='xr-var-item'>"
+        f"{summarize_variable(name, values, has_attrs=True)}</li>"
         for name, values in dataset
     )
 
@@ -250,7 +250,8 @@ def summarize_vars(dataset):
 
 def collapsible_section(name, inline_details="", details="", n_items=None,
                         enabled=True, collapsed=False,
-                        add_value_variance_labels=False):
+                        add_value_variance_labels=False,
+                        has_attrs=False):
     # "unique" id to expand/collapse the section
     data_id = "section-" + str(uuid.uuid4())
 
@@ -349,7 +350,7 @@ mask_section = partial(
 data_section = partial(
     _mapping_section,
     name="Data",
-    details_func=summarize_vars,
+    details_func=summarize_data,
     max_items_collapse=15,
 )
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -329,7 +329,6 @@ coord_section = partial(
     name="Coordinates",
     details_func=summarize_coords,
     max_items_collapse=25,
-    add_value_variance_labels=True,
 )
 
 label_section = partial(
@@ -385,13 +384,28 @@ def dataset_repr(ds):
 
     header_components = [f"<div class='xr-obj-type'>{escape(obj_type)}</div>"]
 
-    sections = [
-        dim_section(ds),
-        coord_section(ds.coords),
-        label_section(ds.labels),
-        data_section(ds),
-        mask_section(ds.masks),
-        attr_section(ds.attrs),
-    ]
+    sections = [dim_section(ds)]
+
+    # ensure that the values/variances labels are present
+    # the first section will add them will also flip this
+    # flag so that they are not repeatedly
+    add_value_variance_labels = True
+    if len(ds.coords) > 0:
+        sections.append(coord_section(
+            ds.coords, add_value_variance_labels=add_value_variance_labels))
+        add_value_variance_labels = False
+    if len(ds.labels) > 0:
+        sections.append(label_section(
+            ds.labels, add_value_variance_labels=add_value_variance_labels))
+        add_value_variance_labels = False
+
+    sections.append(data_section(
+        ds, add_value_variance_labels=add_value_variance_labels))
+    add_value_variance_labels = False
+
+    if len(ds.masks) > 0:
+        sections.append(mask_section(ds.masks))
+    if len(ds.attrs) > 0:
+        sections.append(attr_section(ds.attrs))
 
     return _obj_repr(header_components, sections)

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -228,7 +228,8 @@ def summarize_variable(name, var, is_index=False, has_attrs=False):
             xr-preview'>{variances_preview}</div>",
         f"<input id='{attrs_id}' class='xr-var-attrs-in' ",
         f"type='checkbox' {disabled}>",
-        f"<label for='{attrs_id}' class='{'xr-hide-icon' if not has_attrs else ''}'"
+        f"<label for='{attrs_id}' "
+        f"class='{'' if has_attrs else 'xr-hide-icon'}'"
         " title='Show/Hide attributes'>",
         f"{attrs_icon}</label>",
         f"<input id='{data_id}' class='xr-var-data-in' type='checkbox'>",

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -41,6 +41,8 @@ def _make_row(data_html, variances_html=None):
 
 
 def _format_row(data, size):
+    if size == 0:
+        return _make_row("[]")
     return _make_row(_format_array(data, size))
 
 

--- a/python/src/scipp/table_html/style.css
+++ b/python/src/scipp/table_html/style.css
@@ -341,4 +341,11 @@ label.xr-hide-icon svg{
 
 .sc-section-header{
   color:#555;
+  margin: auto 0;
+}
+.sc-section-header-text{
+  display:inline-block;
+  vertical-align: middle;
+  /* matches the margin from  xr-section-item */
+  margin-bottom: 5px;
 }


### PR DESCRIPTION
- Show `[]` for sparse entry with no data
- Match vertical align/margin of section names
- Hides sections if they're empty. Shows Value/Variance headers on first shown section. 
- Only show/hide attributes button for Data. This changes the `is_attr` variable to `has_attr=False`, as now only Data has a subsection for attributes

Fixes #747