### PR TITLE
to_html sparse ellipsis and improved formatting

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -408,7 +408,7 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
                  [](const T &self) {
                    if constexpr (std::is_same_v<T, DataArray> ||
                                  std::is_same_v<T, DataProxy>)
-                     return self.hasData() ? py::cast(self.unit()) : py::none();
+                     return self.hasData() ? self.unit() : units::counts;
                    else
                      return self.unit();
                  },

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -24,13 +24,13 @@ def _is_dataset(x):
     return isinstance(x, sc.Dataset) or isinstance(x, sc.DataProxy)
 
 
-def _format_array(data, size):
+def _format_array(data, size, ellipsis_after):
     i = 0
     s = []
     while i < size:
-        if i == 2 and size > 4:
+        if i == ellipsis_after and size > 2 * ellipsis_after + 1:
             s.append("...")
-            i = size - 2
+            i = size - ellipsis_after
         elem = data[i]
         if not hasattr(data, "dtype") or data.dtype != np.bool:
             elem = round(elem, 2)
@@ -43,17 +43,17 @@ def _make_row(data_html, variances_html=None):
     return f"<div>{data_html}</div>"
 
 
-def _get_row(data, size):
+def _get_row(data, size, ellipsis_after):
     if size == 0:
         return "[]"
-    return _format_array(data, size)
+    return _format_array(data, size, ellipsis_after)
 
 
 def _format_non_sparse(var, has_variances):
     size = reduce(operator.mul, var.shape, 1)
     # flatten avoids displaying square brackets in the output
     data = retrieve(var, variances=has_variances).flatten()
-    return _make_row(_get_row(data, size))
+    return _make_row(_get_row(data, size, ellipsis_after=2))
 
 
 def _get_sparse(var, variances, ellipsis_after):
@@ -65,7 +65,7 @@ def _get_sparse(var, variances, ellipsis_after):
             s.append("...")
             i = size - ellipsis_after
         data = retrieve(var, variances=variances)[i]
-        s.append(_get_row(data, len(data)))
+        s.append(_get_row(data, len(data), ellipsis_after))
         i += 1
     return s
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -51,6 +51,8 @@ def _format_non_sparse(var, has_variances):
 
 
 def _get_sparse(var, variances, ellipsis_after):
+    if hasattr(var, "data") and var.data is None:
+        return ["no data, implicitly 1"]
     size = var.shape[0]
     i = 0
     s = []
@@ -66,9 +68,6 @@ def _get_sparse(var, variances, ellipsis_after):
 
 
 def _format_sparse(var, has_variances):
-    if hasattr(var, "data") and var.data is None:
-        return "no data in sparse array"
-
     s = _get_sparse(var, has_variances, ellipsis_after=2)
     return "".join([_make_row(row) for row in s])
 
@@ -93,10 +92,9 @@ def retrieve(var, variances=False, single=False):
 
 def _short_data_repr_html_non_sparse(var, variances=False):
     if hasattr(var, "data"):
-        data_repr = repr(retrieve(var.data, variances))
+        return repr(retrieve(var.data, variances))
     else:
-        data_repr = repr(retrieve(var, variances))
-    return data_repr
+        return repr(retrieve(var, variances))
 
 
 def _short_data_repr_html_sparse(var, variances=False):

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -45,8 +45,8 @@ def _make_row(data_html, variances_html=None):
 
 def _get_row(data, size, ellipsis_after):
     if size == 0:
-        return "[]"
-    return _format_array(data, size, ellipsis_after)
+        return "list()"
+    return 'list(' + _format_array(data, size, ellipsis_after) + ')'
 
 
 def _format_non_sparse(var, has_variances):
@@ -105,7 +105,8 @@ def _short_data_repr_html_non_sparse(var, variances=False):
 
 
 def _short_data_repr_html_sparse(var, variances=False):
-    return "\n".join(_get_sparse(var, variances, ellipsis_after=3))
+    return "array([" + ",\n       ".join(
+        _get_sparse(var, variances, ellipsis_after=3)) + "])"
 
 
 def short_data_repr_html(var, variances=False):

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -43,17 +43,11 @@ def _make_row(data_html, variances_html=None):
     return f"<div>{data_html}</div>"
 
 
-def _get_row(data, size, ellipsis_after):
-    if size == 0:
-        return "list()"
-    return 'list(' + _format_array(data, size, ellipsis_after) + ')'
-
-
 def _format_non_sparse(var, has_variances):
     size = reduce(operator.mul, var.shape, 1)
     # flatten avoids displaying square brackets in the output
     data = retrieve(var, variances=has_variances).flatten()
-    return _make_row(_get_row(data, size, ellipsis_after=2))
+    return _make_row(_format_array(data, size, ellipsis_after=2))
 
 
 def _get_sparse(var, variances, ellipsis_after):
@@ -65,7 +59,8 @@ def _get_sparse(var, variances, ellipsis_after):
             s.append("...")
             i = size - ellipsis_after
         data = retrieve(var, variances=variances)[i]
-        s.append(_get_row(data, len(data), ellipsis_after))
+        s.append('list(' + _format_array(data, len(data), ellipsis_after) +
+                 ')')
         i += 1
     return s
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -66,9 +66,9 @@ def _get_sparse(var, variances, ellipsis_after, summary=False):
             s.append("...")
             i = size - ellipsis_after
         data = retrieve(var, variances=variances)[i]
-        s.append('list(' +
-                 _format_array(data, len(data), ellipsis_after, do_ellide) +
-                 ')')
+        s.append('sparse({})'.format(
+            f'len={len(data)}' if summary else _format_array(
+                data, len(data), ellipsis_after, do_ellide)))
         i += 1
     return s
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -15,7 +15,6 @@ CSS_FILE_PATH = f"{os.path.dirname(__file__)}/style.css"
 with open(CSS_FILE_PATH, 'r') as f:
     CSS_STYLE = "".join(f.readlines())
 
-
 ICONS_SVG_PATH = f"{os.path.dirname(__file__)}/icons-svg-inline.html"
 with open(ICONS_SVG_PATH, 'r') as f:
     ICONS_SVG = "".join(f.readlines())
@@ -62,13 +61,14 @@ def _get_sparse(var, variances, ellipsis_after):
     i = 0
     s = []
     while i < size:
-        if i == ellipsis_after and size > 2*ellipsis_after+1:
+        if i == ellipsis_after and size > 2 * ellipsis_after + 1:
             s.append("...")
             i = size - ellipsis_after
         data = retrieve(var, variances=variances)[i]
         s.append(_get_row(data, len(data)))
         i += 1
     return s
+
 
 def _format_sparse(var, has_variances):
     if hasattr(var, "data") and var.data is None:
@@ -125,45 +125,39 @@ def format_dims(dims, sizes, coords):
         return ""
 
     dim_css_map = {
-        dim: " class='xr-has-index'" if dim in coords else "" for dim in dims
+        dim: " class='xr-has-index'" if dim in coords else ""
+        for dim in dims
     }
 
     dims_li = "".join(
-        f"<li><span{dim_css_map[dim]}>" f"{escape(str(dim))}</span>: "
+        f"<li><span{dim_css_map[dim]}>"
+        f"{escape(str(dim))}</span>: "
         f"{size if size != sc.Dimensions.Sparse else 'Sparse' }</li>"
-        for dim, size in zip(dims, sizes)
-    )
+        for dim, size in zip(dims, sizes))
 
     return f"<ul class='xr-dim-list'>{dims_li}</ul>"
 
 
 def summarize_attrs_simple(attrs):
-    attrs_dl = "".join(
-        f"<dt><span>{escape(name)} :</span></dt>" f"<dd>{values}</dd>"
-        for name, values in attrs
-    )
+    attrs_dl = "".join(f"<dt><span>{escape(name)} :</span></dt>"
+                       f"<dd>{values}</dd>" for name, values in attrs)
 
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 
 
 def summarize_attrs(attrs):
-    attrs_li = "".join(
-        f"<li class='xr-var-item'>\
+    attrs_li = "".join(f"<li class='xr-var-item'>\
             {summarize_variable(name, values, has_attrs=False)}</li>"
-        for name, values in attrs
-    )
+                       for name, values in attrs)
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
 
 
 def _icon(icon_name):
     # icon_name is defined in icon-svg-inline.html
-    return (
-        "<svg class='icon xr-{0}'>"
-        "<use xlink:href='#{0}'>"
-        "</use>"
-        "</svg>".format(icon_name)
-
-    )
+    return ("<svg class='icon xr-{0}'>"
+            "<use xlink:href='#{0}'>"
+            "</use>"
+            "</svg>".format(icon_name))
 
 
 def summarize_coord(dim, var):
@@ -191,10 +185,9 @@ def summarize_variable(name, var, is_index=False, has_attrs=False):
                       attributes, then this hides the show/hide button.
     """
     cssclass_idx = " class='xr-has-index'" if is_index else ""
-    dims_text = ', '.join(escape(f'{str(dim)} [sparse]'
-                                 if dim == var.sparse_dim
-                                 else str(dim))
-                          for dim in var.dims)
+    dims_text = ', '.join(
+        escape(f'{str(dim)} [sparse]' if dim == var.sparse_dim else str(dim))
+        for dim in var.dims)
     dims_str = f"({dims_text})"
     name = escape(name)
     dtype = var.dtype
@@ -249,13 +242,16 @@ def summarize_data(dataset):
     vars_li = "".join(
         "<li class='xr-var-item'>"
         f"{summarize_variable(name, values, has_attrs=has_attrs)}</li>"
-        for name, values in dataset
-    )
+        for name, values in dataset)
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
-def collapsible_section(name, inline_details="", details="", n_items=None,
-                        enabled=True, collapsed=False,
+def collapsible_section(name,
+                        inline_details="",
+                        details="",
+                        n_items=None,
+                        enabled=True,
+                        collapsed=False,
                         add_value_variance_labels=False,
                         has_attrs=False):
     # "unique" id to expand/collapse the section
@@ -278,19 +274,21 @@ def collapsible_section(name, inline_details="", details="", n_items=None,
     else:
         val_var_html = ""
 
-    return (
-        f"<input id='{data_id}' class='xr-section-summary-in' "
-        f"type='checkbox' {enabled} {collapsed}>"
-        f"<label for='{data_id}' class='xr-section-summary' {tip}>"
-        f"{name}:{n_items_span}</label>"
-        f"<div class='xr-section-inline-details'>{inline_details}</div>"
-        f"{val_var_html}"
-        f"<div class='xr-section-details'>{details}</div>"
-    )
+    return (f"<input id='{data_id}' class='xr-section-summary-in' "
+            f"type='checkbox' {enabled} {collapsed}>"
+            f"<label for='{data_id}' class='xr-section-summary' {tip}>"
+            f"{name}:{n_items_span}</label>"
+            f"<div class='xr-section-inline-details'>{inline_details}</div>"
+            f"{val_var_html}"
+            f"<div class='xr-section-details'>{details}</div>")
 
 
-def _mapping_section(mapping, name, details_func, max_items_collapse,
-                     enabled=True, add_value_variance_labels=False):
+def _mapping_section(mapping,
+                     name,
+                     details_func,
+                     max_items_collapse,
+                     enabled=True,
+                     add_value_variance_labels=False):
     n_items = len(mapping)
     collapsed = n_items >= max_items_collapse
 
@@ -308,9 +306,10 @@ def dim_section(dataset):
     coords = dataset.coords if hasattr(dataset, "coords") else []
     dim_list = format_dims(dataset.dims, dataset.shape, coords)
 
-    return collapsible_section(
-        "Dimensions", inline_details=dim_list, enabled=False, collapsed=True
-    )
+    return collapsible_section("Dimensions",
+                               inline_details=dim_list,
+                               enabled=False,
+                               collapsed=True)
 
 
 def array_section(obj):
@@ -321,17 +320,15 @@ def array_section(obj):
     data_repr = short_data_repr_html(obj)
     data_icon = _icon("icon-database")
 
-    return (
-        "<div class='xr-array-wrap'>"
-        f"<input id='{data_id}' \
+    return ("<div class='xr-array-wrap'>"
+            f"<input id='{data_id}' \
             class='xr-array-in' type='checkbox' {collapsed}>"
-        f"<label for='{data_id}' \
+            f"<label for='{data_id}' \
             title='Show/hide data repr'>{data_icon}</label>"
-        f"<div class='xr-array-preview \
+            f"<div class='xr-array-preview \
             xr-preview'><span>{preview}</span></div>"
-        f"<pre class='xr-array-data'>{data_repr}</pre>"
-        "</div>"
-    )
+            f"<pre class='xr-array-data'>{data_repr}</pre>"
+            "</div>")
 
 
 coord_section = partial(
@@ -341,20 +338,15 @@ coord_section = partial(
     max_items_collapse=25,
 )
 
-label_section = partial(
-    _mapping_section,
-    name="Labels",
-    details_func=summarize_coords,
-    max_items_collapse=10
-)
+label_section = partial(_mapping_section,
+                        name="Labels",
+                        details_func=summarize_coords,
+                        max_items_collapse=10)
 
-mask_section = partial(
-    _mapping_section,
-    name="Masks",
-    details_func=summarize_coords,
-    max_items_collapse=10
-)
-
+mask_section = partial(_mapping_section,
+                       name="Masks",
+                       details_func=summarize_coords,
+                       max_items_collapse=10)
 
 data_section = partial(
     _mapping_section,
@@ -374,18 +366,16 @@ attr_section = partial(
 def _obj_repr(header_components, sections):
     header = f"<div class='xr-header'>"\
         f"{''.join(h for h in header_components)}</div>"
-    sections = "".join(
-        f"<li class='xr-section-item'>{s}</li>" for s in sections)
+    sections = "".join(f"<li class='xr-section-item'>{s}</li>"
+                       for s in sections)
 
-    return (
-        "<div>"
-        f"{ICONS_SVG}<style>{CSS_STYLE}</style>"
-        "<div class='xr-wrap'>"
-        f"{header}"
-        f"<ul class='xr-sections'>{sections}</ul>"
-        "</div>"
-        "</div>"
-    )
+    return ("<div>"
+            f"{ICONS_SVG}<style>{CSS_STYLE}</style>"
+            "<div class='xr-wrap'>"
+            f"{header}"
+            f"<ul class='xr-sections'>{sections}</ul>"
+            "</div>"
+            "</div>")
 
 
 def dataset_repr(ds):
@@ -400,17 +390,19 @@ def dataset_repr(ds):
     # flag so that they are not repeatedly
     add_value_variance_labels = True
     if len(ds.coords) > 0:
-        sections.append(coord_section(
-            ds.coords, add_value_variance_labels=add_value_variance_labels))
+        sections.append(
+            coord_section(ds.coords,
+                          add_value_variance_labels=add_value_variance_labels))
         add_value_variance_labels = False
     if len(ds.labels) > 0:
-        sections.append(label_section(
-            ds.labels, add_value_variance_labels=add_value_variance_labels))
+        sections.append(
+            label_section(ds.labels,
+                          add_value_variance_labels=add_value_variance_labels))
         add_value_variance_labels = False
 
-    sections.append(data_section(
-        ds if hasattr(ds, '__len__') else [('', ds)],
-        add_value_variance_labels=add_value_variance_labels))
+    sections.append(
+        data_section(ds if hasattr(ds, '__len__') else [('', ds)],
+                     add_value_variance_labels=add_value_variance_labels))
     add_value_variance_labels = False
 
     if len(ds.masks) > 0:

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -66,16 +66,18 @@ def _get_sparse(var, variances, ellipsis_after, summary=False):
             s.append("...")
             i = size - ellipsis_after
         data = retrieve(var, variances=variances)[i]
-        s.append('sparse({})'.format(
-            f'len={len(data)}' if summary else _format_array(
-                data, len(data), ellipsis_after, do_ellide)))
+        if summary:
+            s.append(f'len={len(data)}')
+        else:
+            s.append('sparse({})'.format(
+                _format_array(data, len(data), ellipsis_after, do_ellide)))
         i += 1
     return s
 
 
 def _format_sparse(var, has_variances):
-    s = _get_sparse(var, has_variances, ellipsis_after=2, summary=True)
-    return "".join([_make_row(row) for row in s])
+    s = _get_sparse(var, has_variances, ellipsis_after=1, summary=True)
+    return _make_row(", ".join([row for row in s]))
 
 
 def inline_variable_repr(var, has_variances=False):


### PR DESCRIPTION
Fix #753.

Note than one commit is just some formatting applied (yapf), maybe better to review commit-by-commit and skip the format one.

Also fix handling of sparse arrays with no data (which was broken again?), now in a better way: Unit shows the implied unit of "counts" (which is used when histogramming such sparse data), and the impicit value of 1.