### PR TITLE
_repr_html_

### DIFF
--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "var = sc.Variable(dims=[Dim.Y, Dim.X], values=np.random.rand(4,5))\n",
     "sc.show(var)\n",
-    "print(var)"
+    "var"
    ]
   },
   {
@@ -69,8 +69,7 @@
     "    data=var,\n",
     "    coords={Dim.X: x, Dim.Y: y})\n",
     "sc.show(array)\n",
-    "print(array)\n",
-    "print(array.values)"
+    "array"
    ]
   },
   {
@@ -129,7 +128,8 @@
    "outputs": [],
    "source": [
     "dataset['c'] = dataset['b'][Dim.X, 2]\n",
-    "sc.show(dataset)"
+    "sc.show(dataset)\n",
+    "dataset"
    ]
   },
   {
@@ -185,13 +185,6 @@
     "dataset['b'] *= dataset['scalar']\n",
     "print(dataset)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -210,7 +203,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -205,7 +205,7 @@
    "source": [
     "d['bob'] = d['alice']\n",
     "sc.table(d)\n",
-    "print(d)"
+    "d"
    ]
   },
   {
@@ -723,7 +723,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.7"
   },
   "nbsphinx": {
    "allow_errors": true

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -296,8 +296,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d\n",
-    "plot(d[Dim.Z, 0])"
+    "plot(d[Dim.Z, 0])\n",
+    "d"
    ]
   },
   {
@@ -330,8 +330,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d\n",
-    "plot(d[Dim.Z, 0])"
+    "plot(d[Dim.Z, 0])\n",
+    "d"
    ]
   },
   {

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "sc.show(d)\n",
-    "print(d)"
+    "d"
    ]
   },
   {
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(d)\n",
+    "d\n",
     "plot(d[Dim.Z, 0])"
    ]
   },
@@ -330,7 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(d)\n",
+    "d\n",
     "plot(d[Dim.Z, 0])"
    ]
   },
@@ -459,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.7"
   },
   "nbsphinx": {
    "allow_errors": true

--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "scalar = 1.2 * sc.units.m\n",
     "sc.show(scalar)\n",
-    "print(scalar)"
+    "scalar"
    ]
   },
   {

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -157,10 +157,18 @@
    "source": [
     "# Range of length 1\n",
     "sc.show(d[Dim.X, 1:2])\n",
-    "print(d[Dim.X, 1:2])\n",
+    "d[Dim.X, 1:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# No range\n",
     "sc.show(d[Dim.X, 1])\n",
-    "print(d[Dim.X, 1])"
+    "d[Dim.X, 1]"
    ]
   },
   {

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -13,4 +13,11 @@ from .table import table
 from . import plot
 from .extend_units import *
 from . import config
-from .table_html import to_html
+from .table_html import to_html, make_html
+
+setattr(Variable, '_repr_html_', make_html)
+setattr(VariableConstProxy, '_repr_html_', make_html)
+setattr(DataArray, '_repr_html_', make_html)
+setattr(DataConstProxy, '_repr_html_', make_html)
+setattr(Dataset, '_repr_html_', make_html)
+setattr(DatasetConstProxy, '_repr_html_', make_html)

--- a/python/src/scipp/table_html/__init__.py
+++ b/python/src/scipp/table_html/__init__.py
@@ -6,12 +6,14 @@ from .._scipp import core as sc
 from .formatting_html import dataset_repr, variable_repr
 
 
-def to_html(container):
-    from IPython.display import display, HTML
-
+def make_html(container):
     if isinstance(container, sc.Variable) or isinstance(
             container, sc.VariableProxy):
-        rep = variable_repr(container)
+        return variable_repr(container)
     else:
-        rep = dataset_repr(container)
-    display(HTML(rep))
+        return dataset_repr(container)
+
+
+def to_html(container):
+    from IPython.display import display, HTML
+    display(HTML(make_html(container)))

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -32,7 +32,7 @@ def _format_array(data, size, ellipsis_after, do_ellide=True):
             s.append("...")
             i = size - ellipsis_after
         elem = data[i]
-        if not hasattr(data, "dtype") or data.dtype != np.bool:
+        if hasattr(elem, "__round__"):
             elem = round(elem, 2)
         s.append(str(elem))
         i += 1
@@ -46,7 +46,9 @@ def _make_row(data_html, variances_html=None):
 def _format_non_sparse(var, has_variances):
     size = reduce(operator.mul, var.shape, 1)
     # flatten avoids displaying square brackets in the output
-    data = retrieve(var, variances=has_variances).flatten()
+    data = retrieve(var, variances=has_variances)
+    if hasattr(data, 'flatten'):
+        data = data.flatten()
     return _make_row(_format_array(data, size, ellipsis_after=2))
 
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -7,7 +7,6 @@ import uuid
 
 from functools import partial, reduce
 from html import escape
-import numpy as np
 
 from .._scipp import core as sc
 


### PR DESCRIPTION
Based on #754.

Add `_repr_html_` based on `to_html`. This implies that this will be used in the docs based on Jupyter notebooks.

To do (as follow-up PRs?):

- [x] Fix CSS, font in docs is too large. (in #752)
- [x] Format sparse coords and labels? (in #746)