### PR TITLE
Fix segfault when copying Variable containing PyObject

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -743,6 +743,8 @@ public:
         m_parent->eraseSparseCoord(*m_name);
       } else if constexpr (std::is_same_v<Base, LabelsConstProxy>)
         m_parent->eraseSparseLabels(*m_name, key);
+      else if constexpr (std::is_same_v<Base, AttrsConstProxy>)
+        m_parent->eraseAttr(*m_name, key);
       else
         throw std::runtime_error("The instance cannot be sparse.");
     }

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -51,10 +51,28 @@ TEST_F(AttributesTest, dataset_item_attrs) {
   ASSERT_EQ(d["a"].attrs().size(), 0);
 }
 
+TEST_F(AttributesTest, dataset_sparse_item_attrs) {
+  Dataset d;
+  d.setData("sparse",
+            makeVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse}));
+  d["sparse"].attrs().set("scalar", scalar);
+  d.attrs().set("dataset_attr", scalar);
+
+  ASSERT_FALSE(d.attrs().contains("scalar"));
+
+  ASSERT_EQ(d["sparse"].attrs().size(), 1);
+  ASSERT_TRUE(d["sparse"].attrs().contains("scalar"));
+  ASSERT_FALSE(d["sparse"].attrs().contains("dataset_attr"));
+
+  d["sparse"].attrs().erase("scalar");
+  ASSERT_EQ(d["sparse"].attrs().size(), 0);
+}
+
 TEST_F(AttributesTest, dataset_item_attrs_dimensions_exceeding_data) {
   Dataset d;
   d.setData("scalar", scalar);
   EXPECT_THROW(d["scalar"].attrs().set("x", varX), except::DimensionError);
+  ASSERT_FALSE(d["scalar"].attrs().contains("x"));
 }
 
 TEST_F(AttributesTest, slice_dataset_item_attrs) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -54,15 +54,11 @@ VariableConcept::VariableConcept(const Dimensions &dimensions)
     : m_dimensions(dimensions) {}
 
 Variable::Variable(const VariableConstProxy &slice)
-    : Variable(*slice.m_variable) {
-  if (slice.m_view) {
-    setUnit(slice.unit());
-    setDims(slice.dims());
-    // There is a bug in the implementation of MultiIndex used in VariableView
-    // in case one of the dimensions has extent 0.
-    if (dims().volume() != 0)
-      data().copy(slice.data(), Dim::Invalid, 0, 0, 1);
-  }
+    : Variable(slice, slice.dims()) {
+  // There is a bug in the implementation of MultiIndex used in VariableView
+  // in case one of the dimensions has extent 0.
+  if (dims().volume() != 0)
+    data().copy(slice.data(), Dim::Invalid, 0, 0, 1);
 }
 
 Variable::Variable(const Variable &parent, const Dimensions &dims)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,6 +10,7 @@ pybind11_add_module(_scipp
                     groupby.cpp
                     neutron.cpp
                     operations.cpp
+                    py_object.cpp
                     scipp.cpp
                     sparse_container.cpp
                     units_neutron.cpp

--- a/python/bind_operators.h
+++ b/python/bind_operators.h
@@ -11,11 +11,10 @@ namespace py = pybind11;
 
 template <class Other, class T, class... Ignored>
 void bind_comparison(pybind11::class_<T, Ignored...> &c) {
-  // Not releasing GIL here due to segfault in Python C API
-  // (PyObject_RichCompare). It is unclear whether this is an issue with Python,
-  // with pybind11, or something we are doing wrong.
-  c.def("__eq__", [](T &a, Other &b) { return a == b; }, py::is_operator());
-  c.def("__ne__", [](T &a, Other &b) { return a != b; }, py::is_operator());
+  c.def("__eq__", [](T &a, Other &b) { return a == b; }, py::is_operator(),
+        py::call_guard<py::gil_scoped_release>());
+  c.def("__ne__", [](T &a, Other &b) { return a != b; }, py::is_operator(),
+        py::call_guard<py::gil_scoped_release>());
 }
 
 template <class Other, class T, class... Ignored>

--- a/python/py_object.cpp
+++ b/python/py_object.cpp
@@ -8,6 +8,11 @@ namespace py = pybind11;
 
 namespace scipp::python {
 
+PyObject::~PyObject() {
+  py::gil_scoped_acquire acquire;
+  m_object = py::object();
+}
+
 PyObject::PyObject(const py::object &object) {
   if (object) {
     // It is essential to acquire the GIL here. For reasons not entirely clear,

--- a/python/py_object.cpp
+++ b/python/py_object.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "py_object.h"
+
+namespace py = pybind11;
+
+namespace scipp::python {
+
+PyObject::PyObject(const py::object &object) {
+  if (object) {
+    // It is essential to acquire the GIL here. For reasons not entirely clear,
+    // calling Python code otherwise causes a segfault if the GIL has been
+    // released previously. Since this copy operation is called by anything that
+    // copies variables, this includes almost every C++ function with Python
+    // bindings because we typically do release the GIL everywhere.
+    py::gil_scoped_acquire acquire;
+    py::module copy = py::module::import("copy");
+    py::object deepcopy = copy.attr("deepcopy");
+    m_object = deepcopy(object);
+  } else {
+    m_object = object;
+  }
+}
+
+bool PyObject::operator==(const PyObject &other) const {
+  // Similar to above, not releasing GIL here due to segfault in Python C API
+  // (PyObject_RichCompare).
+  py::gil_scoped_acquire acquire;
+  return to_pybind().equal(other.to_pybind());
+}
+
+} // namespace scipp::python

--- a/python/py_object.cpp
+++ b/python/py_object.cpp
@@ -25,7 +25,7 @@ PyObject::PyObject(const py::object &object) {
 }
 
 bool PyObject::operator==(const PyObject &other) const {
-  // Similar to above, not releasing GIL here due to segfault in Python C API
+  // Similar to above, re-acquiring GIL here due to segfault in Python C API
   // (PyObject_RichCompare).
   py::gil_scoped_acquire acquire;
   return to_pybind().equal(other.to_pybind());

--- a/python/py_object.h
+++ b/python/py_object.h
@@ -17,23 +17,15 @@ public:
   PyObject() = default;
   PyObject(PyObject &&other) = default;
   PyObject &operator=(PyObject &&other) = default;
+  PyObject(const PyObject &other) : PyObject(other.m_object) {}
+  PyObject &operator=(const PyObject &other) { return *this = PyObject(other); }
 
-  PyObject(const PyObject &other) { *this = other; }
-  PyObject &operator=(const PyObject &other) {
-    py::object copy = py::module::import("copy");
-    py::object deepcopy = copy.attr("deepcopy");
-    m_object = deepcopy(other.m_object);
-    return *this;
-  }
-
-  PyObject(const py::object &object) : m_object(object) {}
+  PyObject(const py::object &object);
 
   const py::object &to_pybind() const noexcept { return m_object; }
   py::object &to_pybind() noexcept { return m_object; }
 
-  bool operator==(const PyObject &other) const {
-    return to_pybind().equal(other.to_pybind());
-  }
+  bool operator==(const PyObject &other) const;
 
 private:
   py::object m_object;

--- a/python/py_object.h
+++ b/python/py_object.h
@@ -19,6 +19,7 @@ public:
   PyObject &operator=(PyObject &&other) = default;
   PyObject(const PyObject &other) : PyObject(other.m_object) {}
   PyObject &operator=(const PyObject &other) { return *this = PyObject(other); }
+  ~PyObject();
 
   PyObject(const py::object &object);
 


### PR DESCRIPTION
Apparently calling Python code from C++ code that has released the GIL leads to segfaults. I do not understand why this is happening, and the pybind11 documentation gives no useful hint.

- Fixes #762.
- Fixes #765 which was discovered during debugging.
- Avoid copying full variable when constructing from slice. This has a potentially large overhead (my guess that this is a left-over from when we had copy-on-write).