### PR TITLE
Remove Variance column, display them on new row

### DIFF
--- a/python/src/scipp/table_html/style.css
+++ b/python/src/scipp/table_html/style.css
@@ -4,6 +4,7 @@
 */
 
 .xr-wrap {
+  font-size: 14px;
   min-width: 300px;
   max-width: 800px;
 }
@@ -39,7 +40,7 @@
 .xr-sections {
   padding-left: 0 !important;
   display: grid;
-  grid-template-columns: 150px auto auto auto 1fr 1fr 20px 20px;
+  grid-template-columns: 150px auto auto auto 1fr 20px 20px;
 }
 
 .xr-section-item {
@@ -159,7 +160,7 @@
 .xr-dim-list li {
   display: inline-block;
   padding: 0;
-  margin: 0;
+  margin: 0!important;
 }
 
 .xr-dim-list:before {
@@ -221,9 +222,6 @@
 }
 .xr-value-preview {
   grid-column: 5;
-}
-.xr-variance-preview {
-  grid-column: 6;
 }
 .xr-var-preview-variances{
   text-align:right;
@@ -330,19 +328,11 @@ label.xr-hide-icon svg{
   opacity: 0;
 }
 
-.sc-var-values{
-  grid-column: 1;
-}
-
-.sc-var-variances{
-  grid-column: 2;
-  padding-left: 5px;
-}
-
 .sc-section-header{
   color:#555;
   margin: auto 0;
 }
+
 .sc-section-header-text{
   display:inline-block;
   vertical-align: middle;


### PR DESCRIPTION
- Removes relevant CSS classes, and makes the grid 1 column smaller
- Removes Values/Variances column headers