### PR TITLE
Revert "Only PR builds to run travis tests"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,19 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: type = pull_request
+      if: NOT type = cron
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - compiler: clang
       name: "clang"
-      if: type = pull_request
+      if: NOT type = cron
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - os: osx
       name: "apple clang"
-      if: type = pull_request
+      if: NOT type = cron
       osx_image: xcode10.2
       before_install: brew install ccache ninja
       env:


### PR DESCRIPTION
Reverts scipp/scipp#735.

As long as #756 is not implemented (and also runs C++ tests) we should not skip testing before deploying, to reduce the risk of broken packages.