### PR TITLE
Conda All-Tests in Conda-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,19 @@ jobs:
     - stage: "Unit tests"
       compiler: gcc
       name: "gcc"
-      if: NOT type = cron
+      if: type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - compiler: clang
       name: "clang"
-      if: NOT type = cron
+      if: type = pull_request
       before_install: .travis/before_install.sh
       install: .travis/install_linux_toolchain.sh
       script: .travis/run_tests.sh
     - os: osx
       name: "apple clang"
-      if: NOT type = cron
+      if: type = pull_request
       osx_image: xcode10.2
       before_install: brew install ccache ninja
       env:

--- a/.travis/conda_build_and_deploy.sh
+++ b/.travis/conda_build_and_deploy.sh
@@ -6,5 +6,6 @@ set -x
 conda-build \
   --user 'scipp' \
   --token "$ANACONDA_TOKEN" \
+  --no-remove-work-dir \
   $@ \
   ./conda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ for:
   - if "%APPVEYOR_REPO_TAG%"=="false" if "%APPVEYOR_REPO_BRANCH%"=="master" set LABEL=dev
   - echo using label %LABEL%
   - echo deploy build started %time%
-  - conda-build --user scipp --token %ANACONDA_TOKEN% --label %LABEL% ../conda
+  - conda-build --user scipp --token %ANACONDA_TOKEN% --label %LABEL% --no-remove-work-dir ../conda
 
 
 

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -2,8 +2,21 @@ mkdir build
 
 cd build
 
-cmake -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DPYTHON_EXECUTABLE=%CONDA_PREFIX%\python -DWITH_CXX_TEST=OFF ..
+call %MINICONDA%\Scripts\clcache.exe -s
+echo building in %cd%
+cmake -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DPYTHON_EXECUTABLE=%CONDA_PREFIX%\python -DWITH_CXX_TEST=OFF -DCLCACHE_PATH=%MINICONDA%\Scripts ..
 
-cmake --build . --target install --config Release
+:: The following is disabled owing to build time restrictions. Use clcache to improve build times.
+::cmake --build . --target all-tests --config Release || echo ERROR && exit /b
+:::: C++ tests
+::
+::core\test\Release\scipp-core-test.exe || echo ERROR && exit /b
+::neutron\test\Release\scipp-neutron-test.exe || echo ERROR && exit /b
+::units\test\Release\scipp-units-test.exe || echo ERROR && exit /b
 
+cmake --build . --target install --config Release || echo ERROR && exit /b
+
+::  Build, install and move scipp Python library to site packages location
 move %CONDA_PREFIX%\scipp %CONDA_PREFIX%\lib\
+
+call %MINICONDA%\Scripts\clcache.exe -s

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -19,6 +19,12 @@ if [ $rc -ne 0 ]; then
   exit $rc
 fi
 
+cmake --build . --target all-tests -- -v 
+# C++ tests
+./common/test/scipp-common-test
+./units/test/scipp-units-test
+./core/test/scipp-core-test
+./neutron/test/scipp-neutron-test
+
 # Build, install and move scipp Python library to site packages location
-cmake --build . --target install -- -v && \
-  mv "$CONDA_PREFIX/scipp" "$CONDA_PREFIX"/lib/python*/
+cmake --build . --target install -- -v && mv "$CONDA_PREFIX/scipp" "$CONDA_PREFIX"/lib/python*/

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,6 +17,14 @@ requirements:
     - numpy {{ numpy }}
     - python {{ python }}
 
+test:
+  import:
+    - scipp
+  commands:
+  # Note that the following is fetching source again and using master 
+    - python -m pip install -r {{ environ.get('SRC_DIR') }}/python/requirements.txt 
+    - python -m pytest -v {{ environ.get('SRC_DIR') }}/python
+  
 build:
   # Build number is number of Git commits since last tag, if that fails use 0
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -25,6 +33,8 @@ build:
     - CXX
     - OSX_VERSION
     - GENERATOR
+    - MINICONDA
+    - SRC_DIR
 about:
   home: https://scipp.readthedocs.io/en/latest/
   license: GPLv3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 matplotlib
-nose
 ipywidgets
 pytest
 ipyvolume


### PR DESCRIPTION
Fixes #756 

This should result in faster builds and better test checking on all non-windows platforms

* conda/build.sh builds `all-test` target and runs all c++ tests prior to build `install` 
* conda/bld.bat builds SHOULD (and can) `all-test` target and run all c++ tests prior to build `install` but doesn't because of outstanding appveyor problem https://help.appveyor.com/discussions/problems/25672-appveyor-cache-not-updated
* conda/meta.yaml includes basic "import" check for scipp
* Python tests run under conda/meta.yaml as part of test step
* Note the `--no-remove-work-dir` flag to conda-build which is necessary to allow ptest based testing 