### PR TITLE
Test GIL acquire in scipp::python::PyObject

### DIFF
--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -26,7 +26,7 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
       .def("__getitem__", &T::operator[], py::return_value_policy::move,
            py::keep_alive<0, 1>())
       .def("__setitem__", &T::set)
-      .def("__delitem__", &T::erase)
+      .def("__delitem__", &T::erase, py::call_guard<py::gil_scoped_release>())
       .def("__iter__",
            [](T &self) {
              return py::make_iterator(self.begin(), self.end(),
@@ -85,12 +85,12 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
         py::keep_alive<0, 1>());
   c.def("__contains__", &T::contains);
   c.def("copy", [](const T &self) { return Dataset(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def("__copy__", [](const T &self) { return Dataset(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def("__deepcopy__",
         [](const T &self, const py::dict &) { return Dataset(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def_property_readonly("dims",
                           [](const T &self) {
                             std::vector<Dim> dims;
@@ -117,12 +117,12 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
   c.def_property_readonly("name", &T::name, R"(The name of the held data.)");
   c.def("__repr__", [](const T &self) { return to_string(self); });
   c.def("copy", [](const T &self) { return DataArray(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def("__copy__", [](const T &self) { return DataArray(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def("__deepcopy__",
         [](const T &self, const py::dict &) { return DataArray(self); },
-        "Return a (deep) copy.");
+        py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.");
   c.def_property(
       "data",
       py::cpp_function(
@@ -216,7 +216,8 @@ void init_dataset(py::module &m) {
              for (const auto [name, item] : self.slice(Slice(dim, i)))
                item.assign(other[name]);
            })
-      .def("__delitem__", &Dataset::erase)
+      .def("__delitem__", &Dataset::erase,
+           py::call_guard<py::gil_scoped_release>())
       .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataArray &data) {
              self.setData(name, data);

--- a/python/py_object.cpp
+++ b/python/py_object.cpp
@@ -15,11 +15,11 @@ PyObject::~PyObject() {
 
 PyObject::PyObject(const py::object &object) {
   if (object) {
-    // It is essential to acquire the GIL here. For reasons not entirely clear,
-    // calling Python code otherwise causes a segfault if the GIL has been
-    // released previously. Since this copy operation is called by anything that
-    // copies variables, this includes almost every C++ function with Python
-    // bindings because we typically do release the GIL everywhere.
+    // It is essential to acquire the GIL here. Calling Python code otherwise
+    // causes a segfault if the GIL has been released previously. Since this
+    // copy operation is called by anything that copies variables, this includes
+    // almost every C++ function with Python bindings because we typically do
+    // release the GIL everywhere.
     py::gil_scoped_acquire acquire;
     py::module copy = py::module::import("copy");
     py::object deepcopy = copy.attr("deepcopy");

--- a/python/py_object.h
+++ b/python/py_object.h
@@ -12,6 +12,11 @@ namespace py = pybind11;
 namespace scipp::python {
 
 /// Wrapper around pybind11::object to provide deep copy and deep comparison.
+///
+/// Whenever this class makes calls to Python it acquires the GIL first to
+/// ensure that it can be used as part of code that has a released GIL. Since
+/// this class is meant as an element type in Variable, this is often the case,
+/// e.g., in any operation that makes copies of variables.
 class PyObject {
 public:
   PyObject() = default;

--- a/python/tests/test_variable_py_object.py
+++ b/python/tests/test_variable_py_object.py
@@ -35,6 +35,8 @@ def test_scalar_Variable_py_object_change():
 
 def test_scalar_Variable_py_object_copy_is_deep_copy():
     var = sc.Variable(value=[1, 2, 3])
+    # Dataset.copy() releases the GIL. This will segfault unless
+    # scipp::python::PyObject::PyObject acquires the GIL.
     copy = var.copy()
     copy.value[0] = 666
     assert copy.value == [666, 2, 3]
@@ -46,3 +48,11 @@ def test_scalar_Variable_py_object_comparison():
     b = sc.Variable(value=[1, 2])
     assert a == b
     assert not (a != b)
+
+
+def test_py_object_delitem():
+    d = sc.Dataset()
+    d['a'] = sc.Variable(value=[1, 2])
+    # Dataset.__delitem__ releases the GIL. This will segfault unless
+    # scipp::python::PyObject::~PyObject acquires the GIL.
+    del d['a']

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -256,12 +256,12 @@ void init_variable(py::module &m) {
       .def("rename_dims", &rename_dims<Variable>, py::arg("dims_dict"),
            "Rename dimensions.")
       .def("copy", [](const Variable &self) { return self; },
-           "Return a (deep) copy.")
+           py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.")
       .def("__copy__", [](Variable &self) { return Variable(self); },
-           "Return a (deep) copy.")
+           py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.")
       .def("__deepcopy__",
            [](Variable &self, py::dict) { return Variable(self); },
-           "Return a (deep) copy.")
+           py::call_guard<py::gil_scoped_release>(), "Return a (deep) copy.")
       .def_property_readonly("dtype", &Variable::dtype)
       .def("__radd__", [](Variable &a, double &b) { return a + b; },
            py::is_operator())


### PR DESCRIPTION
See also https://github.com/scipp/scipp/pull/766.

Note that there are no `assert` statements since this just segfaults if it is wrong. Remove the GIL acquire in `py_object.cpp` if you want to "see" it in action.