### PR TITLE
Catching warnings from setting invalid axis limits when plotting with log axes

### DIFF
--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -13,6 +13,7 @@ import numpy as np
 import copy as cp
 import matplotlib.pyplot as plt
 import ipywidgets as widgets
+import warnings
 
 
 def plot_1d(input_data=None, axes=None, values=None, variances=None,
@@ -95,7 +96,9 @@ class Slicer1d(Slicer):
         yrange = [ymin-dy, ymax+dy]
         if logy:
             yrange = 10.0**np.array(yrange)
-        self.ax.set_ylim(yrange)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.ax.set_ylim(yrange)
         if logx:
             self.ax.set_xscale("log")
         if logy:
@@ -228,7 +231,9 @@ class Slicer1d(Slicer):
                         fmt="none")
 
         deltax = 0.05 * (new_x[-1] - new_x[0])
-        self.ax.set_xlim([new_x[0] - deltax, new_x[-1] + deltax])
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.ax.set_xlim([new_x[0] - deltax, new_x[-1] + deltax])
         self.ax.set_xlabel(axis_label(self.slider_x[dim_str],
                                       name=self.slider_labels[dim_str]))
         return

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -14,6 +14,7 @@ from .._scipp.core import Variable
 import numpy as np
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
+import warnings
 
 
 def plot_2d(input_data=None, axes=None, values=None, variances=None,
@@ -176,13 +177,15 @@ class Slicer2d(Slicer):
 
         extent_array = np.array(list(self.extent.values())).flatten()
         for key in self.ax.keys():
-            self.im[key].set_extent(extent_array)
-            if self.params["masks"]["show"]:
-                self.im[self.get_mask_key(key)].set_extent(extent_array)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning)
+                self.im[key].set_extent(extent_array)
+                if self.params["masks"]["show"]:
+                    self.im[self.get_mask_key(key)].set_extent(extent_array)
+                self.ax[key].set_xlim(self.extent["x"])
+                self.ax[key].set_ylim(self.extent["y"])
             self.ax[key].set_xlabel(axlabels["x"])
             self.ax[key].set_ylabel(axlabels["y"])
-            self.ax[key].set_xlim(self.extent["x"])
-            self.ax[key].set_ylim(self.extent["y"])
 
         return
 


### PR DESCRIPTION
This removes warnings like these:
![Screenshot at 2019-12-16 14-37-25](https://user-images.githubusercontent.com/39047984/70911175-984df480-2011-11ea-80b0-8e1bf380025c.png)
