### PR TITLE
Avoid copies in plot

### DIFF
--- a/python/src/scipp/config.py
+++ b/python/src/scipp/config.py
@@ -25,13 +25,13 @@ class _Plot:
         # Resolution
         self.dpi = 96
 
-        # Aspect ratio for images: 'equal' will conserve the aspect ratio,
-        # while 'auto' will stretch the image to the size of the figure
+        # Aspect ratio for images: "equal" will conserve the aspect ratio,
+        # while "auto" will stretch the image to the size of the figure
         self.aspect = "auto"
 
         # Make list of markers for matplotlib
-        self.marker = ['o', 'v', '^', '<', '>', '1', '2', '3', '4', '8', 's',
-                       'p', '*', 'h', 'H', '+', 'x', 'D', 'd']
+        self.marker = ["o", "^", "s", "d", "*", "1", "P", "h", "X", "v", "<",
+                       ">", "2", "3", "4", "8", "p", "H", "+", "x", "D"]
 
         # Default line width for 1D plots
         self.linewidth = [1.5]

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -20,16 +20,11 @@ def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
         raise RuntimeError("Invalid number of dimensions for "
                            "plotting: {}".format(ndim))
 
-    print("==================", name)
-    print(scipp_obj_dict)
     if sparse_dim is not None and bins is not None:
         sparse_dict = {}
         for key, obj in scipp_obj_dict.items():
-            sparse_dict[name] =  histogram_sparse_data(obj, sparse_dim, bins)
+            sparse_dict[name] = histogram_sparse_data(obj, sparse_dim, bins)
         scipp_obj_dict = sparse_dict
-    print("++++++++++++++++++")
-    print(scipp_obj_dict)
-
 
     if projection is None:
         if ndim < 3:

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -20,9 +20,16 @@ def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
         raise RuntimeError("Invalid number of dimensions for "
                            "plotting: {}".format(ndim))
 
+    print("==================", name)
+    print(scipp_obj_dict)
     if sparse_dim is not None and bins is not None:
-        scipp_obj_dict = {name: histogram_sparse_data(
-            scipp_obj_dict[name], sparse_dim, bins)}
+        sparse_dict = {}
+        for key, obj in scipp_obj_dict.items():
+            sparse_dict[name] =  histogram_sparse_data(obj, sparse_dim, bins)
+        scipp_obj_dict = sparse_dict
+    print("++++++++++++++++++")
+    print(scipp_obj_dict)
+
 
     if projection is None:
         if ndim < 3:

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -34,8 +34,7 @@ def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
     projection = projection.lower()
 
     if sparse_dim is not None and bins is None:
-        return plot_sparse(scipp_obj_dict[name], ndim=ndim,
-                           sparse_dim=sparse_dim,
+        return plot_sparse(scipp_obj_dict, ndim=ndim, sparse_dim=sparse_dim,
                            mpl_scatter_params=mpl_line_params, **kwargs)
     elif projection == "1d":
         return plot_1d(scipp_obj_dict, mpl_line_params=mpl_line_params,

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -9,11 +9,11 @@ from .plot_sparse import plot_sparse
 from .sparse import histogram_sparse_data
 
 
-def dispatch(input_data, ndim=0, name=None, collapse=None, sparse_dim=None,
+def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
              bins=None, projection=None, mpl_line_params=None,  **kwargs):
     """
-    Function to automatically dispatch the input dataset to the appropriate
-    plotting function depending on its dimensions
+    Function to automatically dispatch the dict of scipp objects to the
+    appropriate plotting function depending on its dimensions.
     """
 
     if ndim < 1:
@@ -21,7 +21,7 @@ def dispatch(input_data, ndim=0, name=None, collapse=None, sparse_dim=None,
                            "plotting: {}".format(ndim))
 
     if sparse_dim is not None and bins is not None:
-        input_data = histogram_sparse_data(input_data, sparse_dim, bins)
+        scipp_obj_dict = histogram_sparse_data(scipp_obj_dict, sparse_dim, bins)
 
     if projection is None:
         if ndim < 3:
@@ -31,14 +31,14 @@ def dispatch(input_data, ndim=0, name=None, collapse=None, sparse_dim=None,
     projection = projection.lower()
 
     if sparse_dim is not None and bins is None:
-        return plot_sparse(input_data, ndim=ndim, sparse_dim=sparse_dim,
+        return plot_sparse(scipp_obj_dict, ndim=ndim, sparse_dim=sparse_dim,
                            mpl_scatter_params=mpl_line_params, **kwargs)
     elif projection == "1d":
-        return plot_1d(input_data, mpl_line_params=mpl_line_params, **kwargs)
+        return plot_1d(scipp_obj_dict, mpl_line_params=mpl_line_params, **kwargs)
     elif projection == "2d":
-        return plot_2d(input_data, name=name, **kwargs)
+        return plot_2d(scipp_obj_dict, name=name, **kwargs)
     elif projection == "3d":
-        return plot_3d(input_data, name=name, **kwargs)
+        return plot_3d(scipp_obj_dict, name=name, **kwargs)
     else:
         raise RuntimeError("Wrong projection type. Expected either '2d' "
                            "or '3d', got {}.".format(projection))

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -21,7 +21,8 @@ def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
                            "plotting: {}".format(ndim))
 
     if sparse_dim is not None and bins is not None:
-        scipp_obj_dict = histogram_sparse_data(scipp_obj_dict, sparse_dim, bins)
+        scipp_obj_dict = {name: histogram_sparse_data(
+            scipp_obj_dict[name], sparse_dim, bins)}
 
     if projection is None:
         if ndim < 3:
@@ -31,14 +32,16 @@ def dispatch(scipp_obj_dict, ndim=0, name=None, collapse=None, sparse_dim=None,
     projection = projection.lower()
 
     if sparse_dim is not None and bins is None:
-        return plot_sparse(scipp_obj_dict, ndim=ndim, sparse_dim=sparse_dim,
+        return plot_sparse(scipp_obj_dict[name], ndim=ndim,
+                           sparse_dim=sparse_dim,
                            mpl_scatter_params=mpl_line_params, **kwargs)
     elif projection == "1d":
-        return plot_1d(scipp_obj_dict, mpl_line_params=mpl_line_params, **kwargs)
+        return plot_1d(scipp_obj_dict, mpl_line_params=mpl_line_params,
+                       **kwargs)
     elif projection == "2d":
-        return plot_2d(scipp_obj_dict, name=name, **kwargs)
+        return plot_2d(scipp_obj_dict[name], **kwargs)
     elif projection == "3d":
-        return plot_3d(scipp_obj_dict, name=name, **kwargs)
+        return plot_3d(scipp_obj_dict[name], **kwargs)
     else:
         raise RuntimeError("Wrong projection type. Expected either '2d' "
                            "or '3d', got {}.".format(projection))

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -18,15 +18,6 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
     from .plot_collapse import plot_collapse
     from .dispatch import dispatch
 
-    tp = type(scipp_obj)
-    # # Convert non-Datasets to temporary Dataset
-    # if (tp is sc.DataProxy) or (tp is sc.DataArray) or \
-    #    (tp is sc.VariableProxy) or (tp is sc.Variable):
-    #     ds = sc.Dataset()
-    #     ds[scipp_obj.name if hasattr(scipp_obj, "name")
-    #         else " "] = scipp_obj
-    #     scipp_obj = ds
-
     inventory = dict()
     if type(scipp_obj) is sc.Dataset:
         for name, var in sorted(scipp_obj):
@@ -43,10 +34,6 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
 
     # Counter for 1d/sparse data
     line_count = -1
-
-
-
-
 
     # Create a list of variables which will then be dispatched to correct
     # plotting function.
@@ -113,15 +100,12 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
     output = SciPlot()
     for key, val in tobeplotted.items():
         if collapse is not None:
-            output[key] = plot_collapse(scipp_obj_dict=val["scipp_obj_dict"],
-                                        name=key,
-                                        dim=collapse,
-                                        axes=val["axes"],
-                                        **kwargs)
+            output[key] = plot_collapse(
+                data_array=val["scipp_obj_dict"][key], dim=collapse,
+                axes=val["axes"], **kwargs)
         else:
             output[key] = dispatch(scipp_obj_dict=val["scipp_obj_dict"],
-                                   name=key,
-                                   ndim=val["ndims"],
+                                   name=key, ndim=val["ndims"],
                                    sparse_dim=sparse_dim[key],
                                    projection=projection,
                                    axes=val["axes"],

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -96,8 +96,6 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
                 tobeplotted[key]["mpl_line_params"][n].append(p)
             sparse_dim[key] = sp_dim
 
-    print(tobeplotted)
-
     # Plot all the subsets
     output = SciPlot()
     for key, val in tobeplotted.items():

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -8,7 +8,7 @@ from .sciplot import SciPlot
 
 
 def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
-         marker=None, linestyle=None, linewidth=None, **kwargs):
+         marker=None, linestyle=None, linewidth=None, bins=None, **kwargs):
     """
     Wrapper function to plot any kind of dataset
     """
@@ -48,7 +48,8 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
         if ndims > 0:
             sp_dim = var.sparse_dim
             ax = axes
-            if ndims == 1 or projection == "1d" or projection == "1D":
+            if ndims == 1 or projection == "1d" or projection == "1D" or \
+               (sp_dim is not None and bins is None):
                 # Construct a key from the dimensions
                 if axes is not None:
                     # Check if we are dealing with a dict mapping dimensions to
@@ -110,5 +111,6 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
                                    projection=projection,
                                    axes=val["axes"],
                                    mpl_line_params=val["mpl_line_params"],
+                                   bins=bins,
                                    **kwargs)
     return output

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -20,7 +20,7 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
 
     inventory = dict()
     tp = type(scipp_obj)
-    if tp is sc.Dataset:
+    if tp is sc.Dataset or tp is sc.DatasetProxy:
         for name, var in sorted(scipp_obj):
             inventory[name] = var
     elif tp is sc.Variable or tp is sc.VariableProxy:

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -24,7 +24,7 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
             inventory[name] = var
     else:
         inventory[scipp_obj.name if hasattr(scipp_obj, "name")
-                  else " ".name] = scipp_obj
+                  else " "] = scipp_obj
 
     # Prepare container for matplotlib line parameters
     line_params = {"color": color,

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -96,6 +96,8 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
                 tobeplotted[key]["mpl_line_params"][n].append(p)
             sparse_dim[key] = sp_dim
 
+    print(tobeplotted)
+
     # Plot all the subsets
     output = SciPlot()
     for key, val in tobeplotted.items():

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -19,12 +19,14 @@ def plot(scipp_obj, collapse=None, projection=None, axes=None, color=None,
     from .dispatch import dispatch
 
     inventory = dict()
-    if type(scipp_obj) is sc.Dataset:
+    tp = type(scipp_obj)
+    if tp is sc.Dataset:
         for name, var in sorted(scipp_obj):
             inventory[name] = var
+    elif tp is sc.Variable or tp is sc.VariableProxy:
+        inventory[str(tp)] = sc.DataArray(data=scipp_obj)
     else:
-        inventory[scipp_obj.name if hasattr(scipp_obj, "name")
-                  else " "] = scipp_obj
+        inventory[scipp_obj.name] = scipp_obj
 
     # Prepare container for matplotlib line parameters
     line_params = {"color": color,

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -239,7 +239,7 @@ class Slicer1d(Slicer):
             warnings.filterwarnings("ignore", category=UserWarning)
             self.ax.set_xlim([new_x[0] - deltax, new_x[-1] + deltax])
         self.ax.set_xlabel(name_with_unit(self.slider_x[dim_str],
-                                      name=self.slider_labels[dim_str]))
+                                          name=self.slider_labels[dim_str]))
         return
 
     def slice_data(self, var):

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -6,7 +6,8 @@
 from ..config import plot as config
 from .render import render_plot
 from .slicer import Slicer
-from .tools import axis_label, edges_to_centers
+from .tools import edges_to_centers
+from ..utils import name_with_unit
 
 # Other imports
 import numpy as np
@@ -92,7 +93,7 @@ class Slicer1d(Slicer):
             else:
                 ymin = min(ymin, np.nanmin(var.values - err))
                 ymax = max(ymax, np.nanmax(var.values + err))
-            ylab = axis_label(var=var, name="")
+            ylab = name_with_unit(var=var, name="")
 
         dy = 0.05*(ymax - ymin)
         yrange = [ymin-dy, ymax+dy]
@@ -232,8 +233,8 @@ class Slicer1d(Slicer):
 
         deltax = 0.05 * (new_x[-1] - new_x[0])
         self.ax.set_xlim([new_x[0] - deltax, new_x[-1] + deltax])
-        self.ax.set_xlabel(axis_label(self.slider_x[dim_str],
-                                      name=self.slider_labels[dim_str]))
+        self.ax.set_xlabel(name_with_unit(self.slider_x[dim_str],
+                                          name=self.slider_labels[dim_str]))
         return
 
     def slice_data(self, var):
@@ -241,6 +242,8 @@ class Slicer1d(Slicer):
         # Slice along dimensions with active sliders
         for key, val in self.slider.items():
             if not val.disabled:
+                self.lab[key].value = self.make_slider_label(
+                    self.slider_x[key], val.value)
                 vslice = vslice[val.dim, val.value]
         return vslice
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -16,7 +16,7 @@ import ipywidgets as widgets
 import matplotlib.pyplot as plt
 
 
-def plot_2d(scipp_obj_dict=None, axes=None, values=None, variances=None,
+def plot_2d(data_array=None, axes=None, values=None, variances=None,
             masks=None, filename=None, name=None, figsize=None, mpl_axes=None,
             aspect=None, cmap=None, log=False, vmin=None, vmax=None,
             color=None, logx=False, logy=False, logxy=False):
@@ -26,8 +26,7 @@ def plot_2d(scipp_obj_dict=None, axes=None, values=None, variances=None,
     particular dimension.
     """
 
-    sv = Slicer2d(scipp_obj_dict=scipp_obj_dict,
-                  data_array=scipp_obj_dict[name], axes=axes, values=values,
+    sv = Slicer2d(data_array=data_array, axes=axes, values=values,
                   variances=variances, masks=masks, mpl_axes=mpl_axes,
                   aspect=aspect, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
                   color=color, logx=logx or logxy, logy=logy or logxy)
@@ -40,15 +39,14 @@ def plot_2d(scipp_obj_dict=None, axes=None, values=None, variances=None,
 
 class Slicer2d(Slicer):
 
-    def __init__(self, scipp_obj_dict=None, data_array=None, axes=None,
-                 values=None, variances=None, masks=None, mpl_axes=None,
-                 aspect=None, cmap=None, log=None, vmin=None, vmax=None,
-                 color=None, logx=False, logy=False):
+    def __init__(self, data_array=None, axes=None, values=None, variances=None,
+                 masks=None, mpl_axes=None, aspect=None, cmap=None, log=None,
+                 vmin=None, vmax=None, color=None, logx=False, logy=False):
 
-        super().__init__(scipp_obj_dict=scipp_obj_dict, data_array=data_array,
-                         axes=axes, values=values, variances=variances,
-                         masks=masks, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
-                         color=color, aspect=aspect, button_options=['X', 'Y'])
+        super().__init__(data_array=data_array, axes=axes, values=values,
+                         variances=variances, masks=masks, cmap=cmap, log=log,
+                         vmin=vmin, vmax=vmax, color=color, aspect=aspect,
+                         button_options=['X', 'Y'])
 
         self.members.update({"images": {}, "colorbars": {}})
         self.extent = {"x": [0, 1], "y": [0, 1]}

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -16,7 +16,7 @@ import ipywidgets as widgets
 import matplotlib.pyplot as plt
 
 
-def plot_2d(input_data=None, axes=None, values=None, variances=None,
+def plot_2d(scipp_obj_dict=None, axes=None, values=None, variances=None,
             masks=None, filename=None, name=None, figsize=None, mpl_axes=None,
             aspect=None, cmap=None, log=False, vmin=None, vmax=None,
             color=None, logx=False, logy=False, logxy=False):
@@ -26,11 +26,8 @@ def plot_2d(input_data=None, axes=None, values=None, variances=None,
     particular dimension.
     """
 
-    var = input_data[name]
-    if axes is None:
-        axes = var.dims
-
-    sv = Slicer2d(input_data=var, axes=axes, values=values,
+    sv = Slicer2d(scipp_obj_dict=scipp_obj_dict,
+                  data_array=scipp_obj_dict[name], axes=axes, values=values,
                   variances=variances, masks=masks, mpl_axes=mpl_axes,
                   aspect=aspect, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
                   color=color, logx=logx or logxy, logy=logy or logxy)
@@ -43,14 +40,15 @@ def plot_2d(input_data=None, axes=None, values=None, variances=None,
 
 class Slicer2d(Slicer):
 
-    def __init__(self, input_data=None, axes=None, values=None, variances=None,
-                 masks=None, mpl_axes=None, aspect=None, cmap=None, log=None,
-                 vmin=None, vmax=None, color=None, logx=False, logy=False):
+    def __init__(self, scipp_obj_dict=None, data_array=None, axes=None,
+                 values=None, variances=None, masks=None, mpl_axes=None,
+                 aspect=None, cmap=None, log=None, vmin=None, vmax=None,
+                 color=None, logx=False, logy=False):
 
-        super().__init__(input_data=input_data, axes=axes, values=values,
-                         variances=variances, masks=masks, cmap=cmap,
-                         log=log, vmin=vmin, vmax=vmax, color=color,
-                         aspect=aspect, button_options=['X', 'Y'])
+        super().__init__(scipp_obj_dict=scipp_obj_dict, data_array=data_array,
+                         axes=axes, values=values, variances=variances,
+                         masks=masks, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
+                         color=color, aspect=aspect, button_options=['X', 'Y'])
 
         self.members.update({"images": {}, "colorbars": {}})
         self.extent = {"x": [0, 1], "y": [0, 1]}
@@ -105,12 +103,12 @@ class Slicer2d(Slicer):
                     extent=extent_array, origin="lower", aspect=self.aspect,
                     interpolation="nearest", cmap=self.params[key]["cmap"])
                 self.ax[key].set_title(
-                    self.input_data.name if key == "values" else "std dev.")
+                    self.data_array.name if key == "values" else "std dev.")
                 if self.params[key]["cbar"]:
                     self.cbar[key] = plt.colorbar(
                         self.im[key], ax=self.ax[key], cax=self.cax[key])
                     self.cbar[key].ax.set_ylabel(
-                        axis_label(var=self.input_data, name=""))
+                        axis_label(var=self.data_array, name=""))
                 if self.cax[key] is None:
                     self.cbar[key].ax.yaxis.set_label_coords(-1.1, 0.5)
                 self.members["images"][key] = self.im[key]
@@ -162,7 +160,7 @@ class Slicer2d(Slicer):
         for key, button in self.buttons.items():
             if self.slider[key].disabled:
                 but_val = button.value.lower()
-                if not self.histograms[key]:
+                if not self.histograms[self.name][key]:
                     xc = self.slider_x[key].values
                     xmin = 1.5 * xc[0] - 0.5 * xc[1]
                     xmax = 1.5 * xc[-1] - 0.5 * xc[-2]
@@ -189,7 +187,7 @@ class Slicer2d(Slicer):
     # Define function to update slices
     def update_slice(self, change):
         # The dimensions to be sliced have been saved in slider_dims
-        vslice = self.input_data
+        vslice = self.data_array
         if self.params["masks"]["show"]:
             mslice = self.masks
         # Slice along dimensions with active sliders
@@ -200,7 +198,7 @@ class Slicer2d(Slicer):
                     self.slider_x[key], val.value)
                 vslice = vslice[val.dim, val.value]
                 # At this point, after masks were combined, all their
-                # dimensions should be contained in the input_data.dims.
+                # dimensions should be contained in the data_array.dims.
                 if self.params["masks"]["show"]:
                     mslice = mslice[val.dim, val.value]
             else:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -158,7 +158,7 @@ class Slicer2d(Slicer):
         for key, button in self.buttons.items():
             if self.slider[key].disabled:
                 but_val = button.value.lower()
-                if not self.histograms[self.name][key]:
+                if not self.histograms[self.data_array.name][key]:
                     xc = self.slider_x[key].values
                     xmin = 1.5 * xc[0] - 0.5 * xc[1]
                     xmax = 1.5 * xc[-1] - 0.5 * xc[-2]

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -6,7 +6,7 @@
 from ..config import plot as config
 from .render import render_plot
 from .slicer import Slicer
-from .tools import axis_label
+from ..utils import name_with_unit
 from .._scipp.core import Variable
 
 
@@ -106,7 +106,7 @@ class Slicer2d(Slicer):
                     self.cbar[key] = plt.colorbar(
                         self.im[key], ax=self.ax[key], cax=self.cax[key])
                     self.cbar[key].ax.set_ylabel(
-                        axis_label(var=self.data_array, name=""))
+                        name_with_unit(var=self.data_array, name=""))
                 if self.cax[key] is None:
                     self.cbar[key].ax.yaxis.set_label_coords(-1.1, 0.5)
                 self.members["images"][key] = self.im[key]
@@ -166,7 +166,7 @@ class Slicer2d(Slicer):
                 else:
                     self.extent[but_val] = self.slider_x[key].values[[0, -1]]
 
-                axlabels[but_val] = axis_label(
+                axlabels[but_val] = name_with_unit(
                             self.slider_x[key],
                             name=self.slider_labels[key])
 

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -20,7 +20,7 @@ except ImportError:
     ipv = None
 
 
-def plot_3d(scipp_obj_dict=None, axes=None, values=None, variances=None,
+def plot_3d(data_array=None, axes=None, values=None, variances=None,
             masks=None, filename=None, name=None, figsize=None, aspect=None,
             cmap=None, log=False, vmin=None, vmax=None, color=None):
     """
@@ -36,12 +36,7 @@ def plot_3d(scipp_obj_dict=None, axes=None, values=None, variances=None,
                            "and ipyevents to be installed. Use conda/pip "
                            "install ipyvolume ipyevents.")
 
-    # var = input_data[name]
-    # if axes is None:
-    #     axes = var.dims
-
-    sv = Slicer3d(scipp_obj_dict=scipp_obj_dict,
-                  data_array=scipp_obj_dict[name], axes=axes, values=values,
+    sv = Slicer3d(data_array=data_array, axes=axes, values=values,
                   variances=variances, masks=masks, cmap=cmap, log=log,
                   vmin=vmin, vmax=vmax, color=color, aspect=aspect)
 
@@ -52,14 +47,13 @@ def plot_3d(scipp_obj_dict=None, axes=None, values=None, variances=None,
 
 class Slicer3d(Slicer):
 
-    def __init__(self, scipp_obj_dict=None, data_array=None, axes=None,
-                 values=None, variances=None, masks=None, cmap=None, log=None,
-                 vmin=None, vmax=None, color=None, aspect=None):
+    def __init__(self, data_array=None, axes=None, values=None, variances=None,
+                 masks=None, cmap=None, log=None, vmin=None, vmax=None,
+                 color=None, aspect=None):
 
-        super().__init__(scipp_obj_dict=scipp_obj_dict, data_array=data_array,
-                         axes=axes, values=values, variances=variances,
-                         masks=masks, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
-                         color=color, aspect=aspect,
+        super().__init__(data_array=data_array, axes=axes, values=values,
+                         variances=variances, masks=masks, cmap=cmap, log=log,
+                         vmin=vmin, vmax=vmax, color=color, aspect=aspect,
                          button_options=['X', 'Y', 'Z'])
 
         self.cube = None

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -20,7 +20,7 @@ except ImportError:
     ipv = None
 
 
-def plot_3d(input_data=None, axes=None, values=None, variances=None,
+def plot_3d(scipp_obj_dict=None, axes=None, values=None, variances=None,
             masks=None, filename=None, name=None, figsize=None, aspect=None,
             cmap=None, log=False, vmin=None, vmax=None, color=None):
     """
@@ -36,11 +36,12 @@ def plot_3d(input_data=None, axes=None, values=None, variances=None,
                            "and ipyevents to be installed. Use conda/pip "
                            "install ipyvolume ipyevents.")
 
-    var = input_data[name]
-    if axes is None:
-        axes = var.dims
+    # var = input_data[name]
+    # if axes is None:
+    #     axes = var.dims
 
-    sv = Slicer3d(input_data=var, axes=axes, values=values,
+    sv = Slicer3d(scipp_obj_dict=scipp_obj_dict,
+                  data_array=scipp_obj_dict[name], axes=axes, values=values,
                   variances=variances, masks=masks, cmap=cmap, log=log,
                   vmin=vmin, vmax=vmax, color=color, aspect=aspect)
 
@@ -51,14 +52,15 @@ def plot_3d(input_data=None, axes=None, values=None, variances=None,
 
 class Slicer3d(Slicer):
 
-    def __init__(self, input_data=None, axes=None, values=None, variances=None,
-                 masks=None, cmap=None, log=None, vmin=None, vmax=None,
-                 color=None, aspect=None):
+    def __init__(self, scipp_obj_dict=None, data_array=None, axes=None,
+                 values=None, variances=None, masks=None, cmap=None, log=None,
+                 vmin=None, vmax=None, color=None, aspect=None):
 
-        super().__init__(input_data=input_data, axes=axes, values=values,
-                         variances=variances, masks=masks, cmap=cmap,
-                         log=log, vmin=vmin, vmax=vmax, color=color,
-                         aspect=aspect, button_options=['X', 'Y', 'Z'])
+        super().__init__(scipp_obj_dict=scipp_obj_dict, data_array=data_array,
+                         axes=axes, values=values, variances=variances,
+                         masks=masks, cmap=cmap, log=log, vmin=vmin, vmax=vmax,
+                         color=color, aspect=aspect,
+                         button_options=['X', 'Y', 'Z'])
 
         self.cube = None
         self.members.update({"surfaces": {}, "wireframes": {}, "outlines": {},
@@ -195,7 +197,7 @@ class Slicer3d(Slicer):
 
     def update_cube(self, update_coordinates=True):
         # The dimensions to be sliced have been saved in slider_dims
-        self.cube = self.input_data
+        self.cube = self.data_array
         self.last_changed_slider_dim = None
         # Slice along dimensions with buttons who have no value, i.e. the
         # dimension is not used for any axis. This reduces the data volume to

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -6,7 +6,7 @@
 from ..config import plot as config
 from .render import render_plot
 from .slicer import Slicer
-from .tools import axis_label
+from ..utils import name_with_unit
 
 # Other imports
 import numpy as np
@@ -177,7 +177,7 @@ class Slicer3d(Slicer):
         buttons_dims = {"x": None, "y": None, "z": None}
         for key, button in self.buttons.items():
             if button.value is not None:
-                titles[button.value.lower()] = axis_label(
+                titles[button.value.lower()] = name_with_unit(
                     self.slider_x[key], name=self.slider_labels[key])
                 buttons_dims[button.value.lower()] = button.dim_str
 

--- a/python/src/scipp/plot/plot_collapse.py
+++ b/python/src/scipp/plot/plot_collapse.py
@@ -11,13 +11,14 @@ from .._scipp import core as sc
 import numpy as np
 
 
-def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
+def plot_collapse(input_data, name=None, dim=None, filename=None, **kwargs):
     """
     Collapse higher dimensions into a 1D plot.
     """
 
     # Get the variable inside the dataset
-    name, var = next(iter(input_data))
+    # name, var = next(iter(input_data))
+    var = input_data[name]
 
     dims = var.dims
     shape = var.shape
@@ -32,8 +33,9 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
             slice_shape[d] = size
             volume *= size
 
-    # Create temporary Dataset to collect all 1D slices as 1D variables
-    ds = sc.Dataset(coords={dim: var.coords[dim]})
+    # Create container to collect all 1D slices as 1D variables
+    # ds = sc.Dataset(coords={dim: var.coords[dim]})
+    all_slices = dict()
 
     # Go through the dims that need to be collapsed, and create an array that
     # holds the range of indices for each dimension
@@ -85,12 +87,12 @@ def plot_collapse(input_data, dim=None, name=None, filename=None, **kwargs):
         for s in line:
             vslice = vslice[s[0], s[1]]
             key += "{}-{}-".format(str(s[0]), s[1])
-        ds[key] = vslice
+        all_slices[key] = vslice
         for p in mpl_line_params.keys():
             mpl_line_params[p].append(get_line_param(name=p, index=i))
 
     # Send the newly created dictionary of DataProxy to the plot_1d function
-    return dispatch(input_data=ds, ndim=1, mpl_line_params=mpl_line_params,
+    return dispatch(input_data=all_slices, ndim=1, mpl_line_params=mpl_line_params,
                     **kwargs)
 
     return

--- a/python/src/scipp/plot/plot_collapse.py
+++ b/python/src/scipp/plot/plot_collapse.py
@@ -5,23 +5,18 @@
 # Scipp imports
 from .dispatch import dispatch
 from .tools import get_line_param
-from .._scipp import core as sc
 
 # Other imports
 import numpy as np
 
 
-def plot_collapse(input_data, name=None, dim=None, filename=None, **kwargs):
+def plot_collapse(data_array, name=None, dim=None, filename=None, **kwargs):
     """
     Collapse higher dimensions into a 1D plot.
     """
 
-    # Get the variable inside the dataset
-    # name, var = next(iter(input_data))
-    var = input_data[name]
-
-    dims = var.dims
-    shape = var.shape
+    dims = data_array.dims
+    shape = data_array.shape
 
     # Gather list of dimensions that are to be collapsed
     slice_dims = []
@@ -34,7 +29,6 @@ def plot_collapse(input_data, name=None, dim=None, filename=None, **kwargs):
             volume *= size
 
     # Create container to collect all 1D slices as 1D variables
-    # ds = sc.Dataset(coords={dim: var.coords[dim]})
     all_slices = dict()
 
     # Go through the dims that need to be collapsed, and create an array that
@@ -82,7 +76,7 @@ def plot_collapse(input_data, name=None, dim=None, filename=None, **kwargs):
     # Extract each entry from the slice_list, make temporary dataset and add to
     # input dictionary for plot_1d
     for i, line in enumerate(slice_list):
-        vslice = var
+        vslice = data_array
         key = ""
         for s in line:
             vslice = vslice[s[0], s[1]]
@@ -92,7 +86,7 @@ def plot_collapse(input_data, name=None, dim=None, filename=None, **kwargs):
             mpl_line_params[p].append(get_line_param(name=p, index=i))
 
     # Send the newly created dictionary of DataProxy to the plot_1d function
-    return dispatch(input_data=all_slices, ndim=1, mpl_line_params=mpl_line_params,
-                    **kwargs)
+    return dispatch(scipp_obj_dict=all_slices, ndim=1,
+                    mpl_line_params=mpl_line_params, **kwargs)
 
     return

--- a/python/src/scipp/plot/plot_sparse.py
+++ b/python/src/scipp/plot/plot_sparse.py
@@ -10,11 +10,12 @@ from .tools import parse_params
 from ..utils import name_with_unit
 
 # Other imports
+import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
 
-def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
+def plot_sparse(scipp_obj_dict, ndim=0, sparse_dim=None, logx=False,
                 logy=False, logxy=False, weights="color", size=10.0,
                 filename=None, axes=None, mpl_axes=None, opacity=0.7,
                 title=None, mpl_scatter_params=None, cmap=None, log=None,
@@ -25,17 +26,34 @@ def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
     sliders.
     """
 
-    xmin, xmax, sparse_data, dims, ndims = visit_sparse_data(
-        data_array, sparse_dim=sparse_dim, return_sparse_data=True,
-        weights=weights)
+    sparse_data = {}
+    data_minmax = []
+    key_save = None
+    key_weights = None
 
-    coords = data_array.coords
+    for key, data_array in scipp_obj_dict.items():
+
+        key_save = key
+
+        xmin, xmax, data, dims, ndims = visit_sparse_data(
+            data_array, sparse_dim=sparse_dim, return_sparse_data=True,
+            weights=weights)
+
+        sparse_data[key] = {"data": data, "dims": dims, "ndims": ndims,
+                            "coords": data_array.coords,
+                            "has_weights": len(data) > ndims}
+
+        if sparse_data[key]["has_weights"]:
+            key_weights = key
+            data_minmax.append(np.amin(data[-1]))
+            data_minmax.append(np.amax(data[-1]))
 
     # Parse parameters for colorbar
-    globs = {"cmap": cmap, "log": log, "vmin": vmin, "vmax": vmax}
-    cbar = parse_params(globs=globs, array=sparse_data[-1])
+    if key_weights is not None:
+        globs = {"cmap": cmap, "log": log, "vmin": vmin, "vmax": vmax}
+        cbar = parse_params(globs=globs, array=data_minmax)
 
-    members = {}
+    members = {"scatter": {}}
     ipv = None
 
     if ndims < 3:
@@ -55,30 +73,38 @@ def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
 
         widg = None
         members.update(ax)
-        params = dict(label=data_array.name, edgecolors="#ffffff",
-                      c=mpl_scatter_params["color"][0],
-                      marker=mpl_scatter_params["marker"][0])
-        xs = sparse_data[ndims - 1]
-        ys = sparse_data[ndims - 2]
-        if len(sparse_data) > ndims:
-            if weights.count("size") > 0:
-                params["s"] = sparse_data[-1] * size
-                params["alpha"] = opacity
-            if weights.count("color") > 0:
-                params["c"] = sparse_data[-1]
-                params["cmap"] = cbar["cmap"]
-                params["norm"] = cbar["norm"]
 
-        scat = ax["ax"].scatter(xs, ys, **params)
-        if len(sparse_data) > ndims and weights.count("color") > 0:
-            colorbar = plt.colorbar(scat, ax=ax["ax"], cax=ax["cax"])
+        for i, (key, data_array) in enumerate(scipp_obj_dict.items()):
+            params = dict(label=data_array.name, edgecolors="#ffffff",
+                          c=mpl_scatter_params["color"][i],
+                          marker=mpl_scatter_params["marker"][i])
+            xs = sparse_data[key]["data"][sparse_data[key]["ndims"] - 1]
+            ys = sparse_data[key]["data"][sparse_data[key]["ndims"] - 2]
+            if sparse_data[key]["has_weights"]:
+                if weights.count("size") > 0:
+                    params["s"] = sparse_data[key]["data"][-1] * size
+                    params["alpha"] = opacity
+                if weights.count("color") > 0:
+                    params["c"] = sparse_data[key]["data"][-1]
+                    params["cmap"] = cbar["cmap"]
+                    params["norm"] = cbar["norm"]
+
+            # print(params["norm"])
+            members["scatter"][key] = ax["ax"].scatter(xs, ys, **params)
+
+        if key_weights is not None and weights.count("color") > 0:
+            colorbar = plt.colorbar(members["scatter"][key_weights],
+                                    ax=ax["ax"], cax=ax["cax"])
             colorbar.ax.set_ylabel(name_with_unit(name="Weights",
                                                   log=cbar["log"]))
             members["colorbars"] = colorbar
 
-        ax["ax"].set_xlabel(name_with_unit(coords[sparse_dim]))
+        ax["ax"].set_xlabel(
+            name_with_unit(sparse_data[key_save]["coords"][sparse_dim]))
         if ndims > 1:
-            ax["ax"].set_ylabel(name_with_unit(coords[dims[int(ndims == 3)]]))
+            ax["ax"].set_ylabel(
+                name_with_unit(
+                    sparse_data[key_save]["coords"][sparse_data[key_save]["dims"][0]]))
 
         ax["ax"].legend()
         if title is not None:
@@ -123,6 +149,6 @@ def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
 
     render_plot(figure=fig, widgets=widg, filename=filename, ipv=ipv)
 
-    members.update({"fig": fig, "scatter": scat})
+    members.update({"fig": fig})
 
     return members

--- a/python/src/scipp/plot/plot_sparse.py
+++ b/python/src/scipp/plot/plot_sparse.py
@@ -6,7 +6,8 @@
 from ..config import plot as config
 from .render import render_plot
 from .sparse import visit_sparse_data
-from .tools import axis_label, parse_params
+from .tools import parse_params
+from ..utils import name_with_unit
 
 # Other imports
 import matplotlib.pyplot as plt
@@ -71,12 +72,13 @@ def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
         scat = ax["ax"].scatter(xs, ys, **params)
         if len(sparse_data) > ndims and weights.count("color") > 0:
             colorbar = plt.colorbar(scat, ax=ax["ax"], cax=ax["cax"])
-            colorbar.ax.set_ylabel(axis_label(name="Weights", log=cbar["log"]))
+            colorbar.ax.set_ylabel(name_with_unit(name="Weights",
+                                                  log=cbar["log"]))
             members["colorbars"] = colorbar
 
-        ax["ax"].set_xlabel(axis_label(coords[sparse_dim]))
+        ax["ax"].set_xlabel(name_with_unit(coords[sparse_dim]))
         if ndims > 1:
-            ax["ax"].set_ylabel(axis_label(coords[dims[int(ndims == 3)]]))
+            ax["ax"].set_ylabel(name_with_unit(coords[dims[int(ndims == 3)]]))
 
         ax["ax"].legend()
         if title is not None:
@@ -105,9 +107,9 @@ def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
         scat = ipv.scatter(x=sparse_data[ndims - 1], y=sparse_data[ndims - 2],
                            z=sparse_data[0], **params)
 
-        fig.xlabel = axis_label(coords[sparse_dim])
-        fig.ylabel = axis_label(coords[dims[int(ndims == 3)]])
-        fig.zlabel = axis_label(coords[dims[0]])
+        fig.xlabel = name_with_unit(coords[sparse_dim])
+        fig.ylabel = name_with_unit(coords[dims[int(ndims == 3)]])
+        fig.zlabel = name_with_unit(coords[dims[0]])
 
         # if logx or logxy:
         #     ax.set_xscale("log")

--- a/python/src/scipp/plot/plot_sparse.py
+++ b/python/src/scipp/plot/plot_sparse.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 from matplotlib import cm
 
 
-def plot_sparse(input_data, ndim=0, sparse_dim=None, logx=False,
+def plot_sparse(data_array, ndim=0, sparse_dim=None, logx=False,
                 logy=False, logxy=False, weights="color", size=10.0,
                 filename=None, axes=None, mpl_axes=None, opacity=0.7,
                 title=None, mpl_scatter_params=None, cmap=None, log=None,
@@ -24,11 +24,11 @@ def plot_sparse(input_data, ndim=0, sparse_dim=None, logx=False,
     sliders.
     """
 
-    xmin, xmax, sparse_data, var, name, dims, ndims = visit_sparse_data(
-        input_data, sparse_dim=sparse_dim, return_sparse_data=True,
+    xmin, xmax, sparse_data, dims, ndims = visit_sparse_data(
+        data_array, sparse_dim=sparse_dim, return_sparse_data=True,
         weights=weights)
 
-    coords = var.coords
+    coords = data_array.coords
 
     # Parse parameters for colorbar
     globs = {"cmap": cmap, "log": log, "vmin": vmin, "vmax": vmax}
@@ -54,7 +54,7 @@ def plot_sparse(input_data, ndim=0, sparse_dim=None, logx=False,
 
         widg = None
         members.update(ax)
-        params = dict(label=name, edgecolors="#ffffff",
+        params = dict(label=data_array.name, edgecolors="#ffffff",
                       c=mpl_scatter_params["color"][0],
                       marker=mpl_scatter_params["marker"][0])
         xs = sparse_data[ndims - 1]

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -4,7 +4,7 @@
 
 from ..config import plot as config
 from .tools import axis_to_dim_label, parse_params
-from .._scipp.core.units import dimensionless
+from ..utils import name_with_unit, value_to_string
 from .._scipp.core import combine_masks, Variable
 
 # Other imports
@@ -214,10 +214,7 @@ class Slicer:
         return
 
     def make_slider_label(self, var, indx):
-        lab = str(var.values[indx])
-        if var.unit != dimensionless:
-            lab += " [{}]".format(var.unit)
-        return lab
+        return name_with_unit(var=var, name=value_to_string(var.values[indx]))
 
     def mask_to_float(self, mask, var):
         return np.where(mask, var, None).astype(np.float)

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -24,7 +24,6 @@ class Slicer:
         if self.scipp_obj_dict is None:
             self.scipp_obj_dict = {data_array.name: data_array}
         self.data_array = data_array
-        self.name = self.data_array.name
 
         # Member container for dict output
         self.members = dict(widgets=dict(sliders=dict(), togglebuttons=dict(),

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -35,17 +35,15 @@ class Slicer:
         globs = {"cmap": cmap, "log": log, "vmin": vmin, "vmax": vmax,
                  "color": color}
 
-        if hasattr(self.data_array, "values"):
-            self.params["values"] = parse_params(params=values, globs=globs,
-                                                 array=self.data_array.values)
+        self.params["values"] = parse_params(params=values, globs=globs,
+                                             array=self.data_array.values)
 
-        if hasattr(self.data_array, "variances"):
-            self.params["variances"] = {"show": False}
-            if self.data_array.variances is not None:
-                self.params["variances"].update(
-                    parse_params(params=variances, defaults={"show": False},
-                                 globs=globs,
-                                 array=np.sqrt(self.data_array.variances)))
+        self.params["variances"] = {"show": False}
+        if self.data_array.variances is not None:
+            self.params["variances"].update(
+                parse_params(params=variances, defaults={"show": False},
+                             globs=globs,
+                             array=np.sqrt(self.data_array.variances)))
 
         self.params["masks"] = parse_params(
             params=masks, defaults={"cmap": "gray", "cbar": False},

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -21,6 +21,8 @@ class Slicer:
         import ipywidgets as widgets
 
         self.scipp_obj_dict = scipp_obj_dict
+        if self.scipp_obj_dict is None:
+            self.scipp_obj_dict = {data_array.name: data_array}
         self.data_array = data_array
         self.name = self.data_array.name
 
@@ -106,49 +108,6 @@ class Slicer:
                 indx = var.dims.index(self.slider_dims[key])
                 self.histograms[name][key] = var.shape[indx] == \
                     x.shape[0] - 1
-
-
-
-        # # # for key, x in self.slider_x.items():
-        # # #     indx = self.data_array.dims.index(self.slider_dims[key])
-        # # #     self.histograms[key] = self.data_array.shape[indx] == x.shape[0]-1
-        # # # # print(self.data_array)
-        # # # # print(hasattr(self.data_array, "name"))
-
-
-        # # if hasattr(self.data_array, "name"):
-        # #     print("has name")
-        # #     for key, x in self.slider_x.items():
-        # #         indx = self.data_array.dims.index(self.slider_dims[key])
-        # #         self.histograms[key] = self.data_array.shape[indx] == \
-        # #             x.shape[0] - 1
-        # # else:
-        # #     print("no name")
-        # #     for name, var in self.data_array:
-        # #         self.histograms[name] = dict()
-        # #         for key, x in self.slider_x.items():
-        # #             indx = var.dims.index(self.slider_dims[key])
-        # #             self.histograms[name][key] = var.shape[indx] == \
-        # #                 x.shape[0] - 1
-        # # print(self.histograms)
-
-
-        # # if hasattr(self.data_array, "name"):
-        # #     print("has name")
-        # #     for key, x in self.slider_x.items():
-        # #         indx = self.data_array.dims.index(self.slider_dims[key])
-        # #         self.histograms[key] = self.data_array.shape[indx] == \
-        # #             x.shape[0] - 1
-        # # else:
-        # #     print("no name")
-        # #     for name, var in self.data_array:
-        # #         self.histograms[name] = dict()
-        # #         for key, x in self.slider_x.items():
-        # #             indx = var.dims.index(self.slider_dims[key])
-        # #             self.histograms[name][key] = var.shape[indx] == \
-        # #                 x.shape[0] - 1
-        # print(self.histograms)
-        # print("=====================")
 
         # Initialise list for VBox container
         self.vbox = []

--- a/python/src/scipp/plot/sparse.py
+++ b/python/src/scipp/plot/sparse.py
@@ -10,18 +10,17 @@ import numpy as np
 from itertools import product
 
 
-def visit_sparse_data(input_data, sparse_dim, return_sparse_data=False,
+def visit_sparse_data(data_array, sparse_dim, return_sparse_data=False,
                       weights=None):
 
     xmin = 1.0e30
     xmax = -1.0e30
-    dims = input_data.dims
-    shapes = input_data.shape
+    dims = data_array.dims
+    shapes = data_array.shape
     ndims = len(dims)
     # Remove the sparse dim from dims
     isparse = dims.index(sparse_dim)
     dims.pop(isparse)
-    shapes.pop(isparse)
 
     # Construct tuple of ranges over dimension shapes
     if ndims > 1:
@@ -31,12 +30,10 @@ def visit_sparse_data(input_data, sparse_dim, return_sparse_data=False,
     else:
         indices = [0],
 
-    # Get default variable to gain access to spare coordinate
-    name, var = next(iter(input_data))
     # Check if weights are present
     data_exists = False
     if weights is not None:
-        data_exists = var.data is not None
+        data_exists = data_array.data is not None
 
     # Prepare scatter data container
     if return_sparse_data:
@@ -51,7 +48,7 @@ def visit_sparse_data(input_data, sparse_dim, return_sparse_data=False,
     for ind in product(*indices):
         # And for each indices combination, slice the original
         # data down to the sparse dimension
-        vslice = var
+        vslice = data_array
         if ndims > 1:
             for i in range(ndims - 1):
                 vslice = vslice[dims[i], ind[i]]
@@ -64,7 +61,7 @@ def visit_sparse_data(input_data, sparse_dim, return_sparse_data=False,
                 for i in range(ndims - 1):
                     scatter_array[i].append(
                         np.ones_like(vals) *
-                        input_data.coords[dims[i]].values[ind[i]])
+                        data_array.coords[dims[i]].values[ind[i]])
                 scatter_array[ndims - 1].append(vals)
                 if data_exists:
                     scatter_array[ndims].append(vslice.values)
@@ -72,29 +69,28 @@ def visit_sparse_data(input_data, sparse_dim, return_sparse_data=False,
     if return_sparse_data:
         for i in range(ndims + data_exists):
             scatter_array[i] = np.concatenate(scatter_array[i])
-        return xmin, xmax, scatter_array, var, name, dims, ndims
+        return xmin, xmax, scatter_array, dims, ndims
     else:
         return xmin, xmax
 
 
-def histogram_sparse_data(input_data, sparse_dim, bins):
-    var = next(iter(input_data))[1]
+def histogram_sparse_data(data_array, sparse_dim, bins):
     if isinstance(bins, bool):
         bins = 256
     if isinstance(bins, int):
         # Find min and max
-        xmin, xmax = visit_sparse_data(input_data, sparse_dim)
+        xmin, xmax = visit_sparse_data(data_array, sparse_dim)
         dx = (xmax - xmin) / float(bins)
         # Add padding
         xmin -= 0.5 * dx
         xmax += 0.5 * dx
         bins = sc.Variable([sparse_dim],
                            values=np.linspace(xmin, xmax, bins + 1),
-                           unit=var.coords[sparse_dim].unit)
+                           unit=data_array.coords[sparse_dim].unit)
     elif isinstance(bins, np.ndarray):
         bins = sc.Variable([sparse_dim], values=bins,
-                           unit=var.coords[sparse_dim].unit)
+                           unit=data_array.coords[sparse_dim].unit)
     elif isinstance(bins, sc.Variable):
         pass
 
-    return sc.histogram(input_data, bins)
+    return sc.histogram(data_array, bins)

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -5,7 +5,6 @@
 # Scipp imports
 from ..config import plot as config
 from .._scipp.core import Dim
-from .._scipp.core.units import dimensionless
 
 # Other imports
 import numpy as np
@@ -34,26 +33,6 @@ def centers_to_edges(x):
     """
     e = edges_to_centers(x)
     return np.concatenate([[2.0 * x[0] - e[0]], e, [2.0 * x[-1] - e[-1]]])
-
-
-def axis_label(var=None, name=None, log=False, replace_dim=True):
-    """
-    Make an axis label with "Name [unit]"
-    """
-    label = ""
-    if name is not None:
-        label = name
-    elif var is not None:
-        label = str(var.dims[-1])
-        if replace_dim:
-            label = label.replace("Dim.", "")
-
-    if log:
-        label = "log\u2081\u2080(" + label + ")"
-    if var is not None:
-        if var.unit != dimensionless:
-            label += " [{}]".format(var.unit)
-    return label
 
 
 def parse_params(params=None, defaults=None, globs=None, array=None):
@@ -124,19 +103,3 @@ def axis_to_dim_label(dataset, axis):
                            "be either a Scipp dimension "
                            "or a string.".format(axis))
     return dim, lab, var
-
-
-def get_1d_axes(var, axes, name):
-    """
-    Utility to simplify getting 1d axes labels and coordinate arrays
-    """
-    if axes is None:
-        axes = {var.dims[0]: var.dims[0]}
-    elif isinstance(axes, str):
-        axes = {var.dims[0]: axes}
-    dim, lab, xcoord = axis_to_dim_label(var, axes[var.dims[0]])
-    x = xcoord.values
-    xlab = axis_label(var=xcoord, name=lab)
-    y = var.values
-    ylab = axis_label(var=var, name="")
-    return xlab, ylab, x, y, axes

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -56,21 +56,24 @@ def parse_params(params=None, defaults=None, globs=None, array=None):
             parsed[key] = val
 
     if array is not None:
+        # TODO: possibly need to add a C++ method for finding min/max of
+        # Variables to avoid the creation of a large array of bools in
+        # np.ma.masked_invalid
         if parsed["log"]:
             with np.errstate(divide="ignore", invalid="ignore"):
-                subset = np.where(np.isfinite(np.log10(array)))
+                subset = np.ma.masked_invalid(np.log10(array), copy=False)
         else:
-            subset = np.where(np.isfinite(array))
+            subset = np.ma.masked_invalid(array, copy=False)
         if parsed["vmin"] is not None:
             vmin = parsed["vmin"]
         else:
-            vmin = np.amin(array[subset])
+            vmin = subset.min()
         if parsed["vmax"] is not None:
             vmax = parsed["vmax"]
         else:
-            vmax = np.amax(array[subset])
+            vmax = subset.max()
         if parsed["log"]:
-            norm = LogNorm(vmin=vmin, vmax=vmax)
+            norm = LogNorm(vmin=10.0**vmin, vmax=10.0**vmax)
         else:
             norm = Normalize(vmin=vmin, vmax=vmax)
         parsed["norm"] = norm

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -4,36 +4,8 @@
 # @author Igor Gudich & Neil Vaytet
 
 from .config import colors
+from .utils import value_to_string, name_with_unit
 from ._scipp import core as sc
-
-
-def value_to_string(val, precision=3):
-    if (not isinstance(val, float)) or (val == 0):
-        text = str(val)
-    elif (abs(val) >= 10.0**(precision+1)) or \
-         (abs(val) <= 10.0**(-precision-1)):
-        text = "{val:.{prec}e}".format(val=val, prec=precision)
-    else:
-        text = "{}".format(val)
-        if len(text) > precision + 2 + (text[0] == '-'):
-            text = "{val:.{prec}f}".format(val=val, prec=precision)
-    return text
-
-
-def title_to_string(var, name=None, replace_dim=True):
-    """
-    Make a column title with "Name [unit]"
-    """
-    if name is not None:
-        text = name
-    else:
-        text = str(var.dims[0])
-        if replace_dim:
-            text = text.replace("Dim.", "")
-
-    if var.unit != sc.units.dimensionless:
-        text += " [{}]".format(var.unit)
-    return text
 
 
 def _make_table_section_name_header(name, section, style):
@@ -94,7 +66,7 @@ def _make_table_unit_headers(section, text_style):
     for key, val in section:
         html.append("<th {} colspan='{}'>{}</th>".format(
             text_style, 1 + (val.variances is not None),
-            title_to_string(val, name=key)))
+            name_with_unit(val, name=key)))
     return "".join(html)
 
 
@@ -179,7 +151,7 @@ def table_from_dataset(dataset, is_hist=False, headers=2):
         if coord is not None:
             html += "<th {} colspan='{}'>{}</th>".format(
                 mstyle, 1 + (coord.variances is not None),
-                title_to_string(coord, replace_dim=False))
+                name_with_unit(coord, replace_dim=False))
 
         html += _make_table_unit_headers(dataset.labels, mstyle)
         html += _make_table_unit_headers(dataset.masks, mstyle)

--- a/python/src/scipp/utils.py
+++ b/python/src/scipp/utils.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Neil Vaytet
+
+from ._scipp.core.units import dimensionless
+
+
+def name_with_unit(var=None, name=None, log=False, replace_dim=True):
+    """
+    Make a column title or axis label with "Name [unit]".
+    """
+    text = ""
+    if name is not None:
+        text = name
+    elif var is not None:
+        text = str(var.dims[-1])
+        if replace_dim:
+            text = text.replace("Dim.", "")
+
+    if log:
+        text = "log\u2081\u2080(" + text + ")"
+    if var is not None:
+        if var.unit != dimensionless:
+            text += " [{}]".format(var.unit)
+    return text
+
+
+def value_to_string(val, precision=3):
+    """
+    Convert a number to a human readable string.
+    """
+    if (not isinstance(val, float)) or (val == 0):
+        text = str(val)
+    elif (abs(val) >= 10.0**(precision+1)) or \
+         (abs(val) <= 10.0**(-precision-1)):
+        text = "{val:.{prec}e}".format(val=val, prec=precision)
+    else:
+        text = "{}".format(val)
+        if len(text) > precision + 2 + (text[0] == '-'):
+            text = "{val:.{prec}f}".format(val=val, prec=precision)
+    return text

--- a/python/tests/test_plot.py
+++ b/python/tests/test_plot.py
@@ -387,3 +387,13 @@ def test_plot_variable():
     plot(v1d)
     plot(v2d)
     plot(v3d)
+
+
+def test_plot_dataset_proxy():
+    d = make_dense_dataset(ndim=2)
+    plot(d[Dim.X, 0])
+
+
+def test_plot_data_array():
+    d = make_dense_dataset(ndim=1)
+    plot(d["Sample"])


### PR DESCRIPTION
`plot.py` was making copies of the input data by grouping data entries into new `Dataset`s.
See [here](https://github.com/scipp/scipp/pull/764#discussion_r358202657) and also [here](https://github.com/scipp/scipp/blob/62cb7627885d7764a17d5242c003c7a420094c39/python/src/scipp/plot/plot.py#L95).

As a result, it was significantly faster to plot a dataset containing only one variable than plotting the subset `d["myvariable"]`.

Here, we group the entries to be plotted into a normal python `dict` of `DataArray`s.

**To test:**
```Py
N = 20000
M = 10000
xx = np.arange(N, dtype=np.float64)
yy = np.arange(M, dtype=np.float64)
x, y = np.meshgrid(xx, yy)
b = N/20.0
c = M/2.0
r = np.sqrt(((x-c)/b)**2 + (y/b)**2)
a = np.sin(r)
d1 = sc.Dataset()
d1.coords[Dim.X] = sc.Variable([Dim.X], values=xx, unit=sc.units.m)
d1.coords[Dim.Y] = sc.Variable([Dim.Y], values=yy, unit=sc.units.m)
d1['Signal'] = sc.Variable([Dim.Y, Dim.X], values=a, unit=sc.units.counts)
```

**Before:**
![Screenshot at 2019-12-16 16-11-05](https://user-images.githubusercontent.com/39047984/70918776-ec5fd580-201f-11ea-9f47-a8aa0f11eed4.png)

**After:**
![Screenshot at 2019-12-16 16-12-27](https://user-images.githubusercontent.com/39047984/70918821-039ec300-2020-11ea-946b-eb2c1c94b76f.png)

**Additional notes:**
- Also fixed the value labels of the sliders for `projection="1d"` plots which were broken since #763 

