### PR TITLE
to_html nested section enhancements

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -272,7 +272,8 @@ def convertEventWorkspace_to_dataarray(ws, load_pulse_times):
                         unit=unit)
     if load_pulse_times:
         labs = sc.Variable([spec_dim, dim],
-                           shape=[nHist, sc.Dimensions.Sparse])
+                           shape=[nHist, sc.Dimensions.Sparse],
+                           dtype=sc.dtype.int64)
 
     # Check for weighted events
     evtp = ws.getSpectrum(0).getEventType()

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -171,7 +171,11 @@ def init_pos(ws):
 def init_spec_axis(ws):
     axis = ws.getAxis(1)
     dim, unit = validate_and_get_unit(axis.getUnit().unitID())
-    return dim, sc.Variable([dim], values=axis.extractValues(), unit=unit)
+    dtype = sc.dtype.int32 if dim == sc.Dim.Spectrum else None
+    return dim, sc.Variable([dim],
+                            values=axis.extractValues(),
+                            unit=unit,
+                            dtype=dtype)
 
 
 def set_common_bins_masks(bin_masks, dim, masked_bins):

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -22,7 +22,7 @@ with open(ICONS_SVG_PATH, 'r') as f:
 
 
 def _is_dataset(x):
-    return isinstance(x, sc.Dataset) or isinstance(x, sc.DataProxy)
+    return isinstance(x, sc.Dataset) or isinstance(x, sc.DatasetProxy)
 
 
 def _format_array(data, size, ellipsis_after, do_ellide=True):
@@ -194,9 +194,11 @@ def _extract_sparse(x):
     return [(key, value) for key, value in x if value.sparse_dim is not None]
 
 
-def _make_inline_attributes(var):
+def _make_inline_attributes(var, has_attrs):
     disabled = "disabled"
     attrs_ul = ""
+    if not has_attrs:
+        return disabled, attrs_ul
     attrs_sections = []
     if hasattr(var, "coords"):
         sparse_coords = _extract_sparse(var.coords)
@@ -247,7 +249,7 @@ def summarize_variable(name, var, is_index=False, has_attrs=False):
     attrs_id = "attrs-" + str(uuid.uuid4())
     data_id = "data-" + str(uuid.uuid4())
 
-    disabled, attrs_ul = _make_inline_attributes(var)
+    disabled, attrs_ul = _make_inline_attributes(var, has_attrs)
 
     preview = inline_variable_repr(var)
     data_repr = f"Values:<br>{short_data_repr_html(var)}"

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -196,7 +196,7 @@ def _extract_sparse(x):
 
 def _make_inline_attributes(var):
     disabled = "disabled"
-    attrs_ul = None
+    attrs_ul = ""
     attrs_sections = []
     if hasattr(var, "coords"):
         sparse_coords = _extract_sparse(var.coords)
@@ -277,7 +277,7 @@ def summarize_variable(name, var, is_index=False, has_attrs=False):
         f"<input id='{data_id}' class='xr-var-data-in' type='checkbox'>",
         f"<label for='{data_id}' title='Show/Hide data repr'>",
         f"{data_icon}</label>",
-        f"<div class='xr-var-attrs'>{attrs_ul}</div>",
+        f"<div class='xr-var-attrs'>{attrs_ul}</div>" if attrs_ul else "",
         f"<pre class='xr-var-data'>{data_repr}</pre>",
     ]
     return "".join(html)

--- a/python/src/scipp/table_html/style.css
+++ b/python/src/scipp/table_html/style.css
@@ -254,14 +254,21 @@
   z-index: 1;
 }
 
-.xr-var-attrs,
+.xr-var-attrs {
+  display: block;
+}
 .xr-var-data {
   display: none;
+}
+.xr-var-attrs,
+.xr-var-data {
   background-color: #fff !important;
   padding-bottom: 5px !important;
 }
 
-.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-attrs-in:checked ~ .xr-var-attrs {
+  display: none;
+}
 .xr-var-data-in:checked ~ .xr-var-data {
   display: block;
 }


### PR DESCRIPTION
- Do not repeat coords or labels from parent, i.e., only show the sparse ones.
- Fix so `DatasetProxy` is handled like `Dataset`.
- Do not show (and thus repeat) nested section for `DataArray` and `DataProxy`.
- Unfold by default. I think this is a better default, given that we frequently deal with event data and important content in attributes. See screenshot for example:

![image](https://user-images.githubusercontent.com/12912489/70973951-fed12200-20a6-11ea-8cb5-2ef7a9e3aadc.png)

- Also included a small fix to the Mantid converter to spectrum numbers are `int32` and not `double`, as well as pulse times fixed to `int64` instead of `double`.
- Fixes #746.

