### PR TITLE
Hides name for DataArray and Variable

### DIFF
--- a/python/src/scipp/table_html/__init__.py
+++ b/python/src/scipp/table_html/__init__.py
@@ -10,7 +10,8 @@ def make_html(container):
     if isinstance(container, sc.Variable) or isinstance(
             container, sc.VariableProxy):
         return variable_repr(container)
-    elif isinstance(container, sc.DataArray):
+    elif isinstance(container, sc.DataArray) or isinstance(
+            container, sc.DataProxy):
         return dataarray_repr(container)
     else:
         return dataset_repr(container)

--- a/python/src/scipp/table_html/__init__.py
+++ b/python/src/scipp/table_html/__init__.py
@@ -3,13 +3,15 @@
 # @file
 # @author Dimitar Tasev
 from .._scipp import core as sc
-from .formatting_html import dataset_repr, variable_repr
+from .formatting_html import dataset_repr, dataarray_repr, variable_repr
 
 
 def make_html(container):
     if isinstance(container, sc.Variable) or isinstance(
             container, sc.VariableProxy):
         return variable_repr(container)
+    elif isinstance(container, sc.DataArray):
+        return dataarray_repr(container)
     else:
         return dataset_repr(container)
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -278,9 +278,14 @@ def _format_common(is_index):
     return cssclass_idx, attrs_id, attrs_icon, data_id, data_icon
 
 
-def _var_f(name, dims_str, dtype, unit,
-           preview, variances_preview,
-           attrs_ul, disabled, data_repr, is_index, has_attrs):
+def _variable_format(name, dims_str, dtype, unit,
+                     preview, variances_preview,
+                     attrs_ul, disabled, data_repr, is_index, has_attrs):
+    """
+    Formats the variable data into the format expected when displaying
+    as a standalone Variable. This happens when a single Variable or
+    DataArray is displayed.
+    """
     cssclass_idx, attrs_id, attrs_icon, data_id, data_icon = _format_common(
         is_index)
 
@@ -307,9 +312,13 @@ def _var_f(name, dims_str, dtype, unit,
     return "".join(html)
 
 
-def _ds_f(name, dims_str, dtype, unit,
-          preview, variances_preview,
-          attrs_ul, disabled, data_repr, is_index, has_attrs):
+def _dataset_format(name, dims_str, dtype, unit,
+                    preview, variances_preview,
+                    attrs_ul, disabled, data_repr, is_index, has_attrs):
+    """
+    Formats the variable data into the format expected when displaying
+    as part of a dataset.
+    """
     cssclass_idx, attrs_id, attrs_icon, data_id, data_icon = _format_common(
         is_index)
 
@@ -379,10 +388,10 @@ def summarize_variable(name, var,
                        has_attrs=False,
                        bin_edges=None):
     if name is None:
-        return _var_f(*_prepare_variable_info(
+        return _variable_format(*_prepare_variable_info(
             name, var, is_index, has_attrs, bin_edges))
     else:
-        return _ds_f(*_prepare_variable_info(
+        return _dataset_format(*_prepare_variable_info(
             name, var, is_index, has_attrs, bin_edges))
 
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -42,7 +42,7 @@ def _format_array(data, size, ellipsis_after, do_ellide=True):
 
 
 def _make_row(data_html, variances_html=None):
-    return f"<div>{escape(data_html)}</div>"
+    return f"<div>{data_html}</div>"
 
 
 def _format_non_sparse(var, has_variances):

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -173,8 +173,9 @@ def _icon(icon_name):
             "</svg>".format(icon_name))
 
 
-def summarize_coord(dim, var, bin_edges=None):
+def summarize_coord(dim, var, ds=None):
     is_index = dim in var.dims
+    bin_edges = find_bin_edges(var, ds) if ds else None
     return summarize_variable(str(dim), var, is_index, bin_edges=bin_edges)
 
 
@@ -191,10 +192,10 @@ def find_bin_edges(var, ds):
     return bin_edges
 
 
-def summarize_coords(coords, ds):
+def summarize_coords(coords, ds=None):
     vars_li = "".join(
         "<li class='xr-var-item'>"
-        f"{summarize_coord(dim, var, bin_edges=find_bin_edges(var, ds))}"
+        f"{summarize_coord(dim, var, ds)}"
         "</span></li>"
         for dim, var in coords)
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -184,11 +184,13 @@ def find_bin_edges(var, ds):
     Checks if the coordinate contains bin-edges.
     """
     bin_edges = []
-    for idx, dim in enumerate(var.dims):
+    non_sparse_dims = [dim for dim in var.dims if dim !=
+                       var.sparse_dim] if var.sparse_dim else var.dims
+
+    for idx, dim in enumerate(non_sparse_dims):
         len = var.shape[idx]
-        if dim in ds.dims:
-            if ds.shape[ds.dims.index(dim)] + 1 == len:
-                bin_edges.append(dim)
+        if dim in ds.dims and ds.shape[ds.dims.index(dim)] + 1 == len:
+            bin_edges.append(dim)
     return bin_edges
 
 
@@ -387,10 +389,12 @@ def summarize_variable(name, var,
 def summarize_data(dataset):
     has_attrs = _is_dataset(dataset)
     vars_li = "".join(
-        "<li class='xr-var-item'>"
-        f"{summarize_variable(name, values, has_attrs=has_attrs)}"
-        "</li>"
-        for name, values in dataset)
+        "<li class='xr-var-item'>{}</li>".format(
+            summarize_variable(
+                name, var,
+                has_attrs=has_attrs,
+                bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
+        for name, var in dataset)
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -42,7 +42,7 @@ def _format_array(data, size, ellipsis_after, do_ellide=True):
 
 
 def _make_row(data_html, variances_html=None):
-    return f"<div>{data_html}</div>"
+    return f"<div>{escape(data_html)}</div>"
 
 
 def _format_non_sparse(var, has_variances):
@@ -253,56 +253,43 @@ def _make_dim_labels(dim, sparse_dim, bin_edges=None):
         return ""
 
 
-def summarize_variable(name, var,
-                       is_index=False,
-                       has_attrs=False,
-                       bin_edges=None):
-    """
-    :param name: Name of the variable
-    :param var: The variable itself, used to display dtype, unit, values, attrs
-    :param is_index: If the variable is an index - used to bold
-                     coordinates that represent the indices of
-                     a dimension that the data contains
-
-    :param has_attrs: If the variable is for a section that cannot contain
-                      attributes, then this hides the show/hide button.
-
-    :param is_bin_edges: If true it will add the [bin-edges] variable
-    """
-    cssclass_idx = " class='xr-has-index'" if is_index else ""
+def _make_dim_str(var, bin_edges, add_sizes=False):
     dims_text = ', '.join(
-        f'{str(dim)}{_make_dim_labels(dim, var.sparse_dim, bin_edges)}'
-        for dim in var.dims)
-    dims_str = escape(f"({dims_text})")
-    name = escape(name)
-    dtype = repr(var.dtype)[6:]
-    unit = '' if var.unit == sc.units.dimensionless else var.unit
+        '{}{}{}'.format(
+            str(dim),
+            _make_dim_labels(dim, var.sparse_dim, bin_edges),
+            f': {size}' if add_sizes else ''
+        )
+        for dim, size in zip(var.dims, var.shape))
+    return dims_text
+
+
+def _format_common(is_index):
+    cssclass_idx = " class='xr-has-index'" if is_index else ""
 
     # "unique" ids required to expand/collapse subsections
     attrs_id = "attrs-" + str(uuid.uuid4())
     data_id = "data-" + str(uuid.uuid4())
-
-    disabled, attrs_ul = _make_inline_attributes(var, has_attrs)
-
-    preview = inline_variable_repr(var)
-    data_repr = f"Values:<br>{short_data_repr_html(var)}"
-    variances_preview = ""
-    if var.variances is not None:
-        variances_preview = inline_variable_repr(var, has_variances=True)
-        data_repr += f"<br><br>Variances:<br>\
-                       <div>{short_data_repr_html(var)}</div>"
-
     attrs_icon = _icon("icon-file-text2")
     data_icon = _icon("icon-database")
 
+    return cssclass_idx, attrs_id, attrs_icon, data_id, data_icon
+
+
+def _var_f(name, dims_str, dtype, unit,
+           preview, variances_preview,
+           attrs_ul, disabled, data_repr, is_index, has_attrs):
+    cssclass_idx, attrs_id, attrs_icon, data_id, data_icon = _format_common(
+        is_index)
+
     html = [
-        f"<div class='xr-var-name'><span{cssclass_idx}>{name}</span></div>",
-        f"<div class='xr-var-dims'>{dims_str}</div>",
-        f"<div class='xr-var-dtype'>{dtype}</div>",
-        f"<div class='xr-var-unit'>{unit}</div>",
+        f"<div class='sc-var-name'><span{cssclass_idx}>{dims_str}</span>"
+        "</div>",
+        f"<div class='xr-var-dtype'>{escape(dtype)}</div>",
+        f"<div class='xr-var-unit'>{escape(unit)}</div>",
         f"<div class='xr-value-preview xr-preview'><span>{preview}</span>",
         "{}</div>".format(f'<span>{variances_preview}</span>'
-                          if var.variances is not None else ''),
+                          if variances_preview is not None else ''),
         f"<input id='{attrs_id}' class='xr-var-attrs-in' ",
         f"type='checkbox' {disabled}>",
         f"<label for='{attrs_id}' "
@@ -318,11 +305,91 @@ def summarize_variable(name, var,
     return "".join(html)
 
 
+def _ds_f(name, dims_str, dtype, unit,
+          preview, variances_preview,
+          attrs_ul, disabled, data_repr, is_index, has_attrs):
+    cssclass_idx, attrs_id, attrs_icon, data_id, data_icon = _format_common(
+        is_index)
+
+    html = [
+        f"<div class='xr-var-name'><span{cssclass_idx}>{escape(name)}</span>"
+        "</div>",
+        f"<div class='xr-var-dims'>{escape(dims_str)}</div>",
+        f"<div class='xr-var-dtype'>{escape(dtype)}</div>",
+        f"<div class='xr-var-unit'>{escape(unit)}</div>",
+        f"<div class='xr-value-preview xr-preview'><span>{preview}</span>",
+        "{}</div>".format(f'<span>{variances_preview}</span>'
+                          if variances_preview is not None else ''),
+        f"<input id='{attrs_id}' class='xr-var-attrs-in' ",
+        f"type='checkbox' {disabled}>",
+        f"<label for='{attrs_id}' "
+        f"class='{'' if has_attrs else 'xr-hide-icon'}'"
+        " title='Show/Hide attributes'>",
+        f"{attrs_icon}</label>",
+        f"<input id='{data_id}' class='xr-var-data-in' type='checkbox'>",
+        f"<label for='{data_id}' title='Show/Hide data repr'>",
+        f"{data_icon}</label>",
+        f"<div class='xr-var-attrs'>{attrs_ul}</div>" if attrs_ul else "",
+        f"<pre class='xr-var-data'>{data_repr}</pre>",
+    ]
+    return "".join(html)
+
+
+def _prepare_variable_info(name, var,
+                           is_index=False,
+                           has_attrs=False,
+                           bin_edges=None):
+    """
+    :param name: Name of the variable
+    :param var: The variable itself, used to display dtype, unit, values, attrs
+    :param is_index: If the variable is an index - used to bold
+                     coordinates that represent the indices of
+                     a dimension that the data contains
+
+    :param has_attrs: If the variable is for a section that cannot contain
+                      attributes, then this hides the show/hide button.
+
+    :param is_bin_edges: If true it will add the [bin-edges] variable
+    """
+
+    dims_str = escape(f"({_make_dim_str(var, bin_edges, name is None)})")
+    dtype = repr(var.dtype)[6:]
+    unit = '' if var.unit == sc.units.dimensionless else repr(var.unit)
+
+    disabled, attrs_ul = _make_inline_attributes(var, has_attrs)
+
+    preview = inline_variable_repr(var)
+    data_repr = f"Values:<br>{short_data_repr_html(var)}"
+    variances_preview = None
+    if var.variances is not None:
+        variances_preview = inline_variable_repr(var, has_variances=True)
+        data_repr += f"<br><br>Variances:<br>\
+                       <div>{short_data_repr_html(var)}</div>"
+
+    return (name, dims_str, dtype, unit,
+            preview, variances_preview,
+            attrs_ul, disabled,
+            data_repr, is_index, has_attrs)
+
+
+def summarize_variable(name, var,
+                       is_index=False,
+                       has_attrs=False,
+                       bin_edges=None):
+    if name is None:
+        return _var_f(*_prepare_variable_info(
+            name, var, is_index, has_attrs, bin_edges))
+    else:
+        return _ds_f(*_prepare_variable_info(
+            name, var, is_index, has_attrs, bin_edges))
+
+
 def summarize_data(dataset):
     has_attrs = _is_dataset(dataset)
     vars_li = "".join(
         "<li class='xr-var-item'>"
-        f"{summarize_variable(name, values, has_attrs=has_attrs)}</li>"
+        f"{summarize_variable(name, values, has_attrs=has_attrs)}"
+        "</li>"
         for name, values in dataset)
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
@@ -357,7 +424,7 @@ def _mapping_section(mapping,
                      details_func=None,
                      max_items_collapse=None,
                      enabled=True):
-    n_items = len(mapping)
+    n_items = len(mapping) if hasattr(mapping, "__len__") else 1
     collapsed = n_items >= max_items_collapse
 
     return collapsible_section(
@@ -379,24 +446,19 @@ def dim_section(dataset):
                                collapsed=True)
 
 
-def array_section(obj):
-    # "unique" id to expand/collapse the section
-    data_id = "section-" + str(uuid.uuid4())
-    collapsed = ""
-    preview = repr(obj.variable)
-    data_repr = short_data_repr_html(obj)
-    data_icon = _icon("icon-database")
+def summarize_array(var):
+    vars_li = "".join(
+        "<li class='xr-var-item'>"
+        f"{summarize_variable(None, var)}</li>")
+    return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
-    return ("<div class='xr-array-wrap'>"
-            f"<input id='{data_id}' \
-            class='xr-array-in' type='checkbox' {collapsed}>"
-            f"<label for='{data_id}' \
-            title='Show/hide data repr'>{data_icon}</label>"
-            f"<div class='xr-array-preview \
-            xr-preview'><span>{preview}</span></div>"
-            f"<pre class='xr-array-data'>{data_repr}</pre>"
-            "</div>")
 
+array_section = partial(
+    _mapping_section,
+    name="Data",
+    details_func=summarize_array,
+    max_items_collapse=10,
+)
 
 coord_section = partial(
     _mapping_section,
@@ -467,6 +529,27 @@ def dataset_repr(ds):
     return _obj_repr(header_components, sections)
 
 
+def dataarray_repr(darray):
+    obj_type = "scipp.{}".format(type(darray).__name__)
+
+    header_components = [f"<div class='xr-obj-type'>{escape(obj_type)}</div>"]
+
+    sections = [dim_section(darray),
+                array_section(darray)]
+
+    if len(darray.coords) > 0:
+        sections.append(coord_section(darray.coords, darray))
+    if len(darray.labels) > 0:
+        sections.append(label_section(darray.labels))
+
+    if len(darray.masks) > 0:
+        sections.append(mask_section(darray.masks))
+    if len(darray.attrs) > 0:
+        sections.append(attr_section(darray.attrs))
+
+    return _obj_repr(header_components, sections)
+
+
 def variable_repr(var):
     obj_type = "scipp.{}".format(type(var).__name__)
 
@@ -474,7 +557,7 @@ def variable_repr(var):
 
     sections = [
         dim_section(var),
-        data_section([('', var)]),
+        array_section(var),
     ]
 
     return _obj_repr(header_components, sections)

--- a/python/src/scipp/table_html/style.css
+++ b/python/src/scipp/table_html/style.css
@@ -351,3 +351,11 @@ label.xr-hide-icon svg{
   /* matches the margin from  xr-section-item */
   margin-bottom: 5px;
 }
+
+.sc-var-name{
+  grid-column: 1/3;
+}
+
+.sc-var-name span{
+  padding-left: 25px;
+}


### PR DESCRIPTION
Shows the Dimensions where the name would be for DataArray and Variable, as their data has no specific name.

Some refactoring of the summarize_variable function. Now delegates to `_variable_format` and `_dataset_format` to properly style the HTML for each output.

This is based on #778 and will show more changes that were made. I'll rebase when that PR is merged.