### PR TITLE
Neutron docs and monitor handling

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -741,9 +741,12 @@ public:
                                         to_string(key) + " found," + suffix);
         }
         m_parent->eraseSparseCoord(*m_name);
-      } else if constexpr (std::is_same_v<Base, LabelsConstProxy>)
-        m_parent->eraseSparseLabels(*m_name, key);
-      else if constexpr (std::is_same_v<Base, AttrsConstProxy>)
+      } else if constexpr (std::is_same_v<Base, LabelsConstProxy>) {
+        if (this->operator[](key).dims().sparse())
+          m_parent->eraseSparseLabels(*m_name, key);
+        else
+          m_parent->eraseLabels(key);
+      } else if constexpr (std::is_same_v<Base, AttrsConstProxy>)
         m_parent->eraseAttr(*m_name, key);
       else
         throw std::runtime_error("The instance cannot be sparse.");

--- a/docs/scipp-neutron/overview.rst
+++ b/docs/scipp-neutron/overview.rst
@@ -60,4 +60,5 @@ Loading Nexus files
 .. autosummary::
    :toctree: ../generated
 
+   from_mantid
    load

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -380,7 +380,7 @@
     "### Monitors\n",
     "\n",
     "If loaded, monitors are available as an attributes named `\"monitors\"`.\n",
-    "For demonstration purposed we can add some fake monitors to demonstrate the versatility of `Dataset`.\n",
+    "For demonstration purposes we can add some fake monitors to demonstrate the versatility of `Dataset`.\n",
     "Storing each monitor as a separate variable that contains a nested data array gives us complete freedom an flexibility.\n",
     "Another approach would be to use a single 1-D variable containing monitor data arrays as elements."
    ]

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -381,7 +381,7 @@
     "\n",
     "If loaded, monitors are available as an attributes named `\"monitors\"`.\n",
     "For demonstration purposes we can add some fake monitors to demonstrate the versatility of `Dataset`.\n",
-    "Storing each monitor as a separate variable that contains a nested data array gives us complete freedom an flexibility.\n",
+    "Storing each monitor as a separate variable that contains a nested data array gives us complete freedom and flexibility.\n",
     "Another approach would be to use a single 1-D variable containing monitor data arrays as elements."
    ]
   },

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "### Monitors\n",
     "\n",
-    "If loaded, monitors are available as an attributes named `\"monitors\"`.\n",
+    "If loaded, monitors are available as an attribute named `\"monitors\"`.\n",
     "For demonstration purposes we can add some fake monitors to demonstrate the versatility of `Dataset`.\n",
     "Storing each monitor as a separate variable that contains a nested data array gives us complete freedom and flexibility.\n",
     "Another approach would be to use a single 1-D variable containing monitor data arrays as elements."

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -220,7 +220,7 @@
     "Attributes allow for storing information with data in a way that leaves it untouched in normal operations.\n",
     "This is used for storing meta-data that does not require processing alongside normal data.\n",
     "For neutron data key examples are: run information, sample information, and neutron monitors.\n",
-    "Scipp simply stores Mantids `Run` and `Sample` objects in the `\"run\"` and `\"sample\"` attributes.\n",
+    "Scipp simply stores Mantid's `Run` and `Sample` objects in the `\"run\"` and `\"sample\"` attributes.\n",
     "Monitors are stored in the `\"monitors\"` attribute."
    ]
   },

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -39,10 +39,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = sc.Dataset()\n",
-    "# Load only a single bank to reduce memory consumption, so we can run this on a laptop\n",
-    "d[\"sample\"] = sc.neutron.load(filename='../data/PG3_4844_event.nxs', load_pulse_times=True, mantid_args={'BankName': 'bank184'})\n",
-    "d[\"vanadium\"] = sc.neutron.load(filename='../data/PG3_4866_event.nxs', load_pulse_times=False, mantid_args={'BankName': 'bank184'})"
+    "events = sc.Dataset()\n",
+    "# Load only a single bank to reduce memory consumption, so this runs on a laptop\n",
+    "events[\"sample\"] = sc.neutron.load(\n",
+    "    filename='PG3_4844_event.nxs',\n",
+    "    load_pulse_times=True,\n",
+    "    mantid_args={'BankName': 'bank184',\n",
+    "                 'LoadMonitors': True}) # Mantid does not load monitors by default\n",
+    "events[\"vanadium\"] = sc.neutron.load(\n",
+    "    filename='PG3_4866_event.nxs',\n",
+    "    load_pulse_times=False,\n",
+    "    mantid_args={'BankName': 'bank184',\n",
+    "                 'LoadMonitors': True})"
    ]
   },
   {
@@ -64,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d"
+    "events"
    ]
   },
   {
@@ -93,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.coords[Dim.Spectrum]"
+    "events.coords[Dim.Spectrum]"
    ]
   },
   {
@@ -126,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.labels['position']"
+    "events.labels['position']"
    ]
   },
   {
@@ -144,8 +152,8 @@
     "#### Beamline geometry\n",
     "\n",
     "Apart from positions of spectra we require additional geometry information for various components in a neutron beamline (instrument).\n",
-    "This is stored in the `component_info` labels, which contain a single nested dataset.\n",
-    "The contents of this dataset are not particularely easy to parse and we instead recommend the use of helper functions such as `sample_position` which will be discussed below:"
+    "This is stored as labels such as `'source_position'` and `'sample_position'`.\n",
+    "We instead recommend the use of helper functions such as `sample_position` which will be discussed below:"
    ]
   },
   {
@@ -154,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.labels['component_info'].value"
+    "events.labels['sample_position'].value"
    ]
   },
   {
@@ -177,16 +185,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.neutron.sample_position(d)"
+    "sc.neutron.sample_position(events).copy() # copy is a temporary hack since const view lacks some properties"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "sc.neutron.scattering_angle(d)"
+    "sc.neutron.scattering_angle(events)"
    ]
   },
   {
@@ -204,7 +214,57 @@
     " For the most part, the structure of `ComponentInfo` (and `DetectorInfo`) in Mantid is easily represented by a `Dataset`, i.e., very little change is required.\n",
     " For example, scanning is simply handled by an extra dimension of, e.g., the position and rotation variables.\n",
     " By using `Dataset` to handle this, we can use exactly the same tools and do not need to implement or learn a new API.*\n",
+    " \n",
+    "### Attributes\n",
     "\n",
+    "Attributes allow for storing information with data in a way that leaves it untouched in normal operations.\n",
+    "This is used for storing meta-data that does not require processing alongside normal data.\n",
+    "For neutron data key examples, are run information, sample information, and neutron monitors.\n",
+    "Scipp simply stores Mantids `Run` and `Sample` objects in the `\"run\"` and `\"sample\"` attributes.\n",
+    "Monitors are stored in the `\"monitors\"` attribute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.to_html(events['sample'].attrs['run'])\n",
+    "sc.to_html(events['sample'].attrs['sample'])\n",
+    "sc.to_html(events['sample'].attrs['monitors'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that these are attributes of the sample (or vanadium).\n",
+    "A dataset itself can also have attributes, but in this case it does not.\n",
+    "Each of the attributes above is a 0-D variable, the easiest way to access this value is the `value` property:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mantid_run = events['sample'].attrs['run'].value\n",
+    "print('The run contains the following properties:\\n{}\\n'.format(mantid_run.keys()))\n",
+    "\n",
+    "mantid_sample = events['sample'].attrs['sample'].value\n",
+    "print('Sample name: {}\\n'.format(mantid_sample.getName()))\n",
+    "\n",
+    "# Each monitor (just 1 in this case) is stored as a data array\n",
+    "print('Monitor:')\n",
+    "sc.to_html(events['sample'].attrs['monitors'].value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Event data\n",
     "\n",
     "Neutron events are stored as **sparse data** in contrast to the regular gridded (\"dense\") data of, e.g., histogrammed data.\n",
@@ -220,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.show(d[Dim.Spectrum, 10:20])"
+    "sc.show(events[Dim.Spectrum, 10:20])"
    ]
   },
   {
@@ -251,7 +311,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d['sample'].coords[sc.Dim.Tof][sc.Dim.Spectrum, 10].values"
+    "events['sample'].coords[sc.Dim.Tof][sc.Dim.Spectrum, 10].values"
    ]
   },
   {
@@ -270,7 +330,7 @@
    "outputs": [],
    "source": [
     "bins = sc.Variable([Dim.Tof], values=np.arange(1000.0, 20000.0, 50.0), unit=sc.units.us)\n",
-    "d = sc.histogram(d, bins)\n",
+    "d = sc.histogram(events, bins)\n",
     "d"
    ]
   },
@@ -319,8 +379,10 @@
    "source": [
     "### Monitors\n",
     "\n",
-    "Monitors are not handled by the Mantid converter yet, but we can add some fake ones to demonstrate the versatility  of `Dataset`.\n",
-    "Storing each monitor as a separate variable that contains a nested dataset gives us complete freedom an flexibility."
+    "If loaded, monitors are available as an attributes named `\"monitors\"`.\n",
+    "For demonstration purposed we can add some fake monitors to demonstrate the versatility of `Dataset`.\n",
+    "Storing each monitor as a separate variable that contains a nested data array gives us complete freedom an flexibility.\n",
+    "Another approach would be to use a single 1-D variable containing monitor data arrays as elements."
    ]
   },
   {
@@ -361,9 +423,9 @@
    "outputs": [],
    "source": [
     "sc.Variable(value=transmission)\n",
-    "d.labels['transmission'] = sc.Variable(value=transmission)\n",
-    "d.labels['beam'] = sc.Variable(value=beam)\n",
-    "d.labels['profile'] = sc.Variable(value=profile)\n",
+    "d['sample'].attrs['transmission'] = sc.Variable(value=transmission)\n",
+    "d['sample'].attrs['beam'] = sc.Variable(value=beam)\n",
+    "d['sample'].attrs['profile'] = sc.Variable(value=profile)\n",
     "d"
    ]
   },
@@ -372,10 +434,13 @@
    "metadata": {},
    "source": [
     "### Exercise 1\n",
-    " Normalize the sample data to the \"beam\" monitor.\n",
+    "Normalize the sample data to the first (and only) monitor in the `\"monitors\"` attribute.\n",
+    "This involves a couple of steps:\n",
+    "1. Normalization in time-of-flight does not make sense. Convert to, e.g., wavelength.\n",
+    "2. The data and the monitor have mismatching bins. Rebin to common binning.\n",
+    "3. Normalize. \n",
     "\n",
-    " ### Solution 1\n",
-    " The binning of the monitor does not match that of the data, so we need to rebin it before the division:"
+    "### Solution 1"
    ]
   },
   {
@@ -384,7 +449,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_over_beam = d['sample'] / sc.rebin(d.labels['beam'].value, Dim.Tof, d.coords[Dim.Tof])\n",
+    "sample = sc.neutron.convert(d['sample'], Dim.Tof, Dim.Wavelength)\n",
+    "# Using bins of first spectrum here, other choices are just as valid\n",
+    "sample = sc.rebin(sample, Dim.Wavelength, sample.coords[Dim.Wavelength][Dim.Spectrum, 0])\n",
+    "\n",
+    "mon = d['sample'].attrs['monitors'].value\n",
+    "mon = sc.neutron.convert(mon, Dim.Tof, Dim.Wavelength)\n",
+    "mon = sc.rebin(mon, Dim.Wavelength, sample.coords[Dim.Wavelength])\n",
+    "\n",
+    "plot(mon)                             \n",
+    "sample_over_beam = sample / mon\n",
     "plot(sample_over_beam)"
    ]
   },
@@ -392,7 +466,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result is meaningless since our \"monitor\" contained just random noise."
+    "We could now continue with the normalized data, but in the following we do not."
    ]
   },
   {
@@ -544,7 +618,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   },
   "nbsphinx": {
    "execute": "never"

--- a/docs/tutorials/neutron-data.ipynb
+++ b/docs/tutorials/neutron-data.ipynb
@@ -219,7 +219,7 @@
     "\n",
     "Attributes allow for storing information with data in a way that leaves it untouched in normal operations.\n",
     "This is used for storing meta-data that does not require processing alongside normal data.\n",
-    "For neutron data key examples, are run information, sample information, and neutron monitors.\n",
+    "For neutron data key examples are: run information, sample information, and neutron monitors.\n",
     "Scipp simply stores Mantids `Run` and `Sample` objects in the `\"run\"` and `\"sample\"` attributes.\n",
     "Monitors are stored in the `\"monitors\"` attribute."
    ]

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -29,6 +29,8 @@ template <class T> static VariableConstProxy sample_position(const T &d) {
 }
 
 template <class T> static Variable flight_path_length(const T &d) {
+  // If there is no sample this returns the straight distance from the source,
+  // as required, e.g., for monitors.
   if (d.labels().contains("sample_position"))
     return l1(d) + l2(d);
   else

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -12,11 +12,6 @@ using namespace scipp::core;
 namespace scipp::neutron {
 
 namespace beamline_impl {
-template <class T> static auto component_positions(const T &d) {
-  return d.labels()["component_info"]
-      .template values<Dataset>()[0]["position"]
-      .data();
-}
 
 template <class T> static VariableConstProxy position(const T &d) {
   if (d.coords().contains(Dim::Position))
@@ -25,13 +20,19 @@ template <class T> static VariableConstProxy position(const T &d) {
     return d.labels()["position"];
 }
 
-template <class T> static Variable source_position(const T &d) {
-  // TODO Need a better mechanism to identify source and sample.
-  return Variable(component_positions(d).slice({Dim::Row, 0}));
+template <class T> static VariableConstProxy source_position(const T &d) {
+  return d.labels()["source_position"];
 }
 
-template <class T> static Variable sample_position(const T &d) {
-  return Variable(component_positions(d).slice({Dim::Row, 1}));
+template <class T> static VariableConstProxy sample_position(const T &d) {
+  return d.labels()["sample_position"];
+}
+
+template <class T> static Variable flight_path_length(const T &d) {
+  if (d.labels().contains("sample_position"))
+    return l1(d) + l2(d);
+  else
+    return norm(position(d) - source_position(d));
 }
 
 template <class T> static Variable l1(const T &d) {
@@ -68,11 +69,14 @@ template <class T> static Variable two_theta(const T &d) {
 core::VariableConstProxy position(const core::DatasetConstProxy &d) {
   return beamline_impl::position(d);
 }
-core::Variable source_position(const core::DatasetConstProxy &d) {
+core::VariableConstProxy source_position(const core::DatasetConstProxy &d) {
   return beamline_impl::source_position(d);
 }
-core::Variable sample_position(const core::DatasetConstProxy &d) {
+core::VariableConstProxy sample_position(const core::DatasetConstProxy &d) {
   return beamline_impl::sample_position(d);
+}
+core::Variable flight_path_length(const core::DatasetConstProxy &d) {
+  return beamline_impl::flight_path_length(d);
 }
 core::Variable l1(const core::DatasetConstProxy &d) {
   return beamline_impl::l1(d);
@@ -90,11 +94,14 @@ core::Variable two_theta(const core::DatasetConstProxy &d) {
 core::VariableConstProxy position(const core::DataConstProxy &d) {
   return beamline_impl::position(d);
 }
-core::Variable source_position(const core::DataConstProxy &d) {
+core::VariableConstProxy source_position(const core::DataConstProxy &d) {
   return beamline_impl::source_position(d);
 }
-core::Variable sample_position(const core::DataConstProxy &d) {
+core::VariableConstProxy sample_position(const core::DataConstProxy &d) {
   return beamline_impl::sample_position(d);
+}
+core::Variable flight_path_length(const core::DataConstProxy &d) {
+  return beamline_impl::flight_path_length(d);
 }
 core::Variable l1(const core::DataConstProxy &d) {
   return beamline_impl::l1(d);

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -16,22 +16,31 @@ namespace beamline_impl {
 template <class T> static VariableConstProxy position(const T &d) {
   if (d.coords().contains(Dim::Position))
     return d.coords()[Dim::Position];
-  else
+  else if (d.labels().contains("position"))
     return d.labels()["position"];
+  else
+    return d.attrs()["position"];
 }
 
 template <class T> static VariableConstProxy source_position(const T &d) {
-  return d.labels()["source_position"];
+  if (d.labels().contains("source_position"))
+    return d.labels()["source_position"];
+  else
+    return d.attrs()["source_position"];
 }
 
 template <class T> static VariableConstProxy sample_position(const T &d) {
-  return d.labels()["sample_position"];
+  if (d.labels().contains("sample_position"))
+    return d.labels()["sample_position"];
+  else
+    return d.attrs()["sample_position"];
 }
 
 template <class T> static Variable flight_path_length(const T &d) {
   // If there is no sample this returns the straight distance from the source,
   // as required, e.g., for monitors.
-  if (d.labels().contains("sample_position"))
+  if (d.labels().contains("sample_position") ||
+      d.attrs().contains("sample_position"))
     return l1(d) + l2(d);
   else
     return norm(position(d) - source_position(d));

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -256,7 +256,7 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // a subsequent unit conversion of an item on its own would not be
         // possible. It needs to be determined if there is a better way to
         // handle attributes so this can be avoided.
-        for ([[maybe_unused]] const auto &[name, data] : iter(x))
+        for (const auto &[name, data] : iter(x))
           data.attrs().set(field, x.labels()[field]);
         x.attrs().set(field, x.labels()[field]);
         x.labels().erase(field);
@@ -268,7 +268,7 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
       if (x.labels().contains(field)) {
         x.labels().set(field, x.attrs()[field]);
         x.attrs().erase(field);
-        for ([[maybe_unused]] const auto &[name, data] : iter(x)) {
+        for (const auto &[name, data] : iter(x)) {
           expect::equals(x.labels()[field], data.attrs()[field]);
           data.attrs().erase(field);
         }

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -256,8 +256,8 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // a subsequent unit conversion of an item on its own would not be
         // possible. It needs to be determined if there is a better way to
         // handle attributes so this can be avoided.
-        for (const auto &[name, data] : iter(x))
-          data.attrs().set(field, x.labels()[field]);
+        for (const auto &item : iter(x))
+          item.second.attrs().set(field, x.labels()[field]);
         x.attrs().set(field, x.labels()[field]);
         x.labels().erase(field);
       }
@@ -268,9 +268,9 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
       if (x.labels().contains(field)) {
         x.labels().set(field, x.attrs()[field]);
         x.attrs().erase(field);
-        for (const auto &[name, data] : iter(x)) {
-          expect::equals(x.labels()[field], data.attrs()[field]);
-          data.attrs().erase(field);
+        for (const auto &item : iter(x)) {
+          expect::equals(x.labels()[field], item.second.attrs()[field]);
+          item.second.attrs().erase(field);
         }
       }
     }

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -74,19 +74,14 @@ template <class T> auto tofToDSpacing(const T &d) {
 }
 
 template <class T> static auto tofToWavelength(const T &d) {
-  const auto l = l1(d) + l2(d);
   return (tof_to_s * m_to_angstrom * boost::units::si::constants::codata::h /
           boost::units::si::constants::codata::m_n) /
-         std::move(l);
+         neutron::flight_path_length(d);
 }
 
 template <class T> auto tofToEnergyConversionFactor(const T &d) {
-  const auto &samplePos = sample_position(d);
-  const auto l1 = neutron::l1(d);
-  const auto specPos = neutron::position(d);
-
   // l_total = l1 + l2
-  auto conversionFactor(norm(specPos - samplePos) + l1);
+  auto conversionFactor = neutron::flight_path_length(d);
   // l_total^2
   conversionFactor *= conversionFactor;
 

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -13,10 +13,12 @@ namespace scipp::neutron {
 
 SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 position(const core::DatasetConstProxy &d);
-SCIPP_NEUTRON_EXPORT core::Variable
+SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 source_position(const core::DatasetConstProxy &d);
-SCIPP_NEUTRON_EXPORT core::Variable
+SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 sample_position(const core::DatasetConstProxy &d);
+SCIPP_NEUTRON_EXPORT core::Variable
+flight_path_length(const core::DatasetConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l1(const core::DatasetConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l2(const core::DatasetConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable
@@ -25,10 +27,12 @@ SCIPP_NEUTRON_EXPORT core::Variable two_theta(const core::DatasetConstProxy &d);
 
 SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 position(const core::DataConstProxy &d);
-SCIPP_NEUTRON_EXPORT core::Variable
+SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 source_position(const core::DataConstProxy &d);
-SCIPP_NEUTRON_EXPORT core::Variable
+SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 sample_position(const core::DataConstProxy &d);
+SCIPP_NEUTRON_EXPORT core::Variable
+flight_path_length(const core::DataConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l1(const core::DataConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l2(const core::DataConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -23,8 +23,12 @@ Dataset makeDatasetWithBeamline() {
                      makeVariable<Eigen::Vector3d>(
                          Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
                          Values{source_pos, sample_pos}));
-  beamline.setLabels("component_info",
-                     makeVariable<Dataset>(Values{components}));
+  beamline.setLabels(
+      "source_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m), Values{source_pos}));
+  beamline.setLabels(
+      "sample_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m), Values{sample_pos}));
   // TODO Need fuzzy comparison for variables to write a convenient test with
   // detectors away from the axes.
   beamline.setLabels("position",

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -62,6 +62,10 @@ TEST_F(BeamlineTest, l2) {
                                  units::Unit(units::m), Values{1.0, 1.0}));
 }
 
+TEST_F(BeamlineTest, flight_path_length) {
+  ASSERT_EQ(flight_path_length(dataset), l1(dataset) + l2(dataset));
+}
+
 template <class T> constexpr T pi = T(3.1415926535897932385L);
 
 TEST_F(BeamlineTest, scattering_angle) {
@@ -70,4 +74,17 @@ TEST_F(BeamlineTest, scattering_angle) {
                                  units::Unit(units::rad),
                                  Values{pi<double> / 2, pi<double> / 2}));
   ASSERT_EQ(scattering_angle(dataset), 0.5 * two_theta(dataset));
+}
+
+TEST_F(BeamlineTest, no_sample) {
+  Dataset d(dataset);
+  d.labels().erase("sample_position");
+  ASSERT_THROW(l1(d), except::NotFoundError);
+  ASSERT_THROW(l2(d), except::NotFoundError);
+  ASSERT_THROW(scattering_angle(d), except::NotFoundError);
+  ASSERT_EQ(flight_path_length(d),
+            makeVariable<double>(
+                Dims{Dim::Spectrum}, Shape{2}, units::Unit(units::m),
+                Values{(Eigen::Vector3d{1.0, 0.0, 0.01} - source_pos).norm(),
+                       (Eigen::Vector3d{0.0, 1.0, 0.01} - source_pos).norm()}));
 }

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -20,14 +20,15 @@ Dataset makeTofDataForUnitConversion(const bool dense_coord = true) {
                                Dims{Dim::Tof}, Shape{4}, units::Unit(units::us),
                                Values{4000, 5000, 6100, 7300}));
 
-  Dataset components;
-  // Source and sample
-  components.setData("position",
-                     makeVariable<Eigen::Vector3d>(
-                         Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
-                         Values{Eigen::Vector3d{0.0, 0.0, -10.0},
-                                Eigen::Vector3d{0.0, 0.0, 0.0}}));
-  tof.setLabels("component_info", makeVariable<Dataset>(Values{components}));
+  static const auto source_pos = Eigen::Vector3d{0.0, 0.0, -10.0};
+  static const auto sample_pos = Eigen::Vector3d{0.0, 0.0, 0.0};
+  tof.setLabels(
+      "source_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m), Values{source_pos}));
+  tof.setLabels(
+      "sample_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m), Values{sample_pos}));
+
   tof.setLabels("position",
                 makeVariable<Eigen::Vector3d>(
                     Dims{Dim::Spectrum}, Shape{2}, units::Unit(units::m),
@@ -169,8 +170,10 @@ TEST(Convert, Tof_to_DSpacing) {
               d1[2] * 1e-3);
 
   ASSERT_EQ(dspacing.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(dspacing.labels()["component_info"],
-            tof.labels()["component_info"]);
+  ASSERT_EQ(dspacing.labels()["source_position"],
+            tof.labels()["source_position"]);
+  ASSERT_EQ(dspacing.labels()["sample_position"],
+            tof.labels()["sample_position"]);
 }
 
 TEST(Convert, converts_sparse_labels) {
@@ -293,8 +296,10 @@ TEST(Convert, Tof_to_Wavelength) {
   EXPECT_NEAR(d1[2], 3956.0 / (1e6 * 11.0 / tof1[2]), d1[2] * 1e-3);
 
   ASSERT_EQ(wavelength.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(wavelength.labels()["component_info"],
-            tof.labels()["component_info"]);
+  ASSERT_EQ(wavelength.labels()["source_position"],
+            tof.labels()["source_position"]);
+  ASSERT_EQ(wavelength.labels()["sample_position"],
+            tof.labels()["sample_position"]);
 }
 
 TEST(Convert, Wavelength_to_Tof) {
@@ -418,7 +423,10 @@ TEST(Convert, Tof_to_Energy_Elastic) {
       e1[2] * 1e-3);
 
   ASSERT_EQ(energy.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(energy.labels()["component_info"], tof.labels()["component_info"]);
+  ASSERT_EQ(energy.labels()["source_position"],
+            tof.labels()["source_position"]);
+  ASSERT_EQ(energy.labels()["sample_position"],
+            tof.labels()["sample_position"]);
 }
 
 TEST(Convert, Energy_to_Tof_Elastic) {

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -67,7 +67,8 @@ TEST(ConvertDataArray, from_tof) {
     Dataset result;
     for (const auto &[name, data] : tof)
       result.setData(name, convert(data, Dim::Tof, dim));
-    EXPECT_EQ(result, expected);
+    for (const auto &[name, data] : result)
+      EXPECT_EQ(data, expected[name]);
   }
 }
 
@@ -79,7 +80,8 @@ TEST(ConvertDataArray, to_tof) {
     Dataset result;
     for (const auto &[name, data] : input)
       result.setData(name, convert(data, dim, Dim::Tof));
-    EXPECT_EQ(result, expected);
+    for (const auto &[name, data] : result)
+      EXPECT_EQ(data, expected[name]);
   }
 }
 
@@ -169,10 +171,10 @@ TEST(Convert, Tof_to_DSpacing) {
   EXPECT_NEAR(d1[2], 3956.0 / (1e6 * 11.0 / tof1[2]) * lambda_to_d,
               d1[2] * 1e-3);
 
-  ASSERT_EQ(dspacing.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(dspacing.labels()["source_position"],
+  ASSERT_EQ(dspacing.attrs()["position"], tof.labels()["position"]);
+  ASSERT_EQ(dspacing.attrs()["source_position"],
             tof.labels()["source_position"]);
-  ASSERT_EQ(dspacing.labels()["sample_position"],
+  ASSERT_EQ(dspacing.attrs()["sample_position"],
             tof.labels()["sample_position"]);
 }
 
@@ -295,10 +297,10 @@ TEST(Convert, Tof_to_Wavelength) {
   EXPECT_NEAR(d1[1], 3956.0 / (1e6 * 11.0 / tof1[1]), d1[1] * 1e-3);
   EXPECT_NEAR(d1[2], 3956.0 / (1e6 * 11.0 / tof1[2]), d1[2] * 1e-3);
 
-  ASSERT_EQ(wavelength.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(wavelength.labels()["source_position"],
+  ASSERT_EQ(wavelength.attrs()["position"], tof.labels()["position"]);
+  ASSERT_EQ(wavelength.attrs()["source_position"],
             tof.labels()["source_position"]);
-  ASSERT_EQ(wavelength.labels()["sample_position"],
+  ASSERT_EQ(wavelength.attrs()["sample_position"],
             tof.labels()["sample_position"]);
 }
 
@@ -422,11 +424,9 @@ TEST(Convert, Tof_to_Energy_Elastic) {
       e1[2], joule_to_mev * 0.5 * neutron_mass * std::pow(1e6 * L / tof1[2], 2),
       e1[2] * 1e-3);
 
-  ASSERT_EQ(energy.labels()["position"], tof.labels()["position"]);
-  ASSERT_EQ(energy.labels()["source_position"],
-            tof.labels()["source_position"]);
-  ASSERT_EQ(energy.labels()["sample_position"],
-            tof.labels()["sample_position"]);
+  ASSERT_EQ(energy.attrs()["position"], tof.labels()["position"]);
+  ASSERT_EQ(energy.attrs()["source_position"], tof.labels()["source_position"]);
+  ASSERT_EQ(energy.attrs()["sample_position"], tof.labels()["sample_position"]);
 }
 
 TEST(Convert, Energy_to_Tof_Elastic) {

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -35,6 +35,14 @@ template <class T> void bind_beamline(py::module &m) {
     :return: A scalar variable containing the sample position.
     :rtype: Variable)");
 
+  m.def("flight_path_length", py::overload_cast<View>(flight_path_length), R"(
+    Compute the length of the total flight path from a data array or a dataset.
+
+    If a sample position is found this is the sum of `l1` and `l2`, otherwise the distance from the source.
+
+    :return: A scalar variable containing the total length of the flight path.
+    :rtype: Variable)");
+
   m.def("l1", py::overload_cast<View>(l1), R"(
     Compute L1, the length of the primary flight path (distance between neutron source and sample) from a data array or a dataset.
 

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -426,18 +426,18 @@ def from_mantid(workspace, **kwargs):
             monitor_ws = workspace.getMonitorWorkspace()
         if monitor_ws.id() == 'Workspace2D':
             dataset.attrs["monitors"] = sc.Variable(
-                value=convert_Workspace2D_to_dataarray(monitor_ws))
+                value=convert_Workspace2D_to_dataarray(monitor_ws, **kwargs))
         elif monitor_ws.id() == 'EventWorkspace':
             dataset.attrs["monitors"] = sc.Variable(
                 value=convertEventWorkspace_to_dataarray(
-                    monitor_ws, load_pulse_times))
+                    monitor_ws, **kwargs))
         # Remove some redundant information that is duplicated from workspace
         mon = dataset.attrs["monitors"].value
         del mon.labels['sample_position']
         del mon.labels['detector_info']
         del mon.attrs['run']
         del mon.attrs['sample']
-    except:
+    except RuntimeError:
         pass
     return dataset
 

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -411,11 +411,15 @@ def load(filename="",
 
     Example of use:
 
-      from scipp.neutron import load
-      d = sc.Dataset()
-      d["sample"] = load(filename='PG3_4844_event.nxs', \
-                         load_pulse_times=True, \
-                         mantid_args={'BankName': 'bank184'})
+    .. highlight:: python
+    .. code-block:: python
+
+        from scipp.neutron import load
+        d = sc.Dataset()
+        d["sample"] = load(filename='PG3_4844_event.nxs',
+                           load_pulse_times=False,
+                           mantid_args={'BankName': 'bank184',
+                                        'LoadMonitors': True})
 
     See also the neutron-data tutorial.
 
@@ -427,6 +431,7 @@ def load(filename="",
     :param str instrument_filename: If specified, over-write the instrument
                                     definition in the final Dataset with the
                                     geometry contained in the file.
+    :param dict mantid_args: Dict of keyword arguments to forward to Mantid.
     :raises: If the Mantid workspace type returned by the Mantid loader is not
              either EventWorkspace or Workspace2D.
     :return: A Dataset containing the neutron event/histogram data and the

--- a/python/src/scipp/neutron/__init__.py
+++ b/python/src/scipp/neutron/__init__.py
@@ -7,4 +7,4 @@
 
 from .._scipp.neutron import *
 from . import diffraction
-from ..compat.mantid import load
+from ..compat.mantid import from_mantid, load

--- a/python/tests/test_neutron_convert.py
+++ b/python/tests/test_neutron_convert.py
@@ -23,23 +23,18 @@ def make_dataset_with_beamline():
                         shape=(4, ),
                         dtype=sc.dtype.vector_3_float64,
                         unit=sc.units.m)
-        },
-        labels={'component_info': sc.Variable(dtype=sc.dtype.Dataset)})
+        })
     d.coords[Dim.Position].values[0] = [1, 0, 0]
     d.coords[Dim.Position].values[1] = [0, 1, 0]
     d.coords[Dim.Position].values[2] = [0, 0, 1]
     d.coords[Dim.Position].values[3] = [-1, 0, 0]
-    component_info = sc.Dataset({
-        'position':
-        sc.Variable(dims=[Dim.Row],
-                    shape=(2, ),
-                    dtype=sc.dtype.vector_3_float64,
-                    unit=sc.units.m)
-    })
-    component_info['position'].values[0] = [0, 0, -10]
-    component_info['position'].values[1] = [0, 0, 0]
 
-    d.labels['component_info'].value = component_info
+    d.labels['source_position'] = sc.Variable(value=np.array([0, 0, -10]),
+                                              dtype=sc.dtype.vector_3_float64,
+                                              unit=sc.units.m)
+    d.labels['sample_position'] = sc.Variable(value=np.array([0, 0, 0]),
+                                              dtype=sc.dtype.vector_3_float64,
+                                              unit=sc.units.m)
     return d
 
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -268,8 +268,15 @@ def test_sparse_slice():
 
 def test_sparse_setitem():
     var = sc.Variable([sc.Dim.X, sc.Dim.Y], [4, sc.Dimensions.Sparse])
+    # __setitem__ of vector
     var[Dim.X, 0].values = np.arange(4)
     assert len(var[Dim.X, 0].values) == 4
+    # __setitem__ of span
+    var.values[1] = np.arange(3)
+    assert len(var[Dim.X, 1].values) == 3
+    # __setitem__ of VariableView
+    var[Dim.X, :].values[2] = np.arange(2)
+    assert len(var[Dim.X, 2].values) == 2
 
 
 def test_sparse_setitem_sparse_fail():

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -281,55 +281,58 @@ void init_variable(py::module &m) {
   //------------------------------------
 
   py::class_<VariableConstProxy>(m, "VariableConstProxy")
-      .def(py::init<const Variable &>());
+      .def(py::init<const Variable &>())
+      .def("copy",
+           [](const VariableConstProxy &self) { return Variable(self); },
+           "Return a (deep) copy.")
+      .def("__copy__",
+           [](const VariableConstProxy &self) { return Variable(self); })
+      .def("__deepcopy__",
+           [](VariableProxy &self, py::dict) { return Variable(self); })
+      .def("__repr__",
+           [](const VariableConstProxy &self) { return to_string(self); });
+
   py::class_<VariableProxy, VariableConstProxy> variableProxy(
       m, "VariableProxy", py::buffer_protocol(), R"(
         Proxy for Variable, representing a sliced or transposed view onto a variable;
         Mostly equivalent to Variable, see there for details.)");
   variableProxy.def_buffer(&make_py_buffer_info);
   variableProxy.def(py::init<Variable &>())
-      .def("copy", [](const VariableProxy &self) { return Variable(self); },
-           "Return a (deep) copy.")
-      .def("__copy__", [](VariableProxy &self) { return Variable(self); })
-      .def("__deepcopy__",
-           [](VariableProxy &self, py::dict) { return Variable(self); })
       .def("__radd__", [](VariableProxy &a, double &b) { return a + b; },
            py::is_operator())
       .def("__rsub__", [](VariableProxy &a, double &b) { return b - a; },
            py::is_operator())
       .def("__rmul__", [](VariableProxy &a, double &b) { return a * b; },
-           py::is_operator())
-      .def("__repr__",
-           [](const VariableProxy &self) { return to_string(self); });
+           py::is_operator());
 
   bind_slice_methods(variable);
   bind_slice_methods(variableProxy);
 
   bind_comparison<Variable>(variable);
-  bind_comparison<VariableProxy>(variable);
+  bind_comparison<VariableConstProxy>(variable);
   bind_comparison<Variable>(variableProxy);
-  bind_comparison<VariableProxy>(variableProxy);
+  bind_comparison<VariableConstProxy>(variableProxy);
 
   bind_in_place_binary<Variable>(variable);
-  bind_in_place_binary<VariableProxy>(variable);
+  bind_in_place_binary<VariableConstProxy>(variable);
   bind_in_place_binary<Variable>(variableProxy);
-  bind_in_place_binary<VariableProxy>(variableProxy);
+  bind_in_place_binary<VariableConstProxy>(variableProxy);
   bind_in_place_binary_scalars(variable);
   bind_in_place_binary_scalars(variableProxy);
 
   bind_binary<Variable>(variable);
-  bind_binary<VariableProxy>(variable);
+  bind_binary<VariableConstProxy>(variable);
   bind_binary<Variable>(variableProxy);
-  bind_binary<VariableProxy>(variableProxy);
+  bind_binary<VariableConstProxy>(variableProxy);
   bind_binary_scalars(variable);
   bind_binary_scalars(variableProxy);
 
   bind_boolean_unary(variable);
   bind_boolean_unary(variableProxy);
   bind_boolean_operators<Variable>(variable);
-  bind_boolean_operators<VariableProxy>(variable);
+  bind_boolean_operators<VariableConstProxy>(variable);
   bind_boolean_operators<Variable>(variableProxy);
-  bind_boolean_operators<VariableProxy>(variableProxy);
+  bind_boolean_operators<VariableConstProxy>(variableProxy);
 
   bind_data_properties(variable);
   bind_data_properties(variableProxy);


### PR DESCRIPTION
As discussed previously, the old way of handling monitors brought a number of issues. This PR is an attempt to improve the logical structure and fixes a number of related problems.

- Store source and sample positions in named labels, instead of "component_info". Could consider moving things back into something like "component_info" later, but the internal structure would need to support having the sample position as optional.
- `neutron::convert` can now do unit conversions if there is no sample. Obviously this is only possible for conversions that do not require the scattering angle.
- To avoid geometry information preventing operations of data in, e.g., wavelength or energy units, `neutron::convert` changes labels to attributes in conversions from TOF. Note the code comments here, about some shortcomings of the way we handle dataset and item attributes. We need to have a longer discussion at some point to determine whether attribute handling can be done in a better way.
- Add some missing `__setitem__` overloads for sparse data (not actually used here).
- Add `from_mantid`, which is used in `neutron.load` and will allow for conversion of workspaces for users that mix scipp with Mantid.
- Remove duplicate information from monitor attributes.
- Update neutron tutorial. This will need more work, since it has become too long to be useful. I will add a short tutorial as a separate task.