### PR TITLE
Avoid copies in _repr_html_ from call to numpy flatten.

### DIFF
--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -47,15 +47,15 @@ def _make_row(data_html, variances_html=None):
 
 def _format_non_sparse(var, has_variances):
     size = reduce(operator.mul, var.shape, 1)
-    # flatten avoids displaying square brackets in the output
     data = retrieve(var, variances=has_variances)
     # avoid unintentional indexing into value of 0-D data
     if len(var.shape) == 0:
         data = [
             data,
         ]
-    if hasattr(data, 'flatten'):
-        data = data.flatten()
+    # ravel avoids displaying square brackets in the output
+    if hasattr(data, 'ravel'):
+        data = data.ravel()
     s = _format_array(data, size, ellipsis_after=2)
     if has_variances:
         s = 'σ² = ' + s


### PR DESCRIPTION
Use ravel instead, which does not make a copy. Previously this copied potentially many GByte of data.