### PR TITLE
Support out arguments in Variable::reciprocal

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -931,7 +931,12 @@ operator/(T v, const units::Unit &unit) {
 
 SCIPP_CORE_EXPORT Variable astype(const VariableConstProxy &var,
                                   const DType type);
-SCIPP_CORE_EXPORT Variable reciprocal(const VariableConstProxy &var);
+
+[[nodiscard]] SCIPP_CORE_EXPORT Variable
+reciprocal(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable reciprocal(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy reciprocal(const VariableConstProxy &var,
+                                           const VariableProxy &out);
 
 SCIPP_CORE_EXPORT std::vector<Variable>
 split(const Variable &var, const Dim dim,

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -624,6 +624,32 @@ TEST(Variable, sqrt_float) {
   EXPECT_EQ(sqrt(var), reference);
 }
 
+TEST(VariableReciprocalOutArg, full_in_place) {
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
+                                  Values{1, 4, 9});
+  auto view = reciprocal(var, var);
+  EXPECT_EQ(var,
+            makeVariable<double>(Dims{Dim::X}, Shape{3},
+                                 units::Unit(units::dimensionless / units::m),
+                                 Values{1., 1. / 4., 1. / 9.}));
+  EXPECT_EQ(view, var);
+  EXPECT_EQ(view.underlying(), var);
+}
+
+TEST(VariableReciprocalOutArg, partial) {
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{3},
+                                        units::Unit(units::m), Values{1, 4, 9});
+  auto out =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::Unit(units::m));
+  auto view = reciprocal(var.slice({Dim::X, 1, 3}), out);
+  EXPECT_EQ(out,
+            makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                 units::Unit(units::dimensionless / units::m),
+                                 Values{1. / 4., 1. / 9.}));
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
+}
+
 TEST(VariableAbsOutArg, full_in_place) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
                                   Values{1, -4, -9});

--- a/core/variable_binary_arithmetic.cpp
+++ b/core/variable_binary_arithmetic.cpp
@@ -26,20 +26,6 @@ template <class T1, class T2> Variable plus(const T1 &a, const T2 &b) {
   return transform<arithmetic_and_matrix_type_pairs>(a, b, plus_);
 }
 
-Variable reciprocal(const VariableConstProxy &var) {
-  return transform<double, float>(
-      var,
-      overloaded{
-          [](const auto &a_) {
-            return static_cast<
-                       detail::element_type_t<std::decay_t<decltype(a_)>>>(1) /
-                   a_;
-          },
-          [](const units::Unit &unit) {
-            return units::Unit(units::dimensionless) / unit;
-          }});
-}
-
 Variable Variable::operator-() const {
   return transform<double, float, int64_t, Eigen::Vector3d>(
       *this, [](const auto a) { return -a; });

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -265,6 +265,42 @@ Variable mean(const VariableConstProxy &var, const Dim dim,
   return mean(var, dim);
 }
 
+Variable reciprocal(const VariableConstProxy &var) {
+  return transform<double, float>(
+      var,
+      overloaded{
+          [](const auto &a_) {
+            return static_cast<
+                       detail::element_type_t<std::decay_t<decltype(a_)>>>(1) /
+                   a_;
+          },
+          [](const units::Unit &unit) {
+            return units::Unit(units::dimensionless) / unit;
+          }});
+}
+
+Variable reciprocal(Variable &&var) {
+  auto out(std::move(var));
+  reciprocal(out, out);
+  return out;
+}
+
+VariableProxy reciprocal(const VariableConstProxy &var,
+                         const VariableProxy &out) {
+  transform_in_place<pair_self_t<double, float>>(
+      out, var,
+      overloaded{
+          [](auto &x, const auto &y) {
+            x = static_cast<detail::element_type_t<std::decay_t<decltype(y)>>>(
+                    1) /
+                y;
+          },
+          [](units::Unit &x, const units::Unit &y) {
+            x = units::Unit(units::dimensionless) / y;
+          }});
+  return out;
+}
+
 Variable abs(const VariableConstProxy &var) {
   using std::abs;
   return transform<double, float>(var, [](const auto x) { return abs(x); });

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -795,3 +795,17 @@ def test_create_1d_with_strings():
 def test_bool_variable_repr():
     a = sc.Variable([Dim.X], values=np.array([False, True, True, False, True]))
     assert [expected in repr(a) for expected in ["True", "False", "..."]]
+
+
+def test_reciprocal():
+    var = sc.Variable([Dim.X], values=np.array([1.0, 2.0]))
+    expected = sc.Variable([Dim.X], values=np.array([1.0 / 1.0, 1.0 / 2.0]))
+    assert sc.reciprocal(var) == expected
+
+
+def test_reciprocal_out():
+    var = sc.Variable([Dim.X], values=np.array([1.0, 2.0]))
+    expected = sc.Variable([Dim.X], values=np.array([1.0 / 1.0, 1.0 / 2.0]))
+    out = sc.reciprocal(x=var, out=var)
+    assert var == expected
+    assert out == expected

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -454,6 +454,25 @@ void init_variable(py::module &m) {
       :return: New sorted variable.
       :rtype: Variable)");
 
+  m.def("reciprocal",
+        [](const VariableConstProxy &self) { return reciprocal(self); },
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
+        Element-wise reciprocal.
+
+        :return: Reciprocal of the input values.
+        :rtype: Variable)");
+
+  m.def("reciprocal",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return reciprocal(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise reciprocal.
+
+        :return: Reciprocal of the input values.
+        :rtype: Variable)");
+
   m.def("split",
         py::overload_cast<const Variable &, const Dim,
                           const std::vector<scipp::index> &>(&split),


### PR DESCRIPTION
Also moved into `variable_operations.cpp` which seems a more appropriate place for these functions.

Re #815