### PR TITLE
Fix and extend neutron::convert benchmarks.

### DIFF
--- a/benchmark/neutron_convert_benchmark.cpp
+++ b/benchmark/neutron_convert_benchmark.cpp
@@ -12,19 +12,51 @@ using namespace scipp::core;
 auto make_beamline(const scipp::index size) {
   Dataset beamline;
 
-  Dataset components;
-  // Source and sample
-  components.setData("position",
-                     makeVariable<Eigen::Vector3d>(
-                         Dims{Dim::Row}, Shape{2}, units::Unit(units::m),
-                         Values{Eigen::Vector3d{0.0, 0.0, -10.0},
-                                Eigen::Vector3d{0.0, 0.0, 0.0}}));
-  beamline.setLabels("component_info",
-                     makeVariable<Dataset>(Values{components}));
+  beamline.setLabels(
+      "source_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m),
+                                    Values{Eigen::Vector3d{0.0, 0.0, -10.0}}));
+  beamline.setLabels(
+      "sample_position",
+      makeVariable<Eigen::Vector3d>(units::Unit(units::m),
+                                    Values{Eigen::Vector3d{0.0, 0.0, 0.0}}));
+
   beamline.setLabels(
       "position", makeVariable<Eigen::Vector3d>(
                       Dims{Dim::Spectrum}, Shape{size}, units::Unit(units::m)));
   return beamline;
+}
+
+auto make_dense_coord_only(const scipp::index size, const scipp::index count,
+                           bool transpose) {
+  auto out = make_beamline(size);
+  auto var = transpose ? makeVariable<double>(Dims{Dim::Tof, Dim::Spectrum},
+                                              Shape{count, size})
+                       : makeVariable<double>(Dims{Dim::Spectrum, Dim::Tof},
+                                              Shape{size, count});
+  out.setCoord(Dim::Tof, std::move(var));
+  return out;
+}
+
+static void BM_neutron_convert(benchmark::State &state, const Dim targetDim) {
+  const scipp::index nBin = state.range(0);
+  const scipp::index nHist = 1e8 / nBin;
+  const bool transpose = state.range(1);
+  const auto dense = make_dense_coord_only(nHist, nBin, transpose);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Dataset data = dense;
+    state.ResumeTiming();
+    data = neutron::convert(std::move(data), Dim::Tof, targetDim);
+    state.PauseTiming();
+    data = Dataset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(state.iterations() * nHist * nBin);
+  state.SetBytesProcessed(state.iterations() * nHist * nBin * 2 *
+                          sizeof(double));
+  state.counters["positions"] = benchmark::Counter(nHist);
+  state.counters["transpose"] = transpose;
 }
 
 auto make_sparse_coord_only(const scipp::index size, const scipp::index count) {
@@ -38,7 +70,8 @@ auto make_sparse_coord_only(const scipp::index size, const scipp::index count) {
   return out;
 }
 
-static void BM_neutron_convert(benchmark::State &state, const Dim targetDim) {
+static void BM_neutron_convert_sparse(benchmark::State &state,
+                                      const Dim targetDim) {
   const scipp::index nEvent = state.range(0);
   const scipp::index nHist = 1e8 / nEvent;
   const auto sparse = make_sparse_coord_only(nHist, nEvent);
@@ -58,14 +91,27 @@ static void BM_neutron_convert(benchmark::State &state, const Dim targetDim) {
 }
 
 // Params are:
-// - nEvent
+// - nBin
+// - transpose
 BENCHMARK_CAPTURE(BM_neutron_convert, Dim::DSpacing, Dim::DSpacing)
     ->RangeMultiplier(2)
-    ->Ranges({{8, 2 << 14}});
+    ->Ranges({{8, 2 << 14}, {false, true}});
 BENCHMARK_CAPTURE(BM_neutron_convert, Dim::Wavelength, Dim::Wavelength)
     ->RangeMultiplier(2)
-    ->Ranges({{8, 2 << 14}});
+    ->Ranges({{8, 2 << 14}, {false, true}});
 BENCHMARK_CAPTURE(BM_neutron_convert, Dim::Energy, Dim::Energy)
+    ->RangeMultiplier(2)
+    ->Ranges({{8, 2 << 14}, {false, true}});
+
+// Params are:
+// - nEvent
+BENCHMARK_CAPTURE(BM_neutron_convert_sparse, Dim::DSpacing, Dim::DSpacing)
+    ->RangeMultiplier(2)
+    ->Ranges({{8, 2 << 14}});
+BENCHMARK_CAPTURE(BM_neutron_convert_sparse, Dim::Wavelength, Dim::Wavelength)
+    ->RangeMultiplier(2)
+    ->Ranges({{8, 2 << 14}});
+BENCHMARK_CAPTURE(BM_neutron_convert_sparse, Dim::Energy, Dim::Energy)
     ->RangeMultiplier(2)
     ->Ranges({{8, 2 << 14}});
 


### PR DESCRIPTION
Add some benchmarks for dense transposed and non-transposed data layouts. I did not observe any significant differences, e.g.,:

```
BM_neutron_convert/Dim::Wavelength/8/0          1204678635 ns   1204617682 ns            1 bytes_per_second=1.237G/s items_per_second=83.0139M/s positions=12.5M transpose=0
BM_neutron_convert/Dim::Wavelength/16/0          871550110 ns    871429925 ns            1 bytes_per_second=1.70997G/s items_per_second=114.754M/s positions=6.25M transpose=0
BM_neutron_convert/Dim::Wavelength/32/0          736052232 ns    736020175 ns            1 bytes_per_second=2.02456G/s items_per_second=135.866M/s positions=3.125M transpose=0
BM_neutron_convert/Dim::Wavelength/64/0          660755168 ns    660661516 ns            1 bytes_per_second=2.25549G/s items_per_second=151.363M/s positions=1.5625M transpose=0
BM_neutron_convert/Dim::Wavelength/128/0         628627676 ns    628597780 ns            1 bytes_per_second=2.37054G/s items_per_second=159.084M/s positions=781.25k transpose=0
BM_neutron_convert/Dim::Wavelength/256/0         583692997 ns    583639853 ns            1 bytes_per_second=2.55314G/s items_per_second=171.339M/s positions=390.625k transpose=0
BM_neutron_convert/Dim::Wavelength/512/0         616091714 ns    615456813 ns            1 bytes_per_second=2.42115G/s items_per_second=162.481M/s positions=195.312k transpose=0
BM_neutron_convert/Dim::Wavelength/1024/0        594630570 ns    594569929 ns            1 bytes_per_second=2.5062G/s items_per_second=168.188M/s positions=97.656k transpose=0
BM_neutron_convert/Dim::Wavelength/2048/0        610848114 ns    610749138 ns            1 bytes_per_second=2.43981G/s items_per_second=163.733M/s positions=48.828k transpose=0
BM_neutron_convert/Dim::Wavelength/4096/0        601430788 ns    601379785 ns            1 bytes_per_second=2.47782G/s items_per_second=166.284M/s positions=24.414k transpose=0
BM_neutron_convert/Dim::Wavelength/8192/0        608555813 ns    608468285 ns            1 bytes_per_second=2.44896G/s items_per_second=164.347M/s positions=12.207k transpose=0
BM_neutron_convert/Dim::Wavelength/16384/0       596883429 ns    596739224 ns            1 bytes_per_second=2.49689G/s items_per_second=167.563M/s positions=6.103k transpose=0
BM_neutron_convert/Dim::Wavelength/32768/0       595127667 ns    595106195 ns            1 bytes_per_second=2.50333G/s items_per_second=167.996M/s positions=3.051k transpose=0
BM_neutron_convert/Dim::Wavelength/8/1          1172938381 ns   1172790961 ns            1 bytes_per_second=1.27057G/s items_per_second=85.2667M/s positions=12.5M transpose=1
BM_neutron_convert/Dim::Wavelength/16/1          890975983 ns    890916676 ns            1 bytes_per_second=1.67257G/s items_per_second=112.244M/s positions=6.25M transpose=1
BM_neutron_convert/Dim::Wavelength/32/1          723586880 ns    723529144 ns            1 bytes_per_second=2.05951G/s items_per_second=138.211M/s positions=3.125M transpose=1
BM_neutron_convert/Dim::Wavelength/64/1          687677343 ns    687651708 ns            1 bytes_per_second=2.16696G/s items_per_second=145.422M/s positions=1.5625M transpose=1
BM_neutron_convert/Dim::Wavelength/128/1         656619039 ns    656561169 ns            1 bytes_per_second=2.26958G/s items_per_second=152.309M/s positions=781.25k transpose=1
BM_neutron_convert/Dim::Wavelength/256/1         619085189 ns    619006741 ns            1 bytes_per_second=2.40727G/s items_per_second=161.549M/s positions=390.625k transpose=1
BM_neutron_convert/Dim::Wavelength/512/1         599774737 ns    599724611 ns            1 bytes_per_second=2.48466G/s items_per_second=166.743M/s positions=195.312k transpose=1
BM_neutron_convert/Dim::Wavelength/1024/1        610052027 ns    609989291 ns            1 bytes_per_second=2.44285G/s items_per_second=163.937M/s positions=97.656k transpose=1
BM_neutron_convert/Dim::Wavelength/2048/1        628111552 ns    628089206 ns            1 bytes_per_second=2.37245G/s items_per_second=159.213M/s positions=48.828k transpose=1
BM_neutron_convert/Dim::Wavelength/4096/1        604930804 ns    604856814 ns            1 bytes_per_second=2.46358G/s items_per_second=165.328M/s positions=24.414k transpose=1
BM_neutron_convert/Dim::Wavelength/8192/1        630522379 ns    630433870 ns            1 bytes_per_second=2.36363G/s items_per_second=158.621M/s positions=12.207k transpose=1
BM_neutron_convert/Dim::Wavelength/16384/1       603366480 ns    603319818 ns            1 bytes_per_second=2.46965G/s items_per_second=165.736M/s positions=6.103k transpose=1
BM_neutron_convert/Dim::Wavelength/32768/1       618533088 ns    618453812 ns            1 bytes_per_second=2.40882G/s items_per_second=161.653M/s positions=3.051k transpose=1
```