### PR TITLE
Self assignment improvements

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -81,6 +81,7 @@ public:
   virtual VariableConceptHandle reshape(const Dimensions &dims) = 0;
 
   virtual bool operator==(const VariableConcept &other) const = 0;
+  virtual bool isSame(const VariableConcept &other) const = 0;
 
   virtual bool isContiguous() const = 0;
   virtual bool isView() const = 0;

--- a/core/include/scipp/core/variable.tcc
+++ b/core/include/scipp/core/variable.tcc
@@ -582,7 +582,7 @@ public:
     // DataModel a pointer comparison is not sufficient here.
     if (hasVariances() != other.hasVariances())
       return false;
-    if (const auto *ptr = dynamic_cast<const ViewModel<T> *>(&other); ptr)
+    if (const auto *ptr = dynamic_cast<const ViewModel<T> *>(&other))
       return m_values.isSame(ptr->m_values);
     return false;
   }

--- a/core/include/scipp/core/variable.tcc
+++ b/core/include/scipp/core/variable.tcc
@@ -362,6 +362,9 @@ public:
     return std::make_unique<DataModel<T>>(this->dims(), m_values, m_variances);
   }
 
+  bool isSame(const VariableConcept &other) const override {
+    return this == &other;
+  }
   bool isContiguous() const override { return true; }
   bool isView() const override { return false; }
   bool isConstView() const override { return false; }
@@ -572,6 +575,16 @@ public:
 
   VariableConceptHandle clone() const override {
     return std::make_unique<ViewModel<T>>(this->dims(), m_values, m_variances);
+  }
+
+  bool isSame(const VariableConcept &other) const override {
+    // Views can be copied but can still refer to same data, so unlike for
+    // DataModel a pointer comparison is not sufficient here.
+    if (hasVariances() != other.hasVariances())
+      return false;
+    if (const auto *ptr = dynamic_cast<const ViewModel<T> *>(&other); ptr)
+      return m_values.isSame(ptr->m_values);
+    return false;
   }
 
   bool isContiguous() const override {

--- a/core/include/scipp/core/variable_view.h
+++ b/core/include/scipp/core/variable_view.h
@@ -148,6 +148,13 @@ public:
     return std::equal(begin(), end(), other.begin());
   }
 
+  /// Return true if *this and other are two equivalent views of the same data.
+  bool isSame(const VariableView<T> &other) const {
+    return (m_variable == other.m_variable) && (m_offset == other.m_offset) &&
+           (m_dimensions == other.m_dimensions) &&
+           (m_targetDimensions == other.m_targetDimensions);
+  }
+
   template <class T2> bool overlaps(const VariableView<T2> &other) const {
     // TODO We could be less restrictive here and use a more sophisticated check
     // based on offsets and dimensions, if there is a performance issue due to

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                transform_sparse_and_dense_test.cpp
                transform_test.cpp
                value_and_variance_test.cpp
+               variable_concept_test.cpp
                variable_custom_type_test.cpp
                variable_operations_test.cpp
                variable_scalar_accessors_test.cpp

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                mean_test.cpp
                merge_test.cpp
                rebin_test.cpp
+               self_assignment_test.cpp
                slice_test.cpp
                sort_test.cpp
                sparse_counts_test.cpp

--- a/core/test/self_assignment_test.cpp
+++ b/core/test/self_assignment_test.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+//
+// The test in this file ensure that comparison operators for Dataset and
+// DatasetConstProxy are correct. More complex tests should build on the
+// assumption that comparison operators are correct.
+#include "test_macros.h"
+#include <gtest/gtest.h>
+
+#include <numeric>
+
+#include "dataset_test_common.h"
+#include "scipp/core/dataset.h"
+#include "scipp/core/dimensions.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+class SelfAssignmentTest : public ::testing::Test {
+protected:
+  SelfAssignmentTest() {
+    dataset.setData("a",
+                    makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 2}));
+  }
+
+  Dataset dataset;
+};
+
+TEST_F(SelfAssignmentTest, dataset_item) {
+  const DataArray expected(dataset["a"]);
+  const auto *expected_ptr = dataset["a"].values<double>().data();
+  dataset.setData("a", dataset["a"]);
+  EXPECT_EQ(dataset["a"], expected);
+  EXPECT_EQ(dataset["a"].values<double>().data(), expected_ptr);
+
+  // Code that checks for self-assignment might erroneously not check for
+  // presence of slices.
+  dataset.setData("a", dataset["a"].slice({Dim::X, 0, 1}));
+  EXPECT_NE(dataset["a"], expected);
+  EXPECT_NE(dataset["a"].values<double>().data(), expected_ptr);
+}
+
+TEST_F(SelfAssignmentTest, data_proxy_assign) {
+  const DataArray expected(dataset["a"]);
+  const auto *expected_ptr = dataset["a"].values<double>().data();
+  dataset["a"].assign(dataset["a"]);
+  EXPECT_EQ(dataset["a"], expected);
+  EXPECT_EQ(dataset["a"].values<double>().data(), expected_ptr);
+
+  // Code that checks for self-assignment might erroneously not check for
+  // presence of slices.
+  dataset["a"].slice({Dim::X, 0, 1}).assign(dataset["a"].slice({Dim::X, 1, 2}));
+  EXPECT_NE(dataset["a"], expected);
+  EXPECT_EQ(dataset["a"].values<double>().data(), expected_ptr);
+}
+
+TEST_F(SelfAssignmentTest, variable_proxy_assign) {
+  const Variable expected(dataset["a"].data());
+  const auto *expected_ptr = dataset["a"].values<double>().data();
+
+  // Without slices the proxy just forward to the data in the underlying
+  // variable, so we test 2 cases here, without and with slice.
+  dataset["a"].data().assign(dataset["a"].data());
+  EXPECT_EQ(dataset["a"].data(), expected);
+  EXPECT_EQ(dataset["a"].values<double>().data(), expected_ptr);
+
+  dataset["a"]
+      .data()
+      .slice({Dim::X, 0, 1})
+      .assign(dataset["a"].data().slice({Dim::X, 0, 1}));
+  // There is no reasonable way to test that no actual copy has happened, this
+  // would pass even if the self-assignment would actually assign all the
+  // elements.
+  EXPECT_EQ(dataset["a"].data(), expected);
+  EXPECT_EQ(dataset["a"].values<double>().data(), expected_ptr);
+}

--- a/core/test/variable_concept_test.cpp
+++ b/core/test/variable_concept_test.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/variable.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+class VariableConceptTest : public ::testing::Test {
+protected:
+  const Variable a{makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 2})};
+  const Variable b{makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 2})};
+};
+
+TEST_F(VariableConceptTest, isSame_no_slice) {
+  const VariableConstProxy a_view(a);
+  const VariableConstProxy a_view2(a);
+  const VariableConstProxy b_view(b);
+
+  EXPECT_TRUE(a.data().isSame(a.data()));
+  EXPECT_FALSE(a.data().isSame(b.data()));
+
+  EXPECT_TRUE(a.data().isSame(a_view.data()));
+  EXPECT_TRUE(a_view.data().isSame(a.data()));
+
+  EXPECT_TRUE(a_view.data().isSame(a_view.data()));
+  EXPECT_TRUE(a_view.data().isSame(a_view2.data()));
+  EXPECT_FALSE(a_view.data().isSame(b_view.data()));
+}
+
+TEST_F(VariableConceptTest, isSame_same_slice) {
+  const VariableConstProxy a_view = a.slice({Dim::X, 0, 2});
+  const VariableConstProxy a_view2 = a.slice({Dim::X, 0, 2});
+  const VariableConstProxy b_view = b.slice({Dim::X, 0, 2});
+
+  EXPECT_TRUE(a.data().isSame(a.data()));
+  EXPECT_FALSE(a.data().isSame(b.data()));
+
+  // Comparing full slice gives false, even though it could technically be true.
+  // This is not an issue for how `isSame` is used. The best way to fix this
+  // would be to ignore slicing that has no effect in the creation of variable
+  // proxies (and similar for data array proxies and dataset proxies).
+  EXPECT_FALSE(a.data().isSame(a_view.data()));
+  EXPECT_FALSE(a_view.data().isSame(a.data()));
+
+  EXPECT_TRUE(a_view.data().isSame(a_view.data()));
+  EXPECT_TRUE(a_view.data().isSame(a_view2.data()));
+  EXPECT_FALSE(a_view.data().isSame(b_view.data()));
+}
+
+TEST_F(VariableConceptTest, isSame_different_slice) {
+  const VariableConstProxy a_view1 = a.slice({Dim::X, 0, 1});
+  const VariableConstProxy a_view2 = a.slice({Dim::X, 1, 2});
+
+  EXPECT_FALSE(a_view1.data().isSame(a_view2.data()));
+}

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -98,6 +98,8 @@ bool Variable::operator!=(const VariableConstProxy &other) const {
 }
 
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
+  if (data().isSame(other.data()))
+    return *this; // Do nothing for self-assignment
   setUnit(other.unit());
   expect::equals(dims(), other.dims());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -99,7 +99,7 @@ bool Variable::operator!=(const VariableConstProxy &other) const {
 
 template <class T> VariableProxy VariableProxy::assign(const T &other) const {
   if (data().isSame(other.data()))
-    return *this; // Do nothing for self-assignment
+    return *this; // Self-assignment, return early.
   setUnit(other.unit());
   expect::equals(dims(), other.dims());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -144,6 +144,10 @@ void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
     c.def("__setitem__", &slicer<T>::template set<DataProxy>);
     c.def("__setitem__", &slicer<T>::template set_range<DataProxy>);
   }
+  if constexpr (std::is_same_v<T, Dataset> || std::is_same_v<T, DatasetProxy>) {
+    c.def("__setitem__", &slicer<T>::template set<DatasetProxy>);
+    c.def("__setitem__", &slicer<T>::template set_range<DatasetProxy>);
+  }
 }
 
 #endif // SCIPPY_BIND_SLICE_METHODS_H

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -210,21 +210,17 @@ void init_dataset(py::module &m) {
            [](Dataset &self, const std::string &name,
               const DataConstProxy &data) { self.setData(name, data); })
       .def("__setitem__",
-           [](Dataset &self, const std::tuple<Dim, scipp::index> &index,
-              DatasetProxy &other) {
-             auto [dim, i] = index;
-             for (const auto [name, item] : self.slice(Slice(dim, i)))
-               item.assign(other[name]);
-           })
-      .def("__delitem__", &Dataset::erase,
-           py::call_guard<py::gil_scoped_release>())
-      .def("__setitem__",
            [](Dataset &self, const std::string &name, const DataArray &data) {
              self.setData(name, data);
            })
+      .def("__delitem__", &Dataset::erase,
+           py::call_guard<py::gil_scoped_release>())
       .def(
           "clear", &Dataset::clear,
           R"(Removes all data (preserving coordinates, attributes, labels and masks.).)");
+  datasetProxy.def("__setitem__",
+                   [](const DatasetProxy &self, const std::string &name,
+                      const DataConstProxy &data) { self[name].assign(data); });
 
   bind_dataset_proxy_methods(dataset);
   bind_dataset_proxy_methods(datasetProxy);

--- a/python/tests/test_setitem.py
+++ b/python/tests/test_setitem.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+from scipp import Dim
+
+
+def test_setitem_required_for_inplace_ops():
+    # Test that all required __setitem__ overloads for in-place operations
+    # are available.
+
+    var = sc.Variable(dims=[Dim.X, Dim.Y], shape=[2, 3])
+    var *= 1.5  # not setitem, just assigns python variable
+    var[Dim.X, 1:] *= 1.5  # Variable.__setitem__
+    var[Dim.X, 1:][Dim.Y, 1:] *= 1.5  # VariableProxy.__setitem__
+
+    a = sc.DataArray(data=var)
+    a *= 1.5  # not setitem, just assigns python variable
+    a[Dim.X, 1:] *= 1.5  # DataArray.__setitem__
+    a[Dim.X, 1:][Dim.Y, 1:] *= 1.5  # DataProxy.__setitem__
+
+    d = sc.Dataset(data={'a': var})
+    d *= 1.5  # not setitem, just assigns python variable
+    d['a'] *= 1.5  # Dataset.__setitem__(string)
+    d[Dim.X, 1:] *= 1.5  # Dataset.__setitem__(slice)
+    d[Dim.X, 1:]['a'] *= 1.5  # DatasetProxy.__setitem__(string)
+    d['a'][Dim.X, 1:] *= 1.5  # DatasetProxy.__setitem__(slice)
+    d[Dim.X, 1:][Dim.Y, 1:] *= 1.5  # DatasetProxy.__setitem__(slice)


### PR DESCRIPTION
Fixes #817, in particular
- Add some missing `__setitem__` overloads that prevented things like `d[Dim.X, :-2]['a'] *= 1.5` to work.
- Add check for self-assignment ensure that no memory allocations and copies are done that are not necessary. This should yield rather significant performance improvements (2x or more in many cases) for operations like `d['sample'] += 1`.