### PR TITLE
Support out arguments in Variable trigonometery operations

### DIFF
--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -192,4 +192,24 @@ BENCHMARK(BM_VariableProxy_assign_1d)
     ->Arg(1e8)
     ->Arg(1e9);
 
+static void BM_Variable_sin_rad(benchmark::State &state) {
+  const auto a =
+      makeVariable<double>(Dims{Dim::X}, Shape{1000}, units::Unit{units::rad});
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(sin(a));
+  }
+}
+BENCHMARK(BM_Variable_sin_rad);
+
+static void BM_Variable_sin_deg(benchmark::State &state) {
+  const auto a =
+      makeVariable<double>(Dims{Dim::X}, Shape{1000}, units::Unit{units::deg});
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(sin(a));
+  }
+}
+BENCHMARK(BM_Variable_sin_deg);
+
 BENCHMARK_MAIN();

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -984,10 +984,25 @@ SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT VariableProxy sin(const VariableConstProxy &var,
                                     const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable cos(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable cos(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy cos(const VariableConstProxy &var,
+                                    const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable tan(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable tan(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy tan(const VariableConstProxy &var,
+                                    const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable asin(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable asin(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy asin(const VariableConstProxy &var,
+                                     const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable acos(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable acos(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy acos(const VariableConstProxy &var,
+                                     const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable atan(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable atan(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy atan(const VariableConstProxy &var,
+                                     const VariableProxy &out);
 
 SCIPP_CORE_EXPORT Variable masks_merge_if_contains(const MasksConstProxy &masks,
                                                    const Dim dim);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -980,6 +980,9 @@ SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 
 // Trigonometrics
 [[nodiscard]] SCIPP_CORE_EXPORT Variable sin(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable sin(Variable &&var);
+SCIPP_CORE_EXPORT VariableProxy sin(const VariableConstProxy &var,
+                                    const VariableProxy &out);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable cos(const VariableConstProxy &var);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable tan(const VariableConstProxy &var);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable asin(const VariableConstProxy &var);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -979,12 +979,12 @@ SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var, const Dim dim,
 SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 
 // Trigonometrics
-SCIPP_CORE_EXPORT Variable sin(const Variable &var);
-SCIPP_CORE_EXPORT Variable cos(const Variable &var);
-SCIPP_CORE_EXPORT Variable tan(const Variable &var);
-SCIPP_CORE_EXPORT Variable asin(const Variable &var);
-SCIPP_CORE_EXPORT Variable acos(const Variable &var);
-SCIPP_CORE_EXPORT Variable atan(const Variable &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable sin(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable cos(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable tan(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable asin(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable acos(const VariableConstProxy &var);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable atan(const VariableConstProxy &var);
 
 SCIPP_CORE_EXPORT Variable masks_merge_if_contains(const MasksConstProxy &masks,
                                                    const Dim dim);

--- a/core/test/variable_trigonometry_test.cpp
+++ b/core/test/variable_trigonometry_test.cpp
@@ -84,6 +84,56 @@ TEST(VariableTrigonometryTest, cos) {
   EXPECT_EQ(cos(deg), expected);
 }
 
+TEST(VariableTrigonometryTest, cos_in_place_full) {
+  auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_view = cos(rad, rad);
+  auto deg_view = cos(deg, deg);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{3},
+      Values{cos(0.0), cos(pi<double>), cos(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad, expected);
+  EXPECT_EQ(rad_view, rad);
+  EXPECT_EQ(rad_view.underlying(), rad);
+
+  EXPECT_EQ(deg, expected);
+  EXPECT_EQ(deg_view, deg);
+  EXPECT_EQ(deg_view.underlying(), deg);
+}
+
+TEST(VariableTrigonometryTest, cos_in_place_partial) {
+  const auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  const auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto deg_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+
+  auto rad_view = cos(rad.slice({Dim::X, 1, 3}), rad_out);
+  auto deg_view = cos(rad.slice({Dim::X, 1, 3}), deg_out);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, Values{cos(pi<double>), cos(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad_out, expected);
+  EXPECT_EQ(rad_view, rad_out);
+  EXPECT_EQ(rad_view.underlying(), rad_out);
+
+  EXPECT_EQ(deg_out, expected);
+  EXPECT_EQ(deg_view, deg_out);
+  EXPECT_EQ(deg_view.underlying(), deg_out);
+}
+
 TEST(VariableTrigonometryTest, tan) {
   const auto rad = makeVariable<double>(
       Dims(), Shape(), units::Unit(units::rad), Values{pi<double>});
@@ -96,12 +146,91 @@ TEST(VariableTrigonometryTest, tan) {
   EXPECT_EQ(tan(deg), expected);
 }
 
+TEST(VariableTrigonometryTest, tan_in_place_full) {
+  auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_view = tan(rad, rad);
+  auto deg_view = tan(deg, deg);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{3},
+      Values{tan(0.0), tan(pi<double>), tan(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad, expected);
+  EXPECT_EQ(rad_view, rad);
+  EXPECT_EQ(rad_view.underlying(), rad);
+
+  EXPECT_EQ(deg, expected);
+  EXPECT_EQ(deg_view, deg);
+  EXPECT_EQ(deg_view.underlying(), deg);
+}
+
+TEST(VariableTrigonometryTest, tan_in_place_partial) {
+  const auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  const auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto deg_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+
+  auto rad_view = tan(rad.slice({Dim::X, 1, 3}), rad_out);
+  auto deg_view = tan(rad.slice({Dim::X, 1, 3}), deg_out);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, Values{tan(pi<double>), tan(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad_out, expected);
+  EXPECT_EQ(rad_view, rad_out);
+  EXPECT_EQ(rad_view.underlying(), rad_out);
+
+  EXPECT_EQ(deg_out, expected);
+  EXPECT_EQ(deg_view, deg_out);
+  EXPECT_EQ(deg_view.underlying(), deg_out);
+}
+
 TEST(VariableTrigonometryTest, asin) {
   const auto var = makeVariable<double>(
       Dims(), Shape(), units::Unit(units::dimensionless), Values{1.0});
   const auto expected = makeVariable<double>(
       Dims(), Shape(), units::Unit(units::rad), Values{0.5 * pi<double>});
   EXPECT_EQ(asin(var), expected);
+}
+
+TEST(VariableTrigonometryTest, asin_in_place_full) {
+  auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto view = asin(var, var);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{asin(0.0), asin(0.5), asin(1.0)});
+
+  EXPECT_EQ(var, expected);
+  EXPECT_EQ(view, var);
+  EXPECT_EQ(view.underlying(), var);
+}
+
+TEST(VariableTrigonometryTest, asin_in_place_partial) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto view = asin(var.slice({Dim::X, 1, 3}), out);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::Unit(units::rad),
+                           Values{asin(0.5), asin(1.0)});
+
+  EXPECT_EQ(out, expected);
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
 }
 
 TEST(VariableTrigonometryTest, acos) {
@@ -112,12 +241,70 @@ TEST(VariableTrigonometryTest, acos) {
   EXPECT_EQ(acos(var), expected);
 }
 
+TEST(VariableTrigonometryTest, acos_in_place_full) {
+  auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto view = acos(var, var);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{acos(0.0), acos(0.5), acos(1.0)});
+
+  EXPECT_EQ(var, expected);
+  EXPECT_EQ(view, var);
+  EXPECT_EQ(view.underlying(), var);
+}
+
+TEST(VariableTrigonometryTest, acos_in_place_partial) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto view = acos(var.slice({Dim::X, 1, 3}), out);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::Unit(units::rad),
+                           Values{acos(0.5), acos(1.0)});
+
+  EXPECT_EQ(out, expected);
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
+}
+
 TEST(VariableTrigonometryTest, atan) {
   const auto var = makeVariable<double>(
       Dims(), Shape(), units::Unit(units::dimensionless), Values{1.0});
   const auto expected = makeVariable<double>(
       Dims(), Shape(), units::Unit(units::rad), Values{0.25 * pi<double>});
   EXPECT_EQ(atan(var), expected);
+}
+
+TEST(VariableTrigonometryTest, atan_in_place_full) {
+  auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto view = atan(var, var);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{atan(0.0), atan(0.5), atan(1.0)});
+
+  EXPECT_EQ(var, expected);
+  EXPECT_EQ(view, var);
+  EXPECT_EQ(view.underlying(), var);
+}
+
+TEST(VariableTrigonometryTest, atan_in_place_partial) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0.0, 0.5, 1.0});
+  auto out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto view = atan(var.slice({Dim::X, 1, 3}), out);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::Unit(units::rad),
+                           Values{atan(0.5), atan(1.0)});
+
+  EXPECT_EQ(out, expected);
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
 }
 
 TEST(VariableTrigonometryTest, unit_fail) {

--- a/core/test/variable_trigonometry_test.cpp
+++ b/core/test/variable_trigonometry_test.cpp
@@ -13,11 +13,63 @@ TEST(VariableTrigonometryTest, sin) {
       Dims(), Shape(), units::Unit(units::rad), Values{pi<double>});
   const auto deg = makeVariable<double>(Dims(), Shape(),
                                         units::Unit(units::deg), Values{180.0});
+
   const auto expected =
       makeVariable<double>(Dims(), Shape(), units::Unit(units::dimensionless),
                            Values{sin(pi<double>)});
+
   EXPECT_EQ(sin(rad), expected);
   EXPECT_EQ(sin(deg), expected);
+}
+
+TEST(VariableTrigonometryTest, sin_in_place_full) {
+  auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_view = sin(rad, rad);
+  auto deg_view = sin(deg, deg);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{3},
+      Values{sin(0.0), sin(pi<double>), sin(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad, expected);
+  EXPECT_EQ(rad_view, rad);
+  EXPECT_EQ(rad_view.underlying(), rad);
+
+  EXPECT_EQ(deg, expected);
+  EXPECT_EQ(deg_view, deg);
+  EXPECT_EQ(deg_view.underlying(), deg);
+}
+
+TEST(VariableTrigonometryTest, sin_in_place_partial) {
+  const auto rad =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::rad),
+                           Values{0.0, pi<double>, 2.0 * pi<double>});
+  const auto deg =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::deg),
+                           Values{0.0, 180.0, 360.0});
+
+  auto rad_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  auto deg_out = makeVariable<double>(Dims{Dim::X}, Shape{2});
+
+  auto rad_view = sin(rad.slice({Dim::X, 1, 3}), rad_out);
+  auto deg_view = sin(rad.slice({Dim::X, 1, 3}), deg_out);
+
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, Values{sin(pi<double>), sin(2.0 * pi<double>)});
+
+  EXPECT_EQ(rad_out, expected);
+  EXPECT_EQ(rad_view, rad_out);
+  EXPECT_EQ(rad_view.underlying(), rad_out);
+
+  EXPECT_EQ(deg_out, expected);
+  EXPECT_EQ(deg_view, deg_out);
+  EXPECT_EQ(deg_view.underlying(), deg_out);
 }
 
 TEST(VariableTrigonometryTest, cos) {

--- a/core/trigonometry.cpp
+++ b/core/trigonometry.cpp
@@ -18,11 +18,8 @@ const auto deg_to_rad =
 Variable sin(const VariableConstProxy &var) {
   using std::sin;
   Variable out(var);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  return transform<double, float>(
-      out, overloaded{transform_flags::expect_no_variance_arg<0>,
-                      [](const auto &x) { return sin(x); }});
+  sin(out, out);
+  return out;
 }
 
 Variable sin(Variable &&var) {
@@ -46,11 +43,8 @@ VariableProxy sin(const VariableConstProxy &var, const VariableProxy &out) {
 Variable cos(const VariableConstProxy &var) {
   using std::cos;
   Variable out(var);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  return transform<double, float>(
-      out, overloaded{transform_flags::expect_no_variance_arg<0>,
-                      [](const auto &x) { return cos(x); }});
+  cos(out, out);
+  return out;
 }
 
 Variable cos(Variable &&var) {
@@ -74,11 +68,8 @@ VariableProxy cos(const VariableConstProxy &var, const VariableProxy &out) {
 Variable tan(const VariableConstProxy &var) {
   using std::tan;
   Variable out(var);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  return transform<double, float>(
-      out, overloaded{transform_flags::expect_no_variance_arg<0>,
-                      [](const auto &x) { return tan(x); }});
+  tan(out, out);
+  return out;
 }
 
 Variable tan(Variable &&var) {

--- a/core/trigonometry.cpp
+++ b/core/trigonometry.cpp
@@ -25,6 +25,24 @@ Variable sin(const VariableConstProxy &var) {
                       [](const auto &x) { return sin(x); }});
 }
 
+Variable sin(Variable &&var) {
+  using std::sin;
+  Variable out(std::move(var));
+  sin(out, out);
+  return out;
+}
+
+VariableProxy sin(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::sin;
+  out.assign(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
+  transform_in_place<double, float>(
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
+                      [](auto &x) { x = sin(x); }});
+  return out;
+}
+
 Variable cos(const VariableConstProxy &var) {
   using std::cos;
   Variable out(var);

--- a/core/trigonometry.cpp
+++ b/core/trigonometry.cpp
@@ -11,52 +11,55 @@
 
 namespace scipp::core {
 
-Variable to_rad(Variable var) {
-  const auto scale = makeVariable<double>(Dims(), Shape(),
-                                          units::Unit(units::rad / units::deg),
-                                          Values{pi<double> / 180.0});
-  return var * scale;
-}
+const auto deg_to_rad =
+    makeVariable<double>(Dims(), Shape(), units::Unit(units::rad / units::deg),
+                         Values{pi<double> / 180.0});
 
-Variable sin(const Variable &var) {
+Variable sin(const VariableConstProxy &var) {
   using std::sin;
-  const Variable &rad = var.unit() == units::deg ? to_rad(var) : var;
+  Variable out(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
   return transform<double, float>(
-      rad, overloaded{transform_flags::expect_no_variance_arg<0>,
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return sin(x); }});
 }
 
-Variable cos(const Variable &var) {
+Variable cos(const VariableConstProxy &var) {
   using std::cos;
-  const Variable &rad = var.unit() == units::deg ? to_rad(var) : var;
+  Variable out(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
   return transform<double, float>(
-      rad, overloaded{transform_flags::expect_no_variance_arg<0>,
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return cos(x); }});
 }
 
-Variable tan(const Variable &var) {
+Variable tan(const VariableConstProxy &var) {
   using std::tan;
-  const Variable &rad = var.unit() == units::deg ? to_rad(var) : var;
+  Variable out(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
   return transform<double, float>(
-      rad, overloaded{transform_flags::expect_no_variance_arg<0>,
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return tan(x); }});
 }
 
-Variable asin(const Variable &var) {
+Variable asin(const VariableConstProxy &var) {
   using std::asin;
   return transform<double, float>(
       var, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return asin(x); }});
 }
 
-Variable acos(const Variable &var) {
+Variable acos(const VariableConstProxy &var) {
   using std::acos;
   return transform<double, float>(
       var, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return acos(x); }});
 }
 
-Variable atan(const Variable &var) {
+Variable atan(const VariableConstProxy &var) {
   using std::atan;
   return transform<double, float>(
       var, overloaded{transform_flags::expect_no_variance_arg<0>,

--- a/core/trigonometry.cpp
+++ b/core/trigonometry.cpp
@@ -53,6 +53,24 @@ Variable cos(const VariableConstProxy &var) {
                       [](const auto &x) { return cos(x); }});
 }
 
+Variable cos(Variable &&var) {
+  using std::cos;
+  Variable out(std::move(var));
+  cos(out, out);
+  return out;
+}
+
+VariableProxy cos(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::cos;
+  out.assign(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
+  transform_in_place<double, float>(
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
+                      [](auto &x) { x = cos(x); }});
+  return out;
+}
+
 Variable tan(const VariableConstProxy &var) {
   using std::tan;
   Variable out(var);
@@ -63,11 +81,46 @@ Variable tan(const VariableConstProxy &var) {
                       [](const auto &x) { return tan(x); }});
 }
 
+Variable tan(Variable &&var) {
+  using std::tan;
+  Variable out(std::move(var));
+  tan(out, out);
+  return out;
+}
+
+VariableProxy tan(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::tan;
+  out.assign(var);
+  if (var.unit() == units::deg)
+    out *= deg_to_rad;
+  transform_in_place<double, float>(
+      out, overloaded{transform_flags::expect_no_variance_arg<0>,
+                      [](auto &x) { x = tan(x); }});
+  return out;
+}
+
 Variable asin(const VariableConstProxy &var) {
   using std::asin;
   return transform<double, float>(
       var, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return asin(x); }});
+}
+
+Variable asin(Variable &&var) {
+  using std::asin;
+  Variable out(std::move(var));
+  asin(out, out);
+  return out;
+}
+
+VariableProxy asin(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::asin;
+  transform_in_place<pair_self_t<double, float>>(
+      out, var,
+      overloaded{transform_flags::expect_no_variance_arg<0>,
+                 transform_flags::expect_no_variance_arg<1>,
+                 [](auto &x, const auto &y) { x = asin(y); }});
+  return out;
 }
 
 Variable acos(const VariableConstProxy &var) {
@@ -77,11 +130,45 @@ Variable acos(const VariableConstProxy &var) {
                       [](const auto &x) { return acos(x); }});
 }
 
+Variable acos(Variable &&var) {
+  using std::acos;
+  Variable out(std::move(var));
+  acos(out, out);
+  return out;
+}
+
+VariableProxy acos(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::acos;
+  transform_in_place<pair_self_t<double, float>>(
+      out, var,
+      overloaded{transform_flags::expect_no_variance_arg<0>,
+                 transform_flags::expect_no_variance_arg<1>,
+                 [](auto &x, const auto &y) { x = acos(y); }});
+  return out;
+}
+
 Variable atan(const VariableConstProxy &var) {
   using std::atan;
   return transform<double, float>(
       var, overloaded{transform_flags::expect_no_variance_arg<0>,
                       [](const auto &x) { return atan(x); }});
+}
+
+Variable atan(Variable &&var) {
+  using std::atan;
+  Variable out(std::move(var));
+  atan(out, out);
+  return out;
+}
+
+VariableProxy atan(const VariableConstProxy &var, const VariableProxy &out) {
+  using std::atan;
+  transform_in_place<pair_self_t<double, float>>(
+      out, var,
+      overloaded{transform_flags::expect_no_variance_arg<0>,
+                 transform_flags::expect_no_variance_arg<1>,
+                 [](auto &x, const auto &y) { x = atan(y); }});
+  return out;
 }
 
 } // namespace scipp::core

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -4,6 +4,7 @@
 # @author Simon Heybrock
 import pytest
 
+import math
 import scipp as sc
 from scipp import Dim
 import numpy as np
@@ -807,5 +808,27 @@ def test_reciprocal_out():
     var = sc.Variable([Dim.X], values=np.array([1.0, 2.0]))
     expected = sc.Variable([Dim.X], values=np.array([1.0 / 1.0, 1.0 / 2.0]))
     out = sc.reciprocal(x=var, out=var)
+    assert var == expected
+    assert out == expected
+
+
+def test_sin():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.sin(0.0), math.sin(math.pi)]),
+                           unit=sc.units.dimensionless)
+    assert sc.sin(var) == expected
+
+
+def test_sin_out():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.sin(0.0), math.sin(math.pi)]),
+                           unit=sc.units.dimensionless)
+    out = sc.sin(x=var, out=var)
     assert var == expected
     assert out == expected

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -832,3 +832,103 @@ def test_sin_out():
     out = sc.sin(x=var, out=var)
     assert var == expected
     assert out == expected
+
+
+def test_cos():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.cos(0.0), math.cos(math.pi)]),
+                           unit=sc.units.dimensionless)
+    assert sc.cos(var) == expected
+
+
+def test_cos_out():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.cos(0.0), math.cos(math.pi)]),
+                           unit=sc.units.dimensionless)
+    out = sc.cos(x=var, out=var)
+    assert var == expected
+    assert out == expected
+
+
+def test_tan():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi / 2.]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.tan(0.0),
+                                            math.tan(math.pi / 2.)]),
+                           unit=sc.units.dimensionless)
+    assert sc.tan(var) == expected
+
+
+def test_tan_out():
+    var = sc.Variable([Dim.X],
+                      values=np.array([0.0, math.pi / 2.]),
+                      unit=sc.units.rad)
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.tan(0.0),
+                                            math.tan(math.pi / 2.)]),
+                           unit=sc.units.dimensionless)
+    out = sc.tan(x=var, out=var)
+    assert var == expected
+    assert out == expected
+
+
+def test_asin():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.asin(0.0), math.asin(0.5)]),
+                           unit=sc.units.rad)
+    assert sc.asin(var) == expected
+
+
+def test_asin_out():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.asin(0.0), math.asin(0.5)]),
+                           unit=sc.units.rad)
+    out = sc.asin(x=var, out=var)
+    assert var == expected
+    assert out == expected
+
+
+def test_acos():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.acos(0.0), math.acos(0.5)]),
+                           unit=sc.units.rad)
+    assert sc.acos(var) == expected
+
+
+def test_acos_out():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.acos(0.0), math.acos(0.5)]),
+                           unit=sc.units.rad)
+    out = sc.acos(x=var, out=var)
+    assert var == expected
+    assert out == expected
+
+
+def test_atan():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.atan(0.0), math.atan(0.5)]),
+                           unit=sc.units.rad)
+    assert sc.atan(var) == expected
+
+
+def test_atan_out():
+    var = sc.Variable([Dim.X], values=np.array([0.0, 0.5]))
+    expected = sc.Variable([Dim.X],
+                           values=np.array([math.atan(0.0), math.atan(0.5)]),
+                           unit=sc.units.rad)
+    out = sc.atan(x=var, out=var)
+    assert var == expected
+    assert out == expected

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -511,12 +511,24 @@ void init_variable(py::module &m) {
         :return: New variable containing the sum.
         :rtype: Variable)");
 
-  m.def("sin", [](const Variable &self) { return sin(self); }, py::arg("x"),
-        py::call_guard<py::gil_scoped_release>(), R"(
+  m.def("sin", [](const VariableConstProxy &self) { return sin(self); },
+        py::arg("x"), py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise sin.
 
         :raises: If the unit is not a plane-angle unit, or if the dtype has no sin, e.g., if it is an integer
         :return: Copy of the input with values replaced by the sin.
+        :rtype: Variable)");
+
+  m.def("sin",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return sin(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise sin.
+
+        :raises: If the unit is not a plane-angle unit, or if the dtype has no sin, e.g., if it is an integer
+        :return: sin of input values.
         :rtype: Variable)");
 
   m.def("cos", [](const Variable &self) { return cos(self); }, py::arg("x"),

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -539,12 +539,36 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the cos.
         :rtype: Variable)");
 
+  m.def("cos",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return cos(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise cos.
+
+        :raises: If the unit is not a plane-angle unit, or if the dtype has no cos, e.g., if it is an integer
+        :return: cos of input values.
+        :rtype: Variable)");
+
   m.def("tan", [](const Variable &self) { return tan(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise tan.
 
         :raises: If the unit is not a plane-angle unit, or if the dtype has no tan, e.g., if it is an integer
         :return: Copy of the input with values replaced by the tan.
+        :rtype: Variable)");
+
+  m.def("tan",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return tan(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise tan.
+
+        :raises: If the unit is not a plane-angle unit, or if the dtype has no tan, e.g., if it is an integer
+        :return: tan of input values.
         :rtype: Variable)");
 
   m.def("asin", [](const Variable &self) { return asin(self); }, py::arg("x"),
@@ -555,6 +579,18 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the asin. Output unit is rad.
         :rtype: Variable)");
 
+  m.def("asin",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return asin(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise atan.
+
+        :raises: If the unit is dimensionless, or if the dtype has no asin, e.g., if it is an integer
+        :return: asin of input values. Output unit is rad.
+        :rtype: Variable)");
+
   m.def("acos", [](const Variable &self) { return acos(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise acos.
@@ -563,11 +599,35 @@ void init_variable(py::module &m) {
         :return: Copy of the input with values replaced by the acos. Output unit is rad.
         :rtype: Variable)");
 
+  m.def("acos",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return acos(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise acos.
+
+        :raises: If the unit is dimensionless, or if the dtype has no acos, e.g., if it is an integer
+        :return: acos of input values. Output unit is rad.
+        :rtype: Variable)");
+
   m.def("atan", [](const Variable &self) { return atan(self); }, py::arg("x"),
         py::call_guard<py::gil_scoped_release>(), R"(
         Element-wise atan.
 
         :raises: If the unit is dimensionless, or if the dtype has no atan, e.g., if it is an integer
         :return: Copy of the input with values replaced by the atan. Output unit is rad.
+        :rtype: Variable)");
+
+  m.def("atan",
+        [](const VariableConstProxy &self, const VariableProxy &out) {
+          return atan(self, out);
+        },
+        py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise atan.
+
+        :raises: If the unit is dimensionless, or if the dtype has no atan, e.g., if it is an integer
+        :return: atan of input values. Output unit is rad.
         :rtype: Variable)");
 }


### PR DESCRIPTION
- Support out arguments on `Variable` trig operations
- Add missing unit tests for Python exports
- Add a benchmark for `Variable::sin` (I used this to make sure my changes to the existing implementation were not slower and have just left it in place)

Re #815.