### PR TITLE
Avoid pessimizing move

### DIFF
--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -27,13 +27,7 @@ static constexpr auto maybe_subspan = [](VariableConstProxy &var,
     *ret = subspan_view(var, dim);
     var = *ret;
   }
-// Suppressing the warning related to preventing the copy elision
-// because "move" is necessary here to keep the subspan view created
-// above valid, copy elision invalidates it for MSVC compiler.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpessimizing-move"
-  return std::move(ret);
-#pragma clang diagnostic pop
+  return ret;
 };
 } // namespace transform_subspan_detail
 

--- a/core/include/scipp/core/transform_subspan.h
+++ b/core/include/scipp/core/transform_subspan.h
@@ -27,7 +27,13 @@ static constexpr auto maybe_subspan = [](VariableConstProxy &var,
     *ret = subspan_view(var, dim);
     var = *ret;
   }
+// Suppressing the warning related to preventing the copy elision
+// because "move" is necessary here to keep the subspan view created
+// above valid, copy elision invalidates it for MSVC compiler.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpessimizing-move"
   return std::move(ret);
+#pragma clang diagnostic pop
 };
 } // namespace transform_subspan_detail
 


### PR DESCRIPTION
To make the things working for MSVS at some point we have done like this:
```cpp
auto x = whatever;
return std::move(x);
```
this causes the warning and indignation of clever clang compiler. Removing `std::move` helps.