### PR TITLE
Non-const overloads for scipp.neutron positions functions

### DIFF
--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -13,7 +13,7 @@ namespace scipp::neutron {
 
 namespace beamline_impl {
 
-template <class T> static VariableConstProxy position(const T &d) {
+template <class T> static auto position(const T &d) {
   if (d.coords().contains(Dim::Position))
     return d.coords()[Dim::Position];
   else if (d.labels().contains("position"))
@@ -22,14 +22,14 @@ template <class T> static VariableConstProxy position(const T &d) {
     return d.attrs()["position"];
 }
 
-template <class T> static VariableConstProxy source_position(const T &d) {
+template <class T> static auto source_position(const T &d) {
   if (d.labels().contains("source_position"))
     return d.labels()["source_position"];
   else
     return d.attrs()["source_position"];
 }
 
-template <class T> static VariableConstProxy sample_position(const T &d) {
+template <class T> static auto sample_position(const T &d) {
   if (d.labels().contains("sample_position"))
     return d.labels()["sample_position"];
   else
@@ -86,6 +86,15 @@ core::VariableConstProxy source_position(const core::DatasetConstProxy &d) {
 core::VariableConstProxy sample_position(const core::DatasetConstProxy &d) {
   return beamline_impl::sample_position(d);
 }
+core::VariableProxy position(const core::DatasetProxy &d) {
+  return beamline_impl::position(d);
+}
+core::VariableProxy source_position(const core::DatasetProxy &d) {
+  return beamline_impl::source_position(d);
+}
+core::VariableProxy sample_position(const core::DatasetProxy &d) {
+  return beamline_impl::sample_position(d);
+}
 core::Variable flight_path_length(const core::DatasetConstProxy &d) {
   return beamline_impl::flight_path_length(d);
 }
@@ -109,6 +118,15 @@ core::VariableConstProxy source_position(const core::DataConstProxy &d) {
   return beamline_impl::source_position(d);
 }
 core::VariableConstProxy sample_position(const core::DataConstProxy &d) {
+  return beamline_impl::sample_position(d);
+}
+core::VariableProxy position(const core::DataProxy &d) {
+  return beamline_impl::position(d);
+}
+core::VariableProxy source_position(const core::DataProxy &d) {
+  return beamline_impl::source_position(d);
+}
+core::VariableProxy sample_position(const core::DataProxy &d) {
   return beamline_impl::sample_position(d);
 }
 core::Variable flight_path_length(const core::DataConstProxy &d) {

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -17,6 +17,11 @@ SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 source_position(const core::DatasetConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 sample_position(const core::DatasetConstProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy position(const core::DatasetProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy
+source_position(const core::DatasetProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy
+sample_position(const core::DatasetProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable
 flight_path_length(const core::DatasetConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l1(const core::DatasetConstProxy &d);
@@ -31,6 +36,11 @@ SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 source_position(const core::DataConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::VariableConstProxy
 sample_position(const core::DataConstProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy position(const core::DataProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy
+source_position(const core::DataProxy &d);
+SCIPP_NEUTRON_EXPORT core::VariableProxy
+sample_position(const core::DataProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable
 flight_path_length(const core::DataConstProxy &d);
 SCIPP_NEUTRON_EXPORT core::Variable l1(const core::DataConstProxy &d);

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -14,28 +14,35 @@ using namespace scipp::neutron;
 
 namespace py = pybind11;
 
-template <class T> void bind_beamline(py::module &m) {
-  using View = const typename T::const_view_type &;
-
-  m.def("position", py::overload_cast<View>(position), R"(
+template <class T> void bind_positions(py::module &m) {
+  m.def("position", py::overload_cast<T>(position), R"(
     Extract the detector pixel positions from a data array or a dataset.
 
     :return: A variable containing the detector pixel positions.
     :rtype: Variable)");
 
-  m.def("source_position", py::overload_cast<View>(source_position), R"(
+  m.def("source_position", py::overload_cast<T>(source_position), R"(
     Extract the neutron source position from a data array or a dataset.
 
     :return: A scalar variable containing the source position.
     :rtype: Variable)");
 
-  m.def("sample_position", py::overload_cast<View>(sample_position), R"(
+  m.def("sample_position", py::overload_cast<T>(sample_position), R"(
     Extract the sample position from a data array or a dataset.
 
     :return: A scalar variable containing the sample position.
     :rtype: Variable)");
+}
 
-  m.def("flight_path_length", py::overload_cast<View>(flight_path_length), R"(
+template <class T> void bind_beamline(py::module &m) {
+  using ConstView = const typename T::const_view_type &;
+  using View = const typename T::view_type &;
+
+  bind_positions<View>(m);
+  bind_positions<ConstView>(m);
+
+  m.def("flight_path_length", py::overload_cast<ConstView>(flight_path_length),
+        R"(
     Compute the length of the total flight path from a data array or a dataset.
 
     If a sample position is found this is the sum of `l1` and `l2`, otherwise the distance from the source.
@@ -43,25 +50,25 @@ template <class T> void bind_beamline(py::module &m) {
     :return: A scalar variable containing the total length of the flight path.
     :rtype: Variable)");
 
-  m.def("l1", py::overload_cast<View>(l1), R"(
+  m.def("l1", py::overload_cast<ConstView>(l1), R"(
     Compute L1, the length of the primary flight path (distance between neutron source and sample) from a data array or a dataset.
 
     :return: A scalar variable containing L1.
     :rtype: Variable)");
 
-  m.def("l2", py::overload_cast<View>(l2), R"(
+  m.def("l2", py::overload_cast<ConstView>(l2), R"(
     Compute L2, the length of the secondary flight paths (distances between sample and detector pixels) from a data array or a dataset.
 
     :return: A variable containing L2 for all detector pixels.
     :rtype: Variable)");
 
-  m.def("scattering_angle", py::overload_cast<View>(scattering_angle), R"(
+  m.def("scattering_angle", py::overload_cast<ConstView>(scattering_angle), R"(
     Compute :math:`\theta`, the scattering angle in Bragg's law, from a data array or a dataset.
 
     :return: A variable containing :math:`\theta` for all detector pixels.
     :rtype: Variable)");
 
-  m.def("two_theta", py::overload_cast<View>(two_theta), R"(
+  m.def("two_theta", py::overload_cast<ConstView>(two_theta), R"(
     Compute :math:`2\theta`, twice the scattering angle in Bragg's law, from a data array or a dataset.
 
     :return: A variable containing :math:`2\theta` for all detector pixels.

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -90,19 +90,11 @@ class InstrumentView:
                                "are a Dataset or a DataArray (and their "
                                "respective proxies).".format(tp))
 
-        # Get detector positions
-        self.det_pos = np.array(sn.position(scipp_obj).values)
-
-        # Find extents of the detectors
-        self.minmax = {}
-        for i, x in enumerate("xyz"):
-            self.minmax[x] = [np.amin(self.det_pos[:, i]),
-                              np.amax(self.det_pos[:, i])]
-
         self.globs = {"cmap": cmap, "log": log, "vmin": vmin, "vmax": vmax}
         self.params = {}
         self.hist_data_array = {}
         self.scalar_map = {}
+        self.minmax = {}
 
         # Find the min/max time-of-flight limits and store them
         self.minmax["tof"] = [np.Inf, np.NINF, 1]
@@ -203,6 +195,14 @@ class InstrumentView:
         # the output widget needs to be displayed first, before any mpl figure
         # is displayed.
         render_plot(widgets=self.box, filename=filename, ipv=ipv)
+
+        # Get detector positions
+        self.det_pos = np.array(
+            sn.position(self.hist_data_array[self.key]).values)
+        # Find extents of the detectors
+        for i, x in enumerate("xyz"):
+            self.minmax[x] = [np.amin(self.det_pos[:, i]),
+                              np.amax(self.det_pos[:, i])]
 
         # Update the figure
         self.change_projection(self.buttons[projection])

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -9,7 +9,7 @@ from ..plot.sciplot import SciPlot
 from ..plot.sparse import histogram_sparse_data, make_bins
 from ..plot.tools import parse_params
 from ..utils import name_with_unit, value_to_string
-from .._scipp import core as sc
+from .._scipp import core as sc, neutron as sn
 
 # Other imports
 import numpy as np
@@ -90,11 +90,8 @@ class InstrumentView:
                                "are a Dataset or a DataArray (and their "
                                "respective proxies).".format(tp))
 
-        # Get detector positions from either coordinates or labels
-        if sc.Dim.Position in scipp_obj.coords:
-            self.det_pos = np.array(scipp_obj.coords[sc.Dim.Position].values)
-        else:
-            self.det_pos = np.array(scipp_obj.labels["position"].values)
+        # Get detector positions
+        self.det_pos = np.array(sn.position(scipp_obj).values)
 
         # Find extents of the detectors
         self.minmax = {}


### PR DESCRIPTION
Added non-const overloads for the positions functions in `scipp.neutron` and the corresponding python bindings.

This now makes it possible to use
```Py
det_pos = scipp.neutron.position(sample_data_array).values
```
in python instead of
```Py
if sc.Dim.Position in sample_data_array.coords:
    det_pos = sample_data_array.coords[sc.Dim.Position].values
else:
    det_pos = sample_data_array.labels["position"].values
```

This is now used in `instrument_view.py`.