### PR TITLE
neutron.convert with out arg

### DIFF
--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -78,10 +78,21 @@ template <class T> void bind_convert(py::module &m) {
     :param data: Input data with time-of-flight dimension (Dim.Tof)
     :param from: Dimension to convert from
     :param to: Dimension to convert into
+    :param out: Optional output container
     :return: New data array or dataset with converted dimension (dimension labels, coordinate values, and units)
     :rtype: DataArray or Dataset)";
   m.def("convert", py::overload_cast<ConstView, const Dim, const Dim>(convert),
         py::arg("data"), py::arg("from"), py::arg("to"),
+        py::call_guard<py::gil_scoped_release>(), doc);
+  m.def("convert",
+        [](py::object &obj, const Dim from, const Dim to, T &out) {
+          auto &data = obj.cast<T &>();
+          if (&data != &out)
+            throw std::runtime_error("Currently only out=<input> is supported");
+          data = convert(std::move(data), from, to);
+          return obj;
+        },
+        py::arg("data"), py::arg("from"), py::arg("to"), py::arg("out"),
         py::call_guard<py::gil_scoped_release>(), doc);
 }
 

--- a/python/tests/test_neutron.py
+++ b/python/tests/test_neutron.py
@@ -46,6 +46,14 @@ def test_neutron_convert():
     assert dspacing.coords[Dim.DSpacing].unit == sc.units.angstrom
 
 
+def test_neutron_convert_out_arg():
+    d = make_dataset_with_beamline()
+
+    dspacing = sc.neutron.convert(d, Dim.Tof, Dim.DSpacing, out=d)
+    assert dspacing.coords[Dim.DSpacing].unit == sc.units.angstrom
+    assert dspacing is d
+
+
 def test_neutron_beamline():
     d = make_dataset_with_beamline()
 


### PR DESCRIPTION
"Poor man's" version with "out" arg --- only supporting case of input=output. Other cases would be much more complex due to issues I started describing in https://github.com/scipp/scipp/issues/832. This however gives us most of the benefits: I see an approx. 5x speedup when using in-place unit conversion as opposed to what was possible before.