### PR TITLE
Adds tests for _repr_html_ and return None for sparse shape

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -390,12 +390,12 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly("shape",
                           [](const T &self) {
                             const auto &dims = self.dims();
-                            auto shape{std::vector<scipp::index>(
-                                dims.shape().begin(), dims.shape().end())};
+                            py::list list = py::cast(dims.shape());
+
                             if (dims.sparse()) {
-                              shape.emplace_back(Dimensions::Sparse);
+                              list.append(py::none());
                             }
-                            return shape;
+                            return list;
                           },
                           "Shape of the data (read-only).",
                           py::return_value_policy::move);

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -390,8 +390,12 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly("shape",
                           [](const T &self) {
                             const auto &dims = self.dims();
-                            py::list list = py::cast(dims.shape());
-
+                            py::list list;
+                            for (auto extent : dims.shape()) {
+                              list.append(extent);
+                            }
+                            // Add None to represent sparse dimension. The can
+                            // be only one.
                             if (dims.sparse()) {
                               list.append(py::none());
                             }

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -390,8 +390,12 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly("shape",
                           [](const T &self) {
                             const auto &dims = self.dims();
-                            return std::vector<scipp::index>(
-                                dims.shape().begin(), dims.shape().end());
+                            auto shape{std::vector<scipp::index>(
+                                dims.shape().begin(), dims.shape().end())};
+                            if (dims.sparse()) {
+                              shape.emplace_back(Dimensions::Sparse);
+                            }
+                            return shape;
                           },
                           "Shape of the data (read-only).",
                           py::return_value_policy::move);

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -394,8 +394,8 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
                             for (auto extent : dims.shape()) {
                               list.append(extent);
                             }
-                            // Add None to represent sparse dimension. The can
-                            // be only one.
+                            // Add None to represent sparse dimension.
+                            // There can be only one.
                             if (dims.sparse()) {
                               list.append(py::none());
                             }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -104,9 +104,13 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
                           py::return_value_policy::move);
   c.def_property_readonly("shape",
                           [](const T &self) {
-                            std::vector<scipp::index> shape;
+                            auto shape = py::list();
                             for (const auto &dim : self.dimensions()) {
-                              shape.push_back(dim.second);
+                              if (dim.second == Dimensions::Sparse) {
+                                shape.append(py::none());
+                              } else {
+                                shape.append(dim.second);
+                              }
                             }
                             return shape;
                           },

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,3 +4,4 @@ ipywidgets
 pytest
 ipyvolume
 ipyevents
+bs4

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -76,7 +76,9 @@ def _get_sparse(var, variances, ellipsis_after, summary=False):
         if summary:
             return [SPARSE_PREFIX.format(size)]
         else:
-            return [_format_array(var.values, size, ellipsis_after, size > 1000)]
+            return [
+                _format_array(var.values, size, ellipsis_after, size > 1000)
+            ]
     else:
         # Handles 2D and higher Variables with a sparse dimension
         size = var.shape[0]
@@ -154,11 +156,10 @@ def format_dims(dims, sizes, coords):
     }
 
     print("Dims and sizes:", dims, sizes)
-    dims_li = "".join(
-        f"<li><span{dim_css_map[dim]}>"
-        f"{escape(str(dim))}</span>: "
-        f"{size if size is not None else 'Sparse' }</li>"
-        for dim, size in zip(dims, sizes))
+    dims_li = "".join(f"<li><span{dim_css_map[dim]}>"
+                      f"{escape(str(dim))}</span>: "
+                      f"{size if size is not None else 'Sparse' }</li>"
+                      for dim, size in zip(dims, sizes))
 
     return f"<ul class='xr-dim-list'>{dims_li}</ul>"
 
@@ -267,13 +268,10 @@ def _make_dim_labels(dim, size, bin_edges=None):
 
 
 def _make_dim_str(var, bin_edges, add_dim_size=False):
-    dims_text = ', '.join(
-        '{}{}{}'.format(
-            str(dim),
-            _make_dim_labels(dim, size, bin_edges),
-            f': {size}' if add_dim_size and size is not None else ''
-        )
-        for dim, size in zip(var.dims, var.shape))
+    dims_text = ', '.join('{}{}{}'.format(
+        str(dim), _make_dim_labels(dim, size, bin_edges),
+        f': {size}' if add_dim_size and size is not None else '')
+                          for dim, size in zip(var.dims, var.shape))
     return dims_text
 
 
@@ -416,7 +414,7 @@ def summarize_data(dataset):
             var,
             has_attrs=has_attrs,
             bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
-        for name, var in dataset)
+                      for name, var in dataset)
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -69,12 +69,8 @@ def _format_non_sparse(var, has_variances):
 def _get_sparse(var, variances, ellipsis_after, summary=False):
     if hasattr(var, "data") and var.data is None:
         return ["No data, implicitly 1"]
-    single = len(var.shape) == 0
 
-    if single:
-        assert False, "AM I even tested??"
-        size = 1
-    elif var.shape[0] is None:
+    if var.shape[0] is None:
         # handles a 1D Variable with only a sparse dimension
         size = len(var.values)
         if summary:
@@ -88,7 +84,7 @@ def _get_sparse(var, variances, ellipsis_after, summary=False):
     i = 0
     s = []
 
-    do_ellide = single or summary or size > 1000 or sum([
+    do_ellide = summary or size > 1000 or sum([
         len(retrieve(var, variances=variances)[i])
         for i in range(min(size, 1000))
     ]) > 1000
@@ -98,7 +94,7 @@ def _get_sparse(var, variances, ellipsis_after, summary=False):
         if i == ellipsis_after and do_ellide and size > 2 * ellipsis_after + 1:
             s.append("...")
             i = size - ellipsis_after
-        item = data if single else data[i]
+        item = data[i]
         if summary:
             s.append(SPARSE_PREFIX.format(len(item)))
         else:

--- a/python/tests/table_html/common.py
+++ b/python/tests/table_html/common.py
@@ -97,22 +97,27 @@ def assert_dims_section(data, dim_section, sparse=False):
             else 'Sparse' in dim_list[0].text
 
 
-def assert_section(section, name, dims, in_dtype, in_unit,
+def assert_section(section,
+                   name,
+                   dims,
+                   in_dtype,
+                   in_unit,
                    has_sparse=False,
                    has_bin_edges=False):
     if isinstance(name, str):
-        return _assert_section_single(section, name, dims,
-                                      in_dtype, in_unit,
-                                      has_sparse,
-                                      has_bin_edges)
+        return _assert_section_single(section, name, dims, in_dtype, in_unit,
+                                      has_sparse, has_bin_edges)
     elif isinstance(name, list):
-        return _assert_section_multiple(section, name,
-                                        dims, in_dtype, in_unit,
+        return _assert_section_multiple(section, name, dims, in_dtype, in_unit,
                                         has_sparse if has_sparse else [],
                                         has_bin_edges if has_bin_edges else [])
 
 
-def _assert_section_single(section, name, dims, in_dtype, in_unit,
+def _assert_section_single(section,
+                           name,
+                           dims,
+                           in_dtype,
+                           in_unit,
                            has_sparse=False,
                            has_bin_edges=False):
     name_html = section.find_all(class_=DATASET_NAME_CSS_CLASS)
@@ -126,8 +131,10 @@ def _assert_section_single(section, name, dims, in_dtype, in_unit,
     assert 0 < len(dims_html) < 2, \
         f"Unexpected number of dimension tags found: {len(name_html)}."\
         "Expected: 1."
-    assert_dims(dims, dims_html[0].text,
-                has_sparse=has_sparse, has_bin_edges=has_bin_edges)
+    assert_dims(dims,
+                dims_html[0].text,
+                has_sparse=has_sparse,
+                has_bin_edges=has_bin_edges)
     assert_dtype(in_dtype, section.find_all(class_=DTYPE_CSS_CLASS))
     assert_unit(in_unit, section.find_all(class_=UNIT_CSS_CLASS))
     value = section.find_all(class_=VALUE_CSS_CLASS)
@@ -137,7 +144,11 @@ def _assert_section_single(section, name, dims, in_dtype, in_unit,
     assert "..." in value[0].text
 
 
-def _assert_section_multiple(section, name, dims, in_dtype, in_unit,
+def _assert_section_multiple(section,
+                             name,
+                             dims,
+                             in_dtype,
+                             in_unit,
                              has_sparse=[],
                              has_bin_edges=[]):
     name_html = section.find_all(class_=DATASET_NAME_CSS_CLASS)
@@ -151,8 +162,10 @@ def _assert_section_multiple(section, name, dims, in_dtype, in_unit,
 
     dims_html = section.find_all(class_=DIMS_CSS_CLASS)
     for dim, sparse, bin_edges in zip(dims, has_sparse, has_bin_edges):
-        assert_dims(dim, dims_html[0].text,
-                    has_sparse=sparse, has_bin_edges=bin_edges)
+        assert_dims(dim,
+                    dims_html[0].text,
+                    has_sparse=sparse,
+                    has_bin_edges=bin_edges)
 
     for dtype in section.find_all(class_=DTYPE_CSS_CLASS):
         assert_dtype(in_dtype, [dtype])

--- a/python/tests/table_html/common.py
+++ b/python/tests/table_html/common.py
@@ -1,0 +1,161 @@
+from typing import List
+
+import bs4
+
+import scipp as sc
+from scipp.table_html.formatting_html import BIN_EDGE_LABEL, SPARSE_LABEL
+
+VARIABLE_OBJECT_TYPE = "scipp.Variable"
+OBJ_TYPE_CSS_CLASS = "xr-obj-type"
+VAR_NAME_CSS_CLASS = "sc-var-name"
+DATASET_NAME_CSS_CLASS = "xr-var-name"
+DTYPE_CSS_CLASS = "xr-var-dtype"
+UNIT_CSS_CLASS = "xr-var-unit"
+VALUE_CSS_CLASS = "xr-value-preview"
+DATA_ICON_CSS_CLASS = "xr-icon-database"
+DIMS_CSS_CLASS = "xr-var-dims"
+DIM_LIST_CSS_CLASS = "xr-dim-list"
+
+ATTR_NAME = "attr"
+LABEL_NAME = "label"
+MASK_NAME = "mask"
+
+
+def assert_obj_type(expected, actual):
+    assert len(actual) == 1
+    assert expected == actual[0].text
+
+
+def assert_dims(dims, text, has_sparse=False, has_bin_edges=False):
+    # this will probably backfire if the "Dim." is changed
+    # but it is a good sanity check for now...
+    assert len(dims) == text.count("Dim"),\
+        f"Expected: {len(dims)}, actual: {text.count('Dim')}"
+    for d in dims:
+        assert str(d) in text
+
+    if has_sparse and not has_bin_edges:
+        # only sparse
+        assert SPARSE_LABEL in text, "Could not find SPARSE"
+        assert BIN_EDGE_LABEL not in text, "Unexpected bin-edge label"
+    elif not has_sparse and has_bin_edges:
+        # only bin edges
+        assert BIN_EDGE_LABEL in text, "Could not find BIN-EDGE"
+        assert SPARSE_LABEL not in text, "Unexpected sparse label"
+    elif has_sparse and has_bin_edges:
+        # both sparse and bin edges present
+        assert BIN_EDGE_LABEL in text, "Could not find BIN-EDGE"
+        assert SPARSE_LABEL in text, "Could not find SPARSE"
+    elif not has_sparse and not has_bin_edges:
+        # none present
+        assert BIN_EDGE_LABEL not in text, "Unexpected bin-edge label"
+        assert SPARSE_LABEL not in text, "Unexpected sparse label"
+
+
+def assert_lengths(lengths, text):
+    for l in lengths:
+        assert str(l) in text
+
+
+def assert_dtype(dtype, res_dtype: List[bs4.element.Tag]):
+    assert len(res_dtype) == 1
+    text = res_dtype[0].text
+    # the dtype text is shortened for display
+    # so we check if the output is contained in the original str
+    assert text in str(dtype)
+
+
+def assert_unit(unit, res_unit: List[bs4.element.Tag]):
+    if unit == "":
+        raise RuntimeError("Empty unit string will assert True to everything."
+                           "Prefer using an actual unit.")
+    assert len(res_unit) == 1
+    text = res_unit[0].text
+    assert str(unit) in text
+
+
+def assert_data_repr_icon_present(tags: List[bs4.element.Tag]):
+    assert len(tags) == 1
+
+
+def assert_common(html, in_dtype):
+    assert_obj_type(VARIABLE_OBJECT_TYPE,
+                    html.find_all(class_=OBJ_TYPE_CSS_CLASS))
+    assert_dtype(in_dtype, html.find_all(class_=DTYPE_CSS_CLASS))
+    assert_data_repr_icon_present(html.find_all(class_=DATA_ICON_CSS_CLASS))
+
+
+def assert_dims_section(data, dim_section, sparse=False):
+    dim_list = dim_section.find_all(class_=DIM_LIST_CSS_CLASS)
+    assert len(dim_list) == 1
+
+    # checks that all dims are formatted with the their extent
+    for dim, size in zip(data.dims, data.shape):
+        assert str(dim) in dim_list[0].text
+        assert str(
+            size) if size != sc.Dimensions.Sparse \
+            else 'Sparse' in dim_list[0].text
+
+
+def assert_section(section, name, dims, in_dtype, in_unit,
+                   has_sparse=False,
+                   has_bin_edges=False):
+    if isinstance(name, str):
+        return _assert_section_single(section, name, dims,
+                                      in_dtype, in_unit,
+                                      has_sparse,
+                                      has_bin_edges)
+    elif isinstance(name, list):
+        return _assert_section_multiple(section, name,
+                                        dims, in_dtype, in_unit,
+                                        has_sparse if has_sparse else [],
+                                        has_bin_edges if has_bin_edges else [])
+
+
+def _assert_section_single(section, name, dims, in_dtype, in_unit,
+                           has_sparse=False,
+                           has_bin_edges=False):
+    name_html = section.find_all(class_=DATASET_NAME_CSS_CLASS)
+    # for checking the names of more than one entry, pass in a list
+    assert 0 < len(name_html) < 2, \
+        f"Unexpected number of name tags found: {len(name_html)}."\
+        "Expected: 1."
+    assert str(name) == name_html[0].text
+
+    dims_html = section.find_all(class_=DIMS_CSS_CLASS)
+    assert 0 < len(dims_html) < 2, \
+        f"Unexpected number of dimension tags found: {len(name_html)}."\
+        "Expected: 1."
+    assert_dims(dims, dims_html[0].text,
+                has_sparse=has_sparse, has_bin_edges=has_bin_edges)
+    assert_dtype(in_dtype, section.find_all(class_=DTYPE_CSS_CLASS))
+    assert_unit(in_unit, section.find_all(class_=UNIT_CSS_CLASS))
+    value = section.find_all(class_=VALUE_CSS_CLASS)
+    assert 0 < len(dims_html) < 2, \
+        f"Unexpected number of value tags found: {len(name_html)}."\
+        "Expected: 1."
+    assert "..." in value[0].text
+
+
+def _assert_section_multiple(section, name, dims, in_dtype, in_unit,
+                             has_sparse=[],
+                             has_bin_edges=[]):
+    name_html = section.find_all(class_=DATASET_NAME_CSS_CLASS)
+
+    assert len(name_html) == len(name),\
+        f"Unexpected number of name tags found: {len(name_html)}."\
+        f"Expected: {len(name)}"
+
+    for n in name:
+        assert str(n) in name_html[0].text
+
+    dims_html = section.find_all(class_=DIMS_CSS_CLASS)
+    for dim, sparse, bin_edges in zip(dims, has_sparse, has_bin_edges):
+        assert_dims(dim, dims_html[0].text,
+                    has_sparse=sparse, has_bin_edges=bin_edges)
+
+    for dtype in section.find_all(class_=DTYPE_CSS_CLASS):
+        assert_dtype(in_dtype, [dtype])
+
+    for unit in section.find_all(class_=UNIT_CSS_CLASS):
+        assert_unit(in_unit, [unit])

--- a/python/tests/table_html/test_to_html_dataarray.py
+++ b/python/tests/table_html/test_to_html_dataarray.py
@@ -11,20 +11,21 @@ from .common import (ATTR_NAME, LABEL_NAME, MASK_NAME, assert_dims_section,
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], (10,)),
-                          ([Dim.X, Dim.Y], (10, 10)),
-                          ([Dim.X, Dim.Y, Dim.Z], (10, 10, 10)),
-                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           (10, 10, 10, 10)))
-                         )
+                         (([Dim.X], (10, )), ([Dim.X, Dim.Y], (10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, 10)), ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                                           (10, 10, 10, 10))))
 def test_basic(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
-    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+    data = sc.Variable(dims,
+                       unit=in_unit,
+                       dtype=in_dtype,
                        values=np.random.rand(*lengths),
                        variances=np.random.rand(*lengths))
 
-    data_array = sc.DataArray(data, coords={dims[0]: data},
+    data_array = sc.DataArray(data,
+                              coords={dims[0]: data},
                               attrs={ATTR_NAME: data},
                               labels={LABEL_NAME: data},
                               masks={MASK_NAME: data})
@@ -32,13 +33,10 @@ def test_basic(dims, lengths):
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(sections,
-                                                ["Dimensions",
-                                                 "Coordinates",
-                                                 "Labels",
-                                                 "Data",
-                                                 "Masks",
-                                                 "Attributes"]):
+    for actual_section, expected_section in zip(
+            sections,
+        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+         ]):
         assert expected_section in actual_section.text
 
     dim_section = sections.pop(0)
@@ -49,7 +47,8 @@ def test_basic(dims, lengths):
         LABEL_NAME,
         "",  # dataarray does not have a data name
         MASK_NAME,
-        ATTR_NAME]
+        ATTR_NAME
+    ]
     assert len(sections) == len(
         data_names), "Sections and expected data names do not match"
     for section, name in zip(sections, data_names):
@@ -58,11 +57,10 @@ def test_basic(dims, lengths):
 
 @pytest.mark.parametrize("dims, lengths",
                          (([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
-                             ([Dim.X, Dim.Y, Dim.Z],
-                              (10, 10, sc.Dimensions.Sparse)),
-                             ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                              (10, 10, 10, sc.Dimensions.Sparse)))
-                         )
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, sc.Dimensions.Sparse))))
 def test_sparse(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
@@ -70,7 +68,9 @@ def test_sparse(dims, lengths):
     data = sc.Variable(dims, lengths, unit=in_unit, dtype=in_dtype)
 
     in_attr_dims = [dims[0]]
-    attr = sc.Variable(in_attr_dims, unit=in_unit, dtype=in_dtype,
+    attr = sc.Variable(in_attr_dims,
+                       unit=in_unit,
+                       dtype=in_dtype,
                        values=np.random.rand(lengths[0]))
 
     data_array = sc.DataArray(data,
@@ -82,13 +82,10 @@ def test_sparse(dims, lengths):
     sections = html.find_all(class_="xr-section-item")
 
     assert len(sections) == 6
-    for actual_section, expected_section in zip(sections,
-                                                ["Dimensions",
-                                                 "Coordinates",
-                                                 "Labels",
-                                                 "Data",
-                                                 "Masks",
-                                                 "Attributes"]):
+    for actual_section, expected_section in zip(
+            sections,
+        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+         ]):
         assert expected_section in actual_section.text
 
     data_section = sections.pop(3)
@@ -100,37 +97,40 @@ def test_sparse(dims, lengths):
     coord_section = sections.pop(0)
     # the original dim used as a label (dim[0]) is not shown,
     # instead the sparse dim is shown
-    assert_section(coord_section, dims[-1],
-                   dims, in_dtype, in_unit, has_sparse=True)
+    assert_section(coord_section,
+                   dims[-1],
+                   dims,
+                   in_dtype,
+                   in_unit,
+                   has_sparse=True)
 
-    data_names = [
-        LABEL_NAME,
-        MASK_NAME,
-        ATTR_NAME]
+    data_names = [LABEL_NAME, MASK_NAME, ATTR_NAME]
 
     for section, name in zip(sections, data_names):
         assert_section(section, name, in_attr_dims, in_dtype, in_unit)
 
 
-@pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], [10]),
-                          ([Dim.X, Dim.Y], [10, 10]),
-                          ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
-                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           [10, 10, 10, 10]))
-                         )
+@pytest.mark.parametrize(
+    "dims, lengths", (([Dim.X], [10]), ([Dim.X, Dim.Y], [10, 10]),
+                      ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
+                      ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum], [10, 10, 10, 10])))
 def test_bin_edge(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
-    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+    data = sc.Variable(dims,
+                       unit=in_unit,
+                       dtype=in_dtype,
                        values=np.random.rand(*lengths),
                        variances=np.random.rand(*lengths))
     # makes the first dimension be bin-edges
     lengths[0] += 1
-    edges = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+    edges = sc.Variable(dims,
+                        unit=in_unit,
+                        dtype=in_dtype,
                         values=np.random.rand(*lengths))
 
-    data_array = sc.DataArray(data, coords={dims[0]: edges},
+    data_array = sc.DataArray(data,
+                              coords={dims[0]: edges},
                               attrs={ATTR_NAME: data},
                               labels={LABEL_NAME: edges},
                               masks={MASK_NAME: edges})
@@ -138,13 +138,10 @@ def test_bin_edge(dims, lengths):
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(sections,
-                                                ["Dimensions",
-                                                 "Coordinates",
-                                                 "Labels",
-                                                 "Data",
-                                                 "Masks",
-                                                 "Attributes"]):
+    for actual_section, expected_section in zip(
+            sections,
+        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+         ]):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)
@@ -156,24 +153,23 @@ def test_bin_edge(dims, lengths):
     dim_section = sections.pop(0)
     assert_dims_section(data, dim_section)
 
-    data_names = [
-        dims[0],
-        LABEL_NAME,
-        MASK_NAME]
+    data_names = [dims[0], LABEL_NAME, MASK_NAME]
 
     for section, name in zip(sections, data_names):
-        assert_section(section, name, dims, in_dtype,
-                       in_unit, has_bin_edges=True)
+        assert_section(section,
+                       name,
+                       dims,
+                       in_dtype,
+                       in_unit,
+                       has_bin_edges=True)
 
 
-@pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X, Dim.Y], [10, sc.Dimensions.Sparse]),
-                          ([Dim.X, Dim.Y, Dim.Z],
-                           [10, 10, sc.Dimensions.Sparse]),
-                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                             [10, 10, 10, sc.Dimensions.Sparse])
-                          )
-                         )
+@pytest.mark.parametrize(
+    "dims, lengths",
+    (([Dim.X, Dim.Y], [10, sc.Dimensions.Sparse]),
+     ([Dim.X, Dim.Y, Dim.Z], [10, 10, sc.Dimensions.Sparse]),
+     ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum], [10, 10, 10, sc.Dimensions.Sparse]))
+)
 def test_bin_edge_and_sparse(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
@@ -182,35 +178,35 @@ def test_bin_edge_and_sparse(dims, lengths):
 
     # attribute data without the sparse dimension
     non_sparse_dims = dims[:-1]
-    non_sparse_data = sc.Variable(
-        non_sparse_dims, lengths[:-1], unit=in_unit, dtype=in_dtype)
+    non_sparse_data = sc.Variable(non_sparse_dims,
+                                  lengths[:-1],
+                                  unit=in_unit,
+                                  dtype=in_dtype)
 
     # makes the first dimension be bin-edges
     lengths[0] += 1
-    non_sparse_bin_edges = sc.Variable(
-        non_sparse_dims, lengths[:-1], unit=in_unit, dtype=in_dtype)
+    non_sparse_bin_edges = sc.Variable(non_sparse_dims,
+                                       lengths[:-1],
+                                       unit=in_unit,
+                                       dtype=in_dtype)
 
-    data_array = sc.DataArray(
-        data, coords={dims[0]: non_sparse_bin_edges},
-        attrs={ATTR_NAME: non_sparse_data},
-        labels={LABEL_NAME: non_sparse_bin_edges},
-        masks={MASK_NAME: non_sparse_bin_edges})
+    data_array = sc.DataArray(data,
+                              coords={dims[0]: non_sparse_bin_edges},
+                              attrs={ATTR_NAME: non_sparse_data},
+                              labels={LABEL_NAME: non_sparse_bin_edges},
+                              masks={MASK_NAME: non_sparse_bin_edges})
 
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(sections,
-                                                ["Dimensions",
-                                                 "Coordinates",
-                                                 "Labels",
-                                                 "Data",
-                                                 "Masks",
-                                                 "Attributes"]):
+    for actual_section, expected_section in zip(
+            sections,
+        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+         ]):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)
-    assert_section(attr_section, ATTR_NAME,
-                   non_sparse_dims, in_dtype, in_unit)
+    assert_section(attr_section, ATTR_NAME, non_sparse_dims, in_dtype, in_unit)
 
     data_section = sections.pop(3)
     assert_section(data_section, "", dims, in_dtype, in_unit, has_sparse=True)
@@ -218,11 +214,12 @@ def test_bin_edge_and_sparse(dims, lengths):
     dim_section = sections.pop(0)
     assert_dims_section(data, dim_section)
 
-    data_names = [
-        dims[0],
-        LABEL_NAME,
-        MASK_NAME]
+    data_names = [dims[0], LABEL_NAME, MASK_NAME]
 
     for section, name in zip(sections, data_names):
-        assert_section(section, name, non_sparse_dims, in_dtype,
-                       in_unit, has_bin_edges=True)
+        assert_section(section,
+                       name,
+                       non_sparse_dims,
+                       in_dtype,
+                       in_unit,
+                       has_bin_edges=True)

--- a/python/tests/table_html/test_to_html_dataarray.py
+++ b/python/tests/table_html/test_to_html_dataarray.py
@@ -1,0 +1,228 @@
+import numpy as np
+import pytest
+from bs4 import BeautifulSoup
+
+import scipp as sc
+from scipp import Dim
+from scipp.table_html import make_html
+
+from .common import (ATTR_NAME, LABEL_NAME, MASK_NAME, assert_dims_section,
+                     assert_section)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], (10,)),
+                          ([Dim.X, Dim.Y], (10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z], (10, 10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, 10)))
+                         )
+def test_basic(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+                       values=np.random.rand(*lengths),
+                       variances=np.random.rand(*lengths))
+
+    data_array = sc.DataArray(data, coords={dims[0]: data},
+                              attrs={ATTR_NAME: data},
+                              labels={LABEL_NAME: data},
+                              masks={MASK_NAME: data})
+
+    html = BeautifulSoup(make_html(data_array), features="html.parser")
+    sections = html.find_all(class_="xr-section-item")
+    assert len(sections) == 6
+    for actual_section, expected_section in zip(sections,
+                                                ["Dimensions",
+                                                 "Coordinates",
+                                                 "Labels",
+                                                 "Data",
+                                                 "Masks",
+                                                 "Attributes"]):
+        assert expected_section in actual_section.text
+
+    dim_section = sections.pop(0)
+    assert_dims_section(data, dim_section)
+
+    data_names = [
+        dims[0],
+        LABEL_NAME,
+        "",  # dataarray does not have a data name
+        MASK_NAME,
+        ATTR_NAME]
+    assert len(sections) == len(
+        data_names), "Sections and expected data names do not match"
+    for section, name in zip(sections, data_names):
+        assert_section(section, name, dims, in_dtype, in_unit)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                             ([Dim.X, Dim.Y, Dim.Z],
+                              (10, 10, sc.Dimensions.Sparse)),
+                             ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                              (10, 10, 10, sc.Dimensions.Sparse)))
+                         )
+def test_sparse(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+
+    data = sc.Variable(dims, lengths, unit=in_unit, dtype=in_dtype)
+
+    in_attr_dims = [dims[0]]
+    attr = sc.Variable(in_attr_dims, unit=in_unit, dtype=in_dtype,
+                       values=np.random.rand(lengths[0]))
+
+    data_array = sc.DataArray(data,
+                              coords={dims[0]: data},
+                              attrs={ATTR_NAME: attr},
+                              labels={LABEL_NAME: attr},
+                              masks={MASK_NAME: attr})
+    html = BeautifulSoup(make_html(data_array), features="html.parser")
+    sections = html.find_all(class_="xr-section-item")
+
+    assert len(sections) == 6
+    for actual_section, expected_section in zip(sections,
+                                                ["Dimensions",
+                                                 "Coordinates",
+                                                 "Labels",
+                                                 "Data",
+                                                 "Masks",
+                                                 "Attributes"]):
+        assert expected_section in actual_section.text
+
+    data_section = sections.pop(3)
+    assert_section(data_section, "", dims, in_dtype, in_unit, has_sparse=True)
+
+    dim_section = sections.pop(0)
+    assert_dims_section(data, dim_section)
+
+    coord_section = sections.pop(0)
+    # the original dim used as a label (dim[0]) is not shown,
+    # instead the sparse dim is shown
+    assert_section(coord_section, dims[-1],
+                   dims, in_dtype, in_unit, has_sparse=True)
+
+    data_names = [
+        LABEL_NAME,
+        MASK_NAME,
+        ATTR_NAME]
+
+    for section, name in zip(sections, data_names):
+        assert_section(section, name, in_attr_dims, in_dtype, in_unit)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], [10]),
+                          ([Dim.X, Dim.Y], [10, 10]),
+                          ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           [10, 10, 10, 10]))
+                         )
+def test_bin_edge(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+                       values=np.random.rand(*lengths),
+                       variances=np.random.rand(*lengths))
+    # makes the first dimension be bin-edges
+    lengths[0] += 1
+    edges = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+                        values=np.random.rand(*lengths))
+
+    data_array = sc.DataArray(data, coords={dims[0]: edges},
+                              attrs={ATTR_NAME: data},
+                              labels={LABEL_NAME: edges},
+                              masks={MASK_NAME: edges})
+
+    html = BeautifulSoup(make_html(data_array), features="html.parser")
+    sections = html.find_all(class_="xr-section-item")
+    assert len(sections) == 6
+    for actual_section, expected_section in zip(sections,
+                                                ["Dimensions",
+                                                 "Coordinates",
+                                                 "Labels",
+                                                 "Data",
+                                                 "Masks",
+                                                 "Attributes"]):
+        assert expected_section in actual_section.text
+
+    attr_section = sections.pop(len(sections) - 1)
+    assert_section(attr_section, ATTR_NAME, dims, in_dtype, in_unit)
+
+    data_section = sections.pop(3)
+    assert_section(data_section, "", dims, in_dtype, in_unit)
+
+    dim_section = sections.pop(0)
+    assert_dims_section(data, dim_section)
+
+    data_names = [
+        dims[0],
+        LABEL_NAME,
+        MASK_NAME]
+
+    for section, name in zip(sections, data_names):
+        assert_section(section, name, dims, in_dtype,
+                       in_unit, has_bin_edges=True)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X, Dim.Y], [10, sc.Dimensions.Sparse]),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           [10, 10, sc.Dimensions.Sparse]),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                             [10, 10, 10, sc.Dimensions.Sparse])
+                          )
+                         )
+def test_bin_edge_and_sparse(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+
+    data = sc.Variable(dims, lengths, unit=in_unit, dtype=in_dtype)
+
+    # attribute data without the sparse dimension
+    non_sparse_dims = dims[:-1]
+    non_sparse_data = sc.Variable(
+        non_sparse_dims, lengths[:-1], unit=in_unit, dtype=in_dtype)
+
+    # makes the first dimension be bin-edges
+    lengths[0] += 1
+    non_sparse_bin_edges = sc.Variable(
+        non_sparse_dims, lengths[:-1], unit=in_unit, dtype=in_dtype)
+
+    data_array = sc.DataArray(
+        data, coords={dims[0]: non_sparse_bin_edges},
+        attrs={ATTR_NAME: non_sparse_data},
+        labels={LABEL_NAME: non_sparse_bin_edges},
+        masks={MASK_NAME: non_sparse_bin_edges})
+
+    html = BeautifulSoup(make_html(data_array), features="html.parser")
+    sections = html.find_all(class_="xr-section-item")
+    assert len(sections) == 6
+    for actual_section, expected_section in zip(sections,
+                                                ["Dimensions",
+                                                 "Coordinates",
+                                                 "Labels",
+                                                 "Data",
+                                                 "Masks",
+                                                 "Attributes"]):
+        assert expected_section in actual_section.text
+
+    attr_section = sections.pop(len(sections) - 1)
+    assert_section(attr_section, ATTR_NAME,
+                   non_sparse_dims, in_dtype, in_unit)
+
+    data_section = sections.pop(3)
+    assert_section(data_section, "", dims, in_dtype, in_unit, has_sparse=True)
+
+    dim_section = sections.pop(0)
+    assert_dims_section(data, dim_section)
+
+    data_names = [
+        dims[0],
+        LABEL_NAME,
+        MASK_NAME]
+
+    for section, name in zip(sections, data_names):
+        assert_section(section, name, non_sparse_dims, in_dtype,
+                       in_unit, has_bin_edges=True)

--- a/python/tests/table_html/test_to_html_dataarray.py
+++ b/python/tests/table_html/test_to_html_dataarray.py
@@ -33,10 +33,10 @@ def test_basic(dims, lengths):
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(
-            sections,
-        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
-         ]):
+    expected_sections = [
+        "Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+    ]
+    for actual_section, expected_section in zip(sections, expected_sections):
         assert expected_section in actual_section.text
 
     dim_section = sections.pop(0)
@@ -82,10 +82,10 @@ def test_sparse(dims, lengths):
     sections = html.find_all(class_="xr-section-item")
 
     assert len(sections) == 6
-    for actual_section, expected_section in zip(
-            sections,
-        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
-         ]):
+    expected_sections = [
+        "Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+    ]
+    for actual_section, expected_section in zip(sections, expected_sections):
         assert expected_section in actual_section.text
 
     data_section = sections.pop(3)
@@ -138,10 +138,10 @@ def test_bin_edge(dims, lengths):
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(
-            sections,
-        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
-         ]):
+    expected_sections = [
+        "Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+    ]
+    for actual_section, expected_section in zip(sections, expected_sections):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)
@@ -198,11 +198,12 @@ def test_bin_edge_and_sparse(dims, lengths):
 
     html = BeautifulSoup(make_html(data_array), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
+
+    expected_sections = [
+        "Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+    ]
     assert len(sections) == 6
-    for actual_section, expected_section in zip(
-            sections,
-        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
-         ]):
+    for actual_section, expected_section in zip(sections, expected_sections):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)

--- a/python/tests/table_html/test_to_html_dataset.py
+++ b/python/tests/table_html/test_to_html_dataset.py
@@ -43,11 +43,12 @@ def test_basic(dims, lengths):
 
     html = BeautifulSoup(make_html(dataset), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
+
+    expected_sections = [
+        "Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+    ]
     assert len(sections) == 6
-    for actual_section, expected_section in zip(
-            sections,
-        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
-         ]):
+    for actual_section, expected_section in zip(sections, expected_sections):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)

--- a/python/tests/table_html/test_to_html_dataset.py
+++ b/python/tests/table_html/test_to_html_dataset.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pytest
+from bs4 import BeautifulSoup
+
+import scipp as sc
+from scipp import Dim
+from scipp.table_html import make_html
+
+from .common import (ATTR_NAME, LABEL_NAME, MASK_NAME, assert_dims_section,
+                     assert_section)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], [10]),
+                          ([Dim.X, Dim.Y], [10, 10]),
+                          ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           [10, 10, 10, 10]))
+                         )
+def test_basic(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+                       values=np.random.rand(*lengths),
+                       variances=np.random.rand(*lengths))
+    data_name = "testdata"
+    bin_edge_data_name = "testdata-binedges"
+    lengths[0] += 1
+    bin_edges = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+                            values=np.random.rand(*lengths),
+                            variances=np.random.rand(*lengths))
+    dataset = sc.Dataset({
+        data_name: data,
+        bin_edge_data_name: bin_edges
+    }, coords={
+        dims[0]: bin_edges,
+    },
+        attrs={"attr": data},
+        labels={"label": bin_edges},
+        masks={"mask": bin_edges})
+
+    html = BeautifulSoup(make_html(dataset), features="html.parser")
+    sections = html.find_all(class_="xr-section-item")
+    assert len(sections) == 6
+    for actual_section, expected_section in zip(sections,
+                                                ["Dimensions",
+                                                 "Coordinates",
+                                                 "Labels",
+                                                 "Data",
+                                                 "Masks",
+                                                 "Attributes"]):
+        assert expected_section in actual_section.text
+
+    attr_section = sections.pop(len(sections) - 1)
+    assert_section(attr_section, ATTR_NAME,
+                   dims, in_dtype, in_unit)
+
+    data_section = sections.pop(3)
+    assert_section(data_section,
+                   [data_name, bin_edge_data_name],
+                   dims, in_dtype, in_unit, has_bin_edges=[True, False])
+
+    dim_section = sections.pop(0)
+    assert_dims_section(data, dim_section)
+
+    data_names = [
+        dims[0],
+        LABEL_NAME,
+        MASK_NAME]
+
+    for section, name in zip(sections, data_names):
+        assert_section(section, name, dims, in_dtype,
+                       in_unit, has_bin_edges=True)
+
+
+def test_sparse_does_not_repeat_dense_coords():
+    sparse = sc.Variable([Dim.Y, Dim.Z], shape=(3, sc.Dimensions.Sparse))
+
+    sparse.values[0].extend(np.arange(0))
+    sparse.values[2].extend(np.arange(0))
+    sparse.values[1].extend(np.arange(0))
+
+    d = sc.Dataset()
+    d['a'] = sc.Variable([Dim.Y, Dim.X, Dim.Z],
+                         shape=(3, 2, 4), variances=True)
+    d['b'] = sc.DataArray(sparse, coords={
+        Dim.Y: sc.Variable([Dim.Y], values=np.arange(4)),
+        Dim.Z: sc.Variable([Dim.Z], shape=(sc.Dimensions.Sparse,)),
+    }, labels={
+        "binedge": sc.Variable([Dim.Y], values=np.random.rand(4))},
+        attrs={
+        "attr": sc.Variable([Dim.Y], values=np.random.rand(3))
+    })
+
+    html = BeautifulSoup(make_html(d), features="html.parser")
+    sections = html.find_all(class_="xr-section-summary")
+    assert ["Coordinates" in section.text for section in sections].count(
+        True) == 2
+
+    attr_section = next(
+        section for section in sections if "Attributes" in section.text)
+
+    # check that this section is a subsection
+    assert "sc-subsection" in attr_section.parent.attrs["class"]
+
+    variables = html.find_all(class_="xr-var-name")
+
+    # check that each dim is only present once
+    assert ["Dim.Z" in var.text for var in variables].count(True) == 1
+    assert ["Dim.Y" in var.text for var in variables].count(True) == 1

--- a/python/tests/table_html/test_to_html_dataset.py
+++ b/python/tests/table_html/test_to_html_dataset.py
@@ -10,67 +10,68 @@ from .common import (ATTR_NAME, LABEL_NAME, MASK_NAME, assert_dims_section,
                      assert_section)
 
 
-@pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], [10]),
-                          ([Dim.X, Dim.Y], [10, 10]),
-                          ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
-                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           [10, 10, 10, 10]))
-                         )
+@pytest.mark.parametrize(
+    "dims, lengths", (([Dim.X], [10]), ([Dim.X, Dim.Y], [10, 10]),
+                      ([Dim.X, Dim.Y, Dim.Z], [10, 10, 10]),
+                      ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum], [10, 10, 10, 10])))
 def test_basic(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
-    data = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+    data = sc.Variable(dims,
+                       unit=in_unit,
+                       dtype=in_dtype,
                        values=np.random.rand(*lengths),
                        variances=np.random.rand(*lengths))
     data_name = "testdata"
     bin_edge_data_name = "testdata-binedges"
     lengths[0] += 1
-    bin_edges = sc.Variable(dims, unit=in_unit, dtype=in_dtype,
+    bin_edges = sc.Variable(dims,
+                            unit=in_unit,
+                            dtype=in_dtype,
                             values=np.random.rand(*lengths),
                             variances=np.random.rand(*lengths))
     dataset = sc.Dataset({
         data_name: data,
         bin_edge_data_name: bin_edges
-    }, coords={
-        dims[0]: bin_edges,
     },
-        attrs={"attr": data},
-        labels={"label": bin_edges},
-        masks={"mask": bin_edges})
+                         coords={
+                             dims[0]: bin_edges,
+                         },
+                         attrs={"attr": data},
+                         labels={"label": bin_edges},
+                         masks={"mask": bin_edges})
 
     html = BeautifulSoup(make_html(dataset), features="html.parser")
     sections = html.find_all(class_="xr-section-item")
     assert len(sections) == 6
-    for actual_section, expected_section in zip(sections,
-                                                ["Dimensions",
-                                                 "Coordinates",
-                                                 "Labels",
-                                                 "Data",
-                                                 "Masks",
-                                                 "Attributes"]):
+    for actual_section, expected_section in zip(
+            sections,
+        ["Dimensions", "Coordinates", "Labels", "Data", "Masks", "Attributes"
+         ]):
         assert expected_section in actual_section.text
 
     attr_section = sections.pop(len(sections) - 1)
-    assert_section(attr_section, ATTR_NAME,
-                   dims, in_dtype, in_unit)
+    assert_section(attr_section, ATTR_NAME, dims, in_dtype, in_unit)
 
     data_section = sections.pop(3)
-    assert_section(data_section,
-                   [data_name, bin_edge_data_name],
-                   dims, in_dtype, in_unit, has_bin_edges=[True, False])
+    assert_section(data_section, [data_name, bin_edge_data_name],
+                   dims,
+                   in_dtype,
+                   in_unit,
+                   has_bin_edges=[True, False])
 
     dim_section = sections.pop(0)
     assert_dims_section(data, dim_section)
 
-    data_names = [
-        dims[0],
-        LABEL_NAME,
-        MASK_NAME]
+    data_names = [dims[0], LABEL_NAME, MASK_NAME]
 
     for section, name in zip(sections, data_names):
-        assert_section(section, name, dims, in_dtype,
-                       in_unit, has_bin_edges=True)
+        assert_section(section,
+                       name,
+                       dims,
+                       in_dtype,
+                       in_unit,
+                       has_bin_edges=True)
 
 
 def test_sparse_does_not_repeat_dense_coords():
@@ -82,23 +83,24 @@ def test_sparse_does_not_repeat_dense_coords():
 
     d = sc.Dataset()
     d['a'] = sc.Variable([Dim.Y, Dim.X, Dim.Z],
-                         shape=(3, 2, 4), variances=True)
-    d['b'] = sc.DataArray(sparse, coords={
-        Dim.Y: sc.Variable([Dim.Y], values=np.arange(4)),
-        Dim.Z: sc.Variable([Dim.Z], shape=(sc.Dimensions.Sparse,)),
-    }, labels={
-        "binedge": sc.Variable([Dim.Y], values=np.random.rand(4))},
-        attrs={
-        "attr": sc.Variable([Dim.Y], values=np.random.rand(3))
-    })
+                         shape=(3, 2, 4),
+                         variances=True)
+    d['b'] = sc.DataArray(
+        sparse,
+        coords={
+            Dim.Y: sc.Variable([Dim.Y], values=np.arange(4)),
+            Dim.Z: sc.Variable([Dim.Z], shape=(sc.Dimensions.Sparse, )),
+        },
+        labels={"binedge": sc.Variable([Dim.Y], values=np.random.rand(4))},
+        attrs={"attr": sc.Variable([Dim.Y], values=np.random.rand(3))})
 
     html = BeautifulSoup(make_html(d), features="html.parser")
     sections = html.find_all(class_="xr-section-summary")
-    assert ["Coordinates" in section.text for section in sections].count(
-        True) == 2
+    assert ["Coordinates" in section.text
+            for section in sections].count(True) == 2
 
-    attr_section = next(
-        section for section in sections if "Attributes" in section.text)
+    attr_section = next(section for section in sections
+                        if "Attributes" in section.text)
 
     # check that this section is a subsection
     assert "sc-subsection" in attr_section.parent.attrs["class"]

--- a/python/tests/table_html/test_to_html_variable.py
+++ b/python/tests/table_html/test_to_html_variable.py
@@ -1,0 +1,135 @@
+
+import numpy as np
+import pytest
+from bs4 import BeautifulSoup
+
+import scipp as sc
+from scipp import Dim
+from scipp.table_html import make_html
+from scipp.table_html.formatting_html import VARIANCE_PREFIX
+
+from .common import (UNIT_CSS_CLASS, VALUE_CSS_CLASS, VAR_NAME_CSS_CLASS,
+                     assert_common, assert_dims, assert_lengths, assert_unit)
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], (10,)),
+                          ([Dim.X, Dim.Y], (10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z], (10, 10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, 10)))
+                         )
+def test_basic(dims, lengths):
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+
+    var = sc.Variable(
+        dims, unit=in_unit, dtype=in_dtype,
+        values=np.random.rand(*lengths),
+        variances=np.random.rand(*lengths))
+
+    html = BeautifulSoup(make_html(var), features="html.parser")
+
+    # Variable's "name" actually contains Dims and their extents
+    name = html.find_all(class_=VAR_NAME_CSS_CLASS)
+    assert len(name) == 1
+    assert_dims(dims, name[0].text)
+    assert_lengths(lengths, name[0].text)
+    assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
+
+    value = html.find_all(class_=VALUE_CSS_CLASS)
+    assert len(value) == 1
+
+    values, variances = [child.text for child in value[0].children]
+    assert "..." in values
+    assert VARIANCE_PREFIX in variances
+
+
+def test_data_not_elided():
+    dims = [Dim.X]
+    lengths = (3,)
+    in_unit = sc.units.m
+    in_dtype = sc.dtype.float32
+
+    var = sc.Variable(
+        dims, unit=in_unit, values=np.random.rand(*lengths), dtype=in_dtype)
+
+    html = BeautifulSoup(make_html(var), features="html.parser")
+    assert_common(html, in_dtype)
+
+    name = html.find_all(class_=VAR_NAME_CSS_CLASS)
+    assert len(name) == 1
+    assert_dims(dims, name[0].text)
+    assert_lengths(lengths, name[0].text)
+    assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
+
+    value = html.find_all(class_=VALUE_CSS_CLASS)
+    assert len(value) == 1
+    assert "..." not in value[0].text
+
+
+def test_empty_sparse_1d_variable():
+    in_dtype = sc.dtype.float32
+    in_unit = sc.units.K
+    var = sc.Variable([Dim.X], [sc.Dimensions.Sparse],
+                      unit=in_unit, dtype=in_dtype)
+
+    html = BeautifulSoup(make_html(var), features="html.parser")
+    assert_common(html, in_dtype)
+    name = html.find_all(class_=VAR_NAME_CSS_CLASS)
+    assert len(name) == 1
+    assert_dims([Dim.X], name[0].text, has_sparse=True)
+    assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
+
+    value = html.find_all(class_=VALUE_CSS_CLASS)
+    assert len(value) == 1
+
+
+def test_sparse_1d_variable():
+    in_dtype = sc.dtype.float32
+    in_unit = sc.units.deg
+    var = sc.Variable([Dim.X], [sc.Dimensions.Sparse],
+                      unit=in_unit, dtype=in_dtype)
+
+    length = 10
+    var.values.extend(np.arange(length))
+
+    html = BeautifulSoup(make_html(var), features="html.parser")
+    assert_common(html, in_dtype)
+
+    name = html.find_all(class_=VAR_NAME_CSS_CLASS)
+    assert len(name) == 1
+    assert_dims([Dim.X], name[0].text, has_sparse=True)
+    assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
+
+    value = html.find_all(class_=VALUE_CSS_CLASS)
+    assert len(value) == 1
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (
+                             ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                             ([Dim.X, Dim.Y, Dim.Z],
+                              (10, 10, sc.Dimensions.Sparse)),
+                             ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                                 (10, 10, 10, sc.Dimensions.Sparse)))
+                         )
+def test_sparse(dims, lengths):
+    in_dtype = sc.dtype.float32
+    in_unit = sc.units.deg
+
+    var = sc.Variable(dims, lengths, unit=in_unit, dtype=in_dtype)
+    length = 10
+    var.values[0].extend(np.arange(length))
+
+    html = BeautifulSoup(make_html(var), features="html.parser")
+    assert_common(html, in_dtype)
+
+    name = html.find_all(class_=VAR_NAME_CSS_CLASS)
+    assert len(name) == 1
+    assert_dims(dims, name[0].text, has_sparse=True)
+    assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
+
+    value = html.find_all(class_=VALUE_CSS_CLASS)
+    assert len(value) == 1
+    assert f"len={length}" in value[0].text

--- a/python/tests/table_html/test_to_html_variable.py
+++ b/python/tests/table_html/test_to_html_variable.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 from bs4 import BeautifulSoup
@@ -13,20 +12,19 @@ from .common import (UNIT_CSS_CLASS, VALUE_CSS_CLASS, VAR_NAME_CSS_CLASS,
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], (10,)),
-                          ([Dim.X, Dim.Y], (10, 10)),
-                          ([Dim.X, Dim.Y, Dim.Z], (10, 10, 10)),
-                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           (10, 10, 10, 10)))
-                         )
+                         (([Dim.X], (10, )), ([Dim.X, Dim.Y], (10, 10)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, 10)), ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                                           (10, 10, 10, 10))))
 def test_basic(dims, lengths):
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
 
-    var = sc.Variable(
-        dims, unit=in_unit, dtype=in_dtype,
-        values=np.random.rand(*lengths),
-        variances=np.random.rand(*lengths))
+    var = sc.Variable(dims,
+                      unit=in_unit,
+                      dtype=in_dtype,
+                      values=np.random.rand(*lengths),
+                      variances=np.random.rand(*lengths))
 
     html = BeautifulSoup(make_html(var), features="html.parser")
 
@@ -47,12 +45,14 @@ def test_basic(dims, lengths):
 
 def test_data_not_elided():
     dims = [Dim.X]
-    lengths = (3,)
+    lengths = (3, )
     in_unit = sc.units.m
     in_dtype = sc.dtype.float32
 
-    var = sc.Variable(
-        dims, unit=in_unit, values=np.random.rand(*lengths), dtype=in_dtype)
+    var = sc.Variable(dims,
+                      unit=in_unit,
+                      values=np.random.rand(*lengths),
+                      dtype=in_dtype)
 
     html = BeautifulSoup(make_html(var), features="html.parser")
     assert_common(html, in_dtype)
@@ -72,7 +72,8 @@ def test_empty_sparse_1d_variable():
     in_dtype = sc.dtype.float32
     in_unit = sc.units.K
     var = sc.Variable([Dim.X], [sc.Dimensions.Sparse],
-                      unit=in_unit, dtype=in_dtype)
+                      unit=in_unit,
+                      dtype=in_dtype)
 
     html = BeautifulSoup(make_html(var), features="html.parser")
     assert_common(html, in_dtype)
@@ -89,7 +90,8 @@ def test_sparse_1d_variable():
     in_dtype = sc.dtype.float32
     in_unit = sc.units.deg
     var = sc.Variable([Dim.X], [sc.Dimensions.Sparse],
-                      unit=in_unit, dtype=in_dtype)
+                      unit=in_unit,
+                      dtype=in_dtype)
 
     length = 10
     var.values.extend(np.arange(length))
@@ -110,13 +112,11 @@ def test_sparse_1d_variable():
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (
-                             ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
-                             ([Dim.X, Dim.Y, Dim.Z],
-                              (10, 10, sc.Dimensions.Sparse)),
-                             ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                                 (10, 10, 10, sc.Dimensions.Sparse)))
-                         )
+                         (([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, sc.Dimensions.Sparse))))
 def test_sparse(dims, lengths):
     in_dtype = sc.dtype.float32
     in_unit = sc.units.deg

--- a/python/tests/table_html/test_to_html_variable.py
+++ b/python/tests/table_html/test_to_html_variable.py
@@ -100,6 +100,9 @@ def test_sparse_1d_variable():
     name = html.find_all(class_=VAR_NAME_CSS_CLASS)
     assert len(name) == 1
     assert_dims([Dim.X], name[0].text, has_sparse=True)
+    # This checks if the 'size' of the Sparse dim is being added
+    # which would add a useless 'None'
+    assert "None" not in name[0].text
     assert_unit(in_unit, html.find_all(class_=UNIT_CSS_CLASS))
 
     value = html.find_all(class_=VALUE_CSS_CLASS)

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -78,13 +78,12 @@ def test_setitem_works_for_view_and_array():
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                         (([Dim.X], (sc.Dimensions.Sparse, )),
                           ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z],
                            (10, 10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           (10, 10, 10, sc.Dimensions.Sparse)))
-                         )
+                           (10, 10, 10, sc.Dimensions.Sparse))))
 def test_sparse_dim_has_none_shape(dims, lengths):
     da = sc.DataArray(sc.Variable(dims, shape=lengths))
 

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import numpy as np
+import pytest
+
 import scipp as sc
 from scipp import Dim
 
@@ -73,3 +75,17 @@ def test_setitem_works_for_view_and_array():
     a = make_dataarray(Dim.X, Dim.Y, seed=0)
     a[Dim.X, :][Dim.X, 0] = a[Dim.X, 1]
     a[Dim.X, 0] = a[Dim.X, 1]
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                          ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, sc.Dimensions.Sparse)))
+                         )
+def test_sparse_dim_has_none_shape(dims, lengths):
+    da = sc.DataArray(sc.Variable(dims, shape=lengths))
+
+    assert da.shape[-1] is None

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
+import numpy as np
 import pytest
 
-import numpy as np
 import scipp as sc
 from scipp import Dim
 
@@ -752,6 +752,23 @@ def test_masks_delitem():
     assert d != dref
     del d.masks['masks']
     assert d == dref
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                          ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, sc.Dimensions.Sparse)))
+                         )
+def test_sparse_dim_has_none_shape(dims, lengths):
+    ds = sc.Dataset(data={
+        "data": sc.Variable(dims, shape=lengths)
+    })
+
+    assert None in ds.shape
+    assert ds["data"].shape[-1] is None
 
 
 # def test_delitem(self):

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -755,17 +755,14 @@ def test_masks_delitem():
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                         (([Dim.X], (sc.Dimensions.Sparse, )),
                           ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z],
                            (10, 10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           (10, 10, 10, sc.Dimensions.Sparse)))
-                         )
+                           (10, 10, 10, sc.Dimensions.Sparse))))
 def test_sparse_dim_has_none_shape(dims, lengths):
-    ds = sc.Dataset(data={
-        "data": sc.Variable(dims, shape=lengths)
-    })
+    ds = sc.Dataset(data={"data": sc.Variable(dims, shape=lengths)})
 
     assert None in ds.shape
     assert ds["data"].shape[-1] is None

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -992,13 +992,12 @@ def test_atan_out():
 
 
 @pytest.mark.parametrize("dims, lengths",
-                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                         (([Dim.X], (sc.Dimensions.Sparse, )),
                           ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z],
                            (10, 10, sc.Dimensions.Sparse)),
                           ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
-                           (10, 10, 10, sc.Dimensions.Sparse)))
-                         )
+                           (10, 10, 10, sc.Dimensions.Sparse))))
 def test_sparse_dim_has_none_shape(dims, lengths):
     data = sc.Variable(dims, shape=lengths)
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -2,12 +2,13 @@
 # Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
+import math
+
+import numpy as np
 import pytest
 
-import math
 import scipp as sc
 from scipp import Dim
-import numpy as np
 
 
 def make_variables():
@@ -988,3 +989,17 @@ def test_atan_out():
     out = sc.atan(x=var, out=var)
     assert var == expected
     assert out == expected
+
+
+@pytest.mark.parametrize("dims, lengths",
+                         (([Dim.X], (sc.Dimensions.Sparse,)),
+                          ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z],
+                           (10, 10, sc.Dimensions.Sparse)),
+                          ([Dim.X, Dim.Y, Dim.Z, Dim.Spectrum],
+                           (10, 10, 10, sc.Dimensions.Sparse)))
+                         )
+def test_sparse_dim_has_none_shape(dims, lengths):
+    data = sc.Variable(dims, shape=lengths)
+
+    assert data.shape[-1] is None

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -993,7 +993,6 @@ def test_atan_out():
     assert out == expected
 
 
-
 @pytest.mark.parametrize("dims, lengths",
                          (([Dim.X], (sc.Dimensions.Sparse, )),
                           ([Dim.X, Dim.Y], (10, sc.Dimensions.Sparse)),
@@ -1005,6 +1004,7 @@ def test_sparse_dim_has_none_shape(dims, lengths):
     data = sc.Variable(dims, shape=lengths)
 
     assert data.shape[-1] is None
+
 
 def test_variable_data_array_binary_ops():
     a = sc.DataArray(1.0 * sc.units.m)


### PR DESCRIPTION
Adds tests for _repr_html_. It uses BeautifulSoup for parsing the generated HTML so that the output can be tested.

The tests aren't overly sensitive, they mostly check if things are present, but don't necessarily check the full layout.

Makes `.shape` return a ~~Dimension::Sparse~~ `None` value in the position of the shape where the Dimension is sparse. This fixes a workaround for finding where to add the `: Sparse` label.
```
sparse = sc.Variable([Dim.Y, Dim.Z], shape=(3, sc.Dimensions.Sparse))

sparse.dims
[Dim.Y, Dim.Z]

sparse.shape
[3, None]
```