### PR TITLE
Detector IDs to Int32

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -55,7 +55,6 @@ def make_detector_info(ws):
     spec_info = ws.spectrumInfo()
     for i, spec in enumerate(spec_info):
         spec_def = spec.spectrumDefinition
-        # This assumes that each detector is part of exactly one spectrum
         for j in range(len(spec_def)):
             det, time = spec_def[j]
             if time != 0:
@@ -64,7 +63,7 @@ def make_detector_info(ws):
                     "not supported yet.")
             spectrum_[det] = i
             has_spectrum_[det] = True
-    detector = sc.Variable([sc.Dim.Detector], values=det_info.detectorIDs())
+    detector = sc.Variable([sc.Dim.Detector], values=det_info.detectorIDs().astype(np.int32))
 
     # Remove any information about detectors without data (a spectrum). This
     # mostly just gets in the way and including it in the default converter

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -63,7 +63,8 @@ def make_detector_info(ws):
                     "not supported yet.")
             spectrum_[det] = i
             has_spectrum_[det] = True
-    detector = sc.Variable([sc.Dim.Detector], values=det_info.detectorIDs().astype(np.int32))
+    detector = sc.Variable([sc.Dim.Detector],
+                           values=det_info.detectorIDs().astype(np.int32))
 
     # Remove any information about detectors without data (a spectrum). This
     # mostly just gets in the way and including it in the default converter

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -64,7 +64,7 @@ def make_detector_info(ws):
             spectrum_[det] = i
             has_spectrum_[det] = True
     detector = sc.Variable([sc.Dim.Detector],
-                           values=det_info.detectorIDs().astype(np.int32))
+                           values=det_info.detectorIDs())
 
     # Remove any information about detectors without data (a spectrum). This
     # mostly just gets in the way and including it in the default converter

--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -64,7 +64,7 @@ def load_calibration(filename, mantid_LoadDiffCal_args={}):
     group_map = {}  # dict from detectorID to group number
     spectrum_info = group_ws.spectrumInfo()
     detector_info = group_ws.detectorInfo()
-    det_ids = detector_info.detectorIDs().astype(np.int32)
+    det_ids = detector_info.detectorIDs()
     for i, spec in enumerate(spectrum_info):
         spec_def = spec.spectrumDefinition
         # We take the first detector in the definition, because that's
@@ -83,7 +83,7 @@ def load_calibration(filename, mantid_LoadDiffCal_args={}):
     cal_data["group"] = sc.Variable([sc.Dim.Row], values=group_list)
 
     cal_data.rename_dims({sc.Dim.Row: sc.Dim.Detector})
-    cal_data.coords[sc.Dim.Detector] = cal_data['detid'].data
+    cal_data.coords[sc.Dim.Detector] = sc.Variable([sc.Dim.Detector], values=cal_data['detid'].values.astype(np.int32))
     del cal_data['detid']
 
     # Delete generated mantid workspaces

--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -83,7 +83,8 @@ def load_calibration(filename, mantid_LoadDiffCal_args={}):
     cal_data["group"] = sc.Variable([sc.Dim.Row], values=group_list)
 
     cal_data.rename_dims({sc.Dim.Row: sc.Dim.Detector})
-    cal_data.coords[sc.Dim.Detector] = sc.Variable([sc.Dim.Detector], values=cal_data['detid'].values.astype(np.int32))
+    cal_data.coords[sc.Dim.Detector] = sc.Variable(
+        [sc.Dim.Detector], values=cal_data['detid'].values.astype(np.int32))
     del cal_data['detid']
 
     # Delete generated mantid workspaces

--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -63,8 +63,9 @@ def load_calibration(filename, mantid_LoadDiffCal_args={}):
     group_ws = output.OutputGroupingWorkspace
     group_map = {}  # dict from detectorID to group number
     spectrum_info = group_ws.spectrumInfo()
+    detector_info = group_ws.detectorInfo()
     det_ids = detector_info.detectorIDs().astype(np.int32)
-    for spec in spectrum_info:
+    for i, spec in enumerate(spectrum_info):
         spec_def = spec.spectrumDefinition
         # We take the first detector in the definition, because that's
         # what Mantid does via DetectorGroup::getID. Id is first det of group.


### PR DESCRIPTION
Fixes #801 

Script to reproduce
```python
from scipp import *
from mantid.simpleapi import *
from scipp.neutron.diffraction import load_calibration
events = Dataset()
events = neutron.load("PG3_4844_event.nxs", load_pulse_times=False)
input = {"InstrumentName": "PG3"}
cal_file = load_calibration("PG3_FERNS_d4832_2011_08_24.cal", mantid_LoadDiffCal_args=input)
cal_file
neutron.diffraction.convert_with_calibration(events, cal_file)
```

Note with the above the script still produces a MismatchError possibly resulting from an merge in neutron.diffraction.convert_with_calibration due to an incompatible cal file? 

RuntimeError:     <scipp.VariableProxy>     int64      [dimensionless]  (Dim.Detector)  [15000, 15001, ..., 1171076, 1171077] expected to be equal to     <scipp.VariableProxy>     int32      [dimensionless]  (Dim.Detector)  [27500, 27501, ..., 231076, 231077]
