### PR TITLE
Fix monitor attribute information after split.

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -454,7 +454,7 @@ def from_mantid(workspace, **kwargs):
 
         monitors = convert_monitors_ws(monitor_ws, converter, **kwargs)
         for name, monitor in monitors:
-            # Remove some redundant information that is duplicated from workspace
+            # Remove redundant information that is duplicated from workspace
             del monitor.labels['sample_position']
             del monitor.labels['detector_info']
             del monitor.attrs['run']

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -454,14 +454,12 @@ def from_mantid(workspace, **kwargs):
 
         monitors = convert_monitors_ws(monitor_ws, converter, **kwargs)
         for name, monitor in monitors:
+            # Remove some redundant information that is duplicated from workspace
+            del monitor.labels['sample_position']
+            del monitor.labels['detector_info']
+            del monitor.attrs['run']
+            del monitor.attrs['sample']
             dataset.attrs[name] = sc.Variable(value=monitor)
-
-        # Remove some redundant information that is duplicated from workspace
-        mon = dataset.attrs["monitors"].value
-        del mon.labels['sample_position']
-        del mon.labels['detector_info']
-        del mon.attrs['run']
-        del mon.attrs['sample']
     except RuntimeError:
         pass
     return dataset

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -184,9 +184,19 @@ class TestMantidConversion(unittest.TestCase):
             ["monitor2", "monitor3"])
         assert expected_monitor_attrs.issubset(attrs)
         for monitor_name in expected_monitor_attrs:
-            monitors = ds.attrs[monitor_name].values
-            assert isinstance(monitors, sc.DataArray)
-            assert monitors.shape == [200001]
+            monitor = ds.attrs[monitor_name].value
+            assert isinstance(monitor, sc.DataArray)
+            assert monitor.shape == [200001]
+            assert 'position' in monitor.labels
+            assert 'source_position' in monitor.labels
+            # This is essential, otherwise unit conversion assumes scattering
+            # from sample:
+            assert 'sample_position' not in monitor.labels
+            # Absence of the following is not crucial, but currently there is
+            # no need for these, and it avoid duplication:
+            assert 'detector_info' not in monitor.labels
+            assert 'run' not in monitor.attrs
+            assert 'sample' not in monitor.attrs
 
     def test_mdhisto_workspace_q(self):
         from mantid.simpleapi import (CreateMDWorkspace, FakeMDEventData,


### PR DESCRIPTION
Monitors must not contain a sample position, otherwise unit conversion assumes that scattering is happening. Fixes bug introduced as part of #827.

Merging right away since this is broken on `master` and may be relied on, please review nevertheless. I have run the tests locally to confirm that this works now (not that the relevant ones are not part of the Travis CI anyway).