### PR TITLE
Data array unit conversion fix

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -249,6 +249,7 @@ void Dataset::rebuildDims() {
 
 /// Set (insert or replace) the coordinate for the given dimension.
 void Dataset::setCoord(const Dim dim, Variable coord) {
+  expect::notSparse(coord);
   setDims(coord.dims(), dim);
   m_coords.insert_or_assign(dim, std::move(coord));
 }
@@ -257,6 +258,7 @@ void Dataset::setCoord(const Dim dim, Variable coord) {
 ///
 /// Note that the label name has no relation to names of data items.
 void Dataset::setLabels(const std::string &labelName, Variable labels) {
+  expect::notSparse(labels);
   setDims(labels.dims());
   m_labels.insert_or_assign(labelName, std::move(labels));
 }
@@ -265,6 +267,7 @@ void Dataset::setLabels(const std::string &labelName, Variable labels) {
 ///
 /// Note that the attribute name has no relation to names of data items.
 void Dataset::setAttr(const std::string &attrName, Variable attr) {
+  expect::notSparse(attr);
   setDims(attr.dims());
   m_attrs.insert_or_assign(attrName, std::move(attr));
 }
@@ -273,6 +276,7 @@ void Dataset::setAttr(const std::string &attrName, Variable attr) {
 void Dataset::setAttr(const std::string &name, const std::string &attrName,
                       Variable attr) {
   expect::contains(*this, name);
+  expect::notSparse(attr);
   if (!operator[](name).dims().contains(attr.dims()))
     throw except::DimensionError(
         "Attribute dimensions must match and not exceed dimensions of data.");
@@ -282,10 +286,10 @@ void Dataset::setAttr(const std::string &name, const std::string &attrName,
 /// Set (insert or replace) the masks for the given mask name.
 ///
 /// Note that the mask name has no relation to names of data items.
-void Dataset::setMask(const std::string &masksName, Variable masks) {
-  setDims(masks.dims());
-
-  m_masks.insert_or_assign(masksName, std::move(masks));
+void Dataset::setMask(const std::string &masksName, Variable mask) {
+  expect::notSparse(mask);
+  setDims(mask.dims());
+  m_masks.insert_or_assign(masksName, std::move(mask));
 }
 
 /// Set (insert or replace) data (values, optional variances) with given name.

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -180,6 +180,15 @@ TEST(DatasetTest, setLabels_with_name_matching_data_name) {
   ASSERT_EQ(d["b"].labels().size(), 1);
 }
 
+TEST(DatasetTest, setters_reject_sparse) {
+  Dataset d;
+  const auto var = makeVariable<int>(Dims{Dim::X}, Shape{Dimensions::Sparse});
+  ASSERT_THROW(d.setCoord(Dim::X, var), except::DimensionError);
+  ASSERT_THROW(d.setLabels("a", var), except::DimensionError);
+  ASSERT_THROW(d.setMask("a", var), except::DimensionError);
+  ASSERT_THROW(d.setAttr("a", var), except::DimensionError);
+}
+
 TEST(DatasetTest, setSparseCoord_not_sparse_fail) {
   Dataset d;
   const auto var = makeVariable<double>(Dims{Dim::X}, Shape{3});

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -35,7 +35,7 @@ static T convert_with_factor(T &&d, const Dim from, const Dim to,
                              const Variable &factor) {
   // 1. Transform coordinate
   // Cannot use *= since often a broadcast into Dim::Spectrum is required.
-  if (d.coords().contains(from)) {
+  if (d.coords().contains(from) && !d.coords()[from].dims().sparse()) {
     const auto &coords = d.coords()[from];
     d.setCoord(from, coords * astype(factor, coords.dtype()));
   }
@@ -95,7 +95,7 @@ template <class T> T tofToEnergy(T &&d) {
   const auto conversionFactor = tofToEnergyConversionFactor(d);
 
   // 2. Transform coordinate
-  if (d.coords().contains(Dim::Tof)) {
+  if (d.coords().contains(Dim::Tof) && !d.coords()[Dim::Tof].dims().sparse()) {
     const auto &coordSq = d.coords()[Dim::Tof] * d.coords()[Dim::Tof];
     d.setCoord(Dim::Tof, (reciprocal(coordSq) *
                           astype(conversionFactor, coordSq.dtype())));
@@ -122,7 +122,8 @@ template <class T> T energyToTof(T &&d) {
   const auto conversionFactor = tofToEnergyConversionFactor(d);
 
   // 2. Transform coordinate
-  if (d.coords().contains(Dim::Energy)) {
+  if (d.coords().contains(Dim::Energy) &&
+      !d.coords()[Dim::Energy].dims().sparse()) {
     const auto &coordSqrt = d.coords()[Dim::Energy];
     d.setCoord(Dim::Energy,
                sqrt(astype(conversionFactor, coordSqrt.dtype()) / coordSqrt));

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -5,8 +5,6 @@
 #ifndef SCIPP_NEUTRON_CONVERT_H
 #define SCIPP_NEUTRON_CONVERT_H
 
-#include <vector>
-
 #include "scipp-neutron_export.h"
 #include "scipp/core/dataset.h"
 #include "scipp/units/unit.h"


### PR DESCRIPTION
A missing check for sparseness led to a hidden bug in unit conversion: The coord would get converted twice, and was stored twice in the output data array.