### PR TITLE
Fix bad attribute/label handling in convert.

### DIFF
--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -242,6 +242,10 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
 }
 
 namespace {
+template <class T> constexpr bool is_dataset(const T &d) {
+  return std::is_same_v<T, Dataset>;
+}
+
 template <class T>
 T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
   auto fields = {"position", "source_position", "sample_position"};
@@ -257,8 +261,9 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // a subsequent unit conversion of an item on its own would not be
         // possible. It needs to be determined if there is a better way to
         // handle attributes so this can be avoided.
-        for (const auto &item : iter(x))
-          item.second.attrs().set(field, x.labels()[field]);
+        if constexpr (is_dataset(x))
+          for (const auto &item : iter(x))
+            item.second.attrs().set(field, x.labels()[field]);
         x.attrs().set(field, x.labels()[field]);
         x.labels().erase(field);
       }
@@ -266,12 +271,14 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
   }
   if (to == Dim::Tof) {
     for (const auto &field : fields) {
-      if (x.labels().contains(field)) {
+      if (x.attrs().contains(field)) {
         x.labels().set(field, x.attrs()[field]);
         x.attrs().erase(field);
-        for (const auto &item : iter(x)) {
-          expect::equals(x.labels()[field], item.second.attrs()[field]);
-          item.second.attrs().erase(field);
+        if constexpr (is_dataset(x)) {
+          for (const auto &item : iter(x)) {
+            expect::equals(x.labels()[field], item.second.attrs()[field]);
+            item.second.attrs().erase(field);
+          }
         }
       }
     }

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -242,10 +242,6 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
 }
 
 namespace {
-template <class T> constexpr bool is_dataset(const T &d) {
-  return std::is_same_v<T, Dataset>;
-}
-
 template <class T>
 T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
   auto fields = {"position", "source_position", "sample_position"};
@@ -261,7 +257,7 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // a subsequent unit conversion of an item on its own would not be
         // possible. It needs to be determined if there is a better way to
         // handle attributes so this can be avoided.
-        if constexpr (is_dataset(x))
+        if constexpr (std::is_same_v<std::decay_t<T>, Dataset>)
           for (const auto &item : iter(x))
             item.second.attrs().set(field, x.labels()[field]);
         x.attrs().set(field, x.labels()[field]);
@@ -274,7 +270,7 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
       if (x.attrs().contains(field)) {
         x.labels().set(field, x.attrs()[field]);
         x.attrs().erase(field);
-        if constexpr (is_dataset(x)) {
+        if constexpr (std::is_same_v<std::decay_t<T>, Dataset>) {
           for (const auto &item : iter(x)) {
             expect::equals(x.labels()[field], item.second.attrs()[field]);
             item.second.attrs().erase(field);

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -236,6 +236,12 @@ TEST(Convert, DSpacing_to_Tof) {
       tof_original["events"].coords()[Dim::Tof].sparseValues<double>();
   EXPECT_TRUE(equals(events[0], events_original[0], 1e-15));
   EXPECT_TRUE(equals(events[1], events_original[1], 1e-12));
+
+  ASSERT_EQ(tof.labels()["position"], tof_original.labels()["position"]);
+  ASSERT_EQ(tof.labels()["source_position"],
+            tof_original.labels()["source_position"]);
+  ASSERT_EQ(tof.labels()["sample_position"],
+            tof_original.labels()["sample_position"]);
 }
 
 TEST(Convert, Tof_to_Wavelength) {
@@ -326,6 +332,12 @@ TEST(Convert, Wavelength_to_Tof) {
       tof_original["events"].coords()[Dim::Tof].sparseValues<double>();
   EXPECT_TRUE(equals(events[0], events_original[0], 1e-15));
   EXPECT_TRUE(equals(events[1], events_original[1], 1e-12));
+
+  ASSERT_EQ(tof.labels()["position"], tof_original.labels()["position"]);
+  ASSERT_EQ(tof.labels()["source_position"],
+            tof_original.labels()["source_position"]);
+  ASSERT_EQ(tof.labels()["sample_position"],
+            tof_original.labels()["sample_position"]);
 }
 
 TEST(Convert, Tof_to_Energy_Elastic) {
@@ -455,6 +467,12 @@ TEST(Convert, Energy_to_Tof_Elastic) {
       tof_original["events"].coords()[Dim::Tof].sparseValues<double>();
   EXPECT_TRUE(equals(events[0], events_original[0], 1e-15));
   EXPECT_TRUE(equals(events[1], events_original[1], 1e-15));
+
+  ASSERT_EQ(tof.labels()["position"], tof_original.labels()["position"]);
+  ASSERT_EQ(tof.labels()["source_position"],
+            tof_original.labels()["source_position"]);
+  ASSERT_EQ(tof.labels()["sample_position"],
+            tof_original.labels()["sample_position"]);
 }
 
 TEST(Convert, convert_with_factor_type_promotion) {


### PR DESCRIPTION
This prevented conversion from TOF to anything else for data that had
previously been converted back to TOF.