### PR TITLE
Fix `flatten` handling of coords

### DIFF
--- a/core/dataset_operations_common.h
+++ b/core/dataset_operations_common.h
@@ -44,21 +44,27 @@ DataArray apply_and_drop_dim_impl(const DataConstProxy &a, Func func,
 /// otherwise.
 template <class Func>
 DataArray apply_or_copy_dim(const DataConstProxy &a, Func func, const Dim dim) {
+  Dimensions drop({dim, a.dims()[dim]});
   std::map<Dim, Variable> coords;
   for (auto &&[d, coord] : a.coords())
-    coords.emplace(d, coord.dims().contains(dim) ? func(coord, dim) : coord);
+    if (coord.dims() != drop)
+      coords.emplace(d, coord.dims().contains(dim) ? func(coord, dim) : coord);
 
   std::map<std::string, Variable> labels;
   for (auto &&[name, label] : a.labels())
-    labels.emplace(name, label.dims().contains(dim) ? func(label, dim) : label);
+    if (label.dims() != drop)
+      labels.emplace(name,
+                     label.dims().contains(dim) ? func(label, dim) : label);
 
   std::map<std::string, Variable> attrs;
   for (auto &&[name, attr] : a.attrs())
-    attrs.emplace(name, attr.dims().contains(dim) ? func(attr, dim) : attr);
+    if (attr.dims() != drop)
+      attrs.emplace(name, attr.dims().contains(dim) ? func(attr, dim) : attr);
 
   std::map<std::string, Variable> masks;
   for (auto &&[name, mask] : a.masks())
-    masks.emplace(name, mask.dims().contains(dim) ? func(mask, dim) : mask);
+    if (mask.dims() != drop)
+      masks.emplace(name, mask.dims().contains(dim) ? func(mask, dim) : mask);
 
   return DataArray(a.hasData() ? func(a.data(), dim)
                                : std::optional<Variable>(),

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -391,7 +391,8 @@ TEST(GroupbyFlattenTest, flatten_coord_and_labels) {
 
 TEST(GroupbyFlattenTest, flatten_coord_and_data) {
   DataArray a{make_sparse_in() * 1.5,
-              {{Dim::X, make_sparse_in()}},
+              {{Dim::X, make_sparse_in()},
+               {Dim::Y, makeVariable<double>(Dims{Dim::Y}, Shape{3})}},
               {{"labels",
                 makeVariable<double>(Dims{Dim::Y}, Shape{3},
                                      units::Unit(units::m), Values{1, 1, 3})}}};

--- a/core/test/sparse_data_operations_consistency_test.cpp
+++ b/core/test/sparse_data_operations_consistency_test.cpp
@@ -18,7 +18,9 @@ static auto make_sparse() {
 }
 
 static auto make_sparse_array_coord_only() {
-  return DataArray(std::optional<Variable>(), {{Dim::X, make_sparse()}});
+  return DataArray(std::optional<Variable>(),
+                   {{Dim::X, make_sparse()},
+                    {Dim::Y, makeVariable<double>(Dimensions{Dim::Y, 2})}});
 }
 
 static auto make_histogram() {


### PR DESCRIPTION
`flatten` failed to drop coords (as well as labels, attrs, and masks) for the flattened dimension. See updated unit test.

Also avoid some copies for 2x performance improvement in some cases.