### PR TITLE
Fix convert_with_calibration so it works with sparse DataArray.

### DIFF
--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -38,7 +38,7 @@ template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
     // data.
     // We are hard-coding some information here: the existence of "spectra",
     // since we require labels named "spectrum" and a corresponding dimension.
-    // Given that this in in a branch that is access only if "detector_info" is
+    // Given that this is in a branch that is access only if "detector_info" is
     // present this should probably be ok.
     cal = groupby(cal, "spectrum", Dim::Spectrum).mean(Dim::Detector);
   } else if (!has_dim(d, cal["tzero"].dims().inner())) {
@@ -51,7 +51,7 @@ template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
   }
 
   // 2. Transform coordinate
-  if (d.coords().contains(Dim::Tof)) {
+  if (d.coords().contains(Dim::Tof) && !d.coords()[Dim::Tof].dims().sparse()) {
     d.setCoord(Dim::Tof, (d.coords()[Dim::Tof] - cal["tzero"].data()) /
                              cal["difc"].data());
   }

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -3,20 +3,16 @@
 set(TARGET_NAME "scipp-neutron-test")
 add_dependencies(all-tests ${TARGET_NAME})
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
-               #EventWorkspace_test.cpp
-               #example_instrument_test.cpp
-               #Run_test.cpp
-               #TableWorkspace_test.cpp
-               #Workspace2D_test.cpp
                beamline_test.cpp
                convert_test.cpp
+               convert_with_calibration_test.cpp
                )
 include_directories(SYSTEM ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR})
 target_link_libraries(${TARGET_NAME}
                       LINK_PRIVATE
                       scipp-neutron
                       scipp_test_helpers
-					  gtest_main
+	              gtest_main
                       ${GTEST_LIBRARIES}
                       ${GMOCK_LIBRARIES})
 set_property(TARGET ${TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION ${INTERPROCEDURAL_OPTIMIZATION_TESTS})

--- a/neutron/test/convert_with_calibration_test.cpp
+++ b/neutron/test/convert_with_calibration_test.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include "test_macros.h"
+#include <gtest/gtest.h>
+
+#include "scipp/core/counts.h"
+#include "scipp/core/dataset.h"
+#include "scipp/core/dimensions.h"
+#include "scipp/neutron/diffraction/convert_with_calibration.h"
+
+using namespace scipp;
+using namespace scipp::core;
+using namespace scipp::neutron;
+
+namespace {
+Dataset makeTofDataForUnitConversion(const bool dense_coord = true) {
+  Dataset tof;
+
+  if (dense_coord)
+    tof.setCoord(Dim::Tof, makeVariable<double>(
+                               Dims{Dim::Tof}, Shape{4}, units::Unit(units::us),
+                               Values{4000, 5000, 6100, 7300}));
+
+  tof.setData("counts",
+              makeVariable<double>(Dims{Dim::Spectrum, Dim::Tof}, Shape{2, 3},
+                                   Values{1, 2, 3, 4, 5, 6}));
+  tof["counts"].data().setUnit(units::counts);
+
+  auto events = makeVariable<double>(Dims{Dim::Spectrum, Dim::Tof},
+                                     Shape{2l, Dimensions::Sparse});
+  events.setUnit(units::us);
+  auto eventLists = events.sparseValues<double>();
+  eventLists[0] = {1000, 3000, 2000, 4000};
+  eventLists[1] = {5000, 6000, 3000};
+  tof.setSparseCoord("events", events);
+  tof.setSparseLabels("events", "aux", events);
+
+  return tof;
+}
+
+Dataset makeCalTable() {
+  Dataset cal;
+  cal.setData("tzero",
+              makeVariable<double>(Dims{Dim::Spectrum}, Shape{2},
+                                   units::Unit(units::us), Values{1.1, 2.2}));
+  cal.setData("difc", makeVariable<double>(Dims{Dim::Spectrum}, Shape{2},
+                                           Values{3.3, 4.4}));
+  return cal;
+}
+}
+
+TEST(ConvertWithCaliabrationDataArray, data_array) {
+  const auto tof = makeTofDataForUnitConversion();
+  const auto cal = makeCalTable();
+
+  for (const auto &[name, data] : tof)
+    EXPECT_NO_THROW(diffraction::convert_with_calibration(copy(data), cal));
+}
+
+TEST(ConvertWithCaliabrationDataArray, dataset) {
+  const auto tof = makeTofDataForUnitConversion();
+  const auto cal = makeCalTable();
+
+  EXPECT_NO_THROW(diffraction::convert_with_calibration(tof, cal));
+}

--- a/neutron/test/convert_with_calibration_test.cpp
+++ b/neutron/test/convert_with_calibration_test.cpp
@@ -55,7 +55,7 @@ TEST(ConvertWithCaliabrationDataArray, data_array) {
 
   for (const auto &item : tof)
     EXPECT_NO_THROW(
-        diffraction::convert_with_calibration(copy(data.second), cal));
+        diffraction::convert_with_calibration(copy(item.second), cal));
 }
 
 TEST(ConvertWithCaliabrationDataArray, dataset) {

--- a/neutron/test/convert_with_calibration_test.cpp
+++ b/neutron/test/convert_with_calibration_test.cpp
@@ -47,7 +47,7 @@ Dataset makeCalTable() {
                                            Values{3.3, 4.4}));
   return cal;
 }
-}
+} // namespace
 
 TEST(ConvertWithCaliabrationDataArray, data_array) {
   const auto tof = makeTofDataForUnitConversion();

--- a/neutron/test/convert_with_calibration_test.cpp
+++ b/neutron/test/convert_with_calibration_test.cpp
@@ -53,8 +53,9 @@ TEST(ConvertWithCaliabrationDataArray, data_array) {
   const auto tof = makeTofDataForUnitConversion();
   const auto cal = makeCalTable();
 
-  for (const auto &[name, data] : tof)
-    EXPECT_NO_THROW(diffraction::convert_with_calibration(copy(data), cal));
+  for (const auto &item : tof)
+    EXPECT_NO_THROW(
+        diffraction::convert_with_calibration(copy(data.second), cal));
 }
 
 TEST(ConvertWithCaliabrationDataArray, dataset) {


### PR DESCRIPTION
Previously fixed in convert in #842 but overlooked here.