### PR TITLE
Throw on dtype mismatch in is_approx

### DIFF
--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -6,11 +6,12 @@
 
 #include "dtype.h"
 #include "scipp/core/dataset.h"
+#include "scipp/core/string.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
-#include "scipp/core/string.h"
 
 #include <atomic>
+#include <sstream>
 
 namespace scipp::core {
 
@@ -19,14 +20,17 @@ namespace scipp::core {
 template <typename T>
 bool is_approx(const VariableConstProxy &a, const VariableConstProxy &b,
                const T tol) {
-  if (a.dtype() != b.dtype())
-    return false; // TODO this should throw rather than return false IMHO
-
-  if(dtype<T> != a.dtype()) {
-    throw std::runtime_error("Type of tolerance " + to_string(dtype<T>) + " not same as lh operand " + to_string(a.dtype()));
+  if (a.dtype() != b.dtype()) {
+    std::stringstream ss;
+    ss << "is_approx. Types do not match. dtype a " << to_string(a.dtype())
+       << ". dtype b " << to_string(b.dtype());
+    throw except::VariableError(ss.str());
   }
-  if(dtype<T> != a.dtype()) {
-    throw std::runtime_error("Type of tolerance " + to_string(dtype<T>) + " not same as rh operand " + to_string(a.dtype()));
+  if (dtype<T> != a.dtype()) {
+    std::stringstream ss;
+    ss << "is_approx. Type of tol " << to_string(dtype<T>)
+       << " not same as type of input arguments " << to_string(a.dtype());
+    throw except::VariableError(ss.str());
   }
 
   if (a.hasVariances() != b.hasVariances())

--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -11,7 +11,6 @@
 #include "scipp/core/variable.h"
 
 #include <atomic>
-#include <sstream>
 
 namespace scipp::core {
 
@@ -21,16 +20,16 @@ template <typename T>
 bool is_approx(const VariableConstProxy &a, const VariableConstProxy &b,
                const T tol) {
   if (a.dtype() != b.dtype()) {
-    std::stringstream ss;
-    ss << "is_approx. Types do not match. dtype a " << to_string(a.dtype())
-       << ". dtype b " << to_string(b.dtype());
-    throw except::VariableError(ss.str());
+    std::string message = "is_approx. Types do not match. dtype a " +
+                          to_string(a.dtype()) + ". dtype b " +
+                          to_string(b.dtype());
+    throw except::TypeError(message);
   }
   if (dtype<T> != a.dtype()) {
-    std::stringstream ss;
-    ss << "is_approx. Type of tol " << to_string(dtype<T>)
-       << " not same as type of input arguments " << to_string(a.dtype());
-    throw except::VariableError(ss.str());
+    std::string message = "is_approx. Type of tol " + to_string(dtype<T>) +
+                          " not same as type of input arguments " +
+                          to_string(a.dtype());
+    throw except::TypeError(message);
   }
 
   if (a.hasVariances() != b.hasVariances())

--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -4,9 +4,11 @@
 #ifndef SCIPP_CORE_COMPARISON_H
 #define SCIPP_CORE_COMPARISON_H
 
+#include "dtype.h"
 #include "scipp/core/dataset.h"
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
+#include "scipp/core/string.h"
 
 #include <atomic>
 
@@ -18,7 +20,14 @@ template <typename T>
 bool is_approx(const VariableConstProxy &a, const VariableConstProxy &b,
                const T tol) {
   if (a.dtype() != b.dtype())
-    return false;
+    return false; // TODO this should throw rather than return false IMHO
+
+  if(dtype<T> != a.dtype()) {
+    throw std::runtime_error("Type of tolerance " + to_string(dtype<T>) + " not same as lh operand " + to_string(a.dtype()));
+  }
+  if(dtype<T> != a.dtype()) {
+    throw std::runtime_error("Type of tolerance " + to_string(dtype<T>) + " not same as rh operand " + to_string(a.dtype()));
+  }
 
   if (a.hasVariances() != b.hasVariances())
     return false;

--- a/core/test/comparison_test.cpp
+++ b/core/test/comparison_test.cpp
@@ -61,12 +61,12 @@ TEST(ComparisonTest, variable_unit_not_equal) {
 TEST(ComparisonTest, variable_mismatched_dtype) {
   const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   const auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
-  EXPECT_FALSE(is_approx(a, b, 0.1));
+  EXPECT_THROW(is_approx(a, b, 0.1), except::VariableError);
 }
 
 TEST(ComparisonTest, tolerance_type_mismatch) {
   const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   const auto b = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
-  EXPECT_THROW(is_approx(a, b, 0 /*implicit int*/), std::runtime_error);
+  EXPECT_THROW(is_approx(a, b, 0 /*implicit int*/), except::VariableError);
   EXPECT_NO_THROW(is_approx(a, b, 0.0f));
 }

--- a/core/test/comparison_test.cpp
+++ b/core/test/comparison_test.cpp
@@ -61,12 +61,12 @@ TEST(ComparisonTest, variable_unit_not_equal) {
 TEST(ComparisonTest, variable_mismatched_dtype) {
   const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   const auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
-  EXPECT_THROW(is_approx(a, b, 0.1), except::VariableError);
+  EXPECT_THROW(is_approx(a, b, 0.1), except::TypeError);
 }
 
 TEST(ComparisonTest, tolerance_type_mismatch) {
   const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   const auto b = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
-  EXPECT_THROW(is_approx(a, b, 0 /*implicit int*/), except::VariableError);
+  EXPECT_THROW(is_approx(a, b, 0 /*implicit int*/), except::TypeError);
   EXPECT_NO_THROW(is_approx(a, b, 0.0f));
 }

--- a/core/test/comparison_test.cpp
+++ b/core/test/comparison_test.cpp
@@ -63,3 +63,10 @@ TEST(ComparisonTest, variable_mismatched_dtype) {
   const auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   EXPECT_FALSE(is_approx(a, b, 0.1));
 }
+
+TEST(ComparisonTest, tolerance_type_mismatch) {
+  const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
+  const auto b = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
+  EXPECT_THROW(is_approx(a, b, 0 /*implicit int*/), std::runtime_error);
+  EXPECT_NO_THROW(is_approx(a, b, 0.0f));
+}


### PR DESCRIPTION
Fixes problems:
* Returning false on a dtype mismatch is undesirable and could hide problems.
* Type argument deduction of tolerance causes deep issues in `scipp::core::visit` though it's easy to check aprori.