### PR TITLE
Explicitly specify integer types in tests

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -154,7 +154,8 @@ def test_create_2D_inner_size_3():
 
 
 def test_astype():
-    var = sc.Variable([sc.Dim.X], values=np.array([1, 2, 3, 4], dtype=int))
+    var = sc.Variable([sc.Dim.X],
+                      values=np.array([1, 2, 3, 4], dtype=np.int64))
     assert var.dtype == sc.dtype.int64
 
     var_as_float = var.astype(sc.dtype.float64)
@@ -162,7 +163,8 @@ def test_astype():
 
 
 def test_astype_bad_conversion():
-    var = sc.Variable([sc.Dim.X], values=np.array([1, 2, 3, 4], dtype=int))
+    var = sc.Variable([sc.Dim.X],
+                      values=np.array([1, 2, 3, 4], dtype=np.int64))
     assert var.dtype == sc.dtype.int64
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Specify integer type in astype() Python unit tests.
Fixes failing tests on Windows.