### PR TITLE
DataArray operation fixes and additions

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -118,12 +118,14 @@ Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,
 
 DataArray &DataArray::operator+=(const DataConstProxy &other) {
   expect::coordsAndLabelsAreSuperset(*this, other);
+  union_or_in_place(masks(), other.masks());
   data() += other.data();
   return *this;
 }
 
 DataArray &DataArray::operator-=(const DataConstProxy &other) {
   expect::coordsAndLabelsAreSuperset(*this, other);
+  union_or_in_place(masks(), other.masks());
   data() -= other.data();
   return *this;
 }

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -94,6 +94,7 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram) {
     EXPECT_TRUE(equals(out_vals[1], expected.values<double>()));
     EXPECT_TRUE(equals(out_vars[1], expected.variances<double>()));
   }
+  EXPECT_EQ(copy(sparse) *= hist, sparse * hist);
 }
 
 TEST(DataArraySparseArithmeticTest, sparse_with_values_times_histogram) {

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -121,12 +121,14 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_with_variance) {
   for (const auto &item : dataset_b) {
     auto dataset_a = datasetFactory.make();
     auto target = dataset_a["data_zyx"];
+    auto data_array = copy(target);
 
     Variable reference(target.data());
     TestFixture::op(reference, item.second.data());
 
     ASSERT_NO_THROW(target = TestFixture::op(target, item.second));
     EXPECT_EQ(target.data(), reference);
+    EXPECT_EQ(TestFixture::op(data_array, item.second), target);
   }
 }
 
@@ -136,6 +138,7 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_without_variance) {
   for (const auto &item : dataset_b) {
     auto dataset_a = datasetFactory.make();
     auto target = dataset_a["data_xyz"];
+    auto data_array = copy(target);
 
     if (item.second.hasVariances()) {
       ASSERT_ANY_THROW(TestFixture::op(target, item.second));
@@ -146,6 +149,7 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_without_variance) {
       ASSERT_NO_THROW(target = TestFixture::op(target, item.second));
       EXPECT_EQ(target.data(), reference);
       EXPECT_FALSE(target.hasVariances());
+      EXPECT_EQ(TestFixture::op(data_array, item.second), target);
     }
   }
 }

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -119,7 +119,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_with_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
-    auto dataset_a = datasetFactory.make();
+    const bool randomMasks = true;
+    auto dataset_a = datasetFactory.make(randomMasks);
     auto target = dataset_a["data_zyx"];
     auto data_array = copy(target);
 
@@ -136,7 +137,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_without_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
-    auto dataset_a = datasetFactory.make();
+    const bool randomMasks = true;
+    auto dataset_a = datasetFactory.make(randomMasks);
     auto target = dataset_a["data_xyz"];
     auto data_array = copy(target);
 
@@ -158,7 +160,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, slice_lhs_with_variance) {
   const auto dataset_b = datasetFactory.make();
 
   for (const auto &item : dataset_b) {
-    auto dataset_a = datasetFactory.make();
+    const bool randomMasks = true;
+    auto dataset_a = datasetFactory.make(randomMasks);
     auto target = dataset_a["data_zyx"];
     const auto &dims = item.second.dims();
 

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -122,8 +122,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_with_variance) {
     auto dataset_a = datasetFactory.make();
     auto target = dataset_a["data_zyx"];
 
-    auto reference(target.data());
-    reference = TestFixture::op(target.data(), item.second.data());
+    Variable reference(target.data());
+    TestFixture::op(reference, item.second.data());
 
     ASSERT_NO_THROW(target = TestFixture::op(target, item.second));
     EXPECT_EQ(target.data(), reference);
@@ -140,8 +140,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, lhs_without_variance) {
     if (item.second.hasVariances()) {
       ASSERT_ANY_THROW(TestFixture::op(target, item.second));
     } else {
-      auto reference(target.data());
-      reference = TestFixture::op(target.data(), item.second.data());
+      Variable reference(target.data());
+      TestFixture::op(reference, item.second.data());
 
       ASSERT_NO_THROW(target = TestFixture::op(target, item.second));
       EXPECT_EQ(target.data(), reference);
@@ -159,8 +159,8 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, slice_lhs_with_variance) {
     const auto &dims = item.second.dims();
 
     for (const Dim dim : dims.labels()) {
-      auto reference(target.data());
-      reference = TestFixture::op(target.data(), item.second.data());
+      Variable reference(target.data());
+      TestFixture::op(reference, item.second.data().slice({dim, 2}));
 
       // Fails if any *other* multi-dimensional coord/label also depends on the
       // slicing dimension, since it will have mismatching values. Note that
@@ -178,12 +178,10 @@ TYPED_TEST(DataProxyBinaryEqualsOpTest, slice_lhs_with_variance) {
             return labels_.second.dims().inner() == dim ||
                    !labels_.second.dims().contains(dim);
           })) {
-        ASSERT_NO_THROW(
-            target = TestFixture::op(target, item.second.slice({dim, 2})));
+        ASSERT_NO_THROW(TestFixture::op(target, item.second.slice({dim, 2})));
         EXPECT_EQ(target.data(), reference);
       } else {
-        ASSERT_ANY_THROW(
-            target = TestFixture::op(target, item.second.slice({dim, 2})));
+        ASSERT_ANY_THROW(TestFixture::op(target, item.second.slice({dim, 2})));
       }
     }
   }

--- a/core/test/dataset_test_common.cpp
+++ b/core/test/dataset_test_common.cpp
@@ -50,8 +50,17 @@ DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
                makeVariable<double>(Dimensions{Dim::X, lx}, Values(rand(lx))));
 }
 
-Dataset DatasetFactory3D::make() {
+Dataset DatasetFactory3D::make(const bool randomMasks) {
   Dataset dataset(base);
+  if (randomMasks) {
+    dataset.setMask("masks_x", makeVariable<bool>(Dimensions{Dim::X, lx},
+                                                  Values(randBool(lx))));
+    dataset.setMask("masks_xy",
+                    makeVariable<bool>(Dimensions{{Dim::X, lx}, {Dim::Y, ly}},
+                                       Values(randBool(lx * ly))));
+    dataset.setMask("masks_z", makeVariable<bool>(Dimensions{Dim::Z, lz},
+                                                  Values(randBool(lz))));
+  }
   dataset.setData("values_x", makeVariable<double>(Dimensions{Dim::X, lx},
                                                    Values(rand(lx))));
   dataset.setData("data_x",

--- a/core/test/dataset_test_common.h
+++ b/core/test/dataset_test_common.h
@@ -41,7 +41,7 @@ public:
   DatasetFactory3D(const scipp::index lx = 4, const scipp::index ly = 5,
                    const scipp::index lz = 6);
 
-  Dataset make();
+  Dataset make(const bool randomMasks = false);
 
   const scipp::index lx;
   const scipp::index ly;
@@ -49,6 +49,7 @@ public:
 
 private:
   Random rand;
+  RandomBool randBool;
   Dataset base;
 };
 

--- a/test/random.h
+++ b/test/random.h
@@ -22,4 +22,17 @@ public:
   }
 };
 
+class RandomBool {
+  std::mt19937 mt{std::random_device()()};
+  std::uniform_int_distribution<int32_t> dist;
+
+public:
+  RandomBool() : dist{0, 1} {}
+  std::vector<bool> operator()(const int64_t size) {
+    std::vector<bool> data(size);
+    std::generate(data.begin(), data.end(), [this]() { return dist(mt); });
+    return data;
+  }
+};
+
 #endif // SCIPP_TEST_RANDOM_H


### PR DESCRIPTION
- Fix missing mask handling. Fixes #873.
- Add missing support for `sparse *= histogram` and `sparse /= histogram`. Fixes #873.
- Fix tests to exercise masking. Previously the dataset factory returned the same masks in every call.
- Fix tests to create correct reference.
