### PR TITLE
Dtype fixes

### DIFF
--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -95,7 +95,7 @@ Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,
   const Dim dim = sparseCoord_.dims().sparseDim();
   return transform<
       std::tuple<args<double, double, double>, args<float, double, double>,
-                 args<float, float, float>>>(
+                 args<float, float, float>, args<double, float, float>>>(
       sparseCoord_, subspan_view(edges_, dim), subspan_view(weights_, dim),
       overloaded{[op](const auto &... a) {
                    return apply_op_sparse_dense<Variance>(op, a...);

--- a/core/test/rebin_test.cpp
+++ b/core/test/rebin_test.cpp
@@ -71,6 +71,18 @@ TEST_F(RebinTest, outer_data_array) {
   ASSERT_EQ(rebin(array, Dim::Y, edges), expected);
 }
 
+TEST_F(RebinTest, outer_data_array_different_edge_dtype) {
+  auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 3});
+  DataArray expected(makeVariable<float>(Dims{Dim::Y, Dim::X}, Shape{1, 4},
+                                         units::Unit(units::counts),
+                                         Values{6, 8, 10, 12}),
+                     {{Dim::X, x}, {Dim::Y, edges}}, {});
+  DataArray array_float(astype(counts, dtype<float>),
+                        {{Dim::X, x}, {Dim::Y, y}});
+
+  ASSERT_EQ(rebin(array_float, Dim::Y, edges), expected);
+}
+
 TEST_F(RebinTest, outer_data_array_with_variances) {
   auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 3});
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 4},


### PR DESCRIPTION
- Add support for more dtype combinations in `rebin` and binary operations between sparse and histogram.
- Fix bug in rebin of outer dimension: Should use dtype of coord, not dtype of data for branch selection.

Fixes #879 (could still do better, but this is a step forward).