### PR TITLE
Add missing Python exports for binary ops

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -988,3 +988,9 @@ def test_atan_out():
     out = sc.atan(x=var, out=var)
     assert var == expected
     assert out == expected
+
+
+def test_variable_data_array_binary_ops():
+    a = sc.DataArray(1.0 * sc.units.m)
+    var = 1.0 * sc.units.m
+    assert a / var == var / a

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -338,8 +338,10 @@ void init_variable(py::module &m) {
 
   bind_binary<Variable>(variable);
   bind_binary<VariableConstProxy>(variable);
+  bind_binary<DataProxy>(variable);
   bind_binary<Variable>(variableProxy);
   bind_binary<VariableConstProxy>(variableProxy);
+  bind_binary<DataProxy>(variableProxy);
   bind_binary_scalars(variable);
   bind_binary_scalars(variableProxy);
 


### PR DESCRIPTION
Adds missing binary operation Python exports for operations between Variable (and proxies) and DataArray (and proxies).

Fixes #871