### PR TITLE
Rebuild dimensions when replacing existing data item

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -234,4 +234,14 @@ BENCHMARK_TEMPLATE(BM_Dataset_copy,
                    GenerateWithSparseDataItems<LONG_STRING_LENGTH>)
     ->Apply(Args_Dataset_copy);
 
+static void BM_Dataset_setData_replace(benchmark::State &state) {
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{1});
+  Dataset d;
+  d.setData("x", var);
+  for (auto _ : state) {
+    d.setData("x", var);
+  }
+}
+BENCHMARK(BM_Dataset_setData_replace);
+
 BENCHMARK_MAIN();

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -303,7 +303,11 @@ void Dataset::setData(const std::string &name, Variable data) {
   if (contains(name) && operator[](name).dims().sparse() != sparseData)
     throw except::DimensionError("Cannot set dense values or variances if "
                                  "coordinates sparse or vice versa");
+
+  const auto rebuild_dims = contains(name);
   m_data[name].data = std::move(data);
+  if (rebuild_dims)
+    rebuildDims();
 }
 
 /// Set (insert or replace) data item with given name.

--- a/core/test/dataset_binary_arithmetic_test.cpp
+++ b/core/test/dataset_binary_arithmetic_test.cpp
@@ -926,15 +926,17 @@ TYPED_TEST(DatasetBinaryOpTest, masks_propagate) {
 Dataset non_trivial_2d_sparse(std::string_view name) {
   Dataset sparse;
   auto var =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, Dimensions::Sparse});
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, Dimensions::Sparse});
   var.sparseValues<double>()[0] = {1.5, 2.5, 3.5, 4.5, 5.5};
   var.sparseValues<double>()[1] = {3.5, 4.5, 5.5, 6.5, 7.5};
   var.sparseValues<double>()[2] = {-1, 0, 0, 1, 1, 2, 2, 2, 4, 4, 4, 6};
+  var.sparseValues<double>()[3] = {1};
   auto dvar =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, Dimensions::Sparse});
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, Dimensions::Sparse});
   dvar.sparseValues<double>()[0] = {1, 2, 3, 4, 5};
   dvar.sparseValues<double>()[1] = {3, 4, 5, 6, 7};
   dvar.sparseValues<double>()[2] = {1, 1, 1, 1, 1, 100, 1, 1, 1, 1, 1, 1};
+  dvar.sparseValues<double>()[3] = {1};
   sparse.setData(std::string(name), dvar);
   sparse.setSparseCoord(std::string(name), var);
   return sparse;

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -165,6 +165,20 @@ TEST(DatasetTest, setData_with_and_without_variances) {
   ASSERT_EQ(d.size(), 2);
 }
 
+TEST(DatasetTest, setData_updates_dimensions) {
+  const auto xy = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3});
+  const auto x = makeVariable<double>(Dims{Dim::X}, Shape{2});
+
+  Dataset d;
+  d.setData("x", xy);
+  d.setData("x", x);
+
+  const auto dims = d.dimensions();
+  ASSERT_TRUE(dims.find(Dim::X) != dims.end());
+  // Dim::Y should no longer appear in dimensions after item "x" was replaced.
+  ASSERT_TRUE(dims.find(Dim::Y) == dims.end());
+}
+
 TEST(DatasetTest, setLabels_with_name_matching_data_name) {
   Dataset d;
   d.setData("a", makeVariable<double>(Dims{Dim::X}, Shape{3}));


### PR DESCRIPTION
I'm not sure there is a faster way to do this without having to write a much more complex means of updating `Dataset::m_dims` (I recall the same consideration when implementing `Dataset::erase`).

Fixes #821