### PR TITLE
Add min and max

### DIFF
--- a/core/dataset_operations.cpp
+++ b/core/dataset_operations.cpp
@@ -8,6 +8,7 @@
 #include "scipp/core/transform.h"
 
 #include "dataset_operations_common.h"
+#include "variable_operations_common.h"
 
 namespace scipp::core {
 

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -102,9 +102,13 @@ static constexpr auto logical = [](const VariableProxy &out_data,
                                    const auto &data_container,
                                    const std::vector<Slice> &group,
                                    const Dim reductionDim) {
-  static_cast<void>(reductionDim); // Will be used for mask handling.
+  bool first = true;
   for (const auto &slice : group) {
     const auto data_slice = data_container.slice(slice);
+    if (first) {
+      out_data.assign(data_slice.data().slice({reductionDim, 0}));
+      first = false;
+    }
     if (!data_slice.masks().empty())
       throw std::runtime_error("This operation does not support masks yet.");
     Func(out_data, data_slice.data());

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -105,12 +105,12 @@ static constexpr auto reduce_idempotent = [](const VariableProxy &out_data,
   bool first = true;
   for (const auto &slice : group) {
     const auto data_slice = data_container.slice(slice);
+    if (!data_slice.masks().empty())
+      throw std::runtime_error("This operation does not support masks yet.");
     if (first) {
       out_data.assign(data_slice.data().slice({reductionDim, 0}));
       first = false;
     }
-    if (!data_slice.masks().empty())
-      throw std::runtime_error("This operation does not support masks yet.");
     Func(out_data, data_slice.data());
   }
 };

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -98,10 +98,10 @@ static constexpr auto sum =
     };
 
 template <void (*Func)(const VariableProxy &, const VariableConstProxy &)>
-static constexpr auto logical = [](const VariableProxy &out_data,
-                                   const auto &data_container,
-                                   const std::vector<Slice> &group,
-                                   const Dim reductionDim) {
+static constexpr auto reduce_idempotent = [](const VariableProxy &out_data,
+                                             const auto &data_container,
+                                             const std::vector<Slice> &group,
+                                             const Dim reductionDim) {
   bool first = true;
   for (const auto &slice : group) {
     const auto data_slice = data_container.slice(slice);
@@ -123,12 +123,22 @@ template <class T> T GroupBy<T>::sum(const Dim reductionDim) const {
 
 /// Reduce each group using `all` and return combined data.
 template <class T> T GroupBy<T>::all(const Dim reductionDim) const {
-  return reduce(groupby_detail::logical<all_impl>, reductionDim);
+  return reduce(groupby_detail::reduce_idempotent<all_impl>, reductionDim);
 }
 
 /// Reduce each group using `any` and return combined data.
 template <class T> T GroupBy<T>::any(const Dim reductionDim) const {
-  return reduce(groupby_detail::logical<any_impl>, reductionDim);
+  return reduce(groupby_detail::reduce_idempotent<any_impl>, reductionDim);
+}
+
+/// Reduce each group using `max` and return combined data.
+template <class T> T GroupBy<T>::max(const Dim reductionDim) const {
+  return reduce(groupby_detail::reduce_idempotent<max_impl>, reductionDim);
+}
+
+/// Reduce each group using `min` and return combined data.
+template <class T> T GroupBy<T>::min(const Dim reductionDim) const {
+  return reduce(groupby_detail::reduce_idempotent<min_impl>, reductionDim);
 }
 
 /// Apply mean to groups and return combined data.

--- a/core/include/scipp/core/groupby.h
+++ b/core/include/scipp/core/groupby.h
@@ -49,6 +49,8 @@ public:
   T sum(const Dim reductionDim) const;
   T all(const Dim reductionDim) const;
   T any(const Dim reductionDim) const;
+  T max(const Dim reductionDim) const;
+  T min(const Dim reductionDim) const;
 
 private:
   T makeReductionOutput(const Dim reductionDim) const;

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -504,10 +504,14 @@ template <bool dry_run> struct in_place {
     using namespace detail;
     std::apply(
         [&op](auto &&arg, auto &&... args) {
-          if constexpr (is_ValuesAndVariances_v<std::decay_t<decltype(arg)>> ||
-                        !(is_ValuesAndVariances_v<
-                              std::decay_t<decltype(args)>> ||
-                          ...) ||
+          constexpr bool in_var_if_out_var = std::is_base_of_v<
+              transform_flags::expect_in_variance_if_out_variance_t, Op>;
+          constexpr bool arg_var =
+              is_ValuesAndVariances_v<std::decay_t<decltype(arg)>>;
+          constexpr bool args_var =
+              (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> || ...);
+          if constexpr ((in_var_if_out_var ? arg_var == args_var
+                                           : arg_var || !args_var) ||
                         std::is_base_of_v<
                             transform_flags::expect_no_variance_arg_t<0>, Op>) {
             transform_in_place_impl(op, std::forward<decltype(arg)>(arg),

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -73,6 +73,10 @@ using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 template <int N> static constexpr auto expect_variance_arg = []() {};
 template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
 
+/// Add this to overloaded operator to indicate that the in-place operation
+/// requires inputs to have a variance of the output has a variance.
+struct expect_in_variance_if_out_variance_t {};
+
 } // namespace transform_flags
 
 } // namespace scipp::core

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -134,6 +134,17 @@ constexpr auto operator/(const T1 a, const ValueAndVariance<T2> b) noexcept {
                                            (b.value * b.value)};
 }
 
+template <class T>
+constexpr auto min(const ValueAndVariance<T> a,
+                   const ValueAndVariance<T> b) noexcept {
+  return a.value < b.value ? a : b;
+}
+template <class T>
+constexpr auto max(const ValueAndVariance<T> a,
+                   const ValueAndVariance<T> b) noexcept {
+  return a.value > b.value ? a : b;
+}
+
 /// Deduction guide for class ValueAndVariances. Using decltype to deal with
 /// potential mixed-type val and var arguments arising in binary operations
 /// between, e.g., double and float.

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -1065,6 +1065,12 @@ SCIPP_CORE_EXPORT VariableProxy atan(const VariableConstProxy &var,
 [[nodiscard]] SCIPP_CORE_EXPORT Variable all(const VariableConstProxy &var,
                                              const Dim dim);
 
+// Other reductions
+[[nodiscard]] SCIPP_CORE_EXPORT Variable max(const VariableConstProxy &var,
+                                             const Dim dim);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable min(const VariableConstProxy &var,
+                                             const Dim dim);
+
 SCIPP_CORE_EXPORT Variable masks_merge_if_contains(const MasksConstProxy &masks,
                                                    const Dim dim);
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -994,13 +994,6 @@ SCIPP_CORE_EXPORT Variable filter(const Variable &var, const Variable &filter);
                                               const Dim dim);
 SCIPP_CORE_EXPORT VariableProxy mean(const VariableConstProxy &var,
                                      const Dim dim, const VariableProxy &out);
-[[nodiscard]] SCIPP_CORE_EXPORT Variable mean(const VariableConstProxy &var,
-                                              const Dim dim,
-                                              const MasksConstProxy &masks);
-SCIPP_CORE_EXPORT VariableProxy mean(const VariableConstProxy &var,
-                                     const Dim dim,
-                                     const MasksConstProxy &masks,
-                                     const VariableProxy &out);
 SCIPP_CORE_EXPORT Variable norm(const VariableConstProxy &var);
 SCIPP_CORE_EXPORT Variable permute(const Variable &var, const Dim dim,
                                    const std::vector<scipp::index> &indices);
@@ -1017,19 +1010,10 @@ SCIPP_CORE_EXPORT VariableProxy sqrt(const VariableConstProxy &var,
 
 [[nodiscard]] SCIPP_CORE_EXPORT Variable flatten(const VariableConstProxy &var,
                                                  const Dim dim);
-[[nodiscard]] SCIPP_CORE_EXPORT Variable flatten(const VariableConstProxy &var,
-                                                 const Dim dim,
-                                                 const MasksConstProxy &masks);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var,
                                              const Dim dim);
 SCIPP_CORE_EXPORT VariableProxy sum(const VariableConstProxy &var,
                                     const Dim dim, const VariableProxy &out);
-[[nodiscard]] SCIPP_CORE_EXPORT Variable sum(const VariableConstProxy &var,
-                                             const Dim dim,
-                                             const MasksConstProxy &masks);
-SCIPP_CORE_EXPORT VariableProxy sum(const VariableConstProxy &var,
-                                    const Dim dim, const MasksConstProxy &masks,
-                                    const VariableProxy &out);
 
 SCIPP_CORE_EXPORT Variable copy(const VariableConstProxy &var);
 

--- a/core/operators.h
+++ b/core/operators.h
@@ -5,6 +5,8 @@
 #ifndef SCIPP_CORE_OPERATORS_H
 #define SCIPP_CORE_OPERATORS_H
 
+#include <algorithm>
+
 #include <Eigen/Dense>
 
 #include "scipp/core/transform_common.h"
@@ -72,6 +74,25 @@ struct or_equals {
     a |= b;
   }
   using types = pair_self_t<bool>;
+};
+
+struct max_equals
+    : public transform_flags::expect_in_variance_if_out_variance_t {
+  template <class A, class B>
+  constexpr void operator()(A &&a, const B &b) const noexcept {
+    using std::max;
+    a = max(a, b);
+  }
+  using types = pair_self_t<double, float, int64_t, int32_t>;
+};
+struct min_equals
+    : public transform_flags::expect_in_variance_if_out_variance_t {
+  template <class A, class B>
+  constexpr void operator()(A &&a, const B &b) const noexcept {
+    using std::min;
+    a = min(a, b);
+  }
+  using types = pair_self_t<double, float, int64_t, int32_t>;
 };
 } // namespace operator_detail
 

--- a/core/operators.h
+++ b/core/operators.h
@@ -64,7 +64,6 @@ struct and_equals {
     a &= b;
   }
   using types = pair_self_t<bool>;
-  static constexpr auto init = true;
 };
 struct or_equals {
   template <class A, class B>
@@ -73,7 +72,6 @@ struct or_equals {
     a |= b;
   }
   using types = pair_self_t<bool>;
-  static constexpr auto init = false;
 };
 } // namespace operator_detail
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL
                rebin_test.cpp
                reduce_logical_test.cpp
                reduce_sparse_test.cpp
+               reduce_various_test.cpp
                self_assignment_test.cpp
                slice_test.cpp
                sort_test.cpp

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -502,3 +502,49 @@ TEST_F(GroupbyLogicalTest, any) {
                                          units::Unit(units::m), Values{1, 3}));
   EXPECT_EQ(groupby(d, "labels2", Dim::Y).any(Dim::X), expected);
 }
+
+struct GroupbyMinMaxTest : public ::testing::Test {
+  GroupbyMinMaxTest() {
+    d.setData("a", makeVariable<double>(Dimensions{{Dim::Z, 2}, {Dim::X, 3}},
+                                        Values{1, 2, 3, 4, 5, 6}));
+    d.setLabels("labels1",
+                makeVariable<double>(Dimensions{Dim::X, 3},
+                                     units::Unit(units::m), Values{1, 2, 3}));
+    d.setLabels("labels2",
+                makeVariable<double>(Dimensions{Dim::X, 3},
+                                     units::Unit(units::m), Values{1, 1, 3}));
+  }
+  Dataset d;
+};
+
+TEST_F(GroupbyMinMaxTest, no_reduction) {
+  Dataset expected(d);
+  expected.rename(Dim::X, Dim::Y);
+  expected.setCoord(Dim::Y, expected.labels()["labels1"]);
+  expected.labels().erase("labels1");
+  expected.labels().erase("labels2");
+  EXPECT_EQ(groupby(d, "labels1", Dim::Y).min(Dim::X), expected);
+  EXPECT_EQ(groupby(d, "labels1", Dim::Y).max(Dim::X), expected);
+}
+
+TEST_F(GroupbyMinMaxTest, min) {
+  Dataset expected;
+  expected.setData("a",
+                   makeVariable<double>(Dimensions{{Dim::Z, 2}, {Dim::Y, 2}},
+                                        Values{1, 3, 4, 6}));
+  expected.setCoord(Dim::Y,
+                    makeVariable<double>(Dimensions{Dim::Y, 2},
+                                         units::Unit(units::m), Values{1, 3}));
+  EXPECT_EQ(groupby(d, "labels2", Dim::Y).min(Dim::X), expected);
+}
+
+TEST_F(GroupbyMinMaxTest, max) {
+  Dataset expected;
+  expected.setData("a",
+                   makeVariable<double>(Dimensions{{Dim::Z, 2}, {Dim::Y, 2}},
+                                        Values{2, 3, 5, 6}));
+  expected.setCoord(Dim::Y,
+                    makeVariable<double>(Dimensions{Dim::Y, 2},
+                                         units::Unit(units::m), Values{1, 3}));
+  EXPECT_EQ(groupby(d, "labels2", Dim::Y).max(Dim::X), expected);
+}

--- a/core/test/reduce_sparse_test.cpp
+++ b/core/test/reduce_sparse_test.cpp
@@ -34,16 +34,6 @@ TEST(ReduceSparseTest, flatten) {
   EXPECT_EQ(flatten(make_sparse(), Dim::Y), expected);
 }
 
-TEST(ReduceSparseTest, flatten_with_mask) {
-  Dataset d;
-  d.setMask("y", makeVariable<bool>(Dims{Dim::Y}, Shape{3},
-                                    Values{false, true, false}));
-  auto expected =
-      makeVariable<double>(Dims{Dim::X}, Shape{Dimensions::Sparse},
-                           Values{sparse_container<double>{1, 2, 3, 6, 7}});
-  EXPECT_EQ(flatten(make_sparse(), Dim::Y, d.masks()), expected);
-}
-
 TEST(ReduceSparseTest, flatten_dataset_with_mask) {
   Dataset d;
   d.setMask("y", makeVariable<bool>(Dims{Dim::Y}, Shape{3},

--- a/core/test/reduce_various_test.cpp
+++ b/core/test/reduce_various_test.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/variable.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(ReduceTest, min_max_fails) {
+  const auto bad = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  EXPECT_THROW(static_cast<void>(min(bad, Dim::Y)), except::DimensionError);
+  EXPECT_THROW(static_cast<void>(max(bad, Dim::Y)), except::DimensionError);
+}
+
+TEST(ReduceTest, min_max) {
+  const auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                        Values{1, 2, 3, 4});
+  EXPECT_EQ(max(var, Dim::X),
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{3, 4}));
+  EXPECT_EQ(max(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2, 4}));
+  EXPECT_EQ(min(var, Dim::X),
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 2}));
+  EXPECT_EQ(min(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 3}));
+}
+
+TEST(ReduceTest, min_max_with_variances) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                           Values{1, 2, 3, 4}, Variances{5, 6, 7, 8});
+  EXPECT_EQ(max(var, Dim::X),
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{3, 4},
+                                 Variances{7, 8}));
+  EXPECT_EQ(max(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2, 4},
+                                 Variances{6, 8}));
+  EXPECT_EQ(min(var, Dim::X),
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 2},
+                                 Variances{5, 6}));
+  EXPECT_EQ(min(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 3},
+                                 Variances{5, 7}));
+}

--- a/core/variable_operations_common.h
+++ b/core/variable_operations_common.h
@@ -5,6 +5,8 @@
 #ifndef SCIPP_CORE_VARIABLE_OPERATIONS_COMMON_H
 #define SCIPP_CORE_VARIABLE_OPERATIONS_COMMON_H
 
+#include "scipp/core/dataset.h"
+
 namespace scipp::core {
 
 void flatten_impl(const VariableProxy &summed, const VariableConstProxy &var,
@@ -12,6 +14,17 @@ void flatten_impl(const VariableProxy &summed, const VariableConstProxy &var,
 void sum_impl(const VariableProxy &summed, const VariableConstProxy &var);
 void all_impl(const VariableProxy &out, const VariableConstProxy &var);
 void any_impl(const VariableProxy &out, const VariableConstProxy &var);
+
+[[nodiscard]] Variable mean(const VariableConstProxy &var, const Dim dim,
+                            const MasksConstProxy &masks);
+VariableProxy mean(const VariableConstProxy &var, const Dim dim,
+                   const MasksConstProxy &masks, const VariableProxy &out);
+[[nodiscard]] Variable flatten(const VariableConstProxy &var, const Dim dim,
+                               const MasksConstProxy &masks);
+[[nodiscard]] Variable sum(const VariableConstProxy &var, const Dim dim,
+                           const MasksConstProxy &masks);
+VariableProxy sum(const VariableConstProxy &var, const Dim dim,
+                  const MasksConstProxy &masks, const VariableProxy &out);
 
 } // namespace scipp::core
 

--- a/core/variable_operations_common.h
+++ b/core/variable_operations_common.h
@@ -9,12 +9,16 @@
 
 namespace scipp::core {
 
+// Helpers for in-place reductions and reductions with groupby.
 void flatten_impl(const VariableProxy &summed, const VariableConstProxy &var,
                   const Variable &mask = makeVariable<bool>(Values{false}));
 void sum_impl(const VariableProxy &summed, const VariableConstProxy &var);
 void all_impl(const VariableProxy &out, const VariableConstProxy &var);
 void any_impl(const VariableProxy &out, const VariableConstProxy &var);
+void max_impl(const VariableProxy &out, const VariableConstProxy &var);
+void min_impl(const VariableProxy &out, const VariableConstProxy &var);
 
+// Helpers for reductions for DataArray and Dataset, which include masks.
 [[nodiscard]] Variable mean(const VariableConstProxy &var, const Dim dim,
                             const MasksConstProxy &masks);
 VariableProxy mean(const VariableConstProxy &var, const Dim dim,

--- a/core/variable_reduction_operations.cpp
+++ b/core/variable_reduction_operations.cpp
@@ -236,17 +236,12 @@ VariableProxy mean(const VariableConstProxy &var, const Dim dim,
 template <class Op>
 void reduce_impl(const VariableProxy &out, const VariableConstProxy &var) {
   expect::notSparse(var);
-  // A better way for initializing the output is needed so this can be used for
-  // more than just boolean logical operations.
-  out ^= makeVariable<bool>(Values{Op::init});
   accumulate_in_place(out, var, Op{});
 }
 
 template <class Op>
 Variable reduce(const VariableConstProxy &var, const Dim dim) {
-  auto dims = var.dims();
-  dims.erase(dim);
-  Variable out(var, dims);
+  Variable out(var.slice({dim, 0}));
   reduce_impl<Op>(out, var);
   return out;
 }

--- a/core/variable_reduction_operations.cpp
+++ b/core/variable_reduction_operations.cpp
@@ -262,4 +262,20 @@ Variable all(const VariableConstProxy &var, const Dim dim) {
   return reduce<operator_detail::and_equals>(var, dim);
 }
 
+/// Return the maximum along given dimension.
+///
+/// Variances are not considered when determining the maximum. If present, the
+/// variance of the maximum element is returned.
+Variable max(const VariableConstProxy &var, const Dim dim) {
+  return reduce<operator_detail::max_equals>(var, dim);
+}
+
+/// Return the minimum along given dimension.
+///
+/// Variances are not considered when determining the minimum. If present, the
+/// variance of the minimum element is returned.
+Variable min(const VariableConstProxy &var, const Dim dim) {
+  return reduce<operator_detail::min_equals>(var, dim);
+}
+
 } // namespace scipp::core

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -29,12 +29,16 @@ General
    :toctree: ../generated
 
    abs
+   all
+   any
    concatenate
    dot
    filter
    histogram
+   max
    mean
    merge
+   min
    norm
    rebin
    reciprocal
@@ -50,11 +54,19 @@ Group-by (split-apply-combine)
    :toctree: ../generated
 
    groupby
+   GroupByDataArray.all
+   GroupByDataArray.any
    GroupByDataArray.flatten
+   GroupByDataArray.max
    GroupByDataArray.mean
+   GroupByDataArray.min
    GroupByDataArray.sum
+   GroupByDataset.all
+   GroupByDataset.any
    GroupByDataset.flatten
+   GroupByDataset.max
    GroupByDataset.mean
+   GroupByDataset.min
    GroupByDataset.sum
 
 Trigonometric

--- a/python/groupby.cpp
+++ b/python/groupby.cpp
@@ -80,6 +80,42 @@ template <class T> void bind_groupby(py::module &m, const std::string &name) {
       :type dim: Dim
       :return: Sum over each group, combined along dimension specified when calling :py:func:`scipp.groupby`
       :rtype: DataArray or Dataset)");
+
+  groupBy.def("all", &GroupBy<T>::all, py::arg("dim"),
+              py::call_guard<py::gil_scoped_release>(), R"(
+      Element-wise AND over the specified dimension within a group.
+
+      :param dim: Dimension to reduce
+      :type dim: Dim
+      :return: AND over each group, combined along dimension specified when calling :py:func:`scipp.groupby`
+      :rtype: DataArray or Dataset)");
+
+  groupBy.def("any", &GroupBy<T>::any, py::arg("dim"),
+              py::call_guard<py::gil_scoped_release>(), R"(
+      Element-wise OR over the specified dimension within a group.
+
+      :param dim: Dimension to reduce
+      :type dim: Dim
+      :return: OR over each group, combined along dimension specified when calling :py:func:`scipp.groupby`
+      :rtype: DataArray or Dataset)");
+
+  groupBy.def("max", &GroupBy<T>::max, py::arg("dim"),
+              py::call_guard<py::gil_scoped_release>(), R"(
+      Element-wise max over the specified dimension within a group.
+
+      :param dim: Dimension to reduce
+      :type dim: Dim
+      :return: Max over each group, combined along dimension specified when calling :py:func:`scipp.groupby`
+      :rtype: DataArray or Dataset)");
+
+  groupBy.def("min", &GroupBy<T>::min, py::arg("dim"),
+              py::call_guard<py::gil_scoped_release>(), R"(
+      Element-wise min over the specified dimension within a group.
+
+      :param dim: Dimension to reduce
+      :type dim: Dim
+      :return: Min over each group, combined along dimension specified when calling :py:func:`scipp.groupby`
+      :rtype: DataArray or Dataset)");
 }
 
 void init_groupby(py::module &m) {

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -158,8 +158,8 @@ def test_astype():
                       values=np.array([1, 2, 3, 4], dtype=np.int64))
     assert var.dtype == sc.dtype.int64
 
-    var_as_float = var.astype(sc.dtype.float64)
-    assert var_as_float.dtype == sc.dtype.float64
+    var_as_float = var.astype(sc.dtype.float32)
+    assert var_as_float.dtype == sc.dtype.float32
 
 
 def test_astype_bad_conversion():

--- a/python/tests/test_variable_proxy.py
+++ b/python/tests/test_variable_proxy.py
@@ -16,11 +16,12 @@ def test_type():
 
 def test_astype():
     variable_slice = sc.Variable([Dim.X],
-                                 values=np.arange(1, 10, dtype=int))[Dim.X, :]
+                                 values=np.arange(1, 10,
+                                                  dtype=np.int64))[Dim.X, :]
     assert variable_slice.dtype == sc.dtype.int64
 
-    var_as_float = variable_slice.astype(sc.dtype.float64)
-    assert var_as_float.dtype == sc.dtype.float64
+    var_as_float = variable_slice.astype(sc.dtype.float32)
+    assert var_as_float.dtype == sc.dtype.float32
 
 
 def apply_test_op(op, a, b, data):

--- a/python/tests/test_variable_reduction.py
+++ b/python/tests/test_variable_reduction.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+from scipp import Dim
+
+
+def test_all():
+    var = sc.Variable([Dim.X], values=[True, False, True])
+    assert sc.all(var, Dim.X) == sc.Variable(value=False)
+
+
+def test_any():
+    var = sc.Variable([Dim.X], values=[True, False, True])
+    assert sc.any(var, Dim.X) == sc.Variable(value=True)
+
+
+def test_min():
+    var = sc.Variable([Dim.X], values=[1, 2, 3])
+    assert sc.min(var, Dim.X) == sc.Variable(value=1)
+
+
+def test_max():
+    var = sc.Variable([Dim.X], values=[1, 2, 3])
+    assert sc.max(var, Dim.X) == sc.Variable(value=3)

--- a/python/tests/test_variable_reduction.py
+++ b/python/tests/test_variable_reduction.py
@@ -17,10 +17,10 @@ def test_any():
 
 
 def test_min():
-    var = sc.Variable([Dim.X], values=[1, 2, 3])
-    assert sc.min(var, Dim.X) == sc.Variable(value=1)
+    var = sc.Variable([Dim.X], values=[1.0, 2.0, 3.0])
+    assert sc.min(var, Dim.X) == sc.Variable(value=1.0)
 
 
 def test_max():
-    var = sc.Variable([Dim.X], values=[1, 2, 3])
-    assert sc.max(var, Dim.X) == sc.Variable(value=3)
+    var = sc.Variable([Dim.X], values=[1.0, 2.0, 3.0])
+    assert sc.max(var, Dim.X) == sc.Variable(value=3.0)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -681,4 +681,56 @@ void init_variable(py::module &m) {
         :raises: If the unit is dimensionless, or if the dtype has no atan, e.g., if it is an integer
         :return: atan of input values. Output unit is rad.
         :rtype: Variable)");
+
+  m.def("all", py::overload_cast<const VariableConstProxy &, const Dim>(&all),
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise AND over the specified dimension.
+
+        :param x: Data to reduce.
+        :param dim: Dimension to reduce.
+        :raises: If the dimension does not exist, or if the dtype is not bool
+        :seealso: :py:class:`scipp.any`
+        :return: New variable containing the reduced values.
+        :rtype: Variable)");
+
+  m.def("any", py::overload_cast<const VariableConstProxy &, const Dim>(&any),
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise OR over the specified dimension.
+
+        :param x: Data to reduce.
+        :param dim: Dimension to reduce.
+        :raises: If the dimension does not exist, or if the dtype is not bool
+        :seealso: :py:class:`scipp.all`
+        :return: New variable containing the reduced values.
+        :rtype: Variable)");
+
+  m.def("min",
+        [](const VariableConstProxy &self, const Dim dim) {
+          return min(self, dim);
+        },
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise min over the specified dimension.
+
+        :param x: Data to reduce.
+        :param dim: Dimension to reduce.
+        :seealso: :py:class:`scipp.max`
+        :return: New variable containing the min values.
+        :rtype: Variable)");
+
+  m.def("max",
+        [](const VariableConstProxy &self, const Dim dim) {
+          return max(self, dim);
+        },
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+        R"(
+        Element-wise max over the specified dimension.
+
+        :param x: Data to reduce.
+        :param dim: Dimension to reduce.
+        :seealso: :py:class:`scipp.min`
+        :return: New variable containing the max values.
+        :rtype: Variable)");
 }

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -144,7 +144,7 @@ public:
 };
 
 SCIPP_UNITS_DECLARE_DIMENSIONS(Detector, DSpacing, Energy, EnergyTransfer,
-                               Position, Q, QSquared, Qx, Qy, Qz, Row,
+                               Group, Position, Q, QSquared, Qx, Qy, Qz, Row,
                                ScatteringAngle, Spectrum, Temperature, Time,
                                Tof, Wavelength, X, Y, Z)
 


### PR DESCRIPTION
Add `min` and `max` for variables, and support in `groupby`. This can be used, e.g., in a powder workflow for grouping detectors and ensuring that diffraction focus grouping info is consistent.

Note that thanks to previous (and ongoing) improvements addition of these and similar reduction operations is now quite straightforward, reusing a lot of code.

Also add Python bindings.