### PR TITLE
Document the configuration file

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Documentation
    python-reference/dtype
    python-reference/units
    python-reference/error-propagation
+   python-reference/runtime-configuration
 
 .. toctree::
    :caption: Neutron-scattering

--- a/docs/python-reference/runtime-configuration.rst
+++ b/docs/python-reference/runtime-configuration.rst
@@ -1,0 +1,21 @@
+.. _runtime_configuration:
+
+Runtime Configuration
+=====================
+
+The ``scipp`` Python module supports several configuration options which may be set based on preference.
+Most of these are related to layout of items in Jupyter Notebooks and plotting.
+
+The location of the configuration file varies between operating systems.
+To determine where it is located on a particular installation the following Python may be used:
+
+.. code-block:: python
+
+  import scipp as sc
+  print(sc.user_configuration_filename)
+
+When the ``scipp`` module is imported and no configuiration file exists a default one is created.
+If a configuration file already exists it will not be modified, i.e. new options will not automatically be added to it when Scipp is updated.
+
+The fields in the configuration file are not strictly defined and may vary between Scipp versions.
+For this reason it is advised to browse this file to determine what options are available.

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -6,6 +6,7 @@
 # flake8: noqa
 
 from . import runtime_config
+user_configuration_filename = runtime_config.config_filename
 config = runtime_config.load()
 del runtime_config
 


### PR DESCRIPTION
Specific options are not listed as these are likely subject to change over Scipp versions.
Instead users are pointed to the file itself.

Should options be unclear then they likely require new (more verbose) names.