### PR TITLE
Groupby benchmark

### DIFF
--- a/benchmark/groupby_benchmark.cpp
+++ b/benchmark/groupby_benchmark.cpp
@@ -41,8 +41,8 @@ auto make_2d_sparse(const scipp::index size, const scipp::index count) {
   }
   auto sparse = make_2d_sparse_coord_only<T>(size, count);
   sparse.setData(std::move(var));
-  // Replacing this line by `copy(sparse)` yields more than 2x higher
-  // performance. It is not clear whether this is just due to improved
+  // Replacing the line below by `return copy(sparse);` yields more than 2x
+  // higher performance. It is not clear whether this is just due to improved
   // "re"-allocation performance in the benchmark loop (compared to fresh
   // allocations) or something else.
   return sparse;

--- a/benchmark/groupby_benchmark.cpp
+++ b/benchmark/groupby_benchmark.cpp
@@ -17,7 +17,32 @@ auto make_2d_sparse_coord_only(const scipp::index size,
   auto vals = var.sparseValues<double>();
   for (scipp::index i = 0; i < size; ++i)
     vals[i].resize(count);
-  DataArray sparse(std::nullopt, {{Dim::Y, std::move(var)}});
+  // Not using initializer_list to init coord map to avoid distortion of
+  // benchmark --- initializer_list induces a copy and yields 2x higher
+  // performance due to some details of the memory and allocation system that
+  // are not entirely understood.
+  std::map<Dim, Variable> map;
+  map.emplace(Dim::Y, std::move(var));
+  DataArray sparse(std::nullopt, std::move(map));
+  return sparse;
+}
+
+auto make_2d_sparse(const scipp::index size, const scipp::index count) {
+  auto var = makeVariable<double>(Dims{Dim::X, Dim::Y},
+                                  Shape{size, Dimensions::Sparse}, Values{},
+                                  Variances{});
+  auto vals = var.sparseValues<double>();
+  auto vars = var.sparseVariances<double>();
+  for (scipp::index i = 0; i < size; ++i) {
+    vals[i].resize(count);
+    vars[i].resize(count);
+  }
+  auto sparse = make_2d_sparse_coord_only(size, count);
+  sparse.setData(std::move(var));
+  // Replacing this line by `copy(sparse)` yields more than 2x higher
+  // performance. It is not clear whether this is just due to improved
+  // "re"-allocation performance in the benchmark loop (compared to fresh
+  // allocations) or something else.
   return sparse;
 }
 
@@ -25,19 +50,29 @@ static void BM_groupby_flatten(benchmark::State &state) {
   const scipp::index nEvent = 1e8;
   const scipp::index nHist = state.range(0);
   const scipp::index nGroup = state.range(1);
-  auto sparse = make_2d_sparse_coord_only(nHist, nEvent / nHist);
+  const bool coord_only = state.range(2);
+  auto sparse = coord_only ? make_2d_sparse_coord_only(nHist, nEvent / nHist)
+                           : make_2d_sparse(nHist, nEvent / nHist);
   std::vector<int64_t> group_(nHist);
   std::iota(group_.begin(), group_.end(), 0);
   auto group = makeVariable<int64_t>(Dims{Dim::X}, Shape{nHist},
                                      Values(group_.begin(), group_.end()));
   sparse.labels().set("group", group / (nHist / nGroup));
   for (auto _ : state) {
-    benchmark::DoNotOptimize(groupby(sparse, "group", Dim::Z).flatten(Dim::X));
+    auto flat = groupby(sparse, "group", Dim::Z).flatten(Dim::X);
+    state.PauseTiming();
+    flat = DataArray();
+    state.ResumeTiming();
   }
   state.SetItemsProcessed(state.iterations() * nEvent);
   // Not taking into account vector reallocations, just the raw "effective" size
   // (read event, write to output).
-  state.SetBytesProcessed(state.iterations() * (2 * nEvent) * sizeof(double));
+  int64_t data_factor = coord_only ? 1 : 3;
+  state.SetBytesProcessed(state.iterations() * (2 * nEvent * data_factor) *
+                          sizeof(double));
+  state.counters["coord-only"] = coord_only;
+  state.counters["groups"] = nGroup;
+  state.counters["inputs"] = nHist;
 }
 // Params are:
 // - nHist
@@ -46,6 +81,6 @@ static void BM_groupby_flatten(benchmark::State &state) {
 // a copy of the input with reshuffling events.
 BENCHMARK(BM_groupby_flatten)
     ->RangeMultiplier(4)
-    ->Ranges({{64, 2 << 17}, {1, 64}});
+    ->Ranges({{64, 2 << 19}, {1, 64}, {true, false}});
 
 BENCHMARK_MAIN();

--- a/core/include/scipp/core/slice.h
+++ b/core/include/scipp/core/slice.h
@@ -20,12 +20,12 @@ public:
   Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_);
   Slice(const Dim dim_, const scipp::index begin_);
   Slice &operator=(const Slice &) = default;
-  bool operator==(const Slice &other) const;
-  bool operator!=(const Slice &other) const;
-  scipp::index begin() const;
-  scipp::index end() const;
-  Dim dim() const;
-  bool isRange() const;
+  bool operator==(const Slice &other) const noexcept;
+  bool operator!=(const Slice &other) const noexcept;
+  scipp::index begin() const noexcept { return m_begin; };
+  scipp::index end() const noexcept { return m_end; };
+  Dim dim() const noexcept { return m_dim; };
+  bool isRange() const noexcept { return m_end != -1; };
 
 private:
   Dim m_dim;

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -647,7 +647,6 @@ public:
                      const scipp::index begin, const scipp::index end = -1)
       : m_variable(&variable),
         m_view(variable.data().makeView(dim, begin, end)) {}
-  VariableConstProxy(const VariableConstProxy &other) = default;
   VariableConstProxy(const VariableConstProxy &slice, const Dim dim,
                      const scipp::index begin, const scipp::index end = -1)
       : m_variable(slice.m_variable),
@@ -769,7 +768,6 @@ public:
       : VariableConstProxy(variable), m_mutableVariable(&variable) {
     m_view = variable.data().reshape(dims);
   }
-  VariableProxy(const VariableProxy &other) = default;
   VariableProxy(Variable &variable, const Dim dim, const scipp::index begin,
                 const scipp::index end = -1)
       : VariableConstProxy(variable), m_mutableVariable(&variable) {

--- a/core/slice.cpp
+++ b/core/slice.cpp
@@ -41,16 +41,13 @@ Slice::Slice(const Dim dim_, const index begin_)
     : m_dim(dim_), m_begin(begin_), m_end(-1) {
   validate_begin(begin_);
 }
-scipp::index Slice::begin() const { return m_begin; }
-scipp::index Slice::end() const { return m_end; }
-Dim Slice::dim() const { return m_dim; }
 
-bool Slice::isRange() const { return m_end != -1; }
-
-bool Slice::operator==(const Slice &other) const {
+bool Slice::operator==(const Slice &other) const noexcept {
   return m_dim == other.dim() && m_begin == other.m_begin &&
          m_end == other.m_end;
 }
-bool Slice::operator!=(const Slice &other) const { return !(*this == other); }
+bool Slice::operator!=(const Slice &other) const noexcept {
+  return !(*this == other);
+}
 
 } // namespace scipp::core


### PR DESCRIPTION
Including some minor optimizations. The benchmark with many groups indicates that the overhead of slicing and proxies is significant and may need to be improved (this is not a surprise, since the current implementation was aimed at conceptual correctness).