### PR TITLE
Fix plot of sparse data with on-the-fly histogram shows only one dataset entry

### DIFF
--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -60,9 +60,9 @@ def dispatch(scipp_obj_dict,
                        mpl_line_params=mpl_line_params,
                        **kwargs)
     elif projection == "2d":
-        return plot_2d(scipp_obj_dict[name], output=output, **kwargs)
+        return plot_2d(scipp_obj_dict, output=output, **kwargs)
     elif projection == "3d":
-        return plot_3d(scipp_obj_dict[name], output=output, **kwargs)
+        return plot_3d(scipp_obj_dict, output=output, **kwargs)
     else:
         raise RuntimeError("Wrong projection type. Expected either '2d' "
                            "or '3d', got {}.".format(projection))

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -46,7 +46,6 @@ def plot_1d(scipp_obj_dict=None,
     #     axes = data_array.dims
 
     sv = Slicer1d(scipp_obj_dict=scipp_obj_dict,
-                  # data_array=data_array,
                   axes=axes,
                   values=values,
                   variances=variances,
@@ -68,7 +67,6 @@ def plot_1d(scipp_obj_dict=None,
 class Slicer1d(Slicer):
     def __init__(self,
                  scipp_obj_dict=None,
-                 # data_array=None,
                  axes=None,
                  values=None,
                  variances=None,
@@ -79,7 +77,6 @@ class Slicer1d(Slicer):
                  logy=False):
 
         super().__init__(scipp_obj_dict=scipp_obj_dict,
-                         # data_array=data_array,
                          axes=axes,
                          values=values,
                          variances=variances,
@@ -250,7 +247,8 @@ class Slicer1d(Slicer):
             })
 
         # if self.params["masks"]["show"]:
-        #     mslice = self.slice_masks()
+        if self.masks is not None:
+            mslice = self.slice_masks()
 
         xmin = np.Inf
         xmax = np.NINF
@@ -275,13 +273,12 @@ class Slicer1d(Slicer):
                                   })
                 # Add masks if any
                 if self.params["masks"][name]["show"]:
-                    mslice = self.slice_masks()
                     me = np.concatenate(([False], mslice.values))
                     [self.members["masks"][name]] = self.ax.step(
                         new_x,
                         self.mask_to_float(me, ye),
                         linewidth=self.mpl_line_params["linewidth"][name] * 3,
-                        color=self.params["masks"]["color"],
+                        color=self.params["masks"][name]["color"],
                         zorder=9)
 
             else:
@@ -302,7 +299,7 @@ class Slicer1d(Slicer):
                         new_x,
                         self.mask_to_float(mslice.values, vslice.values),
                         zorder=10,
-                        mec=self.params["masks"]["color"],
+                        mec=self.params["masks"][name]["color"],
                         mew=3,
                         linestyle="none",
                         **{
@@ -335,7 +332,8 @@ class Slicer1d(Slicer):
                 warnings.filterwarnings("ignore", category=UserWarning)
                 self.ax.set_xlim([xmin - deltax, xmax + deltax])
         self.ax.set_xlabel(
-            name_with_unit(self.slider_x[self.name][dim], name=self.slider_labels[self.name][dim]))
+            name_with_unit(self.slider_x[self.name][dim],
+                           name=self.slider_labels[self.name][dim]))
         if self.slider_ticks[self.name][dim] is not None:
             self.ax.set_xticklabels(self.get_custom_ticks(self.ax, dim))
         return
@@ -359,7 +357,7 @@ class Slicer1d(Slicer):
 
     # Define function to update slices
     def update_slice(self, change):
-        if self.params["masks"]["show"]:
+        if self.masks is not None:
             mslice = self.slice_masks()
         for i, (name, var) in enumerate(sorted(self.scipp_obj_dict.items())):
             vslice = self.slice_data(var)
@@ -368,7 +366,7 @@ class Slicer1d(Slicer):
                 vals = np.concatenate(([0], vals))
             self.members["lines"][name].set_ydata(vals)
 
-            if self.params["masks"]["show"]:
+            if self.params["masks"][name]["show"]:
                 msk = mslice.values
                 if self.histograms[name][self.button_axis_to_dim["x"]]:
                     msk = np.concatenate(([False], msk))
@@ -391,7 +389,7 @@ class Slicer1d(Slicer):
     def keep_trace(self, owner):
         lab = self.keep_buttons[owner.id][0].value
         lines_to_keep = ["lines"]
-        if self.params["masks"]["show"]:
+        if self.params["masks"][lab]["show"]:
             lines_to_keep.append("masks")
         for l in lines_to_keep:
             self.ax.lines.append(cp.copy(self.members[l][lab]))

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -40,11 +40,6 @@ def plot_1d(scipp_obj_dict=None,
 
     """
 
-    # # Get the first entry in the dict of scipp objects
-    # _, data_array = next(iter(scipp_obj_dict.items()))
-    # if axes is None:
-    #     axes = data_array.dims
-
     sv = Slicer1d(scipp_obj_dict=scipp_obj_dict,
                   axes=axes,
                   values=values,
@@ -131,7 +126,7 @@ class Slicer1d(Slicer):
         self.names = []
         ymin = np.Inf
         ymax = np.NINF
-        for i, (name, var) in enumerate(sorted(self.scipp_obj_dict.items())):
+        for name, var in self.scipp_obj_dict.items():
             self.names.append(name)
             if self.variances[name]:
                 err = np.sqrt(var.variances)
@@ -359,7 +354,7 @@ class Slicer1d(Slicer):
     def update_slice(self, change):
         if self.masks is not None:
             mslice = self.slice_masks()
-        for i, (name, var) in enumerate(sorted(self.scipp_obj_dict.items())):
+        for name, var in self.scipp_obj_dict.items():
             vslice = self.slice_data(var)
             vals = vslice.values
             if self.histograms[name][self.button_axis_to_dim["x"]]:

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -241,7 +241,6 @@ class Slicer1d(Slicer):
                 "masks": {}
             })
 
-        # if self.params["masks"]["show"]:
         if self.masks is not None:
             mslice = self.slice_masks()
 

--- a/python/src/scipp/plot/plot_1d.py
+++ b/python/src/scipp/plot/plot_1d.py
@@ -40,13 +40,13 @@ def plot_1d(scipp_obj_dict=None,
 
     """
 
-    # Get the first entry in the dict of scipp objects
-    _, data_array = next(iter(scipp_obj_dict.items()))
-    if axes is None:
-        axes = data_array.dims
+    # # Get the first entry in the dict of scipp objects
+    # _, data_array = next(iter(scipp_obj_dict.items()))
+    # if axes is None:
+    #     axes = data_array.dims
 
     sv = Slicer1d(scipp_obj_dict=scipp_obj_dict,
-                  data_array=data_array,
+                  # data_array=data_array,
                   axes=axes,
                   values=values,
                   variances=variances,
@@ -68,7 +68,7 @@ def plot_1d(scipp_obj_dict=None,
 class Slicer1d(Slicer):
     def __init__(self,
                  scipp_obj_dict=None,
-                 data_array=None,
+                 # data_array=None,
                  axes=None,
                  values=None,
                  variances=None,
@@ -79,7 +79,7 @@ class Slicer1d(Slicer):
                  logy=False):
 
         super().__init__(scipp_obj_dict=scipp_obj_dict,
-                         data_array=data_array,
+                         # data_array=data_array,
                          axes=axes,
                          values=values,
                          variances=variances,
@@ -249,13 +249,13 @@ class Slicer1d(Slicer):
                 "masks": {}
             })
 
-        if self.params["masks"]["show"]:
-            mslice = self.slice_masks()
+        # if self.params["masks"]["show"]:
+        #     mslice = self.slice_masks()
 
         xmin = np.Inf
         xmax = np.NINF
         for name, var in self.scipp_obj_dict.items():
-            new_x = var.coords[dim].values
+            new_x = self.slider_x[name][dim].values
             xmin = min(new_x[0], xmin)
             xmax = max(new_x[-1], xmax)
 
@@ -274,7 +274,8 @@ class Slicer1d(Slicer):
                                       for key in ["color", "linewidth"]
                                   })
                 # Add masks if any
-                if self.params["masks"]["show"]:
+                if self.params["masks"][name]["show"]:
+                    mslice = self.slice_masks()
                     me = np.concatenate(([False], mslice.values))
                     [self.members["masks"][name]] = self.ax.step(
                         new_x,
@@ -296,7 +297,7 @@ class Slicer1d(Slicer):
                                       for key in self.mpl_line_params.keys()
                                   })
                 # Add masks if any
-                if self.params["masks"]["show"]:
+                if self.params["masks"][name]["show"]:
                     [self.members["masks"][name]] = self.ax.plot(
                         new_x,
                         self.mask_to_float(mslice.values, vslice.values),
@@ -334,8 +335,8 @@ class Slicer1d(Slicer):
                 warnings.filterwarnings("ignore", category=UserWarning)
                 self.ax.set_xlim([xmin - deltax, xmax + deltax])
         self.ax.set_xlabel(
-            name_with_unit(self.slider_x[dim], name=self.slider_labels[dim]))
-        if self.slider_ticks[dim] is not None:
+            name_with_unit(self.slider_x[self.name][dim], name=self.slider_labels[self.name][dim]))
+        if self.slider_ticks[self.name][dim] is not None:
             self.ax.set_xticklabels(self.get_custom_ticks(self.ax, dim))
         return
 
@@ -345,7 +346,7 @@ class Slicer1d(Slicer):
         for dim, val in self.slider.items():
             if not val.disabled:
                 self.lab[dim].value = self.make_slider_label(
-                    self.slider_x[dim], val.value)
+                    self.slider_x[self.name][dim], val.value)
                 vslice = vslice[val.dim, val.value]
         return vslice
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 import warnings
 
 
-def plot_2d(data_array=None,
+def plot_2d(scipp_obj_dict=None,
             output=None,
             axes=None,
             values=None,
@@ -40,7 +40,7 @@ def plot_2d(data_array=None,
     particular dimension.
     """
 
-    sv = Slicer2d(data_array=data_array,
+    sv = Slicer2d(scipp_obj_dict=scipp_obj_dict,
                   axes=axes,
                   values=values,
                   variances=variances,
@@ -66,7 +66,7 @@ def plot_2d(data_array=None,
 
 class Slicer2d(Slicer):
     def __init__(self,
-                 data_array=None,
+                 scipp_obj_dict=None,
                  axes=None,
                  values=None,
                  variances=None,
@@ -81,7 +81,7 @@ class Slicer2d(Slicer):
                  logx=False,
                  logy=False):
 
-        super().__init__(data_array=data_array,
+        super().__init__(scipp_obj_dict=scipp_obj_dict,
                          axes=axes,
                          values=values,
                          variances=variances,

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -153,7 +153,7 @@ class Slicer2d(Slicer):
                     aspect=self.aspect,
                     interpolation="nearest",
                     cmap=self.params[key][self.name]["cmap"])
-                self.ax[key].set_title(self.data_array.name if key ==
+                self.ax[key].set_title(self.name if key ==
                                        "values" else "std dev.")
                 if self.params[key][self.name]["cbar"]:
                     self.cbar[key] = plt.colorbar(self.im[key],
@@ -215,7 +215,7 @@ class Slicer2d(Slicer):
         for dim, button in self.buttons.items():
             if self.slider[dim].disabled:
                 but_val = button.value.lower()
-                if not self.histograms[self.data_array.name][dim]:
+                if not self.histograms[self.name][dim]:
                     xc = self.slider_x[self.name][dim].values
                     if self.slider_nx[self.name][dim] < 2:
                         xmin = xc[0] - 0.5

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -99,7 +99,7 @@ class Slicer2d(Slicer):
 
         # Get or create matplotlib axes
         self.fig = None
-        cax = [None] * (1 + self.params["variances"]["show"])
+        cax = [None] * (1 + self.params["variances"][self.name]["show"])
         if mpl_axes is not None:
             if isinstance(mpl_axes, dict):
                 ax = [None, None]
@@ -118,15 +118,15 @@ class Slicer2d(Slicer):
         else:
             self.fig, ax = plt.subplots(
                 1,
-                1 + self.params["variances"]["show"],
+                1 + self.params["variances"][self.name]["show"],
                 figsize=(config.plot.width / config.plot.dpi,
                          config.plot.height /
-                         (1.0 + self.params["variances"]["show"]) /
+                         (1.0 + self.params["variances"][self.name]["show"]) /
                          config.plot.dpi),
                 dpi=config.plot.dpi,
                 sharex=True,
                 sharey=True)
-            if not self.params["variances"]["show"]:
+            if not self.params["variances"][self.name]["show"]:
                 ax = [ax]
 
         self.ax = dict()
@@ -137,25 +137,25 @@ class Slicer2d(Slicer):
         self.ax["values"] = ax[0]
         self.cax["values"] = cax[0]
         panels = ["values"]
-        if self.params["variances"]["show"]:
+        if self.params["variances"][self.name]["show"]:
             self.ax["variances"] = ax[1]
             self.cax["variances"] = cax[1]
             panels.append("variances")
 
         extent_array = np.array(list(self.extent.values())).flatten()
         for key in panels:
-            if self.params[key]["show"]:
+            if self.params[key][self.name]["show"]:
                 self.im[key] = self.ax[key].imshow(
                     [[1.0, 1.0], [1.0, 1.0]],
-                    norm=self.params[key]["norm"],
+                    norm=self.params[key][self.name]["norm"],
                     extent=extent_array,
                     origin="lower",
                     aspect=self.aspect,
                     interpolation="nearest",
-                    cmap=self.params[key]["cmap"])
+                    cmap=self.params[key][self.name]["cmap"])
                 self.ax[key].set_title(self.data_array.name if key ==
                                        "values" else "std dev.")
-                if self.params[key]["cbar"]:
+                if self.params[key][self.name]["cbar"]:
                     self.cbar[key] = plt.colorbar(self.im[key],
                                                   ax=self.ax[key],
                                                   cax=self.cax[key])
@@ -165,15 +165,15 @@ class Slicer2d(Slicer):
                     self.cbar[key].ax.yaxis.set_label_coords(-1.1, 0.5)
                 self.members["images"][key] = self.im[key]
                 self.members["colorbars"][key] = self.cbar[key]
-                if self.params["masks"]["show"]:
+                if self.params["masks"][self.name]["show"]:
                     self.im[self.get_mask_key(key)] = self.ax[key].imshow(
                         [[1.0, 1.0], [1.0, 1.0]],
                         extent=extent_array,
-                        norm=self.params[key]["norm"],
+                        norm=self.params[key][self.name]["norm"],
                         origin="lower",
                         interpolation="nearest",
                         aspect=self.aspect,
-                        cmap=self.params["masks"]["cmap"])
+                        cmap=self.params["masks"][self.name]["cmap"])
                 if logx:
                     self.ax[key].set_xscale("log")
                 if logy:
@@ -216,8 +216,8 @@ class Slicer2d(Slicer):
             if self.slider[dim].disabled:
                 but_val = button.value.lower()
                 if not self.histograms[self.data_array.name][dim]:
-                    xc = self.slider_x[dim].values
-                    if self.slider_nx[dim] < 2:
+                    xc = self.slider_x[self.name][dim].values
+                    if self.slider_nx[self.name][dim] < 2:
                         xmin = xc[0] - 0.5
                         xmax = xc[0] + 0.5
                     else:
@@ -225,10 +225,12 @@ class Slicer2d(Slicer):
                         xmax = 1.5 * xc[-1] - 0.5 * xc[-2]
                     self.extent[but_val] = [xmin, xmax]
                 else:
-                    self.extent[but_val] = self.slider_x[dim].values[[0, -1]]
+                    self.extent[but_val] = self.slider_x[
+                        self.name][dim].values[[0, -1]]
 
                 axparams[but_val]["labels"] = name_with_unit(
-                    self.slider_x[dim], name=self.slider_labels[dim])
+                    self.slider_x[self.name][dim],
+                    name=self.slider_labels[self.name][dim])
                 axparams[but_val]["dim"] = dim
 
         extent_array = np.array(list(self.extent.values())).flatten()
@@ -236,14 +238,14 @@ class Slicer2d(Slicer):
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
                 self.im[key].set_extent(extent_array)
-                if self.params["masks"]["show"]:
+                if self.params["masks"][self.name]["show"]:
                     self.im[self.get_mask_key(key)].set_extent(extent_array)
                 self.ax[key].set_xlim(self.extent["x"])
                 self.ax[key].set_ylim(self.extent["y"])
             self.ax[key].set_xlabel(axparams["x"]["labels"])
             self.ax[key].set_ylabel(axparams["y"]["labels"])
             for xy, param in axparams.items():
-                if self.slider_ticks[param["dim"]] is not None:
+                if self.slider_ticks[self.name][param["dim"]] is not None:
                     getattr(self.ax[key], "set_{}ticklabels".format(xy))(
                         self.get_custom_ticks(ax=self.ax[key],
                                               dim=param["dim"],
@@ -255,18 +257,18 @@ class Slicer2d(Slicer):
         Slice data according to new slider value.
         """
         vslice = self.data_array
-        if self.params["masks"]["show"]:
+        if self.params["masks"][self.name]["show"]:
             mslice = self.masks
         # Slice along dimensions with active sliders
         button_dims = [None, None]
         for dim, val in self.slider.items():
             if not val.disabled:
                 self.lab[dim].value = self.make_slider_label(
-                    self.slider_x[dim], val.value)
+                    self.slider_x[self.name][dim], val.value)
                 vslice = vslice[val.dim, val.value]
                 # At this point, after masks were combined, all their
                 # dimensions should be contained in the data_array.dims.
-                if self.params["masks"]["show"]:
+                if self.params["masks"][self.name]["show"]:
                     mslice = mslice[val.dim, val.value]
             else:
                 button_dims[self.buttons[dim].value.lower() == "x"] = val.dim
@@ -275,8 +277,8 @@ class Slicer2d(Slicer):
         slice_dims = vslice.dims
         transp = slice_dims != button_dims
 
-        if self.params["masks"]["show"]:
-            shape_list = [self.shapes[bdim] for bdim in button_dims]
+        if self.params["masks"][self.name]["show"]:
+            shape_list = [self.shapes[self.name][bdim] for bdim in button_dims]
             # Use scipp's automatic broadcast functionality to broadcast
             # lower dimension masks to higher dimensions.
             # TODO: creating a Variable here could become expensive when
@@ -297,7 +299,7 @@ class Slicer2d(Slicer):
             if transp:
                 arr = arr.T
             self.im[key].set_data(arr)
-            if self.params["masks"]["show"]:
+            if self.params["masks"][self.name]["show"]:
                 self.im[self.get_mask_key(key)].set_data(
                     self.mask_to_float(msk.values, arr))
 

--- a/python/src/scipp/plot/plot_3d.py
+++ b/python/src/scipp/plot/plot_3d.py
@@ -20,7 +20,7 @@ except ImportError:
     ipv = None
 
 
-def plot_3d(data_array=None,
+def plot_3d(scipp_obj_dict=None,
             output=None,
             axes=None,
             values=None,
@@ -47,7 +47,7 @@ def plot_3d(data_array=None,
                            "and ipyevents to be installed. Use conda/pip "
                            "install ipyvolume ipyevents.")
 
-    sv = Slicer3d(data_array=data_array,
+    sv = Slicer3d(scipp_obj_dict=scipp_obj_dict,
                   axes=axes,
                   values=values,
                   variances=variances,
@@ -66,7 +66,7 @@ def plot_3d(data_array=None,
 
 class Slicer3d(Slicer):
     def __init__(self,
-                 data_array=None,
+                 scipp_obj_dict=None,
                  axes=None,
                  values=None,
                  variances=None,
@@ -78,7 +78,7 @@ class Slicer3d(Slicer):
                  color=None,
                  aspect=None):
 
-        super().__init__(data_array=data_array,
+        super().__init__(scipp_obj_dict=scipp_obj_dict,
                          axes=axes,
                          values=values,
                          variances=variances,
@@ -92,12 +92,7 @@ class Slicer3d(Slicer):
                          button_options=['X', 'Y', 'Z'])
 
         self.cube = None
-        self.members.update({
-            "surfaces": {},
-            "wireframes": {},
-            "outlines": {},
-            "fig": {}
-        })
+        self.members.update({"surfaces": {}, "wireframes": {}, "fig": {}})
 
         # Initialise Figure and VBox objects
         self.fig = ipv.figure(width=config.plot.width,
@@ -106,12 +101,13 @@ class Slicer3d(Slicer):
         self.scalar_map = dict()
 
         panels = ["values"]
-        if self.params["variances"]["show"]:
+        if self.params["variances"][self.name]["show"]:
             panels.append("variances")
 
         for key in panels:
             self.scalar_map[key] = cm.ScalarMappable(
-                norm=self.params[key]["norm"], cmap=self.params[key]["cmap"])
+                norm=self.params[key][self.name]["norm"],
+                cmap=self.params[key][self.name]["cmap"])
             self.members["surfaces"][key] = {}
             self.members["wireframes"][key] = {}
 
@@ -119,14 +115,10 @@ class Slicer3d(Slicer):
 
         # Store min/max for each dimension for invisible scatter
         self.xminmax = dict()
-        for dim, var in self.slider_x.items():
+        for dim, var in self.slider_x[self.name].items():
             self.xminmax[dim] = [var.values[0], var.values[-1]]
-        outl_x, outl_y, outl_z = self.get_box()
+        self.set_axes_range()
 
-        self.outline = ipv.plot_wireframe(outl_x,
-                                          outl_y,
-                                          outl_z,
-                                          color="black")
         self.wireframes = dict()
         self.surfaces = dict()
 
@@ -166,7 +158,6 @@ class Slicer3d(Slicer):
         self.box = widgets.VBox(self.box)
         self.box.layout.align_items = 'center'
 
-        self.members["outlines"]["values"] = self.outline
         self.members["fig"]["values"] = self.fig
 
         return
@@ -196,18 +187,7 @@ class Slicer3d(Slicer):
                 self.button_axis_to_dim[ax_dim] = dim
 
         self.fig.meshes = []
-        # Update the outline
-        outl_x, outl_y, outl_z = self.get_box()
-        outl_x = outl_x.flatten()
-        outl_y = outl_y.flatten()
-        outl_z = outl_z.flatten()
-        self.outline.x = outl_x
-        self.outline.y = outl_y
-        self.outline.z = outl_z
-        self.fig.xlim = list(outl_x[[0, -1]])
-        self.fig.ylim = list(outl_y[[0, -1]])
-        self.fig.zlim = list(outl_z[[0, -1]])
-
+        self.set_axes_range()
         self.update_axes()
         # self.box.children = tuple([ipv.gcc()] + self.vbox)
 
@@ -220,7 +200,8 @@ class Slicer3d(Slicer):
         for dim, button in self.buttons.items():
             if button.value is not None:
                 titles[button.value.lower()] = name_with_unit(
-                    self.slider_x[dim], name=self.slider_labels[dim])
+                    self.slider_x[self.name][dim],
+                    name=self.slider_labels[self.name][dim])
                 # buttons_dims[button.value.lower()] = button.dim
                 buttons_dims[button.value.lower()] = dim
 
@@ -242,7 +223,7 @@ class Slicer3d(Slicer):
         for dim, val in self.slider.items():
             if self.buttons[dim].value is None:
                 self.lab[dim].value = self.make_slider_label(
-                    self.slider_x[dim], val.value)
+                    self.slider_x[self.name][dim], val.value)
                 self.cube = self.cube[dim, val.value]
 
         # The dimensions to be sliced have been saved in slider_dims
@@ -254,10 +235,10 @@ class Slicer3d(Slicer):
                 s = self.buttons[dim].value.lower()
                 button_dim[s] = dim
                 self.lab[dim].value = self.make_slider_label(
-                    self.slider_x[dim], val.value)
+                    self.slider_x[self.name][dim], val.value)
                 vslices[s] = {
                     "slice": self.cube[dim, val.value],
-                    "loc": self.slider_x[dim].values[val.value]
+                    "loc": self.slider_x[self.name][dim].values[val.value]
                 }
 
         # Now make 3 slices
@@ -303,7 +284,7 @@ class Slicer3d(Slicer):
             # slice_indices = {"x": 0, "y": 1, "z": 2}
             dim = change["owner"].dim
             self.lab[dim].value = self.make_slider_label(
-                self.slider_x[dim], change["new"])
+                self.slider_x[self.name][dim], change["new"])
 
             # Now move slice
             ax_dim = self.buttons[dim].value.lower()
@@ -311,7 +292,7 @@ class Slicer3d(Slicer):
             setattr(
                 self.wireframes[ax_dim], ax_dim,
                 getattr(self.wireframes[ax_dim], ax_dim) * 0.0 +
-                self.slider_x[dim].values[change["new"]])
+                self.slider_x[self.name][dim].values[change["new"]])
 
             self.last_changed_slider_dim = dim
         return
@@ -329,7 +310,7 @@ class Slicer3d(Slicer):
             setattr(
                 self.surfaces[ax_dim], ax_dim,
                 getattr(self.surfaces[ax_dim], ax_dim) * 0.0 +
-                self.slider_x[dim].values[index])
+                self.slider_x[self.name][dim].values[index])
 
             self.surfaces[self.buttons[dim].value.lower()].color = \
                 self.scalar_map["values"].to_rgba(
@@ -372,12 +353,14 @@ class Slicer3d(Slicer):
         for key, val in self.permutations.items():
             meshes[key] = dict()
             meshes[key][val[0]], meshes[key][val[1]] = np.meshgrid(
-                self.slider_x[self.button_axis_to_dim[val[0]]].values,
-                self.slider_x[self.button_axis_to_dim[val[1]]].values,
+                self.slider_x[self.name][self.button_axis_to_dim[
+                    val[0]]].values,
+                self.slider_x[self.name][self.button_axis_to_dim[
+                    val[1]]].values,
                 indexing="ij")
         return meshes
 
-    def get_box(self):
+    def set_axes_range(self):
         if self.aspect == "equal":
             max_size = 0.0
             dx = {"x": 0, "y": 0, "z": 0}
@@ -392,14 +375,20 @@ class Slicer3d(Slicer):
                     self.xminmax[self.button_axis_to_dim[ax]][1] + 0.5 * diff
                 ]
 
-            return np.meshgrid(arrays["x"],
-                               arrays["y"],
-                               arrays["z"],
-                               indexing="ij")
+            outl_x, outl_y, outl_z = np.meshgrid(arrays["x"],
+                                                 arrays["y"],
+                                                 arrays["z"],
+                                                 indexing="ij")
         elif self.aspect == "auto":
-            return np.meshgrid(self.xminmax[self.button_axis_to_dim["x"]],
-                               self.xminmax[self.button_axis_to_dim["y"]],
-                               self.xminmax[self.button_axis_to_dim["z"]],
-                               indexing="ij")
+            outl_x, outl_y, outl_z = np.meshgrid(
+                self.xminmax[self.button_axis_to_dim["x"]],
+                self.xminmax[self.button_axis_to_dim["y"]],
+                self.xminmax[self.button_axis_to_dim["z"]],
+                indexing="ij")
         else:
             raise RuntimeError("Unknown aspect ratio: {}".format(self.aspect))
+
+        self.fig.xlim = list(outl_x.flatten()[[0, -1]])
+        self.fig.ylim = list(outl_y.flatten()[[0, -1]])
+        self.fig.zlim = list(outl_z.flatten()[[0, -1]])
+        return

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -15,7 +15,7 @@ import matplotlib.ticker as ticker
 class Slicer:
     def __init__(self,
                  scipp_obj_dict=None,
-                 data_array=None,
+                 # data_array=None,
                  axes=None,
                  values=None,
                  variances=None,
@@ -32,9 +32,11 @@ class Slicer:
         import ipywidgets as widgets
 
         self.scipp_obj_dict = scipp_obj_dict
-        if self.scipp_obj_dict is None:
-            self.scipp_obj_dict = {data_array.name: data_array}
-        self.data_array = data_array
+        # if self.scipp_obj_dict is None:
+        #     self.scipp_obj_dict = {data_array.name: data_array}
+        # if len(self.scipp_obj_dict) == 1:
+        #     self.name = list(self.scipp_obj_dict.keys())[0]
+        #     self.data_array = self.scipp_obj_dict[self.name]
 
         # Member container for dict output
         self.members = dict(widgets=dict(sliders=dict(),
@@ -44,7 +46,11 @@ class Slicer:
                                          labels=dict()))
 
         # Parse parameters for values, variances and masks
-        self.params = dict()
+        self.params = {
+            "values": {},
+            "variances": {},
+            "masks": {}
+        }
         globs = {
             "cmap": cmap,
             "log": log,
@@ -53,72 +59,115 @@ class Slicer:
             "color": color
         }
 
-        self.params["values"] = parse_params(params=values,
-                                             globs=globs,
-                                             array=self.data_array.values)
+        # # Process axes dimensions
+        # if axes is None:
+        #     axes = self.scipp_obj_dict.dims
+        # # Protect against duplicate entries in axes
+        # if len(axes) != len(set(axes)):
+        #     raise RuntimeError("Duplicate entry in axes: {}".format(axes))
+        # self.ndim = len(axes)
 
-        self.params["variances"] = {"show": False}
-        if self.data_array.variances is not None:
-            self.params["variances"].update(
-                parse_params(params=variances,
-                             defaults={"show": False},
-                             globs=globs,
-                             array=np.sqrt(self.data_array.variances)))
-
-        self.params["masks"] = parse_params(params=masks,
-                                            defaults={
-                                                "cmap": "gray",
-                                                "cbar": False
-                                            },
-                                            globs=globs)
-        self.params["masks"]["show"] = (self.params["masks"]["show"]
-                                        and len(self.data_array.masks) > 0)
-        if self.params["masks"]["show"]:
-            self.masks = combine_masks(self.data_array.masks,
-                                       self.data_array.dims,
-                                       self.data_array.shape)
-
-        self.labels = self.data_array.labels
-        self.shapes = dict(zip(self.data_array.dims, self.data_array.shape))
         # Save aspect ratio setting
         self.aspect = aspect
         if self.aspect is None:
             self.aspect = config.plot.aspect
 
-        # Size of the slider coordinate arrays
-        self.slider_nx = dict()
-        # Store coordinates of dimensions that will be in sliders
-        self.slider_x = dict()
-        # Store ticklabels for a dimension
-        self.slider_ticks = dict()
-        # Store labels for sliders if any
-        self.slider_labels = dict()
+        # # Containers
+        # self.labels = self.scipp_obj_dict.labels
+        # self.shapes = dict(zip(self.scipp_obj_dict.dims, self.scipp_obj_dict.shape))
+        # self.masks = None
 
-        # Process axes dimensions
-        if axes is None:
-            axes = self.data_array.dims
-        # Protect against duplicate entries in axes
-        if len(axes) != len(set(axes)):
-            raise RuntimeError("Duplicate entry in axes: {}".format(axes))
-        # Iterate through axes and collect dimensions
-        for ax in axes:
-            dim, lab, var, ticks = self.axis_label_and_ticks(ax)
-            if (lab is not None) and (dim in axes):
-                raise RuntimeError("The dimension of the labels cannot also "
-                                   "be specified as another axis.")
-            self.slider_labels[dim] = lab
-            self.slider_x[dim] = var
-            self.slider_ticks[dim] = ticks
-            self.slider_nx[dim] = self.shapes[dim]
-        self.ndim = len(self.slider_nx)
+
+        self.labels = {}
+        self.shapes = {}
+        self.masks = {}
+
+        # Size of the slider coordinate arrays
+        self.slider_nx = {}
+        # Store coordinates of dimensions that will be in sliders
+        self.slider_x = {}
+        # Store ticklabels for a dimension
+        self.slider_ticks = {}
+        # Store labels for sliders if any
+        self.slider_labels = {}
+        # Record which variables are histograms along which dimension
+        self.histograms = {}
+
+
+        for name, array in self.scipp_obj_dict.items():
+
+            self.data_array = array
+            self.name = name
+
+
+            self.params["values"][name] = parse_params(params=values,
+                                                 globs=globs,
+                                                 array=array.values)
+
+            self.params["variances"][name] = {"show": False}
+            if array.variances is not None:
+                self.params["variances"][name].update(
+                    parse_params(params=variances,
+                                 defaults={"show": False},
+                                 globs=globs,
+                                 array=np.sqrt(array.variances)))
+
+            self.params["masks"][name] = parse_params(params=masks,
+                                                defaults={
+                                                    "cmap": "gray",
+                                                    "cbar": False
+                                                },
+                                                globs=globs)
+            self.params["masks"][name]["show"] = (self.params["masks"][name]["show"]
+                                            and len(array.masks) > 0)
+            if self.params["masks"][name]["show"]:
+                self.masks = combine_masks(array.masks,
+                                           array.dims,
+                                           array.shape)
+
+            self.labels[name] = array.labels
+            self.shapes[name] = dict(zip(array.dims, array.shape))
+            # # # Save aspect ratio setting
+            # # self.aspect = aspect
+            # # if self.aspect is None:
+            # #     self.aspect = config.plot.aspect
+
+            # Size of the slider coordinate arrays
+            self.slider_nx[name] = {}
+            # Store coordinates of dimensions that will be in sliders
+            self.slider_x[name] = {}
+            # Store ticklabels for a dimension
+            self.slider_ticks[name] = {}
+            # Store labels for sliders if any
+            self.slider_labels[name] = {}
+
+            # Process axes dimensions
+            if axes is None:
+                axes = array.dims
+            # Protect against duplicate entries in axes
+            if len(axes) != len(set(axes)):
+                raise RuntimeError("Duplicate entry in axes: {}".format(axes))
+            self.ndim = len(axes)
+
+            # Iterate through axes and collect dimensions
+            for ax in axes:
+                dim, lab, var, ticks = self.axis_label_and_ticks(ax, array)
+                if (lab is not None) and (dim in axes):
+                    raise RuntimeError("The dimension of the labels cannot also "
+                                       "be specified as another axis.")
+                self.slider_labels[name][dim] = lab
+                self.slider_x[name][dim] = var
+                self.slider_ticks[name][dim] = ticks
+                self.slider_nx[name][dim] = self.shapes[name][dim]
+            # self.ndim = len(self.slider_nx)
 
         # Save information on histograms
-        self.histograms = dict()
-        for name, var in self.scipp_obj_dict.items():
-            self.histograms[name] = dict()
-            for dim, x in self.slider_x.items():
-                indx = var.dims.index(dim)
-                self.histograms[name][dim] = var.shape[indx] == x.shape[0] - 1
+        # self.histograms = dict()
+        # for name, var in self.scipp_obj_dict.items():
+            self.histograms[name] = {}
+            for dim, x in self.slider_x[name].items():
+                indx = array.dims.index(dim)
+                self.histograms[name][dim] = array.shape[indx] == x.shape[0] - 1
 
         # Initialise list for VBox container
         self.vbox = []
@@ -135,27 +184,27 @@ class Slicer:
         # Now begin loop to construct sliders
         button_values = [None] * (self.ndim - len(button_options)) + \
             button_options[::-1]
-        for i, dim in enumerate(self.slider_x.keys()):
+        for i, dim in enumerate(self.slider_x[self.name].keys()):
             key = str(dim)
             # If this is a 3d projection, place slices half-way
             if len(button_options) == 3 and (not volume):
-                indx = (self.slider_nx[dim] - 1) // 2
-            if self.slider_labels[dim] is not None:
-                descr = self.slider_labels[dim]
+                indx = (self.slider_nx[self.name][dim] - 1) // 2
+            if self.slider_labels[self.name][dim] is not None:
+                descr = self.slider_labels[self.name][dim]
             else:
                 descr = str(dim)
             # Add an IntSlider to slide along the z dimension of the array
             self.slider[dim] = widgets.IntSlider(
                 value=indx,
                 min=0,
-                max=self.slider_nx[dim] - 1,
+                max=self.slider_nx[self.name][dim] - 1,
                 step=1,
                 description=descr,
                 continuous_update=True,
                 readout=False,
                 disabled=((i >= self.ndim - len(button_options))
                           and ((len(button_options) < 3) or volume)))
-            labvalue = self.make_slider_label(self.slider_x[dim], indx)
+            labvalue = self.make_slider_label(self.slider_x[self.name][dim], indx)
             if self.ndim == len(button_options):
                 self.slider[dim].layout.display = 'none'
                 labvalue = descr
@@ -213,7 +262,7 @@ class Slicer:
             self.members["widgets"]["togglebuttons"][key] = self.buttons[dim]
             self.members["widgets"]["labels"][key] = self.lab[dim]
 
-        if self.params["masks"]["show"]:
+        if self.params["masks"][self.name]["show"]:
             self.masks_button = widgets.ToggleButton(
                 value=self.params["masks"]["show"],
                 description="Hide masks"
@@ -233,7 +282,7 @@ class Slicer:
     def mask_to_float(self, mask, var):
         return np.where(mask, var, None).astype(np.float)
 
-    def axis_label_and_ticks(self, axis):
+    def axis_label_and_ticks(self, axis, data_array):
         """
         Get dimensions and label (if present) from requested axis
         """
@@ -243,10 +292,10 @@ class Slicer:
             lab = None
             make_fake_coord = False
             fake_unit = None
-            if not self.data_array.coords.__contains__(dim):
+            if not data_array.coords.__contains__(dim):
                 make_fake_coord = True
             else:
-                tp = self.data_array.coords[dim].dtype
+                tp = data_array.coords[dim].dtype
                 if tp == dtype.vector_3_float64:
                     make_fake_coord = True
                     ticks = {
@@ -259,22 +308,22 @@ class Slicer:
                     make_fake_coord = True
                     ticks = {"formatter": lambda x: x}
                 if make_fake_coord:
-                    fake_unit = self.data_array.coords[dim].unit
-                    ticks["coord"] = self.data_array.coords[dim]
+                    fake_unit = data_array.coords[dim].unit
+                    ticks["coord"] = data_array.coords[dim]
             if make_fake_coord:
                 args = {"values": np.arange(self.shapes[dim])}
                 if fake_unit is not None:
                     args["unit"] = fake_unit
                 var = Variable([dim], **args)
             else:
-                var = self.data_array.coords[dim]
+                var = data_array.coords[dim]
         elif isinstance(axis, str):
             # By convention, the last dim of the labels is the inner dimension,
             # but note that for now two-dimensional labels are not supported in
             # the plotting.
-            dim = self.data_array.labels[axis].dims[-1]
+            dim = data_array.labels[axis].dims[-1]
             lab = axis
-            var = self.data_array.labels[lab]
+            var = data_array.labels[lab]
         else:
             raise RuntimeError("Unsupported axis found in 'axes': {}. This "
                                "must be either a Scipp dimension "
@@ -293,7 +342,7 @@ class Slicer:
             xticks = getticks()
         new_ticks = [""] * len(xticks)
         for i, x in enumerate(xticks):
-            if x >= 0 and x < self.slider_nx[dim]:
-                new_ticks[i] = self.slider_ticks[dim]["formatter"](
-                    self.slider_ticks[dim]["coord"].values[int(x)])
+            if x >= 0 and x < self.slider_nx[self.name][dim]:
+                new_ticks[i] = self.slider_ticks[self.name][dim]["formatter"](
+                    self.slider_ticks[self.name][dim]["coord"].values[int(x)])
         return new_ticks

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -125,7 +125,8 @@ class Slicer:
 
             # Iterate through axes and collect dimensions
             for ax in axes:
-                dim, lab, var, ticks = self.axis_label_and_ticks(ax, array)
+                dim, lab, var, ticks = self.axis_label_and_ticks(
+                    ax, array, name)
                 if (lab is not None) and (dim in axes):
                     raise RuntimeError(
                         "The dimension of the labels cannot also "
@@ -256,7 +257,7 @@ class Slicer:
     def mask_to_float(self, mask, var):
         return np.where(mask, var, None).astype(np.float)
 
-    def axis_label_and_ticks(self, axis, data_array):
+    def axis_label_and_ticks(self, axis, data_array, name):
         """
         Get dimensions and label (if present) from requested axis
         """
@@ -285,7 +286,7 @@ class Slicer:
                     fake_unit = data_array.coords[dim].unit
                     ticks["coord"] = data_array.coords[dim]
             if make_fake_coord:
-                args = {"values": np.arange(self.shapes[dim])}
+                args = {"values": np.arange(self.shapes[name][dim])}
                 if fake_unit is not None:
                     args["unit"] = fake_unit
                 var = Variable([dim], **args)

--- a/python/tests/plot/test_plot.py
+++ b/python/tests/plot/test_plot.py
@@ -504,3 +504,22 @@ def test_plot_2d_with_dimension_of_size_1():
                          unit=sc.units.counts)
     plot(d["a"])
     plot(d["b"])
+
+
+def test_sparse_data_slice_with_on_the_fly_histogram():
+    N = 50
+    M = 10
+    var = sc.Variable(dims=[Dim.X, Dim.Tof],
+                      shape=[M, sc.Dimensions.Sparse],
+                      unit=sc.units.us)
+    for i in range(M):
+        v = np.random.normal(50.0, scale=20.0, size=int(np.random.rand() * N))
+        var[Dim.X, i].values = v
+
+    d = sc.Dataset()
+    d.coords[Dim.X] = sc.Variable([Dim.X],
+                                  values=np.arange(M),
+                                  unit=sc.units.m)
+    d['a'] = sc.DataArray(coords={Dim.Tof: var})
+    d['b'] = sc.DataArray(coords={Dim.Tof: var * 1.1})
+    plot(d[Dim.X, 4], bins=100)


### PR DESCRIPTION
Fixed by having a x coordinate array for each dict entry instead of using global coordinates.

This
```Py
N = 50
M = 10
var = sc.Variable(dims=[Dim.X, Dim.Tof],
                  shape=[M, sc.Dimensions.Sparse],
                  unit=sc.units.us)
for i in range(M):
    v = np.random.normal(50.0, scale=20.0, size=int(np.random.rand()*N))
    var[Dim.X, i].values = v

d = sc.Dataset()
d.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(M), unit=sc.units.m)
d['a'] = sc.DataArray(coords={Dim.Tof: var})
d['b'] = sc.DataArray(coords={Dim.Tof: var * 1.1})
plot(d[Dim.X, 4], bins=100)
```
now produces
![Screenshot at 2020-01-23 14-11-20](https://user-images.githubusercontent.com/39047984/72987227-3f306800-3dea-11ea-8495-8d66ffffd092.png)


Fixes #866 