### PR TITLE
Proxy and iterator refactor

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,6 +7,10 @@ add_executable(groupby_benchmark EXCLUDE_FROM_ALL groupby_benchmark.cpp)
 add_dependencies(all-benchmarks groupby_benchmark)
 target_link_libraries(groupby_benchmark LINK_PRIVATE scipp-core benchmark)
 
+add_executable(slice_benchmark EXCLUDE_FROM_ALL slice_benchmark.cpp)
+add_dependencies(all-benchmarks slice_benchmark)
+target_link_libraries(slice_benchmark LINK_PRIVATE scipp-core benchmark)
+
 add_executable(histogram_benchmark EXCLUDE_FROM_ALL histogram_benchmark.cpp)
 add_dependencies(all-benchmarks histogram_benchmark)
 target_link_libraries(histogram_benchmark

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -150,7 +150,7 @@ BENCHMARK_TEMPLATE(BM_Dataset_labels_slice, Generate6D<LONG_STRING_LENGTH>,
 template <class Gen>
 static void BM_Dataset_item_access(benchmark::State &state) {
   const auto d = std::get<0>(Gen()());
-  const auto name = d.begin()->second.name();
+  const auto name = d.begin()->name();
   for (auto _ : state) {
     d[name];
   }
@@ -165,8 +165,7 @@ static void BM_Dataset_iterate_items(benchmark::State &state) {
   const auto itemCount = state.range(0);
   const auto d = std::get<0>(Gen()(itemCount));
   for (auto _ : state) {
-    for (const auto &[name, item] : d) {
-      benchmark::DoNotOptimize(name);
+    for (const auto &item : d) {
       benchmark::DoNotOptimize(item);
     }
   }
@@ -186,8 +185,7 @@ static void BM_Dataset_iterate_slice_items(benchmark::State &state) {
   const auto d = std::get<0>(Gen()(itemCount));
   const auto s = Slice()(d);
   for (auto _ : state) {
-    for (const auto &[name, item] : s) {
-      benchmark::DoNotOptimize(name);
+    for (const auto &item : s) {
       benchmark::DoNotOptimize(item);
     }
   }

--- a/benchmark/slice_benchmark.cpp
+++ b/benchmark/slice_benchmark.cpp
@@ -57,8 +57,8 @@ static void BM_dataset_slice_aggregate(benchmark::State &state) {
   for (auto _ : state) {
     auto slice = d.slice({Dim::X, 1});
     for (const auto &item : slice) {
-      if (!item.second.dims().contains(Dim::X))
-        benchmark::DoNotOptimize(item.second.data());
+      if (!item.dims().contains(Dim::X))
+        benchmark::DoNotOptimize(item.data());
     }
   }
   state.SetItemsProcessed(state.iterations());

--- a/benchmark/slice_benchmark.cpp
+++ b/benchmark/slice_benchmark.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+#include <benchmark/benchmark.h>
+
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+auto make_table() {
+  const scipp::index nCol = 3;
+  const scipp::index nRow = 10;
+  Dataset d;
+  const auto column = makeVariable<double>(Dims{Dim::X}, Shape{nRow});
+  d.setData("a", column);
+  d.setData("b", column);
+  d.setData("c", column);
+  return d;
+}
+
+static void BM_dataset_create_view(benchmark::State &state) {
+  auto d = make_table();
+  for (auto _ : state) {
+    DatasetProxy view(d);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+static void BM_dataset_slice(benchmark::State &state) {
+  auto d = make_table();
+  for (auto _ : state) {
+    d.slice({Dim::X, 1});
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK(BM_dataset_create_view);
+BENCHMARK(BM_dataset_slice);
+
+BENCHMARK_MAIN();

--- a/benchmark/slice_benchmark.cpp
+++ b/benchmark/slice_benchmark.cpp
@@ -35,7 +35,25 @@ static void BM_dataset_slice(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations());
 }
 
+static void BM_dataset_slice_item(benchmark::State &state) {
+  auto d = make_table();
+  for (auto _ : state) {
+    d.slice({Dim::X, 1})["b"];
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+static void BM_dataset_slice_item_dims(benchmark::State &state) {
+  auto d = make_table();
+  for (auto _ : state) {
+    d.slice({Dim::X, 1})["b"].dims();
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
 BENCHMARK(BM_dataset_create_view);
 BENCHMARK(BM_dataset_slice);
+BENCHMARK(BM_dataset_slice_item);
+BENCHMARK(BM_dataset_slice_item_dims);
 
 BENCHMARK_MAIN();

--- a/core/counts.cpp
+++ b/core/counts.cpp
@@ -49,10 +49,8 @@ Dataset toDensity(Dataset d, const Dim dim) {
 
 Dataset toDensity(Dataset d, const std::vector<Dim> &dims) {
   const auto binWidths = getBinWidths(d.coords(), dims);
-  for (const auto &[name, data] : d) {
-    static_cast<void>(name);
+  for (const auto &data : d)
     toDensity(data, binWidths);
-  }
   return d;
 }
 
@@ -81,10 +79,8 @@ Dataset fromDensity(Dataset d, const Dim dim) {
 
 Dataset fromDensity(Dataset d, const std::vector<Dim> &dims) {
   const auto binWidths = getBinWidths(d.coords(), dims);
-  for (const auto &[name, data] : d) {
-    static_cast<void>(name);
+  for (const auto &data : d)
     fromDensity(data, binWidths);
-  }
   return d;
 }
 

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -34,12 +34,12 @@ void requireValid(const DataArray &a) {
 
 DataConstProxy DataArray::get() const {
   requireValid(*this);
-  return m_holder.begin()->second;
+  return *m_holder.begin();
 }
 
 DataProxy DataArray::get() {
   requireValid(*this);
-  return m_holder.begin()->second;
+  return *m_holder.begin();
 }
 
 namespace {

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -247,22 +247,6 @@ void Dataset::rebuildDims() {
   }
 }
 
-std::vector<std::string> Dataset::keys() const {
-  std::vector<std::string> keys;
-  keys.reserve(size());
-  for (const auto &item : m_data)
-    keys.push_back(item.first);
-  return keys;
-}
-
-std::vector<std::string> DatasetConstProxy::keys() const {
-  std::vector<std::string> keys;
-  keys.reserve(size());
-  for (const auto &item : *this)
-    keys.push_back(item.name());
-  return keys;
-}
-
 /// Set (insert or replace) the coordinate for the given dimension.
 void Dataset::setCoord(const Dim dim, Variable coord) {
   expect::notSparse(coord);

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -873,7 +873,7 @@ std::pair<boost::container::small_vector<DataProxy, 8>, detail::slice_list>
 DatasetConstProxy::slice_items(const T &view, const Slice slice) {
   auto slices = view.slices();
   boost::container::small_vector<DataProxy, 8> items;
-  scipp::index extent = INT64_MAX;
+  scipp::index extent = std::numeric_limits<scipp::index>::max();
   for (const auto &item : view) {
     const auto &dims = item.dims();
     if (dims.contains(slice.dim())) {
@@ -883,7 +883,7 @@ DatasetConstProxy::slice_items(const T &view, const Slice slice) {
       extent = std::min(extent, dims[slice.dim()]);
     }
   }
-  if (extent == INT64_MAX) {
+  if (extent == std::numeric_limits<scipp::index>::max()) {
     // Fallback: Could not determine extent from data (not data that depends on
     // slicing dimension), use `dimensions()` to also consider coords.
     const auto currentDims = view.dimensions();

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -247,6 +247,22 @@ void Dataset::rebuildDims() {
   }
 }
 
+std::vector<std::string> Dataset::keys() const {
+  std::vector<std::string> keys;
+  keys.reserve(size());
+  for (const auto &item : m_data)
+    keys.push_back(item.first);
+  return keys;
+}
+
+std::vector<std::string> DatasetConstProxy::keys() const {
+  std::vector<std::string> keys;
+  keys.reserve(size());
+  for (const auto &item : *this)
+    keys.push_back(item.name());
+  return keys;
+}
+
 /// Set (insert or replace) the coordinate for the given dimension.
 void Dataset::setCoord(const Dim dim, Variable coord) {
   expect::notSparse(coord);

--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -822,12 +822,9 @@ DatasetConstProxy DatasetConstProxy::slice(const Slice slice1) const {
   sliced.m_dataset = m_dataset;
   sliced.m_slices = m_slices;
   auto &items = sliced.m_items;
-  std::remove_copy_if(begin(), end(), std::back_inserter(items),
-                      [&slice1](const auto &item) {
-                        return !item.second.dims().contains(slice1.dim());
-                      });
-  for (auto &item : items)
-    item.second = item.second.slice(slice1);
+  for (const auto &item : *this)
+    if (item.second.dims().contains(slice1.dim()))
+      items.emplace_back(item.first, item.second.slice(slice1));
   // The dimension extent is either given by the coordinate, or by data, which
   // can be 1 shorter in case of a bin-edge coordinate.
   scipp::index extent = currentDims.at(slice1.dim());

--- a/core/dataset_operations.cpp
+++ b/core/dataset_operations.cpp
@@ -12,6 +12,20 @@
 
 namespace scipp::core {
 
+auto union_(const DatasetConstProxy &a, const DatasetConstProxy &b) {
+  std::map<std::string, DataArray> out;
+
+  for (const auto &item : a)
+    out.emplace(item.name(), item);
+  for (const auto &item : b) {
+    if (const auto it = a.find(item.name()); it != a.end())
+      expect::equals(item, *it);
+    else
+      out.emplace(item.name(), item);
+  }
+  return out;
+}
+
 Dataset merge(const DatasetConstProxy &a, const DatasetConstProxy &b) {
   // When merging datasets the contents of the masks are not OR'ed, but
   // checked if present in both dataset with the same values with `union_`.
@@ -93,9 +107,9 @@ DataArray concatenate(const DataConstProxy &a, const DataConstProxy &b,
 Dataset concatenate(const DatasetConstProxy &a, const DatasetConstProxy &b,
                     const Dim dim) {
   Dataset result;
-  for (const auto &[name, item] : a)
-    if (b.contains(name))
-      result.setData(name, concatenate(item, b[name], dim));
+  for (const auto &item : a)
+    if (b.contains(item.name()))
+      result.setData(item.name(), concatenate(item, b[item.name()], dim));
   return result;
 }
 

--- a/core/dataset_operations_common.h
+++ b/core/dataset_operations_common.h
@@ -127,8 +127,8 @@ template <class Func, class... Args>
 Dataset apply_to_items(const DatasetConstProxy &d, Func func, const Dim dim,
                        Args &&... args) {
   Dataset result;
-  for (const auto &[name, data] : d)
-    result.setData(name, func(data, dim, std::forward<Args>(args)...));
+  for (const auto &data : d)
+    result.setData(data.name(), func(data, dim, std::forward<Args>(args)...));
   for (auto &&[name, attr] : d.attrs())
     if (!attr.dims().contains(dim))
       result.setAttr(name, attr);

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -36,8 +36,8 @@ T GroupBy<T>::reduce(Op op, const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto &[name, item] : m_data) {
-        const auto out_data = out_slice[name].data();
+      for (const auto &item : m_data) {
+        const auto out_data = out_slice[item.name()].data();
         op(out_data, item, groups()[group], reductionDim);
       }
     } else {
@@ -73,8 +73,8 @@ template <class T> T GroupBy<T>::flatten(const Dim reductionDim) const {
   for (scipp::index group = 0; group < size(); ++group) {
     const auto out_slice = out.slice({dim(), group});
     if constexpr (std::is_same_v<T, Dataset>) {
-      for (const auto &[name, item] : m_data)
-        apply(out_slice[name], item, group);
+      for (const auto &item : m_data)
+        apply(out_slice[item.name()], item, group);
     } else {
       apply(out_slice, m_data, group);
     }
@@ -168,9 +168,9 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
 
   // 3. sum/N -> mean
   if constexpr (std::is_same_v<T, Dataset>) {
-    for (const auto &[name, item] : out) {
+    for (const auto &item : out) {
       if (isInt(item.data().dtype()))
-        out.setData(name, item.data() * scale);
+        out.setData(item.name(), item.data() * scale);
       else
         item *= scale;
     }

--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -142,9 +142,9 @@ DataArray histogram(const DataConstProxy &sparse, const Variable &binEdges) {
 Dataset histogram(const Dataset &dataset, const VariableConstProxy &bins) {
   auto out(Dataset(DatasetConstProxy::makeProxyWithEmptyIndexes(dataset)));
   out.setCoord(bins.dims().inner(), bins);
-  for (const auto &[name, item] : dataset) {
+  for (const auto &item : dataset) {
     if (item.dims().sparse())
-      out.setData(std::string(name), histogram(item, bins));
+      out.setData(item.name(), histogram(item, bins));
   }
   return out;
 }

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -41,8 +41,8 @@ struct DatasetData {
 
 using dataset_item_map = std::unordered_map<std::string, DatasetData>;
 
-using slice_list =
-    boost::container::small_vector<std::pair<Slice, scipp::index>, 2>;
+// TODO segfault when using small_vector, why?
+using slice_list = std::vector<std::pair<Slice, scipp::index>>;
 
 template <class Var> auto makeSlice(Var &var, const slice_list &slices) {
   std::conditional_t<std::is_const_v<Var>, VariableConstProxy, VariableProxy>

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -849,10 +849,10 @@ public:
 
 private:
   const Dataset *m_dataset;
-  boost::container::small_vector<std::pair<std::string, DataConstProxy>, 8>
-      m_items;
 
 protected:
+  boost::container::small_vector<std::pair<std::string, DataConstProxy>, 8>
+      m_items;
   void expectValidKey(const std::string &name) const;
   detail::slice_list m_slices;
 };
@@ -863,8 +863,7 @@ private:
   DatasetProxy(DatasetConstProxy &&base, Dataset *dataset);
 
 public:
-  DatasetProxy(Dataset &dataset)
-      : DatasetProxy(DatasetConstProxy(dataset), &dataset) {}
+  DatasetProxy(Dataset &dataset);
 
   CoordsProxy coords() const noexcept;
   LabelsProxy labels() const noexcept;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -41,8 +41,8 @@ struct DatasetData {
 
 using dataset_item_map = std::unordered_map<std::string, DatasetData>;
 
-// TODO segfault when using small_vector, why?
-using slice_list = std::vector<std::pair<Slice, scipp::index>>;
+using slice_list =
+    boost::container::small_vector<std::pair<Slice, scipp::index>, 2>;
 
 template <class Var> auto makeSlice(Var &var, const slice_list &slices) {
   std::conditional_t<std::is_const_v<Var>, VariableConstProxy, VariableProxy>

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -160,6 +160,10 @@ public:
                            : std::optional<VariableProxy>{}),
         m_mutableDataset(&dataset), m_mutableData(&data) {}
 
+  explicit DataProxy(DataConstProxy &&base)
+      : DataConstProxy(std::move(base)), m_mutableDataset{nullptr},
+        m_mutableData{nullptr} {}
+
   CoordsProxy coords() const noexcept;
   LabelsProxy labels() const noexcept;
   MasksProxy masks() const noexcept;
@@ -241,10 +245,6 @@ public:
   }
 
 private:
-  friend class DatasetConstProxy;
-  DataProxy(DataConstProxy &&base)
-      : DataConstProxy(std::move(base)), m_mutableDataset{nullptr},
-        m_mutableData{nullptr} {}
   Dataset *m_mutableDataset;
   detail::dataset_item_map::value_type *m_mutableData;
 };

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -869,8 +869,12 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
 
 /// Const proxy for Dataset, implementing slicing and item selection.
 class SCIPP_CORE_EXPORT DatasetConstProxy {
-  static constexpr auto make_const_view =
-      [](const DataProxy &view) -> const DataConstProxy & { return view; };
+  struct make_const_view {
+    constexpr const DataConstProxy &operator()(const DataProxy &view) const
+        noexcept {
+      return view;
+    }
+  };
 
 public:
   using key_type = std::string;
@@ -898,11 +902,11 @@ public:
 
   auto begin() const && = delete;
   auto begin() const &noexcept {
-    return boost::make_transform_iterator(m_items.begin(), make_const_view);
+    return boost::make_transform_iterator(m_items.begin(), make_const_view{});
   }
   auto end() const && = delete;
   auto end() const &noexcept {
-    return boost::make_transform_iterator(m_items.end(), make_const_view);
+    return boost::make_transform_iterator(m_items.end(), make_const_view{});
   }
 
   auto items_begin() const && = delete;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -255,11 +255,12 @@ template <> struct is_const<DatasetConstProxy> : std::true_type {};
 template <class D> struct make_item {
   D *dataset;
   using P = std::conditional_t<is_const<D>::value, DataConstProxy, DataProxy>;
-  template <class T> std::pair<std::string, P> operator()(T &item) const {
+  template <class T> auto operator()(T &item) const {
     if constexpr (std::is_same_v<std::remove_const_t<D>, Dataset>)
-      return {item.first, P(*dataset, item)};
+      return std::pair<const std::string &, P>{item.first, P(*dataset, item)};
     else
-      return {item.first, P(dataset->dataset(), item, dataset->slices())};
+      return std::pair<std::string, P>{
+          item.first, P(dataset->dataset(), item, dataset->slices())};
   }
 };
 template <class D> make_item(D *)->make_item<D>;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -144,10 +144,6 @@ public:
   DataProxy(Dataset &dataset, detail::dataset_item_map::value_type &data,
             const detail::slice_list &slices = {});
 
-  explicit DataProxy(DataConstProxy &&base)
-      : DataConstProxy(std::move(base)), m_mutableDataset{nullptr},
-        m_mutableData{nullptr} {}
-
   CoordsProxy coords() const noexcept;
   LabelsProxy labels() const noexcept;
   MasksProxy masks() const noexcept;
@@ -218,6 +214,12 @@ public:
   }
 
 private:
+  friend class DatasetConstProxy;
+  // For internal use in DatasetConstProxy.
+  explicit DataProxy(DataConstProxy &&base)
+      : DataConstProxy(std::move(base)), m_mutableDataset{nullptr},
+        m_mutableData{nullptr} {}
+
   Dataset *m_mutableDataset;
   detail::dataset_item_map::value_type *m_mutableData;
 };
@@ -952,6 +954,10 @@ public:
 
 protected:
   explicit DatasetConstProxy() : m_dataset(nullptr) {}
+  template <class T>
+  static std::pair<boost::container::small_vector<DataProxy, 8>,
+                   detail::slice_list>
+  slice_items(const T &view, const Slice slice);
   const Dataset *m_dataset;
   boost::container::small_vector<DataProxy, 8> m_items;
   void expectValidKey(const std::string &name) const;

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -814,7 +814,7 @@ public:
 
   bool contains(const std::string &name) const noexcept;
 
-  DataConstProxy operator[](const std::string &name) const;
+  const DataConstProxy &operator[](const std::string &name) const;
 
   auto begin() const && = delete;
   auto begin() const &noexcept { return m_items.begin(); }
@@ -871,7 +871,7 @@ public:
   AttrsProxy attrs() const noexcept;
   MasksProxy masks() const noexcept;
 
-  DataProxy operator[](const std::string &name) const;
+  const DataProxy &operator[](const std::string &name) const;
 
   auto begin() const && = delete;
   auto begin() const &noexcept { return m_mutableItems.begin(); }

--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -403,8 +403,6 @@ public:
     return boost::make_transform_iterator(m_data.end(), detail::make_key);
   }
 
-  std::vector<std::string> keys() const;
-
   void setCoord(const Dim dim, Variable coord);
   void setLabels(const std::string &labelName, Variable labels);
   void setMask(const std::string &masksName, Variable masks);
@@ -596,15 +594,6 @@ public:
   /// Returns whether a given key is present in the proxy.
   bool contains(const Key &k) const {
     return m_items.find(k) != m_items.cend();
-  }
-
-  std::vector<Key> keys() {
-    std::vector<Key> keys;
-    keys.reserve(m_items.size());
-    for (const auto &p : m_items) {
-      keys.push_back(p.first);
-    }
-    return keys;
   }
 
   /// Return a const proxy to the coordinate for given dimension.
@@ -902,8 +891,6 @@ public:
   MasksConstProxy masks() const noexcept;
 
   bool contains(const std::string &name) const noexcept;
-
-  std::vector<std::string> keys() const;
 
   const DataConstProxy &operator[](const std::string &name) const;
 

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -754,6 +754,8 @@ protected:
   VariableConceptHandle m_view;
 };
 
+class DataConstProxy;
+
 /** Mutable view into (a subset of) a Variable.
  *
  * By inheriting from VariableConstProxy any code that works for
@@ -778,10 +780,6 @@ public:
       : VariableConstProxy(slice), m_mutableVariable(slice.m_mutableVariable) {
     m_view = slice.data().makeView(dim, begin, end);
   }
-
-  // For internal use in DataConstProxy. TODO make this private.
-  VariableProxy(VariableConstProxy &&base)
-      : VariableConstProxy(std::move(base)), m_mutableVariable{nullptr} {}
 
   VariableProxy slice(const Slice slice) const {
     return VariableProxy(*this, slice.dim(), slice.begin(), slice.end());
@@ -874,6 +872,9 @@ public:
   scipp::index size() const { return data().size(); }
 
 private:
+  friend class Variable;
+  friend class DataConstProxy;
+
   template <class Var>
   static VariableProxy makeTransposed(Var &var,
                                       const std::vector<Dim> &dimOrder) {
@@ -882,8 +883,9 @@ private:
     return res;
   }
 
-private:
-  friend class Variable;
+  // For internal use in DataConstProxy.
+  explicit VariableProxy(VariableConstProxy &&base)
+      : VariableConstProxy(std::move(base)), m_mutableVariable{nullptr} {}
 
   template <class T> VariableView<T> cast() const;
   template <class T> VariableView<T> castVariances() const;

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -779,6 +779,10 @@ public:
     m_view = slice.data().makeView(dim, begin, end);
   }
 
+  // For internal use in DataConstProxy. TODO make this private.
+  VariableProxy(VariableConstProxy &&base)
+      : VariableConstProxy(std::move(base)), m_mutableVariable{nullptr} {}
+
   VariableProxy slice(const Slice slice) const {
     return VariableProxy(*this, slice.dim(), slice.begin(), slice.end());
   }

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -268,7 +268,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
       s << "Data:\n";
     std::set<std::string> sorted_items;
     for (const auto &item : dataset)
-      sorted_items.insert(item.first);
+      sorted_items.insert(item.name());
     for (const auto &name : sorted_items)
       s << format_data_proxy(name, dataset[name], dims);
   }
@@ -281,7 +281,7 @@ template <class T> Dimensions dimensions(const T &dataset) {
   Dimensions datasetDims;
   Dim sparse = Dim::Invalid;
   for (const auto &item : dataset) {
-    const auto &dims = item.second.dims();
+    const auto &dims = item.dims();
     for (const auto dim : dims.labels()) {
       if (!datasetDims.contains(dim)) {
         if (dim == dims.sparseDim())

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -24,7 +24,7 @@ TEST_F(AttributesTest, dataset_attrs) {
   ASSERT_TRUE(d.attrs().contains("scalar"));
   ASSERT_TRUE(d.attrs().contains("x"));
   const auto attrs = d.attrs();
-  ASSERT_EQ(std::set(attrs.keys_begin(), attrs.keys_end()),
+  ASSERT_EQ(std::set<std::string>(attrs.keys_begin(), attrs.keys_end()),
             (std::set<std::string>{"scalar", "x"}));
   ASSERT_EQ(d.dimensions(),
             (std::unordered_map<Dim, scipp::index>{{Dim::X, 2}}));

--- a/core/test/attributes_test.cpp
+++ b/core/test/attributes_test.cpp
@@ -23,7 +23,9 @@ TEST_F(AttributesTest, dataset_attrs) {
   ASSERT_EQ(d.attrs().size(), 2);
   ASSERT_TRUE(d.attrs().contains("scalar"));
   ASSERT_TRUE(d.attrs().contains("x"));
-  ASSERT_EQ(d.attrs().keys(), (std::vector<std::string>{"scalar", "x"}));
+  const auto attrs = d.attrs();
+  ASSERT_EQ(std::set(attrs.keys_begin(), attrs.keys_end()),
+            (std::set<std::string>{"scalar", "x"}));
   ASSERT_EQ(d.dimensions(),
             (std::unordered_map<Dim, scipp::index>{{Dim::X, 2}}));
   d.eraseAttr("scalar");

--- a/core/test/data_array_comparison_test.cpp
+++ b/core/test/data_array_comparison_test.cpp
@@ -223,44 +223,44 @@ TEST_F(DataArray_comparison_operators, single_values_and_variances) {
 
 TEST_F(DataArray_comparison_operators, self) {
   for (const auto item : dataset) {
-    DataArray a(item.second);
+    DataArray a(item);
     expect_eq(a, a);
   }
 }
 
 TEST_F(DataArray_comparison_operators, copy) {
   auto copy = dataset;
-  for (const auto [name, a] : copy) {
-    expect_eq(a, dataset[name]);
+  for (const auto &a : copy) {
+    expect_eq(a, dataset[a.name()]);
   }
 }
 
 TEST_F(DataArray_comparison_operators, extra_coord) {
   auto extra = dataset;
   extra.setCoord(Dim::Z, makeVariable<double>(Values{0.0}));
-  for (const auto [name, a] : extra)
-    expect_ne(a, dataset[name]);
+  for (const auto &a : extra)
+    expect_ne(a, dataset[a.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, extra_labels) {
   auto extra = dataset;
   extra.setLabels("extra", makeVariable<double>(Values{0.0}));
-  for (const auto [name, a] : extra)
-    expect_ne(a, dataset[name]);
+  for (const auto &a : extra)
+    expect_ne(a, dataset[a.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, extra_mask) {
   auto extra = dataset;
   extra.setMask("extra", makeVariable<bool>(Values{false}));
-  for (const auto [name, a] : extra)
-    expect_ne(a, dataset[name]);
+  for (const auto &a : extra)
+    expect_ne(a, dataset[a.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, extra_attr) {
   auto extra = dataset;
-  for (const auto [name, a] : extra) {
-    extra.setAttr(name, "extra", makeVariable<double>(Values{0.0}));
-    expect_ne(a, dataset[name]);
+  for (const auto &a : extra) {
+    extra.setAttr(a.name(), "extra", makeVariable<double>(Values{0.0}));
+    expect_ne(a, dataset[a.name()]);
   }
 }
 
@@ -290,8 +290,8 @@ TEST_F(DataArray_comparison_operators, different_coord_insertion_order) {
   a.setCoord(Dim::Y, dataset.coords()[Dim::Y]);
   b.setCoord(Dim::Y, dataset.coords()[Dim::Y]);
   b.setCoord(Dim::X, dataset.coords()[Dim::X]);
-  for (const auto [name, a_] : a)
-    expect_ne(a_, b[name]);
+  for (const auto &a_ : a)
+    expect_ne(a_, b[a_.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, different_label_insertion_order) {
@@ -301,8 +301,8 @@ TEST_F(DataArray_comparison_operators, different_label_insertion_order) {
   a.setLabels("y", dataset.coords()[Dim::Y]);
   b.setLabels("y", dataset.coords()[Dim::Y]);
   b.setLabels("x", dataset.coords()[Dim::X]);
-  for (const auto [name, a_] : a)
-    expect_ne(a_, b[name]);
+  for (const auto &a_ : a)
+    expect_ne(a_, b[a_.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, different_attr_insertion_order) {
@@ -312,8 +312,8 @@ TEST_F(DataArray_comparison_operators, different_attr_insertion_order) {
   a.setAttr("y", dataset.coords()[Dim::Y]);
   b.setAttr("y", dataset.coords()[Dim::Y]);
   b.setAttr("x", dataset.coords()[Dim::X]);
-  for (const auto [name, a_] : a)
-    expect_ne(a_, b[name]);
+  for (const auto &a_ : a)
+    expect_ne(a_, b[a_.name()]);
 }
 
 TEST_F(DataArray_comparison_operators, with_sparse_dimension_data) {

--- a/core/test/dataset_proxy_test.cpp
+++ b/core/test/dataset_proxy_test.cpp
@@ -61,7 +61,7 @@ TYPED_TEST(DatasetProxyTest, name) {
   for (const auto &name : {"a", "b", "c"})
     EXPECT_EQ(proxy[name].name(), name);
   for (const auto &name : {"a", "b", "c"})
-    EXPECT_EQ(proxy.find(name)->second.name(), name);
+    EXPECT_EQ(proxy.find(name)->name(), name);
 }
 
 TYPED_TEST(DatasetProxyTest, find_and_contains) {
@@ -72,13 +72,13 @@ TYPED_TEST(DatasetProxyTest, find_and_contains) {
   auto &&proxy = TestFixture::access(d);
 
   EXPECT_EQ(proxy.find("not a thing"), proxy.end());
-  EXPECT_EQ(proxy.find("a")->first, "a");
-  EXPECT_EQ(proxy.find("a")->second, proxy["a"]);
+  EXPECT_EQ(proxy.find("a")->name(), "a");
+  EXPECT_EQ(*proxy.find("a"), proxy["a"]);
   EXPECT_FALSE(proxy.contains("not a thing"));
   EXPECT_TRUE(proxy.contains("a"));
 
-  EXPECT_EQ(proxy.find("b")->first, "b");
-  EXPECT_EQ(proxy.find("b")->second, proxy["b"]);
+  EXPECT_EQ(proxy.find("b")->name(), "b");
+  EXPECT_EQ(*proxy.find("b"), proxy["b"]);
 }
 
 TYPED_TEST(DatasetProxyTest, find_in_slice) {
@@ -91,8 +91,8 @@ TYPED_TEST(DatasetProxyTest, find_in_slice) {
 
   const auto slice = proxy.slice({Dim::X, 1});
 
-  EXPECT_EQ(slice.find("a")->first, "a");
-  EXPECT_EQ(slice.find("a")->second, slice["a"]);
+  EXPECT_EQ(slice.find("a")->name(), "a");
+  EXPECT_EQ(*slice.find("a"), slice["a"]);
   EXPECT_EQ(slice.find("b"), slice.end());
   EXPECT_TRUE(slice.contains("a"));
   EXPECT_FALSE(slice.contains("b"));
@@ -148,15 +148,15 @@ TYPED_TEST(DatasetProxyTest, iterators) {
 
   auto it = proxy.begin();
   ASSERT_NE(it, proxy.end());
-  found.insert(it->first);
+  found.insert(it->name());
 
   ASSERT_NO_THROW(++it);
   ASSERT_NE(it, proxy.end());
-  found.insert(it->first);
+  found.insert(it->name());
 
   ASSERT_NO_THROW(++it);
   ASSERT_NE(it, proxy.end());
-  found.insert(it->first);
+  found.insert(it->name());
 
   EXPECT_EQ(found, expected);
 

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -254,14 +254,14 @@ TEST(DatasetTest, setSparseLabels) {
 
 TEST(DatasetTest, iterators_return_types) {
   Dataset d;
-  ASSERT_TRUE((std::is_same_v<decltype(d.begin()->second), DataProxy>));
-  ASSERT_TRUE((std::is_same_v<decltype(d.end()->second), DataProxy>));
+  ASSERT_TRUE((std::is_same_v<decltype(*d.begin()), DataProxy>));
+  ASSERT_TRUE((std::is_same_v<decltype(*d.end()), DataProxy>));
 }
 
 TEST(DatasetTest, const_iterators_return_types) {
   const Dataset d;
-  ASSERT_TRUE((std::is_same_v<decltype(d.begin()->second), DataConstProxy>));
-  ASSERT_TRUE((std::is_same_v<decltype(d.end()->second), DataConstProxy>));
+  ASSERT_TRUE((std::is_same_v<decltype(*d.begin()), DataConstProxy>));
+  ASSERT_TRUE((std::is_same_v<decltype(*d.end()), DataConstProxy>));
 }
 
 TEST(DatasetTest, set_dense_data_with_sparse_coord) {

--- a/core/test/slice_test.cpp
+++ b/core/test/slice_test.cpp
@@ -538,12 +538,12 @@ TYPED_TEST_SUITE(DataProxy3DTest, DataProxyTypes);
 // slicing DataProxy.
 TYPED_TEST(DataProxy3DTest, slice_single) {
   auto &d = TestFixture::dataset();
-  for (const auto [name, item] : d) {
+  for (const auto &item : d) {
     for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
       if (item.dims().contains(dim)) {
         EXPECT_ANY_THROW(item.slice({dim, -1}));
         for (scipp::index i = 0; i < item.dims()[dim]; ++i)
-          EXPECT_EQ(item.slice({dim, i}), d.slice({dim, i})[name]);
+          EXPECT_EQ(item.slice({dim, i}), d.slice({dim, i})[item.name()]);
         EXPECT_ANY_THROW(item.slice({dim, item.dims()[dim]}));
       } else {
         EXPECT_ANY_THROW(item.slice({dim, 0}));
@@ -554,13 +554,13 @@ TYPED_TEST(DataProxy3DTest, slice_single) {
 
 TYPED_TEST(DataProxy3DTest, slice_length_0) {
   auto &d = TestFixture::dataset();
-  for (const auto [name, item] : d) {
+  for (const auto &item : d) {
     for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
       if (item.dims().contains(dim)) {
         EXPECT_ANY_THROW(item.slice({dim, -1, -1}));
         for (scipp::index i = 0; i < item.dims()[dim]; ++i)
           EXPECT_EQ(item.slice({dim, i, i + 0}),
-                    d.slice({dim, i, i + 0})[name]);
+                    d.slice({dim, i, i + 0})[item.name()]);
         EXPECT_ANY_THROW(
             item.slice({dim, item.dims()[dim], item.dims()[dim] + 0}));
       } else {
@@ -572,13 +572,13 @@ TYPED_TEST(DataProxy3DTest, slice_length_0) {
 
 TYPED_TEST(DataProxy3DTest, slice_length_1) {
   auto &d = TestFixture::dataset();
-  for (const auto [name, item] : d) {
+  for (const auto &item : d) {
     for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
       if (item.dims().contains(dim)) {
         EXPECT_ANY_THROW(item.slice({dim, -1, 0}));
         for (scipp::index i = 0; i < item.dims()[dim]; ++i)
           EXPECT_EQ(item.slice({dim, i, i + 1}),
-                    d.slice({dim, i, i + 1})[name]);
+                    d.slice({dim, i, i + 1})[item.name()]);
         EXPECT_ANY_THROW(
             item.slice({dim, item.dims()[dim], item.dims()[dim] + 1}));
       } else {
@@ -590,13 +590,13 @@ TYPED_TEST(DataProxy3DTest, slice_length_1) {
 
 TYPED_TEST(DataProxy3DTest, slice) {
   auto &d = TestFixture::dataset();
-  for (const auto [name, item] : d) {
+  for (const auto &item : d) {
     for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
       if (item.dims().contains(dim)) {
         EXPECT_ANY_THROW(item.slice({dim, -1, 1}));
         for (scipp::index i = 0; i < item.dims()[dim] - 1; ++i)
           EXPECT_EQ(item.slice({dim, i, i + 2}),
-                    d.slice({dim, i, i + 2})[name]);
+                    d.slice({dim, i, i + 2})[item.name()]);
         EXPECT_ANY_THROW(
             item.slice({dim, item.dims()[dim], item.dims()[dim] + 2}));
       } else {
@@ -610,13 +610,13 @@ TYPED_TEST(DataProxy3DTest, slice_slice_range) {
   auto &d = TestFixture::dataset();
   const auto slice = d.slice({Dim::X, 2, 4});
   // Slice proxy created from DatasetProxy as opposed to directly from Dataset.
-  for (const auto [name, item] : slice) {
+  for (const auto &item : slice) {
     for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
       if (item.dims().contains(dim)) {
         EXPECT_ANY_THROW(item.slice({dim, -1}));
         for (scipp::index i = 0; i < item.dims()[dim]; ++i)
           EXPECT_EQ(item.slice({dim, i}),
-                    d.slice({Dim::X, 2, 4}, {dim, i})[name]);
+                    d.slice({Dim::X, 2, 4}, {dim, i})[item.name()]);
         EXPECT_ANY_THROW(item.slice({dim, item.dims()[dim]}));
       } else {
         EXPECT_ANY_THROW(item.slice({dim, 0}));
@@ -633,12 +633,12 @@ TYPED_TEST(DataProxy3DTest, slice_single_with_edges) {
   for (const auto &edgeDims : {x, xy, yz, xyz}) {
     typename TestFixture::dataset_type d =
         TestFixture::datasetWithEdges(edgeDims);
-    for (const auto [name, item] : d) {
+    for (const auto &item : d) {
       for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
         if (item.dims().contains(dim)) {
           EXPECT_ANY_THROW(item.slice({dim, -1}));
           for (scipp::index i = 0; i < item.dims()[dim]; ++i)
-            EXPECT_EQ(item.slice({dim, i}), d.slice({dim, i})[name]);
+            EXPECT_EQ(item.slice({dim, i}), d.slice({dim, i})[item.name()]);
           EXPECT_ANY_THROW(item.slice({dim, item.dims()[dim]}));
         } else {
           EXPECT_ANY_THROW(item.slice({dim, 0}));
@@ -656,13 +656,13 @@ TYPED_TEST(DataProxy3DTest, slice_length_0_with_edges) {
   for (const auto &edgeDims : {x, xy, yz, xyz}) {
     typename TestFixture::dataset_type d =
         TestFixture::datasetWithEdges(edgeDims);
-    for (const auto [name, item] : d) {
+    for (const auto &item : d) {
       for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
         if (item.dims().contains(dim)) {
           EXPECT_ANY_THROW(item.slice({dim, -1, -1}));
           for (scipp::index i = 0; i < item.dims()[dim]; ++i) {
             const auto slice = item.slice({dim, i, i + 0});
-            EXPECT_EQ(slice, d.slice({dim, i, i + 0})[name]);
+            EXPECT_EQ(slice, d.slice({dim, i, i + 0})[item.name()]);
             if (std::set(edgeDims).count(dim)) {
               EXPECT_EQ(slice.coords()[dim].dims()[dim], 1);
             }
@@ -685,13 +685,13 @@ TYPED_TEST(DataProxy3DTest, slice_length_1_with_edges) {
   for (const auto &edgeDims : {x, xy, yz, xyz}) {
     typename TestFixture::dataset_type d =
         TestFixture::datasetWithEdges(edgeDims);
-    for (const auto [name, item] : d) {
+    for (const auto &item : d) {
       for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
         if (item.dims().contains(dim)) {
           EXPECT_ANY_THROW(item.slice({dim, -1, 0}));
           for (scipp::index i = 0; i < item.dims()[dim]; ++i) {
             const auto slice = item.slice({dim, i, i + 1});
-            EXPECT_EQ(slice, d.slice({dim, i, i + 1})[name]);
+            EXPECT_EQ(slice, d.slice({dim, i, i + 1})[item.name()]);
             if (std::set(edgeDims).count(dim)) {
               EXPECT_EQ(slice.coords()[dim].dims()[dim], 2);
             }
@@ -714,13 +714,13 @@ TYPED_TEST(DataProxy3DTest, slice_with_edges) {
   for (const auto &edgeDims : {x, xy, yz, xyz}) {
     typename TestFixture::dataset_type d =
         TestFixture::datasetWithEdges(edgeDims);
-    for (const auto [name, item] : d) {
+    for (const auto &item : d) {
       for (const auto dim : {Dim::X, Dim::Y, Dim::Z}) {
         if (item.dims().contains(dim)) {
           EXPECT_ANY_THROW(item.slice({dim, -1, 1}));
           for (scipp::index i = 0; i < item.dims()[dim] - 1; ++i) {
             const auto slice = item.slice({dim, i, i + 2});
-            EXPECT_EQ(slice, d.slice({dim, i, i + 2})[name]);
+            EXPECT_EQ(slice, d.slice({dim, i, i + 2})[item.name()]);
             if (std::set(edgeDims).count(dim)) {
               EXPECT_EQ(slice.coords()[dim].dims()[dim], 3);
             }

--- a/docs/user-guide/computation.ipynb
+++ b/docs/user-guide/computation.ipynb
@@ -278,7 +278,7 @@
    "outputs": [],
    "source": [
     "d3 = d1 + d2\n",
-    "for name, _ in d3:\n",
+    "for name in d3:\n",
     "    print(name)"
    ]
   },

--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -553,7 +553,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for name, data in d:\n",
+    "for name in d:\n",
     "    print(name)"
    ]
   },

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -41,8 +41,7 @@ static T convert_with_factor(T &&d, const Dim from, const Dim to,
   }
 
   // 2. Transform sparse coordinates
-  for (const auto &[name, data] : iter(d)) {
-    static_cast<void>(name);
+  for (const auto &data : iter(d)) {
     if (data.dims().sparse()) {
       data.coords()[from] *= factor;
     }
@@ -102,8 +101,7 @@ template <class T> T tofToEnergy(T &&d) {
   }
 
   // 3. Transform sparse coordinates
-  for (const auto &[name, data] : iter(d)) {
-    static_cast<void>(name);
+  for (const auto &data : iter(d)) {
     if (data.coords()[Dim::Tof].dims().sparse()) {
       transform_in_place<pair_self_t<double, float>>(
           data.coords()[Dim::Tof], conversionFactor,
@@ -130,8 +128,7 @@ template <class T> T energyToTof(T &&d) {
   }
 
   // 3. Transform sparse coordinates
-  for (const auto &[name, data] : iter(d)) {
-    static_cast<void>(name);
+  for (const auto &data : iter(d)) {
     if (data.coords()[Dim::Energy].dims().sparse()) {
       transform_in_place<pair_self_t<double, float>>(
           data.coords()[Dim::Energy], conversionFactor,
@@ -219,8 +216,8 @@ Dataset tofToDeltaE(const Dataset &d) {
 
 template <class T> T convert_impl(T d, const Dim from, const Dim to) {
   for (const auto &item : iter(d))
-    if (item.second.hasData())
-      expect::notCountDensity(item.second.unit());
+    if (item.hasData())
+      expect::notCountDensity(item.unit());
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
     return convert_with_factor(std::move(d), from, to, tofToDSpacing(d));
   if ((from == Dim::DSpacing) && (to == Dim::Tof))
@@ -259,7 +256,7 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // handle attributes so this can be avoided.
         if constexpr (std::is_same_v<std::decay_t<T>, Dataset>)
           for (const auto &item : iter(x))
-            item.second.attrs().set(field, x.labels()[field]);
+            item.attrs().set(field, x.labels()[field]);
         x.attrs().set(field, x.labels()[field]);
         x.labels().erase(field);
       }
@@ -272,8 +269,8 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         x.attrs().erase(field);
         if constexpr (std::is_same_v<std::decay_t<T>, Dataset>) {
           for (const auto &item : iter(x)) {
-            expect::equals(x.labels()[field], item.second.attrs()[field]);
-            item.second.attrs().erase(field);
+            expect::equals(x.labels()[field], item.attrs()[field]);
+            item.attrs().erase(field);
           }
         }
       }

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -21,8 +21,8 @@ template <class T> bool has_dim(const T &d, const Dim dim) {
 
 template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
   for (const auto &item : iter(d))
-    if (item.second.hasData())
-      expect::notCountDensity(item.second.unit());
+    if (item.hasData())
+      expect::notCountDensity(item.unit());
 
   // 1. There may be a grouping of detectors, in which case we need to apply it
   // to the cal information first.
@@ -62,8 +62,7 @@ template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
   }
 
   // 3. Transform sparse coordinates
-  for (const auto &[name, data] : iter(d)) {
-    static_cast<void>(name);
+  for (const auto &data : iter(d)) {
     if (data.coords()[Dim::Tof].dims().sparse()) {
       data.coords()[Dim::Tof] -= cal["tzero"].data();
       data.coords()[Dim::Tof] /= cal["difc"].data();

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -65,10 +65,10 @@ TEST(ConvertDataArray, from_tof) {
   for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
     const auto expected = convert(tof, Dim::Tof, dim);
     Dataset result;
-    for (const auto &[name, data] : tof)
-      result.setData(name, convert(data, Dim::Tof, dim));
-    for (const auto &[name, data] : result)
-      EXPECT_EQ(data, expected[name]);
+    for (const auto &data : tof)
+      result.setData(data.name(), convert(data, Dim::Tof, dim));
+    for (const auto &data : result)
+      EXPECT_EQ(data, expected[data.name()]);
   }
 }
 
@@ -78,10 +78,10 @@ TEST(ConvertDataArray, to_tof) {
     const auto input = convert(tof, Dim::Tof, dim);
     const auto expected = convert(input, dim, Dim::Tof);
     Dataset result;
-    for (const auto &[name, data] : input)
-      result.setData(name, convert(data, dim, Dim::Tof));
-    for (const auto &[name, data] : result)
-      EXPECT_EQ(data, expected[name]);
+    for (const auto &data : input)
+      result.setData(data.name(), convert(data, dim, Dim::Tof));
+    for (const auto &data : result)
+      EXPECT_EQ(data, expected[data.name()]);
   }
 }
 

--- a/neutron/test/convert_with_calibration_test.cpp
+++ b/neutron/test/convert_with_calibration_test.cpp
@@ -57,7 +57,7 @@ TEST(ConvertWithCaliabrationDataArray, data_array) {
 
   for (const auto &item : tof) {
     const auto dspacing =
-        diffraction::convert_with_calibration(copy(item.second), cal);
+        diffraction::convert_with_calibration(copy(item), cal);
     ASSERT_TRUE(dspacing.coords().contains(Dim::DSpacing));
     ASSERT_EQ(dspacing.coords()[Dim::DSpacing].unit(), scipp::units::angstrom);
   }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -22,8 +22,7 @@ using namespace scipp::core;
 template <class T> auto dim_extent(const T &object, const Dim dim) {
   if constexpr (std::is_same_v<T, Dataset> || std::is_same_v<T, DatasetProxy>) {
     scipp::index extent = -1;
-    for (const auto &[key, item] : object) {
-      static_cast<void>(key);
+    for (const auto &item : object) {
       if (item.dims().contains(dim)) {
         if (extent == -1)
           extent = item.dims()[dim];

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -111,7 +111,8 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
                                       py::return_value_policy::move);
            },
            py::keep_alive<0, 1>())
-      .def("keys", &T::keys)
+      .def("keys", [](T &self) { return keys_view(self); },
+           py::keep_alive<0, 1>())
       .def("values", [](T &self) { return values_view(self); },
            py::keep_alive<0, 1>())
       .def("items", [](T &self) { return items_view(self); },
@@ -163,7 +164,8 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
                                    py::return_value_policy::move);
         },
         py::return_value_policy::move, py::keep_alive<0, 1>());
-  c.def("keys", &T::keys);
+  c.def("keys", [](T &self) { return keys_view(self); },
+        py::return_value_policy::move, py::keep_alive<0, 1>());
   c.def("values", [](T &self) { return values_view(self); },
         py::return_value_policy::move, py::keep_alive<0, 1>());
   c.def("items", [](T &self) { return items_view(self); },
@@ -246,6 +248,12 @@ void init_dataset(py::module &m) {
   bind_helper_view<items_view, LabelsProxy>(m, "LabelsProxy");
   bind_helper_view<items_view, MasksProxy>(m, "MasksProxy");
   bind_helper_view<items_view, AttrsProxy>(m, "AttrsProxy");
+  bind_helper_view<keys_view, Dataset>(m, "Dataset");
+  bind_helper_view<keys_view, DatasetProxy>(m, "DatasetProxy");
+  bind_helper_view<keys_view, CoordsProxy>(m, "CoordsProxy");
+  bind_helper_view<keys_view, LabelsProxy>(m, "LabelsProxy");
+  bind_helper_view<keys_view, MasksProxy>(m, "MasksProxy");
+  bind_helper_view<keys_view, AttrsProxy>(m, "AttrsProxy");
   bind_helper_view<values_view, Dataset>(m, "Dataset");
   bind_helper_view<values_view, DatasetProxy>(m, "DatasetProxy");
   bind_helper_view<values_view, CoordsProxy>(m, "CoordsProxy");

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -112,11 +112,12 @@ void bind_mutable_proxy(py::module &m, const std::string &name) {
            },
            py::keep_alive<0, 1>())
       .def("keys", [](T &self) { return keys_view(self); },
-           py::keep_alive<0, 1>())
+           py::keep_alive<0, 1>(), R"(view on self's keys)")
       .def("values", [](T &self) { return values_view(self); },
-           py::keep_alive<0, 1>())
+           py::keep_alive<0, 1>(), R"(view on self's values)")
       .def("items", [](T &self) { return items_view(self); },
-           py::return_value_policy::move, py::keep_alive<0, 1>())
+           py::return_value_policy::move, py::keep_alive<0, 1>(),
+           R"(view on self's items)")
       .def("__contains__", &T::contains);
   bind_comparison<T>(proxy);
 }
@@ -165,11 +166,14 @@ void bind_dataset_proxy_methods(py::class_<T, Ignored...> &c) {
         },
         py::return_value_policy::move, py::keep_alive<0, 1>());
   c.def("keys", [](T &self) { return keys_view(self); },
-        py::return_value_policy::move, py::keep_alive<0, 1>());
+        py::return_value_policy::move, py::keep_alive<0, 1>(),
+        R"(view on self's keys)");
   c.def("values", [](T &self) { return values_view(self); },
-        py::return_value_policy::move, py::keep_alive<0, 1>());
+        py::return_value_policy::move, py::keep_alive<0, 1>(),
+        R"(view on self's values)");
   c.def("items", [](T &self) { return items_view(self); },
-        py::return_value_policy::move, py::keep_alive<0, 1>());
+        py::return_value_policy::move, py::keep_alive<0, 1>(),
+        R"(view on self's items)");
   c.def("__getitem__",
         [](T &self, const std::string &name) { return self[name]; },
         py::keep_alive<0, 1>());
@@ -237,11 +241,6 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
 void init_dataset(py::module &m) {
   py::class_<Slice>(m, "Slice");
 
-  bind_mutable_proxy<CoordsProxy, CoordsConstProxy>(m, "Coords");
-  bind_mutable_proxy<LabelsProxy, LabelsConstProxy>(m, "Labels");
-  bind_mutable_proxy<MasksProxy, MasksConstProxy>(m, "Masks");
-  bind_mutable_proxy<AttrsProxy, AttrsConstProxy>(m, "Attrs");
-
   bind_helper_view<items_view, Dataset>(m, "Dataset");
   bind_helper_view<items_view, DatasetProxy>(m, "DatasetProxy");
   bind_helper_view<items_view, CoordsProxy>(m, "CoordsProxy");
@@ -260,6 +259,11 @@ void init_dataset(py::module &m) {
   bind_helper_view<values_view, LabelsProxy>(m, "LabelsProxy");
   bind_helper_view<values_view, MasksProxy>(m, "MasksProxy");
   bind_helper_view<values_view, AttrsProxy>(m, "AttrsProxy");
+
+  bind_mutable_proxy<CoordsProxy, CoordsConstProxy>(m, "Coords");
+  bind_mutable_proxy<LabelsProxy, LabelsConstProxy>(m, "Labels");
+  bind_mutable_proxy<MasksProxy, MasksConstProxy>(m, "Masks");
+  bind_mutable_proxy<AttrsProxy, AttrsConstProxy>(m, "Attrs");
 
   py::class_<DataArray> dataArray(m, "DataArray", R"(
     Named variable with associated coords, labels, and attributes.)");

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -109,7 +109,8 @@ class InstrumentView:
         self.data_arrays = {}
         tp = type(scipp_obj)
         if tp is sc.Dataset or tp is sc.DatasetProxy:
-            for key, var in sorted(scipp_obj):
+            for key in sorted(scipp_obj.keys()):
+                var = scipp_obj[key]
                 if self.dim in var.dims:
                     self.data_arrays[key] = var
         elif tp is sc.DataArray or tp is sc.DataProxy:

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -37,8 +37,8 @@ def plot(scipp_obj,
     inventory = dict()
     tp = type(scipp_obj)
     if tp is sc.Dataset or tp is sc.DatasetProxy:
-        for name, var in sorted(scipp_obj):
-            inventory[name] = var
+        for name in sorted(scipp_obj.keys()):
+            inventory[name] = scipp_obj[name]
     elif tp is sc.Variable or tp is sc.VariableProxy:
         inventory[str(tp)] = sc.DataArray(data=scipp_obj)
     elif tp is sc.DataArray or tp is sc.DataProxy:

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -144,11 +144,11 @@ class VariableDrawer():
             extra_item_count += 1
         if is_data_array(self._variable):
             if self._variable.sparse_dim is not None:
-                for name, label in self._variable.labels:
+                for name, label in self._variable.labels.items():
                     if label.sparse_dim is not None:
                         extra_item_count += 1
                 sparse_dim = self._variable.sparse_dim
-                for dim, coord in self._variable.coords:
+                for dim in self._variable.coords:
                     if dim == sparse_dim:
                         extra_item_count += 1
         if self._variable.values is None:
@@ -272,7 +272,7 @@ class VariableDrawer():
                         items.append(
                             (name, mask.values, config.colors['mask']))
                 sparse_dim = self._variable.sparse_dim
-                for dim, coord in self._variable.coords:
+                for dim in self._variable.coords:
                     if dim == sparse_dim:
                         items.append((str(sparse_dim),
                                       self._variable.coords[sparse_dim].values,
@@ -372,8 +372,8 @@ class DatasetDrawer():
         else:
             # Render highest-dimension items last so coords are optically
             # aligned
-            for data in self._dataset.values():
-                item = (data.name(), data, config.colors['data'])
+            for name, data in self._dataset.items():
+                item = (name, data, config.colors['data'])
                 # Using only x and 0d areas for 1-D dataset
                 if len(dims) == 1 or data.dims != dims:
                     if len(data.dims) == 0:
@@ -393,7 +393,7 @@ class DatasetDrawer():
                 self._dataset.coords, self._dataset.labels,
                 self._dataset.masks, self._dataset.attrs
         ]):
-            for name, var in items:
+            for name, var in items.items():
                 if var.sparse_dim is not None:
                     continue
                 item = (name, var, config.colors[what])

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -322,7 +322,7 @@ class DatasetDrawer():
             dims = self._dataset.dims
         else:
             dims = []
-            for name, item in self._dataset:
+            for item in self._dataset.values():
                 if item.sparse_dim is not None:
                     dims = item.dims
                     break
@@ -372,8 +372,8 @@ class DatasetDrawer():
         else:
             # Render highest-dimension items last so coords are optically
             # aligned
-            for name, data in self._dataset:
-                item = (name, data, config.colors['data'])
+            for data in self._dataset.values():
+                item = (data.name(), data, config.colors['data'])
                 # Using only x and 0d areas for 1-D dataset
                 if len(dims) == 1 or data.dims != dims:
                     if len(data.dims) == 0:

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -19,7 +19,7 @@ def _make_table_section_name_header(name, section, style):
     contain Data, Labels, Masks, etc.
     """
     col_separators = 0
-    for key, sec in section:
+    for key, sec in section.items():
         col_separators += 1 + (sec.variances is not None)
     if col_separators > 0:
         return "<th {} colspan='{}'>{}</th>".format(style, col_separators,
@@ -62,7 +62,7 @@ def _make_table_unit_headers(section, text_style):
     Adds a row containing the unit of the section
     """
     html = []
-    for key, val in section:
+    for key, val in section.items():
         html.append("<th {} colspan='{}'>{}</th>".format(
             text_style, 1 + (val.variances is not None),
             name_with_unit(val, name=key)))
@@ -74,7 +74,7 @@ def _make_table_subsections(section, text_style):
     Adds Value | Variance columns for the section.
     """
     html = []
-    for key, val in section:
+    for key, val in section.items():
         html.append("<th {}>Values</th>".format(text_style))
         if val.variances is not None:
             html.append("<th {}>Variances</th>".format(text_style))
@@ -83,7 +83,7 @@ def _make_table_subsections(section, text_style):
 
 def _make_value_rows(section, coord, index, base_style, edge_style, row_start):
     html = []
-    for key, val in section:
+    for key, val in section.items():
         header_line_for_bin_edges = False
         if coord is not None:
             if len(val.values) == len(coord.values) - 1:
@@ -105,7 +105,7 @@ def _make_value_rows(section, coord, index, base_style, edge_style, row_start):
 
 def _make_trailing_cells(section, coord, index, size, base_style, edge_style):
     html = []
-    for key, val in section:
+    for key, val in section.items():
         if len(val.values) == len(coord.values) - 1:
             if index == size - 1:
                 html.append("<td {}></td>".format(edge_style))
@@ -201,7 +201,7 @@ def table_from_dataset(dataset,
 
     if size is None:  # handle 0D variable
         html += "<tr {}>".format(hover_style)
-        for key, val in dataset:
+        for key, val in dataset.items():
             html += "<td {}>{}</td>".format(base_style,
                                             value_to_string(val.value))
             if val.variances is not None:
@@ -288,7 +288,7 @@ class TableViewer:
                 self.is_histogram[key] = False
 
             # Next add the variables
-            for name, var in dataset:
+            for name, var in dataset.items():
                 if len(var.dims) == 1:
                     dim = var.dims[0]
                     key = str(dim)
@@ -304,7 +304,7 @@ class TableViewer:
                     self.tabledict["0D Variables"][name] = var
 
             # Next add only the 1D coordinates
-            for dim, var in dataset.coords:
+            for dim, var in dataset.coords.items():
                 if len(var.dims) == 1:
                     key = str(dim)
                     if dim not in self.tabledict["1D Variables"][key].coords:
@@ -312,7 +312,7 @@ class TableViewer:
                         is_empty[key] = False
 
             # Next add the labels
-            for name, lab in dataset.labels:
+            for name, lab in dataset.labels.items():
                 if len(lab.dims) == 1:
                     dim = lab.dims[0]
                     key = str(dim)
@@ -326,7 +326,7 @@ class TableViewer:
                     is_empty[key] = False
 
             # Next add the masks
-            for name, mask in dataset.masks:
+            for name, mask in dataset.masks.items():
                 if len(mask.dims) == 1:
                     dim = mask.dims[0]
                     key = str(dim)

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -149,7 +149,7 @@ def format_dims(dims, sizes, coords):
 
 def summarize_attrs_simple(attrs):
     attrs_dl = "".join(f"<dt><span>{escape(name)} :</span></dt>"
-                       f"<dd>{values}</dd>" for name, values in attrs)
+                       f"<dd>{values}</dd>" for name, values in attrs.items())
 
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 
@@ -157,7 +157,7 @@ def summarize_attrs_simple(attrs):
 def summarize_attrs(attrs):
     attrs_li = "".join(f"<li class='xr-var-item'>\
             {summarize_variable(name, values, has_attrs=False)}</li>"
-                       for name, values in attrs)
+                       for name, values in attrs.items())
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
 
 
@@ -193,7 +193,7 @@ def find_bin_edges(var, ds):
 def summarize_coords(coords, ds=None):
     vars_li = "".join("<li class='xr-var-item'>"
                       f"{summarize_coord(dim, var, ds)}"
-                      "</span></li>" for dim, var in coords)
+                      "</span></li>" for dim, var in coords.items())
 
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
@@ -203,7 +203,10 @@ def _extract_sparse(x):
     Returns the (key, value) pairs where value has a sparse dim
     :param x: dict-like, e.g., coords proxy or labels proxy
     """
-    return [(key, value) for key, value in x if value.sparse_dim is not None]
+    return {
+        key: value
+        for key, value in x.items() if value.sparse_dim is not None
+    }
 
 
 def _make_inline_attributes(var, has_attrs):
@@ -404,7 +407,7 @@ def summarize_data(dataset):
             var,
             has_attrs=has_attrs,
             bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
-                      for name, var in dataset)
+                      for name, var in dataset.items())
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
@@ -451,7 +454,7 @@ def _mapping_section(mapping,
 
 
 def dim_section(dataset):
-    coords = dataset.coords if hasattr(dataset, "coords") else []
+    coords = dataset.coords if hasattr(dataset, "coords") else dict()
     dim_list = format_dims(dataset.dims, dataset.shape, coords)
 
     return collapsible_section("Dimensions",
@@ -530,7 +533,7 @@ def dataset_repr(ds):
     if len(ds.labels) > 0:
         sections.append(label_section(ds.labels, ds))
 
-    sections.append(data_section(ds if hasattr(ds, '__len__') else [('', ds)]))
+    sections.append(data_section(ds if hasattr(ds, '__len__') else {'': ds}))
 
     if len(ds.masks) > 0:
         sections.append(mask_section(ds.masks, ds))

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -80,29 +80,6 @@ def test_del_item_missing():
         del d['not an item']
 
 
-def make_dataset_abc():
-    d = sc.Dataset()
-    d['a'] = 1.0 * sc.units.m
-    d['b'] = 2.0 * sc.units.m
-    d['c'] = 3.0 * sc.units.m
-    return d
-
-
-def test_iter():
-    d = make_dataset_abc()
-    keys = d.keys()
-    assert len(keys) == 3
-    for key in ['a', 'b', 'c']:
-        assert key in keys
-
-
-def test_items():
-    d = make_dataset_abc()
-    assert len(d.items()) == 3
-    for name, value in d.items():
-        assert name == value.name
-
-
 def test_coord_setitem():
     var = sc.Variable([Dim.X], values=np.arange(4))
     d = sc.Dataset({'a': var}, coords={Dim.X: var})

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -159,7 +159,7 @@ def test_coords_keys():
     d = sc.Dataset()
     d.coords[Dim.X] = sc.Variable(1.0)
     assert len(d.coords.keys()) == 1
-    assert d.coords.keys() == [Dim.X]
+    assert Dim.X in d.coords.keys()
 
 
 def test_labels_setitem():
@@ -195,7 +195,7 @@ def test_labels_keys():
     d = sc.Dataset()
     d.labels["b"] = sc.Variable(1.0)
     assert len(d.labels.keys()) == 1
-    assert d.labels.keys() == ["b"]
+    assert "b" in d.labels.keys()
 
 
 def test_masks_setitem():
@@ -254,7 +254,7 @@ def test_attrs_keys():
     d = sc.Dataset()
     d.attrs["b"] = sc.Variable(1.0)
     assert len(d.attrs.keys()) == 1
-    assert d.attrs.keys() == ["b"]
+    assert "b" in d.attrs.keys()
 
 
 def test_slice_item():

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -80,6 +80,29 @@ def test_del_item_missing():
         del d['not an item']
 
 
+def make_dataset_abc():
+    d = sc.Dataset()
+    d['a'] = 1.0 * sc.units.m
+    d['b'] = 2.0 * sc.units.m
+    d['c'] = 3.0 * sc.units.m
+    return d
+
+
+def test_iter():
+    d = make_dataset_abc()
+    keys = d.keys()
+    assert len(keys) == 3
+    for key in ['a', 'b', 'c']:
+        assert key in keys
+
+
+def test_items():
+    d = make_dataset_abc()
+    assert len(d.items()) == 3
+    for name, value in d.items():
+        assert name == value.name
+
+
 def test_coord_setitem():
     var = sc.Variable([Dim.X], values=np.arange(4))
     d = sc.Dataset({'a': var}, coords={Dim.X: var})

--- a/python/tests/test_iteration.py
+++ b/python/tests/test_iteration.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import pytest
+
+import scipp as sc
+from scipp import Dim
+
+
+@pytest.fixture(params=['Dataset', 'DatasetProxy'])
+def dataset_abc(request):
+    d = sc.Dataset()
+    d['a'] = sc.Variable([Dim.X], values=[1, 2])
+    d['b'] = sc.Variable([Dim.X], values=[3, 4])
+    d['c'] = sc.Variable([Dim.X], values=[5, 6])
+    # Using yield so `d` does not go out of scope when returning slice
+    if request.param == 'Dataset':
+        yield d
+    else:
+        yield d[Dim.X, 0]
+
+
+def test_dataset_iter(dataset_abc):
+    found = set()
+    for key in dataset_abc:
+        found.add(key)
+    assert found == set(['a', 'b', 'c'])
+
+
+def test_dataset_keys(dataset_abc):
+    assert set(dataset_abc.keys()) == set(['a', 'b', 'c'])
+
+
+def test_dataset_values(dataset_abc):
+    found = set()
+    for value in dataset_abc.values():
+        found.add(value.name)
+    assert found == set(['a', 'b', 'c'])
+
+
+def test_dataset_items(dataset_abc):
+    assert len(dataset_abc.items()) == 3
+    found = set()
+    for name, value in dataset_abc.items():
+        assert name == value.name
+        found.add(name)
+    assert found == set(['a', 'b', 'c'])
+
+
+def make_coords_xyz():
+    d = sc.Dataset()
+    d.coords[Dim.X] = 1.0 * sc.units.m
+    d.coords[Dim.Y] = 2.0 * sc.units.m
+    d.coords[Dim.Z] = 3.0 * sc.units.m
+    return d
+
+
+def test_dataset_coords_iter():
+    d = make_coords_xyz()
+    found = set()
+    for key in d.coords:
+        found.add(key)
+    assert found == set([Dim.X, Dim.Y, Dim.Z])
+
+
+def test_dataset_coords_keys():
+    d = make_coords_xyz()
+    assert set(d.coords.keys()) == set([Dim.X, Dim.Y, Dim.Z])
+
+
+def test_dataset_coords_values():
+    d = make_coords_xyz()
+    found = set()
+    for value in d.coords.values():
+        found.add(value.value)
+    assert found == set([1.0, 2.0, 3.0])
+
+
+def test_dataset_coords_items():
+    d = make_coords_xyz()
+    assert len(d.coords.items()) == 3
+    found = set()
+    for dim, value in d.coords.items():
+        found.add(dim)
+    assert found == set([Dim.X, Dim.Y, Dim.Z])

--- a/python/tests/test_lifetime.py
+++ b/python/tests/test_lifetime.py
@@ -44,20 +44,20 @@ def test_lifetime_coords_of_temporary():
     assert (d + d).labels['aux'].values[-1] == 9
 
 
-def test_lifetime_iter():
+def test_lifetime_items_iter():
     var = sc.Variable(dims=[Dim.X], values=np.arange(10))
     d = sc.Dataset({'a': var}, coords={Dim.X: var}, labels={'aux': var})
-    for name, item in d + d:
+    for key, item in (d + d).items():
         assert item.data == var + var
-    for dim, coord in (d + d).coords:
+    for dim, coord in (d + d).coords.items():
         assert coord == var
-    for name, item in d[Dim.X, 1:5]:
+    for key, item in d[Dim.X, 1:5].items():
         assert item.data == var[Dim.X, 1:5]
-    for dim, coord in d[Dim.X, 1:5].coords:
+    for dim, coord in d[Dim.X, 1:5].coords.items():
         assert coord == var[Dim.X, 1:5]
-    for name, item in (d + d)[Dim.X, 1:5]:
+    for key, item in (d + d)[Dim.X, 1:5].items():
         assert item.data == (var + var)[Dim.X, 1:5]
-    for dim, coord in (d + d)[Dim.X, 1:5].coords:
+    for dim, coord in (d + d)[Dim.X, 1:5].coords.items():
         assert coord == var[Dim.X, 1:5]
 
 


### PR DESCRIPTION
Benchmarks of `groupby` for many groups have indicated performance issues with the view/slicing mechanism of datasets. Previously this was done on-the-fly, resulting in potentially repeated creation of slice views such as `VariableProxy`. This PR started as an attempt to improve this by directly creating all required proxies. Due to the nature of some of the changes it was of advantage to also undertake the planned refactor of the iterators in the Python side.

- Speedup of dataset slicing (only tested on C++ side so far).
- Moderate speedup for `groupby` operations. Not a lot though, due to a variety of reasons (slicing is not the only bottleneck).
- `__iter__`, `items`, `keys`, and `values` methods of dataset and coord proxies now conforming to what users will expect and know from a Python dict.
- Storing `VariableProxy` in `DataProxy` will allow for creation of transposed views of data arrays. Previously this would not have been possible without adding additional fields to `DataProxy` (and therefore `transpose` was only implemented for variables.

Slicing before:
```
BM_dataset_create_view           80.3 ns         80.3 ns     34867057 items_per_second=12.4492M/s
BM_dataset_slice                  736 ns          736 ns      3807819 items_per_second=1.35808M/s
BM_dataset_slice_item             796 ns          796 ns      3517446 items_per_second=1.25706M/s
BM_dataset_slice_item_dims        929 ns          929 ns      3012139 items_per_second=1076.23k/s
BM_dataset_slice_aggregate       1781 ns         1781 ns      1581668 items_per_second=561.591k/s
```

Slicing after (note that except for the last one these appear worse, but actually cost is now paid once for 3 columns in the dataset and all methods, whereas above the view are recreated in each case, so, e.g., a factor of 3 should be added to the "before" case, depending on how many calls there are):
```
BM_dataset_create_view            115 ns          115 ns     24131383 items_per_second=8.67587M/s
BM_dataset_slice                 1014 ns         1014 ns      2755611 items_per_second=986.617k/s
BM_dataset_slice_item            1048 ns         1048 ns      2669955 items_per_second=954.189k/s
BM_dataset_slice_item_dims       1065 ns         1065 ns      2643657 items_per_second=939.135k/s
BM_dataset_slice_aggregate       1056 ns         1056 ns      2658306 items_per_second=946.597k/s

```

Groupby before:
```
BM_groupby_large_table/64        87671097 ns     87672534 ns            8 bytes_per_second=730.011M/s groups=64 items_per_second=23.9203M/s
BM_groupby_large_table/128       90239267 ns     90239978 ns            8 bytes_per_second=709.263M/s groups=128 items_per_second=23.2397M/s
BM_groupby_large_table/256       87617166 ns     87614996 ns            8 bytes_per_second=730.558M/s groups=256 items_per_second=23.936M/s
BM_groupby_large_table/512       87825984 ns     87825048 ns            8 bytes_per_second=728.899M/s groups=512 items_per_second=23.8787M/s
BM_groupby_large_table/1024      94010700 ns     94010296 ns            7 bytes_per_second=681.109M/s groups=1024 items_per_second=22.3077M/s
BM_groupby_large_table/2048     105925447 ns    105926060 ns            7 bytes_per_second=604.785M/s groups=2.048k items_per_second=19.7983M/s
BM_groupby_large_table/4096     106698348 ns    106697916 ns            7 bytes_per_second=600.996M/s groups=4.096k items_per_second=19.655M/s
BM_groupby_large_table/8192     126080028 ns    126067284 ns            6 bytes_per_second=509.648M/s groups=8.192k items_per_second=16.6352M/s
BM_groupby_large_table/16384    165389759 ns    165381432 ns            4 bytes_per_second=390.008M/s groups=16.384k items_per_second=12.6807M/s
BM_groupby_large_table/32768    245663863 ns    245640070 ns            3 bytes_per_second=264.615M/s groups=32.768k items_per_second=8.5375M/s
BM_groupby_large_table/65536    404470054 ns    404422056 ns            2 bytes_per_second=163.196M/s groups=65.536k items_per_second=5.18555M/s
BM_groupby_large_table/131072   751819263 ns    751786528 ns            1 bytes_per_second=90.4512M/s groups=131.072k items_per_second=2.78956M/s
BM_groupby_large_table/262144  1483129387 ns   1483099398 ns            1 bytes_per_second=48.547M/s groups=262.144k items_per_second=1.41403M/s
BM_groupby_large_table/524288  2767397663 ns   2767324116 ns            1 bytes_per_second=28.9088M/s groups=524.288k items_per_second=757.827k/s
BM_groupby_large_table/1048576 5400508781 ns   5400177748 ns            1 bytes_per_second=17.7772M/s groups=1048.58k items_per_second=388.349k/s
BM_groupby_large_table/2097152 10955659064 ns   10955183720 ns            1 bytes_per_second=11.684M/s groups=2.09715M items_per_second=191.43k/s
```

Groupby after (note speedup for 1M rows and above):
```
BM_groupby_large_table/64        83887688 ns     83888016 ns            8 bytes_per_second=762.945M/s groups=64 items_per_second=24.9994M/s
BM_groupby_large_table/128       84272965 ns     84271769 ns            8 bytes_per_second=759.494M/s groups=128 items_per_second=24.8856M/s
BM_groupby_large_table/256       84754902 ns     84750423 ns            8 bytes_per_second=755.251M/s groups=256 items_per_second=24.745M/s
BM_groupby_large_table/512       86365489 ns     86363897 ns            8 bytes_per_second=741.231M/s groups=512 items_per_second=24.2827M/s
BM_groupby_large_table/1024      88075793 ns     88072847 ns            8 bytes_per_second=727.026M/s groups=1024 items_per_second=23.8116M/s
BM_groupby_large_table/2048      92691084 ns     92682926 ns            8 bytes_per_second=691.201M/s groups=2.048k items_per_second=22.6272M/s
BM_groupby_large_table/4096     101385755 ns    101382549 ns            7 bytes_per_second=632.505M/s groups=4.096k items_per_second=20.6855M/s
BM_groupby_large_table/8192     118417507 ns    118411428 ns            6 bytes_per_second=542.6M/s groups=8.192k items_per_second=17.7107M/s
BM_groupby_large_table/16384    152774989 ns    152762977 ns            5 bytes_per_second=422.223M/s groups=16.384k items_per_second=13.7281M/s
BM_groupby_large_table/32768    222488098 ns    222485214 ns            3 bytes_per_second=292.154M/s groups=32.768k items_per_second=9.42603M/s
BM_groupby_large_table/65536    357741720 ns    357711840 ns            2 bytes_per_second=184.506M/s groups=65.536k items_per_second=5.86269M/s
BM_groupby_large_table/131072   640350638 ns    640330232 ns            1 bytes_per_second=106.195M/s groups=131.072k items_per_second=3.27511M/s
BM_groupby_large_table/262144  1219344410 ns   1219293992 ns            1 bytes_per_second=59.0506M/s groups=262.144k items_per_second=1.71997M/s
BM_groupby_large_table/524288  2352173713 ns   2352057460 ns            1 bytes_per_second=34.0128M/s groups=524.288k items_per_second=891.624k/s
BM_groupby_large_table/1048576 4699586608 ns   4699372954 ns            1 bytes_per_second=20.4283M/s groups=1048.58k items_per_second=446.262k/s
BM_groupby_large_table/2097152 9565647495 ns   9565025781 ns            1 bytes_per_second=13.3821M/s groups=2.09715M items_per_second=219.252k/s
```