### PR TITLE
Refactor nan_to_num

### DIFF
--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -278,11 +278,7 @@ check_all_or_none_variances(const Op &, const Args &... valAndVariances) {
   constexpr bool force_same =
       std::is_base_of_v<transform_flags::expect_all_or_none_have_variance_t,
                         Op>;
-  return force_same && !(force_same && (valAndVariances && ...)) &&
-         ((force_same && (valAndVariances && ...)) || (valAndVariances || ...));
-
-  // return force_same && !((valAndVariances && ...) ^ (!valAndVariances &&
-  // ...));
+  return force_same && !((valAndVariances && ...) ^ (!valAndVariances && ...));
 }
 
 /// Recursion endpoint for do_transform.
@@ -296,7 +292,7 @@ static void do_transform(Op op, Out &&out, Tuple &&processed) {
       [&op, &out, &out_val](auto &&... args) {
         if constexpr (check_all_or_none_variances(
                           op, is_ValuesAndVariances_v<
-                                  std::decay<decltype(args)>>...)) {
+                                  std::decay_t<decltype(args)>>...)) {
           throw except::VariancesError(
               "Expected either all or none of inputs to have variances.");
         } else if constexpr ((is_ValuesAndVariances_v<

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -272,6 +272,21 @@ struct TransformSparse {
   }
 };
 
+template <class Op, class... Args>
+constexpr static bool check_all_or_none_variances(const Op &,
+                                                  const Args &... args) {
+  constexpr bool force_same =
+      std::is_base_of_v<transform_flags::expect_all_or_none_have_variance_t,
+                        Op>;
+  constexpr bool all_variances =
+      force_same &&
+      (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> && ...);
+  constexpr bool variances =
+      all_variances ||
+      (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> || ...);
+  return force_same && !all_variances && variances;
+}
+
 /// Recursion endpoint for do_transform.
 ///
 /// Call transform_elements with or without variances for output, depending on
@@ -281,18 +296,12 @@ static void do_transform(Op op, Out &&out, Tuple &&processed) {
   auto out_val = out.values();
   std::apply(
       [&op, &out, &out_val](auto &&... args) {
-        constexpr bool force_same = std::is_base_of_v<
-            transform_flags::expect_all_or_none_have_variance_t, Op>;
-        constexpr bool all_variances =
-            force_same &&
-            (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> && ...);
-        constexpr bool variances =
-            all_variances ||
-            (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> || ...);
-        if constexpr (force_same && !all_variances && variances) {
+        if constexpr (check_all_or_none_variances(op, args...)) {
           throw except::VariancesError(
               "Expected either all or none of inputs to have variances.");
-        } else if constexpr (variances) {
+        } else if constexpr ((is_ValuesAndVariances_v<
+                                  std::decay_t<decltype(args)>> ||
+                              ...)) {
           auto out_var = out.variances();
           transform_elements(op, ValuesAndVariances{out_val, out_var},
                              std::forward<decltype(args)>(args)...);
@@ -520,10 +529,14 @@ template <bool dry_run> struct in_place {
               is_ValuesAndVariances_v<std::decay_t<decltype(arg)>>;
           constexpr bool args_var =
               (is_ValuesAndVariances_v<std::decay_t<decltype(args)>> || ...);
-          if constexpr ((in_var_if_out_var ? arg_var == args_var
-                                           : arg_var || !args_var) ||
-                        std::is_base_of_v<
-                            transform_flags::expect_no_variance_arg_t<0>, Op>) {
+          if constexpr (check_all_or_none_variances(op, arg, args...)) {
+            throw except::VariancesError(
+                "Expected either all or none of inputs to have variances.");
+          } else if constexpr ((in_var_if_out_var ? arg_var == args_var
+                                                  : arg_var || !args_var) ||
+                               std::is_base_of_v<
+                                   transform_flags::expect_no_variance_arg_t<0>,
+                                   Op>) {
             transform_in_place_impl(op, std::forward<decltype(arg)>(arg),
                                     std::forward<decltype(args)>(args)...);
           } else {
@@ -669,8 +682,10 @@ template <bool dry_run> struct in_place {
         visit_impl<Ts...>::apply(makeTransformInPlace(op), var.dataHandle(),
                                  other.dataHandle()...);
       } else if constexpr (sizeof...(Other) > 1) {
-        static_assert("Transform with more than 2 arguments not implemented "
-                      "yet for element-wise operation.");
+        // No sparse data supported yet in this case.
+        core::visit(std::tuple<Ts...>{})
+            .apply(makeTransformInPlace(op), var.dataHandle(),
+                   other.dataHandle()...);
       } else {
         // Note that if only one of the inputs is sparse it must be the one
         // being transformed in-place, so there are only three cases here.

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -77,6 +77,10 @@ template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
 /// requires inputs to have a variance of the output has a variance.
 struct expect_in_variance_if_out_variance_t {};
 
+static constexpr auto expect_all_or_none_have_variance = []() {};
+using expect_all_or_none_have_variance_t =
+    decltype(expect_all_or_none_have_variance);
+
 } // namespace transform_flags
 
 } // namespace scipp::core

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -1269,16 +1269,13 @@ TEST(VariableTest, nan_to_num) {
   EXPECT_EQ(b, expected);
 }
 
-TEST(VariableTest, nan_to_num_with_variance) {
+TEST(VariableTest,
+     nan_to_num_with_variance_throws_if_replacement_has_no_variance) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2},
                                 Values{1.0, double(NAN)}, Variances{0.1, 0.2});
 
   const auto replacement_value = makeVariable<double>(Values{-1});
-  Variable b = nan_to_num(a, replacement_value);
-  auto expected = makeVariable<double>(
-      Dims{Dim::X}, Shape{2}, Values{1.0, replacement_value.value<double>()},
-      Variances{0.1, replacement_value.value<double>()});
-  EXPECT_EQ(b, expected);
+  EXPECT_THROW(nan_to_num(a, replacement_value), except::VariancesError);
 }
 
 TEST(VariableTest, nan_to_num_with_variance_and_variance_on_replacement) {

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -1240,16 +1240,6 @@ TEST(VariableTest, boolean_xor) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(VariableTest, nan_to_num_throws_when_replacment_not_single_value) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, double(NAN)});
-  // Replacement has 2 values
-  const auto replacement_value =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{-1, -1});
-  EXPECT_THROW(auto replaced = nan_to_num(a, replacement_value),
-               except::SizeError);
-}
-
 TEST(VariableTest, nan_to_num_throws_when_input_and_replace_types_differ) {
   auto a =
       makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, double(NAN)});

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -1265,7 +1265,8 @@ TEST(VariableTest,
                                 Values{1.0, double(NAN)}, Variances{0.1, 0.2});
 
   const auto replacement_value = makeVariable<double>(Values{-1});
-  EXPECT_THROW(nan_to_num(a, replacement_value), except::VariancesError);
+  EXPECT_THROW(auto replaced = nan_to_num(a, replacement_value),
+               except::VariancesError);
 }
 
 TEST(VariableTest, nan_to_num_with_variance_and_variance_on_replacement) {

--- a/core/test/variable_operations_test.cpp
+++ b/core/test/variable_operations_test.cpp
@@ -1310,18 +1310,13 @@ TEST(VariableTest, nan_to_num_inplace) {
   EXPECT_EQ(a, expected);
 }
 
-TEST(VariableTest, nan_to_num_inplace_with_variance) {
+TEST(VariableTest,
+     nan_to_num_inplace_with_variance_throws_if_replacement_has_no_variance) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{3},
                                 Values{1.0, double(NAN), 3.0},
                                 Variances{0.1, 0.2, 0.3});
   const auto replacement_value = makeVariable<double>(Values{-1});
-  VariableProxy b = nan_to_num(a, replacement_value, a);
-  auto expected = makeVariable<double>(
-      Dims{Dim::X}, Shape{3},
-      Values{1.0, replacement_value.value<double>(), 3.0},
-      Variances{0.1, replacement_value.value<double>(), 0.3});
-  EXPECT_EQ(b, expected);
-  EXPECT_EQ(a, expected);
+  EXPECT_THROW(nan_to_num(a, replacement_value, a), except::VariancesError);
 }
 
 TEST(VariableTest, nan_to_num_inplace_out_has_no_variances) {
@@ -1332,12 +1327,7 @@ TEST(VariableTest, nan_to_num_inplace_out_has_no_variances) {
   auto out = makeVariable<double>(
       Dims{Dim::X}, Shape{2}, Values{1.0, double(NAN)}, Variances{0.1, 0.2});
 
-  VariableProxy b = nan_to_num(a, replacement_value, out);
-  auto expected = makeVariable<double>(
-      Dims{Dim::X}, Shape{2}, Values{1.0, replacement_value.value<double>()},
-      Variances{1.0, replacement_value.value<double>()});
-  EXPECT_EQ(b, expected);
-  EXPECT_EQ(out, expected);
+  EXPECT_THROW(nan_to_num(a, replacement_value, out), except::VariancesError);
 }
 
 TEST(VariableTest,


### PR DESCRIPTION
- Add new flag for `transform` and `transform_in_place`.
- Support more arguments in `transform_in_place` (will not handle sparse data).
- Check units of replacement values.
- Do not check unit of out value (it is overwritten, just like values).