### PR TITLE
Powder-diffraction related improvements

### DIFF
--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -202,7 +202,7 @@ template <class T> struct MakeGroups {
       // Use contiguous (thick) slices if possible to avoid overhead of slice
       // handling in follow-up "apply" steps.
       const auto begin = i;
-      const auto value = *it;
+      const auto &value = *it;
       while (it != end && *it == value) {
         ++it;
         ++i;
@@ -214,7 +214,7 @@ template <class T> struct MakeGroups {
     std::vector<T> keys;
     std::vector<GroupByGrouping::group> groups;
     for (auto &item : indices) {
-      keys.push_back(item.first);
+      keys.emplace_back(std::move(item.first));
       groups.emplace_back(std::move(item.second));
     }
     auto keys_ = makeVariable<T>(Dimensions{dims}, Values(std::move(keys)));

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -196,13 +196,17 @@ template <class T> struct MakeGroups {
 
     const auto dim = key.dims().inner();
     std::map<T, std::vector<Slice>> indices;
-    for (scipp::index i = 0; i < scipp::size(values);) {
+    const auto end = values.end();
+    scipp::index i = 0;
+    for (auto it = values.begin(); it != end;) {
       // Use contiguous (thick) slices if possible to avoid overhead of slice
       // handling in follow-up "apply" steps.
       const auto begin = i;
-      const auto value = values[i];
-      while (i < scipp::size(values) && values[i] == value)
+      const auto value = *it;
+      while (it != end && *it == value) {
+        ++it;
         ++i;
+      }
       indices[value].emplace_back(dim, begin, i);
     }
 

--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -108,7 +108,8 @@ DataArray histogram(const DataConstProxy &sparse,
           return transform_subspan<
               std::tuple<args<double, double, double, double>,
                          args<double, float, double, double>,
-                         args<double, float, double, float>>>(
+                         args<double, float, double, float>,
+                         args<double, double, float, double>>>(
               dim_, binEdges_.dims()[dim_] - 1, sparse_.coords()[dim_],
               sparse_.data(), binEdges_,
               overloaded{make_histogram_from_weighted,

--- a/core/include/scipp/core/groupby.h
+++ b/core/include/scipp/core/groupby.h
@@ -5,6 +5,7 @@
 #ifndef SCIPP_CORE_GROUPBY_H
 #define SCIPP_CORE_GROUPBY_H
 
+#include <boost/container/small_vector.hpp>
 #include <vector>
 
 #include <scipp/core/dataset.h>
@@ -16,19 +17,18 @@ namespace scipp::core {
 /// Stores the actual grouping details, independent of the container type.
 class SCIPP_CORE_EXPORT GroupByGrouping {
 public:
-  GroupByGrouping(Variable &&key, std::vector<std::vector<Slice>> &&groups)
+  using group = boost::container::small_vector<Slice, 4>;
+  GroupByGrouping(Variable &&key, std::vector<group> &&groups)
       : m_key(std::move(key)), m_groups(std::move(groups)) {}
 
   scipp::index size() const noexcept { return scipp::size(m_groups); }
   Dim dim() const noexcept { return m_key.dims().inner(); }
   const Variable &key() const noexcept { return m_key; }
-  const std::vector<std::vector<Slice>> &groups() const noexcept {
-    return m_groups;
-  }
+  const std::vector<group> &groups() const noexcept { return m_groups; }
 
 private:
   Variable m_key;
-  std::vector<std::vector<Slice>> m_groups;
+  std::vector<group> m_groups;
 };
 
 /// Helper class for implementing "split-apply-combine" functionality.
@@ -40,7 +40,7 @@ public:
   scipp::index size() const noexcept { return m_grouping.size(); }
   Dim dim() const noexcept { return m_grouping.dim(); }
   const Variable &key() const noexcept { return m_grouping.key(); }
-  const std::vector<std::vector<Slice>> &groups() const noexcept {
+  const std::vector<GroupByGrouping::group> &groups() const noexcept {
     return m_grouping.groups();
   }
 

--- a/neutron/diffraction/convert_with_calibration.cpp
+++ b/neutron/diffraction/convert_with_calibration.cpp
@@ -65,7 +65,7 @@ template <class T> T convert_with_calibration_impl(T d, Dataset cal) {
   for (const auto &data : iter(d)) {
     if (data.coords()[Dim::Tof].dims().sparse()) {
       data.coords()[Dim::Tof] -= cal["tzero"].data();
-      data.coords()[Dim::Tof] /= cal["difc"].data();
+      data.coords()[Dim::Tof] *= reciprocal(cal["difc"].data());
     }
   }
 

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -123,7 +123,7 @@ def _make_trailing_cells(section, coord, index, size, base_style, edge_style):
 
 def _make_overflow_cells(section, base_style):
     html = []
-    for key, val in section:
+    for key, val in section.items():
         html.append("<td {}>...</td>".format(base_style))
         if val.variances is not None:
             html.append("<td {}>...</td>".format(base_style))
@@ -133,7 +133,7 @@ def _make_overflow_cells(section, base_style):
 def _make_overflow_row(dataset, coord, base_style, hover_style):
     html = ["<tr {}>".format(hover_style)]
     if coord is not None:
-        html.append(_make_overflow_cells([(" ", coord)], base_style))
+        html.append(_make_overflow_cells({" ": coord}, base_style))
     html.append(_make_overflow_cells(dataset.labels, base_style))
     html.append(_make_overflow_cells(dataset.masks, base_style))
     html.append(_make_overflow_cells(dataset, base_style))

--- a/units/include/scipp/units/neutron.h
+++ b/units/include/scipp/units/neutron.h
@@ -154,14 +154,14 @@ template <> struct supported_units<neutron::Unit> {
   using type = decltype(detail::make_unit(
       std::make_tuple(m, dimensionless / m),
       std::make_tuple(
-          dimensionless, rad, deg, rad / deg, deg / rad, counts, s, kg,
-          angstrom, meV, us, dimensionless / us, dimensionless / s, counts / us,
-          counts / angstrom, counts / meV, m *m *m, meV *us *us / (m * m),
-          meV *us *us *dimensionless, kg *m / s, m / s, c, c *m, meV / c,
-          dimensionless / c, K, us / angstrom, us / (angstrom * angstrom),
-          us / (m * angstrom), angstrom / us, (m * angstrom) / us, us *us,
-          dimensionless / (us * us), dimensionless / meV,
-          dimensionless / angstrom, angstrom *angstrom,
+          dimensionless, rad, deg, rad / deg, deg / rad, counts,
+          dimensionless / counts, s, kg, angstrom, meV, us, dimensionless / us,
+          dimensionless / s, counts / us, counts / angstrom, counts / meV,
+          m *m *m, meV *us *us / (m * m), meV *us *us *dimensionless, kg *m / s,
+          m / s, c, c *m, meV / c, dimensionless / c, K, us / angstrom,
+          us / (angstrom * angstrom), us / (m * angstrom), angstrom / us,
+          (m * angstrom) / us, us *us, dimensionless / (us * us),
+          dimensionless / meV, dimensionless / angstrom, angstrom *angstrom,
           dimensionless / (angstrom * angstrom))));
 };
 template <> struct counts_unit<neutron::Unit> {


### PR DESCRIPTION
- `histogram` can now deal with sparse data values in `float32` ("single-precision event weights"). This is useful for better performance. Note that the histogrammed output is still double precision.
- Use multiplication instead of division to speed up `neutron.diffraction.convert_with_calibration`.
- Performance improvements in `groupby`:
  - Better mask handling for small speedup with many outputs.
  - Avoiding expensive random access to multi-dimensional indices for significant speedups with many inputs.
- Fix missing `items()` in `table.py` (overlooked during iterator refactor).
- Add unit `1/counts`, a useful intermediate value.

See also commit messages.