### PR TITLE
Fix slow table

### DIFF
--- a/python/src/scipp/runtime_config.py
+++ b/python/src/scipp/runtime_config.py
@@ -81,7 +81,7 @@ defaults = {
         "data": "#ffe680",
         "labels": "#afdde9",
         "attrs": "#ff8080",
-        "masks": "#d2b4de",
+        "masks": "#cccccc",
         "hover": "#d6eaf8",
     },
     "table_max_size": 50,

--- a/python/src/scipp/runtime_config.py
+++ b/python/src/scipp/runtime_config.py
@@ -77,11 +77,11 @@ defaults = {
     },
     # The colors for each dataset member used in table and show functions
     "colors": {
-        "coord": "#dde9af",
+        "coords": "#dde9af",
         "data": "#ffe680",
         "labels": "#afdde9",
-        "attr": "#ff8080",
-        "mask": "#cccccc",
+        "attrs": "#ff8080",
+        "masks": "#d2b4de",
         "hover": "#d6eaf8",
     },
     "table_max_size": 50,

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -270,13 +270,13 @@ class VariableDrawer():
                 for name, mask in self._variable.masks:
                     if label.sparse_dim is not None:
                         items.append(
-                            (name, mask.values, config.colors['mask']))
+                            (name, mask.values, config.colors['masks']))
                 sparse_dim = self._variable.sparse_dim
                 for dim in self._variable.coords:
                     if dim == sparse_dim:
                         items.append((str(sparse_dim),
                                       self._variable.coords[sparse_dim].values,
-                                      config.colors['coord']))
+                                      config.colors['coords']))
 
         for i, (name, data, color) in enumerate(items):
             svg += '<g>'
@@ -389,7 +389,7 @@ class DatasetDrawer():
                 else:
                     area_xy.append(item)
 
-        for what, items in zip(['coord', 'labels', 'mask', 'attr'], [
+        for what, items in zip(['coords', 'labels', 'masks', 'attrs'], [
                 self._dataset.coords, self._dataset.labels,
                 self._dataset.masks, self._dataset.attrs
         ]):

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -108,13 +108,12 @@ def _make_overflow_row(dict_of_variables, base_style, hover_style):
     return "".join(html)
 
 
-def _table_from_dict_of_variables(
-    dict_of_variables,
-    is_bin_centers=None,
-    size=None,
-    headers=2,
-    row_start=0,
-    max_rows=None):
+def _table_from_dict_of_variables(dict_of_variables,
+                                  is_bin_centers=None,
+                                  size=None,
+                                  headers=2,
+                                  row_start=0,
+                                  max_rows=None):
     base_style = ("style='border: 1px solid black; padding: 0px 5px 0px 5px; "
                   "text-align: right;")
 

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -42,28 +42,13 @@ class TableViewer:
             self.tabledict[group] = {}
             self.is_bin_centers[group] = {}
             self.sizes[group] = {}
-        # empty_dict = {"coord": {}, "data": {}, "labels": {}, "masks": {}}
-        # for key in self.tabledict:
-        #     self.is_bin_centers[key] = {"data": {}, "labels": {}, "masks": {}}
         self.headers = 0
         self.trigger_update = True
-        is_empty = {}
-
-        # tp = type(scipp_obj)
 
         if is_dataset_or_array(scipp_obj):
 
-        # if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
-
             self.headers = 2
 
-            # # First add one entry per dimension
-            # for dim in dataset.dims:
-            #     key = str(dim)
-            #     self.tabledict["1D Variables"][key] = {}
-            #     is_empty[key] = True
-            #     self.is_bin_centers[key] = False
-            # if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
             if is_dataset(scipp_obj):
                 iterlist = scipp_obj.items()
             else:
@@ -77,11 +62,9 @@ class TableViewer:
                         self.tabledict["1D Variables"][key] = self.make_dict()
                         self.sizes["1D Variables"][key] = []
                         self.is_bin_centers["1D Variables"][key] = self.make_dict()
-                        # self.tabledict["1D Variables"][key]["dim"] = key
                     self.is_bin_centers[group][key]["coord"][key] = False
                     self.tabledict["1D Variables"][key]["coord"][key] = var
                     self.sizes["1D Variables"][key].append(var.shape[0])
-                        # is_empty[key] = False
 
             # Next add the labels
             for name, lab in scipp_obj.labels.items():
@@ -89,18 +72,11 @@ class TableViewer:
                 if ndims < 2:
                     group = "{}D Variables".format(ndims)
                     dim = lab.dims[0] if ndims == 1 else sc.Dim.Invalid
-
-                    # if len(lab.dims) == 1:
-                    #     dim = lab.dims[0]
-                    # else:
-                    #     dim = sc.Dim.Invalid
-
                     key = str(dim)
                     if key not in self.tabledict[group]:
                         self.tabledict[group][key] = self.make_dict()
                         self.is_bin_centers[group][key] = self.make_dict()
                         self.sizes[group][key] = []
-                        # self.tabledict[group][key]["dim"] = key
                     self.is_bin_centers[group][key]["labels"][name] = False
                     if dim in scipp_obj.coords:
                         if scipp_obj.coords[dim].shape[0] == lab.shape[0] + 1:
@@ -109,39 +85,23 @@ class TableViewer:
                     self.tabledict[group][key]["labels"][name] = lab
                     self.sizes[group][key].append(lab.shape[0] if ndims > 0 else None)
 
-                # if dim in scipp_obj.coords:
-                #     if len(scipp_obj.coords[dim].values) == len(
-                #             lab.values) + 1:
-                #         self.is_bin_centers["1D Variables"][key]["labels"][name] = True
-                #     # self.tabledict["1D Variables"][key].coords[dim] = \
-                #     #     dataset.coords[dim]
-                # # self.tabledict["1D Variables"][key].labels[name] = lab
-                # # is_empty[key] = False
-
-
             # Next add the masks
             for name, mask in scipp_obj.masks.items():
                 ndims = len(mask.dims)
                 if ndims < 2:
                     group = "{}D Variables".format(ndims)
                     dim = mask.dims[0] if ndims == 1 else sc.Dim.Invalid
-
                     key = str(dim)
                     if key not in self.tabledict[group]:
                         self.tabledict[group][key] = self.make_dict()
                         self.is_bin_centers[group][key] = self.make_dict()
                         self.sizes[group][key] = []
-                        # self.tabledict[group][key]["dim"] = key
                     self.is_bin_centers[group][key]["masks"][name] = False
                     if dim in scipp_obj.coords:
                         if scipp_obj.coords[dim].shape[0] == mask.shape[0] + 1:
-                        # if len(scipp_obj.coords[dim].values) == len(
-                        #         mask.values) + 1:
                             self.is_bin_centers[group][key]["masks"][name] = True
                     self.tabledict[group][key]["masks"][name] = mask
                     self.sizes[group][key].append(mask.shape[0] if ndims > 0 else None)
-
-
 
             # Next add the data
             for name, var in iterlist:
@@ -149,121 +109,23 @@ class TableViewer:
                 if ndims < 2:
                     group = "{}D Variables".format(ndims)
                     dim = var.dims[0] if ndims == 1 else sc.Dim.Invalid
-
                     key = str(dim)
-                    # print(name, key)
-                    # print(self.is_bin_centers)
                     if key not in self.tabledict[group]:
                         self.tabledict[group][key] = self.make_dict()
                         self.is_bin_centers[group][key] = self.make_dict()
                         self.sizes[group][key] = []
-                        # self.tabledict[group][key]["dim"] = key
-                    # print(self.is_bin_centers)
                     self.is_bin_centers[group][key]["data"][name] = False
                     if dim in scipp_obj.coords:
                         if scipp_obj.coords[dim].shape[0] == var.shape[0] + 1:
-                        # if len(scipp_obj.coords[dim].values) == len(
-                        #         var.values) + 1:
                             self.is_bin_centers[group][key]["data"][name] = True
                     self.tabledict[group][key]["data"][name] = var.data
                     self.sizes[group][key].append(var.shape[0] if ndims > 0 else None)
 
-
-
-
-
-
-
-        #         if len(var.dims) < 2:
-
-        #             group = "{}D Variables".format(len(var.dims))
-        #             if len(var.dims) == 1:
-        #                 dim = var.dims[0]
-        #                 key = str(dim)
-        #             else:
-        #                 key = row_key
-
-        #             if key not in self.tabledict[group]:
-        #                 self.tabledict[group][key] = {"coord": {}, "data": {}, "labels": {}, "masks": {}}
-
-        #             if len(var.coords) > 0:
-        #                 if len(var.coords[dim].values) == len(var.values) + 1:
-        #                     self.is_bin_centers["1D Variables"][key] = True
-        #                 # self.tabledict["1D Variables"][key]["coord"][key] = \
-        #                 #     var.coords[dim]
-        #             self.tabledict["1D Variables"][key]["data"][name] = var.data
-
-
-        #                 # is_empty[key] = False
-
-        #             elif len(var.dims) == 0:
-        #                 if row_key not in self.tabledict["0D Variables"]:
-        #                     self.tabledict["1D Variables"][row_key] = {}
-        #                 self.tabledict["0D Variables"][row_key][name] = var
-
-        #     # # Next add only the 1D coordinates
-        #     # for dim, var in dataset.coords.items():
-        #     #     if len(var.dims) == 1:
-        #     #         key = str(dim)
-        #     #         if dim not in self.tabledict["1D Variables"][key].coords:
-        #     #             self.tabledict["1D Variables"][key].coords[dim] = var
-        #     #             is_empty[key] = False
-
-        #     # Next add the labels
-        #     for name, lab in dataset.labels.items():
-        #         if len(lab.dims) == 1:
-        #             dim = lab.dims[0]
-        #             key = str(dim)
-        #             if len(dataset.coords) > 0:
-        #                 if len(dataset.coords[dim].values) == len(
-        #                         lab.values) + 1:
-        #                     self.is_bin_centers[key] = True
-        #                 self.tabledict["1D Variables"][key].coords[dim] = \
-        #                     dataset.coords[dim]
-        #             self.tabledict["1D Variables"][key].labels[name] = lab
-        #             is_empty[key] = False
-
-        #     # # Next add the masks
-        #     # for name, mask in dataset.masks.items():
-        #     #     if len(mask.dims) == 1:
-        #     #         dim = mask.dims[0]
-        #     #         key = str(dim)
-        #     #         if len(dataset.coords) > 0:
-        #     #             if len(dataset.coords[dim].values) == len(
-        #     #                     mask.values) + 1:
-        #     #                 self.is_bin_centers[key] = True
-        #     #             self.tabledict["1D Variables"][key].coords[dim] = \
-        #     #                 dataset.coords[dim]
-        #     #         self.tabledict["1D Variables"][key].masks[name] = mask
-        #     #         is_empty[key] = False
-
-        #     # # Now purge out the empty entries
-        #     # for key, val in is_empty.items():
-        #     #     if val:
-        #     #         del (self.tabledict["1D Variables"][key])
-
-        # # elif (tp is sc.DataArray) or (tp is sc.DataProxy):
-        # #     self.headers = 2
-        # #     key = dataset.name
-        # #     self.tabledict["default"][row_key] = {key: dataset}
-        # #     # if len(dataset.coords) > 0:
-        # #     #     dim = dataset.dims[0]
-        # #     #     self.tabledict["default"][key].coords[dim] = dataset.coords[
-        # #     #         dim]
-
-
-        # elif is_variable(scipp_obj):
-        #     self.headers = 1
-        #     key = str(scipp_obj.dims[0])
-        #     # TODO: does moving here invalidate the input?
-        #     self.tabledict["default"][key] = {key: detail.move_to_data_array(data=scipp_obj)}
-        #     self.is_bin_centers[key] = False
-
         else:
+
             ndims = len(scipp_obj.shape)
             if ndims < 2:
                 group = "{}D Variables".format(ndims)
-                # group = "default"
                 if is_variable(scipp_obj):
                     self.headers = 1
                     key = str(scipp_obj.dims[0])
@@ -273,20 +135,11 @@ class TableViewer:
                     key = " "
                     var = sc.Variable([sc.Dim.Row], values=scipp_obj)
 
-                # # self.tabledict[group][key] = {}
-                # if is_var:
-                #     var = scipp_obj
-                # else:
-                #     var = sc.Variable([sc.Dim.Row], values=scipp_obj)
                 self.tabledict[group][key] = {"data": {key: var}}
-
-                #     self.tabledict["default"][key][key]
-                # {key: detail.move_to_data_array(data=sc.Variable([sc.Dim.Row],
-                #                                              values=scipp_obj))}
                 self.is_bin_centers[group][key] = {"data": {key: False}}
                 self.sizes[group][key] = scipp_obj.shape
 
-        print(self.tabledict)
+        # Get max size for each dim
         for group in self.sizes.keys():
             for key in self.sizes[group].keys():
                 max_size = 0
@@ -296,9 +149,6 @@ class TableViewer:
                         max_size = max(max_size, s)
                         size_is_defined = True
                 self.sizes[group][key] = max_size if size_is_defined else None
-        print(self.sizes)
-        print(self.is_bin_centers)
-
 
         subtitle = "<span style='font-weight:normal;color:grey;"
         subtitle += "font-style:italic;background-color:#ffffff;"
@@ -306,7 +156,6 @@ class TableViewer:
         subtitle += "{}</span>"
         title = str(type(scipp_obj)).replace("<class '", "").replace("scipp._scipp.core.",
                                            "").replace("'>", "")
-        print("title is", title)
 
         self.box = [
             self.widgets.HTML(value="<span style='font-weight:bold;"
@@ -316,65 +165,17 @@ class TableViewer:
         self.sliders = {}
         self.label = self.widgets.Label(value="rows")
         self.nrows = {}
-        # self.sizes = {}
 
-        # other_variables = {"default": None, "0D Variables": subtitle.format("0D Variables")}
-        # for group, output in other_variables.items():
-
-
-
-        # for group in self.tabledict.keys():
-        #     if len(self.tabledict[group]) > 0:
-        #         for key, val in self.tabledict[group].items():
-        #             html = self.table_from_dict_of_variables(val,
-        #                                         is_bin_centers=self.is_bin_centers[group][key],
-        #                                         size=self.sizes[group][key],
-        #                                         headers=self.headers,
-        #                                         max_rows=config.table_max_size)
-
-        #         # html = table_from_dict_of_variables(self.tabledict["0D Variables"],
-        #         #                                 headers=self.headers,
-        #         #                                 max_rows=config.table_max_size)
-        #         self.tables[group] = {" ": self.widgets.HTML(value=html)}
-        #         hbox = self.make_hbox(group, " ", self.sizes[group][key])
-        #         if output is not None:
-        #             hbox = [self.widgets.HTML(value=output), hbox]
-        #         self.box.append(self.widgets.VBox(hbox))
-        
-
-        # # # if len(self.tabledict["default"]) > 0:
-        # # #     html, size = table_from_dataset(self.tabledict["default"],
-        # # #                                     headers=self.headers,
-        # # #                                     max_rows=config.table_max_size)
-        # # #     self.tables["default"] = {" ": self.widgets.HTML(value=html)}
-        # # #     hbox = self.make_hbox("default", " ", size)
-        # # #     self.box.append(hbox)
-        # # #     self.sizes["default"] = {" ": size}
-        # # if len(self.tabledict["0D Variables"]) > 0:
-        # #     # self.tables["0D Variables"] = {}
-        # #     output = subtitle.format("0D Variables")
-        # #     html, size = table_from_dataset(self.tabledict["0D Variables"],
-        # #                                     headers=self.headers,
-        # #                                     max_rows=config.table_max_size)
-        # #     self.tables["0D Variables"][" "] = self.widgets.HTML(value=html)
-        # #     hbox = self.make_hbox("0D Variables", " ", size)
-        # #     self.box.append(
-        # #         self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
-        # # print(self.box)
-
+        # Generate 0D and 1D tables
         for group in self.tabledict.keys():
 
             if len(self.tabledict[group]) > 0:
                 self.tables[group] = {}
-                # self.sizes["1D Variables"] = {}
                 output = subtitle.format(group)
 
-                # self.tabs = self.widgets.Tab(layout=self.widgets.Layout(
-                #     width="initial"))
                 children = []
                 for key, val in sorted(self.tabledict[group].items()):
                     html = self.table_from_dict_of_variables(val,
-                                                    # dim_key=key,
                                                     is_bin_centers=self.is_bin_centers[group][key],
                                                     size=self.sizes[group][key],
                                                     headers=self.headers,
@@ -384,7 +185,6 @@ class TableViewer:
                     hbox = self.make_hbox(group, key, self.sizes[group][key])
                     children.append(hbox)
 
-                    # self.sizes["1D Variables"][key] = size
                 vbox = [self.widgets.HTML(value=output)]
 
                 if group == "1D Variables":
@@ -455,25 +255,6 @@ class TableViewer:
                 ])
         return hbox
 
-
-
-
-    # def make_table_section_name_header(self, name, section, style):
-    #     """
-    #     Adds a first row of the table that contains the names of the sections
-    #     being displayed in the table. This is usually the first row and will
-    #     contain Data, Labels, Masks, etc.
-    #     """
-    #     col_separators = 0
-    #     for key, sec in section.items():
-    #         col_separators += 1 + (sec.variances is not None)
-    #     if col_separators > 0:
-    #         return "<th {} colspan='{}'>{}</th>".format(style, col_separators,
-    #                                                     name)
-    #     else:
-    #         return ""
-
-
     def make_table_sections(self, dict_of_variables, base_style):
 
         html = ["<tr>"]
@@ -486,31 +267,6 @@ class TableViewer:
                 style = "{} background-color: {};text-align: center;'".format(base_style, config.colors[key])
                 html.append("<th {} colspan='{}'>{}</th>".format(style, col_separators,
                                                             key))
-            # else:
-            #     return ""
-
-        # coord_style = "{} background-color: {};text-align: center;'".format(
-        #     base_style, config.colors["coord"])
-        # label_style = "{} background-color: {};text-align: center;'".format(
-        #     base_style, config.colors["labels"])
-        # mask_style = "{} background-color: {};text-align: center;'".format(
-        #     base_style, config.colors["mask"])
-        # data_style = "{} background-color: {};text-align: center;'".format(
-        #     base_style, config.colors["data"])
-
-        # colsp_coord = 0
-        # if coord is not None:
-        #     colsp_coord = 1 + (coord.variances is not None)
-        # html = ["<tr>"]
-
-        # if colsp_coord > 0:
-        #     html.append("<th {} colspan='{}'>Coordinate</th>".format(
-        #         coord_style, colsp_coord))
-        # html.append(
-        #     self.make_table_section_name_header("Labels", labels, label_style))
-        # html.append(
-        #     self.make_table_section_name_header("Masks", masks, mask_style))
-        # html.append(self.make_table_section_name_header("Data", dict_of_data_arrays, data_style))
 
         html.append("</tr>")
 
@@ -521,17 +277,6 @@ class TableViewer:
         """
         Adds a row containing the unit of the section
         """
-
-            # if coord is not None:
-            #     html += "<th {} colspan='{}'>{}</th>".format(
-            #         mstyle, 1 + (coord.variances is not None),
-            #         name_with_unit(coord, replace_dim=False))
-
-            # html += self.make_table_unit_headers(labels, mstyle)
-            # html += self.make_table_unit_headers(masks, mstyle)
-            # html += self.make_table_unit_headers(dict_of_data_arrays, mstyle)
-
-
         html = []
         for key, section in dict_of_variables.items():
             for name, val in section.items():
@@ -554,19 +299,10 @@ class TableViewer:
         return "".join(html)
 
 
-    # def make_value_rows(self, section, coord, index, base_style, edge_style, row_start):
     def make_value_rows(self, dict_of_variables, is_bin_centers, index, base_style, edge_style, row_start):
-        # print("========================================")
-        # print(dict_of_variables)
         html = []
         for key, section in dict_of_variables.items():
             for name, val in section.items():
-                # print(key, name)
-                # header_line_for_bin_edges = False
-                # if coord is not None:
-                #     if len(val.values) == len(coord.values) - 1:
-                #         header_line_for_bin_edges = True
-                # if header_line_for_bin_edges:
                 if is_bin_centers[key][name]:
                     if index == row_start:
                         html.append("<td {}></td>".format(edge_style))
@@ -587,7 +323,6 @@ class TableViewer:
         for key, section in dict_of_variables.items():
             for name, val in section.items():
                 if is_bin_centers[key][name]:
-                # if len(val.values) == len(coord.values) - 1:
                     if index == size - 1:
                         html.append("<td {}></td>".format(edge_style))
                         if val.variances is not None:
@@ -601,16 +336,6 @@ class TableViewer:
 
         return "".join(html)
 
-
-    # def make_overflow_cells(self, section, base_style):
-    #     html = []
-    #     for key, val in section.items():
-    #         html.append("<td {}>...</td>".format(base_style))
-    #         if val.variances is not None:
-    #             html.append("<td {}>...</td>".format(base_style))
-    #     return "".join(html)
-
-
     def make_overflow_row(self, dict_of_variables, base_style, hover_style):
         html = ["<tr {}>".format(hover_style)]
         for key, section in dict_of_variables.items():
@@ -619,14 +344,8 @@ class TableViewer:
                 if val.variances is not None:
                     html.append("<td {}>...</td>".format(base_style))
 
-        # if coord is not None:
-        #     html.append(self.make_overflow_cells({" ": coord}, base_style))
-        # html.append(self.make_overflow_cells(labels, base_style))
-        # html.append(self.make_overflow_cells(masks, base_style))
-        # html.append(self.make_overflow_cells(dict_of_data_arrays, base_style))
         html.append("</tr>")
         return "".join(html)
-
 
     def table_from_dict_of_variables(self, dict_of_variables,
                            is_bin_centers=None,
@@ -650,65 +369,20 @@ class TableViewer:
         # Declare table
         html = "<table style='border-collapse: collapse;'>"
 
-
-        # # Get first entry in dict of data arrays
-        # data_array = next(iter(dict_of_data_arrays.values()))
-        # labels = data_array.labels
-        # masks = data_array.masks
-
-        # # dims = data_array.dims
-        # coord = None
-        # # if len(dims) > 0:
-        # #     # DataArray should contain only one dim, so get the first in list
-        # #     size = data_array.shape[0]
-        # #     if len(data_array.coords) > 0:
-        # #         coord = data_array.coords[dims[0]]
-        # #         if is_hist:
-        # #             size += 1
-
-        # if len(dict_of_variables["coord"]) > 0:
-        #     coord = dict_of_variables["coord"][dim_key]
-
         if headers > 1:
             html += self.make_table_sections(dict_of_variables, base_style)
-
         if headers > 0:
             html += "<tr {}>".format(hover_style)
-
             html += self.make_table_unit_headers(dict_of_variables, mstyle)
-            # if coord is not None:
-            #     html += "<th {} colspan='{}'>{}</th>".format(
-            #         mstyle, 1 + (coord.variances is not None),
-            #         name_with_unit(coord, replace_dim=False))
-
-            # html += self.make_table_unit_headers(labels, mstyle)
-            # html += self.make_table_unit_headers(masks, mstyle)
-            # html += self.make_table_unit_headers(dict_of_data_arrays, mstyle)
-
             html += "</tr><tr {}>".format(hover_style)
-
             html += self.make_table_subsections(dict_of_variables, vstyle)
-
-            # if coord is not None:
-            #     html += "<th {}>Values</th>".format(vstyle)
-            #     if coord.variances is not None:
-            #         html += "<th {}>Variances</th>".format(vstyle)
-            # html += self.make_table_subsections(labels, vstyle)
-            # html += self.make_table_subsections(masks, vstyle)
-            # html += self.make_table_subsections(dict_of_data_arrays, vstyle)
             html += "</tr>"
-
-        # html += "</table>"
-        # return html, 1
 
         # the base style still does not have a closing quote, so we add it here
         base_style += "'"
 
-        print(dict_of_variables)
-
         if size is None:  # handle 0D variable
             html += "<tr {}>".format(hover_style)
-            # for key, val in dict_of_variables.items():
             for key, section in dict_of_variables.items():
                 for name, val in section.items():
                     html += "<td {}>{}</td>".format(base_style,
@@ -723,56 +397,19 @@ class TableViewer:
                 html += self.make_overflow_row(dict_of_variables, base_style, hover_style)
             for i in range(row_start, row_end):
                 html += "<tr {}>".format(hover_style)
-                # Add coordinates
-
                 html += self.make_value_rows(dict_of_variables, is_bin_centers, i, base_style,
                                          edge_style, row_start)
-
-
-
-                # if coord is not None:
-                #     text = value_to_string(coord.values[i])
-                #     html += "<td rowspan='2' {}>{}</td>".format(base_style, text)
-                #     if coord.variances is not None:
-                #         text = value_to_string(coord.variances[i])
-                #         html += "<td rowspan='2' {}>{}</td>".format(
-                #             base_style, text)
-
-                # html += self.make_value_rows(labels, coord, i, base_style,
-                #                          edge_style, row_start)
-                # html += self.make_value_rows(masks, coord, i, base_style,
-                #                          edge_style, row_start)
-                # html += self.make_value_rows(dict_of_data_arrays, coord, i, base_style, edge_style,
-                #                          row_start)
-
                 html += "</tr><tr {}>".format(hover_style)
                 # If there are bin edges, we need to add trailing cells for data
                 # and labels
                 html += self.make_trailing_cells(dict_of_variables, is_bin_centers, i, row_end,
                                                  base_style, edge_style)
-                # if coord is not None:
-                #     html += self.make_trailing_cells(labels, coord, i, row_end,
-                #                                  base_style, edge_style)
-                #     html += self.make_trailing_cells(masks, coord, i, row_end,
-                #                                  base_style, edge_style)
-                #     html += self.make_trailing_cells(dict_of_data_arrays, coord, i, row_end,
-                #                                  base_style, edge_style)
                 html += "</tr>"
             if row_end != size:
                 html += self.make_overflow_row(dict_of_variables, base_style, hover_style)
 
         html += "</table>"
         return html
-
-
-
-
-
-
-
-
-
-
 
     def update_slider(self, change):
         key = change["owner"].key
@@ -789,22 +426,9 @@ class TableViewer:
 
     def update_table(self, change):
         # if self.trigger_update:
-        print("fired")
         key = change["owner"].key
         group = change["owner"].group
-        # to_table = self.tabledict[group]
-        # # This extra indexing step comes from the fact that for the
-        # # default key, the tabledict is a Dataset, while for the 1D
-        # # Variables it is a dict of Datasets.
-        # if group != "default":
-        #     to_table = to_table[key]
-        # html, size = table_from_dict_of_data_arrays(self.tabledict[group][key],
-        #                                 is_hist=self.is_bin_centers[key],
-        #                                 headers=self.headers,
-        #                                 row_start=self.sliders[key].value,
-        #                                 max_rows=self.nrows[key].value)
         html = self.table_from_dict_of_variables(self.tabledict[group][key],
-                                            # dim_key=key,
                                             is_bin_centers=self.is_bin_centers[group][key],
                                             size=self.sizes[group][key],
                                             headers=self.headers,

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -263,24 +263,28 @@ class TableViewer:
             ndims = len(scipp_obj.shape)
             if ndims < 2:
                 group = "{}D Variables".format(ndims)
-            group = "default"
-            is_var = is_variable(scipp_obj)
-            self.headers = is_var
-            # self.headers = 0
-            key = " "
+                # group = "default"
+                if is_variable(scipp_obj):
+                    self.headers = 1
+                    key = str(scipp_obj.dims[0])
+                    var = scipp_obj
+                else:
+                    self.headers = 0
+                    key = " "
+                    var = sc.Variable([sc.Dim.Row], values=scipp_obj)
 
-            # self.tabledict[group][key] = {}
-            if is_var:
-                var = scipp_obj
-            else:
-                var = sc.Variable([sc.Dim.Row], values=scipp_obj)
-            self.tabledict[group][key] = {key: var}
+                # # self.tabledict[group][key] = {}
+                # if is_var:
+                #     var = scipp_obj
+                # else:
+                #     var = sc.Variable([sc.Dim.Row], values=scipp_obj)
+                self.tabledict[group][key] = {"data": {key: var}}
 
-            #     self.tabledict["default"][key][key]
-            # {key: detail.move_to_data_array(data=sc.Variable([sc.Dim.Row],
-            #                                              values=scipp_obj))}
-            self.is_bin_centers[group][key] = False
-            self.sizes[group][key] = scipp_obj.shape
+                #     self.tabledict["default"][key][key]
+                # {key: detail.move_to_data_array(data=sc.Variable([sc.Dim.Row],
+                #                                              values=scipp_obj))}
+                self.is_bin_centers[group][key] = {"data": {key: False}}
+                self.sizes[group][key] = scipp_obj.shape
 
         print(self.tabledict)
         for group in self.sizes.keys():
@@ -300,8 +304,9 @@ class TableViewer:
         subtitle += "font-style:italic;background-color:#ffffff;"
         subtitle += "text-align:left;font-size:1.2em;padding: 1px;'>"
         subtitle += "{}</span>"
-        title = str(type(scipp_obj)).replace("<class 'scipp._scipp.core.",
+        title = str(type(scipp_obj)).replace("<class '", "").replace("scipp._scipp.core.",
                                            "").replace("'>", "")
+        print("title is", title)
 
         self.box = [
             self.widgets.HTML(value="<span style='font-weight:bold;"
@@ -351,6 +356,7 @@ class TableViewer:
         #     hbox = self.make_hbox("0D Variables", " ", size)
         #     self.box.append(
         #         self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
+        print(self.box)
         if len(self.tabledict["1D Variables"]) > 0:
             self.tables["1D Variables"] = {}
             # self.sizes["1D Variables"] = {}

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -109,13 +109,12 @@ def _make_overflow_row(dict_of_variables, base_style, hover_style):
 
 
 def _table_from_dict_of_variables(
-        dict_of_variables,
-        is_bin_centers=None,
-        # dim_key=None,
-        size=None,
-        headers=2,
-        row_start=0,
-        max_rows=None):
+    dict_of_variables,
+    is_bin_centers=None,
+    size=None,
+    headers=2,
+    row_start=0,
+    max_rows=None):
     base_style = ("style='border: 1px solid black; padding: 0px 5px 0px 5px; "
                   "text-align: right;")
 

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -45,10 +45,7 @@ def _make_table_subsections(dict_of_variables, text_style, plural):
     """
     Adds Value | Variance columns for the section.
     """
-    if plural:
-        s = "s"
-    else:
-        s = ""
+    s = "s" if plural else ""
     html = []
     for key, section in dict_of_variables.items():
         for name, val in section.items():

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -5,370 +5,257 @@
 
 # Scipp imports
 from . import config
-from .utils import value_to_string, name_with_unit
+from . import detail
+from .utils import value_to_string, name_with_unit, is_dataset_or_array, is_dataset, is_variable
 from ._scipp import core as sc
 
 # Other imports
 import numpy as np
 
 
-def _make_table_section_name_header(name, section, style):
-    """
-    Adds a first row of the table that contains the names of the sections
-    being displayed in the table. This is usually the first row and will
-    contain Data, Labels, Masks, etc.
-    """
-    col_separators = 0
-    for key, sec in section.items():
-        col_separators += 1 + (sec.variances is not None)
-    if col_separators > 0:
-        return "<th {} colspan='{}'>{}</th>".format(style, col_separators,
-                                                    name)
-    else:
-        return ""
 
 
-def _make_table_sections(dataset, coord, base_style):
-    coord_style = "{} background-color: {};text-align: center;'".format(
-        base_style, config.colors["coord"])
-    label_style = "{} background-color: {};text-align: center;'".format(
-        base_style, config.colors["labels"])
-    mask_style = "{} background-color: {};text-align: center;'".format(
-        base_style, config.colors["mask"])
-    data_style = "{} background-color: {};text-align: center;'".format(
-        base_style, config.colors["data"])
 
-    colsp_coord = 0
-    if coord is not None:
-        colsp_coord = 1 + (coord.variances is not None)
-    html = ["<tr>"]
-
-    if colsp_coord > 0:
-        html.append("<th {} colspan='{}'>Coordinate</th>".format(
-            coord_style, colsp_coord))
-    html.append(
-        _make_table_section_name_header("Labels", dataset.labels, label_style))
-    html.append(
-        _make_table_section_name_header("Masks", dataset.masks, mask_style))
-    html.append(_make_table_section_name_header("Data", dataset, data_style))
-
-    html.append("</tr>")
-
-    return "".join(html)
-
-
-def _make_table_unit_headers(section, text_style):
-    """
-    Adds a row containing the unit of the section
-    """
-    html = []
-    for key, val in section.items():
-        html.append("<th {} colspan='{}'>{}</th>".format(
-            text_style, 1 + (val.variances is not None),
-            name_with_unit(val, name=key)))
-    return "".join(html)
-
-
-def _make_table_subsections(section, text_style):
-    """
-    Adds Value | Variance columns for the section.
-    """
-    html = []
-    for key, val in section.items():
-        html.append("<th {}>Values</th>".format(text_style))
-        if val.variances is not None:
-            html.append("<th {}>Variances</th>".format(text_style))
-    return "".join(html)
-
-
-def _make_value_rows(section, coord, index, base_style, edge_style, row_start):
-    html = []
-    for key, val in section.items():
-        header_line_for_bin_edges = False
-        if coord is not None:
-            if len(val.values) == len(coord.values) - 1:
-                header_line_for_bin_edges = True
-        if header_line_for_bin_edges:
-            if index == row_start:
-                html.append("<td {}></td>".format(edge_style))
-                if val.variances is not None:
-                    html.append("<td {}></td>".format(edge_style))
-        else:
-            html.append("<td rowspan='2' {}>{}</td>".format(
-                base_style, value_to_string(val.values[index])))
-            if val.variances is not None:
-                html.append("<td rowspan='2' {}>{}</td>".format(
-                    base_style, value_to_string(val.variances[index])))
-
-    return "".join(html)
-
-
-def _make_trailing_cells(section, coord, index, size, base_style, edge_style):
-    html = []
-    for key, val in section.items():
-        if len(val.values) == len(coord.values) - 1:
-            if index == size - 1:
-                html.append("<td {}></td>".format(edge_style))
-                if val.variances is not None:
-                    html.append("<td {}></td>".format(edge_style))
-            else:
-                html.append("<td rowspan='2' {}>{}</td>".format(
-                    base_style, value_to_string(val.values[index])))
-                if val.variances is not None:
-                    html.append("<td rowspan='2' {}>{}</td>".format(
-                        base_style, value_to_string(val.variances[index])))
-
-    return "".join(html)
-
-
-def _make_overflow_cells(section, base_style):
-    html = []
-    for key, val in section:
-        html.append("<td {}>...</td>".format(base_style))
-        if val.variances is not None:
-            html.append("<td {}>...</td>".format(base_style))
-    return "".join(html)
-
-
-def _make_overflow_row(dataset, coord, base_style, hover_style):
-    html = ["<tr {}>".format(hover_style)]
-    if coord is not None:
-        html.append(_make_overflow_cells([(" ", coord)], base_style))
-    html.append(_make_overflow_cells(dataset.labels, base_style))
-    html.append(_make_overflow_cells(dataset.masks, base_style))
-    html.append(_make_overflow_cells(dataset, base_style))
-    html.append("</tr>")
-    return "".join(html)
-
-
-def table_from_dataset(dataset,
-                       is_hist=False,
-                       headers=2,
-                       row_start=0,
-                       max_rows=None):
-    base_style = ("style='border: 1px solid black; padding: 0px 5px 0px 5px; "
-                  "text-align: right;")
-
-    mstyle = base_style + "text-align: center;"
-    vstyle = mstyle + "background-color: #f0f0f0;'"
-    mstyle += "'"
-    edge_style = ("style='border: 0px solid white;background-color: #ffffff; "
-                  "height:1.2em;'")
-    hover_style = ("onMouseOver=\"this.style.backgroundColor='" +
-                   config.colors["hover"] +
-                   "'\" onMouseOut=\"this.style.backgroundColor='#ffffff'\"")
-
-    # Declare table
-    html = "<table style='border-collapse: collapse;'>"
-    dims = dataset.dims
-    size = coord = None
-    if len(dims) > 0:
-        # Dataset should contain only one dim, so get the first in list
-        size = dataset.shape[0]
-        if len(dataset.coords) > 0:
-            coord = dataset.coords[dims[0]]
-            if is_hist:
-                size += 1
-
-    if headers > 1:
-        html += _make_table_sections(dataset, coord, base_style)
-
-    if headers > 0:
-        html += "<tr {}>".format(hover_style)
-
-        if coord is not None:
-            html += "<th {} colspan='{}'>{}</th>".format(
-                mstyle, 1 + (coord.variances is not None),
-                name_with_unit(coord, replace_dim=False))
-
-        html += _make_table_unit_headers(dataset.labels, mstyle)
-        html += _make_table_unit_headers(dataset.masks, mstyle)
-        html += _make_table_unit_headers(dataset, mstyle)
-
-        html += "</tr><tr {}>".format(hover_style)
-
-        if coord is not None:
-            html += "<th {}>Values</th>".format(vstyle)
-            if coord.variances is not None:
-                html += "<th {}>Variances</th>".format(vstyle)
-        html += _make_table_subsections(dataset.labels, vstyle)
-        html += _make_table_subsections(dataset.masks, vstyle)
-        html += _make_table_subsections(dataset, vstyle)
-        html += "</tr>"
-
-    # the base style still does not have a closing quote, so we add it here
-    base_style += "'"
-
-    if size is None:  # handle 0D variable
-        html += "<tr {}>".format(hover_style)
-        for key, val in dataset.items():
-            html += "<td {}>{}</td>".format(base_style,
-                                            value_to_string(val.value))
-            if val.variances is not None:
-                html += "<td {}>{}</td>".format(base_style,
-                                                value_to_string(val.variance))
-        html += "</tr>"
-    else:
-        row_end = min(size, row_start + max_rows)
-        if row_start > 0:
-            html += _make_overflow_row(dataset, coord, base_style, hover_style)
-        for i in range(row_start, row_end):
-            html += "<tr {}>".format(hover_style)
-            # Add coordinates
-            if coord is not None:
-                text = value_to_string(coord.values[i])
-                html += "<td rowspan='2' {}>{}</td>".format(base_style, text)
-                if coord.variances is not None:
-                    text = value_to_string(coord.variances[i])
-                    html += "<td rowspan='2' {}>{}</td>".format(
-                        base_style, text)
-
-            html += _make_value_rows(dataset.labels, coord, i, base_style,
-                                     edge_style, row_start)
-            html += _make_value_rows(dataset.masks, coord, i, base_style,
-                                     edge_style, row_start)
-            html += _make_value_rows(dataset, coord, i, base_style, edge_style,
-                                     row_start)
-
-            html += "</tr><tr {}>".format(hover_style)
-            # If there are bin edges, we need to add trailing cells for data
-            # and labels
-            if coord is not None:
-                html += _make_trailing_cells(dataset.labels, coord, i, row_end,
-                                             base_style, edge_style)
-                html += _make_trailing_cells(dataset.masks, coord, i, row_end,
-                                             base_style, edge_style)
-                html += _make_trailing_cells(dataset, coord, i, row_end,
-                                             base_style, edge_style)
-            html += "</tr>"
-        if row_end != size:
-            html += _make_overflow_row(dataset, coord, base_style, hover_style)
-
-    html += "</table>"
-    return html, size
-
-
-def table(dataset):
+def table(scipp_obj):
     """
     Create a html table from the contents of a Dataset (0D and 1D Variables
-    only). The entries will be grouped by dimensions/coordinates.
+    only), DataArray, Variable or raw numpy array.
+    The entries will be grouped by dimensions/coordinates.
     """
 
     from IPython.display import display
-    tv = TableViewer(dataset)
+    tv = TableViewer(scipp_obj)
     display(tv.box)
 
 
 class TableViewer:
-    def __init__(self, dataset):
+    def __init__(self, scipp_obj):
 
         self.widgets = __import__("ipywidgets")
 
+        default_key = " "
         self.tabledict = {
-            "default": sc.Dataset(),
-            "0D Variables": sc.Dataset(),
+            "default": {},
+            "0D Variables": {},
             "1D Variables": {}
         }
-        self.is_histogram = {}
+        self.is_histogram = self.tabledict.copy()
+        empty_dict = {"coord": {}, "data": {}, "labels": {}, "masks": {}}
+        # for key in self.tabledict:
+        #     self.is_histogram[key] = {"data": {}, "labels": {}, "masks": {}}
         self.headers = 0
         self.trigger_update = True
         is_empty = {}
 
-        tp = type(dataset)
+        # tp = type(scipp_obj)
 
-        if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
+        if is_dataset_or_array(scipp_obj):
+
+        # if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
 
             self.headers = 2
 
-            # First add one entry per dimension
-            for dim in dataset.dims:
-                key = str(dim)
-                self.tabledict["1D Variables"][key] = sc.Dataset()
-                is_empty[key] = True
-                self.is_histogram[key] = False
+            # # First add one entry per dimension
+            # for dim in dataset.dims:
+            #     key = str(dim)
+            #     self.tabledict["1D Variables"][key] = {}
+            #     is_empty[key] = True
+            #     self.is_histogram[key] = False
+            # if (tp is sc.Dataset) or (tp is sc.DatasetProxy):
+            if is_dataset(scipp_obj):
+                iterlist = scipp_obj.items()
+            else:
+                iterlist = [(scipp_obj.name, scipp_obj)]
 
-            # Next add the variables
-            for name, var in dataset.items():
-                if len(var.dims) == 1:
-                    dim = var.dims[0]
-                    key = str(dim)
-                    if len(var.coords) > 0:
-                        if len(var.coords[dim].values) == len(var.values) + 1:
-                            self.is_histogram[key] = True
-                        self.tabledict["1D Variables"][key].coords[dim] = \
-                            var.coords[dim]
-                    self.tabledict["1D Variables"][key][name] = var.data
-                    is_empty[key] = False
-
-                elif len(var.dims) == 0:
-                    self.tabledict["0D Variables"][name] = var
-
-            # Next add only the 1D coordinates
-            for dim, var in dataset.coords.items():
+            # First add the 1D coordinates
+            for dim, var in scipp_obj.coords.items():
                 if len(var.dims) == 1:
                     key = str(dim)
-                    if dim not in self.tabledict["1D Variables"][key].coords:
-                        self.tabledict["1D Variables"][key].coords[dim] = var
-                        is_empty[key] = False
+                    if key not in self.tabledict["1D Variables"]:
+                        self.tabledict["1D Variables"][key] = empty_dict.copy()
+                        # self.tabledict["1D Variables"][key]["dim"] = key
+                    self.tabledict["1D Variables"][key]["coord"][key] = var
+                        # is_empty[key] = False
 
             # Next add the labels
-            for name, lab in dataset.labels.items():
-                if len(lab.dims) == 1:
-                    dim = lab.dims[0]
+            for name, lab in scipp_obj.labels.items():
+                ndims = len(lab.dims)
+                if ndims < 2:
+                    group = "{}D Variables".format(ndims)
+                    dim = lab.dims[0] if ndims == 1 else sc.Dim.Invalid
+
+                    # if len(lab.dims) == 1:
+                    #     dim = lab.dims[0]
+                    # else:
+                    #     dim = sc.Dim.Invalid
+
                     key = str(dim)
-                    if len(dataset.coords) > 0:
-                        if len(dataset.coords[dim].values) == len(
+                    if key not in self.tabledict[group]:
+                        self.tabledict[group][key] = empty_dict.copy()
+                        self.is_histogram[group][key] = empty_dict.copy()
+                        # self.tabledict[group][key]["dim"] = key
+                    self.is_histogram[group][key]["labels"][name] = False
+                    if dim in scipp_obj.coords:
+                        if len(scipp_obj.coords[dim].values) == len(
                                 lab.values) + 1:
-                            self.is_histogram[key] = True
-                        self.tabledict["1D Variables"][key].coords[dim] = \
-                            dataset.coords[dim]
-                    self.tabledict["1D Variables"][key].labels[name] = lab
-                    is_empty[key] = False
+                            self.is_histogram[group][key]["labels"][name] = True
+
+                    
+                    self.tabledict[group][key]["labels"][name] = lab
+
+                # if dim in scipp_obj.coords:
+                #     if len(scipp_obj.coords[dim].values) == len(
+                #             lab.values) + 1:
+                #         self.is_histogram["1D Variables"][key]["labels"][name] = True
+                #     # self.tabledict["1D Variables"][key].coords[dim] = \
+                #     #     dataset.coords[dim]
+                # # self.tabledict["1D Variables"][key].labels[name] = lab
+                # # is_empty[key] = False
+
 
             # Next add the masks
-            for name, mask in dataset.masks.items():
-                if len(mask.dims) == 1:
-                    dim = mask.dims[0]
+            for name, mask in scipp_obj.masks.items():
+                ndims = len(mask.dims)
+                if ndims < 2:
+                    group = "{}D Variables".format(ndims)
+                    dim = mask.dims[0] if ndims == 1 else sc.Dim.Invalid
+
                     key = str(dim)
-                    if len(dataset.coords) > 0:
-                        if len(dataset.coords[dim].values) == len(
+                    if key not in self.tabledict[group]:
+                        self.tabledict[group][key] = empty_dict.copy()
+                        self.is_histogram[group][key] = empty_dict.copy()
+                        # self.tabledict[group][key]["dim"] = key
+                    self.is_histogram[group][key]["masks"][name] = False
+                    if dim in scipp_obj.coords:
+                        if len(scipp_obj.coords[dim].values) == len(
                                 mask.values) + 1:
-                            self.is_histogram[key] = True
-                        self.tabledict["1D Variables"][key].coords[dim] = \
-                            dataset.coords[dim]
-                    self.tabledict["1D Variables"][key].masks[name] = mask
-                    is_empty[key] = False
+                            self.is_histogram[group][key]["masks"][name] = True
+                    self.tabledict[group][key]["masks"][name] = mask
 
-            # Now purge out the empty entries
-            for key, val in is_empty.items():
-                if val:
-                    del (self.tabledict["1D Variables"][key])
 
-        elif (tp is sc.DataArray) or (tp is sc.DataProxy):
-            self.headers = 2
-            key = dataset.name
-            self.tabledict["default"][key] = dataset.data
-            if len(dataset.coords) > 0:
-                dim = dataset.dims[0]
-                self.tabledict["default"][key].coords[dim] = dataset.coords[
-                    dim]
-        elif (tp is sc.Variable) or (tp is sc.VariableProxy):
+
+            # Next add the data
+            for name, var in iterlist:
+                ndims = len(var.dims)
+                if ndims < 2:
+                    group = "{}D Variables".format(ndims)
+                    dim = var.dims[0] if ndims == 1 else sc.Dim.Invalid
+
+                    key = str(dim)
+                    # print(name, key)
+                    # print(self.is_histogram)
+                    if key not in self.tabledict[group]:
+                        self.tabledict[group][key] = empty_dict.copy()
+                        self.is_histogram[group][key] = empty_dict.copy()
+                        # self.tabledict[group][key]["dim"] = key
+                    self.is_histogram[group][key]["data"][name] = False
+                    if dim in scipp_obj.coords:
+                        if len(scipp_obj.coords[dim].values) == len(
+                                var.values) + 1:
+                            self.is_histogram[group][key]["data"][name] = True
+                    self.tabledict[group][key]["data"][name] = var.data
+
+
+
+
+
+
+        #         if len(var.dims) < 2:
+
+        #             group = "{}D Variables".format(len(var.dims))
+        #             if len(var.dims) == 1:
+        #                 dim = var.dims[0]
+        #                 key = str(dim)
+        #             else:
+        #                 key = row_key
+
+        #             if key not in self.tabledict[group]:
+        #                 self.tabledict[group][key] = {"coord": {}, "data": {}, "labels": {}, "masks": {}}
+
+        #             if len(var.coords) > 0:
+        #                 if len(var.coords[dim].values) == len(var.values) + 1:
+        #                     self.is_histogram["1D Variables"][key] = True
+        #                 # self.tabledict["1D Variables"][key]["coord"][key] = \
+        #                 #     var.coords[dim]
+        #             self.tabledict["1D Variables"][key]["data"][name] = var.data
+
+
+        #                 # is_empty[key] = False
+
+        #             elif len(var.dims) == 0:
+        #                 if row_key not in self.tabledict["0D Variables"]:
+        #                     self.tabledict["1D Variables"][row_key] = {}
+        #                 self.tabledict["0D Variables"][row_key][name] = var
+
+        #     # # Next add only the 1D coordinates
+        #     # for dim, var in dataset.coords.items():
+        #     #     if len(var.dims) == 1:
+        #     #         key = str(dim)
+        #     #         if dim not in self.tabledict["1D Variables"][key].coords:
+        #     #             self.tabledict["1D Variables"][key].coords[dim] = var
+        #     #             is_empty[key] = False
+
+        #     # Next add the labels
+        #     for name, lab in dataset.labels.items():
+        #         if len(lab.dims) == 1:
+        #             dim = lab.dims[0]
+        #             key = str(dim)
+        #             if len(dataset.coords) > 0:
+        #                 if len(dataset.coords[dim].values) == len(
+        #                         lab.values) + 1:
+        #                     self.is_histogram[key] = True
+        #                 self.tabledict["1D Variables"][key].coords[dim] = \
+        #                     dataset.coords[dim]
+        #             self.tabledict["1D Variables"][key].labels[name] = lab
+        #             is_empty[key] = False
+
+        #     # # Next add the masks
+        #     # for name, mask in dataset.masks.items():
+        #     #     if len(mask.dims) == 1:
+        #     #         dim = mask.dims[0]
+        #     #         key = str(dim)
+        #     #         if len(dataset.coords) > 0:
+        #     #             if len(dataset.coords[dim].values) == len(
+        #     #                     mask.values) + 1:
+        #     #                 self.is_histogram[key] = True
+        #     #             self.tabledict["1D Variables"][key].coords[dim] = \
+        #     #                 dataset.coords[dim]
+        #     #         self.tabledict["1D Variables"][key].masks[name] = mask
+        #     #         is_empty[key] = False
+
+        #     # # Now purge out the empty entries
+        #     # for key, val in is_empty.items():
+        #     #     if val:
+        #     #         del (self.tabledict["1D Variables"][key])
+
+        # # elif (tp is sc.DataArray) or (tp is sc.DataProxy):
+        # #     self.headers = 2
+        # #     key = dataset.name
+        # #     self.tabledict["default"][row_key] = {key: dataset}
+        # #     # if len(dataset.coords) > 0:
+        # #     #     dim = dataset.dims[0]
+        # #     #     self.tabledict["default"][key].coords[dim] = dataset.coords[
+        # #     #         dim]
+        elif is_variable(scipp_obj):
             self.headers = 1
-            key = str(dataset.dims[0])
-            self.tabledict["default"][key] = dataset
+            key = str(scipp_obj.dims[0])
+            # TODO: does moving here invalidate the input?
+            self.tabledict["default"][row_key] = {key: detail.move_to_data_array(data=scipp_obj)}
             self.is_histogram[key] = False
         else:
             self.headers = 0
             key = " "
-            self.tabledict["default"][key] = sc.Variable([sc.Dim.Row],
-                                                         values=dataset)
+            self.tabledict["default"][row_key] = {key: detail.move_to_data_array(data=sc.Variable([sc.Dim.Row],
+                                                         values=scipp_obj))}
             self.is_histogram[key] = False
+
+        print(self.tabledict)
 
         subtitle = "<span style='font-weight:normal;color:grey;"
         subtitle += "font-style:italic;background-color:#ffffff;"
         subtitle += "text-align:left;font-size:1.2em;padding: 1px;'>"
         subtitle += "{}</span>"
-        title = str(type(dataset)).replace("<class 'scipp._scipp.core.",
+        title = str(type(scipp_obj)).replace("<class 'scipp._scipp.core.",
                                            "").replace("'>", "")
 
         self.box = [
@@ -381,24 +268,24 @@ class TableViewer:
         self.nrows = {}
         self.sizes = {}
 
-        if len(self.tabledict["default"]) > 0:
-            html, size = table_from_dataset(self.tabledict["default"],
-                                            headers=self.headers,
-                                            max_rows=config.table_max_size)
-            self.tables["default"] = {" ": self.widgets.HTML(value=html)}
-            hbox = self.make_hbox("default", " ", size)
-            self.box.append(hbox)
-            self.sizes["default"] = {" ": size}
-        if len(self.tabledict["0D Variables"]) > 0:
-            self.tables["0D Variables"] = {}
-            output = subtitle.format("0D Variables")
-            html, size = table_from_dataset(self.tabledict["0D Variables"],
-                                            headers=self.headers,
-                                            max_rows=config.table_max_size)
-            self.tables["0D Variables"][" "] = self.widgets.HTML(value=html)
-            hbox = self.make_hbox("0D Variables", " ", size)
-            self.box.append(
-                self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
+        # if len(self.tabledict["default"]) > 0:
+        #     html, size = table_from_dataset(self.tabledict["default"],
+        #                                     headers=self.headers,
+        #                                     max_rows=config.table_max_size)
+        #     self.tables["default"] = {" ": self.widgets.HTML(value=html)}
+        #     hbox = self.make_hbox("default", " ", size)
+        #     self.box.append(hbox)
+        #     self.sizes["default"] = {" ": size}
+        # if len(self.tabledict["0D Variables"]) > 0:
+        #     self.tables["0D Variables"] = {}
+        #     output = subtitle.format("0D Variables")
+        #     html, size = table_from_dataset(self.tabledict["0D Variables"],
+        #                                     headers=self.headers,
+        #                                     max_rows=config.table_max_size)
+        #     self.tables["0D Variables"][" "] = self.widgets.HTML(value=html)
+        #     hbox = self.make_hbox("0D Variables", " ", size)
+        #     self.box.append(
+        #         self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
         if len(self.tabledict["1D Variables"]) > 0:
             self.tables["1D Variables"] = {}
             self.sizes["1D Variables"] = {}
@@ -407,8 +294,9 @@ class TableViewer:
                 width="initial"))
             children = []
             for key, val in sorted(self.tabledict["1D Variables"].items()):
-                html, size = table_from_dataset(val,
-                                                is_hist=self.is_histogram[key],
+                html, size = self.table_from_dict_of_variables(val,
+                                                dim_key=key,
+                                                # is_hist=self.is_histogram[key],
                                                 headers=self.headers,
                                                 max_rows=config.table_max_size)
                 self.tables["1D Variables"][key] = self.widgets.HTML(
@@ -468,6 +356,298 @@ class TableViewer:
                 ])
         return hbox
 
+
+
+
+    # def make_table_section_name_header(self, name, section, style):
+    #     """
+    #     Adds a first row of the table that contains the names of the sections
+    #     being displayed in the table. This is usually the first row and will
+    #     contain Data, Labels, Masks, etc.
+    #     """
+    #     col_separators = 0
+    #     for key, sec in section.items():
+    #         col_separators += 1 + (sec.variances is not None)
+    #     if col_separators > 0:
+    #         return "<th {} colspan='{}'>{}</th>".format(style, col_separators,
+    #                                                     name)
+    #     else:
+    #         return ""
+
+
+    def make_table_sections(self, dict_of_variables, base_style):
+
+        html = ["<tr>"]
+        for key, section in dict_of_variables.items():
+
+            col_separators = 0
+            for var in section.values():
+                col_separators += 1 + (var.variances is not None)
+            if col_separators > 0:
+                style = "{} background-color: {};text-align: center;'".format(base_style, config.colors[key])
+                html.append("<th {} colspan='{}'>{}</th>".format(style, col_separators,
+                                                            key))
+            # else:
+            #     return ""
+
+        # coord_style = "{} background-color: {};text-align: center;'".format(
+        #     base_style, config.colors["coord"])
+        # label_style = "{} background-color: {};text-align: center;'".format(
+        #     base_style, config.colors["labels"])
+        # mask_style = "{} background-color: {};text-align: center;'".format(
+        #     base_style, config.colors["mask"])
+        # data_style = "{} background-color: {};text-align: center;'".format(
+        #     base_style, config.colors["data"])
+
+        # colsp_coord = 0
+        # if coord is not None:
+        #     colsp_coord = 1 + (coord.variances is not None)
+        # html = ["<tr>"]
+
+        # if colsp_coord > 0:
+        #     html.append("<th {} colspan='{}'>Coordinate</th>".format(
+        #         coord_style, colsp_coord))
+        # html.append(
+        #     self.make_table_section_name_header("Labels", labels, label_style))
+        # html.append(
+        #     self.make_table_section_name_header("Masks", masks, mask_style))
+        # html.append(self.make_table_section_name_header("Data", dict_of_data_arrays, data_style))
+
+        html.append("</tr>")
+
+        return "".join(html)
+
+
+    def make_table_unit_headers(self, dict_of_variables, text_style):
+        """
+        Adds a row containing the unit of the section
+        """
+
+            # if coord is not None:
+            #     html += "<th {} colspan='{}'>{}</th>".format(
+            #         mstyle, 1 + (coord.variances is not None),
+            #         name_with_unit(coord, replace_dim=False))
+
+            # html += self.make_table_unit_headers(labels, mstyle)
+            # html += self.make_table_unit_headers(masks, mstyle)
+            # html += self.make_table_unit_headers(dict_of_data_arrays, mstyle)
+
+
+        html = []
+        for key, section in dict_of_variables.items():
+            for name, val in section.items():
+                html.append("<th {} colspan='{}'>{}</th>".format(
+                    text_style, 1 + (val.variances is not None),
+                    name_with_unit(val, name=name)))
+        return "".join(html)
+
+
+    def make_table_subsections(self, dict_of_variables, text_style):
+        """
+        Adds Value | Variance columns for the section.
+        """
+        html = []
+        for key, section in dict_of_variables.items():
+            for name, val in section.items():
+                html.append("<th {}>Values</th>".format(text_style))
+                if val.variances is not None:
+                    html.append("<th {}>Variances</th>".format(text_style))
+        return "".join(html)
+
+
+    def make_value_rows(self, section, coord, index, base_style, edge_style, row_start):
+        html = []
+        for key, val in section.items():
+            header_line_for_bin_edges = False
+            if coord is not None:
+                if len(val.values) == len(coord.values) - 1:
+                    header_line_for_bin_edges = True
+            if header_line_for_bin_edges:
+                if index == row_start:
+                    html.append("<td {}></td>".format(edge_style))
+                    if val.variances is not None:
+                        html.append("<td {}></td>".format(edge_style))
+            else:
+                html.append("<td rowspan='2' {}>{}</td>".format(
+                    base_style, value_to_string(val.values[index])))
+                if val.variances is not None:
+                    html.append("<td rowspan='2' {}>{}</td>".format(
+                        base_style, value_to_string(val.variances[index])))
+
+        return "".join(html)
+
+
+    def make_trailing_cells(self, section, coord, index, size, base_style, edge_style):
+        html = []
+        for key, val in section.items():
+            if len(val.values) == len(coord.values) - 1:
+                if index == size - 1:
+                    html.append("<td {}></td>".format(edge_style))
+                    if val.variances is not None:
+                        html.append("<td {}></td>".format(edge_style))
+                else:
+                    html.append("<td rowspan='2' {}>{}</td>".format(
+                        base_style, value_to_string(val.values[index])))
+                    if val.variances is not None:
+                        html.append("<td rowspan='2' {}>{}</td>".format(
+                            base_style, value_to_string(val.variances[index])))
+
+        return "".join(html)
+
+
+    def make_overflow_cells(self, section, base_style):
+        html = []
+        for key, val in section.items():
+            html.append("<td {}>...</td>".format(base_style))
+            if val.variances is not None:
+                html.append("<td {}>...</td>".format(base_style))
+        return "".join(html)
+
+
+    def make_overflow_row(self, dict_of_data_arrays, coord, labels, masks, base_style, hover_style):
+        html = ["<tr {}>".format(hover_style)]
+        if coord is not None:
+            html.append(self.make_overflow_cells({" ": coord}, base_style))
+        html.append(self.make_overflow_cells(labels, base_style))
+        html.append(self.make_overflow_cells(masks, base_style))
+        html.append(self.make_overflow_cells(dict_of_data_arrays, base_style))
+        html.append("</tr>")
+        return "".join(html)
+
+
+    def table_from_dict_of_variables(self, dict_of_variables,
+                           # is_hist=False,
+                           dim_key=None,
+                           headers=2,
+                           row_start=0,
+                           max_rows=None):
+        base_style = ("style='border: 1px solid black; padding: 0px 5px 0px 5px; "
+                      "text-align: right;")
+
+        mstyle = base_style + "text-align: center;"
+        vstyle = mstyle + "background-color: #f0f0f0;'"
+        mstyle += "'"
+        edge_style = ("style='border: 0px solid white;background-color: #ffffff; "
+                      "height:1.2em;'")
+        hover_style = ("onMouseOver=\"this.style.backgroundColor='" +
+                       config.colors["hover"] +
+                       "'\" onMouseOut=\"this.style.backgroundColor='#ffffff'\"")
+
+        # Declare table
+        html = "<table style='border-collapse: collapse;'>"
+
+
+        # # Get first entry in dict of data arrays
+        # data_array = next(iter(dict_of_data_arrays.values()))
+        # labels = data_array.labels
+        # masks = data_array.masks
+
+        # dims = data_array.dims
+        coord = None
+        # if len(dims) > 0:
+        #     # DataArray should contain only one dim, so get the first in list
+        #     size = data_array.shape[0]
+        #     if len(data_array.coords) > 0:
+        #         coord = data_array.coords[dims[0]]
+        #         if is_hist:
+        #             size += 1
+
+        if len(dict_of_variables["coord"]) > 0:
+            coord = dict_of_variables["coord"][dim_key]
+
+        if headers > 1:
+            html += self.make_table_sections(dict_of_variables, base_style)
+
+        if headers > 0:
+            html += "<tr {}>".format(hover_style)
+
+            html += self.make_table_unit_headers(dict_of_variables, mstyle)
+            # if coord is not None:
+            #     html += "<th {} colspan='{}'>{}</th>".format(
+            #         mstyle, 1 + (coord.variances is not None),
+            #         name_with_unit(coord, replace_dim=False))
+
+            # html += self.make_table_unit_headers(labels, mstyle)
+            # html += self.make_table_unit_headers(masks, mstyle)
+            # html += self.make_table_unit_headers(dict_of_data_arrays, mstyle)
+
+            html += "</tr><tr {}>".format(hover_style)
+
+            html += self.make_table_subsections(dict_of_variables, vstyle)
+
+            # if coord is not None:
+            #     html += "<th {}>Values</th>".format(vstyle)
+            #     if coord.variances is not None:
+            #         html += "<th {}>Variances</th>".format(vstyle)
+            # html += self.make_table_subsections(labels, vstyle)
+            # html += self.make_table_subsections(masks, vstyle)
+            # html += self.make_table_subsections(dict_of_data_arrays, vstyle)
+            html += "</tr>"
+
+        html += "</table>"
+        return html, 1
+
+        # the base style still does not have a closing quote, so we add it here
+        base_style += "'"
+
+        if size is None:  # handle 0D variable
+            html += "<tr {}>".format(hover_style)
+            for key, val in dict_of_data_arrays.items():
+                html += "<td {}>{}</td>".format(base_style,
+                                                value_to_string(val.value))
+                if val.variances is not None:
+                    html += "<td {}>{}</td>".format(base_style,
+                                                    value_to_string(val.variance))
+            html += "</tr>"
+        else:
+            row_end = min(size, row_start + max_rows)
+            if row_start > 0:
+                html += self.make_overflow_row(dict_of_data_arrays, coord, labels, masks, base_style, hover_style)
+            for i in range(row_start, row_end):
+                html += "<tr {}>".format(hover_style)
+                # Add coordinates
+                if coord is not None:
+                    text = value_to_string(coord.values[i])
+                    html += "<td rowspan='2' {}>{}</td>".format(base_style, text)
+                    if coord.variances is not None:
+                        text = value_to_string(coord.variances[i])
+                        html += "<td rowspan='2' {}>{}</td>".format(
+                            base_style, text)
+
+                html += self.make_value_rows(labels, coord, i, base_style,
+                                         edge_style, row_start)
+                html += self.make_value_rows(masks, coord, i, base_style,
+                                         edge_style, row_start)
+                html += self.make_value_rows(dict_of_data_arrays, coord, i, base_style, edge_style,
+                                         row_start)
+
+                html += "</tr><tr {}>".format(hover_style)
+                # If there are bin edges, we need to add trailing cells for data
+                # and labels
+                if coord is not None:
+                    html += self.make_trailing_cells(labels, coord, i, row_end,
+                                                 base_style, edge_style)
+                    html += self.make_trailing_cells(masks, coord, i, row_end,
+                                                 base_style, edge_style)
+                    html += self.make_trailing_cells(dict_of_data_arrays, coord, i, row_end,
+                                                 base_style, edge_style)
+                html += "</tr>"
+            if row_end != size:
+                html += self.make_overflow_row(dict_of_data_arrays, coord, labels, masks, base_style, hover_style)
+
+        html += "</table>"
+        return html, size
+
+
+
+
+
+
+
+
+
+
+
     def update_slider(self, change):
         key = change["owner"].key
         group = change["owner"].group
@@ -484,13 +664,13 @@ class TableViewer:
         if self.trigger_update:
             key = change["owner"].key
             group = change["owner"].group
-            to_table = self.tabledict[group]
-            # This extra indexing step comes from the fact that for the
-            # default key, the tabledict is a Dataset, while for the 1D
-            # Variables it is a dict of Datasets.
-            if group != "default":
-                to_table = to_table[key]
-            html, size = table_from_dataset(to_table,
+            # to_table = self.tabledict[group]
+            # # This extra indexing step comes from the fact that for the
+            # # default key, the tabledict is a Dataset, while for the 1D
+            # # Variables it is a dict of Datasets.
+            # if group != "default":
+            #     to_table = to_table[key]
+            html, size = table_from_dict_of_data_arrays(self.tabledict[group][key],
                                             is_hist=self.is_histogram[key],
                                             headers=self.headers,
                                             row_start=self.sliders[key].value,

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -33,8 +33,8 @@ class TableViewer:
 
         self.widgets = __import__("ipywidgets")
 
-        default_key = " "
-        groups = ["default", "0D Variables", "1D Variables"]
+        # default_key = " "
+        groups = ["0D Variables", "1D Variables"]
         self.tabledict = {}
         self.is_bin_centers = {}
         self.sizes = {}
@@ -318,72 +318,88 @@ class TableViewer:
         self.nrows = {}
         # self.sizes = {}
 
-        other_variables = {"default": None, "0D Variables": subtitle.format("0D Variables")}
-        for group, output in other_variables.items():
-            if len(self.tabledict[group]) > 0:
-                for key, val in self.tabledict[group].items():
-                    html = self.table_from_dict_of_variables(val,
-                                                is_bin_centers=self.is_bin_centers[group][key],
-                                                size=self.sizes[group][key],
-                                                headers=self.headers,
-                                                max_rows=config.table_max_size)
+        # other_variables = {"default": None, "0D Variables": subtitle.format("0D Variables")}
+        # for group, output in other_variables.items():
 
-                # html = table_from_dict_of_variables(self.tabledict["0D Variables"],
-                #                                 headers=self.headers,
-                #                                 max_rows=config.table_max_size)
-                self.tables[group] = {" ": self.widgets.HTML(value=html)}
-                hbox = self.make_hbox(group, " ", self.sizes[group][key])
-                if output is not None:
-                    hbox = [self.widgets.HTML(value=output), hbox]
-                self.box.append(self.widgets.VBox(hbox))
+
+
+        # for group in self.tabledict.keys():
+        #     if len(self.tabledict[group]) > 0:
+        #         for key, val in self.tabledict[group].items():
+        #             html = self.table_from_dict_of_variables(val,
+        #                                         is_bin_centers=self.is_bin_centers[group][key],
+        #                                         size=self.sizes[group][key],
+        #                                         headers=self.headers,
+        #                                         max_rows=config.table_max_size)
+
+        #         # html = table_from_dict_of_variables(self.tabledict["0D Variables"],
+        #         #                                 headers=self.headers,
+        #         #                                 max_rows=config.table_max_size)
+        #         self.tables[group] = {" ": self.widgets.HTML(value=html)}
+        #         hbox = self.make_hbox(group, " ", self.sizes[group][key])
+        #         if output is not None:
+        #             hbox = [self.widgets.HTML(value=output), hbox]
+        #         self.box.append(self.widgets.VBox(hbox))
         
 
-        # # if len(self.tabledict["default"]) > 0:
-        # #     html, size = table_from_dataset(self.tabledict["default"],
+        # # # if len(self.tabledict["default"]) > 0:
+        # # #     html, size = table_from_dataset(self.tabledict["default"],
+        # # #                                     headers=self.headers,
+        # # #                                     max_rows=config.table_max_size)
+        # # #     self.tables["default"] = {" ": self.widgets.HTML(value=html)}
+        # # #     hbox = self.make_hbox("default", " ", size)
+        # # #     self.box.append(hbox)
+        # # #     self.sizes["default"] = {" ": size}
+        # # if len(self.tabledict["0D Variables"]) > 0:
+        # #     # self.tables["0D Variables"] = {}
+        # #     output = subtitle.format("0D Variables")
+        # #     html, size = table_from_dataset(self.tabledict["0D Variables"],
         # #                                     headers=self.headers,
         # #                                     max_rows=config.table_max_size)
-        # #     self.tables["default"] = {" ": self.widgets.HTML(value=html)}
-        # #     hbox = self.make_hbox("default", " ", size)
-        # #     self.box.append(hbox)
-        # #     self.sizes["default"] = {" ": size}
-        # if len(self.tabledict["0D Variables"]) > 0:
-        #     # self.tables["0D Variables"] = {}
-        #     output = subtitle.format("0D Variables")
-        #     html, size = table_from_dataset(self.tabledict["0D Variables"],
-        #                                     headers=self.headers,
-        #                                     max_rows=config.table_max_size)
-        #     self.tables["0D Variables"][" "] = self.widgets.HTML(value=html)
-        #     hbox = self.make_hbox("0D Variables", " ", size)
-        #     self.box.append(
-        #         self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
-        print(self.box)
-        if len(self.tabledict["1D Variables"]) > 0:
-            self.tables["1D Variables"] = {}
-            # self.sizes["1D Variables"] = {}
-            output = subtitle.format("1D Variables")
-            self.tabs = self.widgets.Tab(layout=self.widgets.Layout(
-                width="initial"))
-            children = []
-            for key, val in sorted(self.tabledict["1D Variables"].items()):
-                html = self.table_from_dict_of_variables(val,
-                                                # dim_key=key,
-                                                is_bin_centers=self.is_bin_centers["1D Variables"][key],
-                                                size=self.sizes["1D Variables"][key],
-                                                headers=self.headers,
-                                                max_rows=config.table_max_size)
-                self.tables["1D Variables"][key] = self.widgets.HTML(
-                    value=html)
-                hbox = self.make_hbox("1D Variables", key, self.sizes["1D Variables"][key])
-                children.append(hbox)
-                # self.sizes["1D Variables"][key] = size
+        # #     self.tables["0D Variables"][" "] = self.widgets.HTML(value=html)
+        # #     hbox = self.make_hbox("0D Variables", " ", size)
+        # #     self.box.append(
+        # #         self.widgets.VBox([self.widgets.HTML(value=output), hbox]))
+        # # print(self.box)
 
-            self.tabs.children = children
-            for i, key in enumerate(
-                    sorted(self.tabledict["1D Variables"].keys())):
-                self.tabs.set_title(i, key)
-            self.box.append(
-                self.widgets.VBox([self.widgets.HTML(value=output),
-                                   self.tabs]))
+        for group in self.tabledict.keys():
+
+            if len(self.tabledict[group]) > 0:
+                self.tables[group] = {}
+                # self.sizes["1D Variables"] = {}
+                output = subtitle.format(group)
+
+                # self.tabs = self.widgets.Tab(layout=self.widgets.Layout(
+                #     width="initial"))
+                children = []
+                for key, val in sorted(self.tabledict[group].items()):
+                    html = self.table_from_dict_of_variables(val,
+                                                    # dim_key=key,
+                                                    is_bin_centers=self.is_bin_centers[group][key],
+                                                    size=self.sizes[group][key],
+                                                    headers=self.headers,
+                                                    max_rows=config.table_max_size)
+                    self.tables[group][key] = self.widgets.HTML(
+                        value=html)
+                    hbox = self.make_hbox(group, key, self.sizes[group][key])
+                    children.append(hbox)
+
+                    # self.sizes["1D Variables"][key] = size
+                vbox = [self.widgets.HTML(value=output)]
+
+                if group == "1D Variables":
+                    self.tabs = self.widgets.Tab(layout=self.widgets.Layout(
+                        width="initial"))
+                    self.tabs.children = children
+                    for i, key in enumerate(
+                            sorted(self.tabledict[group].keys())):
+                        self.tabs.set_title(i, key)
+                    vbox.append(self.tabs)
+                else:
+                    vbox.append(hbox)
+
+                self.box.append(self.widgets.VBox(vbox))
+
 
         self.box = self.widgets.VBox(self.box,
                                      layout=self.widgets.Layout(
@@ -410,8 +426,16 @@ class TableViewer:
                     continuous_update=True,
                     layout=self.widgets.Layout(width='150px'))
                 self.nrows[key].observe(self.update_slider, names="value")
-                self.sliders[key] = self.widgets.SelectionSlider(
-                    options=np.arange(size - self.nrows[key].value + 1)[::-1],
+                # self.sliders[key] = self.widgets.SelectionSlider(
+                #     options=np.arange(size - self.nrows[key].value + 1)[::-1],
+                #     value=0,
+                #     description="Starting row",
+                #     orientation='vertical',
+                #     continuous_update=False,
+                #     layout=self.widgets.Layout(height='400px'))
+                self.sliders[key] = self.widgets.IntSlider(
+                    min=0,
+                    max=size - self.nrows[key].value + 1,
                     value=0,
                     description="Starting row",
                     orientation='vertical',
@@ -755,33 +779,35 @@ class TableViewer:
         group = change["owner"].group
         val = self.sliders[key].value
         # Prevent update while options are being changed
-        self.trigger_update = False
-        self.sliders[key].options = np.arange(self.sizes[group][key] -
-                                              change["new"] + 1)[::-1]
-        # Re-enable table updating
-        self.trigger_update = True
-        self.sliders[key].value = min(val, self.sliders[key].options[0])
+        # self.trigger_update = False
+        # self.sliders[key].options = np.arange(self.sizes[group][key] -
+        #                                       change["new"] + 1)[::-1]
+        self.sliders[key].max = self.sizes[group][key] - change["new"] + 1
+        # # Re-enable table updating
+        # self.trigger_update = True
+        # self.sliders[key].value = min(val, self.sliders[key].max)
 
     def update_table(self, change):
-        if self.trigger_update:
-            key = change["owner"].key
-            group = change["owner"].group
-            # to_table = self.tabledict[group]
-            # # This extra indexing step comes from the fact that for the
-            # # default key, the tabledict is a Dataset, while for the 1D
-            # # Variables it is a dict of Datasets.
-            # if group != "default":
-            #     to_table = to_table[key]
-            # html, size = table_from_dict_of_data_arrays(self.tabledict[group][key],
-            #                                 is_hist=self.is_bin_centers[key],
-            #                                 headers=self.headers,
-            #                                 row_start=self.sliders[key].value,
-            #                                 max_rows=self.nrows[key].value)
-            html = self.table_from_dict_of_variables(self.tabledict[group][key],
-                                                # dim_key=key,
-                                                is_bin_centers=self.is_bin_centers[group][key],
-                                                size=self.sizes[group][key],
-                                                headers=self.headers,
-                                                row_start=self.sliders[key].value,
-                                                max_rows=self.nrows[key].value)
-            self.tables[group][key].value = html
+        # if self.trigger_update:
+        print("fired")
+        key = change["owner"].key
+        group = change["owner"].group
+        # to_table = self.tabledict[group]
+        # # This extra indexing step comes from the fact that for the
+        # # default key, the tabledict is a Dataset, while for the 1D
+        # # Variables it is a dict of Datasets.
+        # if group != "default":
+        #     to_table = to_table[key]
+        # html, size = table_from_dict_of_data_arrays(self.tabledict[group][key],
+        #                                 is_hist=self.is_bin_centers[key],
+        #                                 headers=self.headers,
+        #                                 row_start=self.sliders[key].value,
+        #                                 max_rows=self.nrows[key].value)
+        html = self.table_from_dict_of_variables(self.tabledict[group][key],
+                                            # dim_key=key,
+                                            is_bin_centers=self.is_bin_centers[group][key],
+                                            size=self.sizes[group][key],
+                                            headers=self.headers,
+                                            row_start=self.sliders[key].value,
+                                            max_rows=self.nrows[key].value)
+        self.tables[group][key].value = html

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -10,6 +10,173 @@ from .utils import (value_to_string, name_with_unit, is_dataset_or_array,
 from ._scipp import core as sc
 
 
+def _make_table_sections(dict_of_variables, base_style):
+
+    html = ["<tr>"]
+    for key, section in dict_of_variables.items():
+        heading = key[0].upper() + key[1:]
+
+        col_separators = 0
+        for var in section.values():
+            col_separators += 1 + (var.variances is not None)
+        if col_separators > 0:
+            style = "{} background-color: {};text-align: center;'".format(
+                base_style, config.colors[key.lower()])
+            html.append("<th {} colspan='{}'>{}</th>".format(
+                style, col_separators, heading))
+
+    html.append("</tr>")
+
+    return "".join(html)
+
+
+def _make_table_unit_headers(dict_of_variables, text_style):
+    """
+    Adds a row containing the unit of the section
+    """
+    html = []
+    for key, section in dict_of_variables.items():
+        for name, val in section.items():
+            html.append("<th {} colspan='{}'>{}</th>".format(
+                text_style, 1 + (val.variances is not None),
+                name_with_unit(val, name=name)))
+    return "".join(html)
+
+
+def _make_table_subsections(dict_of_variables, text_style):
+    """
+    Adds Value | Variance columns for the section.
+    """
+    html = []
+    for key, section in dict_of_variables.items():
+        for name, val in section.items():
+            html.append("<th {}>Values</th>".format(text_style))
+            if val.variances is not None:
+                html.append("<th {}>Variances</th>".format(text_style))
+    return "".join(html)
+
+
+def _make_value_rows(dict_of_variables, is_bin_centers, index, base_style,
+                     edge_style, row_start):
+    html = []
+    for key, section in dict_of_variables.items():
+        for name, val in section.items():
+            if is_bin_centers[key][name]:
+                if index == row_start:
+                    html.append("<td {}></td>".format(edge_style))
+                    if val.variances is not None:
+                        html.append("<td {}></td>".format(edge_style))
+            else:
+                html.append("<td rowspan='2' {}>{}</td>".format(
+                    base_style, value_to_string(val.values[index])))
+                if val.variances is not None:
+                    html.append("<td rowspan='2' {}>{}</td>".format(
+                        base_style, value_to_string(val.variances[index])))
+
+    return "".join(html)
+
+
+def _make_trailing_cells(dict_of_variables, is_bin_centers, index, size,
+                         base_style, edge_style):
+    html = []
+    for key, section in dict_of_variables.items():
+        for name, val in section.items():
+            if is_bin_centers[key][name]:
+                if index == size - 1:
+                    html.append("<td {}></td>".format(edge_style))
+                    if val.variances is not None:
+                        html.append("<td {}></td>".format(edge_style))
+                else:
+                    html.append("<td rowspan='2' {}>{}</td>".format(
+                        base_style, value_to_string(val.values[index])))
+                    if val.variances is not None:
+                        html.append("<td rowspan='2' {}>{}</td>".format(
+                            base_style, value_to_string(val.variances[index])))
+
+    return "".join(html)
+
+
+def _make_overflow_row(dict_of_variables, base_style, hover_style):
+    html = ["<tr {}>".format(hover_style)]
+    for key, section in dict_of_variables.items():
+        for name, val in section.items():
+            html.append("<td {}>...</td>".format(base_style))
+            if val.variances is not None:
+                html.append("<td {}>...</td>".format(base_style))
+
+    html.append("</tr>")
+    return "".join(html)
+
+
+def _table_from_dict_of_variables(
+        dict_of_variables,
+        is_bin_centers=None,
+        # dim_key=None,
+        size=None,
+        headers=2,
+        row_start=0,
+        max_rows=None):
+    base_style = ("style='border: 1px solid black; padding: 0px 5px 0px 5px; "
+                  "text-align: right;")
+
+    mstyle = base_style + "text-align: center;"
+    vstyle = mstyle + "background-color: #f0f0f0;'"
+    mstyle += "'"
+    edge_style = ("style='border: 0px solid white;background-color: #ffffff; "
+                  "height:1.2em;'")
+    hover_style = ("onMouseOver=\"this.style.backgroundColor='" +
+                   config.colors["hover"] +
+                   "'\" onMouseOut=\"this.style.backgroundColor='#ffffff'\"")
+
+    # Declare table
+    html = "<table style='border-collapse: collapse;'>"
+
+    if headers > 1:
+        html += _make_table_sections(dict_of_variables, base_style)
+    if headers > 0:
+        html += "<tr {}>".format(hover_style)
+        html += _make_table_unit_headers(dict_of_variables, mstyle)
+        html += "</tr><tr {}>".format(hover_style)
+        html += _make_table_subsections(dict_of_variables, vstyle)
+        html += "</tr>"
+
+    # the base style still does not have a closing quote, so we add it here
+    base_style += "'"
+
+    if size is None:  # handle 0D variable
+        html += "<tr {}>".format(hover_style)
+        for key, section in dict_of_variables.items():
+            for name, val in section.items():
+                html += "<td {}>{}</td>".format(base_style,
+                                                value_to_string(val.value))
+                if val.variances is not None:
+                    html += "<td {}>{}</td>".format(
+                        base_style, value_to_string(val.variance))
+        html += "</tr>"
+    else:
+        row_end = min(size, row_start + max_rows)
+        # If we are not starting at the first row, add overflow
+        if row_start > 0:
+            html += _make_overflow_row(dict_of_variables, base_style,
+                                       hover_style)
+        for i in range(row_start, row_end):
+            html += "<tr {}>".format(hover_style)
+            html += _make_value_rows(dict_of_variables, is_bin_centers, i,
+                                     base_style, edge_style, row_start)
+            html += "</tr><tr {}>".format(hover_style)
+            # If there are bin edges, we need to add trailing cells
+            html += _make_trailing_cells(dict_of_variables, is_bin_centers, i,
+                                         row_end, base_style, edge_style)
+            html += "</tr>"
+        # If we are not ending at the last row, add overflow
+        if row_end != size:
+            html += _make_overflow_row(dict_of_variables, base_style,
+                                       hover_style)
+
+    html += "</table>"
+    return html
+
+
 def table(scipp_obj):
     """
     Create a html table from the contents of a Dataset (0D and 1D Variables
@@ -40,87 +207,39 @@ class TableViewer:
         self.trigger_update = True
 
         if is_dataset_or_array(scipp_obj):
-
             self.headers = 2
-
             if is_dataset(scipp_obj):
                 iterlist = scipp_obj.items()
             else:
                 iterlist = [(scipp_obj.name, scipp_obj)]
-
-            # First add the 1D coordinates
-            for dim, var in scipp_obj.coords.items():
-                if len(var.dims) == 1:
-                    key = str(dim)
-                    if key not in self.tabledict["1D Variables"]:
-                        self.tabledict["1D Variables"][key] = self.make_dict()
-                        self.sizes["1D Variables"][key] = []
-                        self.is_bin_centers["1D Variables"][
-                            key] = self.make_dict()
-                    self.is_bin_centers[group][key]["coords"][key] = False
-                    self.tabledict["1D Variables"][key]["coords"][key] = var
-                    self.sizes["1D Variables"][key].append(var.shape[0])
-
-            # Next add the labels
-            for name, lab in scipp_obj.labels.items():
-                ndims = len(lab.dims)
-                if ndims < 2:
-                    group = "{}D Variables".format(ndims)
-                    dim = lab.dims[0] if ndims == 1 else sc.Dim.Invalid
-                    key = str(dim)
-                    if key not in self.tabledict[group]:
-                        self.tabledict[group][key] = self.make_dict()
-                        self.is_bin_centers[group][key] = self.make_dict()
-                        self.sizes[group][key] = []
-                    self.is_bin_centers[group][key]["labels"][name] = False
-                    if dim in scipp_obj.coords:
-                        if scipp_obj.coords[dim].shape[0] == lab.shape[0] + 1:
-                            self.is_bin_centers[group][key]["labels"][
-                                name] = True
-
-                    self.tabledict[group][key]["labels"][name] = lab
-                    self.sizes[group][key].append(
-                        lab.shape[0] if ndims > 0 else None)
-
-            # Next add the masks
-            for name, mask in scipp_obj.masks.items():
-                ndims = len(mask.dims)
-                if ndims < 2:
-                    group = "{}D Variables".format(ndims)
-                    dim = mask.dims[0] if ndims == 1 else sc.Dim.Invalid
-                    key = str(dim)
-                    if key not in self.tabledict[group]:
-                        self.tabledict[group][key] = self.make_dict()
-                        self.is_bin_centers[group][key] = self.make_dict()
-                        self.sizes[group][key] = []
-                    self.is_bin_centers[group][key]["masks"][name] = False
-                    if dim in scipp_obj.coords:
-                        if scipp_obj.coords[dim].shape[0] == mask.shape[0] + 1:
-                            self.is_bin_centers[group][key]["masks"][
-                                name] = True
-                    self.tabledict[group][key]["masks"][name] = mask
-                    self.sizes[group][key].append(
-                        mask.shape[0] if ndims > 0 else None)
-
-            # Next add the data
-            for name, var in iterlist:
-                ndims = len(var.dims)
-                if ndims < 2:
-                    group = "{}D Variables".format(ndims)
-                    dim = var.dims[0] if ndims == 1 else sc.Dim.Invalid
-                    key = str(dim)
-                    if key not in self.tabledict[group]:
-                        self.tabledict[group][key] = self.make_dict()
-                        self.is_bin_centers[group][key] = self.make_dict()
-                        self.sizes[group][key] = []
-                    self.is_bin_centers[group][key]["data"][name] = False
-                    if dim in scipp_obj.coords:
-                        if scipp_obj.coords[dim].shape[0] == var.shape[0] + 1:
-                            self.is_bin_centers[group][key]["data"][
-                                name] = True
-                    self.tabledict[group][key]["data"][name] = var.data
-                    self.sizes[group][key].append(
-                        var.shape[0] if ndims > 0 else None)
+            # Note that capital 'D' is intentional on 'Data' to avoid the
+            # '.data' attribute of a DataArray being picked up
+            for field in ["coords", "labels", "masks", "Data"]:
+                if hasattr(scipp_obj, field):
+                    iter_items = getattr(scipp_obj, field).items()
+                else:
+                    iter_items = iterlist
+                for name, var in iter_items:
+                    ndims = len(var.dims)
+                    name_str = str(name)
+                    if ndims < 2:
+                        group = "{}D Variables".format(ndims)
+                        dim = var.dims[0] if ndims == 1 else sc.Dim.Invalid
+                        key = str(dim)
+                        if key not in self.tabledict[group]:
+                            self.tabledict[group][key] = self.make_dict()
+                            self.is_bin_centers[group][key] = self.make_dict()
+                            self.sizes[group][key] = []
+                        self.is_bin_centers[group][key][field][
+                            name_str] = False
+                        if dim in scipp_obj.coords:
+                            if scipp_obj.coords[dim].shape[
+                                    0] == var.shape[0] + 1:
+                                self.is_bin_centers[group][key][field][
+                                    name_str] = True
+                        self.tabledict[group][key][field][name_str] = var
+                        self.sizes[group][key].append(
+                            var.shape[0] if ndims > 0 else None)
 
         else:
 
@@ -136,8 +255,8 @@ class TableViewer:
                     key = " "
                     var = sc.Variable([sc.Dim.Row], values=scipp_obj)
 
-                self.tabledict[group][key] = {"data": {key: var}}
-                self.is_bin_centers[group][key] = {"data": {key: False}}
+                self.tabledict[group][key] = {"Data": {key: var}}
+                self.is_bin_centers[group][key] = {"Data": {key: False}}
                 self.sizes[group][key] = scipp_obj.shape
 
         # Get max size for each dim
@@ -177,7 +296,7 @@ class TableViewer:
 
                 children = []
                 for key, val in sorted(self.tabledict[group].items()):
-                    html = self.table_from_dict_of_variables(
+                    html = _table_from_dict_of_variables(
                         val,
                         is_bin_centers=self.is_bin_centers[group][key],
                         size=self.sizes[group][key],
@@ -211,7 +330,7 @@ class TableViewer:
         return
 
     def make_dict(self):
-        return {"coords": {}, "data": {}, "labels": {}, "masks": {}}
+        return {"coords": {}, "Data": {}, "labels": {}, "masks": {}}
 
     def make_hbox(self, group, key, size):
         hbox = self.tables[group][key]
@@ -255,172 +374,6 @@ class TableViewer:
                 ])
         return hbox
 
-    def make_table_sections(self, dict_of_variables, base_style):
-
-        html = ["<tr>"]
-        for key, section in dict_of_variables.items():
-
-            col_separators = 0
-            for var in section.values():
-                col_separators += 1 + (var.variances is not None)
-            if col_separators > 0:
-                style = "{} background-color: {};text-align: center;'".format(
-                    base_style, config.colors[key])
-                html.append("<th {} colspan='{}'>{}</th>".format(
-                    style, col_separators, key))
-
-        html.append("</tr>")
-
-        return "".join(html)
-
-    def make_table_unit_headers(self, dict_of_variables, text_style):
-        """
-        Adds a row containing the unit of the section
-        """
-        html = []
-        for key, section in dict_of_variables.items():
-            for name, val in section.items():
-                html.append("<th {} colspan='{}'>{}</th>".format(
-                    text_style, 1 + (val.variances is not None),
-                    name_with_unit(val, name=name)))
-        return "".join(html)
-
-    def make_table_subsections(self, dict_of_variables, text_style):
-        """
-        Adds Value | Variance columns for the section.
-        """
-        html = []
-        for key, section in dict_of_variables.items():
-            for name, val in section.items():
-                html.append("<th {}>Values</th>".format(text_style))
-                if val.variances is not None:
-                    html.append("<th {}>Variances</th>".format(text_style))
-        return "".join(html)
-
-    def make_value_rows(self, dict_of_variables, is_bin_centers, index,
-                        base_style, edge_style, row_start):
-        html = []
-        for key, section in dict_of_variables.items():
-            for name, val in section.items():
-                if is_bin_centers[key][name]:
-                    if index == row_start:
-                        html.append("<td {}></td>".format(edge_style))
-                        if val.variances is not None:
-                            html.append("<td {}></td>".format(edge_style))
-                else:
-                    html.append("<td rowspan='2' {}>{}</td>".format(
-                        base_style, value_to_string(val.values[index])))
-                    if val.variances is not None:
-                        html.append("<td rowspan='2' {}>{}</td>".format(
-                            base_style, value_to_string(val.variances[index])))
-
-        return "".join(html)
-
-    def make_trailing_cells(self, dict_of_variables, is_bin_centers, index,
-                            size, base_style, edge_style):
-        html = []
-        for key, section in dict_of_variables.items():
-            for name, val in section.items():
-                if is_bin_centers[key][name]:
-                    if index == size - 1:
-                        html.append("<td {}></td>".format(edge_style))
-                        if val.variances is not None:
-                            html.append("<td {}></td>".format(edge_style))
-                    else:
-                        html.append("<td rowspan='2' {}>{}</td>".format(
-                            base_style, value_to_string(val.values[index])))
-                        if val.variances is not None:
-                            html.append("<td rowspan='2' {}>{}</td>".format(
-                                base_style,
-                                value_to_string(val.variances[index])))
-
-        return "".join(html)
-
-    def make_overflow_row(self, dict_of_variables, base_style, hover_style):
-        html = ["<tr {}>".format(hover_style)]
-        for key, section in dict_of_variables.items():
-            for name, val in section.items():
-                html.append("<td {}>...</td>".format(base_style))
-                if val.variances is not None:
-                    html.append("<td {}>...</td>".format(base_style))
-
-        html.append("</tr>")
-        return "".join(html)
-
-    def table_from_dict_of_variables(
-            self,
-            dict_of_variables,
-            is_bin_centers=None,
-            # dim_key=None,
-            size=None,
-            headers=2,
-            row_start=0,
-            max_rows=None):
-        base_style = (
-            "style='border: 1px solid black; padding: 0px 5px 0px 5px; "
-            "text-align: right;")
-
-        mstyle = base_style + "text-align: center;"
-        vstyle = mstyle + "background-color: #f0f0f0;'"
-        mstyle += "'"
-        edge_style = (
-            "style='border: 0px solid white;background-color: #ffffff; "
-            "height:1.2em;'")
-        hover_style = (
-            "onMouseOver=\"this.style.backgroundColor='" +
-            config.colors["hover"] +
-            "'\" onMouseOut=\"this.style.backgroundColor='#ffffff'\"")
-
-        # Declare table
-        html = "<table style='border-collapse: collapse;'>"
-
-        if headers > 1:
-            html += self.make_table_sections(dict_of_variables, base_style)
-        if headers > 0:
-            html += "<tr {}>".format(hover_style)
-            html += self.make_table_unit_headers(dict_of_variables, mstyle)
-            html += "</tr><tr {}>".format(hover_style)
-            html += self.make_table_subsections(dict_of_variables, vstyle)
-            html += "</tr>"
-
-        # the base style still does not have a closing quote, so we add it here
-        base_style += "'"
-
-        if size is None:  # handle 0D variable
-            html += "<tr {}>".format(hover_style)
-            for key, section in dict_of_variables.items():
-                for name, val in section.items():
-                    html += "<td {}>{}</td>".format(base_style,
-                                                    value_to_string(val.value))
-                    if val.variances is not None:
-                        html += "<td {}>{}</td>".format(
-                            base_style, value_to_string(val.variance))
-            html += "</tr>"
-        else:
-            row_end = min(size, row_start + max_rows)
-            # If we are not starting at the first row, add overflow
-            if row_start > 0:
-                html += self.make_overflow_row(dict_of_variables, base_style,
-                                               hover_style)
-            for i in range(row_start, row_end):
-                html += "<tr {}>".format(hover_style)
-                html += self.make_value_rows(dict_of_variables, is_bin_centers,
-                                             i, base_style, edge_style,
-                                             row_start)
-                html += "</tr><tr {}>".format(hover_style)
-                # If there are bin edges, we need to add trailing cells
-                html += self.make_trailing_cells(dict_of_variables,
-                                                 is_bin_centers, i, row_end,
-                                                 base_style, edge_style)
-                html += "</tr>"
-            # If we are not ending at the last row, add overflow
-            if row_end != size:
-                html += self.make_overflow_row(dict_of_variables, base_style,
-                                               hover_style)
-
-        html += "</table>"
-        return html
-
     def update_slider(self, change):
         key = change["owner"].key
         group = change["owner"].group
@@ -432,7 +385,7 @@ class TableViewer:
         group = change["owner"].group
         index = self.sliders[key].max - self.sliders[key].value
         self.readouts[key].value = str(index)
-        html = self.table_from_dict_of_variables(
+        html = _table_from_dict_of_variables(
             self.tabledict[group][key],
             is_bin_centers=self.is_bin_centers[group][key],
             size=self.sizes[group][key],

--- a/python/src/scipp/utils.py
+++ b/python/src/scipp/utils.py
@@ -4,6 +4,7 @@
 # @author Neil Vaytet
 
 from ._scipp.core.units import dimensionless
+from ._scipp.core import Variable, VariableProxy, Dataset, DatasetProxy, DataArray, DataProxy
 
 
 def name_with_unit(var=None, name=None, log=False, replace_dim=True):
@@ -40,3 +41,31 @@ def value_to_string(val, precision=3):
         if len(text) > precision + 2 + (text[0] == '-'):
             text = "{val:.{prec}f}".format(val=val, prec=precision)
     return text
+
+
+def is_variable(obj):
+    """
+    Return True if the input is of type scipp.core.Variable.
+    """
+    return isinstance(obj, Variable) or isinstance(obj, VariableProxy)
+
+
+def is_dataset(obj):
+    """
+    Return True if the input is of type scipp.core.Variable.
+    """
+    return isinstance(obj, Dataset) or isinstance(obj, DatasetProxy)
+
+
+def is_data_array(obj):
+    """
+    Return True if the input is of type scipp.core.Variable.
+    """
+    return isinstance(obj, DataArray) or isinstance(obj, DataProxy)
+
+
+def is_dataset_or_array(obj):
+    """
+    Return True if the input object is either a Dataset or DataArray.
+    """
+    return is_dataset(obj) or is_data_array(obj)


### PR DESCRIPTION
The new implementation of `table` (#907) was very slow to render when a large number of rows was present in the data (~30s to render the table for 3M rows), even if only a small subset of the rows was being displayed.

This came from the use of an `SelectionSlider` whose array of `options` was being converted to strings.

This new implementation changes many things and the diff might be difficult to follow. At the same time as replacing the `SelectionSlider` with a `IntSlider`, we are now no longer copying `Variables` into a new `Dataset` when constructing the table columns. Instead, we store the `Variables` into a `dict` of `Variables`.

**Reviewer:** make sure to test on your machine with a few cases. Some slow-down is apparent when displaying ~200 rows and more, since the update of the table is now continuous with the slider movement (this is a biproduct of having to use a `IntSlider` which cannot be flipped to be top to bottom like a scrollbar, and therefore needs an additional `Label` widget to display the starting row index).

To test: try the following or a variant
```Py
d = sc.Dataset()
d.coords[Dim.Position] = sc.Variable([Dim.Position], values=np.arange(10.0), variances=np.random.rand(10))
d.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(11))
d.coords[Dim.Y] = sc.Variable([Dim.Y], values=np.arange(12))
d.labels["sample"] = sc.Variable([Dim.Position], values=np.arange(9))
d.labels["eee"] = sc.Variable([Dim.Position], values=np.arange(10))
d.masks["eee"] = sc.Variable([Dim.Position], values=np.zeros([10]))
d['sample'] = sc.Variable([Dim.Position], values=np.arange(10))
d['sample2'] = sc.Variable([Dim.Position], values=np.arange(9.0), variances=np.random.rand(9))
d['Xaa'] = sc.Variable([Dim.X], values=np.arange(10))
d['scalar'] = sc.Variable(1.5)
d['scalarAndVar'] = sc.Variable(21.5, variance=0.56)
d.labels["kkk"] = sc.Variable(91.5, variance=0.56)
sc.table(d)
sc.table(d["sample"])
sc.table(d["sample"].data)
sc.table(d["sample"].data.values)
```
and with a large number of rows:
```Py
d = sc.Dataset()
N = 20000
d.coords[Dim.Tof] = sc.Variable([Dim.Tof], values=np.arange(N).astype(np.float64),
                                unit=sc.units.us)
d.coords[Dim.X] = sc.Variable([Dim.X], values=np.arange(N).astype(np.float64),
                                unit=sc.units.m)
d['Sample'] = sc.Variable([Dim.Tof], values=10.0*np.random.rand(N),
                          unit=sc.units.counts, variances=np.random.rand(N))
d['Background'] = sc.Variable([Dim.Tof], values=10.0*np.random.rand(N-1),
                          unit=sc.units.counts)
d['hitme'] = sc.Variable([Dim.Tof], values=10.0*np.random.rand(N),
                          unit=sc.units.counts)
d['weight'] = sc.Variable([Dim.X], values=10.0*np.random.rand(N),
                          unit=sc.units.kg)
sc.table(d)
```