### PR TITLE
Sparse - histogram operations fix

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -19,6 +19,14 @@ target_link_libraries(histogram_benchmark
                       scipp-core
                       scipp_test_helpers)
 
+add_executable(sparse_histogram_op_benchmark EXCLUDE_FROM_ALL sparse_histogram_op_benchmark.cpp)
+add_dependencies(all-benchmarks sparse_histogram_op_benchmark)
+target_link_libraries(sparse_histogram_op_benchmark
+                      LINK_PRIVATE
+                      benchmark
+                      scipp-core
+                      scipp_test_helpers)
+
 add_executable(neutron_convert_benchmark EXCLUDE_FROM_ALL neutron_convert_benchmark.cpp)
 add_dependencies(all-benchmarks neutron_convert_benchmark)
 target_link_libraries(neutron_convert_benchmark

--- a/benchmark/sparse_histogram_op_benchmark.cpp
+++ b/benchmark/sparse_histogram_op_benchmark.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+/// @file
+#include <numeric>
+
+#include <benchmark/benchmark.h>
+
+#include "random.h"
+
+#include "scipp/core/dataset.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+auto make_2d_sparse_coord(const scipp::index size, const scipp::index count) {
+  auto var = makeVariable<double>(Dims{Dim::X, Dim::Y},
+                                  Shape{size, Dimensions::Sparse});
+  auto vals = var.sparseValues<double>();
+  Random rand(0.0, 1000.0);
+  for (scipp::index i = 0; i < size; ++i) {
+    auto data = rand(count);
+    vals[i].assign(data.begin(), data.end());
+  }
+  return var;
+}
+
+auto make_2d_sparse_coord_only(const scipp::index size,
+                               const scipp::index count) {
+  return DataArray(std::nullopt, {{Dim::Y, make_2d_sparse_coord(size, count)}});
+}
+
+auto make_2d_sparse(const scipp::index size, const scipp::index count) {
+  auto coord = make_2d_sparse_coord(size, count);
+  auto data = coord * makeVariable<double>(Values{0.0}, Variances{0.0}) + 1.0;
+
+  return DataArray(std::move(data), {{Dim::Y, std::move(coord)}});
+}
+
+auto make_histogram(const scipp::index nEdge) {
+  std::vector<double> edges_(nEdge);
+  std::iota(edges_.begin(), edges_.end(), 0.0);
+  auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{nEdge},
+                                    Values(edges_.begin(), edges_.end()));
+  edges *= 1000.0 / nEdge; // ensure all events are in range
+
+  return DataArray(makeVariable<double>(Dims{Dim::Y}, Shape{nEdge - 1},
+                                        Values{}, Variances{}),
+                   {{Dim::Y, std::move(edges)}});
+}
+
+// For comparison: How fast could memory for events be allocated if it were in a
+// single packed array (as opposed to many small vectors).
+static void BM_dense_alloc_baseline(benchmark::State &state) {
+  const scipp::index total_events = state.range(0);
+  for (auto _ : state) {
+    std::vector<double> vals(total_events);
+    std::vector<double> vars(total_events);
+  }
+  state.SetItemsProcessed(state.iterations() * total_events);
+  int write_data = 2; // values and variances
+  state.SetBytesProcessed(state.iterations() * write_data * total_events *
+                          sizeof(double));
+  state.counters["total_events"] = total_events;
+}
+
+BENCHMARK(BM_dense_alloc_baseline)->RangeMultiplier(4)->Ranges({{64, 2 << 20}});
+
+static void BM_sparse_histogram_op(benchmark::State &state) {
+  const scipp::index nEvent = state.range(0);
+  const scipp::index nEdge = state.range(1);
+  const bool inplace = state.range(2);
+  const scipp::index nHist = 2e7 / nEvent;
+  const bool data = state.range(3);
+  const auto sparse = data ? make_2d_sparse(nHist, nEvent)
+                           : make_2d_sparse_coord_only(nHist, nEvent);
+  const auto histogram = make_histogram(nEdge);
+  for (auto _ : state) {
+    if (inplace) {
+      state.PauseTiming();
+      auto sparse_ = sparse;
+      state.ResumeTiming();
+      sparse_ *= histogram;
+    } else {
+      static_cast<void>(sparse * histogram);
+    }
+  }
+  scipp::index total_events = nHist * nEvent;
+  state.SetItemsProcessed(state.iterations() * total_events);
+  int read_coord = 1;
+  int read_data = data ? 2 : 0; // values and variances
+  int write_data = 2;           // values and variances
+  state.SetBytesProcessed(state.iterations() *
+                          (read_coord + read_data + write_data) * total_events *
+                          sizeof(double));
+  state.counters["sparse-with-data"] = data;
+  state.counters["total_events"] = total_events;
+  state.counters["inplace"] = inplace;
+}
+
+// Params are:
+// - nEvent
+// - nEdge
+// - inplace
+// - sparse with data
+BENCHMARK(BM_sparse_histogram_op)
+    ->RangeMultiplier(4)
+    ->Ranges({{64, 2 << 14}, {128, 2 << 11}, {true, false}, {true, false}});
+
+BENCHMARK_MAIN();

--- a/core/data_array.cpp
+++ b/core/data_array.cpp
@@ -120,7 +120,7 @@ namespace sparse_dense_op_impl_detail {
 template <class Coord, class Data, class Edge, class Weight>
 using args = std::tuple<sparse_container<Coord>, span<const Data>,
                         span<const Edge>, span<const Weight>>;
-}
+} // namespace sparse_dense_op_impl_detail
 
 template <int ImplicitData, class Op>
 Variable sparse_dense_op_impl(Op op, const VariableConstProxy &sparseCoord_,

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -813,6 +813,16 @@ template <class... TypeTuples, class Op>
                                var3);
     }
 
+/// Transform the data elements of four variables and return a new Variable.
+template <class... TypeTuples, class Op>
+[[nodiscard]] Variable
+    transform(const VariableConstProxy &var1, const VariableConstProxy &var2,
+              const VariableConstProxy &var3, const VariableConstProxy &var4,
+              Op op) {
+      return detail::transform(std::tuple_cat(TypeTuples{}...), op, var1, var2,
+                               var3, var4);
+    }
+
 } // namespace scipp::core
 
 #endif // SCIPP_CORE_TRANSFORM_H

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -496,9 +496,6 @@ private:
 /// in certain classes.
 /// Example: makeVariable<float>(units::Unit(units::kg),
 /// Shape{1, 2}, Dims{Dim::X, Dim::Y}, Values({3, 4})).
-
-// The name should be changed to makeVariable after refactoring:
-// getting rid of all other makeVariable.
 template <class T, class... Ts> Variable makeVariable(Ts &&... ts) {
   using helper = detail::ConstructorArgumentsMatcher<Variable, Ts...>;
   constexpr bool useDimsAndShape =

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -54,6 +54,15 @@ auto make_histogram() {
   return DataArray(data, {{Dim::X, edges}});
 }
 
+auto make_histogram_no_variance() {
+  auto edges =
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
+                           units::Unit(units::us), Values{0, 2, 4, 1, 3, 5});
+  auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2.0, 3.0});
+
+  return DataArray(data, {{Dim::X, edges}});
+}
+
 TEST(DataArraySparseArithmeticTest, fail_sparse_op_non_histogram) {
   const auto sparse = make_sparse();
   auto coord = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
@@ -91,6 +100,34 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram) {
                              Variances{1, 1, 1, 1}) *
         makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{2.0, 2.0, 3.0, 0.0},
                              Variances{0.3, 0.3, 0.4, 0.0});
+    EXPECT_TRUE(equals(out_vals[1], expected.values<double>()));
+    EXPECT_TRUE(equals(out_vars[1], expected.variances<double>()));
+  }
+  EXPECT_EQ(copy(sparse) *= hist, sparse * hist);
+}
+
+TEST(DataArraySparseArithmeticTest, sparse_times_histogram_without_variances) {
+  const auto sparse = make_sparse();
+  auto hist = make_histogram_no_variance();
+
+  for (const auto result : {sparse * hist, hist * sparse}) {
+    EXPECT_EQ(result.coords()[Dim::X], sparse.coords()[Dim::X]);
+    EXPECT_TRUE(result.hasVariances());
+
+    const auto out_vals = result.data().sparseValues<double>();
+    const auto out_vars = result.data().sparseVariances<double>();
+
+    auto expected =
+        makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 1, 1},
+                             Variances{1, 1, 1}) *
+        makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{2.0, 3.0, 3.0});
+    EXPECT_TRUE(equals(out_vals[0], expected.values<double>()));
+    EXPECT_TRUE(equals(out_vars[0], expected.variances<double>()));
+    // out of range of edges -> value set to 0, consistent with rebin behavior
+    expected = makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 1, 1, 1},
+                                    Variances{1, 1, 1, 1}) *
+               makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                    Values{2.0, 2.0, 3.0, 0.0});
     EXPECT_TRUE(equals(out_vals[1], expected.values<double>()));
     EXPECT_TRUE(equals(out_vars[1], expected.variances<double>()));
   }

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -83,6 +83,7 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram) {
   for (const auto result : {sparse * hist, hist * sparse}) {
     EXPECT_EQ(result.coords()[Dim::X], sparse.coords()[Dim::X]);
     EXPECT_TRUE(result.hasVariances());
+    EXPECT_EQ(result.unit(), units::counts);
 
     const auto out_vals = result.data().sparseValues<double>();
     const auto out_vars = result.data().sparseVariances<double>();
@@ -113,6 +114,7 @@ TEST(DataArraySparseArithmeticTest, sparse_times_histogram_without_variances) {
   for (const auto result : {sparse * hist, hist * sparse}) {
     EXPECT_EQ(result.coords()[Dim::X], sparse.coords()[Dim::X]);
     EXPECT_TRUE(result.hasVariances());
+    EXPECT_EQ(result.unit(), units::counts);
 
     const auto out_vals = result.data().sparseValues<double>();
     const auto out_vars = result.data().sparseVariances<double>();
@@ -146,6 +148,7 @@ TEST(DataArraySparseArithmeticTest, sparse_with_values_times_histogram) {
   for (const auto result : {sparse * hist, hist * sparse}) {
     EXPECT_EQ(result.coords()[Dim::X], sparse.coords()[Dim::X]);
     EXPECT_TRUE(result.hasVariances());
+    EXPECT_EQ(result.unit(), units::counts);
     const auto out_vals = result.data().sparseValues<double>();
     const auto out_vars = result.data().sparseVariances<double>();
 
@@ -174,6 +177,7 @@ TEST(DataArraySparseArithmeticTest, sparse_over_histogram) {
   const auto result = sparse / hist;
   EXPECT_EQ(result.coords()[Dim::X], sparse.coords()[Dim::X]);
   EXPECT_TRUE(result.hasVariances());
+  EXPECT_EQ(result.unit(), units::counts);
   const auto out_vals = result.data().sparseValues<double>();
   const auto out_vars = result.data().sparseVariances<double>();
 


### PR DESCRIPTION
Fix #918.

Also adds benchmarks. Note that the current implementation is suboptimal if the sparse array has explicit data. Due to the amount of code that would need to be duplicated I did not handle this case separately though, until we have real-life applications where this is a bottleneck.