### PR TITLE
Appveyor build feature branch only with PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ cache: C:\Users\appveyor\clcache -> appveyor.yml
 
 init:
 # For branches not associated with a PR - we exit appveyor
+- echo pr title %APPVEYOR_PULL_REQUEST_TITLE%
 - ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,7 @@ cache: C:\Users\appveyor\clcache -> appveyor.yml
 init:
 # For branches not associated with a PR - we exit appveyor
 - echo pr title %APPVEYOR_PULL_REQUEST_TITLE%
-- echo %APPVEYOR_PULL_REQUEST_NUMBER%
-- echo %APPVEYOR_PULL_REQUEST_TITLE%
-- echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%
-- echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
+- echo %APPVEYOR_REPO_BRANCH%
 - ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,13 @@ environment:
   
 cache: C:\Users\appveyor\clcache -> appveyor.yml
 
-init:
+
+install:
 # For branches not associated with a PR - we exit appveyor
 - git config --add remote.origin.fetch +refs/pull/*/head:refs/remotes/origin/pull/*
 - git fetch origin
 - git branch --remote --contains HEAD | FIND /C "origin/pull"
 - ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
-
-install:
 - echo install started %time%
 - cd %APPVEYOR_BUILD_FOLDER%
 - git submodule update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ environment:
   
 cache: C:\Users\appveyor\clcache -> appveyor.yml
 
+init:
+# For branches not associated with a PR - we exit appveyor
+- ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
+
 install:
 - echo install started %time%
 - cd %APPVEYOR_BUILD_FOLDER%
@@ -55,6 +59,9 @@ for:
   branches:
       only:
          - master
+
+  init:
+  - echo skipping init checks
   
   build_script:
   # Build step would take too long

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,9 @@ cache: C:\Users\appveyor\clcache -> appveyor.yml
 
 init:
 # For branches not associated with a PR - we exit appveyor
-- echo pr title %APPVEYOR_PULL_REQUEST_TITLE%
-- echo %APPVEYOR_REPO_BRANCH%
+- git config --add remote.origin.fetch +refs/pull/*/head:refs/remotes/origin/pull/*
+- git fetch origin
+- git branch --remote --contains HEAD | FIND /C "origin/pull"
 - ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,10 @@ cache: C:\Users\appveyor\clcache -> appveyor.yml
 init:
 # For branches not associated with a PR - we exit appveyor
 - echo pr title %APPVEYOR_PULL_REQUEST_TITLE%
+- echo %APPVEYOR_PULL_REQUEST_NUMBER%
+- echo %APPVEYOR_PULL_REQUEST_TITLE%
+- echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%
+- echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
 - ps: if (!$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
 
 install:


### PR DESCRIPTION
Appveyor allows `Do not build feature branches with open Pull Requests` but does not seem to allow prevention of building feature branches without open PR. We do not want to build every feature branch, only those with an associated PR.

**WIP**