### PR TITLE
Fix Windows HTML tests

### DIFF
--- a/python/tests/table_html/common.py
+++ b/python/tests/table_html/common.py
@@ -157,9 +157,11 @@ def _assert_section_multiple(section,
         f"Unexpected number of name tags found: {len(name_html)}."\
         f"Expected: {len(name)}"
 
+    names = [html.text for html in name_html]
+
+    # assert that the name is present in the currently visible variables
     for n in name:
-        assert str(n) in name_html[
-            0].text, f"Did not find {str(n)} in {name_html[0].text}"
+        assert str(n) in names
 
     dims_html = section.find_all(class_=DIMS_CSS_CLASS)
     for dim, sparse, bin_edges in zip(dims, has_sparse, has_bin_edges):

--- a/python/tests/table_html/common.py
+++ b/python/tests/table_html/common.py
@@ -158,7 +158,8 @@ def _assert_section_multiple(section,
         f"Expected: {len(name)}"
 
     for n in name:
-        assert str(n) in name_html[0].text
+        assert str(n) in name_html[
+            0].text, f"Did not find {str(n)} in {name_html[0].text}"
 
     dims_html = section.find_all(class_=DIMS_CSS_CLASS)
     for dim, sparse, bin_edges in zip(dims, has_sparse, has_bin_edges):


### PR DESCRIPTION
Adjusts the common assert function so that the name isn't position dependent. Now checks if the name is present at all (we don't really care about the position anyway)