### PR TITLE
Run and Sample extract for Mantid Compatibility

### DIFF
--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -385,21 +385,23 @@ def test_to_workspace_2d(param_dim):
     def test_set_run(self):
         import mantid.simpleapi as mantid
         target = mantid.CloneWorkspace(self.base_event_ws)
-        from mantid.api import Run
-        run = Run()
         d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
         d.attrs["run"].value.addProperty("test_property", 1, True)
+        # before
+        self.assertFalse(target.run().hasProperty("test_property"))
         mantidcompat.extract_run_to_workspace(d, target)
-        target.run().hasProperty("test_property")
+        # after
+        self.assertTrue(target.run().hasProperty("test_property"))
 
     def test_set_sample(self):
         import mantid.simpleapi as mantid
         target = mantid.CloneWorkspace(self.base_event_ws)
-        from mantid.api import Run, Sample
-        run = Run()
         d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
         d.attrs["sample"].value.setThickness(3)
+        # before
+        self.assertNotEqual(3, target.sample().getThickness())
         mantidcompat.extract_sample_to_workspace(d, target)
+        # after
         self.assertEqual(3, target.sample().getThickness())
 
 

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -389,7 +389,7 @@ def test_to_workspace_2d(param_dim):
         d.attrs["run"].value.addProperty("test_property", 1, True)
         # before
         self.assertFalse(target.run().hasProperty("test_property"))
-        mantidcompat.extract_run_to_workspace(d, target)
+        target.setRun(d.attrs["run"].value)
         # after
         self.assertTrue(target.run().hasProperty("test_property"))
 
@@ -400,7 +400,7 @@ def test_to_workspace_2d(param_dim):
         d.attrs["sample"].value.setThickness(3)
         # before
         self.assertNotEqual(3, target.sample().getThickness())
-        mantidcompat.extract_sample_to_workspace(d, target)
+        target.setSample(d.attrs["sample"].value)
         # after
         self.assertEqual(3, target.sample().getThickness())
 

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -382,6 +382,26 @@ def test_to_workspace_2d(param_dim):
         np.testing.assert_array_equal(ws.readE(i), y[Dim.Spectrum,
                                                      i].variances)
 
+    def test_set_run(self):
+        import mantid.simpleapi as mantid
+        target = mantid.CloneWorkspace(self.base_event_ws)
+        from mantid.api import Run
+        run = Run()
+        d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
+        d.attrs["run"].value.addProperty("test_property", 1, True)
+        mantidcompat.extract_run_to_workspace(d, target)
+        target.run().hasProperty("test_property")
+
+    def test_set_sample(self):
+        import mantid.simpleapi as mantid
+        target = mantid.CloneWorkspace(self.base_event_ws)
+        from mantid.api import Run, Sample
+        run = Run()
+        d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
+        d.attrs["sample"].value.setThickness(3)
+        mantidcompat.extract_sample_to_workspace(d, target)
+        self.assertEqual(3, target.sample().getThickness())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This will not work without [this](https://github.com/mantidproject/mantid/pull/27831) mantid PR being merged first.

Add `extract_run_to_workspace` and `extract_sample_to_workspace` methods. Not 100% sure how this is intended to be used within the DREAM workflow.