### PR TITLE
Multi-threading with TBB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ include(pybind11)
 include(GoogleBenchmark)
 include(GenerateExportHeader)
 find_package(Boost 1.67 REQUIRED)
+find_package(TBB REQUIRED CONFIG)
+
 
 if("${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" VERSION_LESS "3.5")
   message(FATAL_ERROR "Python v3 interpreter must be greater than or equal to 3.5. Found ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 option(WITH_CTEST "Enable ctest integration of tests" ON)
 option(DYNAMIC_LIB "Build shared libraries" OFF)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT result OUTPUT output)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ include(pybind11)
 include(GoogleBenchmark)
 include(GenerateExportHeader)
 find_package(Boost 1.67 REQUIRED)
-find_package(TBB REQUIRED CONFIG)
+find_package(TBB CONFIG)
+if(TBB_FOUND)
+  configure_file(core/include/scipp/core/parallel-tbb.h core/include/scipp/core/parallel.h COPYONLY)
+else()
+  configure_file(core/include/scipp/core/parallel-fallback.h core/include/scipp/core/parallel.h COPYONLY)
+endif()
 
 
 if("${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" VERSION_LESS "3.5")

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -11,14 +11,17 @@ requirements:
     - cmake
     - gxx_linux-64 7.3.* [linux64]
     - git
-    - python {{ python }}
     - ninja
+    - python {{ python }}
+    - tbb
+    - tbb-devel
   run:
     - numpy {{ numpy }}
     - python {{ python }}
     - appdirs
     - python-configuration
     - pyyaml
+    - tbb
 
 test:
   import:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -55,7 +55,7 @@ endif(DYNAMIC_LIB)
 add_library(${TARGET_NAME} ${LINK_TYPE} ${INC_FILES} ${SRC_FILES})
 generate_export_header(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME}
-                      PUBLIC scipp-common scipp-units Boost::boost)
+                      PUBLIC scipp-common scipp-units Boost::boost TBB::tbb)
 # Include tcb/span as system header to avoid compiler warnings.
 target_include_directories(
   ${TARGET_NAME} SYSTEM

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -55,7 +55,11 @@ endif(DYNAMIC_LIB)
 add_library(${TARGET_NAME} ${LINK_TYPE} ${INC_FILES} ${SRC_FILES})
 generate_export_header(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME}
-                      PUBLIC scipp-common scipp-units Boost::boost TBB::tbb)
+                      PUBLIC scipp-common scipp-units Boost::boost)
+if(TBB_FOUND)
+  target_link_libraries(${TARGET_NAME} PUBLIC TBB::tbb)
+endif()
+
 # Include tcb/span as system header to avoid compiler warnings.
 target_include_directories(
   ${TARGET_NAME} SYSTEM
@@ -67,6 +71,7 @@ target_include_directories(
   ${TARGET_NAME}
   PUBLIC $<INSTALL_INTERFACE:include>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
          ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${TARGET_NAME} SYSTEM
                            PUBLIC ${CMAKE_BINARY_DIR}/Eigen-src)

--- a/core/groupby.cpp
+++ b/core/groupby.cpp
@@ -4,12 +4,11 @@
 /// @author Simon Heybrock
 #include <numeric>
 
-#include "tbb/parallel_for.h"
-
 #include "scipp/core/except.h"
 #include "scipp/core/groupby.h"
 #include "scipp/core/histogram.h"
 #include "scipp/core/indexed_slice_view.h"
+#include "scipp/core/parallel.h"
 #include "scipp/core/tag_util.h"
 
 #include "dataset_operations_common.h"
@@ -48,8 +47,7 @@ T GroupBy<T>::reduce(Op op, const Dim reductionDim) const {
       }
     }
   };
-  tbb::parallel_for(tbb::blocked_range<scipp::index>(0, size()),
-                    process_groups);
+  parallel::parallel_for(parallel::blocked_range(0, size()), process_groups);
   return out;
 }
 

--- a/core/include/scipp/core/element_array.h
+++ b/core/include/scipp/core/element_array.h
@@ -115,15 +115,7 @@ public:
   ///
   /// Unlike std::vector::resize, this does *not* preserve existing element
   /// values.
-  void resize(const scipp::index new_size) {
-    if (new_size == 0) {
-      m_data.reset();
-      m_size = 0;
-    } else {
-      m_data = std::make_unique<T[]>(new_size);
-      m_size = new_size;
-    }
-  }
+  void resize(const scipp::index new_size) { *this = element_array(new_size); }
 
   /// Resize with default-initialized elements. Use with care.
   void resize(const scipp::index new_size, const default_init_elements_t &) {

--- a/core/include/scipp/core/parallel-fallback.h
+++ b/core/include/scipp/core/parallel-fallback.h
@@ -5,17 +5,28 @@
 #ifndef SCIPP_CORE_PARALLEL_H
 #define SCIPP_CORE_PARALLEL_H
 
-#include <tbb/parallel_for.h>
-
 #include "scipp/common/index.h"
 
-/// Wrappers for multi-threading using TBB.
+/// Fallback wrappers without actual threading, in case TBB is not available.
 namespace scipp::core::parallel {
 
-using blocked_range = tbb::blocked_range<scipp::index>;
+class blocked_range {
+public:
+  constexpr blocked_range(const scipp::index begin, const scipp::index end,
+                          const scipp::index grainsize = 1) noexcept
+      : m_begin(begin), m_end(end) {
+    static_cast<void>(grainsize);
+  }
+  constexpr scipp::index begin() const noexcept { return m_begin; }
+  constexpr scipp::index end() const noexcept { return m_end; }
 
-template <class... Args> void parallel_for(Args &&... args) {
-  tbb::parallel_for(std::forward<Args>(args)...);
+private:
+  scipp::index m_begin;
+  scipp::index m_end;
+};
+
+template <class Op> void parallel_for(const blocked_range &range, Op &&op) {
+  op(range);
 }
 
 } // namespace scipp::core::parallel

--- a/core/include/scipp/core/parallel-fallback.h
+++ b/core/include/scipp/core/parallel-fallback.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_PARALLEL_H
+#define SCIPP_CORE_PARALLEL_H
+
+#include <tbb/parallel_for.h>
+
+#include "scipp/common/index.h"
+
+/// Wrappers for multi-threading using TBB.
+namespace scipp::core::parallel {
+
+using blocked_range = tbb::blocked_range<scipp::index>;
+
+template <class... Args> void parallel_for(Args &&... args) {
+  tbb::parallel_for(std::forward<Args>(args)...);
+}
+
+} // namespace scipp::core::parallel
+
+#endif // SCIPP_CORE_PARALLEL_H

--- a/core/include/scipp/core/parallel-tbb.h
+++ b/core/include/scipp/core/parallel-tbb.h
@@ -5,28 +5,17 @@
 #ifndef SCIPP_CORE_PARALLEL_H
 #define SCIPP_CORE_PARALLEL_H
 
+#include <tbb/parallel_for.h>
+
 #include "scipp/common/index.h"
 
-/// Fallback wrappers without actual threading, in case TBB is not available.
+/// Wrappers for multi-threading using TBB.
 namespace scipp::core::parallel {
 
-class blocked_range {
-public:
-  constexpr blocked_range(const scipp::index begin, const scipp::index end,
-                          const scipp::index grainsize = 1) noexcept
-      : m_begin(begin), m_end(end) {
-    static_cast<void>(grainsize);
-  }
-  constexpr scipp::index begin() const noexcept { return m_begin; }
-  constexpr scipp::index end() const noexcept { return m_end; }
+using blocked_range = tbb::blocked_range<scipp::index>;
 
-private:
-  scipp::index m_begin;
-  scipp::index m_end;
-};
-
-template <class Op> void parallel_for(const blocked_range &range, Op &&op) {
-  op(range);
+template <class... Args> void parallel_for(Args &&... args) {
+  tbb::parallel_for(std::forward<Args>(args)...);
 }
 
 } // namespace scipp::core::parallel

--- a/core/include/scipp/core/parallel-tbb.h
+++ b/core/include/scipp/core/parallel-tbb.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_CORE_PARALLEL_H
+#define SCIPP_CORE_PARALLEL_H
+
+#include "scipp/common/index.h"
+
+/// Fallback wrappers without actual threading, in case TBB is not available.
+namespace scipp::core::parallel {
+
+class blocked_range {
+public:
+  constexpr blocked_range(const scipp::index begin, const scipp::index end,
+                          const scipp::index grainsize = 1) noexcept
+      : m_begin(begin), m_end(end) {
+    static_cast<void>(grainsize);
+  }
+  constexpr scipp::index begin() const noexcept { return m_begin; }
+  constexpr scipp::index end() const noexcept { return m_end; }
+
+private:
+  scipp::index m_begin;
+  scipp::index m_end;
+};
+
+template <class Op> void parallel_for(const blocked_range &range, Op &&op) {
+  op(range);
+}
+
+} // namespace scipp::core::parallel
+
+#endif // SCIPP_CORE_PARALLEL_H

--- a/core/include/scipp/core/parallel-tbb.h
+++ b/core/include/scipp/core/parallel-tbb.h
@@ -12,7 +12,17 @@
 /// Wrappers for multi-threading using TBB.
 namespace scipp::core::parallel {
 
-using blocked_range = tbb::blocked_range<scipp::index>;
+auto blocked_range(const scipp::index begin, const scipp::index end,
+                   const scipp::index grainsize = -1) {
+  // TBB's default grain-size is 1, which is probably quite inefficient in
+  // some cases, in particular given the slow random-access of ViewIndex. A
+  // good default value is not known right now. In practice this should also
+  // depend heavily on whether we are processing small elements like `double`
+  // or something large like `sparse_container<double>`.
+  return tbb::blocked_range<scipp::index>(
+      begin, end,
+      grainsize == -1 ? std::max(1l, (end - begin) / 24) : grainsize);
+}
 
 template <class... Args> void parallel_for(Args &&... args) {
   tbb::parallel_for(std::forward<Args>(args)...);

--- a/core/include/scipp/core/parallel-tbb.h
+++ b/core/include/scipp/core/parallel-tbb.h
@@ -12,8 +12,8 @@
 /// Wrappers for multi-threading using TBB.
 namespace scipp::core::parallel {
 
-auto blocked_range(const scipp::index begin, const scipp::index end,
-                   const scipp::index grainsize = -1) {
+inline auto blocked_range(const scipp::index begin, const scipp::index end,
+                          const scipp::index grainsize = -1) {
   // TBB's default grain-size is 1, which is probably quite inefficient in
   // some cases, in particular given the slow random-access of ViewIndex. A
   // good default value is not known right now. In practice this should also

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -23,10 +23,9 @@
 #ifndef SCIPP_CORE_TRANSFORM_H
 #define SCIPP_CORE_TRANSFORM_H
 
-#include "tbb/parallel_for.h"
-
 #include "scipp/common/overloaded.h"
 #include "scipp/core/except.h"
+#include "scipp/core/parallel.h"
 #include "scipp/core/transform_common.h"
 #include "scipp/core/value_and_variance.h"
 #include "scipp/core/values_and_variances.h"
@@ -245,8 +244,8 @@ static void transform_elements(Op op, Out &&out, Ts &&... other) {
       iter::advance(end, range.end());
       run(indices, std::get<0>(end));
     };
-    tbb::parallel_for(tbb::blocked_range<scipp::index>(0, out.size()),
-                      run_parallel);
+    parallel::parallel_for(parallel::blocked_range(0, out.size()),
+                           run_parallel);
   }
 }
 
@@ -564,8 +563,8 @@ template <bool dry_run> struct in_place {
           iter::advance(end, range.end());
           run(indices, std::get<0>(end));
         };
-        tbb::parallel_for(tbb::blocked_range<scipp::index>(0, arg.size()),
-                          run_parallel);
+        parallel::parallel_for(parallel::blocked_range(0, arg.size()),
+                               run_parallel);
       }
     }
   }

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -57,6 +57,8 @@ public:
     return m_fullIndex != other.m_fullIndex;
   }
 
+  constexpr bool has_stride_zero() const noexcept { return m_dims > m_subdims; }
+
 private:
   // NOTE:
   // We investigated different containers for the m_delta, m_coord & m_extent

--- a/core/variable_operations_common.h
+++ b/core/variable_operations_common.h
@@ -11,7 +11,7 @@ namespace scipp::core {
 
 // Helpers for in-place reductions and reductions with groupby.
 void flatten_impl(const VariableProxy &summed, const VariableConstProxy &var,
-                  const Variable &mask = makeVariable<bool>(Values{false}));
+                  const VariableConstProxy &mask);
 void sum_impl(const VariableProxy &summed, const VariableConstProxy &var);
 void all_impl(const VariableProxy &out, const VariableConstProxy &var);
 void any_impl(const VariableProxy &out, const VariableConstProxy &var);


### PR DESCRIPTION
Add multi-threading based on `tbb::parallel_for`.

- Covering `transform`, `transform_in_place`, `groupby`, and copy operations.
- Not covering `transform_in_place` for reduction operations.
- Probably some other bits that are not covered, such as copy operations from Python.
- Also includes some refactor in `groupby.cpp`, reducing code duplication (threading has to be added only in 1 place).

Note that `cmake` is setup to link to TBB only if found. For now we are not adding any explicit config for this. When building in a conda env, install `tbb` and `tbb-devel` from `conda-forge` to make it work out-of-the box.

Note that the build servers do *not* have TBB installed right now, so the tests are not running with multi-threading. I'd ask the reviewers to install conda themselves to give this a try (run tests, etc.).

Fixes #811.