### PR TITLE
Fix some Workspace "leaks" in Mantid compat layer

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -16,25 +16,28 @@ from .._scipp import core as sc
 def run_mantid_alg(alg, *args, **kwargs):
     try:
         from mantid import simpleapi as mantid
-        from mantid.api import Workspace
+        from mantid.api import AnalysisDataService
     except ImportError:
         raise ImportError(
             "Mantid Python API was not found, please install Mantid framework "
             "as detailed in the installation instructions (https://scipp."
             "readthedocs.io/en/latest/getting-started/installation.html)")
+    # Deal with multiple calls to this function, which may have conflicting
+    # names in the global AnalysisDataService.
     run_mantid_alg.workspace_id += 1
-    ws = getattr(mantid, alg)(
-        OutputWorkspace=f'scipp.run_mantid_alg.{run_mantid_alg.workspace_id}',
-        *args,
-        **kwargs)
+    ws_name = f'scipp.run_mantid_alg.{run_mantid_alg.workspace_id}'
+    # Deal with non-standard ways to define the prefix of output workspaces
+    if alg == 'Fit':
+        kwargs['Output'] = ws_name
+    else:
+        kwargs['OutputWorkspace'] = ws_name
+    ws = getattr(mantid, alg)(*args, **kwargs)
     try:
         yield ws
     finally:
-        if isinstance(ws, Workspace):
-            mantid.DeleteWorkspace(ws)
-        else:
-            for w in ws:
-                mantid.DeleteWorkspace(w)
+        for name in AnalysisDataService.Instance().getObjectNames():
+            if name.startswith(ws_name):
+                mantid.DeleteWorkspace(name)
 
 
 run_mantid_alg.workspace_id = 0
@@ -745,4 +748,4 @@ def fit(ws, function, workspace_index, start_x, end_x):
                             'cost_function': sc.Variable(fit.CostFunction)
                         })
 
-    return ds
+        return ds

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -29,6 +29,8 @@ def run_mantid_alg(alg, *args, **kwargs):
     # Deal with non-standard ways to define the prefix of output workspaces
     if alg == 'Fit':
         kwargs['Output'] = ws_name
+    elif alg == 'LoadDiffCal':
+        kwargs['WorkspaceName'] = ws_name
     else:
         kwargs['OutputWorkspace'] = ws_name
     ws = getattr(mantid, alg)(*args, **kwargs)

--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -5,8 +5,8 @@
 import numpy as np
 
 from ..._scipp import core as sc
+from ...compat.mantid import run_mantid_alg
 from ...compat.mantid import convert_TableWorkspace_to_dataset
-from .. import exceptions
 
 
 def load_calibration(filename, mantid_args={}):
@@ -38,54 +38,44 @@ def load_calibration(filename, mantid_args={}):
     :rtype: Dataset
     """
 
-    try:
-        import mantid.simpleapi as mantid
-    except ImportError as e:
-        raise exceptions.MantidNotFoundError from e
-
     if "WorkspaceName" not in mantid_args:
         mantid_args["WorkspaceName"] = "cal_output"
 
-    output = mantid.LoadDiffCal(Filename=filename, **mantid_args)
+    with run_mantid_alg('LoadDiffCal', Filename=filename, **mantid_args) as output:
+        cal_ws = output.OutputCalWorkspace
+        cal_data = convert_TableWorkspace_to_dataset(cal_ws)
 
-    cal_ws = output.OutputCalWorkspace
-    cal_data = convert_TableWorkspace_to_dataset(cal_ws)
+        # Modify units of cal_data
+        cal_data["difc"].unit = sc.units.us / sc.units.angstrom
+        cal_data[
+            "difa"].unit = sc.units.us / sc.units.angstrom / sc.units.angstrom
+        cal_data["tzero"].unit = sc.units.us
 
-    # Modify units of cal_data
-    cal_data["difc"].unit = sc.units.us / sc.units.angstrom
-    cal_data["difa"].unit = sc.units.us / sc.units.angstrom / sc.units.angstrom
-    cal_data["tzero"].unit = sc.units.us
+        # Note that despite masking and grouping stored in separate workspaces,
+        # there is no need to handle potentially mismatching ordering: All
+        # workspaces have been created by the same algorithm, which should
+        # guarantee ordering.
+        mask_ws = output.OutputMaskWorkspace
+        group_ws = output.OutputGroupingWorkspace
+        rows = mask_ws.getNumberHistograms()
+        mask = np.fromiter((mask_ws.readY(i)[0] for i in range(rows)),
+                           count=rows,
+                           dtype=np.bool)
+        group = np.fromiter((group_ws.readY(i)[0] for i in range(rows)),
+                            count=rows,
+                            dtype=np.int32)
 
-    # Note that despite masking and grouping stored in separate workspaces,
-    # there is no need to handle potentially mismatching ordering: All
-    # workspaces have been created by the same algorithm, which should
-    # guarantee ordering.
-    mask_ws = output.OutputMaskWorkspace
-    group_ws = output.OutputGroupingWorkspace
-    rows = mask_ws.getNumberHistograms()
-    mask = np.fromiter((mask_ws.readY(i)[0] for i in range(rows)),
-                       count=rows,
-                       dtype=np.bool)
-    group = np.fromiter((group_ws.readY(i)[0] for i in range(rows)),
-                        count=rows,
-                        dtype=np.int32)
+        # This is deliberately not stored as a mask since that would make
+        # subsequent handling, e.g., with groupby, more complicated. The mask is
+        # conceptually not masking rows in this table, i.e., it is not marking
+        # invalid rows, but rather describes masking for other data.
+        cal_data["mask"] = sc.Variable([sc.Dim.Row], values=mask)
+        cal_data["group"] = sc.Variable([sc.Dim.Row], values=group)
 
-    # This is deliberately not stored as a mask since that would make
-    # subsequent handling, e.g., with groupby, more complicated. The mask is
-    # conceptually not masking rows in this table, i.e., it is not marking
-    # invalid rows, but rather describes masking for other data.
-    cal_data["mask"] = sc.Variable([sc.Dim.Row], values=mask)
-    cal_data["group"] = sc.Variable([sc.Dim.Row], values=group)
+        cal_data.rename_dims({sc.Dim.Row: sc.Dim.Detector})
+        cal_data.coords[sc.Dim.Detector] = sc.Variable(
+            [sc.Dim.Detector],
+            values=cal_data['detid'].values.astype(np.int32))
+        del cal_data['detid']
 
-    cal_data.rename_dims({sc.Dim.Row: sc.Dim.Detector})
-    cal_data.coords[sc.Dim.Detector] = sc.Variable(
-        [sc.Dim.Detector], values=cal_data['detid'].values.astype(np.int32))
-    del cal_data['detid']
-
-    # Delete generated mantid workspaces
-    base_name = mantid_args["WorkspaceName"]
-    mantid.mtd.remove(base_name + "_cal")
-    mantid.mtd.remove(base_name + "_group")
-    mantid.mtd.remove(base_name + "_mask")
-
-    return cal_data
+        return cal_data

--- a/python/src/scipp/neutron/diffraction/load.py
+++ b/python/src/scipp/neutron/diffraction/load.py
@@ -41,7 +41,8 @@ def load_calibration(filename, mantid_args={}):
     if "WorkspaceName" not in mantid_args:
         mantid_args["WorkspaceName"] = "cal_output"
 
-    with run_mantid_alg('LoadDiffCal', Filename=filename, **mantid_args) as output:
+    with run_mantid_alg('LoadDiffCal', Filename=filename,
+                        **mantid_args) as output:
         cal_ws = output.OutputCalWorkspace
         cal_data = convert_TableWorkspace_to_dataset(cal_ws)
 
@@ -66,9 +67,9 @@ def load_calibration(filename, mantid_args={}):
                             dtype=np.int32)
 
         # This is deliberately not stored as a mask since that would make
-        # subsequent handling, e.g., with groupby, more complicated. The mask is
-        # conceptually not masking rows in this table, i.e., it is not marking
-        # invalid rows, but rather describes masking for other data.
+        # subsequent handling, e.g., with groupby, more complicated. The mask
+        # is conceptually not masking rows in this table, i.e., it is not
+        # marking invalid rows, but rather describes masking for other data.
         cal_data["mask"] = sc.Variable([sc.Dim.Row], values=mask)
         cal_data["group"] = sc.Variable([sc.Dim.Row], values=group)
 

--- a/python/src/scipp/neutron/exceptions.py
+++ b/python/src/scipp/neutron/exceptions.py
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
-# Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
-# @author Mads Bertelsen
-
-MantidNotFoundError = ImportError(
-    "Mantid Python API was not found, please install Mantid framework "
-    "as detailed in the installation instructions (https://scipp."
-    "readthedocs.io/en/latest/getting-started/installation.html)")

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -146,9 +146,12 @@ class TestMantidConversion(unittest.TestCase):
                                       [True, True, True])
 
     def test_Workspace2D_with_separate_monitors(self):
+        from mantid.simpleapi import mtd
+        mtd.clear()
         filename = MantidDataHelper.find_file("WISH00016748.raw")
         ds = mantidcompat.load(filename,
                                mantid_args={"LoadMonitors": "Separate"})
+        self.assertEqual(len(mtd), 0, mtd.getObjectNames())
         attrs = ds.attrs.keys()
         expected_monitor_attrs = set(
             ["monitor1", "monitor2", "monitor3", "monitor4", "monitor5"])
@@ -160,9 +163,12 @@ class TestMantidConversion(unittest.TestCase):
             assert monitors.shape == [4471]
 
     def test_Workspace2D_with_include_monitors(self):
+        from mantid.simpleapi import mtd
+        mtd.clear()
         filename = MantidDataHelper.find_file("WISH00016748.raw")
         ds = mantidcompat.load(filename,
                                mantid_args={"LoadMonitors": "Include"})
+        self.assertEqual(len(mtd), 0, mtd.getObjectNames())
         attrs = ds.attrs.keys()
         expected_monitor_attrs = set(
             ["monitor1", "monitor2", "monitor3", "monitor4", "monitor5"])
@@ -173,8 +179,11 @@ class TestMantidConversion(unittest.TestCase):
             assert monitors.shape == [4471]
 
     def test_EventWorkspace_with_monitors(self):
+        from mantid.simpleapi import mtd
+        mtd.clear()
         filename = MantidDataHelper.find_file("CNCS_51936_event.nxs")
         ds = mantidcompat.load(filename, mantid_args={"LoadMonitors": True})
+        self.assertEqual(len(mtd), 0, mtd.getObjectNames())
         attrs = ds.attrs.keys()
         expected_monitor_attrs = set(["monitor2", "monitor3"])
         assert expected_monitor_attrs.issubset(attrs)


### PR DESCRIPTION
Previously `StoreInADS=False` was used to prevent insertion of workspaces into the ADS. However, the `AlgorithmManager` (or something else?) still maintained ownership so memory was never freed, resulting in large extra memory consumption.