### PR TITLE
Add support for removing variances

### DIFF
--- a/core/include/scipp/core/dataset.h
+++ b/core/include/scipp/core/dataset.h
@@ -130,12 +130,6 @@ public:
 
   void setUnit(const units::Unit unit) const;
 
-  /// Set variances for the data. If the data has no variances array, it is
-  /// created.
-  template <class T> void setVariances(detail::element_array<T> &&v) const {
-    data().setVariances(std::move(v));
-  }
-
   /// Return untyped proxy for data (values and optional variances).
   const VariableProxy &data() const {
     if (!hasData())
@@ -939,10 +933,6 @@ public:
   units::Unit unit() const { return get().unit(); }
 
   void setUnit(const units::Unit unit) { get().setUnit(unit); }
-
-  template <class T> void setVariances(detail::element_array<T> &&v) {
-    get().setVariances(std::move(v));
-  }
 
   /// Return true if the data array contains data values.
   bool hasData() const { return get().hasData(); }

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -470,7 +470,7 @@ public:
   const auto &dataHandle() && = delete;
   const auto &dataHandle() & { return m_object.mutableVariant(); }
 
-  void setVariances(Variable variances);
+  void setVariances(Variable v);
 
 private:
   template <class... Ts> struct ConstructVariable {
@@ -862,7 +862,7 @@ public:
   VariableProxy operator&=(const VariableConstProxy &other) const;
   VariableProxy operator^=(const VariableConstProxy &other) const;
 
-  void setVariances(Variable variances) const;
+  void setVariances(Variable v) const;
 
   void setUnit(const units::Unit &unit) const;
   void expectCanSetUnit(const units::Unit &unit) const;

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -99,6 +99,8 @@ public:
                     const scipp::index offset, const scipp::index otherBegin,
                     const scipp::index otherEnd) = 0;
 
+  virtual void setVariances(Variable &&variances) = 0;
+
   const Dimensions &dims() const { return m_dimensions; }
 
   friend class Variable;
@@ -140,8 +142,6 @@ public:
     std::terminate();
   }
   static DType static_dtype() noexcept { return scipp::core::dtype<T>; }
-
-  virtual void setVariances(detail::element_array<T> &&v) = 0;
 
   virtual scipp::span<T> values() = 0;
   virtual scipp::span<T> values(const Dim dim, const scipp::index begin,
@@ -470,7 +470,7 @@ public:
   const auto &dataHandle() && = delete;
   const auto &dataHandle() & { return m_object.mutableVariant(); }
 
-  template <class T> void setVariances(detail::element_array<T> &&v);
+  void setVariances(Variable variances);
 
 private:
   template <class... Ts> struct ConstructVariable {
@@ -862,7 +862,7 @@ public:
   VariableProxy operator&=(const VariableConstProxy &other) const;
   VariableProxy operator^=(const VariableConstProxy &other) const;
 
-  template <class T> void setVariances(detail::element_array<T> &&v) const;
+  void setVariances(Variable variances) const;
 
   void setUnit(const units::Unit &unit) const;
   void expectCanSetUnit(const units::Unit &unit) const;

--- a/core/include/scipp/core/variable.tcc
+++ b/core/include/scipp/core/variable.tcc
@@ -266,8 +266,8 @@ public:
   void setVariances(Variable &&variances) override {
     if (!canHaveVariances<value_type>())
       throw except::VariancesError("This data type cannot have variances.");
-    if(!variances)
-      m_variances.reset();
+    if (!variances)
+      return m_variances.reset();
     expect::equals(this->dims(), variances.dims());
     m_variances.emplace(
         std::move(requireT<DataModel>(variances.data()).m_values));

--- a/core/include/scipp/core/variable.tcc
+++ b/core/include/scipp/core/variable.tcc
@@ -268,6 +268,9 @@ public:
       throw except::VariancesError("This data type cannot have variances.");
     if (!variances)
       return m_variances.reset();
+    if (variances.hasVariances())
+      throw except::VariancesError(
+          "Cannot set variances from variable with variances.");
     expect::equals(this->dims(), variances.dims());
     m_variances.emplace(
         std::move(requireT<DataModel>(variances.data()).m_values));

--- a/core/test/dataset_test.cpp
+++ b/core/test/dataset_test.cpp
@@ -351,17 +351,6 @@ TEST(DatasetTest, slice_validation_complex) {
                except::SliceError);
 }
 
-TEST(DataProxyTest, set_variances) {
-  auto d = make_1_values<bool>("a", {Dim::X, 3}, units::m, {true, false, true});
-  EXPECT_THROW(d["a"].setVariances<double>({1, 2, 3}), except::TypeError);
-
-  auto dd = make_1_values<double>("a", {Dim::X, 3}, units::m, {1.0, 1.0, 1.0});
-  EXPECT_ANY_THROW(dd["a"].setVariances<double>({2.0, 2.0, 2.0, 2.0}));
-  dd["a"].setVariances<double>({3.0, 3.0, 3.0});
-  EXPECT_EQ(equals(dd["a"].variances<double>(), std::vector{3.0, 3.0, 3.0}),
-            true);
-}
-
 TEST(DatasetTest, sum_and_mean) {
   auto ds = make_1_values_and_variances<float>(
       "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});

--- a/core/test/sparse_data_operations_consistency_test.cpp
+++ b/core/test/sparse_data_operations_consistency_test.cpp
@@ -55,10 +55,10 @@ TEST(SparseDataOperationsConsistencyTest, multiply) {
   ab = histogram(sparse * hist, edges);
   ba = histogram(sparse, edges) * hist;
 
-  // Case 2: Multiple events per bin => uncertainties differ, set to 0 before
+  // Case 2: Multiple events per bin => uncertainties differ, remove before
   // comparison.
-  ab.setVariances<double>({0, 0, 0, 0});
-  ba.setVariances<double>({0, 0, 0, 0});
+  ab.data().setVariances(Variable());
+  ba.data().setVariances(Variable());
   EXPECT_EQ(ab, ba);
 }
 
@@ -94,11 +94,11 @@ TEST(SparseDataOperationsConsistencyTest, flatten_multiply_sum) {
   // ... except that summing last also leads to smaller variances
   EXPECT_NE(mhf, smh);
 
-  // Cross-group: Uncertainties differ due to multiple events per bin, set to 0.
-  hfm.setVariances<double>({0, 0});
-  mhf.setVariances<double>({0, 0});
-  msh.setVariances<double>({0, 0});
-  smh.setVariances<double>({0, 0});
+  // Cross-group: Uncertainties differ due to multiple events per bin, remove.
+  hfm.data().setVariances(Variable());
+  mhf.data().setVariances(Variable());
+  msh.data().setVariances(Variable());
+  smh.data().setVariances(Variable());
   EXPECT_EQ(hfm, mhf);
   EXPECT_EQ(hfm, msh);
   EXPECT_EQ(hfm, smh);

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -79,7 +79,7 @@ TEST(VariableUniversalConstructorTest, dimensions_unit_basic) {
   EXPECT_EQ(oneMore, variable);
 }
 
-TEST(VariableUniversalConstructorTest, type_construcors_mix) {
+TEST(VariableUniversalConstructorTest, type_constructors_mix) {
   auto flt = std::vector{1.5f, 3.6f};
   auto v1 = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 1},
                      Values(flt.begin(), flt.end()), Variances({2.0, 3.0}));
@@ -87,7 +87,8 @@ TEST(VariableUniversalConstructorTest, type_construcors_mix) {
                      Values({1.5, 3.6}), Variances({2, 3}));
   auto v3 = Variable(dtype<float>, units::Unit(), Dims{Dim::X, Dim::Y},
                      Shape{2, 1}, Values({1.5f, 3.6f}));
-  v3.setVariances<float>({2, 3});
+  v3.setVariances(
+      makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, Values{2, 3}));
   EXPECT_EQ(v1, v2);
   EXPECT_EQ(v1, v3);
 

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1035,20 +1035,23 @@ TEST(VariableTest, values_variances) {
 }
 
 template <typename Var> void test_set_variances(Var &var) {
+  const auto v = var * 2.0;
   var.setVariances(Variable(var));
   ASSERT_TRUE(equals(var.template variances<double>(), {1.0, 2.0, 3.0}));
-  var.setVariances(var * 2.0);
+  // Fail because `var` has variances (setVariances uses only the values)
+  EXPECT_THROW(var.setVariances(var * 2.0), except::VariancesError);
+  var.setVariances(v);
   ASSERT_TRUE(equals(var.template variances<double>(), {2.0, 4.0, 6.0}));
 
-  Variable bad_dims(var);
+  Variable bad_dims(v);
   bad_dims.rename(Dim::X, Dim::Y);
   EXPECT_THROW(var.setVariances(bad_dims), except::DimensionError);
 
-  Variable bad_unit(var);
+  Variable bad_unit(v);
   bad_unit.setUnit(units::s);
   EXPECT_THROW(var.setVariances(bad_unit), except::UnitError);
 
-  EXPECT_THROW(var.setVariances(astype(var, dtype<float>)), except::TypeError);
+  EXPECT_THROW(var.setVariances(astype(v, dtype<float>)), except::TypeError);
 }
 
 TEST(VariableTest, set_variances) {

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1035,13 +1035,20 @@ TEST(VariableTest, values_variances) {
 }
 
 template <typename Var> void test_set_variances(Var &var) {
-  var.template setVariances<double>({5.0, 6.0, 7.0});
-  ASSERT_TRUE(equals(var.template variances<double>(), {5.0, 6.0, 7.0}));
-  var.template setVariances<double>({1.0, 2.0, 3.0});
+  var.setVariances(Variable(var));
   ASSERT_TRUE(equals(var.template variances<double>(), {1.0, 2.0, 3.0}));
-  EXPECT_THROW(var.template setVariances<double>({1.0, 2.0, 3.0, 4.0}),
-               except::SizeError);
-  EXPECT_NO_THROW(var.template setVariances<float>({1.0, 2.0, 3.0}));
+  var.setVariances(var * 2.0);
+  ASSERT_TRUE(equals(var.template variances<double>(), {2.0, 4.0, 6.0}));
+
+  Variable bad_dims(var);
+  bad_dims.rename(Dim::X, Dim::Y);
+  EXPECT_THROW(var.setVariances(bad_dims), except::DimensionError);
+
+  Variable bad_unit(var);
+  bad_unit.setUnit(units::s);
+  EXPECT_THROW(var.setVariances(bad_unit), except::UnitError);
+
+  EXPECT_THROW(var.setVariances(astype(var, dtype<float>)), except::TypeError);
 }
 
 TEST(VariableTest, set_variances) {
@@ -1050,11 +1057,37 @@ TEST(VariableTest, set_variances) {
   test_set_variances(var);
 }
 
+TEST(VariableTest, set_variances_moves) {
+  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3});
+  Variable variances(var);
+  const auto ptr = variances.values<double>().data();
+  var.setVariances(std::move(variances));
+  EXPECT_EQ(var.variances<double>().data(), ptr);
+}
+
+TEST(VariableTest, set_variances_remove) {
+  Variable var =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{}, Variances{});
+  EXPECT_TRUE(var.hasVariances());
+  EXPECT_NO_THROW(var.setVariances(Variable()));
+  EXPECT_FALSE(var.hasVariances());
+}
+
 TEST(VariableProxyTest, set_variances) {
   Variable var = makeVariable<double>(
       Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{1.0, 2.0, 3.0});
   auto proxy = VariableProxy(var);
   test_set_variances(proxy);
+  EXPECT_THROW(
+      var.slice({Dim::X, 0}).setVariances(Variable(var.slice({Dim::X, 0}))),
+      except::VariancesError);
+}
+
+TEST(VariableProxyTest, set_variances_slice_fail) {
+  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3});
+  EXPECT_THROW(
+      var.slice({Dim::X, 0}).setVariances(Variable(var.slice({Dim::X, 0}))),
+      except::VariancesError);
 }
 
 TEST(VariableProxyTest, create_with_variance) {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -221,6 +221,20 @@ void Variable::rename(const Dim from, const Dim to) {
     data().m_dimensions.relabel(dims().index(from), to);
 }
 
+void Variable::setVariances(Variable variances) {
+  data().setVariances(std::move(variances));
+}
+
+void VariableProxy::setVariances(Variable variances) const {
+  // If the proxy wraps the whole variable (common case: iterating a dataset)
+  // m_view is not set. A more complex check would be to verify dimensions,
+  // shape, and strides, but this should be sufficient for now.
+  if (m_view)
+    throw except::VariancesError(
+        "Cannot add variances via sliced or reshaped view of Variable.");
+  m_mutableVariable->setVariances(std::move(variances));
+}
+
 namespace detail {
 void throw_variance_without_value() {
   throw except::VariancesError("Can't have variance without values");

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -221,20 +221,20 @@ void Variable::rename(const Dim from, const Dim to) {
     data().m_dimensions.relabel(dims().index(from), to);
 }
 
-void Variable::setVariances(Variable variances) {
-  if (variances)
-    expect::equals(unit(), variances.unit());
-  data().setVariances(std::move(variances));
+void Variable::setVariances(Variable v) {
+  if (v)
+    expect::equals(unit(), v.unit());
+  data().setVariances(std::move(v));
 }
 
-void VariableProxy::setVariances(Variable variances) const {
+void VariableProxy::setVariances(Variable v) const {
   // If the proxy wraps the whole variable (common case: iterating a dataset)
   // m_view is not set. A more complex check would be to verify dimensions,
   // shape, and strides, but this should be sufficient for now.
   if (m_view)
     throw except::VariancesError(
         "Cannot add variances via sliced or reshaped view of Variable.");
-  m_mutableVariable->setVariances(std::move(variances));
+  m_mutableVariable->setVariances(std::move(v));
 }
 
 namespace detail {

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -222,7 +222,8 @@ void Variable::rename(const Dim from, const Dim to) {
 }
 
 void Variable::setVariances(Variable variances) {
-  expect::equals(unit(), variances.unit());
+  if (variances)
+    expect::equals(unit(), variances.unit());
   data().setVariances(std::move(variances));
 }
 

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -222,6 +222,7 @@ void Variable::rename(const Dim from, const Dim to) {
 }
 
 void Variable::setVariances(Variable variances) {
+  expect::equals(unit(), variances.unit());
   data().setVariances(std::move(variances));
 }
 

--- a/core/variable_instantiate_basic.cpp
+++ b/core/variable_instantiate_basic.cpp
@@ -27,9 +27,4 @@ INSTANTIATE_VARIABLE(sparse_container<std::string>)
 INSTANTIATE_VARIABLE(sparse_container<bool>)
 INSTANTIATE_VARIABLE(sparse_container<Eigen::Vector3d>)
 
-INSTANTIATE_SET_VARIANCES(double)
-INSTANTIATE_SET_VARIANCES(float)
-INSTANTIATE_SET_VARIANCES(int64_t)
-INSTANTIATE_SET_VARIANCES(int32_t)
-
 } // namespace scipp::core

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -650,6 +650,8 @@ def test_dataset_proxy_set_variance():
     d["a"].variances = variances
     assert d["a"].variances is not None
     np.testing.assert_array_equal(d["a"].variances, variances)
+    d["a"].variances = None
+    assert d["a"].variances == None
 
 
 def test_sort():

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -651,7 +651,7 @@ def test_dataset_proxy_set_variance():
     assert d["a"].variances is not None
     np.testing.assert_array_equal(d["a"].variances, variances)
     d["a"].variances = None
-    assert d["a"].variances == None
+    assert d["a"].variances is None
 
 
 def test_sort():

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -762,6 +762,17 @@ def test_copy_variance():
     assert var == expected
 
 
+def test_remove_variance():
+    values = np.random.rand(2, 3)
+    variances = np.random.rand(2, 3)
+    var = sc.Variable(dims=[Dim.X, Dim.Y], values=values, variances=variances)
+    expected = sc.Variable(dims=[Dim.X, Dim.Y], values=values)
+    assert var.variances is not None
+    var.variances = None
+    assert var.variances is None
+    assert var == expected
+
+
 def test_set_variance_convert_dtype():
     values = np.random.rand(2, 3)
     variances = np.arange(6).reshape(2, 3)


### PR DESCRIPTION
- Refactor inflexible mechanism for setting variances.
- Support `var.variances = None` for removal of variances in Python.

Fixes #915.