### PR TITLE
Small Conda tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 env:
   global:
     - PYTHON_EXECUTABLE="/usr/bin/python3"
-    - GENERATOR=Ninja
 
 jobs:
   include:

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
+
 set -x
 
 mkdir -p 'build' && cd 'build'
 
 # Perform CMake configuration
 cmake \
-  -G"$GENERATOR" \
+  -G Ninja \
   -DPYTHON_EXECUTABLE="$CONDA_PREFIX/bin/python" \
   -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_VERSION \

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,7 +38,6 @@ build:
     - CC
     - CXX
     - OSX_VERSION
-    - GENERATOR
     - MINICONDA
     - SRC_DIR
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ test:
   import:
     - scipp
   commands:
-    # Note that the following is fetching source again and using master
+    # Run  Python tests from external source directory
     - python -m pip install -r {{ environ.get('SRC_DIR') }}/python/requirements.txt
     - python -m pytest -v {{ environ.get('SRC_DIR') }}/python
 
@@ -40,6 +40,7 @@ build:
     - OSX_VERSION
     - MINICONDA
     - SRC_DIR
+
 about:
   home: https://scipp.readthedocs.io/en/latest/
   license: GPLv3


### PR DESCRIPTION
- Removes the not needed `GENERATOR` variable
- Fixes a comment regarding Python tests

Re #889 