### PR TITLE
Support string-based dimension labels

### DIFF
--- a/core/test/slice_test.cpp
+++ b/core/test/slice_test.cpp
@@ -95,7 +95,8 @@ class Dataset3DTest : public ::testing::Test {
 protected:
   Dataset3DTest() : dataset(factory.make()) {}
 
-  Dataset datasetWithEdges(const std::initializer_list<Dim> &edgeDims) {
+  Dataset datasetWithEdges(
+      const std::initializer_list<units::neutron::DimId> &edgeDims) {
     auto d = dataset;
     for (const auto dim : edgeDims) {
       auto dims = dataset.coords()[dim].dims();

--- a/python/tests/test_dim.py
+++ b/python/tests/test_dim.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from scipp import Dim
+
+
+def test_dim():
+    assert Dim.X == Dim.X
+    assert Dim.X != Dim.Y
+
+
+def test_dim_from_string():
+    a = Dim('a')
+    b = Dim('b')
+    a2 = Dim('a')
+    assert str(a) == 'a'
+    assert a == a
+    assert a != b
+    assert a == a2
+
+
+def test_dim_builtin_from_string():
+    x = Dim('Dim.X')
+    assert str(x) == 'Dim.X'
+    assert x == Dim.X
+    assert x != Dim.Y

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -48,7 +48,59 @@ scipp::core::Variable doDivScalarUnit(const units::Unit &unit,
 }
 
 void init_units_neutron(py::module &m) {
-  bind_enum(m, "Dim", Dim::Invalid, 4);
+  py::class_<units::Dim>(m, "Dim", "Dimension label")
+      .def(py::init<const std::string &>())
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      // Pre-defined labels are temporarily useful for refactoring and may be
+      // removed later.
+      .def_property_readonly_static(
+          "Detector", [](const py::object &) { return Dim(Dim::Detector); })
+      .def_property_readonly_static(
+          "DSpacing", [](const py::object &) { return Dim(Dim::DSpacing); })
+      .def_property_readonly_static(
+          "Energy", [](const py::object &) { return Dim(Dim::Energy); })
+      .def_property_readonly_static(
+          "EnergyTransfer",
+          [](const py::object &) { return Dim(Dim::EnergyTransfer); })
+      .def_property_readonly_static(
+          "Group", [](const py::object &) { return Dim(Dim::Group); })
+      .def_property_readonly_static(
+          "Invalid", [](const py::object &) { return Dim(Dim::Invalid); })
+      .def_property_readonly_static(
+          "Position", [](const py::object &) { return Dim(Dim::Position); })
+      .def_property_readonly_static(
+          "Q", [](const py::object &) { return Dim(Dim::Q); })
+      .def_property_readonly_static(
+          "Qx", [](const py::object &) { return Dim(Dim::Qx); })
+      .def_property_readonly_static(
+          "Qy", [](const py::object &) { return Dim(Dim::Qy); })
+      .def_property_readonly_static(
+          "Qz", [](const py::object &) { return Dim(Dim::Qz); })
+      .def_property_readonly_static(
+          "QSquared", [](const py::object &) { return Dim(Dim::QSquared); })
+      .def_property_readonly_static(
+          "Row", [](const py::object &) { return Dim(Dim::Row); })
+      .def_property_readonly_static(
+          "ScatteringAngle",
+          [](const py::object &) { return Dim(Dim::ScatteringAngle); })
+      .def_property_readonly_static(
+          "Spectrum", [](const py::object &) { return Dim(Dim::Spectrum); })
+      .def_property_readonly_static(
+          "Temperature",
+          [](const py::object &) { return Dim(Dim::Temperature); })
+      .def_property_readonly_static(
+          "Time", [](const py::object &) { return Dim(Dim::Time); })
+      .def_property_readonly_static(
+          "Tof", [](const py::object &) { return Dim(Dim::Tof); })
+      .def_property_readonly_static(
+          "Wavelength", [](const py::object &) { return Dim(Dim::Wavelength); })
+      .def_property_readonly_static(
+          "X", [](const py::object &) { return Dim(Dim::X); })
+      .def_property_readonly_static(
+          "Y", [](const py::object &) { return Dim(Dim::Y); })
+      .def_property_readonly_static(
+          "Z", [](const py::object &) { return Dim(Dim::Z); });
 
   py::class_<units::Unit>(m, "Unit", "A physical unit.")
       .def(py::init())

--- a/python/units_neutron.cpp
+++ b/python/units_neutron.cpp
@@ -52,6 +52,8 @@ void init_units_neutron(py::module &m) {
       .def(py::init<const std::string &>())
       .def(py::self == py::self)
       .def(py::self != py::self)
+      .def(hash(py::self))
+      .def("__repr__", [](const Dim &dim) { return dim.name(); })
       // Pre-defined labels are temporarily useful for refactoring and may be
       // removed later.
       .def_property_readonly_static(

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -7,7 +7,7 @@ set(INC_FILES
     include/scipp/units/unit.tcc include/scipp/units/neutron.h
 )
 
-set(SRC_FILES dummy.cpp except.cpp neutron.cpp string.cpp)
+set(SRC_FILES dim.cpp dummy.cpp except.cpp neutron.cpp string.cpp)
 
 # For now we just enable "neutron" units by default. In the future we may want
 # to build separate libraries with separate units.

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/units/dim.h"
+
+namespace scipp::units {
+
+std::unordered_map<std::string, DimId> Dim::custom_ids;
+
+std::string to_string(const Dim dim) { return dim.name(); }
+
+} // namespace scipp::units

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -6,6 +6,8 @@
 
 namespace scipp::units {
 
+std::unordered_map<std::string, DimId> Dim::builtin_ids{
+    {Dim(Dim::X).name(), Dim::X}};
 std::unordered_map<std::string, DimId> Dim::custom_ids;
 
 std::string to_string(const Dim dim) { return dim.name(); }

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @author Simon Heybrock
-#ifndef SCIPP_UNITS_DUMMY_H
-#define SCIPP_UNITS_DUMMY_H
+#ifndef SCIPP_UNITS_DIM_H
+#define SCIPP_UNITS_DIM_H
 
-#include "scipp/units/unit.h"
+#include <unordered_map>
+
+#include "scipp/units/dummy.h"
+#include "scipp/units/neutron.h"
 
 namespace scipp::units {
-namespace next {
-using DimId = scipp::units::Dim;
-
 class Dim {
 public:
   constexpr static auto Invalid = DimId::Invalid;
@@ -46,16 +46,10 @@ public:
 private:
   DimId m_id;
   static std::unordered_map<std::string, DimId> custom_ids;
-  static int32_t custom_count;
 };
 
-std::unordered_map<std::string, DimId> Dim::custom_ids;
-int32_t Dim::custom_count{0};
-
-std::string to_string(const Dim dim) { return dim.name(); }
-
-} // namespace next
+std::string to_string(const Dim dim);
 
 } // namespace scipp::units
 
-#endif // SCIPP_UNITS_DUMMY_H
+#endif // SCIPP_UNITS_DIM_H

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @author Simon Heybrock
+#ifndef SCIPP_UNITS_DUMMY_H
+#define SCIPP_UNITS_DUMMY_H
+
+#include "scipp/units/unit.h"
+
+namespace scipp::units {
+namespace next {
+using DimId = scipp::units::Dim;
+
+class Dim {
+public:
+  constexpr static auto Invalid = DimId::Invalid;
+  constexpr static auto X = DimId::X;
+  constexpr static auto Y = DimId::Y;
+  constexpr static auto Z = DimId::Z;
+
+  Dim(const DimId id) : m_id(id) {}
+  explicit Dim(const std::string &label) {
+    if (const auto it = custom_ids.find(label); it != custom_ids.end())
+      m_id = it->second;
+    else {
+      m_id = static_cast<DimId>(1000 + custom_ids.size());
+      custom_ids[label] = m_id;
+    }
+  }
+
+  std::string name() const {
+    if (static_cast<int64_t>(m_id) < 1000)
+      return to_string(m_id);
+    for (const auto &item : custom_ids)
+      if (item.second == m_id)
+        return item.first;
+    return "unreachable"; // throw or terminate?
+  }
+
+  constexpr bool operator==(const Dim &other) const noexcept {
+    return m_id == other.m_id;
+  }
+  constexpr bool operator!=(const Dim &other) const noexcept {
+    return m_id != other.m_id;
+  }
+
+private:
+  DimId m_id;
+  static std::unordered_map<std::string, DimId> custom_ids;
+  static int32_t custom_count;
+};
+
+std::unordered_map<std::string, DimId> Dim::custom_ids;
+int32_t Dim::custom_count{0};
+
+std::string to_string(const Dim dim) { return dim.name(); }
+
+} // namespace next
+
+} // namespace scipp::units
+
+#endif // SCIPP_UNITS_DUMMY_H

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -40,12 +40,13 @@ public:
   constexpr Dim(const DimId id) : m_id(id) {}
   explicit Dim(const std::string &label) {
     // Note that this is not thread-safe yet.
-    if (const auto it = custom_ids.find(label); it != custom_ids.end())
-      m_id = it->second;
-    else {
-      m_id = static_cast<DimId>(1000 + custom_ids.size());
-      custom_ids[label] = m_id;
-    }
+    for (const auto &ids : {builtin_ids, custom_ids})
+      if (const auto it = ids.find(label); it != ids.end()) {
+        m_id = it->second;
+        return;
+      }
+    m_id = static_cast<DimId>(1000 + custom_ids.size());
+    custom_ids[label] = m_id;
   }
 
   constexpr DimId id() const noexcept { return m_id; }
@@ -71,6 +72,7 @@ public:
 
 private:
   DimId m_id;
+  static std::unordered_map<std::string, DimId> builtin_ids;
   static std::unordered_map<std::string, DimId> custom_ids;
 };
 

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -17,6 +17,10 @@ public:
   constexpr static auto X = DimId::X;
   constexpr static auto Y = DimId::Y;
   constexpr static auto Z = DimId::Z;
+  constexpr static auto Tof = DimId::Tof;
+  constexpr static auto Q = DimId::Q;
+  constexpr static auto Time = DimId::Time;
+  constexpr static auto Row = DimId::Row;
 
   constexpr Dim(const DimId id) : m_id(id) {}
   explicit Dim(const std::string &label) {

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -24,6 +24,7 @@ public:
   constexpr static auto Qx = DimId::Qx;
   constexpr static auto Qy = DimId::Qy;
   constexpr static auto Qz = DimId::Qz;
+  constexpr static auto QSquared = DimId::QSquared;
   constexpr static auto Row = DimId::Row;
   constexpr static auto ScatteringAngle = DimId::ScatteringAngle;
   constexpr static auto Spectrum = DimId::Spectrum;
@@ -38,6 +39,7 @@ public:
   constexpr Dim() : m_id(DimId::Invalid) {}
   constexpr Dim(const DimId id) : m_id(id) {}
   explicit Dim(const std::string &label) {
+    // Note that this is not thread-safe yet.
     if (const auto it = custom_ids.find(label); it != custom_ids.end())
       m_id = it->second;
     else {

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -13,15 +13,29 @@
 namespace scipp::units {
 class Dim {
 public:
+  constexpr static auto Detector = DimId::Detector;
+  constexpr static auto DSpacing = DimId::DSpacing;
+  constexpr static auto Energy = DimId::Energy;
+  constexpr static auto EnergyTransfer = DimId::EnergyTransfer;
+  constexpr static auto Group = DimId::Row;
   constexpr static auto Invalid = DimId::Invalid;
+  constexpr static auto Position = DimId::Position;
+  constexpr static auto Q = DimId::Q;
+  constexpr static auto Qx = DimId::Qx;
+  constexpr static auto Qy = DimId::Qy;
+  constexpr static auto Qz = DimId::Qz;
+  constexpr static auto Row = DimId::Row;
+  constexpr static auto ScatteringAngle = DimId::ScatteringAngle;
+  constexpr static auto Spectrum = DimId::Spectrum;
+  constexpr static auto Temperature = DimId::Temperature;
+  constexpr static auto Time = DimId::Time;
+  constexpr static auto Tof = DimId::Tof;
+  constexpr static auto Wavelength = DimId::Wavelength;
   constexpr static auto X = DimId::X;
   constexpr static auto Y = DimId::Y;
   constexpr static auto Z = DimId::Z;
-  constexpr static auto Tof = DimId::Tof;
-  constexpr static auto Q = DimId::Q;
-  constexpr static auto Time = DimId::Time;
-  constexpr static auto Row = DimId::Row;
 
+  constexpr Dim() : m_id(DimId::Invalid) {}
   constexpr Dim(const DimId id) : m_id(id) {}
   explicit Dim(const std::string &label) {
     if (const auto it = custom_ids.find(label); it != custom_ids.end())

--- a/units/include/scipp/units/dimension.h
+++ b/units/include/scipp/units/dimension.h
@@ -15,14 +15,14 @@
 /// is a reserved name and is automatically added to the list. This also defines
 /// a `to_string` function for the defined enum.
 #define SCIPP_UNITS_DECLARE_DIMENSIONS(...)                                    \
-  enum class SCIPP_UNITS_EXPORT Dim : uint16_t { __VA_ARGS__, Invalid };       \
+  enum class SCIPP_UNITS_EXPORT DimId : uint16_t { __VA_ARGS__, Invalid };     \
                                                                                \
   namespace detail2 {                                                          \
   constexpr const char *names = #__VA_ARGS__;                                  \
-  constexpr auto ndim = static_cast<size_t>(Dim::Invalid);                     \
+  constexpr auto ndim = static_cast<size_t>(DimId::Invalid);                   \
   }                                                                            \
                                                                                \
-  SCIPP_UNITS_EXPORT std::string to_string(const Dim dim);
+  SCIPP_UNITS_EXPORT std::string to_string(const DimId dim);
 
 /// Macro to define dimension labels.
 ///
@@ -67,8 +67,8 @@
       make_dim_names(std::make_index_sequence<MODULE::detail2::ndim>());       \
   }                                                                            \
                                                                                \
-  std::string MODULE::to_string(const Dim dim) {                               \
-    if (dim == Dim::Invalid)                                                   \
+  std::string MODULE::to_string(const DimId dim) {                             \
+    if (dim == DimId::Invalid)                                                 \
       return std::string("Dim.Invalid");                                       \
     return "Dim." + std::string(dim_names[static_cast<uint16_t>(dim)]);        \
   }

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -5,8 +5,7 @@
 #ifndef SCIPP_UNITS_UNIT_H
 #define SCIPP_UNITS_UNIT_H
 
-#include "scipp/units/dummy.h"
-#include "scipp/units/neutron.h"
+#include "scipp/units/dim.h"
 
 namespace scipp {
 using scipp::units::Dim;

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -2,7 +2,9 @@
 # contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-units-test")
 add_dependencies(all-tests ${TARGET_NAME})
-add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dim_test.cpp dimension_test.cpp unit_test.cpp)
+add_executable(
+  ${TARGET_NAME} EXCLUDE_FROM_ALL dim_test.cpp dimension_test.cpp unit_test.cpp
+)
 target_link_libraries(
   ${TARGET_NAME}
   LINK_PRIVATE

--- a/units/test/CMakeLists.txt
+++ b/units/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-units-test")
 add_dependencies(all-tests ${TARGET_NAME})
-add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dimension_test.cpp unit_test.cpp)
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL dim_test.cpp dimension_test.cpp unit_test.cpp)
 target_link_libraries(
   ${TARGET_NAME}
   LINK_PRIVATE

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -16,6 +16,8 @@ TEST(DimTest, basics) {
   EXPECT_EQ(Dim("abc").name(), "abc");
 }
 
+TEST(DimTest, builtin_from_string) { EXPECT_EQ(Dim(Dim::X), Dim("Dim.X")); }
+
 TEST(DimTest, id) {
   const auto max_builtin = Dim(Dim::Invalid).id();
   const auto first_custom = Dim("a").id();

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/units/dim.h"
+
+using namespace scipp::units::next;
+
+TEST(DimTest, basics) {
+  EXPECT_EQ(Dim(Dim::X), Dim(Dim::X));
+  EXPECT_NE(Dim(Dim::X), Dim(Dim::Y));
+  EXPECT_EQ(Dim("abc"), Dim("abc"));
+  EXPECT_NE(Dim("abc"), Dim("def"));
+  EXPECT_EQ(Dim(Dim::X).name(), "Dim.X");
+  EXPECT_EQ(Dim("abc").name(), "abc");
+}

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -7,10 +7,21 @@
 using namespace scipp::units;
 
 TEST(DimTest, basics) {
+  EXPECT_EQ(Dim(), Dim(Dim::Invalid));
   EXPECT_EQ(Dim(Dim::X), Dim(Dim::X));
   EXPECT_NE(Dim(Dim::X), Dim(Dim::Y));
   EXPECT_EQ(Dim("abc"), Dim("abc"));
   EXPECT_NE(Dim("abc"), Dim("def"));
   EXPECT_EQ(Dim(Dim::X).name(), "Dim.X");
   EXPECT_EQ(Dim("abc").name(), "abc");
+}
+
+TEST(DimTest, id) {
+  const auto max_builtin = Dim(Dim::Invalid).id();
+  const auto first_custom = Dim("a").id();
+  EXPECT_TRUE(max_builtin < first_custom);
+  const auto base = static_cast<int64_t>(first_custom);
+  EXPECT_EQ(static_cast<int64_t>(Dim("b").id()), base + 1);
+  EXPECT_EQ(static_cast<int64_t>(Dim("c").id()), base + 2);
+  EXPECT_EQ(static_cast<int64_t>(Dim("a").id()), base);
 }

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -4,7 +4,7 @@
 
 #include "scipp/units/dim.h"
 
-using namespace scipp::units::next;
+using namespace scipp::units;
 
 TEST(DimTest, basics) {
   EXPECT_EQ(Dim(Dim::X), Dim(Dim::X));

--- a/units/test/dimension_test.cpp
+++ b/units/test/dimension_test.cpp
@@ -10,8 +10,8 @@ using namespace scipp;
 using namespace scipp::units;
 
 TEST(DimensionTest, basics) {
-  EXPECT_EQ(to_string(dummy::Dim::Invalid), "Dim.Invalid");
-  EXPECT_EQ(to_string(dummy::Dim::X), "Dim.X");
-  EXPECT_EQ(to_string(dummy::Dim::Y), "Dim.Y");
-  EXPECT_EQ(to_string(dummy::Dim::Z), "Dim.Z");
+  EXPECT_EQ(to_string(dummy::DimId::Invalid), "Dim.Invalid");
+  EXPECT_EQ(to_string(dummy::DimId::X), "Dim.X");
+  EXPECT_EQ(to_string(dummy::DimId::Y), "Dim.Y");
+  EXPECT_EQ(to_string(dummy::DimId::Z), "Dim.Z");
 }


### PR DESCRIPTION
This is the first step of #936, adding support for string-based labels, but not yet changing anything related to `coords` and `labels`.

Notes:
- Not thread-safe yet (missing lock around `custom_ids` map), but this is not a problem for now, since the TBB threading is unrelated (not creating new labels), and we are not using multi-threading in Python yet (and not using custom labels yet either). It may evenbe possible to avoid this entirely if we can ensure that the `string -> Dim` conversion always happens under the GIL, but I am not entirely clear on this yet.
- For simplicity I kept the old string representations for now. My plan is to change, e.g., `'Dim.X'` to `'x'` in a later step.
- Keeping old dim labels (now static members instead of enum) for now. I think we can keep them indefinitely on the C++ side (construction labels explicitly as `Dim("x")` seems like a good syntax there anyway, instead of using strings directly everywhere). On the Python side I still feel that we should eventually move to preferring direct use of strings everywhere.