### PR TITLE
Strings as coord keys

### DIFF
--- a/core/dataset.cpp
+++ b/core/dataset.cpp
@@ -35,9 +35,12 @@ auto makeViewItems(const Dimensions &dims, T1 &coords, T2 *sparse = nullptr) {
     // for multi-dimensional coordinates.
     auto contained = [&dims](const auto &item2) {
       const auto &coordDims = item2.second.dims();
-      if constexpr (std::is_same_v<Key, Dim>)
-        return coordDims.empty() || dims.contains(item2.first);
-      else
+      if constexpr (std::is_same_v<Key, Dim>) {
+        const bool is_dimension_coord = coordDims.contains(item2.first);
+        return coordDims.empty() ||
+               (is_dimension_coord ? dims.contains(item2.first)
+                                   : dims.contains(coordDims.inner()));
+      } else
         return coordDims.empty() || dims.contains(coordDims.inner());
     };
     if (contained(item)) {

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -7,7 +7,6 @@
 
 #include "scipp/core/dimensions.h"
 #include "scipp/core/except.h"
-#include "scipp/core/variable.h"
 
 namespace scipp::core {
 

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -354,6 +354,7 @@ void init_variable(py::module &m) {
   bind_data_properties(variable);
   bind_data_properties(variableView);
 
+  py::implicitly_convertible<std::string, Dim>();
   py::implicitly_convertible<Variable, VariableConstView>();
   py::implicitly_convertible<Variable, VariableView>();
 


### PR DESCRIPTION
Two more small steps in the dim-label refactor:

- Strings now supported in the Python API (not need to wrap as `Dim('x')` any more).
- Fold dimension check of coord and labels (see commit message for details).

Note that the second step is strictly speaking untested (apart from not breaking any of the *existing* behavior, i.e., that for dimension-coords). In the next step, when removing the `labels` properties I will switch all the tests we had for labels to test the coords, so also the non-dimension-coord part will be tested.

Part of #936.