### PR TITLE
Dim label cleanup part 2

### DIFF
--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include <limits>
+
 #include "scipp/units/dim.h"
 
 namespace scipp::units {
@@ -43,7 +45,11 @@ Dim::Dim(const std::string &label) {
     m_id = it->second;
     return;
   }
-  m_id = static_cast<DimId>(1000 + custom_ids.size());
+  const auto id = scipp::size(custom_ids) + 1000;
+  if (id > std::numeric_limits<std::underlying_type<DimId>::type>::max())
+    throw std::runtime_error(
+        "Exceeded maximum number of different dimension labels.");
+  m_id = static_cast<DimId>(id);
   custom_ids[label] = m_id;
 }
 

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -31,6 +31,7 @@ std::unordered_map<std::string, DimId> Dim::builtin_ids{
     {"z", Dim::Z}};
 
 std::unordered_map<std::string, DimId> Dim::custom_ids;
+std::mutex Dim::mutex;
 
 std::string to_string(const Dim dim) { return dim.name(); }
 

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -39,34 +39,11 @@ public:
 
   constexpr Dim() : m_id(DimId::Invalid) {}
   constexpr Dim(const DimId id) : m_id(id) {}
-  explicit Dim(const std::string &label) {
-    // Note that this is not thread-safe yet.
-    if (const auto it = builtin_ids.find(label); it != builtin_ids.end()) {
-      m_id = it->second;
-      return;
-    }
-    const std::lock_guard lock(mutex);
-    if (const auto it = custom_ids.find(label); it != custom_ids.end()) {
-      m_id = it->second;
-      return;
-    }
-    m_id = static_cast<DimId>(1000 + custom_ids.size());
-    custom_ids[label] = m_id;
-  }
+  explicit Dim(const std::string &label);
 
   constexpr DimId id() const noexcept { return m_id; }
 
-  std::string name() const {
-    if (static_cast<int64_t>(m_id) < 1000)
-      for (const auto &item : builtin_ids)
-        if (item.second == m_id)
-          return item.first;
-    const std::lock_guard lock(mutex);
-    for (const auto &item : custom_ids)
-      if (item.second == m_id)
-        return item.first;
-    return "unreachable"; // throw or terminate?
-  }
+  std::string name() const;
 
   constexpr bool operator==(const Dim &other) const noexcept {
     return m_id == other.m_id;

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -42,9 +42,8 @@ TEST(DimTest, unique_builtin_name) {
 
 void add_dims() {
   for (int64_t i = 0; i < 128; ++i)
-    for (scipp::index repeat = 0; repeat < 16; ++repeat) {
+    for (scipp::index repeat = 0; repeat < 16; ++repeat)
       static_cast<void>(Dim("custom" + std::to_string(i)).name());
-    }
 }
 
 TEST(DimTest, thread_safe) {
@@ -60,10 +59,6 @@ TEST(DimTest, thread_safe) {
 // is no way of resetting the static map of known custom labels. It can be run
 // separately though.
 TEST(DimTest, DISABLED_label_count_overflow) {
-  // Prime the custom labels with those used in other tests. Otherwise other
-  // tests running after this will fail due to overflow.
-  for (const auto &name : {"abc", "def", "a", "b", "c"})
-    static_cast<void>(Dim(name));
   // Note that the id of "first" is not necessarily the value coded in the
   // implementation but rather depends on which tests have run before.
   const auto end =

--- a/units/test/dim_test.cpp
+++ b/units/test/dim_test.cpp
@@ -2,7 +2,9 @@
 // Copyright (c) 2019 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <set>
+#include <thread>
 
 #include "scipp/units/dim.h"
 
@@ -36,4 +38,41 @@ TEST(DimTest, unique_builtin_name) {
   for (int64_t i = 0; i < expected; ++i)
     names.emplace(Dim(static_cast<DimId>(i)).name());
   EXPECT_EQ(names.size(), expected);
+}
+
+void add_dims() {
+  for (int64_t i = 0; i < 128; ++i)
+    for (scipp::index repeat = 0; repeat < 16; ++repeat) {
+      static_cast<void>(Dim("custom" + std::to_string(i)).name());
+    }
+}
+
+TEST(DimTest, thread_safe) {
+  std::vector<std::thread> threads;
+  threads.reserve(100);
+  for (auto i = 0; i < 100; ++i)
+    threads.emplace_back(add_dims);
+  for (auto &t : threads)
+    t.join();
+}
+
+// This tests works, but is in conflict with the thread-safety test, since there
+// is no way of resetting the static map of known custom labels. It can be run
+// separately though.
+TEST(DimTest, DISABLED_label_count_overflow) {
+  // Prime the custom labels with those used in other tests. Otherwise other
+  // tests running after this will fail due to overflow.
+  for (const auto &name : {"abc", "def", "a", "b", "c"})
+    static_cast<void>(Dim(name));
+  // Note that the id of "first" is not necessarily the value coded in the
+  // implementation but rather depends on which tests have run before.
+  const auto end =
+      std::numeric_limits<std::underlying_type<DimId>::type>::max();
+  const auto count = end - static_cast<int64_t>(Dim("first").id());
+  for (int64_t i = 0; i < count; ++i)
+    Dim("custom" + std::to_string(i));
+  EXPECT_EQ(
+      static_cast<int64_t>(Dim("custom" + std::to_string(count - 1)).id()),
+      end);
+  EXPECT_THROW(Dim("overflow"), std::runtime_error);
 }


### PR DESCRIPTION
- Avoid (unlikely) overflow of `DimId`.
- Add locks for thread safety.

Note the expensive reverse lookup from `DimId` to name. If this turns out to be a performance bottleneck we can also add the reverse map.

Part of #936.