### PR TITLE
Fixes for Mantid converters

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -498,8 +498,10 @@ def from_mantid(workspace, **kwargs):
     workspaces_to_delete = []
     if workspace.id() == 'Workspace2D' or workspace.id() == 'RebinnedOutput':
         has_monitors = False
-        for spec in workspace.spectrumInfo():
-            has_monitors |= spec.isMonitor
+        spec_info = workspace.spectrumInfo()
+        for i in range(len(spec_info)):
+            if spec_info.hasDetectors(i):
+                has_monitors |= spec_info.isMonitor(i)
             if has_monitors:
                 break
         if has_monitors:

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -181,7 +181,7 @@ def validate_and_get_unit(unit):
             sc.units.dimensionless / (sc.units.angstrom * sc.units.angstrom)
         ],
         "Label": ['spectrum', sc.units.dimensionless],
-        "Empty": ['spectrum', sc.units.dimensionless]
+        "Empty": ['empty', sc.units.dimensionless]
     }
 
     if unit not in known_units.keys():

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -63,6 +63,13 @@ class TestMantidConversion(unittest.TestCase):
         ws = mantid.LoadEmptyInstrument(InstrumentName='PG3')
         a = mantidcompat.from_mantid(ws)
 
+    def test_from_mantid_CreateWorkspace(self):
+        import mantid.simpleapi as mantid
+        dataX = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
+        dataY = [1,2,3,4,5,6,7,8,9,10,11,12]
+        ws = mantid.CreateWorkspace(DataX=dataX, DataY=dataY, NSpec=4, UnitX="Wavelength")
+        a = mantidcompat.from_mantid(ws)
+
     def test_unit_conversion(self):
         import mantid.simpleapi as mantid
         eventWS = mantid.CloneWorkspace(self.base_event_ws)

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -58,6 +58,11 @@ class TestMantidConversion(unittest.TestCase):
         delta = sc.sum(delta, 'tof')
         self.assertLess(np.abs(delta.value), 1e-5)
 
+    def test_from_mantid_LoadEmptyInstrument(self):
+        import mantid.simpleapi as mantid
+        ws = mantid.LoadEmptyInstrument(InstrumentName='PG3')
+        a = mantidcompat.from_mantid(ws)
+
     def test_unit_conversion(self):
         import mantid.simpleapi as mantid
         eventWS = mantid.CloneWorkspace(self.base_event_ws)

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -61,14 +61,17 @@ class TestMantidConversion(unittest.TestCase):
     def test_from_mantid_LoadEmptyInstrument(self):
         import mantid.simpleapi as mantid
         ws = mantid.LoadEmptyInstrument(InstrumentName='PG3')
-        a = mantidcompat.from_mantid(ws)
+        mantidcompat.from_mantid(ws)
 
     def test_from_mantid_CreateWorkspace(self):
         import mantid.simpleapi as mantid
-        dataX = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
-        dataY = [1,2,3,4,5,6,7,8,9,10,11,12]
-        ws = mantid.CreateWorkspace(DataX=dataX, DataY=dataY, NSpec=4, UnitX="Wavelength")
-        a = mantidcompat.from_mantid(ws)
+        dataX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        dataY = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        ws = mantid.CreateWorkspace(DataX=dataX,
+                                    DataY=dataY,
+                                    NSpec=4,
+                                    UnitX="Wavelength")
+        mantidcompat.from_mantid(ws)
 
     def test_unit_conversion(self):
         import mantid.simpleapi as mantid


### PR DESCRIPTION
- Avoid duplicate dimension label when converting from Mantid
  Previously `'spectrum'` was used for multiple corresponding dimensions in Mantid. As a result workspaces created by `LoadEmptyInstrument` caused a fail in `sc.neutron.from_mantid`.
- Fix issue with workspace created with `CreateWorkspace`, or any without instrument.