### PR TITLE
Show masks in instrument view

### DIFF
--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -242,12 +242,12 @@ class InstrumentView:
         # self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
 
         self.masks_colormap = self.widgets.Dropdown(
-                options=sorted(m for m in self.mpl_cm.datad if not m.endswith("_r"))
+                options=sorted(m for m in self.mpl_cm.datad if not m.endswith("_r")),
                 value=self.masks_params[self.key]["cmap"],
                 description="",
                 disabled = not self.masks_cmap_or_color.value == "colormap",
                 layout={'width': "100px"})
-        self.masks_colormap.on_submit(self.update_masks_colormap)
+        self.masks_colormap.observe(self.update_masks_colormap, names="value")
 
         self.masks_solid_color = self.widgets.ColorPicker(concise=False,
                                   description='',
@@ -549,8 +549,8 @@ class InstrumentView:
             "Show masks"
         self.update_colors({"new": self.slider.value})
 
-    def update_masks_colormap(self, owner):
-        self.masks_params[self.key]["cmap"] = owner.value
+    def update_masks_colormap(self, change):
+        self.masks_params[self.key]["cmap"] = change["new"]
         self.masks_cmap[self.key] = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
         self.masks_scalar_map[self.key] = self.mpl_cm.ScalarMappable(
                 cmap=self.masks_cmap[self.key], norm=self.params[self.key]["norm"])

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -84,6 +84,7 @@ class InstrumentView:
         self.widgets = importlib.import_module("ipywidgets")
         self.mpl = importlib.import_module("matplotlib")
         self.mpl_cm = importlib.import_module("matplotlib.cm")
+        self.mpl_plt = importlib.import_module("matplotlib.pyplot")
         self.mpl_figure = importlib.import_module("matplotlib.figure")
         self.mpl_colors = importlib.import_module("matplotlib.colors")
         self.mpl_backend_agg = importlib.import_module(
@@ -155,7 +156,7 @@ class InstrumentView:
             self.minmax["tof"][1] = max(self.minmax["tof"][1], var.values[-1])
             self.minmax["tof"][2] = var.shape[0]
 
-        available_cmaps = sorted(m for m in self.mpl.pyplot.colormaps()
+        available_cmaps = sorted(m for m in self.mpl_plt.colormaps()
                                  if not m.endswith("_r"))
 
         # Store current active data entry (DataArray)
@@ -449,7 +450,7 @@ class InstrumentView:
         cb1.set_label(
             name_with_unit(var=self.hist_data_array[self.key], name=""))
         canvas.draw()
-        image = np.fromstring(canvas.tostring_rgb(), dtype='uint8')
+        image = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')
         shp = list(fig.canvas.get_width_height())[::-1] + [3]
         self.cbar_image.value = self.pil.Image.fromarray(
             image.reshape(shp))._repr_png_()

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -235,11 +235,35 @@ class InstrumentView:
                 button_style="")
         self.masks_showhide.observe(self.toggle_masks, names="value")
 
+        self.masks_cmap_or_color = self.widgets.RadioButtons(
+            options=['colormap', 'solid color'],
+            description='Mask color:',
+            layout={'width': "250px"})
+        # self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
+
+        self.masks_colormap = self.widgets.Dropdown(
+                options=sorted(m for m in self.mpl_cm.datad if not m.endswith("_r"))
+                value=self.masks_params[self.key]["cmap"],
+                description="",
+                disabled = not self.masks_cmap_or_color.value == "colormap",
+                layout={'width': "100px"})
+        self.masks_colormap.on_submit(self.update_masks_colormap)
+
+        self.masks_solid_color = self.widgets.ColorPicker(concise=False,
+                                  description='',
+                                  value='#%02X%02X%02X' %
+                                  (tuple(np.random.randint(0, 255, 3))),
+                                  disabled=not self.masks_cmap_or_color.value == "solid color",
+            layout={'width': "100px"})
+        # self.masks_solid_color.observe(self.update_masks_solid_color, names="value")
+
+
+
         # Place widgets in boxes
         self.vbox = self.widgets.VBox([
             self.widgets.HBox([self.dropdown, self.slider, self.label]),
             self.widgets.HBox([self.nbins, self.bin_size]), self.togglebuttons,
-            self.widgets.HBox([self.masks_showhide])])
+            self.widgets.HBox([self.masks_showhide, self.masks_cmap_or_color, self.masks_colormap, self.masks_solid_color])])
 
         # Get detector positions
         self.det_pos = np.array(sn.position(
@@ -524,3 +548,25 @@ class InstrumentView:
         change["owner"].description = "Hide masks" if change["new"] else \
             "Show masks"
         self.update_colors({"new": self.slider.value})
+
+    def update_masks_colormap(self, owner):
+        self.masks_params[self.key]["cmap"] = owner.value
+        self.masks_cmap[self.key] = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
+        self.masks_scalar_map[self.key] = self.mpl_cm.ScalarMappable(
+                cmap=self.masks_cmap[self.key], norm=self.params[self.key]["norm"])
+        self.update_colors({"new": self.slider.value})
+
+
+# self.masks_params[key] = parse_params(params=self.masks,
+#                                                       defaults={
+#                                                           "cmap": "gray",
+#                                                           "cbar": False
+#                                                       })
+
+
+    # def get_colormap(self, key):
+    #     self.cmap[key] = self.mpl_cm.get_cmap(self.params[key]["cmap"])
+    #     self.cmap[key].set_bad(color=self.nan_color)
+
+
+

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -155,20 +155,8 @@ class InstrumentView:
             self.minmax["tof"][1] = max(self.minmax["tof"][1], var.values[-1])
             self.minmax["tof"][2] = var.shape[0]
 
-            # # Parse mask parameters and combine masks into one
-            # self.mask_params[key] = parse_params(params=masks,
-            #                                           defaults={
-            #                                               "cmap": "gray",
-            #                                               "cbar": False
-            #                                           })
-            # self.mask_params[key]["show"] = (
-            #     self.mask_params[key]["show"] and len(data_array.masks) > 0)
-            # if self.mask_params[key]["show"] and (key not in self.masks):
-            #     self.masks[key] = sc.combine_masks(data_array.masks, data_array.dims,
-            #                                data_array.shape)
-
-
-        available_cmaps = sorted(m for m in self.mpl.pyplot.colormaps() if not m.endswith("_r"))
+        available_cmaps = sorted(m for m in self.mpl.pyplot.colormaps()
+                                 if not m.endswith("_r"))
 
         # Store current active data entry (DataArray)
         keys = list(self.data_arrays.keys())
@@ -179,18 +167,17 @@ class InstrumentView:
             options=['colormap', 'solid color'],
             description='Mask color:',
             layout={'width': "250px"})
-        self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
+        self.masks_cmap_or_color.observe(self.toggle_color_selection,
+                                         names="value")
 
         # Rebin all DataArrays to common Tof axis
         self.rebin_data(np.linspace(*self.minmax["tof"]))
 
         # Create dropdown menu to select the DataArray
-        # keys = list(self.hist_data_array.keys())
         self.dropdown = self.widgets.Dropdown(options=keys,
                                               description="Select entry:",
                                               layout={"width": "initial"})
         self.dropdown.observe(self.change_data_array, names="value")
-
 
         # Create a Tof slider and its label
         self.tof_dim_indx = self.hist_data_array[self.key].dims.index(self.dim)
@@ -207,14 +194,13 @@ class InstrumentView:
 
         # Add dropdown to change cmap
         self.select_colormap = self.widgets.Combobox(
-        options=available_cmaps,
-        value=self.params[self.key]["cmap"],
-        description="Select colormap",
-        ensure_option=True,
-        layout={'width': "200px"},
-        style={"description_width": "initial"})
+            options=available_cmaps,
+            value=self.params[self.key]["cmap"],
+            description="Select colormap",
+            ensure_option=True,
+            layout={'width': "200px"},
+            style={"description_width": "initial"})
         self.select_colormap.observe(self.update_colormap, names="value")
-
 
         # Add text boxes to change number of bins/bin size
         self.nbins = self.widgets.Text(value=str(
@@ -256,46 +242,41 @@ class InstrumentView:
 
         # Create control section for masks
         self.masks_showhide = self.widgets.ToggleButton(
-                value=True,
-                description="Hide masks",
-                button_style="")
+            value=True, description="Hide masks", button_style="")
         self.masks_showhide.observe(self.toggle_masks, names="value")
 
-        # self.masks_cmap_or_color = self.widgets.RadioButtons(
-        #     options=['colormap', 'solid color'],
-        #     description='Mask color:',
-        #     layout={'width': "250px"})
-        # self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
-
         self.masks_colormap = self.widgets.Combobox(
-                options=available_cmaps,
-                value=self.masks_params[self.key]["cmap"],
-                description="",
-                ensure_option=True,
-                disabled = not self.masks_cmap_or_color.value == "colormap",
-                layout={'width': "100px"})
+            options=available_cmaps,
+            value=self.masks_params[self.key]["cmap"],
+            description="",
+            ensure_option=True,
+            disabled=not self.masks_cmap_or_color.value == "colormap",
+            layout={'width': "100px"})
         self.masks_colormap.observe(self.update_masks_colormap, names="value")
 
-        self.masks_solid_color = self.widgets.ColorPicker(concise=False,
-                                  description='',
-                                  value='#%02X%02X%02X' %
-                                  (tuple(np.random.randint(0, 255, 3))),
-                                  disabled=not self.masks_cmap_or_color.value == "solid color",
+        self.masks_solid_color = self.widgets.ColorPicker(
+            concise=False,
+            description='',
+            value='#%02X%02X%02X' % (tuple(np.random.randint(0, 255, 3))),
+            disabled=not self.masks_cmap_or_color.value == "solid color",
             layout={'width': "100px"})
-        self.masks_solid_color.observe(self.update_masks_solid_color, names="value")
-
-        # # Masks colormap
-        # self.masks_cmap = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
-        # self.masks_scalar_map = self.mpl_cm.ScalarMappable(
-        #         cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
+        self.masks_solid_color.observe(self.update_masks_solid_color,
+                                       names="value")
 
         # Place widgets in boxes
         box_list = [
-            self.widgets.HBox([self.dropdown, self.slider, self.label, self.select_colormap]),
+            self.widgets.HBox(
+                [self.dropdown, self.slider, self.label,
+                 self.select_colormap]),
             self.widgets.HBox([self.nbins, self.bin_size]), self.togglebuttons
-            ]
+        ]
+        # Only show mask controls if masks are present
         if masks_present:
-            box_list.append(self.widgets.HBox([self.masks_showhide, self.masks_cmap_or_color, self.masks_colormap, self.masks_solid_color]))
+            box_list.append(
+                self.widgets.HBox([
+                    self.masks_showhide, self.masks_cmap_or_color,
+                    self.masks_colormap, self.masks_solid_color
+                ]))
 
         self.vbox = self.widgets.VBox(box_list)
 
@@ -336,8 +317,8 @@ class InstrumentView:
 
         # The point cloud and its properties
         self.pts = self.p3.BufferAttribute(array=self.det_pos)
-        self.colors = self.p3.BufferAttribute(array=np.zeros(
-            [np.shape(self.det_pos)[0], 4], dtype=np.float32))
+        self.colors = self.p3.BufferAttribute(
+            array=np.zeros([np.shape(self.det_pos)[0], 4], dtype=np.float32))
         self.geometry = self.p3.BufferGeometry(attributes={
             'position': self.pts,
             'color': self.colors
@@ -428,21 +409,29 @@ class InstrumentView:
 
             # Parse mask parameters and combine masks into one
             self.masks_params[key] = parse_params(params=self.masks,
-                                                      defaults={
-                                                          "cmap": "gray",
-                                                          "cbar": False
-                                                      })
+                                                  defaults={
+                                                      "cmap": "gray",
+                                                      "cbar": False
+                                                  })
             self.masks_params[key]["show"] = (
-                self.masks_params[key]["show"] and len(self.hist_data_array[key].masks) > 0)
-            if self.masks_params[key]["show"] and (key not in self.masks_variables):
-                self.masks_variables[key] = sc.combine_masks(self.hist_data_array[key].masks, self.hist_data_array[key].dims,
-                                           self.hist_data_array[key].shape)
-        # if key not in self.masks_cmap:
+                self.masks_params[key]["show"]
+                and len(self.hist_data_array[key].masks) > 0)
+            if self.masks_params[key]["show"] and (
+                    key not in self.masks_variables):
+                self.masks_variables[key] = sc.combine_masks(
+                    self.hist_data_array[key].masks,
+                    self.hist_data_array[key].dims,
+                    self.hist_data_array[key].shape)
+
+        # Update the colormap with the new normalization since binning has
+        # changed
         if self.masks_cmap_or_color.value == "colormap":
-            self.masks_cmap = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
+            self.masks_cmap = self.mpl_cm.get_cmap(
+                self.masks_params[self.key]["cmap"])
         else:
             self.mpl_colors.LinearSegmentedColormap.from_list(
-            "tmp", [self.masks_solid_color.value, self.masks_solid_color.value])
+                "tmp",
+                [self.masks_solid_color.value, self.masks_solid_color.value])
         self.masks_scalar_map = self.mpl_cm.ScalarMappable(
             cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
 
@@ -467,11 +456,11 @@ class InstrumentView:
 
     def update_colors(self, change):
         arr = self.hist_data_array[self.key][self.dim, change["new"]].values
-        # if self.log:
-        #     arr = np.ma.masked_where(arr <= 0, arr)
         colors = self.scalar_map[self.key].to_rgba(arr).astype(np.float32)
-        if self.key in self.masks_variables and self.masks_params[self.key]["show"]:
-            masks_colors = self.masks_scalar_map.to_rgba(arr).astype(np.float32)
+        if self.key in self.masks_variables and self.masks_params[
+                self.key]["show"]:
+            masks_colors = self.masks_scalar_map.to_rgba(arr).astype(
+                np.float32)
             masks_inds = np.where(self.masks_variables[self.key].values)
             colors[masks_inds] = masks_colors[masks_inds]
 
@@ -587,9 +576,10 @@ class InstrumentView:
 
     def update_colormap(self, change):
         self.params[self.key]["cmap"] = change["new"]
-        self.cmap[self.key] = self.mpl_cm.get_cmap(self.params[self.key]["cmap"])
+        self.cmap[self.key] = self.mpl_cm.get_cmap(
+            self.params[self.key]["cmap"])
         self.scalar_map[self.key] = self.mpl_cm.ScalarMappable(
-                cmap=self.cmap[self.key], norm=self.params[self.key]["norm"])
+            cmap=self.cmap[self.key], norm=self.params[self.key]["norm"])
         self.update_colorbar()
         self.update_colors({"new": self.slider.value})
 
@@ -601,9 +591,10 @@ class InstrumentView:
 
     def update_masks_colormap(self, change):
         self.masks_params[self.key]["cmap"] = change["new"]
-        self.masks_cmap = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
+        self.masks_cmap = self.mpl_cm.get_cmap(
+            self.masks_params[self.key]["cmap"])
         self.masks_scalar_map = self.mpl_cm.ScalarMappable(
-                cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
+            cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
         self.update_colors({"new": self.slider.value})
 
     def update_masks_solid_color(self, change):
@@ -611,7 +602,7 @@ class InstrumentView:
             "tmp", [change["new"], change["new"]])
         self.masks_cmap.set_bad(color=change["new"])
         self.masks_scalar_map = self.mpl_cm.ScalarMappable(
-                cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
+            cmap=self.masks_cmap, norm=self.params[self.key]["norm"])
         self.update_colors({"new": self.slider.value})
 
     def toggle_color_selection(self, change):
@@ -621,4 +612,5 @@ class InstrumentView:
         if is_colormap:
             self.update_masks_colormap({"new": self.masks_colormap.value})
         else:
-            self.update_masks_solid_color({"new": self.masks_solid_color.value})
+            self.update_masks_solid_color(
+                {"new": self.masks_solid_color.value})

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -555,7 +555,11 @@ class InstrumentView:
     def change_data_array(self, change):
         self.key = change["new"]
         self.update_colorbar()
-        self.update_colors({"new": self.slider.value})
+        if self.masks_cmap_or_color.value == "colormap":
+            self.update_masks_colormap({"new": self.masks_colormap.value})
+        else:
+            self.update_masks_solid_color({"new": self.masks_solid_color.value})
+        # self.update_colors({"new": self.slider.value})
 
     def update_colormap(self, change):
         self.params[self.key]["cmap"] = change["new"]

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -85,6 +85,7 @@ class InstrumentView:
         self.mpl = importlib.import_module("matplotlib")
         self.mpl_cm = importlib.import_module("matplotlib.cm")
         self.mpl_figure = importlib.import_module("matplotlib.figure")
+        self.mpl_colors = importlib.import_module("matplotlib.colors")
         self.mpl_backend_agg = importlib.import_module(
             "matplotlib.backends.backend_agg")
         self.pil = importlib.import_module("PIL")
@@ -162,6 +163,7 @@ class InstrumentView:
             #                                data_array.shape)
 
 
+        available_cmaps = sorted(m for m in self.mpl.pyplot.colormaps() if not m.endswith("_r"))
 
 
         # Rebin all DataArrays to common Tof axis
@@ -189,6 +191,17 @@ class InstrumentView:
             readout=False)
         self.slider.observe(self.update_colors, names="value")
         self.label = self.widgets.Label()
+
+        # Add dropdown to change cmap
+        self.select_colormap = self.widgets.Combobox(
+        options=available_cmaps,
+        value=self.params[self.key]["cmap"],
+        description="Select colormap",
+        ensure_option=True,
+        layout={'width': "200px"},
+        style={"description_width": "initial"})
+        self.select_colormap.observe(self.update_colormap, names="value")
+
 
         # Add text boxes to change number of bins/bin size
         self.nbins = self.widgets.Text(value=str(
@@ -239,12 +252,13 @@ class InstrumentView:
             options=['colormap', 'solid color'],
             description='Mask color:',
             layout={'width': "250px"})
-        # self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
+        self.masks_cmap_or_color.observe(self.toggle_color_selection, names="value")
 
-        self.masks_colormap = self.widgets.Dropdown(
-                options=sorted(m for m in self.mpl_cm.datad if not m.endswith("_r")),
+        self.masks_colormap = self.widgets.Combobox(
+                options=available_cmaps,
                 value=self.masks_params[self.key]["cmap"],
                 description="",
+                ensure_option=True,
                 disabled = not self.masks_cmap_or_color.value == "colormap",
                 layout={'width': "100px"})
         self.masks_colormap.observe(self.update_masks_colormap, names="value")
@@ -255,13 +269,13 @@ class InstrumentView:
                                   (tuple(np.random.randint(0, 255, 3))),
                                   disabled=not self.masks_cmap_or_color.value == "solid color",
             layout={'width': "100px"})
-        # self.masks_solid_color.observe(self.update_masks_solid_color, names="value")
+        self.masks_solid_color.observe(self.update_masks_solid_color, names="value")
 
 
 
         # Place widgets in boxes
         self.vbox = self.widgets.VBox([
-            self.widgets.HBox([self.dropdown, self.slider, self.label]),
+            self.widgets.HBox([self.dropdown, self.slider, self.label, self.select_colormap]),
             self.widgets.HBox([self.nbins, self.bin_size]), self.togglebuttons,
             self.widgets.HBox([self.masks_showhide, self.masks_cmap_or_color, self.masks_colormap, self.masks_solid_color])])
 
@@ -386,8 +400,9 @@ class InstrumentView:
             # Parse input parameters for colorbar
             self.params[key] = parse_params(
                 globs=self.globs, array=self.hist_data_array[key].values)
-            self.cmap[key] = self.mpl_cm.get_cmap(self.params[key]["cmap"])
-            self.cmap[key].set_bad(color=self.nan_color)
+            if key not in self.cmap:
+                self.cmap[key] = self.mpl_cm.get_cmap(self.params[key]["cmap"])
+                self.cmap[key].set_bad(color=self.nan_color)
             self.scalar_map[key] = self.mpl_cm.ScalarMappable(
                 cmap=self.cmap[key], norm=self.params[key]["norm"])
 
@@ -402,7 +417,8 @@ class InstrumentView:
             if self.masks_params[key]["show"] and (key not in self.masks_variables):
                 self.masks_variables[key] = sc.combine_masks(self.hist_data_array[key].masks, self.hist_data_array[key].dims,
                                            self.hist_data_array[key].shape)
-            self.masks_cmap[key] = self.mpl_cm.get_cmap(self.masks_params[key]["cmap"])
+            if key not in self.masks_cmap:
+                self.masks_cmap[key] = self.mpl_cm.get_cmap(self.masks_params[key]["cmap"])
             self.masks_scalar_map[key] = self.mpl_cm.ScalarMappable(
                 cmap=self.masks_cmap[key], norm=self.params[key]["norm"])
 
@@ -430,8 +446,6 @@ class InstrumentView:
         # if self.log:
         #     arr = np.ma.masked_where(arr <= 0, arr)
         colors = self.scalar_map[self.key].to_rgba(arr).astype(np.float32)
-        # print(colors)
-        # print(np.shape(colors))
         if self.key in self.masks_variables and self.masks_params[self.key]["show"]:
             masks_colors = self.masks_scalar_map[self.key].to_rgba(arr).astype(np.float32)
             masks_inds = np.where(self.masks_variables[self.key].values)
@@ -543,6 +557,14 @@ class InstrumentView:
         self.update_colorbar()
         self.update_colors({"new": self.slider.value})
 
+    def update_colormap(self, change):
+        self.params[self.key]["cmap"] = change["new"]
+        self.cmap[self.key] = self.mpl_cm.get_cmap(self.params[self.key]["cmap"])
+        self.scalar_map[self.key] = self.mpl_cm.ScalarMappable(
+                cmap=self.cmap[self.key], norm=self.params[self.key]["norm"])
+        self.update_colorbar()
+        self.update_colors({"new": self.slider.value})
+
     def toggle_masks(self, change):
         self.masks_params[self.key]["show"] = change["new"]
         change["owner"].description = "Hide masks" if change["new"] else \
@@ -556,17 +578,20 @@ class InstrumentView:
                 cmap=self.masks_cmap[self.key], norm=self.params[self.key]["norm"])
         self.update_colors({"new": self.slider.value})
 
+    def update_masks_solid_color(self, change):
+        # self.masks_params[self.key]["cmap"] = change["new"]
+        self.masks_cmap[self.key] = self.mpl_colors.LinearSegmentedColormap.from_list(
+            "tmp", [change["new"], change["new"]])
+        # self.masks_cmap[self.key] = self.mpl_cm.get_cmap(self.masks_params[self.key]["cmap"])
+        self.masks_scalar_map[self.key] = self.mpl_cm.ScalarMappable(
+                cmap=self.masks_cmap[self.key], norm=self.params[self.key]["norm"])
+        self.update_colors({"new": self.slider.value})
 
-# self.masks_params[key] = parse_params(params=self.masks,
-#                                                       defaults={
-#                                                           "cmap": "gray",
-#                                                           "cbar": False
-#                                                       })
-
-
-    # def get_colormap(self, key):
-    #     self.cmap[key] = self.mpl_cm.get_cmap(self.params[key]["cmap"])
-    #     self.cmap[key].set_bad(color=self.nan_color)
-
-
-
+    def toggle_color_selection(self, change):
+        is_colormap = change["new"] == "colormap"
+        self.masks_colormap.disabled = not is_colormap
+        self.masks_solid_color.disabled = is_colormap
+        if is_colormap:
+            self.update_masks_colormap({"new": self.masks_colormap.value})
+        else:
+            self.update_masks_solid_color({"new": self.masks_solid_color.value})

--- a/python/tests/neutron/test_neutron.py
+++ b/python/tests/neutron/test_neutron.py
@@ -91,3 +91,11 @@ def test_neutron_instrument_view_with_dataset():
     d['b'] = sc.Variable(['position', 'tof'],
                          values=np.arange(36.).reshape(4, 9))
     sc.neutron.instrument_view(d)
+
+
+def test_neutron_instrument_view_with_masks():
+    d = make_dataset_with_beamline()
+    x = np.transpose(d.coords['position'].values)[0, :]
+    d['a'].masks['amask'] = sc.Variable(dims=['position'],
+                                        values=np.less(np.abs(x), 0.5))
+    sc.neutron.instrument_view(d["a"])


### PR DESCRIPTION
Masks are now visible in the instrument view.

Following the convention of plotting masks on 2D images, they appear as greyscale data by default. This can be changed to a solid color by using the new control buttons at the bottom of the control section.

Masks can be shown/hidden using the "show/hide masks" toggle button.

In addition, it is now also possible to change the colormap for the data with a dropdown menu.

Example:
```Py
import numpy as np
import scipp as sc

sample = sc.neutron.load(filename='PG3_4871_event.nxs')
z = np.transpose(sc.neutron.position(sample).values)[2, :]
sample.masks['zmask'] = sc.Variable(dims=['spectrum'], values=np.less(z, 0))

sc.neutron.instrument_view(sample)
```

![Screenshot_2020-03-03_10-54-47](https://user-images.githubusercontent.com/39047984/75764033-8bea5580-5d3d-11ea-95ee-54d3498356d6.png)

Fixes #996 