### PR TITLE
Use ipympl backend when running in JupyterLab

### DIFF
--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -22,10 +22,14 @@ try:
         if is_doc_build:
             ipy.run_line_magic("matplotlib", "inline")
         elif "IPKernelApp" in ipy.config:
-            ipy.run_line_magic("matplotlib", "notebook")
-            ipy.run_cell_magic(
-                "html", "", "<style>.output_wrapper "
-                ".ui-dialog-titlebar {display: none;}</style>")
+            try:
+                # Use the ipympl (matplotlib widget) backend if installed
+                ipy.run_line_magic("matplotlib", "widget")
+            except ImportError:
+                ipy.run_line_magic("matplotlib", "notebook")
+                ipy.run_cell_magic(
+                    "html", "", "<style>.output_wrapper "
+                    ".ui-dialog-titlebar {display: none;}</style>")
 except ImportError:
     pass
 

--- a/python/src/scipp/plot/render.py
+++ b/python/src/scipp/plot/render.py
@@ -10,7 +10,6 @@ def render_plot(figure=None, widgets=None, filename=None, ipv=None):
 
     # Delay imports
     import IPython.display as disp
-    import matplotlib
 
     if filename is not None:
         if ipv is not None:
@@ -22,7 +21,6 @@ def render_plot(figure=None, widgets=None, filename=None, ipv=None):
         else:
             figure.savefig(filename, bbox_inches="tight")
     else:
-        if widgets is not None and (ipv is not None
-                                    or matplotlib.get_backend() == "nbAgg"):
+        if widgets is not None:
             disp.display(widgets)
     return

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -7,7 +7,6 @@ from .. import config
 
 # Other imports
 import numpy as np
-from matplotlib.colors import Normalize, LogNorm, LinearSegmentedColormap
 
 
 def get_line_param(name=None, index=None):
@@ -38,6 +37,8 @@ def parse_params(params=None, defaults=None, globs=None, array=None):
     """
     Construct the colorbar settings using default and input values
     """
+    from matplotlib.colors import Normalize, LogNorm, LinearSegmentedColormap
+
     parsed = dict(config.plot.params)
     if defaults is not None:
         for key, val in defaults.items():


### PR DESCRIPTION
The `%matplotlib notebook` backend is not available in JupyterLab.
Instead, the `ipympl` package has to be used (https://github.com/matplotlib/ipympl)

This PR makes scipp check if the `widget` backend is installed on `__init__` and if so, uses this instead of the `notebook` backend.

It is a little strange that in a Lab notebook, once you have selected the `%matplotlib notebook` backend, you cannot switch back to `%matplotlib widget`, you get an error:
```
Warning: Cannot change to a different GUI toolkit: widget. Using notebook instead.
```

These changes will help using scipp inside the ESS JupyterHub.