### PR TITLE
Fix matplotlib backend selection

### DIFF
--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -89,7 +89,7 @@ class InstrumentView:
         self.mpl_colors = importlib.import_module("matplotlib.colors")
         self.mpl_backend_agg = importlib.import_module(
             "matplotlib.backends.backend_agg")
-        self.pil = importlib.import_module("PIL")
+        self.pil_image = importlib.import_module("PIL.Image")
         self.p3 = importlib.import_module("pythreejs")
 
         self.fig = None
@@ -453,7 +453,7 @@ class InstrumentView:
         canvas.draw()
         image = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')
         shp = list(fig.canvas.get_width_height())[::-1] + [3]
-        self.cbar_image.value = self.pil.Image.fromarray(
+        self.cbar_image.value = self.pil_image.fromarray(
             image.reshape(shp))._repr_png_()
 
     def update_colors(self, change):

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -7,7 +7,6 @@ import importlib
 
 # If we are running inside a notebook, then make plot interactive by default.
 # From: https://stackoverflow.com/a/22424821
-plt = None
 try:
     import matplotlib
     try:
@@ -15,6 +14,8 @@ try:
         ipy = get_ipython()
         if ipy is not None:
 
+            # Check if a docs build is requested in the metadata. If so,
+            # use the default Qt/inline backend.
             cfg = ipy.config
             try:
                 meta = cfg["Session"]["metadata"]
@@ -24,20 +25,21 @@ try:
             except KeyError:
                 is_doc_build = False
 
-            # if is_doc_build:
-            #     import matplotlib.pyplot as plt
-            #     plt.ion()
-            #     print("doc build")
+            # If we are in an IPython kernel, select either widget backend
+            # if installed (for JupyterLan), or notebook backend.
             if "IPKernelApp" in ipy.config and not is_doc_build:
                 try:
                     _ = importlib.import_module("ipympl")
                     matplotlib.use('module://ipympl.backend_nbagg')
                 except ImportError:
                     matplotlib.use('nbAgg')
-                    # import matplotlib.pyplot as plt
-                    # plt.ion()
+                    # Remove the title banner and button from figure
+                    ipy.run_cell_magic(
+                        "html", "", "<style>.output_wrapper "
+                        ".ui-dialog-titlebar {display: none;}</style>")
     except ImportError:
         pass
+    # Turn interactive plotting on
     import matplotlib.pyplot as plt
     plt.ion()
 

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -3,33 +3,44 @@
 # @file
 # @author Neil Vaytet
 
-# flake8: noqa
+import importlib
 
 # If we are running inside a notebook, then make plot interactive by default.
 # From: https://stackoverflow.com/a/22424821
+plt = None
 try:
-    from IPython import get_ipython
-    ipy = get_ipython()
-    if ipy is not None:
-        cfg = ipy.config
-        try:
-            meta = cfg["Session"]["metadata"]
-            if hasattr(meta, "to_dict"):
-                meta = meta.to_dict()
-            is_doc_build = meta["scipp_docs_build"]
-        except KeyError:
-            is_doc_build = False
-        if is_doc_build:
-            ipy.run_line_magic("matplotlib", "inline")
-        elif "IPKernelApp" in ipy.config:
+    import matplotlib
+    try:
+        from IPython import get_ipython
+        ipy = get_ipython()
+        if ipy is not None:
+
+            cfg = ipy.config
             try:
-                # Use the ipympl (matplotlib widget) backend if installed
-                ipy.run_line_magic("matplotlib", "widget")
-            except ImportError:
-                ipy.run_line_magic("matplotlib", "notebook")
-                ipy.run_cell_magic(
-                    "html", "", "<style>.output_wrapper "
-                    ".ui-dialog-titlebar {display: none;}</style>")
+                meta = cfg["Session"]["metadata"]
+                if hasattr(meta, "to_dict"):
+                    meta = meta.to_dict()
+                is_doc_build = meta["scipp_docs_build"]
+            except KeyError:
+                is_doc_build = False
+
+            # if is_doc_build:
+            #     import matplotlib.pyplot as plt
+            #     plt.ion()
+            #     print("doc build")
+            if "IPKernelApp" in ipy.config and not is_doc_build:
+                try:
+                    _ = importlib.import_module("ipympl")
+                    matplotlib.use('module://ipympl.backend_nbagg')
+                except ImportError:
+                    matplotlib.use('nbAgg')
+                    # import matplotlib.pyplot as plt
+                    # plt.ion()
+    except ImportError:
+        pass
+    import matplotlib.pyplot as plt
+    plt.ion()
+
 except ImportError:
     pass
 


### PR DESCRIPTION
Selecting the right backend was modified in #1010 to enable use in JupyterLab, but this actually broke the use of the notebook backend.
Once the `%matplotlib widget` is attempted, even if it fails (maybe only on certain versions of `matplotlib`), it is no longer possible to do `%matplotlib notebook`. It throws with
```
Warning: Cannot change to a different GUI toolkit: notebook. Using widget instead.
```

This PR fixes this.

Also:

Fixes #1018 with a slightly modified way of importing `PIL.Image`
