### PR TITLE
Add tests for existing transform flags

### DIFF
--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -368,6 +368,12 @@ static void do_transform(Op op, Out &&out, Tuple &&processed, const Arg &arg,
           args...);
     }
   } else {
+    if constexpr (std::is_base_of_v<transform_flags::expect_variance_arg_t<
+                                        std::tuple_size_v<Tuple>>,
+                                    Op>)
+      throw except::VariancesError("Variances missing in argument " +
+                                   std::to_string(std::tuple_size_v<Tuple>) +
+                                   " . Must be set.");
     do_transform(op, std::forward<Out>(out),
                  std::tuple_cat(processed, std::tuple(vals)), args...);
   }

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -911,44 +911,106 @@ TEST_F(TransformInPlaceDryRunTest, unchanged_if_success) {
   EXPECT_EQ(a, original);
 }
 
-TEST(TransformFlagsTest, variance_on_arg_throws) {
-  auto a = makeVariable<double>(Values{1}, Variances{1});
-  auto b = makeVariable<double>(Values{1});
+TEST(TransformFlagsTest, no_variance_on_arg_throws) {
+  auto var_with_variance = makeVariable<double>(Values{1}, Variances{1});
+  auto var_no_variance = makeVariable<double>(Values{1});
   auto binary_op = [](auto x, auto y) { return x + y; };
   auto op_arg_0_has_flags =
-      scipp::overloaded{transform_flags::expect_no_variance_arg<0>, binary_op};
-  EXPECT_THROW(transform<std::tuple<double>>(a, b, op_arg_0_has_flags),
+      scipp::overloaded{transform_flags::expect_variance_arg<0>, binary_op};
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_with_variance, var_no_variance, op_arg_0_has_flags));
+  EXPECT_THROW(transform<std::tuple<double>>(var_no_variance, var_with_variance,
+                                             op_arg_0_has_flags),
                except::VariancesError);
-  EXPECT_NO_THROW(transform<std::tuple<double>>(b, a, op_arg_0_has_flags));
-  EXPECT_NO_THROW(transform<std::tuple<double>>(b, b, op_arg_0_has_flags));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_with_variance, var_with_variance, op_arg_0_has_flags));
   auto op_arg_1_has_flags =
-      scipp::overloaded{transform_flags::expect_no_variance_arg<1>, binary_op};
-  EXPECT_THROW(transform<std::tuple<double>>(b, a, op_arg_1_has_flags),
+      scipp::overloaded{transform_flags::expect_variance_arg<1>, binary_op};
+  EXPECT_THROW(transform<std::tuple<double>>(var_with_variance, var_no_variance,
+                                             op_arg_1_has_flags),
                except::VariancesError);
-  EXPECT_NO_THROW(transform<std::tuple<double>>(a, b, op_arg_1_has_flags));
-  EXPECT_NO_THROW(transform<std::tuple<double>>(b, b, op_arg_1_has_flags));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_no_variance, var_with_variance, op_arg_1_has_flags));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_with_variance, var_with_variance, op_arg_1_has_flags));
   auto all_args_with_flag =
-      scipp::overloaded{transform_flags::expect_no_variance_arg<0>,
-                        transform_flags::expect_no_variance_arg<1>, binary_op};
-  EXPECT_THROW(transform<std::tuple<double>>(a, a, all_args_with_flag),
+      scipp::overloaded{transform_flags::expect_variance_arg<0>,
+                        transform_flags::expect_variance_arg<1>, binary_op};
+  EXPECT_THROW(transform<std::tuple<double>>(var_no_variance, var_no_variance,
+                                             all_args_with_flag),
                except::VariancesError);
-  EXPECT_NO_THROW(transform<std::tuple<double>>(b, b, all_args_with_flag));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_with_variance, var_with_variance, all_args_with_flag));
+}
+
+TEST(TransformFlagsTest, no_variance_on_arg_throws_in_place) {
+  auto var_with_variance = makeVariable<double>(Values{1}, Variances{1});
+  auto var_no_variance = makeVariable<double>(Values{1});
+  auto unary_in_place = [](auto &out, auto a) {};
+  auto op_arg_0_has_flags = scipp::overloaded{
+      transform_flags::expect_variance_arg<0>, unary_in_place};
+  EXPECT_THROW(transform_in_place<std::tuple<double>>(
+                   var_no_variance, var_no_variance, op_arg_0_has_flags),
+               except::VariancesError);
+  EXPECT_NO_THROW(transform_in_place<std::tuple<double>>(
+      var_with_variance, var_with_variance, op_arg_0_has_flags));
+  auto op_arg_1_has_flags = scipp::overloaded{
+      transform_flags::expect_variance_arg<1>, unary_in_place};
+  EXPECT_THROW(transform_in_place<std::tuple<double>>(
+                   var_no_variance, var_no_variance, op_arg_1_has_flags),
+               except::VariancesError);
+  EXPECT_NO_THROW(transform_in_place<std::tuple<double>>(
+      var_with_variance, var_with_variance, op_arg_1_has_flags));
 }
 
 TEST(TransformFlagsTest, variance_on_arg_throws_in_place) {
-  auto a = makeVariable<double>(Values{1}, Variances{1});
-  auto b = makeVariable<double>(Values{1});
+  auto var_with_variance = makeVariable<double>(Values{1}, Variances{1});
+  auto var_no_variance = makeVariable<double>(Values{1});
   auto unary_in_place = [](auto &out, auto a) {};
   auto op_arg_0_has_flags = scipp::overloaded{
       transform_flags::expect_no_variance_arg<0>, unary_in_place};
-  EXPECT_THROW(transform_in_place<std::tuple<double>>(a, a, op_arg_0_has_flags),
+  EXPECT_THROW(transform_in_place<std::tuple<double>>(
+                   var_with_variance, var_with_variance, op_arg_0_has_flags),
                except::VariancesError);
-  EXPECT_NO_THROW(
-      transform_in_place<std::tuple<double>>(b, b, op_arg_0_has_flags));
+  EXPECT_NO_THROW(transform_in_place<std::tuple<double>>(
+      var_no_variance, var_no_variance, op_arg_0_has_flags));
   auto op_arg_1_has_flags = scipp::overloaded{
       transform_flags::expect_no_variance_arg<1>, unary_in_place};
-  EXPECT_THROW(transform_in_place<std::tuple<double>>(a, a, op_arg_1_has_flags),
+  EXPECT_THROW(transform_in_place<std::tuple<double>>(
+                   var_with_variance, var_with_variance, op_arg_1_has_flags),
                except::VariancesError);
-  EXPECT_NO_THROW(
-      transform_in_place<std::tuple<double>>(b, b, op_arg_1_has_flags));
+  EXPECT_NO_THROW(transform_in_place<std::tuple<double>>(
+      var_no_variance, var_no_variance, op_arg_1_has_flags));
+}
+
+TEST(TransformFlagsTest, variance_on_arg_throws) {
+  auto var_with_variance = makeVariable<double>(Values{1}, Variances{1});
+  auto var_no_variance = makeVariable<double>(Values{1});
+  auto binary_op = [](auto x, auto y) { return x + y; };
+  auto op_arg_0_has_flags =
+      scipp::overloaded{transform_flags::expect_no_variance_arg<0>, binary_op};
+  EXPECT_THROW(transform<std::tuple<double>>(var_with_variance, var_no_variance,
+                                             op_arg_0_has_flags),
+               except::VariancesError);
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_no_variance, var_with_variance, op_arg_0_has_flags));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_no_variance, var_no_variance, op_arg_0_has_flags));
+  auto op_arg_1_has_flags =
+      scipp::overloaded{transform_flags::expect_no_variance_arg<1>, binary_op};
+  EXPECT_THROW(transform<std::tuple<double>>(var_no_variance, var_with_variance,
+                                             op_arg_1_has_flags),
+               except::VariancesError);
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_with_variance, var_no_variance, op_arg_1_has_flags));
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_no_variance, var_no_variance, op_arg_1_has_flags));
+  auto all_args_with_flag =
+      scipp::overloaded{transform_flags::expect_no_variance_arg<0>,
+                        transform_flags::expect_no_variance_arg<1>, binary_op};
+  EXPECT_THROW(transform<std::tuple<double>>(
+                   var_with_variance, var_with_variance, all_args_with_flag),
+               except::VariancesError);
+  EXPECT_NO_THROW(transform<std::tuple<double>>(
+      var_no_variance, var_no_variance, all_args_with_flag));
 }


### PR DESCRIPTION
Fixes #1016

Add tests for all existing transform flags as utilised in `transform` and `transform_in_place`