### PR TITLE
python exports for atan2

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -859,10 +859,6 @@ def test_atan_out():
 def test_atan2():
     var = sc.Variable()
     assert_export(sc.atan2, y=var, x=var)
-
-
-def test_atan2():
-    var = sc.Variable()
     assert_export(sc.atan2, y=var, x=var, out=var)
 
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -856,6 +856,16 @@ def test_atan_out():
     assert_export(sc.atan, var, out=var)
 
 
+def test_atan2():
+    var = sc.Variable()
+    assert_export(sc.atan2, y=var, x=var)
+
+
+def test_atan2():
+    var = sc.Variable()
+    assert_export(sc.atan2, y=var, x=var, out=var)
+
+
 def test_variable_data_array_binary_ops():
     a = sc.DataArray(1.0 * sc.units.m)
     var = 1.0 * sc.units.m

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -683,6 +683,25 @@ void init_variable(py::module &m) {
         :return: atan of input values. Output unit is rad.
         :rtype: Variable)");
 
+  m.def("atan2",
+        [](const Variable &y, const Variable &x) { return atan2(y, x); },
+        py::arg("y"), py::arg("x"),
+        R"(
+        Element-wise atan2.
+        :raises: If the units of inputs are different, or if the dtype has no atan2, e.g., if it is an integer
+        :return: atan2 of input y and x. Output unit is rad.
+        :rtype: Variable)");
+
+  m.def("atan2",
+        [](const VariableConstView &y, const VariableConstView &x,
+           const VariableView &out) { return atan2(y, x, out); },
+        py::arg("y"), py::arg("x"), py::arg("out"),
+        R"(
+        Element-wise atan2 in place.
+        :raises: If the units of inputs are different, or if the dtype has no atan2, e.g., if it is an integer
+        :return: atan2 of input y and x, written to output. Output unit is rad.
+        :rtype: VariableView)");
+
   m.def("all", py::overload_cast<const VariableConstView &, const Dim>(&all),
         py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
         R"(

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -697,7 +697,7 @@ void init_variable(py::module &m) {
            const VariableView &out) { return atan2(y, x, out); },
         py::arg("y"), py::arg("x"), py::arg("out"),
         R"(
-        Element-wise atan2 in place.
+        Element-wise atan2 with out argument.
         :raises: If the units of inputs are different, or if the dtype has no atan2, e.g., if it is an integer
         :return: atan2 of input y and x, written to output. Output unit is rad.
         :rtype: VariableView)");


### PR DESCRIPTION
Overlooked - should have been added as part of #1012 but needed for new spherical averaging #991 