### PR TITLE
Zip and unzip positions

### DIFF
--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -16,6 +16,8 @@ namespace scipp::core {
 
 namespace element {
 
+namespace geometry {
+
 constexpr auto position = overloaded{
     arg_list<double>,
     transform_flags::expect_no_variance_arg<0>,
@@ -31,6 +33,27 @@ constexpr auto position = overloaded{
       expect::equals(x, units::m);
       return x;
     }};
+
+namespace detail {
+auto x_value = [](const auto &pos) { return pos[0]; };
+auto y_value = [](const auto &pos) { return pos[1]; };
+auto z_value = [](const auto &pos) { return pos[2]; };
+auto unit_validate = [](const units::Unit &u) {
+  expect::equals(u, units::m);
+  return u;
+};
+} // namespace detail
+constexpr auto x = overloaded{arg_list<Eigen::Vector3d>,
+                              transform_flags::expect_no_variance_arg<0>,
+                              detail::x_value, detail::unit_validate};
+constexpr auto y = overloaded{arg_list<Eigen::Vector3d>,
+                              transform_flags::expect_no_variance_arg<0>,
+                              detail::y_value, detail::unit_validate};
+constexpr auto z = overloaded{arg_list<Eigen::Vector3d>,
+                              transform_flags::expect_no_variance_arg<0>,
+                              detail::z_value, detail::unit_validate};
+
+} // namespace geometry
 
 } // namespace element
 

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Owen Arnold
+#ifndef SCIPP_CORE_ELEMENT_GEOMETRIC_OPERATIONS_H
+#define SCIPP_CORE_ELEMENT_GEOMETRIC_OPERATIONS_H
+
+#include "arg_list.h"
+#include "scipp/common/overloaded.h"
+#include "scipp/core/transform.h"
+
+namespace scipp::core {
+
+/// Operators to be used with transform and transform_in_place to implement
+/// geometric operations for Variable.
+
+namespace element {
+
+constexpr auto zip_position = overloaded{
+    transform_flags::expect_no_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<2>,
+    [](const auto &x, const auto &y, const auto &z) {
+      using T = double; // currently only double precision support
+      return Eigen::Matrix<T, 3, 1>(x, y, z);
+    },
+    [](const units::Unit &x, const units::Unit &y, const units::Unit &z) {
+      expect::equals(x, y);
+      expect::equals(x, z);
+      expect::equals(x, units::m);
+      return x;
+    }};
+
+} // namespace element
+
+} // namespace scipp::core
+
+#endif // SCIPP_CORE_ELEMENT_GEOMETRIC_OPERATIONS_H

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -16,7 +16,7 @@ namespace scipp::core {
 
 namespace element {
 
-constexpr auto zip_position = overloaded{
+constexpr auto position = overloaded{
     arg_list<float, double>,
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -35,24 +35,18 @@ constexpr auto position = overloaded{
     }};
 
 namespace detail {
-auto x_value = [](const auto &pos) { return pos[0]; };
-auto y_value = [](const auto &pos) { return pos[1]; };
-auto z_value = [](const auto &pos) { return pos[2]; };
-auto unit_validate = [](const units::Unit &u) {
-  expect::equals(u, units::m);
-  return u;
+template <int N> struct component {
+  static constexpr auto overloads = overloaded{
+      arg_list<Eigen::Vector3d>, [](const auto &pos) { return pos[N]; },
+      [](const units::Unit &u) {
+        expect::equals(u, units::m);
+        return u;
+      }};
 };
 } // namespace detail
-constexpr auto x = overloaded{arg_list<Eigen::Vector3d>,
-                              transform_flags::expect_no_variance_arg<0>,
-                              detail::x_value, detail::unit_validate};
-constexpr auto y = overloaded{arg_list<Eigen::Vector3d>,
-                              transform_flags::expect_no_variance_arg<0>,
-                              detail::y_value, detail::unit_validate};
-constexpr auto z = overloaded{arg_list<Eigen::Vector3d>,
-                              transform_flags::expect_no_variance_arg<0>,
-                              detail::z_value, detail::unit_validate};
-
+constexpr auto x = detail::component<0>::overloads;
+constexpr auto y = detail::component<1>::overloads;
+constexpr auto z = detail::component<2>::overloads;
 } // namespace geometry
 
 } // namespace element

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -17,6 +17,7 @@ namespace scipp::core {
 namespace element {
 
 constexpr auto zip_position = overloaded{
+    arg_list<float, double>,
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     transform_flags::expect_no_variance_arg<2>,

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -17,7 +17,7 @@ namespace scipp::core {
 namespace element {
 
 constexpr auto position = overloaded{
-    arg_list<float, double>,
+    arg_list<double>,
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     transform_flags::expect_no_variance_arg<2>,

--- a/core/element_geometric_operations.h
+++ b/core/element_geometric_operations.h
@@ -42,6 +42,7 @@ template <int N> struct component {
         expect::equals(u, units::m);
         return u;
       }};
+  enum { value = N };
 };
 } // namespace detail
 constexpr auto x = detail::component<0>::overloads;

--- a/core/include/scipp/core/transform.h
+++ b/core/include/scipp/core/transform.h
@@ -855,11 +855,8 @@ Variable transform(std::tuple<Ts...> &&, Op op, const Vars &... vars) {
   auto unit = op(vars.unit()...);
   Variable out;
   try {
-    if constexpr ((is_any_sparse<Ts>::value || ...)) {
+    if constexpr ((is_any_sparse<Ts>::value || ...) || sizeof...(Vars) > 2) {
       out = visit_impl<Ts...>::apply(Transform{op}, vars.dataHandle()...);
-    } else if constexpr (sizeof...(Vars) > 2) {
-      static_assert("Transform with more than 2 arguments not implemented "
-                    "yet for element-wise operation.");
     } else {
       out = core::visit(augment::insert_sparse(std::tuple<Ts...>{}))
                 .apply(Transform{overloaded_sparse{op, TransformSparse{}}},

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -1049,6 +1049,10 @@ nan_to_num(const VariableConstView &var, const VariableConstView &replacement);
                                                   const VariableConstView &y,
                                                   const VariableConstView &z);
 
+[[nodiscard]] SCIPP_CORE_EXPORT Variable x(const VariableConstView &pos);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable y(const VariableConstView &pos);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable z(const VariableConstView &pos);
+
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstView &var);
 SCIPP_CORE_EXPORT void reserve(const VariableView &sparse,

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -1045,13 +1045,15 @@ nan_to_num(const VariableConstView &var, const VariableConstView &replacement);
     const VariableConstView &var, const VariableConstView &replacement);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable neg_inf_to_num(
     const VariableConstView &var, const VariableConstView &replacement);
+namespace geometry {
 [[nodiscard]] SCIPP_CORE_EXPORT Variable position(const VariableConstView &x,
                                                   const VariableConstView &y,
                                                   const VariableConstView &z);
-
 [[nodiscard]] SCIPP_CORE_EXPORT Variable x(const VariableConstView &pos);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable y(const VariableConstView &pos);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable z(const VariableConstView &pos);
+
+} // namespace geometry
 
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstView &var);

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -1045,6 +1045,9 @@ nan_to_num(const VariableConstView &var, const VariableConstView &replacement);
     const VariableConstView &var, const VariableConstView &replacement);
 [[nodiscard]] SCIPP_CORE_EXPORT Variable neg_inf_to_num(
     const VariableConstView &var, const VariableConstView &replacement);
+[[nodiscard]] SCIPP_CORE_EXPORT Variable position(const VariableConstView &x,
+                                                  const VariableConstView &y,
+                                                  const VariableConstView &z);
 
 namespace sparse {
 SCIPP_CORE_EXPORT Variable counts(const VariableConstView &var);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   dimensions_test.cpp
   element_array_test.cpp
   element_unary_operations_test.cpp
+  element_geometric_operations_test.cpp
   element_trigonometry_operations_test.cpp
   event_test.cpp
   except_test.cpp

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -13,19 +13,19 @@ using namespace scipp::core;
 TEST(ElementPositionTest, unit_in_m) {
   const units::Unit m(units::m);
   const units::Unit s(units::s); // Not supported
-  EXPECT_THROW(element::zip_position(s, m, m), except::UnitError);
-  EXPECT_THROW(element::zip_position(m, s, m), except::UnitError);
-  EXPECT_THROW(element::zip_position(m, m, s), except::UnitError);
-  EXPECT_THROW(element::zip_position(s, s, s), except::UnitError);
-  EXPECT_NO_THROW(element::zip_position(m, m, m));
+  EXPECT_THROW(element::position(s, m, m), except::UnitError);
+  EXPECT_THROW(element::position(m, s, m), except::UnitError);
+  EXPECT_THROW(element::position(m, m, s), except::UnitError);
+  EXPECT_THROW(element::position(s, s, s), except::UnitError);
+  EXPECT_NO_THROW(element::position(m, m, m));
 }
 
 TEST(ElementPositionTest, unit_out) {
   const units::Unit m(units::m);
-  EXPECT_EQ(element::zip_position(m, m, m), m);
+  EXPECT_EQ(element::position(m, m, m), m);
 }
 
 TEST(ElementPositionTest, zip_position_values) {
-  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::zip_position(1.0, 2.0, 3.0));
-  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::zip_position(1.0f, 2.0f, 3.0f));
+  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::position(1.0, 2.0, 3.0));
+  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::position(1.0f, 2.0f, 3.0f));
 }

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -29,29 +29,20 @@ TEST(ElementPositionTest, zip_position_values) {
   EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), geometry::position(1.0, 2.0, 3.0));
 }
 
-TEST(ElementPositionTest, unzip_position_x) {
-  Eigen::Vector3d a{1.0, 2.0, 3.0};
-  units::Unit m(units::m);
-  units::Unit K(units::K);
-  EXPECT_EQ(geometry::x(a), 1.0);
-  EXPECT_EQ(geometry::x(m), m);
-  EXPECT_THROW(geometry::x(K), except::UnitError);
-}
+template <typename T> class ElementPositionNTest : public ::testing::Test {};
 
-TEST(ElementPositionTest, unzip_position_y) {
-  Eigen::Vector3d a{1.0, 2.0, 3.0};
-  units::Unit m(units::m);
-  units::Unit K(units::K);
-  EXPECT_EQ(geometry::y(a), 2.0);
-  EXPECT_EQ(geometry::y(m), m);
-  EXPECT_THROW(geometry::y(K), except::UnitError);
-}
+template <int I> using component = geometry::detail::component<I>;
 
-TEST(ElementPositionTest, unzip_position_z) {
+using types = ::testing::Types<component<0>, component<1>, component<2>>;
+TYPED_TEST_SUITE(ElementPositionNTest, types);
+
+TYPED_TEST(ElementPositionNTest, unzip_position) {
+  using T = TypeParam;
+  constexpr auto component = T::overloads;
   Eigen::Vector3d a{1.0, 2.0, 3.0};
   units::Unit m(units::m);
   units::Unit K(units::K);
-  EXPECT_EQ(geometry::z(a), 3.0);
-  EXPECT_EQ(geometry::z(m), m);
+  EXPECT_EQ(component(a), a[T::value]);
+  EXPECT_EQ(geometry::detail::component<T::value>::overloads(m), m);
   EXPECT_THROW(geometry::z(K), except::UnitError);
 }

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "../element_geometric_operations.h"
+#include "fix_typed_test_suite_warnings.h"
+#include "scipp/units/unit.h"
+#include <Eigen/Geometry>
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(ElementPositionTest, unit_in_m) {
+  const units::Unit m(units::m);
+  const units::Unit s(units::s); // Not supported
+  EXPECT_THROW(element::zip_position(s, m, m), except::UnitError);
+  EXPECT_THROW(element::zip_position(m, s, m), except::UnitError);
+  EXPECT_THROW(element::zip_position(m, m, s), except::UnitError);
+  EXPECT_THROW(element::zip_position(s, s, s), except::UnitError);
+  EXPECT_NO_THROW(element::zip_position(m, m, m));
+}
+
+TEST(ElementPositionTest, unit_out) {
+  const units::Unit m(units::m);
+  EXPECT_EQ(element::zip_position(m, m, m), m);
+}
+
+TEST(ElementPositionTest, zip_position_values) {
+  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::zip_position(1.0, 2.0, 3.0));
+}

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -9,22 +9,50 @@
 
 using namespace scipp;
 using namespace scipp::core;
+using namespace element;
 
 TEST(ElementPositionTest, unit_in_m) {
   const units::Unit m(units::m);
   const units::Unit s(units::s); // Not supported
-  EXPECT_THROW(element::position(s, m, m), except::UnitError);
-  EXPECT_THROW(element::position(m, s, m), except::UnitError);
-  EXPECT_THROW(element::position(m, m, s), except::UnitError);
-  EXPECT_THROW(element::position(s, s, s), except::UnitError);
-  EXPECT_NO_THROW(element::position(m, m, m));
+  EXPECT_THROW(geometry::position(s, m, m), except::UnitError);
+  EXPECT_THROW(geometry::position(m, s, m), except::UnitError);
+  EXPECT_THROW(geometry::position(m, m, s), except::UnitError);
+  EXPECT_THROW(geometry::position(s, s, s), except::UnitError);
+  EXPECT_NO_THROW(geometry::position(m, m, m));
 }
 
 TEST(ElementPositionTest, unit_out) {
   const units::Unit m(units::m);
-  EXPECT_EQ(element::position(m, m, m), m);
+  EXPECT_EQ(geometry::position(m, m, m), m);
 }
 
 TEST(ElementPositionTest, zip_position_values) {
-  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::position(1.0, 2.0, 3.0));
+  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), geometry::position(1.0, 2.0, 3.0));
+}
+
+TEST(ElementPositionTest, unzip_position_x) {
+  Eigen::Vector3d a{1.0, 2.0, 3.0};
+  units::Unit m(units::m);
+  units::Unit K(units::K);
+  EXPECT_EQ(geometry::x(a), 1.0);
+  EXPECT_EQ(geometry::x(m), m);
+  EXPECT_THROW(geometry::x(K), except::UnitError);
+}
+
+TEST(ElementPositionTest, unzip_position_y) {
+  Eigen::Vector3d a{1.0, 2.0, 3.0};
+  units::Unit m(units::m);
+  units::Unit K(units::K);
+  EXPECT_EQ(geometry::y(a), 2.0);
+  EXPECT_EQ(geometry::y(m), m);
+  EXPECT_THROW(geometry::y(K), except::UnitError);
+}
+
+TEST(ElementPositionTest, unzip_position_z) {
+  Eigen::Vector3d a{1.0, 2.0, 3.0};
+  units::Unit m(units::m);
+  units::Unit K(units::K);
+  EXPECT_EQ(geometry::z(a), 3.0);
+  EXPECT_EQ(geometry::z(m), m);
+  EXPECT_THROW(geometry::z(K), except::UnitError);
 }

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -27,4 +27,5 @@ TEST(ElementPositionTest, unit_out) {
 
 TEST(ElementPositionTest, zip_position_values) {
   EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::zip_position(1.0, 2.0, 3.0));
+  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::zip_position(1.0f, 2.0f, 3.0f));
 }

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -27,5 +27,4 @@ TEST(ElementPositionTest, unit_out) {
 
 TEST(ElementPositionTest, zip_position_values) {
   EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::position(1.0, 2.0, 3.0));
-  EXPECT_EQ((Eigen::Vector3d(1, 2, 3)), element::position(1.0f, 2.0f, 3.0f));
 }

--- a/core/test/element_geometric_operations_test.cpp
+++ b/core/test/element_geometric_operations_test.cpp
@@ -8,8 +8,7 @@
 #include <Eigen/Geometry>
 
 using namespace scipp;
-using namespace scipp::core;
-using namespace element;
+using namespace scipp::core::element;
 
 TEST(ElementPositionTest, unit_in_m) {
   const units::Unit m(units::m);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1110,6 +1110,17 @@ TEST(VariableTest, construct_mult_dev_unit) {
   EXPECT_EQ(int32_t(1) * units::Unit(units::kg), refMult);
 }
 
+TEST(ZipPositionsTest, test_zip) {
+  const Variable x = makeVariable<double>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{1, 2, 3});
+  auto positions = position(x, x, x);
+  auto values = positions.values<Eigen::Vector3d>();
+  EXPECT_EQ(values.size(), 3);
+  EXPECT_EQ(values[0], (Eigen::Vector3d{1, 1, 1}));
+  EXPECT_EQ(values[1], (Eigen::Vector3d{2, 2, 2}));
+  EXPECT_EQ(values[2], (Eigen::Vector3d{3, 3, 3}));
+}
+
 template <class T> class AsTypeTest : public ::testing::Test {};
 
 using type_pairs =

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1113,7 +1113,7 @@ TEST(VariableTest, construct_mult_dev_unit) {
 TEST(VariableTest, zip_positions) {
   const Variable x = makeVariable<double>(
       Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{1, 2, 3});
-  auto positions = position(x, x, x);
+  auto positions = geometry::position(x, x, x);
   auto values = positions.values<Eigen::Vector3d>();
   EXPECT_EQ(values.size(), 3);
   EXPECT_EQ(values[0], (Eigen::Vector3d{1, 1, 1}));
@@ -1124,7 +1124,7 @@ TEST(VariableTest, unzip_x) {
   const Variable pos = makeVariable<Eigen::Vector3d>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m),
       Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
-  auto x_ = x(pos);
+  auto x_ = geometry::x(pos);
   const auto expected_x = makeVariable<double>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{1.0, 4.0});
   EXPECT_EQ(x_, expected_x);
@@ -1134,7 +1134,7 @@ TEST(VariableTest, unzip_y) {
   const Variable pos = makeVariable<Eigen::Vector3d>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m),
       Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
-  auto y_ = y(pos);
+  auto y_ = geometry::y(pos);
   const auto expected_y = makeVariable<double>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{2.0, 5.0});
   EXPECT_EQ(y_, expected_y);
@@ -1144,7 +1144,7 @@ TEST(VariableTest, unzip_z) {
   const Variable pos = makeVariable<Eigen::Vector3d>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m),
       Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
-  auto z_ = z(pos);
+  auto z_ = geometry::z(pos);
   const auto expected_z = makeVariable<double>(
       Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{3.0, 6.0});
   EXPECT_EQ(z_, expected_z);
@@ -1156,10 +1156,10 @@ TEST(VariableTest, zip_unzip_positions) {
       Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{4, 5, 6});
   const Variable z_in = makeVariable<double>(
       Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{7, 8, 9});
-  auto positions = position(x_in, y_in, z_in);
-  auto x_out = x(positions);
-  auto y_out = y(positions);
-  auto z_out = z(positions);
+  auto positions = geometry::position(x_in, y_in, z_in);
+  auto x_out = geometry::x(positions);
+  auto y_out = geometry::y(positions);
+  auto z_out = geometry::z(positions);
   EXPECT_EQ(x_in, x_out);
   EXPECT_EQ(y_in, y_out);
   EXPECT_EQ(z_in, z_out);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1110,7 +1110,7 @@ TEST(VariableTest, construct_mult_dev_unit) {
   EXPECT_EQ(int32_t(1) * units::Unit(units::kg), refMult);
 }
 
-TEST(ZipPositionsTest, test_zip) {
+TEST(VariableTest, zip_positions) {
   const Variable x = makeVariable<double>(
       Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{1, 2, 3});
   auto positions = position(x, x, x);

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1120,6 +1120,50 @@ TEST(VariableTest, zip_positions) {
   EXPECT_EQ(values[1], (Eigen::Vector3d{2, 2, 2}));
   EXPECT_EQ(values[2], (Eigen::Vector3d{3, 3, 3}));
 }
+TEST(VariableTest, unzip_x) {
+  const Variable pos = makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m),
+      Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
+  auto x_ = x(pos);
+  const auto expected_x = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{1.0, 4.0});
+  EXPECT_EQ(x_, expected_x);
+}
+
+TEST(VariableTest, unzip_y) {
+  const Variable pos = makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m),
+      Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
+  auto y_ = y(pos);
+  const auto expected_y = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{2.0, 5.0});
+  EXPECT_EQ(y_, expected_y);
+}
+
+TEST(VariableTest, unzip_z) {
+  const Variable pos = makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m),
+      Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
+  auto z_ = z(pos);
+  const auto expected_z = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, units::Unit(units::m), Values{3.0, 6.0});
+  EXPECT_EQ(z_, expected_z);
+}
+TEST(VariableTest, zip_unzip_positions) {
+  const Variable x_in = makeVariable<double>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{1, 2, 3});
+  const Variable y_in = makeVariable<double>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{4, 5, 6});
+  const Variable z_in = makeVariable<double>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{7, 8, 9});
+  auto positions = position(x_in, y_in, z_in);
+  auto x_out = x(positions);
+  auto y_out = y(positions);
+  auto z_out = z(positions);
+  EXPECT_EQ(x_in, x_out);
+  EXPECT_EQ(y_in, y_out);
+  EXPECT_EQ(z_in, z_out);
+}
 
 template <class T> class AsTypeTest : public ::testing::Test {};
 

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -299,6 +299,7 @@ Variable neg_inf_to_num(const VariableConstView &var,
                                               element::negative_inf_to_num);
 }
 
+namespace geometry {
 Variable position(const VariableConstView &x, const VariableConstView &y,
                   const VariableConstView &z) {
   return transform<std::tuple<double>>(x, y, z, element::geometry::position);
@@ -312,5 +313,6 @@ Variable y(const VariableConstView &pos) {
 Variable z(const VariableConstView &pos) {
   return transform<std::tuple<Eigen::Vector3d>>(pos, element::geometry::z);
 }
+} // namespace geometry
 
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -301,7 +301,16 @@ Variable neg_inf_to_num(const VariableConstView &var,
 
 Variable position(const VariableConstView &x, const VariableConstView &y,
                   const VariableConstView &z) {
-  return transform<std::tuple<double>>(x, y, z, element::position);
+  return transform<std::tuple<double>>(x, y, z, element::geometry::position);
+}
+Variable x(const VariableConstView &pos) {
+  return transform<std::tuple<Eigen::Vector3d>>(pos, element::geometry::x);
+}
+Variable y(const VariableConstView &pos) {
+  return transform<std::tuple<Eigen::Vector3d>>(pos, element::geometry::y);
+}
+Variable z(const VariableConstView &pos) {
+  return transform<std::tuple<Eigen::Vector3d>>(pos, element::geometry::z);
 }
 
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -301,7 +301,7 @@ Variable neg_inf_to_num(const VariableConstView &var,
 
 Variable position(const VariableConstView &x, const VariableConstView &y,
                   const VariableConstView &z) {
-  return transform<std::tuple<double, float>>(x, y, z, element::position);
+  return transform<std::tuple<double>>(x, y, z, element::position);
 }
 
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -301,7 +301,7 @@ Variable neg_inf_to_num(const VariableConstView &var,
 
 Variable position(const VariableConstView &x, const VariableConstView &y,
                   const VariableConstView &z) {
-  return transform<std::tuple<double, float>>(x, y, z, element::zip_position);
+  return transform<std::tuple<double, float>>(x, y, z, element::position);
 }
 
 } // namespace scipp::core

--- a/core/variable_operations.cpp
+++ b/core/variable_operations.cpp
@@ -10,6 +10,7 @@
 #include "scipp/core/transform.h"
 #include "scipp/core/variable.h"
 
+#include "element_geometric_operations.h"
 #include "element_trigonometry_operations.h"
 #include "element_unary_operations.h"
 #include "operators.h"
@@ -296,6 +297,11 @@ Variable neg_inf_to_num(const VariableConstView &var,
                         const VariableConstView &replacement) {
   return transform<std::tuple<double, float>>(var, replacement,
                                               element::negative_inf_to_num);
+}
+
+Variable position(const VariableConstView &x, const VariableConstView &y,
+                  const VariableConstView &z) {
+  return transform<std::tuple<double, float>>(x, y, z, element::zip_position);
 }
 
 } // namespace scipp::core

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -46,6 +46,10 @@ General
    sort
    sqrt
    sum
+   position
+   x
+   y
+   z
 
 Group-by (split-apply-combine)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -47,9 +47,9 @@ General
    sqrt
    sum
    position
-   x
-   y
-   z
+   geometry.x
+   geometry.y
+   geometry.z
 
 Group-by (split-apply-combine)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -942,3 +942,23 @@ def test_num_to_nan_out_with_multiple_special_replacements():
     expected = sc.Variable(dims=['x'],
                            values=np.array([1] + [replace.value] * 3))
     assert out == expected
+
+
+def test_position():
+    var = sc.Variable()
+    assert_export(sc.position, x=var, y=var, z=var)
+
+
+def test_x():
+    var = sc.Variable()
+    assert_export(sc.x, pos=var)
+
+
+def test_y():
+    var = sc.Variable()
+    assert_export(sc.y, pos=var)
+
+
+def test_z():
+    var = sc.Variable()
+    assert_export(sc.z, pos=var)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -946,19 +946,19 @@ def test_num_to_nan_out_with_multiple_special_replacements():
 
 def test_position():
     var = sc.Variable()
-    assert_export(sc.position, x=var, y=var, z=var)
+    assert_export(sc.geometry.position, x=var, y=var, z=var)
 
 
 def test_x():
     var = sc.Variable()
-    assert_export(sc.x, pos=var)
+    assert_export(sc.geometry.x, pos=var)
 
 
 def test_y():
     var = sc.Variable()
-    assert_export(sc.y, pos=var)
+    assert_export(sc.geometry.y, pos=var)
 
 
 def test_z():
     var = sc.Variable()
-    assert_export(sc.z, pos=var)
+    assert_export(sc.geometry.z, pos=var)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -827,4 +827,32 @@ void init_variable(py::module &m) {
         return events;
       },
       R"(Return true if the data array contains event data. Note that data may be stored as a scalar, but this returns true if any coord contains events.)");
+  m.def("position",
+        [](const Variable &x, const Variable &y, const Variable &z) {
+          return position(x, y, z);
+        },
+        py::arg("x"), py::arg("y"), py::arg("z"),
+        R"(
+        Element-wise zip functionality to produce a Vector3d from independent input variables.
+        :raises: If the units of inputs are not all meters, or if the dtypes of inputs are not double precision floats
+        :return: zip of input x, y and z. Output unit is meters.
+        :rtype: Variable)");
+  m.def("x", [](const Variable &pos) { return x(pos); }, py::arg("pos"),
+        R"(
+        un-zip functionality to produce a Variable of the x component of a Vector3d.
+        :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
+        :return: Extracted x component of input pos. Units in meters.
+        :rtype: Variable)");
+  m.def("y", [](const Variable &pos) { return y(pos); }, py::arg("pos"),
+        R"(
+        un-zip functionality to produce a Variable of the y component of a Vector3d.
+        :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
+        :return: Extracted y component of input pos. Units in meters.
+        :rtype: Variable)");
+  m.def("z", [](const Variable &pos) { return z(pos); }, py::arg("pos"),
+        R"(
+        un-zip functionality to produce a Variable of the z component of a Vector3d.
+        :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
+        :return: Extracted z component of input pos. Units in meters.
+        :rtype: Variable)");
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -829,36 +829,37 @@ void init_variable(py::module &m) {
         return events;
       },
       R"(Return true if the data array contains event data. Note that data may be stored as a scalar, but this returns true if any coord contains events.)");
-  m.def("position",
-        [](const Variable &x, const Variable &y, const Variable &z) {
-          return geometry::position(x, y, z);
-        },
-        py::arg("x"), py::arg("y"), py::arg("z"),
-        R"(
+  auto geom_m = m.def_submodule("geometry");
+  geom_m.def("position",
+             [](const Variable &x, const Variable &y, const Variable &z) {
+               return geometry::position(x, y, z);
+             },
+             py::arg("x"), py::arg("y"), py::arg("z"),
+             R"(
         Element-wise zip functionality to produce a vector_3_float64 from independent input variables.
 
         :raises: If the units of inputs are not all meters, or if the dtypes of inputs are not double precision floats
         :return: zip of input x, y and z. Output unit is meters.
         :rtype: Variable)");
-  m.def("x", [](const Variable &pos) { return geometry::x(pos); },
-        py::arg("pos"),
-        R"(
+  geom_m.def("x", [](const Variable &pos) { return geometry::x(pos); },
+             py::arg("pos"),
+             R"(
         un-zip functionality to produce a Variable of the x component of a vector_3_float64.
 
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
         :return: Extracted x component of input pos. Units in meters.
         :rtype: Variable)");
-  m.def("y", [](const Variable &pos) { return geometry::y(pos); },
-        py::arg("pos"),
-        R"(
+  geom_m.def("y", [](const Variable &pos) { return geometry::y(pos); },
+             py::arg("pos"),
+             R"(
         un-zip functionality to produce a Variable of the y component of a vector_3_float64.
 
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
         :return: Extracted y component of input pos. Units in meters.
         :rtype: Variable)");
-  m.def("z", [](const Variable &pos) { return geometry::z(pos); },
-        py::arg("pos"),
-        R"(
+  geom_m.def("z", [](const Variable &pos) { return geometry::z(pos); },
+             py::arg("pos"),
+             R"(
         un-zip functionality to produce a Variable of the z component of a vector_3_float64.
 
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -688,6 +688,7 @@ void init_variable(py::module &m) {
         py::arg("y"), py::arg("x"),
         R"(
         Element-wise atan2.
+
         :raises: If the units of inputs are different, or if the dtype has no atan2, e.g., if it is an integer
         :return: atan2 of input y and x. Output unit is rad.
         :rtype: Variable)");
@@ -698,6 +699,7 @@ void init_variable(py::module &m) {
         py::arg("y"), py::arg("x"), py::arg("out"),
         R"(
         Element-wise atan2 with out argument.
+
         :raises: If the units of inputs are different, or if the dtype has no atan2, e.g., if it is an integer
         :return: atan2 of input y and x, written to output. Output unit is rad.
         :rtype: VariableView)");

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -831,29 +831,36 @@ void init_variable(py::module &m) {
       R"(Return true if the data array contains event data. Note that data may be stored as a scalar, but this returns true if any coord contains events.)");
   m.def("position",
         [](const Variable &x, const Variable &y, const Variable &z) {
-          return position(x, y, z);
+          return geometry::position(x, y, z);
         },
         py::arg("x"), py::arg("y"), py::arg("z"),
         R"(
-        Element-wise zip functionality to produce a Vector3d from independent input variables.
+        Element-wise zip functionality to produce a vector_3_float64 from independent input variables.
+
         :raises: If the units of inputs are not all meters, or if the dtypes of inputs are not double precision floats
         :return: zip of input x, y and z. Output unit is meters.
         :rtype: Variable)");
-  m.def("x", [](const Variable &pos) { return x(pos); }, py::arg("pos"),
+  m.def("x", [](const Variable &pos) { return geometry::x(pos); },
+        py::arg("pos"),
         R"(
-        un-zip functionality to produce a Variable of the x component of a Vector3d.
+        un-zip functionality to produce a Variable of the x component of a vector_3_float64.
+
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
         :return: Extracted x component of input pos. Units in meters.
         :rtype: Variable)");
-  m.def("y", [](const Variable &pos) { return y(pos); }, py::arg("pos"),
+  m.def("y", [](const Variable &pos) { return geometry::y(pos); },
+        py::arg("pos"),
         R"(
-        un-zip functionality to produce a Variable of the y component of a Vector3d.
+        un-zip functionality to produce a Variable of the y component of a vector_3_float64.
+
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
         :return: Extracted y component of input pos. Units in meters.
         :rtype: Variable)");
-  m.def("z", [](const Variable &pos) { return z(pos); }, py::arg("pos"),
+  m.def("z", [](const Variable &pos) { return geometry::z(pos); },
+        py::arg("pos"),
         R"(
-        un-zip functionality to produce a Variable of the z component of a Vector3d.
+        un-zip functionality to produce a Variable of the z component of a vector_3_float64.
+
         :raises: If the units of inputs are not meters, or if the dtypes of inputs are not double precision floats
         :return: Extracted z component of input pos. Units in meters.
         :rtype: Variable)");


### PR DESCRIPTION
Add `position` function for zip and `x`, `y`, `z` for unzip type behaviour

Needed for scipp based coordinated conversions.