### PR TITLE
Add missing test for /= between event data and histogram

### DIFF
--- a/core/include/scipp/core/comparison.h
+++ b/core/include/scipp/core/comparison.h
@@ -25,7 +25,7 @@ bool is_approx(const VariableConstView &a, const VariableConstView &b,
                           to_string(b.dtype());
     throw except::TypeError(message);
   }
-  if (dtype<T> != a.dtype()) {
+  if (dtype<T> != a.dtype() && dtype<event_list<T>> != a.dtype()) {
     std::string message = "is_approx. Type of tol " + to_string(dtype<T>) +
                           " not same as type of input arguments " +
                           to_string(a.dtype());

--- a/core/test/data_array_test.cpp
+++ b/core/test/data_array_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/core/comparison.h"
 #include "scipp/core/dataset.h"
 
 #include "dataset_test_common.h"
@@ -215,4 +216,11 @@ TEST(DataArraySparseArithmeticTest, sparse_over_histogram) {
   EXPECT_TRUE(equals(span<const double>(out_vars[1]).subspan(0, 3),
                      expected.slice({Dim::X, 0, 3}).variances<double>()));
   EXPECT_TRUE(std::isnan(out_vars[1][3]));
+
+  auto result_inplace = copy(sparse);
+  result_inplace /= hist;
+  EXPECT_TRUE(is_approx(result_inplace.data(), result.data(), 1e-16));
+  EXPECT_EQ(result_inplace.coords(), result.coords());
+  EXPECT_EQ(result_inplace.masks(), result.masks());
+  EXPECT_EQ(result_inplace.attrs(), result.attrs());
 }


### PR DESCRIPTION
Add tests added during debugging.

The actual issue was that `/=` between a *slice* of event data and histogram is not supported. I decided to postpone such an implementation, because it maybe be better to wait for the new API. The main problem is that the operation may require switching from scalar weights to event_list weights, which is not possible with a slice view. In practice normalizing a slice is not very relevant so I don't believe this should be high priority.