### PR TITLE
Flatten fixes

### DIFF
--- a/core/dataset_operations.cpp
+++ b/core/dataset_operations.cpp
@@ -101,6 +101,10 @@ DataArray flatten(const DataArrayConstView &a, const Dim dim) {
   return apply_or_copy_dim(
       a,
       [](const auto &x, const Dim dim_, const auto &mask_) {
+        if (!is_events(x) && min(x, dim_) != max(x, dim_))
+          throw except::EventDataError(
+              "flatten with non-constant scalar weights not "
+              "possible yet.");
         return is_events(x) ? flatten(x, dim_, mask_)
                             : copy(x.slice({dim_, 0}));
       },

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -114,6 +114,10 @@ struct SCIPP_CORE_EXPORT UnalignedError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+struct SCIPP_CORE_EXPORT EventDataError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 } // namespace scipp::except
 
 namespace scipp::core::expect {

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -430,6 +430,13 @@ TEST_F(GroupbyFlattenDefaultWeight, flatten_dataset_coord_only) {
   EXPECT_EQ(groupby(d, Dim("labels")).flatten(Dim::Y), expected_d);
 }
 
+TEST_F(GroupbyFlattenDefaultWeight, flatten_non_constant_scalar_weight_fail) {
+  Dataset d{{{"a", a}, {"b", a}}};
+  d["a"].values<double>()[0] += 0.1;
+  EXPECT_THROW(groupby(d, Dim("labels")).flatten(Dim::Y),
+               except::EventDataError);
+}
+
 TEST(GroupbyFlattenTest, flatten_coord_and_labels) {
   DataArray a{makeVariable<double>(Dims{Dim::Y}, Shape{3},
                                    units::Unit(units::counts), Values{1, 1, 1},

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -406,8 +406,8 @@ struct GroupbyFlattenDefaultWeight : public ::testing::Test {
 
   const DataArray expected{
       makeVariable<double>(Dims{Dim("labels")}, Shape{2},
-                           units::Unit(units::counts), Values{2, 1},
-                           Variances{2, 1}),
+                           units::Unit(units::counts), Values{1, 1},
+                           Variances{1, 1}),
       {{Dim::X, make_sparse_out()},
        {Dim("0-d"), makeVariable<double>(Values{1.2})},
        {Dim("labels"),
@@ -449,7 +449,7 @@ TEST(GroupbyFlattenTest, flatten_coord_and_labels) {
 
   DataArray expected{makeVariable<double>(Dims{Dim("labels")}, Shape{2},
                                           units::Unit(units::counts),
-                                          Values{2, 1}, Variances{2, 1}),
+                                          Values{1, 1}, Variances{1, 1}),
                      {{Dim::X, make_sparse_out()},
                       {Dim("labels"), makeVariable<double>(
                                           Dims{Dim("labels")}, Shape{2},

--- a/core/test/reduce_sparse_test.cpp
+++ b/core/test/reduce_sparse_test.cpp
@@ -48,3 +48,12 @@ TEST(ReduceSparseTest, flatten_dataset_with_mask) {
   EXPECT_EQ(flat["b"].coords()[Dim("label")], expected);
   EXPECT_EQ(flat["b"].data(), expected);
 }
+
+TEST(ReduceSparseTest, flatten_dataset_non_constant_scalar_weight_fail) {
+  Dataset d;
+  d.coords().set(Dim::X, make_sparse());
+  d.setData("b", makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1, 2, 3}));
+  EXPECT_THROW(flatten(d, Dim::Y), except::EventDataError);
+  d.setData("b", makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1, 1, 1}));
+  EXPECT_NO_THROW(flatten(d, Dim::Y));
+}


### PR DESCRIPTION
- Should not sum weights in scalar case (leads to multiple counting of events).
- Disable support for non-constant scalar weights, since this would be too complicated for now.