### PR TITLE
Fix histogram so it drops other event coords.

### DIFF
--- a/core/histogram.cpp
+++ b/core/histogram.cpp
@@ -88,8 +88,9 @@ DataArray histogram(const DataArrayConstView &sparse,
 
   auto result = apply_and_drop_dim(
       sparse,
-      [](const DataArrayConstView &sparse_, const Dim dim_,
+      [](const DataArrayConstView &sparse_, const Dim eventDim, const Dim dim_,
          const VariableConstView &binEdges_) {
+        static_cast<void>(eventDim); // This is just Dim::Invalid
         using namespace histogram_weighted_detail;
         // This supports scalar weights as well as event_list weights.
         return transform_subspan<
@@ -109,7 +110,7 @@ DataArray histogram(const DataArrayConstView &sparse,
                        transform_flags::expect_variance_arg<2>,
                        transform_flags::expect_no_variance_arg<3>});
       },
-      dim, binEdges);
+      dim_of_coord(sparse.coords()[dim], dim), dim, binEdges);
   result.setCoord(dim, binEdges);
   return result;
 }

--- a/core/test/histogram_test.cpp
+++ b/core/test/histogram_test.cpp
@@ -136,6 +136,24 @@ TEST(HistogramTest, data_view) {
   EXPECT_EQ(hist, expected);
 }
 
+TEST(HistogramTest, drops_other_event_coords) {
+  auto events = make_1d_events_default_weights();
+  events.coords().set(Dim("pulse-time"), events.coords()[Dim::Y]);
+  std::vector<double> ref{1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 2, 3, 0, 3, 0};
+  auto edges =
+      makeVariable<double>(Dims{Dim::Y}, Shape{6}, Values{1, 2, 3, 4, 5, 6});
+  auto hist = core::histogram(events, edges);
+  auto expected =
+      make_expected(makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 5},
+                                         units::Unit(units::counts),
+                                         Values(ref.begin(), ref.end()),
+                                         Variances(ref.begin(), ref.end())),
+                    edges);
+
+  EXPECT_FALSE(hist.coords().contains(Dim("pulse=time")));
+  EXPECT_EQ(hist, expected);
+}
+
 TEST(HistogramTest, weight_lists) {
   Variable data = makeVariable<event_list<double>>(Dimensions{{Dim::X, 3}},
                                                    Values{}, Variances{});


### PR DESCRIPTION
This bug was introduced when removing the handling of events via an
explicit dimension label.