### PR TITLE
Fix histogram to not drop scalar coords

### DIFF
--- a/core/dataset_operations_common.h
+++ b/core/dataset_operations_common.h
@@ -29,7 +29,7 @@ DataArray apply_and_drop_dim_impl(const DataArrayConstView &a, Func func,
   std::map<Dim, Variable> coords;
   for (auto &&[d, coord] : a.coords()) {
     // Check coordinates will NOT be dropped
-    if (dim_of_coord(coord, d) != dim) {
+    if (coord.dims().ndim() == 0 || dim_of_coord(coord, d) != dim) {
       expectAlignedCoord(d, coord, dim);
       coords.emplace(d, coord);
     }

--- a/core/test/histogram_test.cpp
+++ b/core/test/histogram_test.cpp
@@ -154,6 +154,14 @@ TEST(HistogramTest, drops_other_event_coords) {
   EXPECT_EQ(hist, expected);
 }
 
+TEST(HistogramTest, keeps_scalar_coords) {
+  auto events = make_1d_events_default_weights();
+  events.coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+  auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
+  auto hist = core::histogram(events, edges);
+  EXPECT_TRUE(hist.coords().contains(Dim("scalar")));
+}
+
 TEST(HistogramTest, weight_lists) {
   Variable data = makeVariable<event_list<double>>(Dimensions{{Dim::X, 3}},
                                                    Values{}, Variances{});


### PR DESCRIPTION
Fixes #1035. This was introduced by #1034.

Need to release 0.3.1 after merging this.