### PR TITLE
Disable option to have integers with variances

### DIFF
--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -112,11 +112,8 @@ private:
 template <class T> constexpr bool canHaveVariances() noexcept {
   using U = std::remove_const_t<T>;
   return std::is_same_v<U, double> || std::is_same_v<U, float> ||
-         std::is_same_v<U, int64_t> || std::is_same_v<U, int32_t> ||
          std::is_same_v<U, sparse_container<double>> ||
          std::is_same_v<U, sparse_container<float>> ||
-         std::is_same_v<U, sparse_container<int64_t>> ||
-         std::is_same_v<U, sparse_container<int32_t>> ||
          std::is_same_v<U, span<const double>> ||
          std::is_same_v<U, span<const float>> ||
          std::is_same_v<U, span<double>> || std::is_same_v<U, span<float>>;

--- a/core/test/groupby_test.cpp
+++ b/core/test/groupby_test.cpp
@@ -13,8 +13,8 @@ using namespace scipp::core;
 struct GroupbyTest : public ::testing::Test {
   GroupbyTest() {
     d.setData("a",
-              makeVariable<int>(Dimensions{Dim::X, 3}, units::Unit(units::m),
-                                Values{1, 2, 3}, Variances{4, 5, 6}));
+              makeVariable<double>(Dimensions{Dim::X, 3}, units::Unit(units::m),
+                                   Values{1, 2, 3}, Variances{4, 5, 6}));
     d.setData("b",
               makeVariable<double>(Dimensions{Dim::X, 3}, units::Unit(units::s),
                                    Values{0.1, 0.2, 0.3}));
@@ -48,8 +48,8 @@ TEST_F(GroupbyTest, fail_key_2d) {
 
 TEST_F(GroupbyTest, fail_key_with_variances) {
   d.setCoord(Dim("variances"),
-             makeVariable<int>(Dimensions{Dim::X, 3}, units::Unit(units::m),
-                               Values{1, 2, 3}, Variances{4, 5, 6}));
+             makeVariable<double>(Dimensions{Dim::X, 3}, units::Unit(units::m),
+                                  Values{1, 2, 3}, Variances{4, 5, 6}));
   EXPECT_THROW(groupby(d, Dim("variances")), except::VariancesError);
   EXPECT_THROW(groupby(d["a"], Dim("variances")), except::VariancesError);
 }
@@ -106,9 +106,9 @@ struct GroupbyMaskedTest : public GroupbyTest {
 TEST_F(GroupbyMaskedTest, sum) {
   Dataset expected;
   const Dim dim("labels2");
-  expected.setData("a",
-                   makeVariable<int>(Dimensions{dim, 2}, units::Unit(units::m),
-                                     Values{1, 3}, Variances{4, 6}));
+  expected.setData("a", makeVariable<double>(Dimensions{dim, 2},
+                                             units::Unit(units::m),
+                                             Values{1, 3}, Variances{4, 6}));
   expected.setData("b", makeVariable<double>(Dimensions{dim, 2},
                                              units::Unit(units::s),
                                              Values{0.1, 0.3}));
@@ -129,9 +129,9 @@ TEST_F(GroupbyMaskedTest, sum) {
 TEST_F(GroupbyMaskedTest, sum_irrelvant_mask) {
   Dataset expected;
   const Dim dim("labels2");
-  expected.setData("a",
-                   makeVariable<int>(Dimensions{dim, 2}, units::Unit(units::m),
-                                     Values{3, 3}, Variances{9, 6}));
+  expected.setData("a", makeVariable<double>(Dimensions{dim, 2},
+                                             units::Unit(units::m),
+                                             Values{3, 3}, Variances{9, 6}));
   expected.setData("b", makeVariable<double>(Dimensions{dim, 2},
                                              units::Unit(units::s),
                                              Values{0.1 + 0.2, 0.3}));

--- a/core/test/sort_test.cpp
+++ b/core/test/sort_test.cpp
@@ -10,13 +10,13 @@ using namespace scipp::core;
 
 TEST(SortTest, variable_1d) {
   const auto var =
-      makeVariable<int>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
-                        Values{1, 2, 3}, Variances{4, 5, 6});
+      makeVariable<float>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
+                          Values{1, 2, 3}, Variances{4, 5, 6});
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
   const auto expected =
-      makeVariable<int>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
-                        Values{3, 1, 2}, Variances{6, 4, 5});
+      makeVariable<float>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
+                          Values{3, 1, 2}, Variances{6, 4, 5});
 
   EXPECT_EQ(sort(var, key), expected);
 }
@@ -44,8 +44,8 @@ TEST(SortTest, variable_2d) {
 TEST(SortTest, dataset_1d) {
   Dataset d;
   d.setData("a",
-            makeVariable<int>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
-                              Values{1, 2, 3}, Variances{4, 5, 6}));
+            makeVariable<float>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
+                                Values{1, 2, 3}, Variances{4, 5, 6}));
   d.setData("b",
             makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::s),
                                  Values{0.1, 0.2, 0.3}));
@@ -55,9 +55,9 @@ TEST(SortTest, dataset_1d) {
                                   Values{1, 2, 3}));
 
   Dataset expected;
-  expected.setData("a", makeVariable<int>(Dims{Dim::X}, Shape{3},
-                                          units::Unit(units::m),
-                                          Values{3, 1, 2}, Variances{6, 4, 5}));
+  expected.setData(
+      "a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
+                               Values{3, 1, 2}, Variances{6, 4, 5}));
   expected.setData("b", makeVariable<double>(Dims{Dim::X}, Shape{3},
                                              units::Unit(units::s),
                                              Values{0.3, 0.1, 0.2}));

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -121,14 +121,14 @@ TEST(VariableUniversalConstructorTest, convertable_types) {
   using namespace scipp::core::detail;
   auto data = std::vector<double>{1.0, 4.5, 2.7, 5.0, 7.0, 6.7};
   auto variable =
-      Variable(dtype<int64_t>, Dims{Dim::X, Dim::Y}, Shape{2, 3}, Values(data),
+      Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3}, Values(data),
                units::Unit(units::kg), Variances(data));
 
-  EXPECT_EQ(variable.dtype(), dtype<int64_t>);
-  EXPECT_TRUE(equals(variable.values<int64_t>(),
-                     std::vector<int64_t>(data.begin(), data.end())));
-  EXPECT_TRUE(equals(variable.variances<int64_t>(),
-                     std::vector<int64_t>(data.begin(), data.end())));
+  EXPECT_EQ(variable.dtype(), dtype<float>);
+  EXPECT_TRUE(equals(variable.values<float>(),
+                     std::vector<float>(data.begin(), data.end())));
+  EXPECT_TRUE(equals(variable.variances<float>(),
+                     std::vector<float>(data.begin(), data.end())));
 }
 
 TEST(VariableUniversalConstructorTest, unconvertable_types) {
@@ -141,9 +141,9 @@ TEST(VariableUniversalConstructorTest, initializer_list) {
   EXPECT_EQ(Variable(dtype<int32_t>, Dims{Dim::X}, Shape{2}, Values{1.0, 1.0}),
             Variable(dtype<int32_t>, Dims{Dim::X}, Shape{2},
                      Values(std::vector<int32_t>(2, 1))));
-  EXPECT_EQ(Variable(dtype<int32_t>, Values{1.0, 1.0}, Dims{Dim::X}, Shape{2},
+  EXPECT_EQ(Variable(dtype<float>, Values{1.0, 1.0}, Dims{Dim::X}, Shape{2},
                      Variances{2.0f, 2.0f}),
-            Variable(dtype<int32_t>, Dims{Dim::X}, Shape{2},
+            Variable(dtype<float>, Dims{Dim::X}, Shape{2},
                      Values(std::vector<int32_t>(2, 1)),
                      Variances(std::vector<double>(2, 2))));
 }

--- a/core/test/variable_test.cpp
+++ b/core/test/variable_test.cpp
@@ -1168,9 +1168,13 @@ TYPED_TEST_SUITE(AsTypeTest, type_pairs);
 TYPED_TEST(AsTypeTest, variable_astype) {
   using T1 = typename TypeParam::first_type;
   using T2 = typename TypeParam::second_type;
-  auto var1 = makeVariable<T1>(Values{1}, Variances{1});
-  auto var2 = makeVariable<T2>(Values{1}, Variances{1});
-  ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
+  Variable var1;
+  Variable var2;
+  if constexpr (canHaveVariances<T1>() && canHaveVariances<T2>()) {
+    var1 = makeVariable<T1>(Values{1}, Variances{1});
+    var2 = makeVariable<T2>(Values{1}, Variances{1});
+    ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
+  }
   var1 = makeVariable<T1>(Values{1});
   var2 = makeVariable<T2>(Values{1});
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -196,8 +196,8 @@ def test_set_item_slice_with_variances_from_numpy():
     d = sc.Dataset(
         coords={'x': sc.Variable(dims=['x'], values=np.arange(4, 8))})
     d['a'] = sc.Variable(dims=['x'],
-                         values=np.arange(4),
-                         variances=np.arange(4))
+                         values=np.arange(4.0),
+                         variances=np.arange(4.0))
     d['a']['x', 2:4].values = np.arange(2)
     d['a']['x', 2:4].variances = np.arange(2, 4)
     assert np.array_equal(d['a'].values, np.array([0.0, 1.0, 0.0, 1.0]))

--- a/python/tests/test_variable_scalar.py
+++ b/python/tests/test_variable_scalar.py
@@ -5,11 +5,17 @@
 import scipp as sc
 
 
+def test_scalar_Variable_values_property_float():
+    var = sc.Variable(value=1.0, variance=2.0)
+    assert var.dtype == sc.dtype.float64
+    assert var.values == 1.0
+    assert var.variances == 2.0
+
+
 def test_scalar_Variable_values_property_int():
-    var = sc.Variable(value=1, variance=2)
+    var = sc.Variable(value=1)
     assert var.dtype == sc.dtype.int64
     assert var.values == 1
-    assert var.variances == 2
 
 
 def test_scalar_Variable_values_property_string():


### PR DESCRIPTION
This is probably of limited use in practice. For now it just increases
compilation times and binary sizes so it is removed. Adding it back in
later if required should be simple.