### PR TITLE
Remove test skip for Run and Sample `__eq__`

### DIFF
--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -79,7 +79,6 @@ class TestMantidConversion(unittest.TestCase):
         del realigned.attrs['sample']
         assert realigned == d
 
-    @pytest.mark.skip(reason="Missing comparison for Mantid Run and Sample.")
     def test_comparison(self):
         a = mantidcompat.convert_EventWorkspace_to_data_array(
             self.base_event_ws, load_pulse_times=False)


### PR DESCRIPTION
All the work done on the Mantid side.  See [mantid pr](https://github.com/mantidproject/mantid/pull/28466) for details.

Changes here simply allow test to execute.

Fixes #1039.