### PR TITLE
Formatting of types that are not known to the module defining Variable

### DIFF
--- a/dataset/test/string_test.cpp
+++ b/dataset/test/string_test.cpp
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "scipp/core/string.h"
-#include "scipp/core/variable.h"
+#include "scipp/dataset/dataset.h"
 
 using namespace scipp;
 using namespace scipp::dataset;
@@ -12,4 +12,10 @@ TEST(StringTest, null_variable) {
   Variable var;
   ASSERT_FALSE(var);
   ASSERT_NO_THROW(to_string(var));
+}
+
+TEST(StringTest, variable_with_dataset_types) {
+  ASSERT_NO_THROW(to_string(makeVariable<Dataset>(Dims{}, Shape{})));
+  ASSERT_NO_THROW(to_string(makeVariable<DataArray>(
+      Values{DataArray(makeVariable<double>(Values{1}))})));
 }

--- a/dataset/variable_instantiate_dataset.cpp
+++ b/dataset/variable_instantiate_dataset.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/string.h"
 #include "scipp/core/variable.tcc"
 #include "scipp/dataset/dataset.h"
 
@@ -11,3 +12,17 @@ INSTANTIATE_VARIABLE(scipp::dataset::Dataset)
 INSTANTIATE_VARIABLE(scipp::dataset::DataArray)
 
 } // namespace scipp::core
+
+namespace scipp::dataset {
+namespace {
+// Insert classes from scipp::dataset into formatting registry. The objects
+// themselves do nothing, but the constructor call with comma operator does the
+// insertion.
+auto register_dataset_types(
+    (core::formatterRegistry().emplace(
+         dtype<Dataset>, std::make_unique<core::Formatter<Dataset>>()),
+     core::formatterRegistry().emplace(
+         dtype<DataArray>, std::make_unique<core::Formatter<DataArray>>()),
+     0));
+} // namespace
+} // namespace scipp::dataset


### PR DESCRIPTION
Introduced by split of `scipp-dataset`, these types could not be formatted any more by `to_string(Variable)` defined in `scipp-core`.

The solution is to add virtual formatters that can be overriden in child modules. Is there a shorter way?