### PR TITLE
Resolves errors and warnings using clang-9/10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.sw?
+compile_commands.json
+
+build/
+.clangd/

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -31,7 +31,7 @@ public:
   Dimensions(const std::vector<Dim> &labels,
              const std::vector<scipp::index> &shape);
   Dimensions(const std::initializer_list<std::pair<Dim, scipp::index>> dims) {
-    for (const auto [label, size] : dims)
+    for (const auto &[label, size] : dims)
       addInner(label, size);
   }
 

--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -50,26 +50,31 @@ enum class DType {
   Unknown
 };
 
-template <class T> constexpr DType dtype = DType::Unknown;
-template <> constexpr DType dtype<double> = DType::Double;
-template <> constexpr DType dtype<float> = DType::Float;
-template <> constexpr DType dtype<int32_t> = DType::Int32;
-template <> constexpr DType dtype<int64_t> = DType::Int64;
-template <> constexpr DType dtype<std::string> = DType::String;
-template <> constexpr DType dtype<bool> = DType::Bool;
+template <class T> inline constexpr DType dtype = DType::Unknown;
+template <> inline constexpr DType dtype<double> = DType::Double;
+template <> inline constexpr DType dtype<float> = DType::Float;
+template <> inline constexpr DType dtype<int32_t> = DType::Int32;
+template <> inline constexpr DType dtype<int64_t> = DType::Int64;
+template <> inline constexpr DType dtype<std::string> = DType::String;
+template <> inline constexpr DType dtype<bool> = DType::Bool;
 template <>
-constexpr DType dtype<sparse_container<double>> = DType::SparseDouble;
-template <> constexpr DType dtype<sparse_container<float>> = DType::SparseFloat;
+inline constexpr DType dtype<sparse_container<double>> = DType::SparseDouble;
 template <>
-constexpr DType dtype<sparse_container<int64_t>> = DType::SparseInt64;
+inline constexpr DType dtype<sparse_container<float>> = DType::SparseFloat;
 template <>
-constexpr DType dtype<sparse_container<int32_t>> = DType::SparseInt32;
-template <> constexpr DType dtype<sparse_container<bool>> = DType::SparseBool;
-template <> constexpr DType dtype<dataset::DataArray> = DType::DataArray;
-template <> constexpr DType dtype<dataset::Dataset> = DType::Dataset;
-template <> constexpr DType dtype<Eigen::Vector3d> = DType::EigenVector3d;
-template <> constexpr DType dtype<Eigen::Quaterniond> = DType::EigenQuaterniond;
-template <> constexpr DType dtype<scipp::python::PyObject> = DType::PyObject;
+inline constexpr DType dtype<sparse_container<int64_t>> = DType::SparseInt64;
+template <>
+inline constexpr DType dtype<sparse_container<int32_t>> = DType::SparseInt32;
+template <>
+inline constexpr DType dtype<sparse_container<bool>> = DType::SparseBool;
+template <> inline constexpr DType dtype<dataset::DataArray> = DType::DataArray;
+template <> inline constexpr DType dtype<dataset::Dataset> = DType::Dataset;
+template <>
+inline constexpr DType dtype<Eigen::Vector3d> = DType::EigenVector3d;
+template <>
+inline constexpr DType dtype<Eigen::Quaterniond> = DType::EigenQuaterniond;
+template <>
+inline constexpr DType dtype<scipp::python::PyObject> = DType::PyObject;
 
 bool isInt(DType tp);
 

--- a/core/test/make_sparse.h
+++ b/core/test/make_sparse.h
@@ -11,14 +11,14 @@ using namespace scipp::core;
 
 template <typename T>
 inline auto make_sparse_variable_with_variance(int length = 2) {
-  Dimensions dims({Dim::Y}, {length});
+  Dimensions dims(Dim::Y, length);
   return makeVariable<sparse_container<T>>(
       Dimensions(dims), Values{sparse_container<T>(), sparse_container<T>()},
       Variances{sparse_container<T>(), sparse_container<T>()});
 }
 
 template <typename T> inline auto make_sparse_variable(int length = 2) {
-  Dimensions dims({Dim::Y}, {length});
+  Dimensions dims(Dim::Y, length);
   return makeVariable<sparse_container<T>>(Dimensions(dims));
 }
 

--- a/core/test/transform_test.cpp
+++ b/core/test/transform_test.cpp
@@ -63,8 +63,8 @@ TEST_F(TransformUnaryTest, elements_of_sparse) {
 }
 
 TEST_F(TransformUnaryTest, elements_of_sparse_with_variance) {
-  auto var = makeVariable<event_list<double>>(Dimensions{{Dim::Y}, {2}},
-                                              Values{}, Variances{});
+  auto var = makeVariable<event_list<double>>(Dimensions{Dim::Y, 2}, Values{},
+                                              Variances{});
   auto vals = var.values<event_list<double>>();
   vals[0] = {1, 2, 3};
   vals[1] = {4};
@@ -83,7 +83,7 @@ TEST_F(TransformUnaryTest, elements_of_sparse_with_variance) {
 }
 
 TEST_F(TransformUnaryTest, sparse_values_variances_size_fail) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(2), sparse_container<double>(1)},
@@ -285,7 +285,7 @@ TEST_F(TransformBinaryTest, dense_sparse) {
 }
 
 TEST_F(TransformBinaryTest, sparse_size_fail) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(2), sparse_container<double>(1)});
@@ -431,7 +431,7 @@ TEST(TransformTest, unary_on_sparse_container) {
 }
 
 TEST(TransformTest, unary_on_sparse_container_with_variance) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(), sparse_container<double>()},
@@ -452,7 +452,7 @@ TEST(TransformTest, unary_on_sparse_container_with_variance) {
 }
 
 TEST(TransformTest, unary_on_sparse_container_with_variance_size_fail) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(), sparse_container<double>()},
@@ -476,7 +476,7 @@ TEST(TransformTest, unary_on_sparse_container_with_variance_size_fail) {
 }
 
 TEST(TransformTest, binary_on_sparse_container_with_variance_size_fail) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(), sparse_container<double>()},
@@ -502,7 +502,7 @@ TEST(TransformTest, binary_on_sparse_container_with_variance_size_fail) {
 
 TEST(TransformTest,
      binary_on_sparse_container_with_variance_accepts_size_mismatch) {
-  Dimensions dims({Dim::Y}, {2});
+  Dimensions dims(Dim::Y, 2);
   auto a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(), sparse_container<double>()},
@@ -528,7 +528,7 @@ TEST(TransformTest,
 class TransformTest_sparse_binary_values_variances_size_fail
     : public ::testing::Test {
 protected:
-  Dimensions dims{{Dim::Y}, {2}};
+  Dimensions dims{Dim::Y, 2};
   Variable a = makeVariable<event_list<double>>(
       Dimensions(dims),
       Values{sparse_container<double>(2), sparse_container<double>(2)},

--- a/core/test/variable_keyword_args_constructor_test.cpp
+++ b/core/test/variable_keyword_args_constructor_test.cpp
@@ -52,7 +52,7 @@ TEST(CreateVariableTest, from_vector) {
 TEST(CreateVariableTest, construct_sparse) {
   auto var = makeVariable<event_list<double>>(Dims{Dim::X}, Shape{2});
 
-  auto dimensions = Dimensions{{Dim::X}, {2}};
+  auto dimensions = Dimensions{Dim::X, 2};
   makeVariable<event_list<double>>(
       Dimensions{dimensions},
       Values{sparse_container<double>(), sparse_container<double>()},

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -39,7 +39,7 @@ std::vector<std::pair<Dim, Variable>> DataArrayConstView::slice_bounds() const {
       combined_slices[dim] = {left, right};
     }
   }
-  for (const auto [dim, interval] : combined_slices) {
+  for (const auto &[dim, interval] : combined_slices) {
     const auto [left, right] = interval;
     const auto coord = m_dataset->coords()[dim];
     bounds.emplace_back(dim, concatenate(coord.slice({dim, left}),

--- a/dataset/include/scipp/dataset/view_decl.h
+++ b/dataset/include/scipp/dataset/view_decl.h
@@ -21,7 +21,7 @@ using slice_list =
     boost::container::small_vector<std::pair<Slice, scipp::index>, 2>;
 
 template <class T> void do_make_slice(T &slice, const slice_list &slices) {
-  for (const auto [params, extent] : slices) {
+  for (const auto &[params, extent] : slices) {
     if (slice.dims().contains(params.dim())) {
       const auto new_end = params.end() + slice.dims()[params.dim()] - extent;
       const auto pointSlice = (new_end == -1);

--- a/dataset/test/copy_test.cpp
+++ b/dataset/test/copy_test.cpp
@@ -34,7 +34,7 @@ TEST_F(CopyTest, data_array_drop_attrs) {
 
 TEST_F(CopyTest, dataset_drop_attrs) {
   // not implemented yet
-  EXPECT_ANY_THROW(copy(dataset, AttrPolicy::Drop));
+  EXPECT_ANY_THROW(auto _ = copy(dataset, AttrPolicy::Drop));
 }
 
 struct CopyOutArgTest : public CopyTest {

--- a/dataset/test/data_array_test.cpp
+++ b/dataset/test/data_array_test.cpp
@@ -333,6 +333,7 @@ TEST_F(DataArrayRealignedEventsPlusMinusTest, minus_equals) {
 
 TEST_F(DataArrayRealignedEventsPlusMinusTest, minus_equals_self) {
   auto out(a);
+#pragma clang diagnostic ignored "-Wself-assign"
   out -= out;
   EXPECT_EQ(out, a - a);
 }

--- a/dataset/test/data_array_test.cpp
+++ b/dataset/test/data_array_test.cpp
@@ -131,7 +131,7 @@ TEST(DataArrayRealignedEventsArithmeticTest, events_times_histogram) {
   const auto realigned = unaligned::realign(
       DataArray(sparse), {{Dim::X, Variable{hist.coords()[Dim::X]}}});
 
-  for (const auto result : {realigned * hist, hist * realigned}) {
+  for (const auto &result : {realigned * hist, hist * realigned}) {
     EXPECT_EQ(result.coords(), realigned.coords());
     EXPECT_FALSE(result.hasData());
     EXPECT_TRUE(result.hasVariances());
@@ -169,7 +169,7 @@ TEST(DataArrayRealignedEventsArithmeticTest,
   const auto realigned = unaligned::realign(
       DataArray(sparse), {{Dim::X, Variable{hist.coords()[Dim::X]}}});
 
-  for (const auto result : {realigned * hist, hist * realigned}) {
+  for (const auto &result : {realigned * hist, hist * realigned}) {
     EXPECT_EQ(result.coords(), realigned.coords());
     EXPECT_FALSE(result.hasData());
     EXPECT_TRUE(result.hasVariances());
@@ -210,7 +210,7 @@ TEST(DataArrayRealignedEventsArithmeticTest,
   const auto realigned = unaligned::realign(
       DataArray(sparse), {{Dim::X, Variable{hist.coords()[Dim::X]}}});
 
-  for (const auto result : {realigned * hist, hist * realigned}) {
+  for (const auto &result : {realigned * hist, hist * realigned}) {
     EXPECT_EQ(result.coords(), realigned.coords());
     EXPECT_FALSE(result.hasData());
     EXPECT_TRUE(result.hasVariances());

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -41,7 +41,7 @@ TEST(DatasetTest, clear) {
 TEST(DatasetTest, erase_non_existant) {
   Dataset d;
   ASSERT_THROW(d.erase("not an item"), except::NotFoundError);
-  ASSERT_THROW(d.extract("not an item"), except::NotFoundError);
+  ASSERT_THROW(auto _ = d.extract("not an item"), except::NotFoundError);
 }
 
 TEST(DatasetTest, erase) {
@@ -84,7 +84,7 @@ TEST(DatasetTest, extract_extents_rebuild) {
   d.setData("a", makeVariable<double>(Dims{Dim::X}, Shape{10}));
   ASSERT_TRUE(d.contains("a"));
 
-  ASSERT_NO_THROW(d.extract("a"));
+  ASSERT_NO_THROW(auto _ = d.extract("a"));
   ASSERT_FALSE(d.contains("a"));
 
   ASSERT_NO_THROW(

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -177,7 +177,7 @@ TEST_P(ConvertTest, Tof_to_DSpacing) {
 
     ASSERT_TRUE(dspacing.contains("events"));
     const auto &events = dspacing["events"];
-    ASSERT_EQ(events.dims(), Dimensions({Dim::Spectrum}, {2}));
+    ASSERT_EQ(events.dims(), Dimensions(Dim::Spectrum, 2));
     const auto &tof0 =
         tof["events"].coords()[Dim::Tof].values<event_list<double>>()[0];
     const auto &d0 =
@@ -215,7 +215,7 @@ TEST(Convert, converts_sparse_labels) {
   // label "conversion" is name change of dim
   Dataset tof = makeTofDatasetEvents();
   Dataset dspacing = convert(tof, Dim::Tof, Dim::DSpacing);
-  Dimensions expected({Dim::Spectrum}, {2});
+  Dimensions expected(Dim::Spectrum, 2);
   EXPECT_EQ(dspacing["events"].coords()[Dim::DSpacing].dims(), expected);
   EXPECT_EQ(dspacing["events"].coords()[Dim("aux")].dims(), expected);
 }
@@ -300,7 +300,7 @@ TEST_P(ConvertTest, Tof_to_Wavelength) {
   } else {
     ASSERT_TRUE(wavelength.contains("events"));
     const auto &events = wavelength["events"];
-    ASSERT_EQ(events.dims(), Dimensions({Dim::Spectrum}, {2}));
+    ASSERT_EQ(events.dims(), Dimensions(Dim::Spectrum, 2));
     const auto &tof0 =
         tof["events"].coords()[Dim::Tof].values<event_list<double>>()[0];
     const auto &d0 =
@@ -426,7 +426,7 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
   } else {
     ASSERT_TRUE(energy.contains("events"));
     const auto &events = energy["events"];
-    ASSERT_EQ(events.dims(), Dimensions({Dim::Spectrum}, {2}));
+    ASSERT_EQ(events.dims(), Dimensions(Dim::Spectrum, 2));
     const auto &tof0 =
         tof["events"].coords()[Dim::Tof].values<event_list<double>>()[0];
     const auto &e0 =


### PR DESCRIPTION
Resolves the following using clang-9 / clang-10 on Ubuntu:

- (Updates .gitignore for some clangd files)
- Compilation error where ODR is violated across multiple TUs
- Warnings from copying in structured bindings (instead of by ref)
- Suppress a warning about self assignment in unit tests
- Removes braces round scalars which caused a warning e.g. `{2}`
- Fixes warnings about discarding a `nodiscard` in tests