### PR TITLE
Reduce overall compile time by ~10% - variable.h

### DIFF
--- a/common/include/scipp/common/index.h
+++ b/common/include/scipp/common/index.h
@@ -4,7 +4,7 @@
 /// @author Simon Heybrock
 #ifndef SCIPP_COMMON_INDEX_H
 #define SCIPP_COMMON_INDEX_H
-#include <cstddef>
+#include <cstdint>
 
 namespace scipp {
 /// Type to use for all container/array sizes and indices.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,7 @@ set(INC_FILES
     include/scipp/core/slice.h
     include/scipp/core/element_array_view.h
     include/scipp/core/variable.h
+    include/scipp/core/variable_concept.h
     include/scipp/core/variable.tcc
     include/scipp/core/view_index.h
     include/scipp/core/variable_keyword_arg_constructor.h
@@ -25,6 +26,7 @@ set(SRC_FILES
     subspan_view.cpp
     string.cpp
     variable.cpp
+    variable_concept.cpp
     variable_binary_arithmetic.cpp
     variable_inplace_arithmetic.cpp
     variable_instantiate_basic.cpp

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -13,6 +13,8 @@
 
 #include <Eigen/Dense>
 
+#include "variable_concept.h"
+
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
@@ -47,73 +49,6 @@ template <class T> struct is_sparse_container : std::false_type {};
 template <class T>
 struct is_sparse_container<sparse_container<T>> : std::true_type {};
 
-class Variable;
-template <class... Known> class VariableConceptHandle_impl;
-// Any item type that is listed here explicitly can be used with the templated
-// `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
-#define KNOWN                                                                  \
-  double, float, int64_t, int32_t, bool, Eigen::Vector3d, Eigen::Quaterniond,  \
-      sparse_container<double>, sparse_container<float>,                       \
-      sparse_container<int64_t>, sparse_container<int32_t>,                    \
-      sparse_container<bool>, span<const double>, span<double>,                \
-      span<const float>, span<float>, span<const int64_t>, span<int64_t>,      \
-      span<const int32_t>, span<int32_t>
-using VariableConceptHandle = VariableConceptHandle_impl<KNOWN>;
-
-/// Abstract base class for any data that can be held by Variable. Also used to
-/// hold views to data by (Const)VariableView. This is using so-called
-/// concept-based polymorphism, see talks by Sean Parent.
-///
-/// This is the most generic representation for a multi-dimensional array of
-/// data. More operations are supportd by the partially-typed VariableConceptT.
-class SCIPP_CORE_EXPORT VariableConcept {
-public:
-  VariableConcept(const Dimensions &dimensions);
-  virtual ~VariableConcept() = default;
-
-  virtual DType dtype() const noexcept = 0;
-  virtual VariableConceptHandle clone() const = 0;
-  virtual VariableConceptHandle
-  makeDefaultFromParent(const Dimensions &dims) const = 0;
-  virtual VariableConceptHandle makeView() const = 0;
-  virtual VariableConceptHandle makeView() = 0;
-  virtual VariableConceptHandle makeView(const Dim dim,
-                                         const scipp::index begin,
-                                         const scipp::index end = -1) const = 0;
-  virtual VariableConceptHandle makeView(const Dim dim,
-                                         const scipp::index begin,
-                                         const scipp::index end = -1) = 0;
-
-  virtual VariableConceptHandle reshape(const Dimensions &dims) const = 0;
-  virtual VariableConceptHandle reshape(const Dimensions &dims) = 0;
-
-  virtual VariableConceptHandle
-  transpose(const std::vector<Dim> &dms) const = 0;
-  virtual VariableConceptHandle transpose(const std::vector<Dim> &dms) = 0;
-
-  virtual bool operator==(const VariableConcept &other) const = 0;
-  virtual bool isSame(const VariableConcept &other) const = 0;
-
-  virtual bool isContiguous() const = 0;
-  virtual bool isView() const = 0;
-  virtual bool isConstView() const = 0;
-  virtual bool hasVariances() const noexcept = 0;
-
-  virtual scipp::index size() const = 0;
-  virtual void copy(const VariableConcept &other, const Dim dim,
-                    const scipp::index offset, const scipp::index otherBegin,
-                    const scipp::index otherEnd) = 0;
-
-  virtual void setVariances(Variable &&variances) = 0;
-
-  const Dimensions &dims() const { return m_dimensions; }
-
-  friend class Variable;
-
-private:
-  Dimensions m_dimensions;
-};
-
 template <class T> constexpr bool canHaveVariances() noexcept {
   using U = std::remove_const_t<T>;
   return std::is_same_v<U, double> || std::is_same_v<U, float> ||
@@ -124,139 +59,7 @@ template <class T> constexpr bool canHaveVariances() noexcept {
          std::is_same_v<U, span<double>> || std::is_same_v<U, span<float>>;
 }
 
-/// Partially typed implementation of VariableConcept. This is a common base
-/// class for DataModel<T> and ViewModel<T>. The former holds data in a
-/// contiguous array, whereas the latter is a (potentially non-contiguous) view
-/// into the former. This base class implements functionality that is common to
-/// both, for a specific T.
-template <class T> class VariableConceptT : public VariableConcept {
-public:
-  using value_type = T;
-
-  VariableConceptT(const Dimensions &dimensions)
-      : VariableConcept(dimensions) {}
-
-  DType dtype() const noexcept override { return scipp::core::dtype<T>; }
-  static DType static_dtype() noexcept { return scipp::core::dtype<T>; }
-
-  virtual scipp::span<T> values() = 0;
-  virtual scipp::span<T> values(const Dim dim, const scipp::index begin,
-                                const scipp::index end) = 0;
-  virtual scipp::span<const T> values() const = 0;
-  virtual scipp::span<const T> values(const Dim dim, const scipp::index begin,
-                                      const scipp::index end) const = 0;
-  virtual scipp::span<T> variances() = 0;
-  virtual scipp::span<T> variances(const Dim dim, const scipp::index begin,
-                                   const scipp::index end) = 0;
-  virtual scipp::span<const T> variances() const = 0;
-  virtual scipp::span<const T> variances(const Dim dim,
-                                         const scipp::index begin,
-                                         const scipp::index end) const = 0;
-  virtual ElementArrayView<T> valuesView(const Dimensions &dims) = 0;
-  virtual ElementArrayView<T> valuesView(const Dimensions &dims, const Dim dim,
-                                         const scipp::index begin) = 0;
-  virtual ElementArrayView<const T>
-  valuesView(const Dimensions &dims) const = 0;
-  virtual ElementArrayView<const T>
-  valuesView(const Dimensions &dims, const Dim dim,
-             const scipp::index begin) const = 0;
-  virtual ElementArrayView<T> variancesView(const Dimensions &dims) = 0;
-  virtual ElementArrayView<T> variancesView(const Dimensions &dims,
-                                            const Dim dim,
-                                            const scipp::index begin) = 0;
-  virtual ElementArrayView<const T>
-  variancesView(const Dimensions &dims) const = 0;
-  virtual ElementArrayView<const T>
-  variancesView(const Dimensions &dims, const Dim dim,
-                const scipp::index begin) const = 0;
-  virtual ElementArrayView<const T>
-  valuesReshaped(const Dimensions &dims) const = 0;
-  virtual ElementArrayView<T> valuesReshaped(const Dimensions &dims) = 0;
-  virtual ElementArrayView<const T>
-  variancesReshaped(const Dimensions &dims) const = 0;
-  virtual ElementArrayView<T> variancesReshaped(const Dimensions &dims) = 0;
-
-  virtual std::unique_ptr<VariableConceptT> copyT() const = 0;
-
-  VariableConceptHandle
-  makeDefaultFromParent(const Dimensions &dims) const override;
-
-  VariableConceptHandle makeView() const override;
-
-  VariableConceptHandle makeView() override;
-
-  VariableConceptHandle makeView(const Dim dim, const scipp::index begin,
-                                 const scipp::index end) const override;
-
-  VariableConceptHandle makeView(const Dim dim, const scipp::index begin,
-                                 const scipp::index end) override;
-
-  VariableConceptHandle reshape(const Dimensions &dims) const override;
-
-  VariableConceptHandle reshape(const Dimensions &dims) override;
-
-  VariableConceptHandle transpose(const std::vector<Dim> &dims) const override;
-
-  VariableConceptHandle transpose(const std::vector<Dim> &dims) override;
-
-  bool operator==(const VariableConcept &other) const override;
-  void copy(const VariableConcept &other, const Dim dim,
-            const scipp::index offset, const scipp::index otherBegin,
-            const scipp::index otherEnd) override;
-};
-
-template <class... Known> class VariableConceptHandle_impl {
-public:
-  using variant_t =
-      std::variant<const VariableConcept *, const VariableConceptT<Known> *...>;
-
-  VariableConceptHandle_impl()
-      : m_object(std::unique_ptr<VariableConcept>(nullptr)) {}
-  template <class T> VariableConceptHandle_impl(T object) {
-    using value_t = typename T::element_type::value_type;
-    if constexpr ((std::is_same_v<value_t, Known> || ...))
-      m_object = std::unique_ptr<VariableConceptT<value_t>>(std::move(object));
-    else
-      m_object = std::unique_ptr<VariableConcept>(std::move(object));
-  }
-  VariableConceptHandle_impl(VariableConceptHandle_impl &&) = default;
-  VariableConceptHandle_impl(const VariableConceptHandle_impl &other)
-      : VariableConceptHandle_impl(other ? other->clone()
-                                         : VariableConceptHandle_impl()) {}
-  VariableConceptHandle_impl &
-  operator=(VariableConceptHandle_impl &&) = default;
-  VariableConceptHandle_impl &
-  operator=(const VariableConceptHandle_impl &other) {
-    if (*this && other) {
-      // Avoid allocation of new element_array if output is of correct shape.
-      // This yields a 5x speedup in assignment operations of variables.
-      auto &concept = **this;
-      auto &otherConcept = *other;
-      if (!concept.isView() && !otherConcept.isView() &&
-          concept.dtype() == otherConcept.dtype() &&
-          concept.dims() == otherConcept.dims() &&
-          concept.hasVariances() == otherConcept.hasVariances()) {
-        concept.copy(otherConcept, Dim::Invalid, 0, 0, 1);
-        return *this;
-      }
-    }
-    return *this = other ? other->clone() : VariableConceptHandle_impl();
-  }
-
-  explicit operator bool() const noexcept;
-  VariableConcept &operator*() const;
-  VariableConcept *operator->() const;
-
-  const auto &mutableVariant() const noexcept { return m_object; }
-
-  variant_t variant() const noexcept;
-
-private:
-  std::variant<std::unique_ptr<VariableConcept>,
-               std::unique_ptr<VariableConceptT<Known>>...>
-      m_object;
-};
-
+class Variable;
 class VariableConstView;
 class VariableView;
 

--- a/core/include/scipp/core/variable_concept.h
+++ b/core/include/scipp/core/variable_concept.h
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#ifndef SCIPP_VARIABLE_CONCEPT_H_
+#define SCIPP_VARIABLE_CONCEPT_H_
+
+#include "scipp-core_export.h"
+#include "scipp/common/index.h"
+#include "scipp/common/span.h"
+#include "scipp/core/dimensions.h"
+#include "scipp/core/dtype.h"
+#include "scipp/core/element_array_view.h"
+
+#include <Eigen/Dense>
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace scipp::core {
+
+class Variable;
+class VariableConcept;
+template <class T> class VariableConceptT;
+
+template <class... Known> class VariableConceptHandle_impl {
+public:
+  using variant_t =
+      std::variant<const VariableConcept *, const VariableConceptT<Known> *...>;
+
+  VariableConceptHandle_impl()
+      : m_object(std::unique_ptr<VariableConcept>(nullptr)) {}
+  template <class T> VariableConceptHandle_impl(T object) {
+    using value_t = typename T::element_type::value_type;
+    if constexpr ((std::is_same_v<value_t, Known> || ...))
+      m_object = std::unique_ptr<VariableConceptT<value_t>>(std::move(object));
+    else
+      m_object = std::unique_ptr<VariableConcept>(std::move(object));
+  }
+  VariableConceptHandle_impl(VariableConceptHandle_impl &&) = default;
+  VariableConceptHandle_impl(const VariableConceptHandle_impl &other)
+      : VariableConceptHandle_impl(other ? other->clone()
+                                         : VariableConceptHandle_impl()) {}
+  VariableConceptHandle_impl &
+  operator=(VariableConceptHandle_impl &&) = default;
+  VariableConceptHandle_impl &
+  operator=(const VariableConceptHandle_impl &other) {
+    if (*this && other) {
+      // Avoid allocation of new element_array if output is of correct shape.
+      // This yields a 5x speedup in assignment operations of variables.
+      auto &concept = **this;
+      auto &otherConcept = *other;
+      if (!concept.isView() && !otherConcept.isView() &&
+          concept.dtype() == otherConcept.dtype() &&
+          concept.dims() == otherConcept.dims() &&
+          concept.hasVariances() == otherConcept.hasVariances()) {
+        concept.copy(otherConcept, Dim::Invalid, 0, 0, 1);
+        return *this;
+      }
+    }
+    return *this = other ? other->clone() : VariableConceptHandle_impl();
+  }
+
+  explicit operator bool() const noexcept;
+  VariableConcept &operator*() const;
+  VariableConcept *operator->() const;
+
+  const auto &mutableVariant() const noexcept { return m_object; }
+
+  variant_t variant() const noexcept;
+
+private:
+  std::variant<std::unique_ptr<VariableConcept>,
+               std::unique_ptr<VariableConceptT<Known>>...>
+      m_object;
+};
+
+// Any item type that is listed here explicitly can be used with the templated
+// `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
+#define KNOWN                                                                  \
+  double, float, int64_t, int32_t, bool, Eigen::Vector3d, Eigen::Quaterniond,  \
+      sparse_container<double>, sparse_container<float>,                       \
+      sparse_container<int64_t>, sparse_container<int32_t>,                    \
+      sparse_container<bool>, span<const double>, span<double>,                \
+      span<const float>, span<float>, span<const int64_t>, span<int64_t>,      \
+      span<const int32_t>, span<int32_t>
+
+extern template class VariableConceptHandle_impl<KNOWN>;
+
+using VariableConceptHandle = VariableConceptHandle_impl<KNOWN>;
+
+/// Abstract base class for any data that can be held by Variable. Also used
+/// to hold views to data by (Const)VariableView. This is using so-called
+/// concept-based polymorphism, see talks by Sean Parent.
+///
+/// This is the most generic representation for a multi-dimensional array of
+/// data. More operations are supportd by the partially-typed
+/// VariableConceptT.
+class SCIPP_CORE_EXPORT VariableConcept {
+public:
+  VariableConcept(const Dimensions &dimensions);
+  virtual ~VariableConcept() = default;
+
+  virtual DType dtype() const noexcept = 0;
+  virtual VariableConceptHandle clone() const = 0;
+  virtual VariableConceptHandle
+  makeDefaultFromParent(const Dimensions &dims) const = 0;
+  virtual VariableConceptHandle makeView() const = 0;
+  virtual VariableConceptHandle makeView() = 0;
+  virtual VariableConceptHandle makeView(const Dim dim,
+                                         const scipp::index begin,
+                                         const scipp::index end = -1) const = 0;
+  virtual VariableConceptHandle makeView(const Dim dim,
+                                         const scipp::index begin,
+                                         const scipp::index end = -1) = 0;
+
+  virtual VariableConceptHandle reshape(const Dimensions &dims) const = 0;
+  virtual VariableConceptHandle reshape(const Dimensions &dims) = 0;
+
+  virtual VariableConceptHandle
+  transpose(const std::vector<Dim> &dms) const = 0;
+  virtual VariableConceptHandle transpose(const std::vector<Dim> &dms) = 0;
+
+  virtual bool operator==(const VariableConcept &other) const = 0;
+  virtual bool isSame(const VariableConcept &other) const = 0;
+
+  virtual bool isContiguous() const = 0;
+  virtual bool isView() const = 0;
+  virtual bool isConstView() const = 0;
+  virtual bool hasVariances() const noexcept = 0;
+
+  virtual scipp::index size() const = 0;
+  virtual void copy(const VariableConcept &other, const Dim dim,
+                    const scipp::index offset, const scipp::index otherBegin,
+                    const scipp::index otherEnd) = 0;
+
+  virtual void setVariances(Variable &&variances) = 0;
+
+  const Dimensions &dims() const { return m_dimensions; }
+
+  friend class Variable;
+
+private:
+  Dimensions m_dimensions;
+};
+
+/// Partially typed implementation of VariableConcept. This is a common base
+/// class for DataModel<T> and ViewModel<T>. The former holds data in a
+/// contiguous array, whereas the latter is a (potentially non-contiguous) view
+/// into the former. This base class implements functionality that is common to
+/// both, for a specific T.
+template <class T> class VariableConceptT : public VariableConcept {
+public:
+  using value_type = T;
+
+  VariableConceptT(const Dimensions &dimensions)
+      : VariableConcept(dimensions) {}
+
+  DType dtype() const noexcept override { return scipp::core::dtype<T>; }
+  static DType static_dtype() noexcept { return scipp::core::dtype<T>; }
+
+  virtual scipp::span<T> values() = 0;
+  virtual scipp::span<T> values(const Dim dim, const scipp::index begin,
+                                const scipp::index end) = 0;
+  virtual scipp::span<const T> values() const = 0;
+  virtual scipp::span<const T> values(const Dim dim, const scipp::index begin,
+                                      const scipp::index end) const = 0;
+  virtual scipp::span<T> variances() = 0;
+  virtual scipp::span<T> variances(const Dim dim, const scipp::index begin,
+                                   const scipp::index end) = 0;
+  virtual scipp::span<const T> variances() const = 0;
+  virtual scipp::span<const T> variances(const Dim dim,
+                                         const scipp::index begin,
+                                         const scipp::index end) const = 0;
+  virtual ElementArrayView<T> valuesView(const Dimensions &dims) = 0;
+  virtual ElementArrayView<T> valuesView(const Dimensions &dims, const Dim dim,
+                                         const scipp::index begin) = 0;
+  virtual ElementArrayView<const T>
+  valuesView(const Dimensions &dims) const = 0;
+  virtual ElementArrayView<const T>
+  valuesView(const Dimensions &dims, const Dim dim,
+             const scipp::index begin) const = 0;
+  virtual ElementArrayView<T> variancesView(const Dimensions &dims) = 0;
+  virtual ElementArrayView<T> variancesView(const Dimensions &dims,
+                                            const Dim dim,
+                                            const scipp::index begin) = 0;
+  virtual ElementArrayView<const T>
+  variancesView(const Dimensions &dims) const = 0;
+  virtual ElementArrayView<const T>
+  variancesView(const Dimensions &dims, const Dim dim,
+                const scipp::index begin) const = 0;
+  virtual ElementArrayView<const T>
+  valuesReshaped(const Dimensions &dims) const = 0;
+  virtual ElementArrayView<T> valuesReshaped(const Dimensions &dims) = 0;
+  virtual ElementArrayView<const T>
+  variancesReshaped(const Dimensions &dims) const = 0;
+  virtual ElementArrayView<T> variancesReshaped(const Dimensions &dims) = 0;
+
+  virtual std::unique_ptr<VariableConceptT> copyT() const = 0;
+
+  VariableConceptHandle
+  makeDefaultFromParent(const Dimensions &dims) const override;
+
+  VariableConceptHandle makeView() const override;
+
+  VariableConceptHandle makeView() override;
+
+  VariableConceptHandle makeView(const Dim dim, const scipp::index begin,
+                                 const scipp::index end) const override;
+
+  VariableConceptHandle makeView(const Dim dim, const scipp::index begin,
+                                 const scipp::index end) override;
+
+  VariableConceptHandle reshape(const Dimensions &dims) const override;
+
+  VariableConceptHandle reshape(const Dimensions &dims) override;
+
+  VariableConceptHandle transpose(const std::vector<Dim> &dims) const override;
+
+  VariableConceptHandle transpose(const std::vector<Dim> &dims) override;
+
+  bool operator==(const VariableConcept &other) const override;
+  void copy(const VariableConcept &other, const Dim dim,
+            const scipp::index offset, const scipp::index otherBegin,
+            const scipp::index otherEnd) override;
+};
+
+} // namespace scipp::core
+
+#endif // SCIPP_VARIABLE_CONCEPT_H_

--- a/core/variable.cpp
+++ b/core/variable.cpp
@@ -3,8 +3,10 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/core/variable.h"
+
 #include "scipp/core/dtype.h"
 #include "scipp/core/except.h"
+#include "scipp/core/variable_concept.h"
 
 namespace scipp::core {
 
@@ -19,50 +21,6 @@ detail::reorderedShape(const scipp::span<const Dim> &order,
                  [&dimensions](auto &a) { return dimensions[a]; });
   return res;
 }
-
-template <class... Known>
-VariableConceptHandle_impl<Known...>::operator bool() const noexcept {
-  return std::visit([](auto &&ptr) { return bool(ptr); }, m_object);
-}
-
-template <class... Known>
-VariableConcept &VariableConceptHandle_impl<Known...>::operator*() const {
-  return std::visit([](auto &&arg) -> VariableConcept & { return *arg; },
-                    m_object);
-}
-
-template <class... Known>
-VariableConcept *VariableConceptHandle_impl<Known...>::operator->() const {
-  return std::visit(
-      [](auto &&arg) -> VariableConcept * { return arg.operator->(); },
-      m_object);
-}
-
-template <class... Known>
-typename VariableConceptHandle_impl<Known...>::variant_t
-VariableConceptHandle_impl<Known...>::variant() const noexcept {
-  return std::visit(
-      [](auto &&arg) {
-        return std::variant<const VariableConcept *,
-                            const VariableConceptT<Known> *...>{arg.get()};
-      },
-      m_object);
-}
-
-// Explicit instantiation of complete class does not work, at least on gcc.
-// Apparently the type is already defined and the attribute is ignored, so we
-// have to do it separately for each method.
-template SCIPP_CORE_EXPORT VariableConceptHandle_impl<KNOWN>::
-operator bool() const;
-template SCIPP_CORE_EXPORT VariableConcept &VariableConceptHandle_impl<KNOWN>::
-operator*() const;
-template SCIPP_CORE_EXPORT VariableConcept *VariableConceptHandle_impl<KNOWN>::
-operator->() const;
-template SCIPP_CORE_EXPORT typename VariableConceptHandle_impl<KNOWN>::variant_t
-VariableConceptHandle_impl<KNOWN>::variant() const noexcept;
-
-VariableConcept::VariableConcept(const Dimensions &dimensions)
-    : m_dimensions(dimensions) {}
 
 Variable::Variable(const VariableConstView &slice)
     : Variable(slice ? Variable(slice, slice.dims()) : Variable()) {

--- a/core/variable_concept.cpp
+++ b/core/variable_concept.cpp
@@ -1,0 +1,44 @@
+#include "scipp/core/variable_concept.h"
+
+#include "scipp/core/dimensions.h"
+
+#include <utility>
+#include <variant>
+
+namespace scipp::core {
+template <class... Known>
+VariableConceptHandle_impl<Known...>::operator bool() const noexcept {
+  return std::visit([](auto &&ptr) { return bool(ptr); }, m_object);
+}
+
+template <class... Known>
+VariableConcept &VariableConceptHandle_impl<Known...>::operator*() const {
+  return std::visit([](auto &&arg) -> VariableConcept & { return *arg; },
+                    m_object);
+}
+
+template <class... Known>
+VariableConcept *VariableConceptHandle_impl<Known...>::operator->() const {
+  return std::visit(
+      [](auto &&arg) -> VariableConcept * { return arg.operator->(); },
+      m_object);
+}
+
+template <class... Known>
+typename VariableConceptHandle_impl<Known...>::variant_t
+VariableConceptHandle_impl<Known...>::variant() const noexcept {
+  return std::visit(
+      [](auto &&arg) {
+        return std::variant<const VariableConcept *,
+                            const VariableConceptT<Known> *...>{arg.get()};
+      },
+      m_object);
+}
+
+VariableConcept::VariableConcept(const Dimensions &dimensions)
+    : m_dimensions(dimensions) {}
+
+// Explicitly instansiate the template once in this TU
+template class VariableConceptHandle_impl<KNOWN>;
+
+} // namespace scipp::core


### PR DESCRIPTION
Reduces the number of template instantiations of the Variable concept polymorphism. 

This was being instantiated for each TU (e.g. tests), which impacts both compile and link time.
Locally, a clang-10 debug build sped up from ~11 minutes to ~10 minutes.

We now mark the instantiation as extern so the current TU initializes it once