### PR TITLE
Decomplicate VariableConceptHandle

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,9 +5,7 @@ add_custom_target(all-benchmarks)
 
 add_executable(groupby_benchmark EXCLUDE_FROM_ALL groupby_benchmark.cpp)
 add_dependencies(all-benchmarks groupby_benchmark)
-target_link_libraries(
-  groupby_benchmark LINK_PRIVATE scipp-dataset benchmark
-)
+target_link_libraries(groupby_benchmark LINK_PRIVATE scipp-dataset benchmark)
 
 add_executable(slice_benchmark EXCLUDE_FROM_ALL slice_benchmark.cpp)
 add_dependencies(all-benchmarks slice_benchmark)
@@ -18,7 +16,8 @@ add_executable(
 )
 add_dependencies(all-benchmarks event_filter_benchmark)
 target_link_libraries(
-  event_filter_benchmark LINK_PRIVATE benchmark scipp-dataset scipp_test_helpers
+  event_filter_benchmark LINK_PRIVATE benchmark scipp-dataset
+  scipp_test_helpers
 )
 
 add_executable(histogram_benchmark EXCLUDE_FROM_ALL histogram_benchmark.cpp)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -5,24 +5,26 @@ add_custom_target(all-benchmarks)
 
 add_executable(groupby_benchmark EXCLUDE_FROM_ALL groupby_benchmark.cpp)
 add_dependencies(all-benchmarks groupby_benchmark)
-target_link_libraries(groupby_benchmark LINK_PRIVATE scipp-core benchmark)
+target_link_libraries(
+  groupby_benchmark LINK_PRIVATE scipp-dataset benchmark
+)
 
 add_executable(slice_benchmark EXCLUDE_FROM_ALL slice_benchmark.cpp)
 add_dependencies(all-benchmarks slice_benchmark)
-target_link_libraries(slice_benchmark LINK_PRIVATE scipp-core benchmark)
+target_link_libraries(slice_benchmark LINK_PRIVATE scipp-dataset benchmark)
 
 add_executable(
   event_filter_benchmark EXCLUDE_FROM_ALL event_filter_benchmark.cpp
 )
 add_dependencies(all-benchmarks event_filter_benchmark)
 target_link_libraries(
-  event_filter_benchmark LINK_PRIVATE benchmark scipp-core scipp_test_helpers
+  event_filter_benchmark LINK_PRIVATE benchmark scipp-dataset scipp_test_helpers
 )
 
 add_executable(histogram_benchmark EXCLUDE_FROM_ALL histogram_benchmark.cpp)
 add_dependencies(all-benchmarks histogram_benchmark)
 target_link_libraries(
-  histogram_benchmark LINK_PRIVATE benchmark scipp-core scipp_test_helpers
+  histogram_benchmark LINK_PRIVATE benchmark scipp-dataset scipp_test_helpers
 )
 
 add_executable(
@@ -31,7 +33,7 @@ add_executable(
 )
 add_dependencies(all-benchmarks sparse_histogram_op_benchmark)
 target_link_libraries(
-  sparse_histogram_op_benchmark LINK_PRIVATE benchmark scipp-core
+  sparse_histogram_op_benchmark LINK_PRIVATE benchmark scipp-dataset
   scipp_test_helpers
 )
 
@@ -40,7 +42,7 @@ add_executable(
 )
 add_dependencies(all-benchmarks neutron_convert_benchmark)
 target_link_libraries(
-  neutron_convert_benchmark LINK_PRIVATE benchmark scipp-core scipp-neutron
+  neutron_convert_benchmark LINK_PRIVATE benchmark scipp-dataset scipp-neutron
   scipp_test_helpers
 )
 
@@ -54,7 +56,7 @@ target_link_libraries(variable_benchmark LINK_PRIVATE scipp-core benchmark)
 
 add_executable(dataset_benchmark EXCLUDE_FROM_ALL dataset_benchmark.cpp)
 add_dependencies(all-benchmarks dataset_benchmark)
-target_link_libraries(dataset_benchmark LINK_PRIVATE scipp-core benchmark)
+target_link_libraries(dataset_benchmark LINK_PRIVATE scipp-dataset benchmark)
 
 add_executable(
   dataset_operations_benchmark EXCLUDE_FROM_ALL
@@ -62,7 +64,7 @@ add_executable(
 )
 add_dependencies(all-benchmarks dataset_operations_benchmark)
 target_link_libraries(
-  dataset_operations_benchmark LINK_PRIVATE scipp-core benchmark
+  dataset_operations_benchmark LINK_PRIVATE scipp-dataset benchmark
 )
 
 add_executable(

--- a/benchmark/common.h
+++ b/benchmark/common.h
@@ -1,29 +1,8 @@
 #pragma once
 
-#include <random>
+#include "scipp/dataset/dataset.h"
 
-#include "../core/test/make_sparse.h"
-
-template <typename T> struct GenerateSparse {
-  auto operator()(int length) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, 100);
-
-    auto a = make_sparse_variable<T>(length);
-    unsigned long long size(0);
-
-    /* Generate a random amount of sparse data for each point */
-    auto vals = a.template values<event_list<T>>();
-    for (scipp::index i = 0; i < length; ++i) {
-      const auto l = dis(gen);
-      size += l;
-      vals[i] = scipp::core::sparse_container<T>(l, i);
-    }
-
-    return std::make_tuple(a, sizeof(T) * size);
-  }
-};
+#include "variable_common.h"
 
 template <int NameLen> struct Generate3DWithDataItems {
   auto operator()(const int itemCount = 5, const int length = 100) {

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -7,7 +7,7 @@
 
 #include "common.h"
 
-#include "scipp/core/dataset.h"
+#include "scipp/dataset/dataset.h"
 
 // Length of a string that can be stored with SSO
 constexpr auto SHORT_STRING_LENGTH = 6;
@@ -15,7 +15,6 @@ constexpr auto SHORT_STRING_LENGTH = 6;
 constexpr auto LONG_STRING_LENGTH = 32;
 
 using namespace scipp;
-using namespace scipp::core;
 
 Variable makeCoordData(const Dimensions &dims) {
   std::vector<double> data(dims.volume());

--- a/benchmark/dataset_operations_benchmark.cpp
+++ b/benchmark/dataset_operations_benchmark.cpp
@@ -7,8 +7,7 @@
 
 #include "common.h"
 
-#include "boost/preprocessor.hpp"
-#include "scipp/core/dataset.h"
+#include "scipp/dataset/dataset.h"
 
 using namespace scipp;
 using namespace scipp::core;

--- a/benchmark/event_filter_benchmark.cpp
+++ b/benchmark/event_filter_benchmark.cpp
@@ -5,11 +5,12 @@
 
 #include "random.h"
 
-#include "scipp/core/dataset.h"
-#include "scipp/core/event.h"
+#include "scipp/core/variable_operations.h"
+
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/event.h"
 
 using namespace scipp;
-using namespace scipp::core;
 
 auto make_2d_sparse_coord(const scipp::index size, const scipp::index count) {
   auto var = makeVariable<event_list<double>>(Dims{Dim::X}, Shape{size});
@@ -49,7 +50,7 @@ static void BM_event_filter(benchmark::State &state) {
   const auto interval = makeVariable<double>(Dims{Dim::Y}, Shape{2},
                                              Values{0.0, 1000 * fraction});
   for (auto _ : state) {
-    benchmark::DoNotOptimize(event::filter(sparse, Dim::Y, interval));
+    benchmark::DoNotOptimize(dataset::event::filter(sparse, Dim::Y, interval));
   }
   state.SetItemsProcessed(state.iterations() * nHist * nEvent);
   state.SetBytesProcessed(state.iterations() * nHist * (data ? 3 : 1) * nEvent *

--- a/benchmark/groupby_benchmark.cpp
+++ b/benchmark/groupby_benchmark.cpp
@@ -5,10 +5,12 @@
 
 #include <benchmark/benchmark.h>
 
-#include "scipp/core/groupby.h"
+#include "scipp/core/variable_operations.h"
+#include "scipp/dataset/groupby.h"
 
 using namespace scipp;
 using namespace scipp::core;
+using namespace scipp::dataset;
 
 template <class T>
 auto make_1d_events_scalar_weights(const scipp::index size,

--- a/benchmark/histogram_benchmark.cpp
+++ b/benchmark/histogram_benchmark.cpp
@@ -7,10 +7,10 @@
 
 #include "random.h"
 
-#include "scipp/core/dataset.h"
+#include "scipp/core/variable_operations.h"
+#include "scipp/dataset/dataset.h"
 
 using namespace scipp;
-using namespace scipp::core;
 
 auto make_2d_sparse_coord(const scipp::index size, const scipp::index count) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{size});

--- a/benchmark/neutron_convert_benchmark.cpp
+++ b/benchmark/neutron_convert_benchmark.cpp
@@ -3,11 +3,10 @@
 /// @file
 #include <benchmark/benchmark.h>
 
-#include "scipp/core/dataset.h"
+#include "scipp/dataset/dataset.h"
 #include "scipp/neutron/convert.h"
 
 using namespace scipp;
-using namespace scipp::core;
 
 auto make_beamline(const scipp::index size) {
   Dataset beamline;

--- a/benchmark/slice_benchmark.cpp
+++ b/benchmark/slice_benchmark.cpp
@@ -3,10 +3,9 @@
 /// @file
 #include <benchmark/benchmark.h>
 
-#include "scipp/core/dataset.h"
+#include "scipp/dataset/dataset.h"
 
 using namespace scipp;
-using namespace scipp::core;
 
 auto make_table() {
   const scipp::index nRow = 10;

--- a/benchmark/sparse_histogram_op_benchmark.cpp
+++ b/benchmark/sparse_histogram_op_benchmark.cpp
@@ -7,11 +7,11 @@
 
 #include "random.h"
 
-#include "scipp/core/dataset.h"
-#include "scipp/core/unaligned.h"
+#include "scipp/core/variable_operations.h"
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/unaligned.h"
 
 using namespace scipp;
-using namespace scipp::core;
 
 auto make_2d_sparse_coord(const scipp::index size, const scipp::index count) {
   auto var = makeVariable<event_list<double>>(Dims{Dim::X}, Shape{size});
@@ -39,7 +39,7 @@ auto make_2d_events_default_weights(const scipp::index size,
   auto weights =
       makeVariable<double>(Dims{Dim::X}, Shape{size},
                            units::Unit(units::counts), Values{}, Variances{});
-  return unaligned::realign(
+  return dataset::unaligned::realign(
       DataArray(weights, {{Dim::Y, make_2d_sparse_coord(size, count)}}),
       {{Dim::Y, make_edges(nEdge)}});
 }
@@ -49,7 +49,7 @@ auto make_2d_events(const scipp::index size, const scipp::index count,
   auto coord = make_2d_sparse_coord(size, count);
   auto data = coord * makeVariable<double>(Values{0.0}, Variances{0.0}) + 1.0;
 
-  return unaligned::realign(
+  return dataset::unaligned::realign(
       DataArray(std::move(data), {{Dim::Y, std::move(coord)}}),
       {{Dim::Y, make_edges(nEdge)}});
 }

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -4,9 +4,10 @@
 /// @author Simon Heybrock
 #include <benchmark/benchmark.h>
 
-#include "common.h"
+#include "variable_common.h"
 
 #include "scipp/core/variable.h"
+#include "scipp/core/variable_operations.h"
 
 using namespace scipp::core;
 using namespace scipp;

--- a/benchmark/variable_common.h
+++ b/benchmark/variable_common.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <random>
+
+#include "../core/test/make_sparse.h"
+
+template <typename T> struct GenerateSparse {
+  auto operator()(int length) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, 100);
+
+    auto a = make_sparse_variable<T>(length);
+    unsigned long long size(0);
+
+    /* Generate a random amount of sparse data for each point */
+    auto vals = a.template values<event_list<T>>();
+    for (scipp::index i = 0; i < length; ++i) {
+      const auto l = dis(gen);
+      size += l;
+      vals[i] = scipp::core::sparse_container<T>(l, i);
+    }
+
+    return std::make_tuple(a, sizeof(T) * size);
+  }
+};

--- a/core/include/scipp/core/apply.h
+++ b/core/include/scipp/core/apply.h
@@ -15,8 +15,7 @@ namespace scipp::core {
 template <class... Ts, class Op, class Var, class... Vars>
 void apply_in_place(Op op, Var &&var, const Vars &... vars) {
   try {
-    scipp::core::visit_impl<Ts...>::apply(op, var.dataHandle(),
-                                          vars.dataHandle()...);
+    scipp::core::visit_impl<Ts...>::apply(op, var.data(), vars.data()...);
   } catch (const std::bad_variant_access &) {
     throw except::TypeError("Cannot apply operation to item dtypes: ", var,
                             vars...);

--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -49,6 +49,14 @@ enum class DType {
   EigenVector3d,
   EigenQuaterniond,
   PyObject,
+  SpanDouble,
+  SpanFloat,
+  SpanInt64,
+  SpanInt32,
+  SpanConstDouble,
+  SpanConstFloat,
+  SpanConstInt64,
+  SpanConstInt32,
   Unknown
 };
 
@@ -69,6 +77,18 @@ template <>
 inline constexpr DType dtype<sparse_container<int32_t>> = DType::SparseInt32;
 template <>
 inline constexpr DType dtype<sparse_container<bool>> = DType::SparseBool;
+template <> inline constexpr DType dtype<span<double>> = DType::SpanDouble;
+template <> inline constexpr DType dtype<span<float>> = DType::SpanFloat;
+template <> inline constexpr DType dtype<span<int64_t>> = DType::SpanInt64;
+template <> inline constexpr DType dtype<span<int32_t>> = DType::SpanInt32;
+template <>
+inline constexpr DType dtype<span<const double>> = DType::SpanConstDouble;
+template <>
+inline constexpr DType dtype<span<const float>> = DType::SpanConstFloat;
+template <>
+inline constexpr DType dtype<span<const int64_t>> = DType::SpanConstInt64;
+template <>
+inline constexpr DType dtype<span<const int32_t>> = DType::SpanConstInt32;
 template <> inline constexpr DType dtype<dataset::DataArray> = DType::DataArray;
 template <> inline constexpr DType dtype<dataset::Dataset> = DType::Dataset;
 template <>

--- a/core/include/scipp/core/variable.h
+++ b/core/include/scipp/core/variable.h
@@ -239,15 +239,6 @@ public:
   VariableConcept &data() && = delete;
   VariableConcept &data() & { return *m_object; }
 
-  /// Return variant of pointers to underlying data.
-  ///
-  /// This is intended for internal use (such as implementing transform
-  /// algorithms) and should not need to be used directly by higher-level code.
-  auto dataHandle() const && = delete;
-  auto dataHandle() const & { return m_object.variant(); }
-  const auto &dataHandle() && = delete;
-  const auto &dataHandle() & { return m_object.mutableVariant(); }
-
   void setVariances(Variable v);
 
 private:
@@ -386,14 +377,6 @@ public:
       return m_variable->data();
   }
 
-  auto dataHandle() const && = delete;
-  auto dataHandle() const & {
-    if (m_view)
-      return m_view.variant();
-    else
-      return m_variable->dataHandle();
-  }
-
   bool hasVariances() const noexcept { return m_variable->hasVariances(); }
 
   // Note: This return a view object (a ElementArrayView) that does reference
@@ -476,13 +459,6 @@ public:
     if (!m_view)
       return m_mutableVariable->data();
     return *m_view;
-  }
-
-  const auto &dataHandle() const && = delete;
-  const auto &dataHandle() const & {
-    if (!m_view)
-      return m_mutableVariable->dataHandle();
-    return m_view.mutableVariant();
   }
 
   // Note: No need to delete rvalue overloads here, see VariableConstView.

--- a/core/include/scipp/core/variable_concept.h
+++ b/core/include/scipp/core/variable_concept.h
@@ -2,10 +2,10 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#ifndef SCIPP_VARIABLE_CONCEPT_H_
-#define SCIPP_VARIABLE_CONCEPT_H_
+#pragma once
 
 #include "scipp-core_export.h"
+#include "scipp/common/deep_ptr.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
 #include "scipp/core/dimensions.h"
@@ -24,23 +24,15 @@ class Variable;
 class VariableConcept;
 template <class T> class VariableConceptT;
 
-class SCIPP_CORE_EXPORT VariableConceptHandle {
+class SCIPP_CORE_EXPORT VariableConceptHandle
+    : public scipp::deep_ptr<VariableConcept> {
 public:
-  VariableConceptHandle() = default;
+  using scipp::deep_ptr<VariableConcept>::deep_ptr;
   template <class T> VariableConceptHandle(T object);
   VariableConceptHandle(VariableConceptHandle &&) = default;
   VariableConceptHandle(const VariableConceptHandle &other);
   VariableConceptHandle &operator=(VariableConceptHandle &&) = default;
   VariableConceptHandle &operator=(const VariableConceptHandle &other);
-
-  explicit operator bool() const noexcept { return m_object.operator bool(); }
-  VariableConcept &operator*() const { return *m_object; };
-  VariableConcept *operator->() const noexcept {
-    return m_object.operator->();
-  };
-
-private:
-  std::unique_ptr<VariableConcept> m_object;
 };
 
 /// Abstract base class for any data that can be held by Variable. Also used
@@ -181,8 +173,7 @@ public:
 
 template <class T>
 VariableConceptHandle::VariableConceptHandle(T object)
-    : m_object(std::unique_ptr<VariableConcept>(std::move(object))) {}
+    : VariableConceptHandle(
+          std::unique_ptr<VariableConcept>(std::move(object))) {}
 
 } // namespace scipp::core
-
-#endif // SCIPP_VARIABLE_CONCEPT_H_

--- a/core/include/scipp/core/variable_concept.h
+++ b/core/include/scipp/core/variable_concept.h
@@ -24,71 +24,24 @@ class Variable;
 class VariableConcept;
 template <class T> class VariableConceptT;
 
-template <class... Known> class VariableConceptHandle_impl {
+class SCIPP_CORE_EXPORT VariableConceptHandle {
 public:
-  using variant_t =
-      std::variant<const VariableConcept *, const VariableConceptT<Known> *...>;
+  VariableConceptHandle() = default;
+  template <class T> VariableConceptHandle(T object);
+  VariableConceptHandle(VariableConceptHandle &&) = default;
+  VariableConceptHandle(const VariableConceptHandle &other);
+  VariableConceptHandle &operator=(VariableConceptHandle &&) = default;
+  VariableConceptHandle &operator=(const VariableConceptHandle &other);
 
-  VariableConceptHandle_impl()
-      : m_object(std::unique_ptr<VariableConcept>(nullptr)) {}
-  template <class T> VariableConceptHandle_impl(T object) {
-    using value_t = typename T::element_type::value_type;
-    if constexpr ((std::is_same_v<value_t, Known> || ...))
-      m_object = std::unique_ptr<VariableConceptT<value_t>>(std::move(object));
-    else
-      m_object = std::unique_ptr<VariableConcept>(std::move(object));
-  }
-  VariableConceptHandle_impl(VariableConceptHandle_impl &&) = default;
-  VariableConceptHandle_impl(const VariableConceptHandle_impl &other)
-      : VariableConceptHandle_impl(other ? other->clone()
-                                         : VariableConceptHandle_impl()) {}
-  VariableConceptHandle_impl &
-  operator=(VariableConceptHandle_impl &&) = default;
-  VariableConceptHandle_impl &
-  operator=(const VariableConceptHandle_impl &other) {
-    if (*this && other) {
-      // Avoid allocation of new element_array if output is of correct shape.
-      // This yields a 5x speedup in assignment operations of variables.
-      auto &concept = **this;
-      auto &otherConcept = *other;
-      if (!concept.isView() && !otherConcept.isView() &&
-          concept.dtype() == otherConcept.dtype() &&
-          concept.dims() == otherConcept.dims() &&
-          concept.hasVariances() == otherConcept.hasVariances()) {
-        concept.copy(otherConcept, Dim::Invalid, 0, 0, 1);
-        return *this;
-      }
-    }
-    return *this = other ? other->clone() : VariableConceptHandle_impl();
-  }
-
-  explicit operator bool() const noexcept;
-  VariableConcept &operator*() const;
-  VariableConcept *operator->() const;
-
-  const auto &mutableVariant() const noexcept { return m_object; }
-
-  variant_t variant() const noexcept;
+  explicit operator bool() const noexcept { return m_object.operator bool(); }
+  VariableConcept &operator*() const { return *m_object; };
+  VariableConcept *operator->() const noexcept {
+    return m_object.operator->();
+  };
 
 private:
-  std::variant<std::unique_ptr<VariableConcept>,
-               std::unique_ptr<VariableConceptT<Known>>...>
-      m_object;
+  std::unique_ptr<VariableConcept> m_object;
 };
-
-// Any item type that is listed here explicitly can be used with the templated
-// `transform`, i.e., we can pass arbitrary functors/lambdas to process data.
-#define KNOWN                                                                  \
-  double, float, int64_t, int32_t, bool, Eigen::Vector3d, Eigen::Quaterniond,  \
-      sparse_container<double>, sparse_container<float>,                       \
-      sparse_container<int64_t>, sparse_container<int32_t>,                    \
-      sparse_container<bool>, span<const double>, span<double>,                \
-      span<const float>, span<float>, span<const int64_t>, span<int64_t>,      \
-      span<const int32_t>, span<int32_t>
-
-extern template class VariableConceptHandle_impl<KNOWN>;
-
-using VariableConceptHandle = VariableConceptHandle_impl<KNOWN>;
 
 /// Abstract base class for any data that can be held by Variable. Also used
 /// to hold views to data by (Const)VariableView. This is using so-called
@@ -225,6 +178,10 @@ public:
             const scipp::index offset, const scipp::index otherBegin,
             const scipp::index otherEnd) override;
 };
+
+template <class T>
+VariableConceptHandle::VariableConceptHandle(T object)
+    : m_object(std::unique_ptr<VariableConcept>(std::move(object))) {}
 
 } // namespace scipp::core
 

--- a/core/include/scipp/core/visit.h
+++ b/core/include/scipp/core/visit.h
@@ -14,13 +14,6 @@ namespace scipp::core {
 template <class T> class VariableConceptT;
 
 namespace visit_detail {
-template <class Variant> struct alternatives_are_const_ptr;
-template <class T, class... Ts>
-struct alternatives_are_const_ptr<std::variant<T, Ts...>> : std::true_type {};
-template <class T, class... Ts>
-struct alternatives_are_const_ptr<std::variant<std::unique_ptr<T>, Ts...>>
-    : std::false_type {};
-
 template <template <class...> class Tuple, class... T, class... V>
 static bool holds_alternatives(Tuple<T...> &&, const V &... v) noexcept {
   return ((dtype<T> == v.dtype()) && ...);

--- a/core/include/scipp/core/visit.h
+++ b/core/include/scipp/core/visit.h
@@ -29,9 +29,9 @@ static bool holds_alternatives(Tuple<T...> &&, const V &... v) noexcept {
 template <template <class...> class Tuple, class... T, class... V>
 static auto get_args(Tuple<T...> &&, V &&... v) noexcept {
   return std::forward_as_tuple(
-      dynamic_cast<std::conditional_t<
-          std::is_const_v<std::remove_reference_t<V>>,
-          const VariableConceptT<T>, VariableConceptT<std::decay_t<T>>> &>(
+      dynamic_cast<
+          std::conditional_t<std::is_const_v<std::remove_reference_t<V>>,
+                             const VariableConceptT<T>, VariableConceptT<T>> &>(
           v)...);
 }
 

--- a/core/include/scipp/core/visit.h
+++ b/core/include/scipp/core/visit.h
@@ -21,22 +21,18 @@ template <class T, class... Ts>
 struct alternatives_are_const_ptr<std::variant<std::unique_ptr<T>, Ts...>>
     : std::false_type {};
 
-template <class Variant, class T>
-using alternative =
-    std::conditional_t<alternatives_are_const_ptr<std::decay_t<Variant>>::value,
-                       const VariableConceptT<T> *,
-                       std::unique_ptr<VariableConceptT<T>>>;
-
 template <template <class...> class Tuple, class... T, class... V>
-static constexpr bool holds_alternatives(Tuple<T...> &&,
-                                         const V &... v) noexcept {
-  return (std::holds_alternative<alternative<V, T>>(v) && ...);
+static bool holds_alternatives(Tuple<T...> &&, const V &... v) noexcept {
+  return ((dtype<T> == v.dtype()) && ...);
 }
 
 template <template <class...> class Tuple, class... T, class... V>
-static constexpr auto get_args(Tuple<T...> &&, V &&... v) noexcept {
+static auto get_args(Tuple<T...> &&, V &&... v) noexcept {
   return std::forward_as_tuple(
-      std::get<alternative<V, T>>(std::forward<V>(v))...);
+      dynamic_cast<std::conditional_t<
+          std::is_const_v<std::remove_reference_t<V>>,
+          const VariableConceptT<T>, VariableConceptT<std::decay_t<T>>> &>(
+          v)...);
 }
 
 template <class... Tuple, class F, class... V>

--- a/core/rebin.cpp
+++ b/core/rebin.cpp
@@ -125,13 +125,9 @@ Variable rebin(const VariableConstView &var, const Dim dim,
   // always be computed on-the-fly for visualization, if required.
   expect::unit_any_of(var, {units::counts, units::Unit(units::dimensionless)});
 
-  auto do_rebin = [dim](auto &&out, auto &&old, auto &&oldCoord_,
-                        auto &&newCoord_) {
+  auto do_rebin = [dim](auto &&outT, auto &&oldT, auto &&oldCoordT,
+                        auto &&newCoordT) {
     // Dimensions of *this and old are guaranteed to be the same.
-    const auto &oldT = *old;
-    const auto &oldCoordT = *oldCoord_;
-    const auto &newCoordT = *newCoord_;
-    auto &outT = *out;
     const auto &out_dims = outT.dims();
 
     // dimension along which the data is being rebinned

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -82,6 +82,22 @@ std::string to_string(const DType dtype) {
     return "PyObject";
   case DType::Unknown:
     return "unknown";
+  case DType::SpanFloat: // defined after Unknown so no Python binding created
+    return "span_float32";
+  case DType::SpanDouble:
+    return "span_float64";
+  case DType::SpanInt64:
+    return "span_int64";
+  case DType::SpanInt32:
+    return "span_int32";
+  case DType::SpanConstFloat:
+    return "span_const_float32";
+  case DType::SpanConstDouble:
+    return "span_const_float64";
+  case DType::SpanConstInt64:
+    return "span_const_int64";
+  case DType::SpanConstInt32:
+    return "span_const_int32";
   default:
     return "unregistered dtype";
   };

--- a/core/variable_concept.cpp
+++ b/core/variable_concept.cpp
@@ -6,39 +6,29 @@
 #include <variant>
 
 namespace scipp::core {
-template <class... Known>
-VariableConceptHandle_impl<Known...>::operator bool() const noexcept {
-  return std::visit([](auto &&ptr) { return bool(ptr); }, m_object);
-}
 
-template <class... Known>
-VariableConcept &VariableConceptHandle_impl<Known...>::operator*() const {
-  return std::visit([](auto &&arg) -> VariableConcept & { return *arg; },
-                    m_object);
-}
+VariableConceptHandle::VariableConceptHandle(const VariableConceptHandle &other)
+    : VariableConceptHandle(other ? other->clone() : VariableConceptHandle()) {}
 
-template <class... Known>
-VariableConcept *VariableConceptHandle_impl<Known...>::operator->() const {
-  return std::visit(
-      [](auto &&arg) -> VariableConcept * { return arg.operator->(); },
-      m_object);
-}
-
-template <class... Known>
-typename VariableConceptHandle_impl<Known...>::variant_t
-VariableConceptHandle_impl<Known...>::variant() const noexcept {
-  return std::visit(
-      [](auto &&arg) {
-        return std::variant<const VariableConcept *,
-                            const VariableConceptT<Known> *...>{arg.get()};
-      },
-      m_object);
+VariableConceptHandle &VariableConceptHandle::
+operator=(const VariableConceptHandle &other) {
+  if (*this && other) {
+    // Avoid allocation of new element_array if output is of correct shape.
+    // This yields a 5x speedup in assignment operations of variables.
+    auto &concept = **this;
+    auto &otherConcept = *other;
+    if (!concept.isView() && !otherConcept.isView() &&
+        concept.dtype() == otherConcept.dtype() &&
+        concept.dims() == otherConcept.dims() &&
+        concept.hasVariances() == otherConcept.hasVariances()) {
+      concept.copy(otherConcept, Dim::Invalid, 0, 0, 1);
+      return *this;
+    }
+  }
+  return *this = other ? other->clone() : VariableConceptHandle();
 }
 
 VariableConcept::VariableConcept(const Dimensions &dimensions)
     : m_dimensions(dimensions) {}
-
-// Explicitly instansiate the template once in this TU
-template class VariableConceptHandle_impl<KNOWN>;
 
 } // namespace scipp::core

--- a/docs/developer/customizing.rst
+++ b/docs/developer/customizing.rst
@@ -12,8 +12,7 @@ At this point we support compile-time customization of:
 - Available units and unit combinations
 - Dimension labels
 - The underlying container used for sparse data.
-- New or custom types that can be stored as elements in a ``Variable``.
-- The built-in types that can be support in operations and by the ``transform`` algorithms.
+- New or custom types that can be stored as elements in a ``Variable`` and by the ``transform`` algorithms.
 
 Some of these are adaptable more readily than others, which require more in-depth changes.
 
@@ -71,15 +70,3 @@ Custom types
 
 To do.
 See https://github.com/scipp/scipp/issues/265.
-
-Built-in types
---------------
-
-The helper ``VariableConceptHandle`` in the header ``core/include/scipp/core/variable.h`` is used to list all types that can be supported in calls to ``transform`` (and its in-place variants) for ``Variable``.
-Essentially adding a type here will add another alternative to the variant in ``Variable`` that is used to hold data.
-
-**Note**
-
-It is *not* required to add all types here.
-``Variable`` can also hold arbitrary other types, as long as the relevant code has been instantiated.
-What is described above is only relevant if a higher level of integration (beyond simply holding data and supporting slicing) is required.


### PR DESCRIPTION
Previously we used `std::variant` to support finding the correct type in the type-erase `Variable`. However, since we anyway use a custom `visit` implementation based on a list of provided types, this is actually not necessary or very useful.

- Use `dtype` instead of checking variant alternative, then cast.
- `dynamic_cast` may be seen as slow, but I observed only marginal improvement in the `groupby_large_table` benchmark when using `static_cast`. `static_cast` should be safe to use, so we can consider that again later.
- No more need for listing "KNOWN" types to support in `transform`.

Based on #1060.