### PR TITLE
Test failure for converting fit output workspaces

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -423,15 +423,14 @@ def _convert_MatrixWorkspace_info(ws):
             make_run(ws),
             "sample":
             make_sample(ws),
-            "rotation":
-            rot,
-            "shape":
-            shp,
             "instrument-name":
             sc.Variable(
                 value=ws.componentInfo().name(ws.componentInfo().root()))
         },
     }
+    if 'spectrum' in spec_coord.dims:
+        info["attrs"].update({"rotation": rot, "shape": shp})
+
     if source_pos is not None:
         info["coords"]["source_position"] = source_pos
 

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -428,7 +428,7 @@ def _convert_MatrixWorkspace_info(ws):
                 value=ws.componentInfo().name(ws.componentInfo().root()))
         },
     }
-    if 'spectrum' in spec_coord.dims:
+    if not np.all(np.isnan(pos.values)):
         info["attrs"].update({"rotation": rot, "shape": shp})
 
     if source_pos is not None:


### PR DESCRIPTION
```RuntimeError: Attribute dimensions must match and not exceed dimensions of data.``` in `TestMantidConversion.test_fit_executes`

No spectrum dimension. Attributes cannot be added. 

Dimension is checked before adding attributes