### PR TITLE
Remove from docs ipynb files that contain output

### DIFF
--- a/.azure-pipelines/templates/documentation_build.yml
+++ b/.azure-pipelines/templates/documentation_build.yml
@@ -39,6 +39,7 @@ jobs:
           mkdir $HOME/.mantid
           echo "usagereports.enabled=0" > $HOME/.mantid/Mantid.user.properties
           sphinx-build . "$(docs_dir)"
+          rm "$(docs_dir)"/*/*.ipynb
         displayName: 'Build documentation'
       - task: PublishBuildArtifacts@1
         inputs:


### PR DESCRIPTION
The docs contain both `.html` and `.ipynb` files created by `nbsphinx`. The latter contain output (figures, 3D scene), are large in size, and are not really needed since the sources (without output) are placed in another (`_sources`) directory.

The current docs are broken on `master` because the total size of the docs is too large.

This simply removed these files before creating docs artifact.