### PR TITLE
Remove doctree files from docs

### DIFF
--- a/.azure-pipelines/templates/documentation_build.yml
+++ b/.azure-pipelines/templates/documentation_build.yml
@@ -37,9 +37,9 @@ jobs:
           source activate scipp_docs
           python data/fetch_neutron_data.py
           mkdir $HOME/.mantid
-          echo "usagereports.enabled=0" > $HOME/.mantid/Mantid.user.properties
-          sphinx-build . "$(docs_dir)"
-          rm "$(docs_dir)"/*/*.ipynb
+          echo -e "usagereports.enabled=0\ndatasearch.directories=$(pwd)/data" > $HOME/.mantid/Mantid.user.properties
+          sphinx-build -d doctrees . "$(docs_dir)"
+          find "$(docs_dir)" -type f -name *.ipynb -delete
         displayName: 'Build documentation'
       - task: PublishBuildArtifacts@1
         inputs:

--- a/docs/data/fetch_neutron_data.py
+++ b/docs/data/fetch_neutron_data.py
@@ -21,7 +21,6 @@ if __name__ == '__main__':
     data_files = {
         "PG3_4871_event.nxs": "a3d0edcb36ab8e9e3342cd8a4440b779",
         "GEM40979.raw": "6df0f1c2fc472af200eec43762e9a874",
-        "CNCS_7860_event.nxs": "1db1853f94b381aca96412fef9629f3f",
         "PG3_4844_event.nxs": "d5ae38871d0a09a28ae01f85d969de1e",
         "PG3_4866_event.nxs": "3d543bc6a646e622b3f4542bc3435e7e"
     }

--- a/docs/scipp-neutron/groupby.ipynb
+++ b/docs/scipp-neutron/groupby.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events = sc.neutron.load(filename='../data/PG3_4844_event.nxs', load_pulse_times=False)"
+    "events = sc.neutron.load(filename='PG3_4844_event.nxs', load_pulse_times=False)"
    ]
   },
   {

--- a/docs/scipp-neutron/instrument-view.ipynb
+++ b/docs/scipp-neutron/instrument-view.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample = sn.load(filename='../data/PG3_4871_event.nxs')"
+    "sample = sn.load(filename='PG3_4871_event.nxs')"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sn.instrument_view(sample, projection=\"Spherical Y\", cmap=\"magma\", vmax=40, bins=10)"
+    "sn.instrument_view(sample, cmap=\"magma\", vmax=1.5, bins=10, log=True)"
    ]
   },
   {
@@ -124,23 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sn.instrument_view(sn.load(filename='../data/GEM40979.raw'), rendering='Fast')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It is also possible to have a logarithmic colorscale:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sn.instrument_view(sn.load(filename='../data/CNCS_7860_event.nxs'), log=True)"
+    "sn.instrument_view(sn.load(filename='GEM40979.raw'), rendering='Fast')"
    ]
   }
  ],

--- a/docs/tutorials/neutron-diffraction.ipynb
+++ b/docs/tutorials/neutron-diffraction.ipynb
@@ -43,11 +43,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample = sc.neutron.load(filename='../data/PG3_4844_event.nxs',\n",
+    "sample = sc.neutron.load(filename='PG3_4844_event.nxs',\n",
     "                         load_pulse_times=False,\n",
     "                         mantid_args={'LoadMonitors': True})\n",
-    "vanadium = sc.neutron.load(filename='../data/PG3_4866_event.nxs',\n",
-    "                                     load_pulse_times=False)"
+    "vanadium = sc.neutron.load(filename='PG3_4866_event.nxs',\n",
+    "                           load_pulse_times=False)"
    ]
   },
   {


### PR DESCRIPTION
To fix current broken docs builds:

- Moved doctrees to a separate directory to avoid copying them into thedocs.
- Also removed hard-coded `../data` paths in the docs and added data path to Mantid search directories
- Merged 2 instrument view examples into 1 to make the page slightly lighter
- deleting `.ipynb` files form docs with `find` instead of `rm */*.ipynb`