### PR TITLE
Cleanup around class Variable

### DIFF
--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -191,4 +191,15 @@ Dimensions merge(const Dimensions &a, const Dimensions &b) {
   return out;
 }
 
+Dimensions transpose(const Dimensions &dims,
+                     const scipp::span<const Dim> &order) {
+  if (order.size() != dims.ndim())
+    throw except::DimensionError("Cannot transpose: Requested new dimension "
+                                 "order contains different number of labels.");
+  std::vector<scipp::index> shape(order.size());
+  std::transform(order.begin(), order.end(), shape.begin(),
+                 [&dims](auto &dim) { return dims[dim]; });
+  return {{order.begin(), order.end()}, shape};
+}
+
 } // namespace scipp::core

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -193,7 +193,10 @@ Dimensions merge(const Dimensions &a, const Dimensions &b) {
 
 Dimensions transpose(const Dimensions &dims,
                      const scipp::span<const Dim> &order) {
-  if (order.size() != dims.ndim())
+  std::vector<Dim> labels{order.begin(), order.end()};
+  if (labels.empty())
+    labels.insert(labels.end(), dims.labels().rbegin(), dims.labels().rend());
+  else if (order.size() != dims.ndim())
     throw except::DimensionError("Cannot transpose: Requested new dimension "
                                  "order contains different number of labels.");
   std::vector<scipp::index> shape(order.size());

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -191,18 +191,16 @@ Dimensions merge(const Dimensions &a, const Dimensions &b) {
   return out;
 }
 
-Dimensions transpose(const Dimensions &dims,
-                     const scipp::span<const Dim> &order) {
-  std::vector<Dim> labels{order.begin(), order.end()};
+Dimensions transpose(const Dimensions &dims, std::vector<Dim> labels) {
   if (labels.empty())
     labels.insert(labels.end(), dims.labels().rbegin(), dims.labels().rend());
-  else if (order.size() != dims.ndim())
+  else if (labels.size() != dims.ndim())
     throw except::DimensionError("Cannot transpose: Requested new dimension "
                                  "order contains different number of labels.");
-  std::vector<scipp::index> shape(order.size());
-  std::transform(order.begin(), order.end(), shape.begin(),
+  std::vector<scipp::index> shape(labels.size());
+  std::transform(labels.begin(), labels.end(), shape.begin(),
                  [&dims](auto &dim) { return dims[dim]; });
-  return {{order.begin(), order.end()}, shape};
+  return {labels, shape};
 }
 
 } // namespace scipp::core

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -134,6 +134,9 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
   return merge(merge(a, b), other...);
 }
 
+SCIPP_CORE_EXPORT Dimensions transpose(const Dimensions &dims,
+                                       const scipp::span<const Dim> &order);
+
 } // namespace scipp::core
 
 namespace scipp {

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -134,8 +134,8 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
   return merge(merge(a, b), other...);
 }
 
-SCIPP_CORE_EXPORT Dimensions
-transpose(const Dimensions &dims, const scipp::span<const Dim> &order = {});
+SCIPP_CORE_EXPORT Dimensions transpose(const Dimensions &dims,
+                                       std::vector<Dim> labels = {});
 
 } // namespace scipp::core
 

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -134,8 +134,8 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
   return merge(merge(a, b), other...);
 }
 
-SCIPP_CORE_EXPORT Dimensions transpose(const Dimensions &dims,
-                                       const scipp::span<const Dim> &order);
+SCIPP_CORE_EXPORT Dimensions
+transpose(const Dimensions &dims, const scipp::span<const Dim> &order = {});
 
 } // namespace scipp::core
 

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -232,3 +232,40 @@ TEST(DimensionsTest, index) {
   EXPECT_EQ(dims.index(Dim::X), 0);
   EXPECT_EQ(dims.index(Dim::Y), 1);
 }
+
+TEST(DimensionsTest, transpose_0d) {
+  Dimensions dims;
+  EXPECT_EQ(transpose(dims), dims);
+  EXPECT_THROW(transpose(dims, {Dim::X}), except::DimensionError);
+}
+
+TEST(DimensionsTest, transpose_1d) {
+  Dimensions dims(Dim::X, 2);
+  EXPECT_EQ(transpose(dims), dims);
+  EXPECT_EQ(transpose(dims, {Dim::X}), dims);
+  EXPECT_THROW(transpose(dims, {Dim::Y}), except::DimensionError);
+  EXPECT_THROW(transpose(dims, {Dim::X, Dim::Y}), except::DimensionError);
+}
+
+TEST(DimensionsTest, transpose_2d) {
+  Dimensions dims({Dim::X, Dim::Y}, {2, 3});
+  Dimensions expected({Dim::Y, Dim::X}, {3, 2});
+  EXPECT_EQ(transpose(dims), expected);
+  EXPECT_EQ(transpose(dims, {Dim::X, Dim::Y}), dims); // no change
+  EXPECT_EQ(transpose(dims, {Dim::Y, Dim::X}), expected);
+  EXPECT_THROW(transpose(dims, {Dim::X}), except::DimensionError);
+  EXPECT_THROW(transpose(dims, {Dim::X, Dim::Z}), except::DimensionError);
+  EXPECT_THROW(transpose(dims, {Dim::X, Dim::Y, Dim::Z}),
+               except::DimensionError);
+}
+
+TEST(DimensionsTest, transpose_3d) {
+  Dimensions xyz({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4});
+  Dimensions zyx({Dim::Z, Dim::Y, Dim::X}, {4, 3, 2});
+  Dimensions zxy({Dim::Z, Dim::X, Dim::Y}, {4, 2, 3});
+  EXPECT_EQ(transpose(xyz), zyx);
+  EXPECT_EQ(transpose(xyz, {Dim::X, Dim::Y, Dim::Z}), xyz); // no change
+  EXPECT_EQ(transpose(xyz, {Dim::Z, Dim::Y, Dim::X}), zyx);
+  EXPECT_EQ(transpose(xyz, {Dim::Z, Dim::X, Dim::Y}), zxy);
+  EXPECT_THROW(transpose(xyz, {Dim::X, Dim::Z}), except::DimensionError);
+}

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -106,14 +106,8 @@ public:
            T variances);
 
   template <class T>
-  static Variable create(const units::Unit &u, const Dims &d, const Shape &s,
-                         element_array<T> &&val);
-  template <class T>
   static Variable create(const units::Unit &u, const Dimensions &d,
                          element_array<T> &&val);
-  template <class T>
-  static Variable create(const units::Unit &u, const Dims &d, const Shape &s,
-                         element_array<T> &&val, element_array<T> &&var);
   template <class T>
   static Variable create(const units::Unit &u, const Dimensions &d,
                          element_array<T> &&val, element_array<T> &&var);

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -376,15 +376,6 @@ public:
 
   auto &underlying() const { return *m_variable; }
 
-private:
-  template <class Var>
-  static VariableConstView makeTransposed(Var &var,
-                                          const std::vector<Dim> &dimOrder) {
-    auto res = VariableConstView(var);
-    res.m_view = res.data().transpose(dimOrder);
-    return res;
-  }
-
 protected:
   friend class Variable;
 
@@ -491,14 +482,6 @@ private:
   // For internal use in DataArrayConstView.
   explicit VariableView(VariableConstView &&base)
       : VariableConstView(std::move(base)), m_mutableVariable{nullptr} {}
-
-  template <class Var>
-  static VariableView makeTransposed(Var &var,
-                                     const std::vector<Dim> &dimOrder) {
-    auto res = VariableView(var);
-    res.m_view = res.data().transpose(dimOrder);
-    return res;
-  }
 
   template <class T> ElementArrayView<T> cast() const;
   template <class T> ElementArrayView<T> castVariances() const;

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -41,8 +41,6 @@ template <class T> typename T::view_type makeViewItem(T &);
 namespace scipp::variable {
 
 namespace detail {
-std::vector<scipp::index> reorderedShape(const scipp::span<const Dim> &order,
-                                         const Dimensions &dimensions);
 void expect0D(const Dimensions &dims);
 } // namespace detail
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -107,13 +107,16 @@ public:
 
   template <class T>
   static Variable create(const units::Unit &u, const Dims &d, const Shape &s,
-                         std::optional<element_array<T>> &&val,
-                         std::optional<element_array<T>> &&var);
-
+                         element_array<T> &&val);
   template <class T>
   static Variable create(const units::Unit &u, const Dimensions &d,
-                         std::optional<element_array<T>> &&val,
-                         std::optional<element_array<T>> &&var);
+                         element_array<T> &&val);
+  template <class T>
+  static Variable create(const units::Unit &u, const Dims &d, const Shape &s,
+                         element_array<T> &&val, element_array<T> &&var);
+  template <class T>
+  static Variable create(const units::Unit &u, const Dimensions &d,
+                         element_array<T> &&val, element_array<T> &&var);
 
   template <class T>
   Variable(const Dimensions &dimensions, std::initializer_list<T> values_)

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -100,10 +100,8 @@ public:
   Variable(const VariableConstView &parent, const Dimensions &dims);
   Variable(const Variable &parent, VariableConceptHandle data);
   template <class T>
-  Variable(const units::Unit unit, const Dimensions &dimensions, T object);
-  template <class T>
   Variable(const units::Unit unit, const Dimensions &dimensions, T values,
-           T variances);
+           std::optional<T> variances);
 
   template <class T>
   Variable(const Dimensions &dimensions, std::initializer_list<T> values_)
@@ -268,13 +266,7 @@ template <class T, class... Ts> Variable makeVariable(Ts &&... ts) {
              std::optional<element_array<T>>>
       args;
   (detail::ArgParser<T>::parse(std::forward<Ts>(ts), args), ...);
-  if (std::get<3>(args))
-    return Variable(std::get<0>(args), std::get<1>(args),
-                    std::move(std::get<2>(args)),
-                    std::move(*std::get<3>(args)));
-  else
-    return Variable(std::get<0>(args), std::get<1>(args),
-                    std::move(std::get<2>(args)));
+  return std::make_from_tuple<Variable>(std::move(args));
 }
 
 template <class... Ts>

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -101,11 +101,6 @@ public:
   Variable(const units::Unit unit, const Dimensions &dimensions, T values,
            std::optional<T> variances);
 
-  template <class T>
-  Variable(const Dimensions &dimensions, std::initializer_list<T> values_)
-      : Variable(units::dimensionless, std::move(dimensions),
-                 element_array<T>(values_.begin(), values_.end())) {}
-
   /// Keyword-argument constructor.
   ///
   /// This is equivalent to `makeVariable`, except that the dtype is passed at

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -84,17 +84,14 @@ struct default_init<Eigen::Matrix<T, Rows, Cols>> {
 template <class T, class... Ts> Variable makeVariable(Ts &&... ts);
 
 /// Variable is a type-erased handle to any data structure representing a
-/// multi-dimensional array. It has a name, a unit, and a set of named
-/// dimensions.
+/// multi-dimensional array. In addition it has a unit and a set of dimension
+/// labels.
 class SCIPP_VARIABLE_EXPORT Variable {
 public:
   using const_view_type = VariableConstView;
   using view_type = VariableView;
 
   Variable() = default;
-  // Having this non-explicit is convenient when passing (potential)
-  // variable slices to functions that do not support slices, but implicit
-  // conversion may introduce risks, so there is a trade-of here.
   explicit Variable(const VariableConstView &slice);
   Variable(const Variable &parent, const Dimensions &dims);
   Variable(const VariableConstView &parent, const Dimensions &dims);

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -767,13 +767,6 @@ Variable Variable::create(const units::Unit &u, const Dimensions &d,
 }
 
 template <class T>
-Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
-                          element_array<T> &&val) {
-  auto dms = Dimensions{d.data, s.data};
-  return create(u, dms, std::move(val));
-}
-
-template <class T>
 Variable Variable::create(const units::Unit &u, const Dimensions &d,
                           element_array<T> &&val,
                           element_array<T> &&var) {
@@ -781,14 +774,6 @@ Variable Variable::create(const units::Unit &u, const Dimensions &d,
     return from_dimensions_and_unit_with_variances<T>(d, u);
   else
     return Variable(u, d, std::move(val), std::move(var));
-}
-
-template <class T>
-Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
-                          element_array<T> &&val,
-                          element_array<T> &&var) {
-  auto dms = Dimensions{d.data, s.data};
-  return create(u, dms, std::move(val), std::move(var));
 }
 
 /// Macro for instantiating classes and functions required for support a new
@@ -807,13 +792,7 @@ Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
       const units::Unit &u, const Dimensions &d,                               \
       element_array<__VA_ARGS__> &&val);                                       \
   template Variable Variable::create<__VA_ARGS__>(                             \
-      const units::Unit &u, const Dims &d, const Shape &s,                     \
-      element_array<__VA_ARGS__> &&val);                                       \
-  template Variable Variable::create<__VA_ARGS__>(                             \
       const units::Unit &u, const Dimensions &d,                               \
-      element_array<__VA_ARGS__> &&val, element_array<__VA_ARGS__> &&var);     \
-  template Variable Variable::create<__VA_ARGS__>(                             \
-      const units::Unit &u, const Dims &d, const Shape &s,                     \
       element_array<__VA_ARGS__> &&val, element_array<__VA_ARGS__> &&var);     \
   template element_array<__VA_ARGS__> &Variable::cast<__VA_ARGS__>(            \
       const bool);                                                             \

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -759,24 +759,34 @@ Variable from_dimensions_and_unit_with_variances(const Dimensions &dms,
 ///       makeVariable<T>(Dims{Dim::X}, Shape{5}, Values{}, Variances{});
 template <class T>
 Variable Variable::create(const units::Unit &u, const Dimensions &d,
-                          std::optional<element_array<T>> &&val,
-                          std::optional<element_array<T>> &&var) {
-  if (val && var) {
-    if (val->size() < 0 && var->size() < 0)
-      return from_dimensions_and_unit_with_variances<T>(d, u);
-    else
-      return Variable(u, d, std::move(*val), std::move(*var));
-  }
-  if (!val || val->size() < 0)
-    return from_dimensions_and_unit<T>(d, u);
+                          element_array<T> &&val) {
+  if (val)
+    return Variable(u, d, std::move(val));
   else
-    return Variable(u, d, std::move(*val));
+    return from_dimensions_and_unit<T>(d, u);
 }
 
 template <class T>
 Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
-                          std::optional<element_array<T>> &&val,
-                          std::optional<element_array<T>> &&var) {
+                          element_array<T> &&val) {
+  auto dms = Dimensions{d.data, s.data};
+  return create(u, dms, std::move(val));
+}
+
+template <class T>
+Variable Variable::create(const units::Unit &u, const Dimensions &d,
+                          element_array<T> &&val,
+                          element_array<T> &&var) {
+  if (!val && !var)
+    return from_dimensions_and_unit_with_variances<T>(d, u);
+  else
+    return Variable(u, d, std::move(val), std::move(var));
+}
+
+template <class T>
+Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
+                          element_array<T> &&val,
+                          element_array<T> &&var) {
   auto dms = Dimensions{d.data, s.data};
   return create(u, dms, std::move(val), std::move(var));
 }
@@ -795,12 +805,16 @@ Variable Variable::create(const units::Unit &u, const Dims &d, const Shape &s,
                               element_array<__VA_ARGS__>);                     \
   template Variable Variable::create<__VA_ARGS__>(                             \
       const units::Unit &u, const Dimensions &d,                               \
-      std::optional<element_array<__VA_ARGS__>> &&val,                         \
-      std::optional<element_array<__VA_ARGS__>> &&var);                        \
+      element_array<__VA_ARGS__> &&val);                                       \
   template Variable Variable::create<__VA_ARGS__>(                             \
       const units::Unit &u, const Dims &d, const Shape &s,                     \
-      std::optional<element_array<__VA_ARGS__>> &&val,                         \
-      std::optional<element_array<__VA_ARGS__>> &&var);                        \
+      element_array<__VA_ARGS__> &&val);                                       \
+  template Variable Variable::create<__VA_ARGS__>(                             \
+      const units::Unit &u, const Dimensions &d,                               \
+      element_array<__VA_ARGS__> &&val, element_array<__VA_ARGS__> &&var);     \
+  template Variable Variable::create<__VA_ARGS__>(                             \
+      const units::Unit &u, const Dims &d, const Shape &s,                     \
+      element_array<__VA_ARGS__> &&val, element_array<__VA_ARGS__> &&var);     \
   template element_array<__VA_ARGS__> &Variable::cast<__VA_ARGS__>(            \
       const bool);                                                             \
   template const element_array<__VA_ARGS__> &Variable::cast<__VA_ARGS__>(      \

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -124,7 +124,7 @@ template <class T>
 VariableConceptHandle
 VariableConceptT<T>::reshape(const Dimensions &dims) const {
   if (this->dims().volume() != dims.volume())
-    throw std::runtime_error(
+    throw except::DimensionError(
         "Cannot reshape to dimensions with different volume");
   return std::make_unique<ViewModel<decltype(valuesReshaped(dims))>>(
       dims, valuesReshaped(dims), optionalVariancesReshaped(*this, dims));
@@ -133,7 +133,7 @@ VariableConceptT<T>::reshape(const Dimensions &dims) const {
 template <class T>
 VariableConceptHandle VariableConceptT<T>::reshape(const Dimensions &dims) {
   if (this->dims().volume() != dims.volume())
-    throw std::runtime_error(
+    throw except::DimensionError(
         "Cannot reshape to dimensions with different volume");
   return std::make_unique<ViewModel<decltype(valuesReshaped(dims))>>(
       dims, valuesReshaped(dims), optionalVariancesReshaped(*this, dims));
@@ -142,8 +142,7 @@ VariableConceptHandle VariableConceptT<T>::reshape(const Dimensions &dims) {
 template <class T>
 VariableConceptHandle
 VariableConceptT<T>::transpose(const std::vector<Dim> &tdims) const {
-  auto dms = Dimensions(std::vector<Dim>(tdims.begin(), tdims.end()),
-                        detail::reorderedShape(tdims, dims()));
+  auto dms = core::transpose(dims(), tdims);
   using U = decltype(valuesView(dms));
   return std::make_unique<ViewModel<U>>(
       dms, valuesView(dms),
@@ -153,8 +152,7 @@ VariableConceptT<T>::transpose(const std::vector<Dim> &tdims) const {
 template <class T>
 VariableConceptHandle
 VariableConceptT<T>::transpose(const std::vector<Dim> &tdims) {
-  auto dms = Dimensions(std::vector<Dim>(tdims.begin(), tdims.end()),
-                        detail::reorderedShape(tdims, dims()));
+  auto dms = core::transpose(dims(), tdims);
   using U = decltype(valuesView(dms));
   return std::make_unique<ViewModel<U>>(
       dms, valuesView(dms),

--- a/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -17,17 +17,14 @@ namespace scipp::variable {
 
 namespace detail {
 
-template <class U> struct vector_base {
+template <class U> struct vector {
   std::vector<U> data;
   template <class... Args>
-  vector_base(Args &&... args) : data(std::forward<Args>(args)...) {}
+  vector(Args &&... args) : data(std::forward<Args>(args)...) {}
+  template <class A, class B> // avoid use of vector(size, value)
+  vector(A &&a, B &&b) : data(std::initializer_list<U>{a, b}) {}
   template <class T>
-  vector_base(std::initializer_list<T> init) : data(init.begin(), init.end()) {}
-};
-
-template <class U> struct vector : public vector_base<U> {
-  using vector_base<U>::vector_base;
-  template <class T> vector(T &&count, U &&value = U()) = delete;
+  vector(std::initializer_list<T> init) : data(init.begin(), init.end()) {}
 };
 
 template <template <class...> class Derived, class... Args> struct arg_tuple {

--- a/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -9,14 +9,7 @@
 
 namespace scipp::variable {
 
-// The structs needed for keyword-like variable constructor are introduced
-// below. Tags are used to match the corresponding arguments treating the
-// arbitrary order of arguments in the constructor, and not mixing values and
-// variances. Structures Values and Variances just forwards the arguments for
-// constructing internal variable structure - array storage.
-
 namespace detail {
-
 template <class U> struct vector {
   std::vector<U> data;
   template <class... Args>
@@ -31,7 +24,6 @@ template <template <class...> class Derived, class... Args> struct arg_tuple {
   std::tuple<std::decay_t<Args>...> tuple;
   arg_tuple(Args &&... args) : tuple(std::forward<Args>(args)...) {}
 };
-
 } // namespace detail
 
 using Shape = detail::vector<scipp::index>;
@@ -42,14 +34,14 @@ struct Values : public detail::arg_tuple<Values, Args...> {
   using detail::arg_tuple<Values, Args...>::arg_tuple;
   template <class T>
   Values(std::initializer_list<T> init)
-      : detail::arg_tuple<Values, Args...>(init) {}
+      : detail::arg_tuple<Values, Args...>(std::move(init)) {}
 };
 template <class... Args>
 struct Variances : public detail::arg_tuple<Variances, Args...> {
   using detail::arg_tuple<Variances, Args...>::arg_tuple;
   template <class T>
   Variances(std::initializer_list<T> init)
-      : detail::arg_tuple<Variances, Args...>(init) {}
+      : detail::arg_tuple<Variances, Args...>(std::move(init)) {}
 };
 
 template <class... Args> Values(Args &&... args)->Values<Args...>;

--- a/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -4,7 +4,6 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <limits>
 #include <type_traits>
 
 namespace scipp::variable {
@@ -81,18 +80,18 @@ template <class ElemT> struct ArgParser {
       std::get<Dimensions>(args) = Dimensions(dims.data, arg.data);
   }
 
-  template <class... Args> void parse(Values<Args...> &&values) {
+  template <class... Args> void parse(Values<Args...> &&arg) {
     if constexpr (std::is_constructible_v<element_array<ElemT>, Args...>)
       std::get<2>(args) =
-          std::make_from_tuple<element_array<ElemT>>(std::move(values.tuple));
+          std::make_from_tuple<element_array<ElemT>>(std::move(arg.tuple));
     else
       throw_keyword_arg_constructor_bad_dtype(core::dtype<ElemT>);
   }
 
-  template <class... Args> void parse(Variances<Args...> &&variances) {
+  template <class... Args> void parse(Variances<Args...> &&arg) {
     if constexpr (std::is_constructible_v<element_array<ElemT>, Args...>)
-      std::get<3>(args) = std::make_from_tuple<element_array<ElemT>>(
-          std::move(variances.tuple));
+      std::get<3>(args) =
+          std::make_from_tuple<element_array<ElemT>>(std::move(arg.tuple));
     else
       throw_keyword_arg_constructor_bad_dtype(core::dtype<ElemT>);
   }

--- a/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -157,16 +157,16 @@ public:
       throw_keyword_arg_constructor_bad_dtype(core::dtype<ElemT>);
       return VarT{}; // unreachable
     } else {
-      std::optional<element_array<ElemT>> values;
+      element_array<ElemT> values;
       if constexpr (hasVal)
         values = std::make_from_tuple<element_array<ElemT>>(std::move(valArgs));
-      std::optional<element_array<ElemT>> variances;
       if constexpr (hasVar)
-        variances =
-            std::make_from_tuple<element_array<ElemT>>(std::move(varArgs));
-      return VarT::template create<ElemT>(
-          std::move(std::get<NonDataTypes>(nonData))..., std::move(values),
-          std::move(variances));
+        return VarT::template create<ElemT>(
+            std::move(std::get<NonDataTypes>(nonData))..., std::move(values),
+            std::make_from_tuple<element_array<ElemT>>(std::move(varArgs)));
+      else
+        return VarT::template create<ElemT>(
+            std::move(std::get<NonDataTypes>(nonData))..., std::move(values));
     }
   }
 

--- a/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -55,6 +55,9 @@ namespace detail {
 
 void throw_keyword_arg_constructor_bad_dtype(const DType dtype);
 
+/// Convert "keyword" args to tuple that can be used to construct Variable
+///
+/// This is an implementation detail of `makeVariable`.
 template <class ElemT> struct ArgParser {
   std::tuple<units::Unit, Dimensions, element_array<ElemT>,
              std::optional<element_array<ElemT>>>

--- a/variable/test/variable_custom_type_test.cpp
+++ b/variable/test/variable_custom_type_test.cpp
@@ -18,8 +18,8 @@ struct CustomType {
 INSTANTIATE_VARIABLE(custom_type, CustomType)
 
 TEST(VariableCustomType, use_custom_templates) {
-  auto input_values = std::initializer_list<CustomType>{1, 2};
-  auto var = Variable{{Dim::X, 2}, input_values};
+  auto var = makeVariable<CustomType>(Dimensions{Dim::X, 2},
+                                      Values{CustomType{1}, CustomType{2}});
   // Check for bad cast or other built-in implicit type assumptions
   EXPECT_NO_THROW(var.values<CustomType>());
   VariableConstView slice = var.slice(Slice(Dim::X, 0));

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -19,12 +19,21 @@ TEST(CreateVariableTest, from_single_value) {
 }
 
 TEST(CreateVariableTest, dims_shape) {
+  // Check that we never use std::vector::vector(size, value)
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X}, Shape{2}),
+            makeVariable<float>(Dimensions({{Dim::X, 2}})));
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X}, Shape{2l}),
+            makeVariable<float>(Dimensions({{Dim::X, 2}})));
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2l, 3}),
+            makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2l, 3l}),
             makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 3}),
             makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape(2, 3)),
-            makeVariable<float>(Dimensions({{Dim::X, 3}, {Dim::Y, 3}})));
+            makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape(2l, 3)),
+            makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
 }
 
 TEST(CreateVariableTest, default_init) {

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -20,7 +20,7 @@ TEST(CreateVariableTest, from_single_value) {
 
 TEST(CreateVariableTest, dims_shape) {
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2l, 3}),
-            makeVariable<float>(Dimensions({{Dim::X, 3}, {Dim::Y, 3}})));
+            makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 3}),
             makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
   EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape(2, 3)),
@@ -51,7 +51,7 @@ TEST(CreateVariableTest, default_init) {
 TEST(CreateVariableTest, from_vector) {
   EXPECT_EQ(makeVariable<double>(Dims{Dim::X}, Shape{3},
                                  Values(std::vector<int>{1, 2, 3})),
-            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values({1, 2, 3})));
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}));
 
   const std::vector<double> v{1, 2, 3};
   auto varRef = makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
@@ -90,18 +90,18 @@ TEST(VariableUniversalConstructorTest, dimensions_unit_basic) {
 TEST(VariableUniversalConstructorTest, type_constructors_mix) {
   auto flt = std::vector{1.5f, 3.6f};
   auto v1 = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 1},
-                     Values(flt.begin(), flt.end()), Variances({2.0, 3.0}));
+                     Values(flt.begin(), flt.end()), Variances{2.0, 3.0});
   auto v2 = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 1},
-                     Values({1.5, 3.6}), Variances({2, 3}));
+                     Values{1.5, 3.6}, Variances{2, 3});
   auto v3 = Variable(dtype<float>, units::Unit(), Dims{Dim::X, Dim::Y},
-                     Shape{2, 1}, Values({1.5f, 3.6f}));
+                     Shape{2, 1}, Values{1.5f, 3.6f});
   v3.setVariances(
       makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, Values{2, 3}));
   EXPECT_EQ(v1, v2);
   EXPECT_EQ(v1, v3);
 
-  v2 = Variable(dtype<float>, Variances({2.0, 3.0}), Dims{Dim::X, Dim::Y},
-                Shape{2, 1}, Values({1.5f, 3.6f}));
+  v2 = Variable(dtype<float>, Variances{2.0, 3.0}, Dims{Dim::X, Dim::Y},
+                Shape{2, 1}, Values{1.5f, 3.6f});
   EXPECT_EQ(v1, v2);
 }
 
@@ -160,5 +160,5 @@ TEST(VariableUniversalConstructorTest, initializer_list) {
 TEST(VariableUniversalConstructorTest, from_vector) {
   EXPECT_EQ(makeVariable<double>(Dims{Dim::X}, Shape{3},
                                  Values(std::vector<int>{1, 2, 3})),
-            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values({1, 2, 3})));
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}));
 }

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -36,6 +36,11 @@ TEST(CreateVariableTest, dims_shape) {
             makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
 }
 
+TEST(CreateVariableTest, dims_shape_order) {
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X}, Shape{2}),
+            makeVariable<float>(Shape{2}, Dims{Dim::X}));
+}
+
 TEST(CreateVariableTest, default_init) {
   auto noVariance = makeVariable<float>(Dims{Dim::X}, Shape{3});
   auto stillNoVariance = makeVariable<float>(Dims{Dim::X}, Shape{3}, Values{});

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -18,6 +18,15 @@ TEST(CreateVariableTest, from_single_value) {
   EXPECT_EQ(var.variance<float>(), 1.0f);
 }
 
+TEST(CreateVariableTest, dims_shape) {
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2l, 3}),
+            makeVariable<float>(Dimensions({{Dim::X, 3}, {Dim::Y, 3}})));
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 3}),
+            makeVariable<float>(Dimensions({{Dim::X, 2}, {Dim::Y, 3}})));
+  EXPECT_EQ(makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape(2, 3)),
+            makeVariable<float>(Dimensions({{Dim::X, 3}, {Dim::Y, 3}})));
+}
+
 TEST(CreateVariableTest, default_init) {
   auto noVariance = makeVariable<float>(Dims{Dim::X}, Shape{3});
   auto stillNoVariance = makeVariable<float>(Dims{Dim::X}, Shape{3}, Values{});

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -1144,10 +1144,10 @@ TEST(TransposeTest, make_transposed_2d) {
   EXPECT_EQ(var.transpose({Dim::Y, Dim::X}), ref);
   EXPECT_EQ(constVar.transpose({Dim::Y, Dim::X}), ref);
 
-  EXPECT_THROW(constVar.transpose({Dim::Y, Dim::Z}), std::runtime_error);
-  EXPECT_THROW(constVar.transpose({Dim::Y}), std::runtime_error);
-  EXPECT_THROW(var.transpose({Dim::Y, Dim::Z}), std::runtime_error);
-  EXPECT_THROW(var.transpose({Dim::Z}), std::runtime_error);
+  EXPECT_THROW(constVar.transpose({Dim::Y, Dim::Z}), except::DimensionError);
+  EXPECT_THROW(constVar.transpose({Dim::Y}), except::DimensionError);
+  EXPECT_THROW(var.transpose({Dim::Y, Dim::Z}), except::DimensionError);
+  EXPECT_THROW(var.transpose({Dim::Z}), except::DimensionError);
 }
 
 TEST(TransposeTest, make_transposed_multiple_d) {
@@ -1163,13 +1163,13 @@ TEST(TransposeTest, make_transposed_multiple_d) {
   EXPECT_EQ(var.transpose({Dim::Y, Dim::Z, Dim::X}), ref);
   EXPECT_EQ(constVar.transpose({Dim::Y, Dim::Z, Dim::X}), ref);
 
-  EXPECT_THROW(constVar.transpose({Dim::Y, Dim::Z}), std::runtime_error);
-  EXPECT_THROW(constVar.transpose({Dim::Y}), std::runtime_error);
-  EXPECT_THROW(var.transpose({Dim::Y, Dim::Z}), std::runtime_error);
-  EXPECT_THROW(var.transpose({Dim::Z}), std::runtime_error);
+  EXPECT_THROW(constVar.transpose({Dim::Y, Dim::Z}), except::DimensionError);
+  EXPECT_THROW(constVar.transpose({Dim::Y}), except::DimensionError);
+  EXPECT_THROW(var.transpose({Dim::Y, Dim::Z}), except::DimensionError);
+  EXPECT_THROW(var.transpose({Dim::Z}), except::DimensionError);
 }
 
-TEST(TransposeTest, different_api) {
+TEST(TransposeTest, reverse) {
   Variable var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 2},
                                       Values{1, 2, 3, 4, 5, 6},
                                       Variances{11, 12, 13, 14, 15, 16});

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -1085,7 +1085,7 @@ TEST(VariableTest, variances_unsupported_type_fail) {
       makeVariable<std::string>(Dims{Dim::X}, Shape{1}, Values{"a"}));
   ASSERT_THROW(makeVariable<std::string>(Dims{Dim::X}, Shape{1}, Values{"a"},
                                          Variances{"variances"}),
-               except::TypeError);
+               except::VariancesError);
 }
 
 TEST(VariableTest, construct_view_dims) {

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -10,18 +10,6 @@
 
 namespace scipp::variable {
 
-std::vector<scipp::index>
-detail::reorderedShape(const scipp::span<const Dim> &order,
-                       const Dimensions &dimensions) {
-  if (order.size() != dimensions.ndim())
-    throw std::runtime_error("Cannot transpose input dimensions should be "
-                             "exactly the same but maybe in different order.");
-  std::vector<scipp::index> res(order.size());
-  std::transform(order.begin(), order.end(), res.begin(),
-                 [&dimensions](auto &a) { return dimensions[a]; });
-  return res;
-}
-
 Variable::Variable(const VariableConstView &slice)
     : Variable(slice ? Variable(slice, slice.dims()) : Variable()) {
   // There is a bug in the implementation of MultiIndex used in ElementArrayView

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -172,37 +172,29 @@ Variable VariableConstView::reshape(const Dimensions &dims) const {
   return reshaped;
 }
 
-template <class DimContainer>
-std::vector<Dim> reverseDimOrder(const DimContainer &container) {
-  return std::vector<Dim>(container.rbegin(), container.rend());
-}
-
 VariableConstView Variable::transpose(const std::vector<Dim> &dims) const & {
-  return VariableConstView::makeTransposed(
-      *this, dims.empty() ? reverseDimOrder(this->dims().labels()) : dims);
+  return VariableConstView(*this).transpose(dims);
 }
 
 VariableView Variable::transpose(const std::vector<Dim> &dims) & {
-  return VariableView::makeTransposed(
-      *this, dims.empty() ? reverseDimOrder(this->dims().labels()) : dims);
+  return VariableView(*this).transpose(dims);
 }
 
 Variable Variable::transpose(const std::vector<Dim> &dims) && {
-  return Variable(VariableConstView::makeTransposed(
-      *this, dims.empty() ? reverseDimOrder(this->dims().labels()) : dims));
+  return Variable(VariableConstView(*this).transpose(dims));
 }
 
 VariableConstView
 VariableConstView::transpose(const std::vector<Dim> &dims) const {
-  auto dms = this->dims();
-  return makeTransposed(*this,
-                        dims.empty() ? reverseDimOrder(dms.labels()) : dims);
+  auto transposed(*this);
+  transposed.m_view = data().transpose(dims);
+  return transposed;
 }
 
 VariableView VariableView::transpose(const std::vector<Dim> &dims) const {
-  auto dms = this->dims();
-  return makeTransposed(*this,
-                        dims.empty() ? reverseDimOrder(dms.labels()) : dims);
+  auto transposed(*this);
+  transposed.m_view = data().transpose(dims);
+  return transposed;
 }
 
 std::vector<scipp::index> VariableConstView::strides() const {


### PR DESCRIPTION
Changes around `variable.h`:

- Cleanup & simplify `transpose` code.
- Move functions from header to cpp
- Rewrite the "keyword arg" constructor for variable in a much shorter manner.