### PR TITLE
Update Getting Started docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ compile_commands.json
 
 build/
 .clangd/
+.idea/
+.vscode/

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -29,7 +29,12 @@ To build and install the library:
 
   conda create -n scipp python=3.7
   conda env activate scipp
-  conda install # populate list here
+  conda install -c conda-forge appdirs numpy # ..etc. populate from meta.yml
+
+
+To build a debug version of the library:
+
+.. code-block:: bash
 
   cmake \
     -GNinja \
@@ -41,6 +46,21 @@ To build and install the library:
 
   cmake --build . --target all-tests
   cmake --build . --target install
+
+Alternatively, to build a release version with all optimizations enabled:
+
+.. code-block:: bash
+
+  cmake \
+    -GNinja \
+    -DPYTHON_EXECUTABLE=$(command -v python3) \
+    -DCMAKE_INSTALL_PREFIX=../install \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+
+  cmake --build . --target all-tests
+  cmake --build . --target install
+
 
 To use the ``scipp`` Python module:
 
@@ -80,6 +100,11 @@ To run the Python tests, run (in the ``python/`` directory):
 
 .. code-block:: bash
 
+  # Pull in all dependencies for tests
+  conda env update --file docs/environment.yml
+  conda activate scipp-docs
+  
+  conda install beautifulsoup4 pytest
+
   cd python
-  python3 -m pip install -r requirements.txt
   python3 -m pytest

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -38,6 +38,7 @@ To build a debug version of the library:
 
   cmake \
     -GNinja \
+    -DCMAKE_BUILD_TYPE=Debug \
     -DPYTHON_EXECUTABLE=$(command -v python3) \
     -DCMAKE_INSTALL_PREFIX=../install \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \


### PR DESCRIPTION
Updates the getting started docs to clarify some things about 
- Installing deps for running scipp (for example we need to use conda-forge since `python-requirements` is only available there) 
- How to get a release build (this is more for future users then developers).
- Running Python unit tests.

Adds some IDE directories to the .gitignore folder
