### PR TITLE
Extracted lambdas for Variable::reciprocal operations and moved them …

### DIFF
--- a/core/include/scipp/core/element/unary_operations.h
+++ b/core/include/scipp/core/element/unary_operations.h
@@ -108,17 +108,23 @@ constexpr auto negative_inf_to_num_out_arg =
                },
                unit_check_and_assign};
 
-constexpr auto reciprocal =
-    overloaded{[](const auto &x) noexcept {
-        return static_cast<core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) / x;
+constexpr auto reciprocal = overloaded{
+    arg_list<double, float>,
+    [](const auto &x) noexcept {
+      return static_cast<
+                 core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
+             x;
     },
     [](const units::Unit &unit) {
-        return units::Unit(units::dimensionless) / unit;
+      return units::Unit(units::dimensionless) / unit;
     }};
 
-constexpr auto reciprocal_out_arg =
-    overloaded{arg_list<double, float>, [](auto &x, const auto &y) {
-      x = static_cast<core::detail::element_type_t<std::decay_t<decltype(y)>>>(1) / y;
+constexpr auto reciprocal_out_arg = overloaded{
+    arg_list<double, float>,
+    [](auto &x, const auto &y) {
+      x = static_cast<core::detail::element_type_t<std::decay_t<decltype(y)>>>(
+              1) /
+          y;
     },
     [](units::Unit &x, const units::Unit &y) {
       x = units::Unit(units::dimensionless) / y;

--- a/core/include/scipp/core/element/unary_operations.h
+++ b/core/include/scipp/core/element/unary_operations.h
@@ -111,13 +111,14 @@ constexpr auto negative_inf_to_num_out_arg =
 constexpr auto reciprocal = overloaded{
     arg_list<double, float>,
     [](const auto &x) noexcept {
-      return static_cast<
-                 core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
-             x;
-    },
-    [](const units::Unit &unit) {
-      return units::Unit(units::dimensionless) / unit;
-    }};
+        return static_cast<
+                   core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
+               x;
+} // namespace element
+, [](const units::Unit &unit) {
+  return units::Unit(units::dimensionless) / unit;
+}
+}; // namespace scipp::core
 
 constexpr auto reciprocal_out_arg = overloaded{
     arg_list<double, float>,

--- a/core/include/scipp/core/element/unary_operations.h
+++ b/core/include/scipp/core/element/unary_operations.h
@@ -108,6 +108,22 @@ constexpr auto negative_inf_to_num_out_arg =
                },
                unit_check_and_assign};
 
+constexpr auto reciprocal =
+    overloaded{[](const auto &x) noexcept {
+        return static_cast<core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) / x;
+    },
+    [](const units::Unit &unit) {
+        return units::Unit(units::dimensionless) / unit;
+    }};
+
+constexpr auto reciprocal_out_arg =
+    overloaded{arg_list<double, float>, [](auto &x, const auto &y) {
+      x = static_cast<core::detail::element_type_t<std::decay_t<decltype(y)>>>(1) / y;
+    },
+    [](units::Unit &x, const units::Unit &y) {
+      x = units::Unit(units::dimensionless) / y;
+    }};
+
 } // namespace element
 
 } // namespace scipp::core

--- a/core/test/element_unary_operations_test.cpp
+++ b/core/test/element_unary_operations_test.cpp
@@ -284,9 +284,10 @@ TYPED_TEST(ElementNegativeInfToNumTest, value_and_variance_out) {
 TEST(ElementReciprocalTest, unit) {
   const units::Unit one_over_m(units::dimensionless / units::m);
   EXPECT_EQ(element::reciprocal(one_over_m), units::m);
+  const units::Unit one_over_s(units::dimensionless / units::s);
+  EXPECT_EQ(element::reciprocal(units::Unit(units::s)), one_over_s);
 }
 
-// Question here: should we use EXPECT_EQ, or rather EXPECT_FLOAT_EQ?
 TEST(ElementReciprocalTest, value) {
   EXPECT_EQ(element::reciprocal(1.23), 1 / 1.23);
   EXPECT_EQ(element::reciprocal(1.23456789f), 1 / 1.23456789f);
@@ -302,6 +303,9 @@ TEST(ElementReciprocalOutArgTest, unit) {
   units::Unit out(units::dimensionless);
   element::reciprocal_out_arg(out, one_over_m);
   EXPECT_EQ(out, units::m);
+  element::reciprocal_out_arg(out, units::Unit(units::s));
+  const units::Unit one_over_s(units::dimensionless / units::s);
+  EXPECT_EQ(out, one_over_s);
 }
 
 TEST(ElementReciprocalOutArgTest, value_double) {

--- a/core/test/element_unary_operations_test.cpp
+++ b/core/test/element_unary_operations_test.cpp
@@ -280,3 +280,51 @@ TYPED_TEST(ElementNegativeInfToNumTest, value_and_variance_out) {
   targetted_replacement_out_arg_test(element::negative_inf_to_num_out_arg, out,
                                      replaceable, nonreplaceable, replacement);
 }
+
+TEST(ElementReciprocalTest, unit) {
+  const units::Unit one_over_m(units::dimensionless / units::m);
+  EXPECT_EQ(element::reciprocal(one_over_m), units::m);
+}
+
+// Question here: should we use EXPECT_EQ, or rather EXPECT_FLOAT_EQ?
+TEST(ElementReciprocalTest, value) {
+  EXPECT_EQ(element::reciprocal(1.23), 1 / 1.23);
+  EXPECT_EQ(element::reciprocal(1.23456789f), 1 / 1.23456789f);
+}
+
+TEST(ElementReciprocalTest, value_and_variance) {
+  const ValueAndVariance x(2.0, 1.0);
+  EXPECT_EQ(element::reciprocal(x), 1 / x);
+}
+
+TEST(ElementReciprocalOutArgTest, unit) {
+  const units::Unit one_over_m(units::dimensionless / units::m);
+  units::Unit out(units::dimensionless);
+  element::reciprocal_out_arg(out, one_over_m);
+  EXPECT_EQ(out, units::m);
+}
+
+TEST(ElementReciprocalOutArgTest, value_double) {
+  double out;
+  element::reciprocal_out_arg(out, 1.23);
+  EXPECT_EQ(out, 1 / 1.23);
+}
+
+TEST(ElementReciprocalOutArgTest, value_float) {
+  float out;
+  element::reciprocal_out_arg(out, 1.23456789f);
+  EXPECT_EQ(out, 1 / 1.23456789f);
+}
+
+TEST(ElementReciprocalOutArgTest, value_and_variance) {
+  const ValueAndVariance x(2.0, 1.0);
+  ValueAndVariance out(x);
+  element::reciprocal_out_arg(out, x);
+  EXPECT_EQ(out, 1 / x);
+}
+
+TEST(ElementReciprocalOutArgTest, supported_types) {
+  auto supported = decltype(element::reciprocal_out_arg)::types{};
+  std::get<double>(supported);
+  std::get<float>(supported);
+}

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -126,15 +126,7 @@ Variable filter(const Variable &var, const Variable &filter) {
 }
 
 Variable reciprocal(const VariableConstView &var) {
-  return transform<double, float>(
-      var, overloaded{[](const auto &a_) {
-                        return static_cast<core::detail::element_type_t<
-                                   std::decay_t<decltype(a_)>>>(1) /
-                               a_;
-                      },
-                      [](const units::Unit &unit) {
-                        return units::Unit(units::dimensionless) / unit;
-                      }});
+  return transform<double, float>(var, element::reciprocal);
 }
 
 Variable reciprocal(Variable &&var) {
@@ -144,18 +136,7 @@ Variable reciprocal(Variable &&var) {
 }
 
 VariableView reciprocal(const VariableConstView &var, const VariableView &out) {
-  transform_in_place<pair_self_t<double, float>>(
-      out, var,
-      overloaded{
-          [](auto &x, const auto &y) {
-            x = static_cast<
-                    core::detail::element_type_t<std::decay_t<decltype(y)>>>(
-                    1) /
-                y;
-          },
-          [](units::Unit &x, const units::Unit &y) {
-            x = units::Unit(units::dimensionless) / y;
-          }});
+  transform_in_place(out, var, element::reciprocal_out_arg);
   return out;
 }
 

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -126,7 +126,7 @@ Variable filter(const Variable &var, const Variable &filter) {
 }
 
 Variable reciprocal(const VariableConstView &var) {
-  return transform<double, float>(var, element::reciprocal);
+  return transform(var, element::reciprocal);
 }
 
 Variable reciprocal(Variable &&var) {

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -627,7 +627,24 @@ TEST(Variable, sqrt_out_arg) {
   EXPECT_EQ(view.underlying(), x);
 }
 
-TEST(VariableReciprocalOutArg, full_in_place) {
+TEST(Variable, reciprocal) {
+  auto var1 = makeVariable<double>(Values{2});
+  auto var2 = makeVariable<double>(Values{0.5});
+  ASSERT_EQ(reciprocal(var1), var2);
+  var1 = makeVariable<double>(Values{2}, Variances{1});
+  var2 = makeVariable<double>(Values{0.5}, Variances{0.0625});
+  ASSERT_EQ(reciprocal(var1), var2);
+}
+
+TEST(Variable, reciprocal_move) {
+  auto var = makeVariable<double>(Values{4});
+  const auto ptr = var.values<double>().data();
+  auto out = reciprocal(std::move(var));
+  EXPECT_EQ(out, makeVariable<double>(Values{0.25}));
+  EXPECT_EQ(out.values<double>().data(), ptr);
+}
+
+TEST(Variable, resiprocal_out_arg_full_in_place) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
                                   Values{1, 4, 9});
   auto view = reciprocal(var, var);
@@ -639,7 +656,7 @@ TEST(VariableReciprocalOutArg, full_in_place) {
   EXPECT_EQ(view.underlying(), var);
 }
 
-TEST(VariableReciprocalOutArg, partial) {
+TEST(Variable, reciprocal_out_arg_partial) {
   const auto var = makeVariable<double>(Dims{Dim::X}, Shape{3},
                                         units::Unit(units::m), Values{1, 4, 9});
   auto out =
@@ -1353,19 +1370,4 @@ TEST(VariableTest, rotate) {
   VariableView vec_new2 = geometry::rotate(vec, rot, vec);
   EXPECT_EQ(vec_new2, rotated);
   EXPECT_EQ(vec, rotated);
-}
-
-template <class T> class ReciprocalTest : public ::testing::Test {};
-
-using test_types = ::testing::Types<float, double>;
-TYPED_TEST_SUITE(ReciprocalTest, test_types);
-
-TYPED_TEST(ReciprocalTest, variable_reciprocal) {
-  using T = TypeParam;
-  auto var1 = makeVariable<T>(Values{2});
-  auto var2 = makeVariable<T>(Values{0.5});
-  ASSERT_EQ(reciprocal(var1), var2);
-  var1 = makeVariable<T>(Values{2}, Variances{1});
-  var2 = makeVariable<T>(Values{0.5}, Variances{0.0625});
-  ASSERT_EQ(reciprocal(var1), var2);
 }


### PR DESCRIPTION
…to core::element;

Could someone please take a look and confirm that this is the correct approach to refactor these operations (I will continue for all remaining operations if it is correct). Based on this discussion: https://github.com/scipp/scipp/issues/1042

I am also not sure about:

 - is it OK to remove typed test ReciprocalTest from variable operations_tests?
 - is it correct to use `EXPECT_EQ` for floating point types instead of `EXPECT_FLOAT_EQ`?
 - when splitting calls to functions in multiple lines, is it always desired to align with the first argument? like here:

```
auto unit_check_and_assign = [](units::Unit &a, const units::Unit &b,
                                const units::Unit &repl) {  <-- this one aligned
  expect::equals(b, repl); <-- impl body using normal tab space
  a = b;
};
```