### PR TITLE
Print expected and user requested extents in mismatch excpt.

### DIFF
--- a/core/except.cpp
+++ b/core/except.cpp
@@ -2,13 +2,23 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include <set>
-
-#include "scipp/core/dimensions.h"
 #include "scipp/core/except.h"
+#include "scipp/common/index.h"
+#include "scipp/core/dimensions.h"
 #include "scipp/core/slice.h"
 
+#include <cmath>
+#include <set>
+
 namespace scipp::except {
+
+DimensionError::DimensionError(const std::string &msg)
+    : Error<core::Dimensions>(msg) {}
+
+DimensionError::DimensionError(scipp::index expectedDim, scipp::index userDim)
+    : DimensionError("Length mismatch on insertion. Expected size: " +
+                     std::to_string(std::abs(expectedDim)) +
+                     " Requested size: " + std::to_string(userDim)) {}
 
 DimensionNotFoundError::DimensionNotFoundError(const core::Dimensions &expected,
                                                const Dim actual)

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -38,13 +38,16 @@ struct SCIPP_CORE_EXPORT TypeError : public std::runtime_error {
       : std::runtime_error(msg + ((to_string(vars.dtype()) + ' ') + ...)) {}
 };
 
-using DimensionError = Error<core::Dimensions>;
-
 using DimensionMismatchError = MismatchError<core::Dimensions>;
 
 template <class T>
 MismatchError(const core::Dimensions &, const T &)
     ->MismatchError<core::Dimensions>;
+
+struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
+  DimensionError(const std::string &msg);
+  DimensionError(scipp::index expectedDim, scipp::index userDim);
+};
 
 struct SCIPP_CORE_EXPORT DimensionNotFoundError : public DimensionError {
   DimensionNotFoundError(const core::Dimensions &expected, const Dim actual);

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -3,6 +3,8 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/dataset/dataset.h"
+#include "scipp/common/index.h"
+#include "scipp/core/except.h"
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/unaligned.h"
 
@@ -186,6 +188,7 @@ void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
   const auto it = dims.find(dim);
   // Internally use negative extent -1 to indicate unknown edge state. The `-1`
   // is required for dimensions with extent 0.
+
   if (it == dims.end()) {
     dims[dim] = extents::makeUnknownEdgeState(extent);
   } else {
@@ -197,12 +200,12 @@ void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
       } else if (extents::oneSmaller(extent, heldExtent) && !isCoord) {
         heldExtent = extent;
       } else {
-        throw except::DimensionError("Length mismatch on insertion");
+        throw except::DimensionError(heldExtent, extent);
       }
     } else {
       // Check for known edge state
       if ((extent != heldExtent || isCoord) && extent != heldExtent + 1)
-        throw except::DimensionError("Length mismatch on insertion");
+        throw except::DimensionError(heldExtent, extent);
     }
   }
 }

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include "scipp/common/index.h"
+#include "scipp/core/except.h"
 #include "test_macros.h"
 #include <gtest/gtest.h>
 
@@ -207,6 +209,18 @@ TEST(DatasetTest, setData_keep_attributes) {
   EXPECT_TRUE(d["x"].attrs().contains("attr"));
   d.setData("x", var, AttrPolicy::Keep);
   EXPECT_TRUE(d["x"].attrs().contains("attr"));
+}
+
+TEST(DatasetTest, setData_with_mismatched_dims) {
+  scipp::index expected_size = 2;
+  const auto original =
+      makeVariable<double>(Dims{Dim::X}, Shape{expected_size});
+  const auto mismatched =
+      makeVariable<double>(Dims{Dim::X}, Shape{expected_size + 1});
+  Dataset d;
+
+  ASSERT_NO_THROW(d.setData("a", original));
+  ASSERT_THROW(d.setData("a", mismatched), except::DimensionError);
 }
 
 TEST(DatasetTest, DataArrayView_setData) {

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -74,7 +74,7 @@ To run the C++ tests, run (in the ``build/`` directory):
   ./dataset/test/scipp-dataset-test
   ./neutron/test/scipp-neutron-test
 
-Note that simply running ``ctest`` also works, but currently it seems to have an issue with gathering templated tests, so calling the test binaries manually is recommended (and much faster).
+``all-tests`` can be used to build all tests at the same time. Note that simply running ``ctest`` also works, but currently it seems to have an issue with gathering templated tests, so calling the test binaries manually is recommended (and much faster).
 
 To run the Python tests, run (in the ``python/`` directory):
 

--- a/variable/test/variable_scalar_accessors_test.cpp
+++ b/variable/test/variable_scalar_accessors_test.cpp
@@ -63,13 +63,13 @@ TYPED_TEST(Variable_scalar_accessors, variance_dim_0) {
 TYPED_TEST(Variable_scalar_accessors, value_dim_1) {
   auto v_ = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.1});
   auto &&v = TestFixture::access(v_);
-  ASSERT_THROW(v.template value<double>(), except::DimensionError);
+  ASSERT_THROW(v.template value<double>(), except::DimensionMismatchError);
 }
 
 TYPED_TEST(Variable_scalar_accessors, variance_dim_1) {
   auto v_ =
       makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.1}, Variances{2.2});
   auto &&v = TestFixture::access(v_);
-  ASSERT_THROW(v.template value<double>(), except::DimensionError);
-  ASSERT_THROW(v.template variance<double>(), except::DimensionError);
+  ASSERT_THROW(v.template value<double>(), except::DimensionMismatchError);
+  ASSERT_THROW(v.template variance<double>(), except::DimensionMismatchError);
 }

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -1019,7 +1019,7 @@ template <typename Var> void test_set_variances(Var &var) {
 
   Variable bad_dims(v);
   bad_dims.rename(Dim::X, Dim::Y);
-  EXPECT_THROW(var.setVariances(bad_dims), except::DimensionError);
+  EXPECT_THROW(var.setVariances(bad_dims), except::DimensionMismatchError);
 
   Variable bad_unit(v);
   bad_unit.setUnit(units::s);


### PR DESCRIPTION
Print the expected and user requested extents in the exception message.
This helps with:
- bin-edge / bin-centre problems where there will be a mismatch of one
- using the wrong data, or getting them confused. The length can be a
good indicator of the actual data your incorrectly trying to use

When we are unsure of the bin-edge state we can be +/- 1 (because we are unsure), but this is better than not giving anything at all IMO

To test:
- Build and run the following
``` python
import scipp as sc
from scipp import Dim

d = sc.Dataset()
d["a"] = sc.Variable([Dim.X], values=[1.0, 2.0])
d["b"] = sc.Variable([Dim.X], values=[1.0, 2.0, 3.0, 5.0])
```
- Check that a sensible error is given


-----

I'm not sure on the policy of external libs, but it might be worth considering [fmt](https://github.com/fmtlib/fmt) to write more-readable exceptions. Additionally, it is faster than the STL `to_string` (not that it matters for an exception)