### PR TITLE
Moved vector operations norm and dot to element namespace

### DIFF
--- a/core/include/scipp/core/element/unary_operations.h
+++ b/core/include/scipp/core/element/unary_operations.h
@@ -121,14 +121,14 @@ constexpr auto negative_inf_to_num_out_arg =
 constexpr auto reciprocal = overloaded{
     arg_list<double, float>,
     [](const auto &x) noexcept {
-        return static_cast<
-                   core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
-               x;
-} // namespace element
-, [](const units::Unit &unit) {
-  return units::Unit(units::dimensionless) / unit;
-}
-}; // namespace scipp::core
+      return static_cast<
+                 core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
+             x;
+    } // namespace element
+    ,
+    [](const units::Unit &unit) {
+      return units::Unit(units::dimensionless) / unit;
+    }}; // namespace scipp::core
 
 constexpr auto reciprocal_out_arg = overloaded{
     arg_list<double, float>,

--- a/core/include/scipp/core/element/unary_operations.h
+++ b/core/include/scipp/core/element/unary_operations.h
@@ -6,6 +6,8 @@
 
 #include <cmath>
 
+#include <Eigen/Dense>
+
 #include "scipp/common/overloaded.h"
 #include "scipp/core/arg_list.h"
 #include "scipp/core/transform_common.h"
@@ -27,10 +29,19 @@ constexpr auto abs_out_arg =
                  x = abs(y);
                }};
 
+constexpr auto norm = overloaded{arg_list<Eigen::Vector3d>,
+                                 [](const auto &x) { return x.norm(); },
+                                 [](const units::Unit &x) { return x; }};
+
 constexpr auto sqrt = [](const auto x) noexcept {
   using std::sqrt;
   return sqrt(x);
 };
+
+constexpr auto dot = overloaded{
+    arg_list<Eigen::Vector3d>,
+    [](const auto &a, const auto &b) { return a.dot(b); },
+    [](const units::Unit &a, const units::Unit &b) { return a * b; }};
 
 constexpr auto sqrt_out_arg =
     overloaded{arg_list<double, float>, [](auto &x, const auto y) {
@@ -110,14 +121,14 @@ constexpr auto negative_inf_to_num_out_arg =
 constexpr auto reciprocal = overloaded{
     arg_list<double, float>,
     [](const auto &x) noexcept {
-      return static_cast<
-                 core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
-             x;
-    } // namespace element
-    ,
-    [](const units::Unit &unit) {
-      return units::Unit(units::dimensionless) / unit;
-    }}; // namespace scipp::core
+        return static_cast<
+                   core::detail::element_type_t<std::decay_t<decltype(x)>>>(1) /
+               x;
+} // namespace element
+, [](const units::Unit &unit) {
+  return units::Unit(units::dimensionless) / unit;
+}
+}; // namespace scipp::core
 
 constexpr auto reciprocal_out_arg = overloaded{
     arg_list<double, float>,

--- a/core/test/element_unary_operations_test.cpp
+++ b/core/test/element_unary_operations_test.cpp
@@ -58,6 +58,22 @@ TEST(ElementAbsOutArgTest, supported_types) {
   std::get<float>(supported);
 }
 
+TEST(ElementNormTest, unit) {
+  const units::Unit s(units::s);
+  const units::Unit m2(units::m * units::m);
+  const units::Unit dimless(units::dimensionless);
+  EXPECT_EQ(element::norm(m2), m2);
+  EXPECT_EQ(element::norm(s), s);
+  EXPECT_EQ(element::norm(dimless), dimless);
+}
+
+TEST(ElementNormTest, value) {
+  Eigen::Vector3d v1(0, 3, 4);
+  Eigen::Vector3d v2(3, 0, -4);
+  EXPECT_EQ(element::norm(v1), 5);
+  EXPECT_EQ(element::norm(v2), 5);
+}
+
 TEST(ElementSqrtTest, unit) {
   const units::Unit m2(units::m * units::m);
   EXPECT_EQ(element::sqrt(m2), units::sqrt(m2));
@@ -103,6 +119,21 @@ TEST(ElementSqrtOutArgTest, supported_types) {
   auto supported = decltype(element::sqrt_out_arg)::types{};
   std::get<double>(supported);
   std::get<float>(supported);
+}
+
+TEST(ElementDotTest, unit) {
+  const units::Unit m(units::m);
+  const units::Unit m2(units::m * units::m);
+  const units::Unit dimless(units::dimensionless);
+  EXPECT_EQ(element::dot(m, m), m2);
+  EXPECT_EQ(element::dot(dimless, dimless), dimless);
+}
+
+TEST(ElementDotTest, value) {
+  Eigen::Vector3d v1(0, 3, -4);
+  Eigen::Vector3d v2(1, 1, -1);
+  EXPECT_EQ(element::dot(v1, v1), 25);
+  EXPECT_EQ(element::dot(v2, v2), 3);
 }
 
 template <typename T> class ElementNanToNumTest : public ::testing::Test {};

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -155,9 +155,7 @@ VariableView abs(const VariableConstView &var, const VariableView &out) {
 }
 
 Variable norm(const VariableConstView &var) {
-  return transform<Eigen::Vector3d>(
-      var, overloaded{[](const auto &x) { return x.norm(); },
-                      [](const units::Unit &x) { return x; }});
+  return transform(var, element::norm);
 }
 
 Variable sqrt(const VariableConstView &var) {
@@ -175,12 +173,7 @@ VariableView sqrt(const VariableConstView &var, const VariableView &out) {
 }
 
 Variable dot(const Variable &a, const Variable &b) {
-  return transform<pair_self_t<Eigen::Vector3d>>(
-      a, b,
-      overloaded{[](const auto &a_, const auto &b_) { return a_.dot(b_); },
-                 [](const units::Unit &a_, const units::Unit &b_) {
-                   return a_ * b_;
-                 }});
+  return transform(a, b, element::dot);
 }
 
 Variable atan2(const Variable &y, const Variable &x) {

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -591,13 +591,14 @@ TEST(Variable, abs_out_arg) {
 }
 
 TEST(Variable, norm_of_vector) {
-  auto reference =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::Unit(units::m),
-                           Values{sqrt(2.0), sqrt(2.0), 2.0});
-  auto var = makeVariable<Eigen::Vector3d>(
+  Eigen::Vector3d v1(1, 0, -1);
+  Eigen::Vector3d v2(1, 1, 0);
+  Eigen::Vector3d v3(0, 0, -2);
+  auto reference = makeVariable<double>(
       Dims{Dim::X}, Shape{3}, units::Unit(units::m),
-      Values{Eigen::Vector3d{1, 0, -1}, Eigen::Vector3d{1, 1, 0},
-             Eigen::Vector3d{0, 0, -2}});
+      Values{element::norm(v1), element::norm(v2), element::norm(v3)});
+  auto var = makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{v1, v2, v3});
   EXPECT_EQ(norm(var), reference);
 }
 
@@ -625,6 +626,18 @@ TEST(Variable, sqrt_out_arg) {
                                     Values{1.23, element::sqrt(1.23)}));
   EXPECT_EQ(view, out);
   EXPECT_EQ(view.underlying(), x);
+}
+
+TEST(Variable, dot_of_vector) {
+  Eigen::Vector3d v1(1.1, 2.2, 3.3);
+  Eigen::Vector3d v2(-4.4, -5.5, -6.6);
+  Eigen::Vector3d v3(0, 0, 0);
+  auto reference = makeVariable<double>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m) * units::Unit(units::m),
+      Values{element::dot(v1, v1), element::dot(v2, v2), element::dot(v3, v3)});
+  auto var = makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{v1, v2, v3});
+  EXPECT_EQ(dot(var, var), reference);
 }
 
 TEST(Variable, reciprocal) {


### PR DESCRIPTION
Norm and Dot operations moved, added tests for elements and for variables; However, I am not sure about few things:

 - should dot operations be moved to something like binary_operations.h (along with xxx_inf_to_num)?
 - no norm and dot implementation for transform_in_place - should it be implemented to be able to execute them with `out` arg?
 - no tests for value_and_variance, because in ValueAndVariance template arg T is supposed to be small, is it OK? what about the issues with fixed-size vectorizable Eigen objects?  [link](https://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html)