### PR TITLE
SANS-related additions: Histogram for dense data and unit conversion

### DIFF
--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -61,7 +61,7 @@ template <class T>
 template <class Op, class CoordOp>
 T GroupBy<T>::reduce(Op op, const Dim reductionDim, CoordOp coord_op) const {
   auto out = makeReductionOutput(reductionDim);
-  const auto mask = ~masks_merge_if_contains(m_data.masks(), reductionDim);
+  const auto mask = ~irreducible_mask(m_data.masks(), reductionDim);
   // Apply to each group, storing result in output slice
   const auto process_groups = [&](const auto &range) {
     for (scipp::index group = range.begin(); group != range.end(); ++group) {
@@ -218,7 +218,7 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
   // 2. Compute number of slices N contributing to each out slice
   auto scale = makeVariable<double>(Dims{dim()}, Shape{size()});
   const auto scaleT = scale.template values<double>();
-  const auto mask = masks_merge_if_contains(m_data.masks(), reductionDim);
+  const auto mask = irreducible_mask(m_data.masks(), reductionDim);
   for (scipp::index group = 0; group < size(); ++group)
     for (const auto &slice : groups()[group]) {
       // N contributing to each slice

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -61,7 +61,9 @@ template <class T>
 template <class Op, class CoordOp>
 T GroupBy<T>::reduce(Op op, const Dim reductionDim, CoordOp coord_op) const {
   auto out = makeReductionOutput(reductionDim);
-  const auto mask = ~irreducible_mask(m_data.masks(), reductionDim);
+  auto mask = irreducible_mask(m_data.masks(), reductionDim);
+  if (mask)
+    mask = ~std::move(mask);
   // Apply to each group, storing result in output slice
   const auto process_groups = [&](const auto &range) {
     for (scipp::index group = range.begin(); group != range.end(); ++group) {
@@ -103,8 +105,7 @@ static constexpr auto flatten = [](const DataArrayView &out, const auto &in,
   bool first = true;
   const auto no_mask = makeVariable<bool>(Values{true});
   for (const auto &slice : group) {
-    auto mask =
-        mask_.dims().contains(reductionDim) ? mask_.slice(slice) : no_mask;
+    auto mask = mask_ ? mask_.slice(slice) : no_mask;
     const auto &array = in.slice(slice);
     if (in.hasData()) {
       if (contains_events(array.data()))
@@ -126,8 +127,7 @@ static constexpr auto flatten_coord =
         return;
       const auto no_mask = makeVariable<bool>(Values{true});
       for (const auto &slice : group) {
-        auto mask =
-            mask_.dims().contains(reductionDim) ? mask_.slice(slice) : no_mask;
+        auto mask = mask_ ? mask_.slice(slice) : no_mask;
         const auto &array = in.slice(slice);
         if (contains_events(out))
           flatten_impl(out, array, mask);
@@ -141,7 +141,7 @@ static constexpr auto sum = [](const DataArrayView &out,
   if (out.hasData()) {
     for (const auto &slice : group) {
       const auto data_slice = data_container.slice(slice);
-      if (mask.dims().contains(reductionDim))
+      if (mask)
         sum_impl(out.data(), data_slice.data() * mask.slice(slice));
       else
         sum_impl(out.data(), data_slice.data());
@@ -165,7 +165,7 @@ static constexpr auto reduce_idempotent =
       bool first = true;
       for (const auto &slice : group) {
         const auto data_slice = data_container.slice(slice);
-        if (mask.dims().contains(reductionDim))
+        if (mask)
           throw std::runtime_error(
               "This operation does not support masks yet.");
         if (first) {
@@ -224,7 +224,7 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
       // N contributing to each slice
       scaleT[group] += slice.end() - slice.begin();
       // N masks for each slice, that need to be subtracted
-      if (mask.dims().contains(reductionDim)) {
+      if (mask) {
         const auto masks_sum = variable::sum(mask.slice(slice), reductionDim);
         scaleT[group] -= masks_sum.template value<int64_t>();
       }

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -121,11 +121,6 @@ DataArray histogram(const DataArrayConstView &events,
   return result;
 }
 
-DataArray histogram(const DataArrayConstView &events,
-                    const Variable &binEdges) {
-  return histogram(events, VariableConstView(binEdges));
-}
-
 Dataset histogram(const Dataset &dataset, const VariableConstView &bins) {
   auto out(Dataset(DatasetConstView::makeViewWithEmptyIndexes(dataset)));
   const Dim dim = bins.dims().inner();

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -130,7 +130,7 @@ DataArray histogram(const DataArrayConstView &events,
               events_.data(), binEdges_, make_histogram);
         },
         dim_of_coord(events.coords()[dim], dim), dim, binEdges);
-  } else {
+  } else if (!is_histogram(events, dim)) {
     result = apply_and_drop_dim(
         events,
         [](const DataArrayConstView &events_, const Dim dim_,
@@ -150,6 +150,10 @@ DataArray histogram(const DataArrayConstView &events,
               make_histogram);
         },
         dim, binEdges);
+  } else {
+    throw except::BinEdgeError(
+        "Data is already histogrammed. Expected event data or dense point "
+        "data, got data with bin edges.");
   }
   result.coords().set(dim, binEdges);
   return result;

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -132,13 +132,6 @@ Dataset histogram(const Dataset &dataset, const VariableConstView &bins) {
   return out;
 }
 
-Dataset histogram(const Dataset &dataset, const Dim &dim) {
-  auto bins = dataset.coords()[dim];
-  if (contains_events(bins))
-    throw except::BinEdgeError("Expected bin edges, got event data.");
-  return histogram(dataset, bins);
-}
-
 /// Return the dimensions of the given data array that have an "bin edge"
 /// coordinate.
 std::set<Dim> edge_dimensions(const DataArrayConstView &a) {

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -136,7 +136,10 @@ DataArray histogram(const DataArrayConstView &events,
         events,
         [](const DataArrayConstView &events_, const Dim dim_,
            const VariableConstView &binEdges_) {
-          const auto mask = ~irreducible_mask(events_.masks(), dim_);
+          const auto mask = irreducible_mask(events_.masks(), dim_);
+          Variable masked;
+          if (mask)
+            masked = events_.data() * ~mask;
           using namespace histogram_dense_detail;
           return transform_subspan<
               std::tuple<args<double, double, double, double>,
@@ -144,7 +147,7 @@ DataArray histogram(const DataArrayConstView &events,
                          args<double, float, double, float>,
                          args<double, double, float, double>>>(
               dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
-              events_.data() * mask, binEdges_,
+              mask ? VariableConstView(masked) : events_.data(), binEdges_,
               overloaded{make_histogram, make_histogram_unit,
                          transform_flags::expect_variance_arg<0>,
                          transform_flags::expect_no_variance_arg<1>,

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -136,7 +136,7 @@ DataArray histogram(const DataArrayConstView &events,
         events,
         [](const DataArrayConstView &events_, const Dim dim_,
            const VariableConstView &binEdges_) {
-          const auto mask = ~masks_merge_if_contains(events_.masks(), dim_);
+          const auto mask = ~irreducible_mask(events_.masks(), dim_);
           using namespace histogram_dense_detail;
           return transform_subspan<
               std::tuple<args<double, double, double, double>,

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -142,9 +142,9 @@ DataArray histogram(const DataArrayConstView &events,
           using namespace histogram_dense_detail;
           return transform_subspan<
               std::tuple<args<double, double, double, double>,
-                         args<double, float, double, double>,
+                         args<float, double, float, double>,
                          args<double, float, double, float>,
-                         args<double, double, float, double>>>(
+                         args<float, float, float, float>>>(
               dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
               mask ? VariableConstView(masked) : events_.data(), binEdges_,
               make_histogram);

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -865,7 +865,7 @@ SCIPP_DATASET_EXPORT DataArray astype(const DataArrayConstView &var,
 SCIPP_DATASET_EXPORT DataArray histogram(const DataArrayConstView &events,
                                          const VariableConstView &binEdges);
 SCIPP_DATASET_EXPORT Dataset histogram(const Dataset &dataset,
-                                       const VariableConstView &bins);
+                                       const VariableConstView &binEdges);
 
 SCIPP_DATASET_EXPORT Dataset merge(const DatasetConstView &a,
                                    const DatasetConstView &b);

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -863,8 +863,6 @@ SCIPP_DATASET_EXPORT DataArray astype(const DataArrayConstView &var,
                                       const DType type);
 
 SCIPP_DATASET_EXPORT DataArray histogram(const DataArrayConstView &events,
-                                         const Variable &binEdges);
-SCIPP_DATASET_EXPORT DataArray histogram(const DataArrayConstView &events,
                                          const VariableConstView &binEdges);
 SCIPP_DATASET_EXPORT Dataset histogram(const Dataset &dataset,
                                        const VariableConstView &bins);

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -866,7 +866,6 @@ SCIPP_DATASET_EXPORT DataArray histogram(const DataArrayConstView &events,
                                          const VariableConstView &binEdges);
 SCIPP_DATASET_EXPORT Dataset histogram(const Dataset &dataset,
                                        const VariableConstView &bins);
-SCIPP_DATASET_EXPORT Dataset histogram(const Dataset &dataset, const Dim &dim);
 
 SCIPP_DATASET_EXPORT Dataset merge(const DatasetConstView &a,
                                    const DatasetConstView &b);

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -261,8 +261,8 @@ public:
   }
 };
 
-SCIPP_DATASET_EXPORT Variable
-masks_merge_if_contains(const MasksConstView &masks, const Dim dim);
+SCIPP_DATASET_EXPORT Variable irreducible_mask(const MasksConstView &masks,
+                                               const Dim dim);
 
 SCIPP_DATASET_EXPORT Variable
 masks_merge_if_contained(const MasksConstView &masks, const Dimensions &dims);

--- a/dataset/test/histogram_test.cpp
+++ b/dataset/test/histogram_test.cpp
@@ -165,6 +165,21 @@ TEST(HistogramTest, data_view) {
   EXPECT_EQ(hist, expected);
 }
 
+TEST(HistogramTest, dense) {
+  auto events = make_1d_events_default_weights();
+  auto edges1 =
+      makeVariable<double>(Dims{Dim::Y}, Shape{6}, Values{1, 2, 3, 4, 5, 6});
+  auto edges2 = makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1, 3, 6});
+  auto expected = dataset::histogram(events, edges2);
+  auto dense = dataset::histogram(events, edges1);
+  EXPECT_THROW(dataset::histogram(dense, edges2), except::BinEdgeError);
+  dense.coords().erase(Dim::Y);
+  dense.coords().set(Dim::Y,
+                     makeVariable<double>(Dims{Dim::Y}, Shape{5},
+                                          Values{1.5, 2.5, 3.5, 4.5, 5.5}));
+  EXPECT_EQ(dataset::histogram(dense, edges2), expected);
+}
+
 TEST(HistogramTest, drops_other_event_coords) {
   auto events = make_1d_events_default_weights();
   events.coords().set(Dim("pulse-time"), events.coords()[Dim::Y]);

--- a/dataset/variable_reduction.cpp
+++ b/dataset/variable_reduction.cpp
@@ -64,15 +64,11 @@ VariableView mean(const VariableConstView &var, const Dim dim,
 /// depend on the reduction dimension. Returns an invalid (empty) variable if
 /// there is no irreducible mask.
 Variable irreducible_mask(const MasksConstView &masks, const Dim dim) {
-  Variable mask_union;
-  for (const auto &mask : masks) {
-    if (mask.second.dims().contains(dim)) {
-      mask_union =
-          (mask_union ? mask_union : makeVariable<bool>(Values{false})) |
-          mask.second;
-    }
-  }
-  return mask_union;
+  Variable union_;
+  for (const auto &mask : masks)
+    if (mask.second.dims().contains(dim))
+      union_ = union_ ? union_ | mask.second : Variable(mask.second);
+  return union_;
 }
 
 /// Merges all the masks that have all their dimensions found in the given set

--- a/dataset/variable_reduction.cpp
+++ b/dataset/variable_reduction.cpp
@@ -17,51 +17,43 @@ Variable flatten(const VariableConstView &var, const Dim dim,
   auto dims = var.dims();
   dims.erase(dim);
   Variable flattened(var, dims);
-  const auto mask = ~irreducible_mask(masks, dim);
+  auto mask = irreducible_mask(masks, dim);
+  if (mask)
+    mask = ~std::move(mask);
+  else
+    mask = makeVariable<bool>(Values{true});
   flatten_impl(flattened, var, mask);
   return flattened;
 }
 
 Variable sum(const VariableConstView &var, const Dim dim,
              const MasksConstView &masks) {
-  if (!masks.empty()) {
-    const auto mask_union = irreducible_mask(masks, dim);
-    if (mask_union.dims().contains(dim))
-      return sum(var * ~mask_union, dim);
-  }
+  if (const auto mask_union = irreducible_mask(masks, dim))
+    return sum(var * ~mask_union, dim);
   return sum(var, dim);
 }
 
 VariableView sum(const VariableConstView &var, const Dim dim,
                  const MasksConstView &masks, const VariableView &out) {
-  if (!masks.empty()) {
-    const auto mask_union = irreducible_mask(masks, dim);
-    if (mask_union.dims().contains(dim))
-      return sum(var * ~mask_union, dim, out);
-  }
+  if (const auto mask_union = irreducible_mask(masks, dim))
+    return sum(var * ~mask_union, dim, out);
   return sum(var, dim, out);
 }
 
 Variable mean(const VariableConstView &var, const Dim dim,
               const MasksConstView &masks) {
-  if (!masks.empty()) {
-    const auto mask_union = irreducible_mask(masks, dim);
-    if (mask_union.dims().contains(dim)) {
-      const auto masks_sum = sum(mask_union, dim);
-      return mean_impl(var * ~mask_union, dim, masks_sum);
-    }
+  if (const auto mask_union = irreducible_mask(masks, dim)) {
+    const auto masks_sum = sum(mask_union, dim);
+    return mean_impl(var * ~mask_union, dim, masks_sum);
   }
   return mean(var, dim);
 }
 
 VariableView mean(const VariableConstView &var, const Dim dim,
                   const MasksConstView &masks, const VariableView &out) {
-  if (!masks.empty()) {
-    const auto mask_union = irreducible_mask(masks, dim);
-    if (mask_union.dims().contains(dim)) {
-      const auto masks_sum = sum(mask_union, dim);
-      return mean_impl(var * ~mask_union, dim, masks_sum, out);
-    }
+  if (const auto mask_union = irreducible_mask(masks, dim)) {
+    const auto masks_sum = sum(mask_union, dim);
+    return mean_impl(var * ~mask_union, dim, masks_sum, out);
   }
   return mean(var, dim, out);
 }
@@ -69,12 +61,15 @@ VariableView mean(const VariableConstView &var, const Dim dim,
 /// Returns the union of all masks with irreducible dimension `dim`.
 ///
 /// Irreducible means that a reduction operation must apply these masks since
-/// depend on the reduction dimensiom.
+/// depend on the reduction dimension. Returns an invalid (empty) variable if
+/// there is no irreducible mask.
 Variable irreducible_mask(const MasksConstView &masks, const Dim dim) {
-  auto mask_union = makeVariable<bool>(Values{false});
+  Variable mask_union;
   for (const auto &mask : masks) {
     if (mask.second.dims().contains(dim)) {
-      mask_union = mask_union | mask.second;
+      mask_union =
+          (mask_union ? mask_union : makeVariable<bool>(Values{false})) |
+          mask.second;
     }
   }
   return mask_union;

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -472,19 +472,6 @@ void init_dataset(py::module &m) {
 
   m.def(
       "histogram",
-      [](const DataArrayConstView &ds, const Variable &bins) {
-        return dataset::histogram(ds, bins);
-      },
-      py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-      R"(Returns a new DataArray with values in bins for events dims.
-
-        :param x: Data to histogram.
-        :param bins: Bin edges.
-        :return: Histogramed data.
-        :rtype: DataArray)");
-
-  m.def(
-      "histogram",
       [](const DataArrayConstView &ds, const VariableConstView &bins) {
         return dataset::histogram(ds, bins);
       },
@@ -499,19 +486,6 @@ void init_dataset(py::module &m) {
   m.def(
       "histogram",
       [](const Dataset &ds, const VariableConstView &bins) {
-        return dataset::histogram(ds, bins);
-      },
-      py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),
-      R"(Returns a new Dataset with values in bins for events dims.
-
-        :param x: Data to histogram.
-        :param bins: Bin edges.
-        :return: Histogramed data.
-        :rtype: Dataset)");
-
-  m.def(
-      "histogram",
-      [](const Dataset &ds, const Variable &bins) {
         return dataset::histogram(ds, bins);
       },
       py::arg("x"), py::arg("bins"), py::call_guard<py::gil_scoped_release>(),

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -491,7 +491,8 @@ def convert_Workspace2D_to_data_array(ws, **ignored):
     # artifact of inflexible data structures and gets in the way when working
     # with scipp.
     if len(spec_coord.values) == 1:
-        array.coords['position'] = array.coords['position'][spec_dim, 0]
+        if 'position' in array.coords:
+            array.coords['position'] = array.coords['position'][spec_dim, 0]
         array = array[spec_dim, 0].copy()
     return array
 


### PR DESCRIPTION
The changes here allow for a simple "Q1D` in scipp:

```python
# assuming `d` stores bin centers, or is event data
d = sc.neutron.convert(d, 'wavelength', 'Q')
d = sc.histogram(d, reference.coords['Q'])
d = sc.sum(d, 'spectrum')
I = d['sample']/d['norm']
```

- Support dense non-histogram data in `histogram`.
- Support wavelength to Q unit conversion.
- I opened #1119 to completely overhaul the unit tests of unit conversions. The current state is unmaintainable, but the refactor done here opens a pathway for better testing. Note that I did therefore not a a test for the Q conversion here, since it would be rewritten from scratch anyway.