### PR TITLE
Fix mantid compat validate unit rejecting correct inputs

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -805,13 +805,16 @@ def validate_dim_and_get_mantid_string(unit_dim):
         'Q^2': "QSquared",
     }
 
-    if unit_dim not in known_units.keys():
+    user_k = str(unit_dim).casefold()
+    known_units = {k.casefold(): v for k, v in known_units.items()}
+
+    if user_k not in known_units:
         raise RuntimeError("Axis unit not currently supported."
                            "Possible values are: {}, "
                            "got '{}'. ".format([k for k in known_units.keys()],
                                                unit_dim))
     else:
-        return known_units[unit_dim]
+        return known_units[user_k]
 
 
 def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -466,6 +466,18 @@ class TestMantidConversion(unittest.TestCase):
         self.assertTrue(
             np.allclose(a, q.to_rotation_matrix().dot(b), rtol=0.0, atol=1e-9))
 
+    def test_validate_units(self):
+        acceptable = ["wavelength", sc.Dim.Wavelength]
+        for i in acceptable:
+            ret = mantidcompat.validate_dim_and_get_mantid_string(i)
+            self.assertEqual(ret, "Wavelength")
+
+    def test_validate_units_throws(self):
+        not_acceptable = [None, "None", "wavlength", 1, 1.0, ["wavelength"]]
+        for i in not_acceptable:
+            with self.assertRaises(RuntimeError):
+                mantidcompat.validate_dim_and_get_mantid_string(i)
+
 
 @pytest.mark.skipif(not mantid_is_available(),
                     reason='Mantid framework is unavailable')


### PR DESCRIPTION
When unit validation was invoked (by 'to_workspace_2d') it was rejecting
correct units since they were Dim.foo types instead of str.

The original calling code used datset.dims[0] so this is should just
work with the returned type. Adds a unit test to exercise both the good
and failure paths.