### PR TITLE
Test cleanup

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -22,6 +22,7 @@ set(INC_FILES
     include/scipp/core/element/comparison.h
     include/scipp/core/element/event_operations.h
     include/scipp/core/element/geometric_operations.h
+    include/scipp/core/element/histogram.h
     include/scipp/core/element/logical.h
     include/scipp/core/element/trigonometry.h
     include/scipp/core/element/unary_operations.h

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/histogram.h"
@@ -41,7 +42,8 @@ constexpr auto variance = [](const auto &v, const scipp::index idx) {
 } // namespace
 
 static constexpr auto histogram = overloaded{
-    [](auto &data, const auto &events, const auto &weights, const auto &edges) {
+    [](const auto &data, const auto &events, const auto &weights,
+       const auto &edges) {
       // Special implementation for linear bins. Gives a 1x to 20x speedup
       // for few and many events per histogram, respectively.
       if (scipp::numeric::is_linspace(edges)) {

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Owen Arnold
+#pragma once
+
+#include <cmath>
+
+#include "scipp/common/overloaded.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/histogram.h"
+#include "scipp/core/transform_common.h"
+
+namespace scipp::core::element {
+
+namespace {
+constexpr auto value = [](const auto &v, const scipp::index idx) {
+  using V = std::decay_t<decltype(v)>;
+  if constexpr (is_ValueAndVariance_v<V>) {
+    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
+      static_cast<void>(idx);
+      return v.value;
+    } else {
+      return v.value[idx];
+    }
+  } else
+    return v.values[idx];
+};
+constexpr auto variance = [](const auto &v, const scipp::index idx) {
+  using V = std::decay_t<decltype(v)>;
+  if constexpr (is_ValueAndVariance_v<V>) {
+    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
+      static_cast<void>(idx);
+      return v.variance;
+    } else {
+      return v.variance[idx];
+    }
+  } else
+    return v.variances[idx];
+};
+} // namespace
+
+static constexpr auto histogram = overloaded{
+    [](auto &data, const auto &events, const auto &weights, const auto &edges) {
+      // Special implementation for linear bins. Gives a 1x to 20x speedup
+      // for few and many events per histogram, respectively.
+      if (scipp::numeric::is_linspace(edges)) {
+        const auto [offset, nbin, scale] = core::linear_edge_params(edges);
+        for (scipp::index i = 0; i < scipp::size(events); ++i) {
+          const auto x = events[i];
+          const double bin = (x - offset) * scale;
+          if (bin >= 0.0 && bin < nbin) {
+            const auto b = static_cast<scipp::index>(bin);
+            const auto w = value(weights, i);
+            const auto e = variance(weights, i);
+            data.value[b] += w;
+            data.variance[b] += e;
+          }
+        }
+      } else {
+        core::expect::histogram::sorted_edges(edges);
+        for (scipp::index i = 0; i < scipp::size(events); ++i) {
+          const auto x = events[i];
+          auto it = std::upper_bound(edges.begin(), edges.end(), x);
+          if (it != edges.end() && it != edges.begin()) {
+            const auto b = --it - edges.begin();
+            const auto w = value(weights, i);
+            const auto e = variance(weights, i);
+            data.value[b] += w;
+            data.variance[b] += e;
+          }
+        }
+      }
+    },
+    [](const units::Unit &events_unit, const units::Unit &weights_unit,
+       const units::Unit &edge_unit) {
+      if (events_unit != edge_unit)
+        throw except::UnitError("Bin edges must have same unit as the events "
+                                "input coordinate.");
+      if (weights_unit != units::counts && weights_unit != units::dimensionless)
+        throw except::UnitError("Weights of event data must be "
+                                "`units::counts` or `units::dimensionless`.");
+      return weights_unit;
+    },
+    transform_flags::expect_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_variance_arg<2>,
+    transform_flags::expect_no_variance_arg<3>};
+
+} // namespace scipp::core::element

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   element_comparison_test.cpp
   element_event_operations_test.cpp
   element_geometric_operations_test.cpp
+  element_histogram_test.cpp
   element_trigonometry_test.cpp
   element_unary_operations_test.cpp
   value_and_variance_test.cpp

--- a/core/test/element_histogram_test.cpp
+++ b/core/test/element_histogram_test.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/common/constants.h"
+#include "scipp/core/element/histogram.h"
+#include "scipp/units/unit.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+TEST(ElementHistogramTest, variance_flags) {
+  static_assert(std::is_base_of_v<transform_flags::expect_variance_arg_t<0>,
+                                  decltype(element::histogram)>);
+  static_assert(std::is_base_of_v<transform_flags::expect_no_variance_arg_t<1>,
+                                  decltype(element::histogram)>);
+  static_assert(std::is_base_of_v<transform_flags::expect_variance_arg_t<2>,
+                                  decltype(element::histogram)>);
+  static_assert(std::is_base_of_v<transform_flags::expect_no_variance_arg_t<3>,
+                                  decltype(element::histogram)>);
+}
+
+TEST(ElementHistogramTest, unit) {
+  // Note that this is an operator for `transform_subspan`, so the overload for
+  // units has one argument fewer than the one for data.
+  for (const auto unit : {units::counts, units::one})
+    EXPECT_EQ(element::histogram(units::m, unit, units::m), unit);
+}
+
+TEST(ElementHistogramTest, event_and_edge_unit_must_match) {
+  EXPECT_NO_THROW(element::histogram(units::m, units::counts, units::m));
+  EXPECT_NO_THROW(element::histogram(units::s, units::counts, units::s));
+  EXPECT_THROW(element::histogram(units::m, units::counts, units::s),
+               except::UnitError);
+  EXPECT_THROW(element::histogram(units::s, units::counts, units::m),
+               except::UnitError);
+}
+
+TEST(ElementHistogramTest, weight_unit_must_be_counts_or_one) {
+  EXPECT_NO_THROW(element::histogram(units::m, units::counts, units::m));
+  EXPECT_NO_THROW(element::histogram(units::m, units::one, units::m));
+  EXPECT_THROW(element::histogram(units::m, units::s, units::m),
+               except::UnitError);
+  EXPECT_THROW(element::histogram(units::m, units::m, units::m),
+               except::UnitError);
+}
+
+TEST(ElementHistogramTest, values) {
+  std::vector<double> edges{2, 4, 6};
+  std::vector<double> events{1, 2, 3, 4, 5, 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
+  std::vector<double> result_vals{0, 0};
+  std::vector<double> result_vars{0, 0};
+  element::histogram(ValueAndVariance(span(result_vals), span(result_vars)),
+                     events, ValuesAndVariances(weight_vals, weight_vars),
+                     edges);
+  EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40 + 50}));
+  EXPECT_EQ(result_vars, std::vector<double>({200 + 300, 400 + 500}));
+}

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -63,7 +63,8 @@ T GroupBy<T>::reduce(Op op, const Dim reductionDim, CoordOp coord_op) const {
   auto out = makeReductionOutput(reductionDim);
   auto mask = irreducible_mask(m_data.masks(), reductionDim);
   if (mask)
-    mask = ~std::move(mask);
+    mask = ~std::move(
+        mask); // `op` multiplies mask into data to zero masked elements
   // Apply to each group, storing result in output slice
   const auto process_groups = [&](const auto &range) {
     for (scipp::index group = range.begin(); group != range.end(); ++group) {

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -4,7 +4,7 @@
 /// @author Simon Heybrock
 #include "scipp/dataset/histogram.h"
 #include "scipp/common/numeric.h"
-#include "scipp/core/histogram.h"
+#include "scipp/core/element/histogram.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/groupby.h"
@@ -18,80 +18,6 @@ using namespace scipp::core;
 using namespace scipp::variable;
 
 namespace scipp::dataset {
-
-namespace {
-constexpr auto value = [](const auto &v, const scipp::index idx) {
-  using V = std::decay_t<decltype(v)>;
-  if constexpr (is_ValueAndVariance_v<V>) {
-    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
-      static_cast<void>(idx);
-      return v.value;
-    } else {
-      return v.value[idx];
-    }
-  } else
-    return v.values[idx];
-};
-constexpr auto variance = [](const auto &v, const scipp::index idx) {
-  using V = std::decay_t<decltype(v)>;
-  if constexpr (is_ValueAndVariance_v<V>) {
-    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
-      static_cast<void>(idx);
-      return v.variance;
-    } else {
-      return v.variance[idx];
-    }
-  } else
-    return v.variances[idx];
-};
-} // namespace
-
-static constexpr auto make_histogram = overloaded{
-    [](auto &data, const auto &events, const auto &weights, const auto &edges) {
-      // Special implementation for linear bins. Gives a 1x to 20x speedup
-      // for few and many events per histogram, respectively.
-      if (scipp::numeric::is_linspace(edges)) {
-        const auto [offset, nbin, scale] = core::linear_edge_params(edges);
-        for (scipp::index i = 0; i < scipp::size(events); ++i) {
-          const auto x = events[i];
-          const double bin = (x - offset) * scale;
-          if (bin >= 0.0 && bin < nbin) {
-            const auto b = static_cast<scipp::index>(bin);
-            const auto w = value(weights, i);
-            const auto e = variance(weights, i);
-            data.value[b] += w;
-            data.variance[b] += e;
-          }
-        }
-      } else {
-        core::expect::histogram::sorted_edges(edges);
-        for (scipp::index i = 0; i < scipp::size(events); ++i) {
-          const auto x = events[i];
-          auto it = std::upper_bound(edges.begin(), edges.end(), x);
-          if (it != edges.end() && it != edges.begin()) {
-            const auto b = --it - edges.begin();
-            const auto w = value(weights, i);
-            const auto e = variance(weights, i);
-            data.value[b] += w;
-            data.variance[b] += e;
-          }
-        }
-      }
-    },
-    [](const units::Unit &events_unit, const units::Unit &weights_unit,
-       const units::Unit &edge_unit) {
-      if (events_unit != edge_unit)
-        throw except::UnitError("Bin edges must have same unit as the events "
-                                "input coordinate.");
-      if (weights_unit != units::counts && weights_unit != units::dimensionless)
-        throw except::UnitError("Weights of event data must be "
-                                "`units::counts` or `units::dimensionless`.");
-      return weights_unit;
-    },
-    transform_flags::expect_variance_arg<0>,
-    transform_flags::expect_no_variance_arg<1>,
-    transform_flags::expect_variance_arg<2>,
-    transform_flags::expect_no_variance_arg<3>};
 
 namespace histogram_events_detail {
 template <class Out, class Coord, class Weight, class Edge>
@@ -127,7 +53,7 @@ DataArray histogram(const DataArrayConstView &events,
                          args<double, float, event_list<double>, float>,
                          args<double, double, event_list<float>, double>>>(
               dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
-              events_.data(), binEdges_, make_histogram);
+              events_.data(), binEdges_, element::histogram);
         },
         dim_of_coord(events.coords()[dim], dim), dim, binEdges);
   } else if (!is_histogram(events, dim)) {
@@ -147,7 +73,7 @@ DataArray histogram(const DataArrayConstView &events,
                          args<float, float, float, float>>>(
               dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
               mask ? VariableConstView(masked) : events_.data(), binEdges_,
-              make_histogram);
+              element::histogram);
         },
         dim, binEdges);
   } else {

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -3,7 +3,6 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/dataset/histogram.h"
-#include "scipp/common/numeric.h"
 #include "scipp/core/element/histogram.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   except_test.cpp
   groupby_test.cpp
   histogram_test.cpp
+  masks_view_test.cpp
   mean_test.cpp
   merge_test.cpp
   rebin_test.cpp

--- a/dataset/test/masks_view_test.cpp
+++ b/dataset/test/masks_view_test.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/dimensions.h"
+#include "scipp/dataset/dataset.h"
+#include "test_macros.h"
+
+using namespace scipp;
+
+TEST(MasksViewTest, irreducible_mask) {
+  DataArray a(
+      makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{2, 3, 4}));
+  const auto x =
+      makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{true, false});
+  const auto y =
+      makeVariable<bool>(Dims{Dim::Y}, Shape{3}, Values{true, false, false});
+  a.masks().set("x", x);
+  a.masks().set("y", y);
+  EXPECT_EQ(irreducible_mask(a.masks(), Dim::X), x);
+  EXPECT_EQ(irreducible_mask(a.masks(), Dim::Y), y);
+  a.masks().set("xy", makeVariable<bool>(
+                          Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                          Values{false, false, false, false, true, false}));
+  EXPECT_EQ(irreducible_mask(a.masks(), Dim::X),
+            makeVariable<bool>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                               Values{true, true, true, false, true, false}));
+  EXPECT_EQ(irreducible_mask(a.masks(), Dim::Y),
+            makeVariable<bool>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                               Values{true, false, false, true, true, false}));
+  EXPECT_EQ(irreducible_mask(a.masks(), Dim::Z), Variable{});
+}

--- a/dataset/test/masks_view_test.cpp
+++ b/dataset/test/masks_view_test.cpp
@@ -27,7 +27,7 @@ TEST(MasksViewTest, irreducible_mask) {
             makeVariable<bool>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                Values{true, true, true, false, true, false}));
   // Combined masks returned from irreducible_mask may be transposed in this
-  // case, if `"y"` combes first in unordered map, so we cannot use == for
+  // case, if `"y"` comes first in unordered map, so we cannot use == for
   // comparison. XOR with expected returns result with order of first argument,
   // so we can compare with none without worrying about potential transpose.
   const auto combined_y_and_xy_mask =

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -11,8 +11,9 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/dataset_util.h"
 
+#include "scipp/neutron/constants.h"
+#include "scipp/neutron/conversions.h"
 #include "scipp/neutron/convert.h"
-#include "scipp/neutron/convert_detail.h"
 
 using namespace scipp::variable;
 using namespace scipp::dataset;

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -5,7 +5,6 @@
 #include "scipp/core/element/arg_list.h"
 
 #include "scipp/variable/event.h"
-#include "scipp/variable/operations.h"
 #include "scipp/variable/transform.h"
 
 #include "scipp/dataset/dataset.h"

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -150,7 +150,7 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
     return convert_generic(std::move(d), from, to, conversions::wavelength_to_q,
                            constants::wavelength_to_q(d));
 
-  throw std::runtime_error(
+  throw except::UnitError(
       "Conversion between requested dimensions not implemented yet.");
 }
 

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -125,24 +125,24 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
       core::expect::notCountDensity(item.unit());
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
     return convert_with_factor(std::move(d), from, to,
-                               constants::tofToDSpacing(d));
+                               constants::tof_to_dspacing(d));
   if ((from == Dim::DSpacing) && (to == Dim::Tof))
     return convert_with_factor(std::move(d), from, to,
-                               reciprocal(constants::tofToDSpacing(d)));
+                               reciprocal(constants::tof_to_dspacing(d)));
 
   if ((from == Dim::Tof) && (to == Dim::Wavelength))
     return convert_with_factor(std::move(d), from, to,
-                               constants::tofToWavelength(d));
+                               constants::tof_to_wavelength(d));
   if ((from == Dim::Wavelength) && (to == Dim::Tof))
     return convert_with_factor(std::move(d), from, to,
-                               reciprocal(constants::tofToWavelength(d)));
+                               reciprocal(constants::tof_to_wavelength(d)));
 
   if ((from == Dim::Tof) && (to == Dim::Energy))
     return convert_generic(std::move(d), from, to, conversions::tof_to_energy,
-                           constants::tofToEnergy(d));
+                           constants::tof_to_energy(d));
   if ((from == Dim::Energy) && (to == Dim::Tof))
     return convert_generic(std::move(d), from, to, conversions::energy_to_tof,
-                           constants::tofToEnergy(d));
+                           constants::tof_to_energy(d));
 
   // lambda <-> Q conversion is symmetric
   if (((from == Dim::Wavelength) && (to == Dim::Q)) ||

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -2,12 +2,6 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include <boost/units/systems/si/codata/electromagnetic_constants.hpp>
-#include <boost/units/systems/si/codata/neutron_constants.hpp>
-#include <boost/units/systems/si/codata/universal_constants.hpp>
-
-#include "scipp/common/constants.h"
-
 #include "scipp/core/element/arg_list.h"
 
 #include "scipp/variable/event.h"
@@ -17,28 +11,13 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/dataset_util.h"
 
-#include "scipp/neutron/beamline.h"
 #include "scipp/neutron/convert.h"
+#include "scipp/neutron/convert_detail.h"
 
 using namespace scipp::variable;
 using namespace scipp::dataset;
 
 namespace scipp::neutron {
-
-const auto tof_to_s = boost::units::quantity<boost::units::si::time>(
-                          1.0 * units::boost_units::us) /
-                      units::boost_units::us;
-const auto J_to_meV =
-    units::boost_units::meV / boost::units::quantity<boost::units::si::energy>(
-                                  1.0 * units::boost_units::meV);
-const auto m_to_angstrom = units::boost_units::angstrom /
-                           boost::units::quantity<boost::units::si::length>(
-                               1.0 * units::boost_units::angstrom);
-// In tof-to-energy conversions we *divide* by time-of-flight (squared), so the
-// tof_to_s factor is in the denominator.
-const auto tofToEnergyPhysicalConstants =
-    0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
-    (tof_to_s * tof_to_s);
 
 template <class T, class Op>
 T convert_generic(T &&d, const Dim from, const Dim to, Op op,
@@ -66,50 +45,6 @@ static T convert_with_factor(T &&d, const Dim from, const Dim to,
   return convert_generic(
       std::forward<T>(d), from, to,
       [](auto &coord, const auto &c) { coord *= c; }, factor);
-}
-
-template <class T> auto tofToDSpacing(const T &d) {
-  const auto &sourcePos = source_position(d);
-  const auto &samplePos = sample_position(d);
-
-  auto beam = samplePos - sourcePos;
-  const auto l1 = norm(beam);
-  beam /= l1;
-  auto scattered = neutron::position(d) - samplePos;
-  const auto l2 = norm(scattered);
-  scattered /= l2;
-
-  // l_total = l1 + l2
-  auto conversionFactor(l1 + l2);
-
-  conversionFactor *= Variable(2.0 * boost::units::si::constants::codata::m_n /
-                               boost::units::si::constants::codata::h /
-                               (m_to_angstrom * tof_to_s));
-  conversionFactor *=
-      sqrt(0.5 * units::one * (1.0 * units::one - dot(beam, scattered)));
-
-  return reciprocal(conversionFactor);
-}
-
-template <class T> static auto tofToWavelength(const T &d) {
-  return Variable(tof_to_s * m_to_angstrom *
-                  boost::units::si::constants::codata::h /
-                  boost::units::si::constants::codata::m_n) /
-         neutron::flight_path_length(d);
-}
-
-template <class T> auto tofToEnergy(const T &d) {
-  // l_total = l1 + l2
-  auto conversionFactor = neutron::flight_path_length(d);
-  // l_total^2
-  conversionFactor *= conversionFactor;
-  conversionFactor *= Variable(tofToEnergyPhysicalConstants);
-  return conversionFactor;
-}
-
-template <class T> auto wavelengthToQ(const T &d) {
-  return sin(neutron::scattering_angle(d)) *
-         (4.0 * scipp::pi<double> * units::one);
 }
 
 /*
@@ -189,35 +124,31 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
     if (item.hasData())
       core::expect::notCountDensity(item.unit());
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
-    return convert_with_factor(std::move(d), from, to, tofToDSpacing(d));
+    return convert_with_factor(std::move(d), from, to,
+                               constants::tofToDSpacing(d));
   if ((from == Dim::DSpacing) && (to == Dim::Tof))
     return convert_with_factor(std::move(d), from, to,
-                               reciprocal(tofToDSpacing(d)));
+                               reciprocal(constants::tofToDSpacing(d)));
 
   if ((from == Dim::Tof) && (to == Dim::Wavelength))
-    return convert_with_factor(std::move(d), from, to, tofToWavelength(d));
+    return convert_with_factor(std::move(d), from, to,
+                               constants::tofToWavelength(d));
   if ((from == Dim::Wavelength) && (to == Dim::Tof))
     return convert_with_factor(std::move(d), from, to,
-                               reciprocal(tofToWavelength(d)));
+                               reciprocal(constants::tofToWavelength(d)));
 
   if ((from == Dim::Tof) && (to == Dim::Energy))
-    return convert_generic(
-        std::move(d), from, to,
-        [](auto &coord, const auto &c) { coord = c / (coord * coord); },
-        tofToEnergy(d));
+    return convert_generic(std::move(d), from, to, conversions::tof_to_energy,
+                           constants::tofToEnergy(d));
   if ((from == Dim::Energy) && (to == Dim::Tof))
-    return convert_generic(
-        std::move(d), from, to,
-        [](auto &coord, const auto &c) { coord = sqrt(c / coord); },
-        tofToEnergy(d));
+    return convert_generic(std::move(d), from, to, conversions::energy_to_tof,
+                           constants::tofToEnergy(d));
 
   // lambda <-> Q conversion is symmetric
   if (((from == Dim::Wavelength) && (to == Dim::Q)) ||
       ((from == Dim::Q) && (to == Dim::Wavelength)))
-    return convert_generic(
-        std::move(d), from, to,
-        [](auto &coord, const auto &c) { coord = c / coord; },
-        wavelengthToQ(d));
+    return convert_generic(std::move(d), from, to, conversions::wavelength_to_q,
+                           constants::wavelengthToQ(d));
 
   throw std::runtime_error(
       "Conversion between requested dimensions not implemented yet.");

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -123,6 +123,12 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
   for (const auto &item : iter(d))
     if (item.hasData())
       core::expect::notCountDensity(item.unit());
+  // This will need to be cleanup up in the future, but it is unclear how to do
+  // so in a future-proof way. Some sort of double-dynamic dispatch based on
+  // `from` and `to` will likely be required (with conversions helpers created
+  // by a dynamic factory based on `Dim`). Conceptually we are dealing with a
+  // bidirectional graph, and we would like to be able to find the shortest
+  // paths between any two points, without defining all-to-all connections.
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
     return convert_with_factor(std::move(d), from, to,
                                constants::tof_to_dspacing(d));

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -148,7 +148,7 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
   if (((from == Dim::Wavelength) && (to == Dim::Q)) ||
       ((from == Dim::Q) && (to == Dim::Wavelength)))
     return convert_generic(std::move(d), from, to, conversions::wavelength_to_q,
-                           constants::wavelengthToQ(d));
+                           constants::wavelength_to_q(d));
 
   throw std::runtime_error(
       "Conversion between requested dimensions not implemented yet.");

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -129,6 +129,10 @@ template <class T> T convert_impl(T d, const Dim from, const Dim to) {
   // by a dynamic factory based on `Dim`). Conceptually we are dealing with a
   // bidirectional graph, and we would like to be able to find the shortest
   // paths between any two points, without defining all-to-all connections.
+  // Approaches based on, e.g., a map of conversions and constants is also
+  // tricky, since in particular the conversions are generic lambdas (passable
+  // to `transform`) and are not readily stored as function pointers or
+  // std::function.
   if ((from == Dim::Tof) && (to == Dim::DSpacing))
     return convert_with_factor(std::move(d), from, to,
                                constants::tof_to_dspacing(d));

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -12,6 +12,8 @@
 
 #include "scipp/units/unit.h"
 
+#include "scipp/variable/operations.h"
+
 #include "scipp/neutron/beamline.h"
 
 namespace scipp::neutron {

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -16,9 +16,7 @@
 
 #include "scipp/neutron/beamline.h"
 
-namespace scipp::neutron {
-
-namespace constants {
+namespace scipp::neutron::constants {
 
 constexpr auto tof_to_s = boost::units::quantity<boost::units::si::time>(
                               1.0 * units::boost_units::us) /
@@ -29,6 +27,7 @@ constexpr auto J_to_meV =
 constexpr auto m_to_angstrom = units::boost_units::angstrom /
                                boost::units::quantity<boost::units::si::length>(
                                    1.0 * units::boost_units::angstrom);
+
 // In tof-to-energy conversions we *divide* by time-of-flight (squared), so the
 // tof_to_s factor is in the denominator.
 constexpr auto tof_to_energy_physical_constants =
@@ -38,6 +37,10 @@ constexpr auto tof_to_energy_physical_constants =
 constexpr auto tof_to_dspacing_physical_constants =
     2.0 * boost::units::si::constants::codata::m_n /
     boost::units::si::constants::codata::h / (m_to_angstrom * tof_to_s);
+
+constexpr auto tof_to_wavelength_physical_constants =
+    tof_to_s * m_to_angstrom * boost::units::si::constants::codata::h /
+    boost::units::si::constants::codata::m_n;
 
 template <class T> auto tof_to_dspacing(const T &d) {
   const auto &sourcePos = source_position(d);
@@ -56,14 +59,12 @@ template <class T> auto tof_to_dspacing(const T &d) {
   conversionFactor *= Variable(tof_to_dspacing_physical_constants * sqrt(0.5));
   conversionFactor *= sqrt(1.0 * units::one - dot(beam, scattered));
 
-  return reciprocal(conversionFactor);
+  reciprocal(conversionFactor, conversionFactor);
+  return conversionFactor;
 }
 
 template <class T> static auto tof_to_wavelength(const T &d) {
-  return Variable(tof_to_s * m_to_angstrom *
-                  boost::units::si::constants::codata::h /
-                  boost::units::si::constants::codata::m_n) /
-         flight_path_length(d);
+  return Variable(tof_to_wavelength_physical_constants) / flight_path_length(d);
 }
 
 template <class T> auto tof_to_energy(const T &d) {
@@ -79,6 +80,4 @@ template <class T> auto wavelength_to_q(const T &d) {
   return sin(scattering_angle(d)) * (4.0 * scipp::pi<double> * units::one);
 }
 
-} // namespace constants
-
-} // namespace scipp::neutron
+} // namespace scipp::neutron::constants

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -20,22 +20,26 @@ namespace scipp::neutron {
 
 namespace constants {
 
-const auto tof_to_s = boost::units::quantity<boost::units::si::time>(
-                          1.0 * units::boost_units::us) /
-                      units::boost_units::us;
-const auto J_to_meV =
+constexpr auto tof_to_s = boost::units::quantity<boost::units::si::time>(
+                              1.0 * units::boost_units::us) /
+                          units::boost_units::us;
+constexpr auto J_to_meV =
     units::boost_units::meV / boost::units::quantity<boost::units::si::energy>(
                                   1.0 * units::boost_units::meV);
-const auto m_to_angstrom = units::boost_units::angstrom /
-                           boost::units::quantity<boost::units::si::length>(
-                               1.0 * units::boost_units::angstrom);
+constexpr auto m_to_angstrom = units::boost_units::angstrom /
+                               boost::units::quantity<boost::units::si::length>(
+                                   1.0 * units::boost_units::angstrom);
 // In tof-to-energy conversions we *divide* by time-of-flight (squared), so the
 // tof_to_s factor is in the denominator.
-const auto tofToEnergyPhysicalConstants =
+constexpr auto tof_to_energy_physical_constants =
     0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
     (tof_to_s * tof_to_s);
 
-template <class T> auto tofToDSpacing(const T &d) {
+constexpr auto tof_to_dspacing_physical_constants =
+    2.0 * boost::units::si::constants::codata::m_n /
+    boost::units::si::constants::codata::h / (m_to_angstrom * tof_to_s);
+
+template <class T> auto tof_to_dspacing(const T &d) {
   const auto &sourcePos = source_position(d);
   const auto &samplePos = sample_position(d);
 
@@ -49,28 +53,25 @@ template <class T> auto tofToDSpacing(const T &d) {
   // l_total = l1 + l2
   auto conversionFactor(l1 + l2);
 
-  conversionFactor *= Variable(2.0 * boost::units::si::constants::codata::m_n /
-                               boost::units::si::constants::codata::h /
-                               (m_to_angstrom * tof_to_s));
-  conversionFactor *=
-      sqrt(0.5 * units::one * (1.0 * units::one - dot(beam, scattered)));
+  conversionFactor *= Variable(tof_to_dspacing_physical_constants * sqrt(0.5));
+  conversionFactor *= sqrt(1.0 * units::one - dot(beam, scattered));
 
   return reciprocal(conversionFactor);
 }
 
-template <class T> static auto tofToWavelength(const T &d) {
+template <class T> static auto tof_to_wavelength(const T &d) {
   return Variable(tof_to_s * m_to_angstrom *
                   boost::units::si::constants::codata::h /
                   boost::units::si::constants::codata::m_n) /
          flight_path_length(d);
 }
 
-template <class T> auto tofToEnergy(const T &d) {
+template <class T> auto tof_to_energy(const T &d) {
   // l_total = l1 + l2
   auto conversionFactor = flight_path_length(d);
   // l_total^2
   conversionFactor *= conversionFactor;
-  conversionFactor *= Variable(tofToEnergyPhysicalConstants);
+  conversionFactor *= Variable(tof_to_energy_physical_constants);
   return conversionFactor;
 }
 

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -42,7 +42,7 @@ template <class T> auto tofToDSpacing(const T &d) {
   auto beam = samplePos - sourcePos;
   const auto l1 = norm(beam);
   beam /= l1;
-  auto scattered = neutron::position(d) - samplePos;
+  auto scattered = position(d) - samplePos;
   const auto l2 = norm(scattered);
   scattered /= l2;
 
@@ -62,21 +62,20 @@ template <class T> static auto tofToWavelength(const T &d) {
   return Variable(tof_to_s * m_to_angstrom *
                   boost::units::si::constants::codata::h /
                   boost::units::si::constants::codata::m_n) /
-         neutron::flight_path_length(d);
+         flight_path_length(d);
 }
 
 template <class T> auto tofToEnergy(const T &d) {
   // l_total = l1 + l2
-  auto conversionFactor = neutron::flight_path_length(d);
+  auto conversionFactor = flight_path_length(d);
   // l_total^2
   conversionFactor *= conversionFactor;
   conversionFactor *= Variable(tofToEnergyPhysicalConstants);
   return conversionFactor;
 }
 
-template <class T> auto wavelengthToQ(const T &d) {
-  return sin(neutron::scattering_angle(d)) *
-         (4.0 * scipp::pi<double> * units::one);
+template <class T> auto wavelength_to_q(const T &d) {
+  return sin(scattering_angle(d)) * (4.0 * scipp::pi<double> * units::one);
 }
 
 } // namespace constants

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -16,20 +16,6 @@
 
 namespace scipp::neutron {
 
-namespace conversions {
-
-constexpr auto tof_to_energy = [](auto &coord, const auto &c) {
-  coord = c / (coord * coord);
-};
-constexpr auto energy_to_tof = [](auto &coord, const auto &c) {
-  coord = sqrt(c / coord);
-};
-constexpr auto wavelength_to_q = [](auto &coord, const auto &c) {
-  coord = c / coord;
-};
-
-} // namespace conversions
-
 namespace constants {
 
 const auto tof_to_s = boost::units::quantity<boost::units::si::time>(

--- a/neutron/include/scipp/neutron/conversions.h
+++ b/neutron/include/scipp/neutron/conversions.h
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
+#include <cmath>
 
 namespace scipp::neutron::conversions {
 
@@ -10,6 +11,7 @@ constexpr auto tof_to_energy = [](auto &coord, const auto &c) {
   coord = c / (coord * coord);
 };
 constexpr auto energy_to_tof = [](auto &coord, const auto &c) {
+  using std::sqrt;
   coord = sqrt(c / coord);
 };
 constexpr auto wavelength_to_q = [](auto &coord, const auto &c) {

--- a/neutron/include/scipp/neutron/conversions.h
+++ b/neutron/include/scipp/neutron/conversions.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+namespace scipp::neutron::conversions {
+
+constexpr auto tof_to_energy = [](auto &coord, const auto &c) {
+  coord = c / (coord * coord);
+};
+constexpr auto energy_to_tof = [](auto &coord, const auto &c) {
+  coord = sqrt(c / coord);
+};
+constexpr auto wavelength_to_q = [](auto &coord, const auto &c) {
+  coord = c / coord;
+};
+
+} // namespace scipp::neutron::conversions

--- a/neutron/include/scipp/neutron/convert_detail.h
+++ b/neutron/include/scipp/neutron/convert_detail.h
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <boost/units/systems/si/codata/electromagnetic_constants.hpp>
+#include <boost/units/systems/si/codata/neutron_constants.hpp>
+#include <boost/units/systems/si/codata/universal_constants.hpp>
+
+#include "scipp/common/constants.h"
+
+#include "scipp/units/unit.h"
+
+#include "scipp/neutron/beamline.h"
+
+namespace scipp::neutron {
+
+namespace conversions {
+
+constexpr auto tof_to_energy = [](auto &coord, const auto &c) {
+  coord = c / (coord * coord);
+};
+constexpr auto energy_to_tof = [](auto &coord, const auto &c) {
+  coord = sqrt(c / coord);
+};
+constexpr auto wavelength_to_q = [](auto &coord, const auto &c) {
+  coord = c / coord;
+};
+
+} // namespace conversions
+
+namespace constants {
+
+const auto tof_to_s = boost::units::quantity<boost::units::si::time>(
+                          1.0 * units::boost_units::us) /
+                      units::boost_units::us;
+const auto J_to_meV =
+    units::boost_units::meV / boost::units::quantity<boost::units::si::energy>(
+                                  1.0 * units::boost_units::meV);
+const auto m_to_angstrom = units::boost_units::angstrom /
+                           boost::units::quantity<boost::units::si::length>(
+                               1.0 * units::boost_units::angstrom);
+// In tof-to-energy conversions we *divide* by time-of-flight (squared), so the
+// tof_to_s factor is in the denominator.
+const auto tofToEnergyPhysicalConstants =
+    0.5 * boost::units::si::constants::codata::m_n * J_to_meV /
+    (tof_to_s * tof_to_s);
+
+template <class T> auto tofToDSpacing(const T &d) {
+  const auto &sourcePos = source_position(d);
+  const auto &samplePos = sample_position(d);
+
+  auto beam = samplePos - sourcePos;
+  const auto l1 = norm(beam);
+  beam /= l1;
+  auto scattered = neutron::position(d) - samplePos;
+  const auto l2 = norm(scattered);
+  scattered /= l2;
+
+  // l_total = l1 + l2
+  auto conversionFactor(l1 + l2);
+
+  conversionFactor *= Variable(2.0 * boost::units::si::constants::codata::m_n /
+                               boost::units::si::constants::codata::h /
+                               (m_to_angstrom * tof_to_s));
+  conversionFactor *=
+      sqrt(0.5 * units::one * (1.0 * units::one - dot(beam, scattered)));
+
+  return reciprocal(conversionFactor);
+}
+
+template <class T> static auto tofToWavelength(const T &d) {
+  return Variable(tof_to_s * m_to_angstrom *
+                  boost::units::si::constants::codata::h /
+                  boost::units::si::constants::codata::m_n) /
+         neutron::flight_path_length(d);
+}
+
+template <class T> auto tofToEnergy(const T &d) {
+  // l_total = l1 + l2
+  auto conversionFactor = neutron::flight_path_length(d);
+  // l_total^2
+  conversionFactor *= conversionFactor;
+  conversionFactor *= Variable(tofToEnergyPhysicalConstants);
+  return conversionFactor;
+}
+
+template <class T> auto wavelengthToQ(const T &d) {
+  return sin(neutron::scattering_angle(d)) *
+         (4.0 * scipp::pi<double> * units::one);
+}
+
+} // namespace constants
+
+} // namespace scipp::neutron

--- a/neutron/test/CMakeLists.txt
+++ b/neutron/test/CMakeLists.txt
@@ -3,8 +3,9 @@
 set(TARGET_NAME "scipp-neutron-test")
 add_dependencies(all-tests ${TARGET_NAME})
 add_executable(
-  ${TARGET_NAME} EXCLUDE_FROM_ALL beamline_test.cpp convert_test.cpp
-                                  convert_with_calibration_test.cpp
+  ${TARGET_NAME} EXCLUDE_FROM_ALL
+  beamline_test.cpp constants_test.cpp conversions_test.cpp convert_test.cpp
+  convert_with_calibration_test.cpp
 )
 include_directories(SYSTEM ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR})
 target_link_libraries(

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -75,15 +75,12 @@ TEST_F(ConstantsTest, tof_to_dspacing) {
 
 TEST_F(ConstantsTest, tof_to_wavelength) {
   EXPECT_EQ(constants::tof_to_wavelength(dummy),
-            Variable(constants::tof_to_s * constants::m_to_angstrom *
-                     boost::units::si::constants::codata::h /
-                     boost::units::si::constants::codata::m_n) /
-                L);
+            Variable(constants::tof_to_wavelength_physical_constants) / L);
 }
 
 TEST_F(ConstantsTest, tof_to_energy) {
   EXPECT_EQ(constants::tof_to_energy(dummy),
-            L * L * Variable(constants::tof_to_dspacing_physical_constants));
+            L * L * Variable(constants::tof_to_energy_physical_constants));
 }
 
 TEST_F(ConstantsTest, wavelength_to_q) {

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -2,8 +2,27 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/variable/arithmetic.h"
+
 #include "scipp/neutron/constants.h"
 
 using namespace scipp;
 using namespace scipp::neutron;
 
+namespace mock {
+
+struct Dummy {};
+
+Variable scattering_angle(const Dummy &) { return 0.123 * units::rad; }
+} // namespace mock
+
+class ConstantsTest : public ::testing::Test {
+protected:
+  mock::Dummy dummy;
+  const Variable scattering_angle = mock::scattering_angle(dummy);
+};
+
+TEST_F(ConstantsTest, wavelength_to_q) {
+  EXPECT_EQ(constants::wavelength_to_q(dummy),
+            sin(scattering_angle) * (4.0 * scipp::pi<double> * units::one));
+}

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -13,16 +13,80 @@ namespace mock {
 
 struct Dummy {};
 
-Variable scattering_angle(const Dummy &) { return 0.123 * units::rad; }
+Variable source_position(const Dummy &) {
+  return makeVariable<Eigen::Vector3d>(Values{Eigen::Vector3d{1.0, 2.0, 3.0}},
+                                       units::m);
+}
+
+Variable sample_position(const Dummy &) {
+  return makeVariable<Eigen::Vector3d>(Values{Eigen::Vector3d{2.0, 4.0, 8.0}},
+                                       units::m);
+}
+
+Variable position(const Dummy &) {
+  return makeVariable<Eigen::Vector3d>(
+      Dims{Dim::X}, Shape{2},
+      Values{Eigen::Vector3d{2.1, 4.1, 8.2}, Eigen::Vector3d{2.2, 4.3, 8.4}},
+      units::m);
+}
+
+Variable scattering_angle(const Dummy &) {
+  // Note: Not related to actual positions.
+  return 0.123 * units::rad;
+}
+
+Variable flight_path_length(const Dummy &dummy) {
+  return norm(sample_position(dummy) - source_position(dummy)) +
+         norm((position(dummy) - sample_position(dummy)));
+}
+
 } // namespace mock
 
 class ConstantsTest : public ::testing::Test {
 protected:
   mock::Dummy dummy;
-  const Variable scattering_angle = mock::scattering_angle(dummy);
+  const Variable theta = mock::scattering_angle(dummy);
+  const Variable L = mock::flight_path_length(dummy);
+  const Variable source = mock::source_position(dummy);
+  const Variable sample = mock::sample_position(dummy);
+  const Variable det = mock::position(dummy);
+
+  Variable normalized_beam() const {
+    auto beam = sample - source;
+    beam /= norm(beam);
+    return beam;
+  }
+
+  Variable normalized_scatter() const {
+    auto scatter = det - sample;
+    scatter /= norm(scatter);
+    return scatter;
+  }
 };
+
+TEST_F(ConstantsTest, tof_to_dspacing) {
+  EXPECT_EQ(constants::tof_to_dspacing(dummy),
+            reciprocal(L *
+                       Variable(constants::tof_to_dspacing_physical_constants *
+                                sqrt(0.5)) *
+                       sqrt(1.0 * units::one -
+                            dot(normalized_beam(), normalized_scatter()))));
+}
+
+TEST_F(ConstantsTest, tof_to_wavelength) {
+  EXPECT_EQ(constants::tof_to_wavelength(dummy),
+            Variable(constants::tof_to_s * constants::m_to_angstrom *
+                     boost::units::si::constants::codata::h /
+                     boost::units::si::constants::codata::m_n) /
+                L);
+}
+
+TEST_F(ConstantsTest, tof_to_energy) {
+  EXPECT_EQ(constants::tof_to_energy(dummy),
+            L * L * Variable(constants::tof_to_dspacing_physical_constants));
+}
 
 TEST_F(ConstantsTest, wavelength_to_q) {
   EXPECT_EQ(constants::wavelength_to_q(dummy),
-            sin(scattering_angle) * (4.0 * scipp::pi<double> * units::one));
+            sin(theta) * (4.0 * scipp::pi<double> * units::one));
 }

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/neutron/constants.h"
+
+using namespace scipp;
+using namespace scipp::neutron;
+

--- a/neutron/test/conversions_test.cpp
+++ b/neutron/test/conversions_test.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/neutron/conversions.h"
+
+using namespace scipp;
+using namespace scipp::neutron;
+
+class ConversionsTest : public ::testing::Test {
+protected:
+  const double coord = 1.2345;
+  const double alpha = 4.56;
+};
+
+TEST_F(ConversionsTest, tof_to_energy) {
+  auto inout = coord;
+  conversions::tof_to_energy(inout, alpha);
+  EXPECT_EQ(inout, alpha / (coord * coord));
+}
+
+TEST_F(ConversionsTest, energy_to_tof) {
+  auto inout = coord;
+  conversions::energy_to_tof(inout, alpha);
+  EXPECT_EQ(inout, std::sqrt(alpha / coord));
+}
+
+TEST_F(ConversionsTest, wavelength_to_q) {
+  auto inout = coord;
+  conversions::wavelength_to_q(inout, alpha);
+  EXPECT_EQ(inout, alpha / coord);
+}

--- a/neutron/test/conversions_test.cpp
+++ b/neutron/test/conversions_test.cpp
@@ -25,8 +25,22 @@ TEST_F(ConversionsTest, energy_to_tof) {
   EXPECT_EQ(inout, std::sqrt(alpha / coord));
 }
 
+TEST_F(ConversionsTest, energy_tof_roundtrip) {
+  auto inout = coord;
+  conversions::energy_to_tof(inout, alpha);
+  conversions::tof_to_energy(inout, alpha);
+  EXPECT_EQ(inout, coord);
+}
+
 TEST_F(ConversionsTest, wavelength_to_q) {
   auto inout = coord;
   conversions::wavelength_to_q(inout, alpha);
   EXPECT_EQ(inout, alpha / coord);
+}
+
+TEST_F(ConversionsTest, wavelength_q_roundtrip) {
+  auto inout = coord;
+  conversions::wavelength_to_q(inout, alpha);
+  conversions::wavelength_to_q(inout, alpha);
+  EXPECT_EQ(inout, coord);
 }


### PR DESCRIPTION
- Tests of building blocks of unit conversions.
- Test `irreducible_mask`.
- Test histogram kernel.

More thorough test for the latter should be added, but leaving those for another time, due to higher priority work.