### PR TITLE
Sort coords/masks/attrs alphabetically when displayed

### DIFF
--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -70,6 +70,13 @@ bool comp(std::pair<std::string, VariableConstView> a,
   return a.first < b.first;
 }
 
+template <class T> auto sorted(const T &map) {
+  std::vector<std::pair<std::string, VariableConstView>> elems(map.begin(),
+                                                               map.end());
+  std::sort(elems.begin(), elems.end(), comp);
+  return elems;
+}
+
 template <class D>
 std::string do_to_string(const D &dataset, const std::string &id,
                          const Dimensions &dims) {
@@ -81,37 +88,26 @@ std::string do_to_string(const D &dataset, const std::string &id,
     s << "Coordinates:\n";
     const auto map = dataset.coords();
 
-    // We need to cast unordered_map to vector so it can be sorted
-    std::vector<std::pair<std::string, VariableConstView>> elem;
-
     // Elsewhere we just need a vector of Dataset attributes,
-    // here we need to call a function on these attributes.
+    // here we need to call a function on these attributes,
+    // so first, cast dim.name() to its own map/vector.
+    std::vector<std::pair<std::string, VariableConstView>> elem;
     for (const auto &[dim, var] : map) {
       std::pair<std::string, VariableConstView> p = {dim.name(), var};
       elem.push_back(p);
     }
-    std::sort(elem.begin(), elem.end(), comp);
-    for (const auto &[name, var] : elem)
+    for (const auto &[name, var] : sorted(elem))
       s << format_variable(name, var, dims);
   }
   if (!dataset.attrs().empty()) {
     s << "Attributes:\n";
-
-    const auto map = dataset.attrs();
-    std::vector<std::pair<std::string, VariableConstView>> elems(map.begin(),
-                                                                 map.end());
-    std::sort(elems.begin(), elems.end(), comp);
-    for (const auto &[name, var] : elems)
+    for (const auto &[name, var] : sorted(dataset.attrs()))
       s << format_variable(name, var, dims);
   }
   if (!dataset.masks().empty()) {
     s << "Masks:\n";
 
-    const auto map = dataset.masks();
-    std::vector<std::pair<std::string, VariableConstView>> elems(map.begin(),
-                                                                 map.end());
-    std::sort(elems.begin(), elems.end(), comp);
-    for (const auto &[name, var] : elems)
+    for (const auto &[name, var] : sorted(dataset.masks()))
       s << format_variable(name, var, dims);
   }
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -1,6 +1,7 @@
 # Original source from
 # https://github.com/jsignell/xarray/blob/1d960933ab252e0f79f7e050e6c9261d55568057/xarray/core/formatting_html.py
 
+import collections
 import operator
 import os
 import uuid
@@ -111,6 +112,12 @@ def _format_events(var, has_variances):
     return _make_row(", ".join([row for row in s]))
 
 
+def _ordered_dict(data):
+    data_ordered = collections.OrderedDict(
+                   sorted(data.items(), key=lambda t: str(t[0])))
+    return data_ordered
+
+
 def inline_variable_repr(var, has_variances=False):
     if is_data_events(var):
         return _format_events(var, has_variances)
@@ -168,7 +175,8 @@ def format_dims(dims, sizes, coords):
 
 def summarize_attrs_simple(attrs):
     attrs_dl = "".join(f"<dt><span>{escape(name)} :</span></dt>"
-                       f"<dd>{values}</dd>" for name, values in attrs.items())
+                       f"<dd>{values}</dd>"
+                       for name, values in _ordered_dict(attrs).items())
 
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 
@@ -176,7 +184,7 @@ def summarize_attrs_simple(attrs):
 def summarize_attrs(attrs):
     attrs_li = "".join(f"<li class='xr-var-item'>\
             {summarize_variable(name, values, has_attrs=False)}</li>"
-                       for name, values in attrs.items())
+                       for name, values in _ordered_dict(attrs).items())
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
 
 
@@ -210,7 +218,8 @@ def find_bin_edges(var, ds):
 def summarize_coords(coords, ds=None):
     vars_li = "".join("<li class='xr-var-item'>"
                       f"{summarize_coord(dim, var, ds)}"
-                      "</span></li>" for dim, var in coords.items())
+                      "</span></li>"
+                      for dim, var in _ordered_dict(coords).items())
 
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
@@ -409,8 +418,9 @@ def summarize_data(dataset):
             name,
             var,
             has_attrs=has_attrs,
-            bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
-                      for name, var in dataset.items())
+            bin_edges=find_bin_edges(var, dataset)
+                      if has_attrs else None))
+                      for name, var in _ordered_dict(dataset).items())
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -114,7 +114,7 @@ def _format_events(var, has_variances):
 
 def _ordered_dict(data):
     data_ordered = collections.OrderedDict(
-                   sorted(data.items(), key=lambda t: str(t[0])))
+        sorted(data.items(), key=lambda t: str(t[0])))
     return data_ordered
 
 
@@ -418,8 +418,7 @@ def summarize_data(dataset):
             name,
             var,
             has_attrs=has_attrs,
-            bin_edges=find_bin_edges(var, dataset)
-                      if has_attrs else None))
+            bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
                       for name, var in _ordered_dict(dataset).items())
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 

--- a/python/tests/table_html/test_to_html_dataarray.py
+++ b/python/tests/table_html/test_to_html_dataarray.py
@@ -43,7 +43,7 @@ def test_basic(dims, lengths):
     assert_dims_section(data, dim_section)
 
     data_names = [
-        dims[0],
+        LABEL_NAME,
         "",  # dataarray does not have a data name
         MASK_NAME,
         ATTR_NAME
@@ -99,7 +99,7 @@ def test_events(dims, lengths):
     # the original dim used as a label (dim[0]) is not shown,
     # instead the events dim is shown
     assert_section(coord_section,
-                   dims[0],
+                   LABEL_NAME,
                    dims,
                    in_dtype,
                    in_unit,
@@ -156,7 +156,7 @@ def test_bin_edge(dims, lengths):
     dim_section = sections.pop(0)
     assert_dims_section(data, dim_section)
 
-    data_names = [dims[0], MASK_NAME]
+    data_names = [LABEL_NAME, MASK_NAME]
 
     for section, name in zip(sections, data_names):
         assert_section(section,
@@ -216,7 +216,7 @@ def test_bin_edge_and_events(dims, lengths):
     dim_section = sections.pop(0)
     assert_dims_section(data, dim_section)
 
-    data_names = [dims[0], MASK_NAME]
+    data_names = [LABEL_NAME, MASK_NAME]
 
     for section, name in zip(sections, data_names):
         assert_section(section,
@@ -225,3 +225,33 @@ def test_bin_edge_and_events(dims, lengths):
                        in_dtype,
                        in_unit,
                        has_bin_edges=True)
+
+
+def dataarray_for_repr_test():
+    y = sc.Variable(['y'], values=np.arange(2.0), unit=sc.units.m)
+    x = sc.Variable(['x'], values=np.arange(3.0), unit=sc.units.m)
+    d = sc.DataArray(data=sc.Variable(dims=['y', 'x'],
+                     values=np.random.rand(2, 3)),
+                     coords={
+                        'yyy': y,
+                        'xxx': x,
+                        'aux': sc.Variable(['x'], values=np.random.rand(3))},
+                     attrs={'attr_zz': x, 'attr_aa': y},
+                     masks={'mask_zz': x, 'mask_aa': y})
+    return d
+
+
+def test_dataarray_repr():
+    repr = dataarray_for_repr_test().__repr__()
+    # make sure the ordering is correct
+    assert repr.find("yyy") > repr.find("xxx") > repr.find("aux")
+    assert repr.find('attr_zz') > repr.find('attr_aa')
+    assert repr.find('mask_zz') > repr.find('mask_aa')
+
+
+def test_dataarray_repr_html():
+    repr = dataarray_for_repr_test()._repr_html_()
+    # make sure the ordering is correct
+    assert repr.find("yyy") > repr.find("xxx") > repr.find("aux")
+    assert repr.find('attr_zz') > repr.find('attr_aa')
+    assert repr.find('mask_zz') > repr.find('mask_aa')

--- a/python/tests/table_html/test_to_html_dataarray.py
+++ b/python/tests/table_html/test_to_html_dataarray.py
@@ -231,13 +231,20 @@ def dataarray_for_repr_test():
     y = sc.Variable(['y'], values=np.arange(2.0), unit=sc.units.m)
     x = sc.Variable(['x'], values=np.arange(3.0), unit=sc.units.m)
     d = sc.DataArray(data=sc.Variable(dims=['y', 'x'],
-                     values=np.random.rand(2, 3)),
+                                      values=np.random.rand(2, 3)),
                      coords={
-                        'yyy': y,
-                        'xxx': x,
-                        'aux': sc.Variable(['x'], values=np.random.rand(3))},
-                     attrs={'attr_zz': x, 'attr_aa': y},
-                     masks={'mask_zz': x, 'mask_aa': y})
+                         'yyy': y,
+                         'xxx': x,
+                         'aux': sc.Variable(['x'], values=np.random.rand(3))
+                     },
+                     attrs={
+                         'attr_zz': x,
+                         'attr_aa': y
+                     },
+                     masks={
+                         'mask_zz': x,
+                         'mask_aa': y
+                     })
     return d
 
 

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -802,6 +802,7 @@ def test_iteration():
     for k in d:
         assert k in expected
 
+
 def test_dataset_html():
     d = sc.Dataset()
     d['z'] = sc.Variable(['x'], values=[1])
@@ -814,14 +815,19 @@ def test_dataset_html():
     # must check against actual __repr__ to make sure ordering is correct
     expected = "<bound method PyCapsule.__repr__ of <scipp.Dataset>\n"\
                "Dimensions: {{x, 1}}\nAttributes:\n"\
-               "    attr1                     float64    [dimensionless]  ()  [1.000000]\n"\
-               "    attr2                     float64    [dimensionless]  ()  [1.000000]\n"\
+               "    attr1                     float64    "\
+               "[dimensionless]  ()  [1.000000]\n"\
+               "    attr2                     float64    "\
+               "[dimensionless]  ()  [1.000000]\n"\
                "Masks:\n"\
-               "    aa_mask                   bool       [dimensionless]  (x)  [True]\n"\
-               "    zz_mask                   bool       [dimensionless]  (x)  [True]\n"\
+               "    aa_mask                   bool       "\
+               "[dimensionless]  (x)  [True]\n"\
+               "    zz_mask                   bool       "\
+               "[dimensionless]  (x)  [True]\n"\
                "Data:\n"\
-               "    a                         int64      [dimensionless]  (x)  [1]\n"\
-               "    z                         int64      [dimensionless]  (x)  [1]\n\n>"
+               "    a                         int64      "\
+               "[dimensionless]  (x)  [1]\n"\
+               "    z                         int64      "\
+               "[dimensionless]  (x)  [1]\n\n>"
 
     assert expected == str(d.__repr__)
-

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -801,3 +801,27 @@ def test_iteration():
     expected = ['a', 'b']
     for k in d:
         assert k in expected
+
+def test_dataset_html():
+    d = sc.Dataset()
+    d['z'] = sc.Variable(['x'], values=[1])
+    d['a'] = sc.Variable(['x'], values=[1])
+    d.attrs['attr2'] = sc.Variable(1.0)
+    d.attrs['attr1'] = sc.Variable(1.0)
+    d.masks['zz_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
+    d.masks['aa_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
+
+    # must check against actual __repr__ to make sure ordering is correct
+    expected = "<bound method PyCapsule.__repr__ of <scipp.Dataset>\n"\
+               "Dimensions: {{x, 1}}\nAttributes:\n"\
+               "    attr1                     float64    [dimensionless]  ()  [1.000000]\n"\
+               "    attr2                     float64    [dimensionless]  ()  [1.000000]\n"\
+               "Masks:\n"\
+               "    aa_mask                   bool       [dimensionless]  (x)  [True]\n"\
+               "    zz_mask                   bool       [dimensionless]  (x)  [True]\n"\
+               "Data:\n"\
+               "    a                         int64      [dimensionless]  (x)  [1]\n"\
+               "    z                         int64      [dimensionless]  (x)  [1]\n\n>"
+
+    assert expected == str(d.__repr__)
+

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -801,39 +801,3 @@ def test_iteration():
     expected = ['a', 'b']
     for k in d:
         assert k in expected
-
-def test_dataset_repr(): 
-    d = sc.Dataset()
-    d['z'] = sc.Variable(['x'], values=[1.0])
-    d['a'] = sc.Variable(['x'], values=[1.0])
-    d.attrs['attr1'] = sc.Variable(1.0)
-    d.attrs['attr2'] = sc.Variable(1.0)
-    d.attrs['attr0'] = sc.Variable(1.0)
-    d.masks['zz_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
-    d.masks['aa_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
-
-    header_repr = "<bound method PyCapsule.__repr__ of <scipp.Dataset>\n"
-    header_html = "<bound method make_html of <scipp.Dataset>\n"
-
-    # must check against actual __repr__ to make sure ordering is correct
-    expected = \
-        "Dimensions: {{x, 1}}\nAttributes:\n"\
-        "    attr0                     float64    [dimensionless]  ()"\
-        "  [1.000000]\n"\
-        "    attr1                     float64    [dimensionless]  ()"\
-        "  [1.000000]\n"\
-        "    attr2                     float64    [dimensionless]  ()"\
-        "  [1.000000]\n"\
-        "Masks:\n"\
-        "    aa_mask                   bool       [dimensionless]  (x)"\
-        "  [True]\n"\
-        "    zz_mask                   bool       [dimensionless]  (x)"\
-        "  [True]\n"\
-        "Data:\n"\
-        "    a                         float64    [dimensionless]  (x)"\
-        "  [1.000000]\n"\
-        "    z                         float64    [dimensionless]  (x)"\
-        "  [1.000000]\n\n>"
-
-    assert header_repr + expected == str(d.__repr__)
-    assert header_html + expected == str(d._repr_html_)

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -802,32 +802,38 @@ def test_iteration():
     for k in d:
         assert k in expected
 
-
-def test_dataset_html():
+def test_dataset_repr(): 
     d = sc.Dataset()
-    d['z'] = sc.Variable(['x'], values=[1])
-    d['a'] = sc.Variable(['x'], values=[1])
-    d.attrs['attr2'] = sc.Variable(1.0)
+    d['z'] = sc.Variable(['x'], values=[1.0])
+    d['a'] = sc.Variable(['x'], values=[1.0])
     d.attrs['attr1'] = sc.Variable(1.0)
+    d.attrs['attr2'] = sc.Variable(1.0)
+    d.attrs['attr0'] = sc.Variable(1.0)
     d.masks['zz_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
     d.masks['aa_mask'] = sc.Variable(dims=['x'], values=np.array([True]))
 
-    # must check against actual __repr__ to make sure ordering is correct
-    expected = "<bound method PyCapsule.__repr__ of <scipp.Dataset>\n"\
-               "Dimensions: {{x, 1}}\nAttributes:\n"\
-               "    attr1                     float64    "\
-               "[dimensionless]  ()  [1.000000]\n"\
-               "    attr2                     float64    "\
-               "[dimensionless]  ()  [1.000000]\n"\
-               "Masks:\n"\
-               "    aa_mask                   bool       "\
-               "[dimensionless]  (x)  [True]\n"\
-               "    zz_mask                   bool       "\
-               "[dimensionless]  (x)  [True]\n"\
-               "Data:\n"\
-               "    a                         int64      "\
-               "[dimensionless]  (x)  [1]\n"\
-               "    z                         int64      "\
-               "[dimensionless]  (x)  [1]\n\n>"
+    header_repr = "<bound method PyCapsule.__repr__ of <scipp.Dataset>\n"
+    header_html = "<bound method make_html of <scipp.Dataset>\n"
 
-    assert expected == str(d.__repr__)
+    # must check against actual __repr__ to make sure ordering is correct
+    expected = \
+        "Dimensions: {{x, 1}}\nAttributes:\n"\
+        "    attr0                     float64    [dimensionless]  ()"\
+        "  [1.000000]\n"\
+        "    attr1                     float64    [dimensionless]  ()"\
+        "  [1.000000]\n"\
+        "    attr2                     float64    [dimensionless]  ()"\
+        "  [1.000000]\n"\
+        "Masks:\n"\
+        "    aa_mask                   bool       [dimensionless]  (x)"\
+        "  [True]\n"\
+        "    zz_mask                   bool       [dimensionless]  (x)"\
+        "  [True]\n"\
+        "Data:\n"\
+        "    a                         float64    [dimensionless]  (x)"\
+        "  [1.000000]\n"\
+        "    z                         float64    [dimensionless]  (x)"\
+        "  [1.000000]\n\n>"
+
+    assert header_repr + expected == str(d.__repr__)
+    assert header_html + expected == str(d._repr_html_)


### PR DESCRIPTION
Attributes and other content of a Dataset/DataArray are now sorted.
The content of unordered map is cast into a vector which is then sorted with std::sort. I assume this is satisfactory performance wise since the vector sizes aren't large - there aren't many coordinates, attributes or masks in a dataset normally.

Fixes #1002.