### PR TITLE
Further CI improvments

### DIFF
--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -64,6 +64,8 @@ stages:
                 -DPYTHON_EXECUTABLE=$(command -v python) \
                 -DCMAKE_INSTALL_PREFIX="$(install_dir)" \
                 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+                -DDYNAMIC_LIB=ON \
                 "$(Build.Repository.LocalPath)"
             displayName: 'CMake configuration'
           - bash: |


### PR DESCRIPTION
See commit message.

Caching, use of shared libraries and no LTO have reduced the Linux build time to ~20 mins (which is more than just the build anyway).

I'm calling this good enough, Mac OS and Windows are still slow and do not yet have caching, shared library or LTO options (setting the usual CMake flags causes a linker error). Someone with access to those platforms will have to add that.