### PR TITLE
Refactor rebin to use transform

### DIFF
--- a/common/include/scipp/common/span/include/tcb/span.hpp
+++ b/common/include/scipp/common/span/include/tcb/span.hpp
@@ -1,7 +1,7 @@
 
 /*
-This is an implementation of std::span from P0122R7
-http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 */
 
 //          Copyright Tristan Brindle 2018.
@@ -14,6 +14,7 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #ifndef TCB_SPAN_NO_EXCEPTIONS
@@ -32,16 +33,6 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
 
 #ifndef TCB_SPAN_NAMESPACE_NAME
 #define TCB_SPAN_NAMESPACE_NAME tcb
-#endif
-
-#ifdef TCB_SPAN_STD_COMPLIANT_MODE
-#define TCB_SPAN_NO_DEPRECATION_WARNINGS
-#endif
-
-#ifndef TCB_SPAN_NO_DEPRECATION_WARNINGS
-#define TCB_SPAN_DEPRECATED_FOR(msg) [[deprecated(msg)]]
-#else
-#define TCB_SPAN_DEPRECATED_FOR(msg)
 #endif
 
 #if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
@@ -97,11 +88,22 @@ inline void contract_violation(const char* msg)
 #define TCB_SPAN_INLINE_VAR
 #endif
 
-#if defined(TCB_SPAN_HAVE_CPP14) ||                                                 \
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
     (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
 #define TCB_SPAN_CONSTEXPR14 constexpr
 #else
 #define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+    (!defined(_MSC_VER) || _MSC_VER > 1900)
+#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#else
+#define TCB_SPAN_CONSTEXPR_ASSIGN
 #endif
 
 #if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
@@ -134,35 +136,41 @@ using byte = std::byte;
 using byte = unsigned char;
 #endif
 
-TCB_SPAN_INLINE_VAR constexpr std::ptrdiff_t dynamic_extent = -1;
+#if defined(TCB_SPAN_HAVE_CPP17)
+#define TCB_SPAN_NODISCARD [[nodiscard]]
+#else
+#define TCB_SPAN_NODISCARD
+#endif
 
-template <typename ElementType, std::ptrdiff_t Extent = dynamic_extent>
+TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
 class span;
 
 namespace detail {
 
-template <typename E, std::ptrdiff_t S>
+template <typename E, std::size_t S>
 struct span_storage {
     constexpr span_storage() noexcept = default;
 
-    constexpr span_storage(E* ptr, std::ptrdiff_t /*unused*/) noexcept
-        : ptr(ptr)
+    constexpr span_storage(E* p_ptr, std::size_t /*unused*/) noexcept
+       : ptr(p_ptr)
     {}
 
     E* ptr = nullptr;
-    static constexpr std::ptrdiff_t size = S;
+    static constexpr std::size_t size = S;
 };
 
 template <typename E>
 struct span_storage<E, dynamic_extent> {
     constexpr span_storage() noexcept = default;
 
-    constexpr span_storage(E* ptr, std::ptrdiff_t size) noexcept
-        : ptr(ptr), size(size)
+    constexpr span_storage(E* p_ptr, std::size_t p_size) noexcept
+        : ptr(p_ptr), size(p_size)
     {}
 
     E* ptr = nullptr;
-    std::ptrdiff_t size = 0;
+    std::size_t size = 0;
 };
 
 // Reimplementation of C++17 std::size() and std::data()
@@ -222,7 +230,7 @@ using uncvref_t =
 template <typename>
 struct is_span : std::false_type {};
 
-template <typename T, std::ptrdiff_t S>
+template <typename T, std::size_t S>
 struct is_span<span<T, S>> : std::true_type {};
 
 template <typename>
@@ -254,7 +262,11 @@ struct is_container_element_type_compatible : std::false_type {};
 
 template <typename T, typename E>
 struct is_container_element_type_compatible<
-    T, E, void_t<decltype(detail::data(std::declval<T>()))>>
+    T, E,
+    typename std::enable_if<
+        !std::is_same<typename std::remove_cv<decltype(
+                          detail::data(std::declval<T>()))>::type,
+                      void>::value>::type>
     : std::is_convertible<
           remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
           E (*)[]> {};
@@ -267,11 +279,8 @@ struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 
 } // namespace detail
 
-template <typename ElementType, std::ptrdiff_t Extent>
+template <typename ElementType, std::size_t Extent>
 class span {
-    static_assert(Extent == dynamic_extent || Extent >= 0,
-                  "A span must have an extent greater than or equal to zero, "
-                  "or a dynamic extent");
     static_assert(std::is_object<ElementType>::value,
                   "A span's ElementType must be an object type (not a "
                   "reference type or void)");
@@ -287,24 +296,26 @@ public:
     // constants and types
     using element_type = ElementType;
     using value_type = typename std::remove_cv<ElementType>::type;
-    using index_type = std::ptrdiff_t;
+    using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
-    using pointer = ElementType*;
-    using reference = ElementType&;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
     using iterator = pointer;
-    using const_iterator = const ElementType*;
+    using const_iterator = const_pointer;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    static constexpr index_type extent = Extent;
+    static constexpr size_type extent = Extent;
 
     // [span.cons], span constructors, copy, assignment, and destructor
-    template <std::ptrdiff_t E = Extent,
-              typename std::enable_if<E <= 0, int>::type = 0>
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
     constexpr span() noexcept
     {}
 
-    TCB_SPAN_CONSTEXPR11 span(pointer ptr, index_type count)
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
         : storage_(ptr, count)
     {
         TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
@@ -314,72 +325,64 @@ public:
         : storage_(first_elem, last_elem - first_elem)
     {
         TCB_SPAN_EXPECT(extent == dynamic_extent ||
-                        last_elem - first_elem == extent);
+                        last_elem - first_elem ==
+                            static_cast<std::ptrdiff_t>(extent));
     }
 
-    template <
-        std::size_t N, std::ptrdiff_t E = Extent,
-        typename std::enable_if<
-            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
-                detail::is_container_element_type_compatible<
-                    element_type (&)[N], ElementType>::value,
-            int>::type = 0>
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
     constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
     {}
 
-    template <
-        std::size_t N, std::ptrdiff_t E = Extent,
-        typename std::enable_if<
-            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
-                detail::is_container_element_type_compatible<
-                    std::array<value_type, N>&, ElementType>::value,
-            int>::type = 0>
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
     TCB_SPAN_ARRAY_CONSTEXPR span(std::array<value_type, N>& arr) noexcept
         : storage_(arr.data(), N)
     {}
 
-    template <
-        std::size_t N, std::ptrdiff_t E = Extent,
-        typename std::enable_if<
-            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
-                detail::is_container_element_type_compatible<
-                    const std::array<value_type, N>&, ElementType>::value,
-            int>::type = 0>
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
     TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<value_type, N>& arr) noexcept
         : storage_(arr.data(), N)
     {}
 
-    template <typename Container,
-              typename std::enable_if<
-                  detail::is_container<Container>::value &&
-                      detail::is_container_element_type_compatible<
-                          Container&, ElementType>::value,
-                  int>::type = 0>
-    TCB_SPAN_CONSTEXPR11 span(Container& cont)
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont)
         : storage_(detail::data(cont), detail::size(cont))
-    {
-        TCB_SPAN_EXPECT(extent == dynamic_extent ||
-                        static_cast<std::ptrdiff_t>(detail::size(cont)) ==
-                            extent);
-    }
+    {}
 
-    template <typename Container,
-              typename std::enable_if<
-                  detail::is_container<Container>::value &&
-                      detail::is_container_element_type_compatible<
-                          const Container&, ElementType>::value,
-                  int>::type = 0>
-    TCB_SPAN_CONSTEXPR11 span(const Container& cont)
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
         : storage_(detail::data(cont), detail::size(cont))
-    {
-        TCB_SPAN_EXPECT(extent == dynamic_extent ||
-                        static_cast<std::ptrdiff_t>(detail::size(cont)) ==
-                            extent);
-    }
+    {}
 
     constexpr span(const span& other) noexcept = default;
 
-    template <typename OtherElementType, std::ptrdiff_t OtherExtent,
+    template <typename OtherElementType, std::size_t OtherExtent,
               typename std::enable_if<
                   (Extent == OtherExtent || Extent == dynamic_extent) &&
                       std::is_convertible<OtherElementType (*)[],
@@ -391,100 +394,81 @@ public:
 
     ~span() noexcept = default;
 
-    TCB_SPAN_CONSTEXPR14 span& operator=(const span& other) noexcept = default;
+    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    operator=(const span& other) noexcept = default;
 
     // [span.sub], span subviews
-    template <std::ptrdiff_t Count>
+    template <std::size_t Count>
     TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
     {
-        TCB_SPAN_EXPECT(Count >= 0 && Count <= size());
+        TCB_SPAN_EXPECT(Count <= size());
         return {data(), Count};
     }
 
-    template <std::ptrdiff_t Count>
+    template <std::size_t Count>
     TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
     {
-        TCB_SPAN_EXPECT(Count >= 0 && Count <= size());
+        TCB_SPAN_EXPECT(Count <= size());
         return {data() + (size() - Count), Count};
     }
 
-    template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent>
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
     using subspan_return_t =
         span<ElementType, Count != dynamic_extent
                               ? Count
                               : (Extent != dynamic_extent ? Extent - Offset
                                                           : dynamic_extent)>;
 
-    template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent>
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
     TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
     {
-        TCB_SPAN_EXPECT((Offset >= 0 && Offset <= size()) &&
-                        (Count == dynamic_extent ||
-                         (Count >= 0 && Offset + Count <= size())));
+        TCB_SPAN_EXPECT(Offset <= size() &&
+                        (Count == dynamic_extent || Offset + Count <= size()));
         return {data() + Offset,
-                Count != dynamic_extent
-                    ? Count
-                    : (Extent != dynamic_extent ? Extent - Offset
-                                                : size() - Offset)};
+                Count != dynamic_extent ? Count : size() - Offset};
     }
 
     TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
-    first(index_type count) const
+    first(size_type count) const
     {
-        TCB_SPAN_EXPECT(count >= 0 && count <= size());
+        TCB_SPAN_EXPECT(count <= size());
         return {data(), count};
     }
 
     TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
-    last(index_type count) const
+    last(size_type count) const
     {
-        TCB_SPAN_EXPECT(count >= 0 && count <= size());
+        TCB_SPAN_EXPECT(count <= size());
         return {data() + (size() - count), count};
     }
 
     TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
-    subspan(index_type offset, index_type count = dynamic_extent) const
+    subspan(size_type offset, size_type count = dynamic_extent) const
     {
-        TCB_SPAN_EXPECT((offset >= 0 && offset <= size()) &&
-                        (count == dynamic_extent ||
-                         (count >= 0 && offset + count <= size())));
+        TCB_SPAN_EXPECT(offset <= size() &&
+                        (count == dynamic_extent || offset + count <= size()));
         return {data() + offset,
                 count == dynamic_extent ? size() - offset : count};
     }
 
     // [span.obs], span observers
-    constexpr index_type size() const noexcept { return storage_.size; }
+    constexpr size_type size() const noexcept { return storage_.size; }
 
-    constexpr index_type size_bytes() const noexcept
+    constexpr size_type size_bytes() const noexcept
     {
         return size() * sizeof(element_type);
     }
 
-    constexpr bool empty() const noexcept { return size() == 0; }
-
-    // [span.elem], span element access
-    TCB_SPAN_CONSTEXPR11 reference operator[](index_type idx) const
+    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
     {
-        TCB_SPAN_EXPECT(idx >= 0 && idx < size());
-        return *(data() + idx);
+        return size() == 0;
     }
 
-    /* Extension: not in P0122 */
-#ifndef TCB_SPAN_STD_COMPLIANT_MODE
-    TCB_SPAN_CONSTEXPR14 reference at(index_type idx) const
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
     {
-#ifndef TCB_SPAN_NO_EXCEPTIONS
-        if (idx < 0 || idx >= size()) {
-            char msgbuf[64] = {
-                0,
-            };
-            std::snprintf(msgbuf, sizeof(msgbuf),
-                          "Index %td is out of range for span of size %td", idx,
-                          size());
-            throw std::out_of_range{msgbuf};
-        }
-#endif // TCB_SPAN_NO_EXCEPTIONS
-        return this->operator[](idx);
+        TCB_SPAN_EXPECT(idx < size());
+        return *(data() + idx);
     }
 
     TCB_SPAN_CONSTEXPR11 reference front() const
@@ -498,16 +482,6 @@ public:
         TCB_SPAN_EXPECT(!empty());
         return *(data() + (size() - 1));
     }
-
-#endif // TCB_SPAN_STD_COMPLIANT_MODE
-
-#ifndef TCB_SPAN_NO_FUNCTION_CALL_OPERATOR
-    TCB_SPAN_DEPRECATED_FOR("Use operator[] instead")
-    constexpr reference operator()(index_type idx) const
-    {
-        return this->operator[](idx);
-    }
-#endif // TCB_SPAN_NO_FUNCTION_CALL_OPERATOR
 
     constexpr pointer data() const noexcept { return storage_.ptr; }
 
@@ -540,6 +514,10 @@ public:
         return const_reverse_iterator(cbegin());
     }
 
+    friend constexpr iterator begin(span s) noexcept { return s.begin(); }
+
+    friend constexpr iterator end(span s) noexcept { return s.end(); }
+
 private:
     storage_type storage_{};
 };
@@ -564,7 +542,7 @@ span(const Container&)->span<const typename Container::value_type>;
 
 #endif // TCB_HAVE_DEDUCTION_GUIDES
 
-template <typename ElementType, std::ptrdiff_t Extent>
+template <typename ElementType, std::size_t Extent>
 constexpr span<ElementType, Extent>
 make_span(span<ElementType, Extent> s) noexcept
 {
@@ -603,147 +581,25 @@ make_span(const Container& cont)
     return {cont};
 }
 
-/* Comparison operators */
-// Implementation note: the implementations of == and < are equivalent to
-// 4-legged std::equal and std::lexicographical_compare respectively
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator==(span<T, X> lhs, span<U, Y> rhs)
-{
-    if (lhs.size() != rhs.size()) {
-        return false;
-    }
-
-    for (std::ptrdiff_t i = 0; i < lhs.size(); i++) {
-        if (lhs[i] != rhs[i]) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator!=(span<T, X> lhs, span<U, Y> rhs)
-{
-    return !(lhs == rhs);
-}
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator<(span<T, X> lhs, span<U, Y> rhs)
-{
-    // No std::min to avoid dragging in <algorithm>
-    const std::ptrdiff_t size =
-        lhs.size() < rhs.size() ? lhs.size() : rhs.size();
-
-    for (std::ptrdiff_t i = 0; i < size; i++) {
-        if (lhs[i] < rhs[i]) {
-            return true;
-        }
-        if (lhs[i] > rhs[i]) {
-            return false;
-        }
-    }
-    return lhs.size() < rhs.size();
-}
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator<=(span<T, X> lhs, span<U, Y> rhs)
-{
-    return !(rhs < lhs);
-}
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator>(span<T, X> lhs, span<U, Y> rhs)
-{
-    return rhs < lhs;
-}
-
-template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
-TCB_SPAN_CONSTEXPR14 bool operator>=(span<T, X> lhs, span<U, Y> rhs)
-{
-    return !(lhs < rhs);
-}
-
-template <typename ElementType, std::ptrdiff_t Extent>
-span<const byte, ((Extent == dynamic_extent)
-                      ? dynamic_extent
-                      : (static_cast<ptrdiff_t>(sizeof(ElementType)) * Extent))>
+template <typename ElementType, std::size_t Extent>
+span<const byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
 as_bytes(span<ElementType, Extent> s) noexcept
 {
     return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
 }
 
 template <
-    class ElementType, ptrdiff_t Extent,
+    class ElementType, size_t Extent,
     typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
-span<byte, ((Extent == dynamic_extent)
-                ? dynamic_extent
-                : (static_cast<ptrdiff_t>(sizeof(ElementType)) * Extent))>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
 as_writable_bytes(span<ElementType, Extent> s) noexcept
 {
     return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
 }
 
-/* Extension: nonmember subview operations */
-
-#ifndef TCB_SPAN_STD_COMPLIANT_MODE
-
-template <std::ptrdiff_t Count, typename T>
-TCB_SPAN_CONSTEXPR11 auto first(T& t)
-    -> decltype(make_span(t).template first<Count>())
-{
-    return make_span(t).template first<Count>();
-}
-
-template <std::ptrdiff_t Count, typename T>
-TCB_SPAN_CONSTEXPR11 auto last(T& t)
-    -> decltype(make_span(t).template last<Count>())
-{
-    return make_span(t).template last<Count>();
-}
-
-template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent,
-          typename T>
-TCB_SPAN_CONSTEXPR11 auto subspan(T& t)
-    -> decltype(make_span(t).template subspan<Offset, Count>())
-{
-    return make_span(t).template subspan<Offset, Count>();
-}
-
-template <typename T>
-TCB_SPAN_CONSTEXPR11 auto first(T& t, std::ptrdiff_t count)
-    -> decltype(make_span(t).first(count))
-{
-    return make_span(t).first(count);
-}
-
-template <typename T>
-TCB_SPAN_CONSTEXPR11 auto last(T& t, std::ptrdiff_t count)
-    -> decltype(make_span(t).last(count))
-{
-    return make_span(t).last(count);
-}
-
-template <typename T>
-TCB_SPAN_CONSTEXPR11 auto subspan(T& t, std::ptrdiff_t offset,
-                                  std::ptrdiff_t count = dynamic_extent)
-    -> decltype(make_span(t).subspan(offset, count))
-{
-    return make_span(t).subspan(offset, count);
-}
-
-#endif // TCB_SPAN_STD_COMPLIANT_MODE
-
-} // namespace TCB_SPAN_NAMESPACE_NAME
-
-/* Extension: support for C++17 structured bindings */
-
-#ifndef TCB_SPAN_STD_COMPLIANT_MODE
-
-namespace TCB_SPAN_NAMESPACE_NAME {
-
-template <std::ptrdiff_t N, typename E, std::ptrdiff_t S>
+template <std::size_t N, typename E, std::size_t S>
 constexpr auto get(span<E, S> s) -> decltype(s[N])
 {
     return s[N];
@@ -753,20 +609,23 @@ constexpr auto get(span<E, S> s) -> decltype(s[N])
 
 namespace std {
 
-template <typename E, ptrdiff_t S>
-class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<E, S>> : public integral_constant<size_t, S> {};
+template <typename ElementType, size_t Extent>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
 
-template <typename E>
-class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<E, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+template <typename ElementType>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
+    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
 
-template <size_t N, typename E, ptrdiff_t S>
-class tuple_element<N, TCB_SPAN_NAMESPACE_NAME::span<E, S>> {
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
 public:
-    using type = E;
+    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+                      I < Extent,
+                  "");
+    using type = ElementType;
 };
 
 } // end namespace std
-
-#endif // TCB_SPAN_STD_COMPLIANT_MODE
 
 #endif // TCB_SPAN_HPP_INCLUDED

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(INC_FILES
     include/scipp/core/element/geometric_operations.h
     include/scipp/core/element/histogram.h
     include/scipp/core/element/logical.h
+    include/scipp/core/element/rebin.h
     include/scipp/core/element/trigonometry.h
     include/scipp/core/element/unary_operations.h
 )

--- a/core/include/scipp/core/element/comparison.h
+++ b/core/include/scipp/core/element/comparison.h
@@ -10,11 +10,9 @@
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 
-namespace scipp::core {
-
 /// Operators to be used with transform and transform_in_place to implement
 /// operations for Variable.
-namespace element {
+namespace scipp::core::element {
 
 constexpr auto comparison =
     overloaded{arg_list<double, float, int64_t, int32_t>,
@@ -50,25 +48,20 @@ constexpr auto equal = overloaded{
 constexpr auto not_equal =
     overloaded{comparison, [](const auto &x, const auto &y) { return x != y; }};
 
-struct max_equals
-    : public transform_flags::expect_in_variance_if_out_variance_t {
-  template <class A, class B>
-  constexpr void operator()(A &&a, const B &b) const noexcept {
-    using std::max;
-    a = max(a, b);
-  }
-  using types = pair_self_t<double, float, int64_t, int32_t>;
-};
-struct min_equals
-    : public transform_flags::expect_in_variance_if_out_variance_t {
-  template <class A, class B>
-  constexpr void operator()(A &&a, const B &b) const noexcept {
-    using std::min;
-    a = min(a, b);
-  }
-  using types = pair_self_t<double, float, int64_t, int32_t>;
-};
+constexpr auto max_equals =
+    overloaded{arg_list<double, float, int64_t, int32_t>,
+               transform_flags::expect_in_variance_if_out_variance,
+               [](auto &&a, const auto &b) {
+                 using std::max;
+                 a = max(a, b);
+               }};
 
-} // namespace element
+constexpr auto min_equals =
+    overloaded{arg_list<double, float, int64_t, int32_t>,
+               transform_flags::expect_in_variance_if_out_variance,
+               [](auto &&a, const auto &b) {
+                 using std::min;
+                 a = min(a, b);
+               }};
 
-} // namespace scipp::core
+} // namespace scipp::core::element

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
-/// @author Owen Arnold
+/// @author Simon Heybrock
 #pragma once
 
 #include <cmath>

--- a/core/include/scipp/core/element/logical.h
+++ b/core/include/scipp/core/element/logical.h
@@ -4,25 +4,18 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include "scipp/common/overloaded.h"
+#include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 
 namespace scipp::core::element {
 
-struct and_equals {
-  template <class A, class B>
-  constexpr void operator()(A &&a, const B &b) const
-      noexcept(noexcept(a &= b)) {
-    a &= b;
-  }
-  using types = pair_self_t<bool>;
-};
-struct or_equals {
-  template <class A, class B>
-  constexpr void operator()(A &&a, const B &b) const
-      noexcept(noexcept(a |= b)) {
-    a |= b;
-  }
-  using types = pair_self_t<bool>;
-};
+constexpr auto and_equals = overloaded{
+    arg_list<bool>,
+    [](auto &&a, const auto &b) noexcept(noexcept(a &= b)) { a &= b; }};
+
+constexpr auto or_equals = overloaded{
+    arg_list<bool>,
+    [](auto &&a, const auto &b) noexcept(noexcept(a |= b)) { a |= b; }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -17,8 +17,8 @@ namespace scipp::core::element {
 static constexpr auto rebin = overloaded{
     [](const auto &data_new, const auto &xnew, const auto &data_old,
        const auto &xold) {
-      const auto oldSize = scipp::size(xold);
-      const auto newSize = scipp::size(xnew);
+      const auto oldSize = scipp::size(xold) - 1;
+      const auto newSize = scipp::size(xnew) - 1;
       scipp::index iold = 0;
       scipp::index inew = 0;
       while ((iold < oldSize) && (inew < newSize)) {

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <cmath>
+
+#include "scipp/common/numeric.h"
+#include "scipp/common/overloaded.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/histogram.h"
+#include "scipp/core/transform_common.h"
+
+namespace scipp::core::element {
+
+static constexpr auto rebin = overloaded{
+    [](const auto &data_new, const auto &xnew, const auto &data_old,
+       const auto &xold) {
+      const auto oldSize = scipp::size(xold);
+      const auto newSize = scipp::size(xnew);
+      scipp::index iold = 0;
+      scipp::index inew = 0;
+      while ((iold < oldSize) && (inew < newSize)) {
+        const auto xo_low = xold[iold];
+        const auto xo_high = xold[iold + 1];
+        const auto xn_low = xnew[inew];
+        const auto xn_high = xnew[inew + 1];
+        if (xn_high <= xo_low)
+          inew++; // old and new bins do not overlap
+        else if (xo_high <= xn_low)
+          iold++; // old and new bins do not overlap
+        else {
+          // delta is the overlap of the bins on the x axis
+          const auto delta = std::min<double>(xn_high, xo_high) -
+                             std::max<double>(xn_low, xo_low);
+          const auto owidth = xo_high - xo_low;
+          const auto scale = delta / owidth;
+          if constexpr (is_ValueAndVariance_v<
+                            std::decay_t<decltype(data_old)>>) {
+            data_new.value[inew] += data_old.value[iold] * scale;
+            data_new.variance[inew] += data_old.variance[iold] * scale;
+          } else {
+            data_new[inew] += data_old[iold] * scale;
+          }
+          if (xn_high > xo_high) {
+            iold++;
+          } else {
+            inew++;
+          }
+        }
+      }
+    },
+    [](const units::Unit &target_edges, const units::Unit &data,
+       const units::Unit &edges) {
+      if (target_edges != edges)
+        throw except::UnitError(
+            "Input and output bin edges must have the same unit.");
+      if (data != units::counts && data != units::one)
+        throw except::UnitError("Only count-data (units::counts or "
+                                "units::dimensionless) can be rebinned.");
+      return data;
+    },
+    transform_flags::expect_in_variance_if_out_variance,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<3>};
+
+} // namespace scipp::core::element

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -71,14 +71,12 @@ using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 /// variances in the specified argument.
 template <int N> static constexpr auto expect_variance_arg = []() {};
 template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
-// TODO Change to lambda when element/comparison.h is refactored to use lambdas.
-struct expect_in_variance_if_out_variance_t {
-  void operator()() {}
-};
+
 /// Add this to overloaded operator to indicate that the in-place operation
 /// requires inputs to have a variance if the output has a variance.
-static constexpr auto expect_in_variance_if_out_variance =
-    expect_in_variance_if_out_variance_t{};
+static constexpr auto expect_in_variance_if_out_variance = []() {};
+using expect_in_variance_if_out_variance_t =
+    decltype(expect_in_variance_if_out_variance);
 
 static constexpr auto expect_all_or_none_have_variance = []() {};
 using expect_all_or_none_have_variance_t =

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -71,10 +71,14 @@ using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 /// variances in the specified argument.
 template <int N> static constexpr auto expect_variance_arg = []() {};
 template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
-
+// TODO Change to lambda when element/comparison.h is refactored to use lambdas.
+struct expect_in_variance_if_out_variance_t {
+  void operator()() {}
+};
 /// Add this to overloaded operator to indicate that the in-place operation
-/// requires inputs to have a variance of the output has a variance.
-struct expect_in_variance_if_out_variance_t {};
+/// requires inputs to have a variance if the output has a variance.
+static constexpr auto expect_in_variance_if_out_variance =
+    expect_in_variance_if_out_variance_t{};
 
 static constexpr auto expect_all_or_none_have_variance = []() {};
 using expect_all_or_none_have_variance_t =

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -51,8 +51,9 @@ DataArray histogram(const DataArrayConstView &events,
                          args<double, float, event_list<double>, double>,
                          args<double, float, event_list<double>, float>,
                          args<double, double, event_list<float>, double>>>(
-              dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
-              events_.data(), binEdges_, element::histogram);
+              dtype<double>, dim_, binEdges_.dims()[dim_] - 1,
+              events_.coords()[dim_], events_.data(), binEdges_,
+              element::histogram);
         },
         dim_of_coord(events.coords()[dim], dim), dim, binEdges);
   } else if (!is_histogram(events, dim)) {
@@ -70,7 +71,8 @@ DataArray histogram(const DataArrayConstView &events,
                          args<float, double, float, double>,
                          args<double, float, double, float>,
                          args<float, float, float, float>>>(
-              dim_, binEdges_.dims()[dim_] - 1, events_.coords()[dim_],
+              dtype<double>, dim_, binEdges_.dims()[dim_] - 1,
+              events_.coords()[dim_],
               mask ? VariableConstView(masked) : events_.data(), binEdges_,
               element::histogram);
         },

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -31,7 +31,7 @@ static constexpr auto maybe_subspan = [](VariableConstView &var,
 } // namespace transform_subspan_detail
 
 template <class Types, class Op, class... Var>
-[[nodiscard]] Variable transform_subspan_impl(const Dim dim,
+[[nodiscard]] Variable transform_subspan_impl(const DType type, const Dim dim,
                                               const scipp::index size, Op op,
                                               Var... var) {
   using namespace transform_subspan_detail;
@@ -39,19 +39,13 @@ template <class Types, class Op, class... Var>
   auto dims =
       merge(var.dims().contains(dim) ? erase(var.dims(), dim) : var.dims()...);
   dims.addInner(dim, size);
-  // This will cause failure below unless the output type (first type in inner
-  // tuple) is the same in all inner tuples.
-  using OutT =
-      typename std::tuple_element_t<0,
-                                    std::tuple_element_t<0, Types>>::value_type;
   const bool variance =
       std::is_base_of_v<core::transform_flags::expect_variance_arg_t<0>, Op> ||
       (std::is_base_of_v<
            core::transform_flags::expect_in_variance_if_out_variance_t, Op> &&
        (var.hasVariances() || ...));
-  Variable out =
-      variance ? makeVariable<OutT>(Dimensions{dims}, Values{}, Variances{})
-               : makeVariable<OutT>(Dimensions{dims});
+  Variable out = variance ? Variable(type, dims, Values{}, Variances{})
+                          : Variable(type, dims);
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 
@@ -73,26 +67,27 @@ template <class Types, class Op, class... Var>
 /// 2. The overload handling the data has one extra argument. This additional
 ///    (first) argument is the "out" argument, as used in `transform_in_place`.
 /// 3. The tuple of supported type combinations must include the type of the out
-///    argument as the first type in the inner tuples. Currently all supported
-///    combinations must have the same output type.
+///    argument as the first type in the inner tuples. The output type must be
+///    passed at runtime as the first argument.
 /// 4. The output type and the type of non-events inputs that depend on `dim`
 ///    must be specified as `span<T>`. The user-provided lambda is called with a
 ///    span of values for these arguments.
 /// 5. Use the flag transform_flags::expect_variance_arg<0> to control whether
 ///    the output should have variances or not.
 template <class Types, class Op>
-[[nodiscard]] Variable transform_subspan(const Dim dim, const scipp::index size,
+[[nodiscard]] Variable transform_subspan(const DType type, const Dim dim,
+                                         const scipp::index size,
                                          const VariableConstView &var1,
                                          const VariableConstView &var2, Op op) {
-  return transform_subspan_impl<Types>(dim, size, op, var1, var2);
+  return transform_subspan_impl<Types>(type, dim, size, op, var1, var2);
 }
 
 template <class Types, class Op>
-[[nodiscard]] Variable transform_subspan(const Dim dim, const scipp::index size,
-                                         const VariableConstView &var1,
-                                         const VariableConstView &var2,
-                                         const VariableConstView &var3, Op op) {
-  return transform_subspan_impl<Types>(dim, size, op, var1, var2, var3);
+[[nodiscard]] Variable
+transform_subspan(const DType type, const Dim dim, const scipp::index size,
+                  const VariableConstView &var1, const VariableConstView &var2,
+                  const VariableConstView &var3, Op op) {
+  return transform_subspan_impl<Types>(type, dim, size, op, var1, var2, var3);
 }
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -44,10 +44,14 @@ template <class Types, class Op, class... Var>
   using OutT =
       typename std::tuple_element_t<0,
                                     std::tuple_element_t<0, Types>>::value_type;
+  const bool variance =
+      std::is_base_of_v<core::transform_flags::expect_variance_arg_t<0>, Op> ||
+      (std::is_base_of_v<
+           core::transform_flags::expect_in_variance_if_out_variance_t, Op> &&
+       (var.hasVariances() || ...));
   Variable out =
-      std::is_base_of_v<core::transform_flags::expect_variance_arg_t<0>, Op>
-          ? makeVariable<OutT>(Dimensions{dims}, Values{}, Variances{})
-          : makeVariable<OutT>(Dimensions{dims});
+      variance ? makeVariable<OutT>(Dimensions{dims}, Values{}, Variances{})
+               : makeVariable<OutT>(Dimensions{dims});
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -24,11 +24,18 @@ template <class T, class C> auto &requireT(C &concept) {
   }
 }
 
+template <class T> struct is_span : std::false_type {};
+template <class T> struct is_span<scipp::span<T>> : std::true_type {};
+template <class T> inline constexpr bool is_span_v = is_span<T>::value;
+
 template <class T1, class T2> bool equal(const T1 &view1, const T2 &view2) {
   if constexpr (std::is_same_v<typename T1::value_type, Eigen::Quaterniond>)
     return std::equal(
         view1.begin(), view1.end(), view2.begin(), view2.end(),
         [](auto &a, auto &b) { return a.coeffs() == b.coeffs(); });
+  else if constexpr(is_span_v<typename T1::value_type>)
+    return std::equal(view1.begin(), view1.end(), view2.begin(), view2.end(),
+        [](auto &a, auto &b) { return equal(a,b); });
   else
     return std::equal(view1.begin(), view1.end(), view2.begin(), view2.end());
 }

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -110,9 +110,9 @@ Variable rebin(const VariableConstView &var, const Dim dim,
     return transform_subspan<std::tuple<
         args<double, double, double, double>, args<float, float, float, float>,
         args<float, double, float, double>, args<float, float, float, double>,
-        args<bool, double, bool, double>>>(dim, newCoord.dims()[dim] - 1,
-                                           newCoord, var, oldCoord,
-                                           core::element::rebin);
+        args<bool, double, bool, double>>>(var.dtype(), dim,
+                                           newCoord.dims()[dim] - 1, newCoord,
+                                           var, oldCoord, core::element::rebin);
 
   } else {
     auto dims = var.dims();

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -17,8 +17,6 @@ bool isBinEdge(const Dim dim, Dimensions edges, const Dimensions &toMatch) {
   return edges[dim] == toMatch[dim];
 }
 
-bool is1D(Dimensions edges) { return edges.shape().size() == 1; }
-
 template <typename T>
 void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
                      Variable &newT, const VariableConstView &oldCoordT,
@@ -72,38 +70,9 @@ Variable rebin(const VariableConstView &var, const Dim dim,
   // to avoid this since it increases complexity. Instead, densities could
   // always be computed on-the-fly for visualization, if required.
   core::expect::unit_any_of(var, {units::counts, units::one});
-
-  /*
-  auto do_rebin = [dim](auto &&outT, auto &&oldT, auto &&oldCoordT,
-                        auto &&newCoordT) {
-    // Dimensions of *this and old are guaranteed to be the same.
-    const auto &out_dims = outT.dims();
-
-    // dimension along which the data is being rebinned
-    const bool rebin_dim_valid = out_dims.inner() == dim;
-
-    const bool input_valid = isBinEdge(dim, oldCoordT.dims(), oldT.dims());
-
-    const bool output_valid =
-        is1D(newCoordT.dims()) && isBinEdge(dim, newCoordT.dims(), out_dims);
-
-    if (rebin_dim_valid && input_valid && output_valid) {
-      rebinInner(dim, oldT, outT, oldCoordT, newCoordT);
-      if (oldT.hasVariances())
-        rebinInner(dim, oldT, outT, oldCoordT, newCoordT, true);
-    } else if (!rebin_dim_valid) {
-      // TODO the new coord should be 1D or the same dim as newCoord.
-      throw std::runtime_error(
-          "The new coord should be the same dimensions as the output coord.");
-    } else if (!input_valid) {
-      throw std::runtime_error(
-          "The input does not have coordinates with bin-edges.");
-    } else if (!output_valid) {
-      throw std::runtime_error(
-          "The output is not 1D or does not have coordinates with bin-edges.");
-    }
-  };
-  */
+  if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
+    throw except::BinEdgeError(
+        "The input does not have coordinates with bin-edges.");
 
   if (var.dims().inner() == dim) {
     using namespace rebin_inner_detail;

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -142,8 +142,8 @@ VariableView mean(const VariableConstView &var, const Dim dim,
 }
 
 template <class Op>
-void reduce_impl(const VariableView &out, const VariableConstView &var) {
-  accumulate_in_place(out, var, Op{});
+void reduce_impl(const VariableView &out, const VariableConstView &var, Op op) {
+  accumulate_in_place(out, var, op);
 }
 
 /// Reduction for idempotent operations such that op(a,a) = a.
@@ -153,30 +153,30 @@ void reduce_impl(const VariableView &out, const VariableConstView &var) {
 /// `max`. Note that masking is not supported here since it would make creation
 /// of a sensible starting value difficult.
 template <class Op>
-Variable reduce_idempotent(const VariableConstView &var, const Dim dim) {
+Variable reduce_idempotent(const VariableConstView &var, const Dim dim, Op op) {
   Variable out(var.slice({dim, 0}));
-  reduce_impl<Op>(out, var);
+  reduce_impl(out, var, op);
   return out;
 }
 
 void any_impl(const VariableView &out, const VariableConstView &var) {
-  reduce_impl<core::element::or_equals>(out, var);
+  reduce_impl(out, var, core::element::or_equals);
 }
 
 Variable any(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent<core::element::or_equals>(var, dim);
+  return reduce_idempotent(var, dim, core::element::or_equals);
 }
 
 void all_impl(const VariableView &out, const VariableConstView &var) {
-  reduce_impl<core::element::and_equals>(out, var);
+  reduce_impl(out, var, core::element::and_equals);
 }
 
 Variable all(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent<core::element::and_equals>(var, dim);
+  return reduce_idempotent(var, dim, core::element::and_equals);
 }
 
 void max_impl(const VariableView &out, const VariableConstView &var) {
-  reduce_impl<core::element::max_equals>(out, var);
+  reduce_impl(out, var, core::element::max_equals);
 }
 
 /// Return the maximum along given dimension.
@@ -184,11 +184,11 @@ void max_impl(const VariableView &out, const VariableConstView &var) {
 /// Variances are not considered when determining the maximum. If present, the
 /// variance of the maximum element is returned.
 Variable max(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent<core::element::max_equals>(var, dim);
+  return reduce_idempotent(var, dim, core::element::max_equals);
 }
 
 void min_impl(const VariableView &out, const VariableConstView &var) {
-  reduce_impl<core::element::min_equals>(out, var);
+  reduce_impl(out, var, core::element::min_equals);
 }
 
 /// Return the minimum along given dimension.
@@ -196,7 +196,7 @@ void min_impl(const VariableView &out, const VariableConstView &var) {
 /// Variances are not considered when determining the minimum. If present, the
 /// variance of the minimum element is returned.
 Variable min(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent<core::element::min_equals>(var, dim);
+  return reduce_idempotent(var, dim, core::element::min_equals);
 }
 
 /// Return the maximum along all dimensions.

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -10,7 +10,7 @@ namespace scipp::variable {
 /// Helper returning vector of subspans with given length.
 template <class T>
 auto make_subspans(const span<T> &data, const scipp::index span_len) {
-  const auto len = data.size() / span_len;
+  const auto len = scipp::size(data) / span_len;
   std::vector<span<T>> spans;
   spans.reserve(len);
   for (scipp::index i = 0; i < len; ++i)
@@ -72,8 +72,8 @@ auto invoke_subspan_view(const DType dtype, Args &&... args) {
 }
 
 template <class Var> Variable subspan_view_impl(Var &var, const Dim dim) {
-  return invoke_subspan_view<double, float, int64_t, int32_t>(var.dtype(), var,
-                                                              dim);
+  return invoke_subspan_view<double, float, int64_t, int32_t, bool>(var.dtype(),
+                                                                    var, dim);
 }
 
 /// Return Variable containing mutable spans over given dimension as elements.

--- a/variable/variable_instantiate_view_elements.cpp
+++ b/variable/variable_instantiate_view_elements.cpp
@@ -18,5 +18,7 @@ INSTANTIATE_VARIABLE(span_const_int64, span<const int64_t>)
 INSTANTIATE_VARIABLE(span_const_int32, span<const int32_t>)
 INSTANTIATE_VARIABLE(span_int64, span<int64_t>)
 INSTANTIATE_VARIABLE(span_int32, span<int32_t>)
+INSTANTIATE_VARIABLE(span_const_bool, span<const bool>)
+INSTANTIATE_VARIABLE(span_bool, span<bool>)
 
 } // namespace scipp::variable


### PR DESCRIPTION
Refactor old code so `transform` can be used. This will give automatic support for multi-threading.

- Extracting kernel into `core::element` will allow for simpler unit testing.
- There are existing unit tests, unit test for kernel not added here, this is a future cleanup task.
- Updated our `tcb::span` since I had issues with spans of `bool`. Note some follow up changes, since `std::span` does not support `operator==` any more.
- Rewrite some helper structs in `element` to use lambas, just like more recent code.
- Improve `transform_subspan` so the output type is not forced to be the same.