### PR TITLE
Cleanup and minor performance improvements

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,6 +27,7 @@ set(INC_FILES
     include/scipp/core/element/rebin.h
     include/scipp/core/element/trigonometry.h
     include/scipp/core/element/unary_operations.h
+    include/scipp/core/element/util.h
 )
 
 set(SRC_FILES

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -9,6 +9,7 @@
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
+#include "scipp/core/element/util.h"
 #include "scipp/core/histogram.h"
 #include "scipp/core/transform_common.h"
 
@@ -44,10 +45,7 @@ constexpr auto variance = [](const auto &v, const scipp::index idx) {
 static constexpr auto histogram = overloaded{
     [](const auto &data, const auto &events, const auto &weights,
        const auto &edges) {
-      for (auto &x : data.value)
-        x = 0.0;
-      for (auto &x : data.variance)
-        x = 0.0;
+      zero(data);
       // Special implementation for linear bins. Gives a 1x to 20x speedup
       // for few and many events per histogram, respectively.
       if (scipp::numeric::is_linspace(edges)) {

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -44,6 +44,10 @@ constexpr auto variance = [](const auto &v, const scipp::index idx) {
 static constexpr auto histogram = overloaded{
     [](const auto &data, const auto &events, const auto &weights,
        const auto &edges) {
+      for (auto &x : data.value)
+        x = 0.0;
+      for (auto &x : data.variance)
+        x = 0.0;
       // Special implementation for linear bins. Gives a 1x to 20x speedup
       // for few and many events per histogram, respectively.
       if (scipp::numeric::is_linspace(edges)) {

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -17,6 +17,16 @@ namespace scipp::core::element {
 static constexpr auto rebin = overloaded{
     [](const auto &data_new, const auto &xnew, const auto &data_old,
        const auto &xold) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(data_old)>>) {
+        for (auto &x : data_new.value)
+          x = 0.0;
+        for (auto &x : data_new.variance)
+          x = 0.0;
+      } else {
+        for (auto &x : data_new)
+          x = 0.0;
+      }
+
       const auto oldSize = scipp::size(xold) - 1;
       const auto newSize = scipp::size(xnew) - 1;
       scipp::index iold = 0;

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -9,6 +9,7 @@
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
+#include "scipp/core/element/util.h"
 #include "scipp/core/histogram.h"
 #include "scipp/core/transform_common.h"
 
@@ -17,16 +18,7 @@ namespace scipp::core::element {
 static constexpr auto rebin = overloaded{
     [](const auto &data_new, const auto &xnew, const auto &data_old,
        const auto &xold) {
-      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(data_old)>>) {
-        for (auto &x : data_new.value)
-          x = 0.0;
-        for (auto &x : data_new.variance)
-          x = 0.0;
-      } else {
-        for (auto &x : data_new)
-          x = 0.0;
-      }
-
+      zero(data_new);
       const auto oldSize = scipp::size(xold) - 1;
       const auto newSize = scipp::size(xnew) - 1;
       scipp::index iold = 0;

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/common/span.h"
+#include "scipp/core/value_and_variance.h"
+
+namespace scipp::core::element {
+
+/// Set the elements referenced by a span to 0
+template <class T> void zero(const scipp::span<T> &data) {
+  for (auto &x : data)
+    x = 0.0;
+}
+
+/// Set the elements references by the spans for values and variances to 0
+template <class T> void zero(const core::ValueAndVariance<span<T>> &data) {
+  zero(data.value);
+  zero(data.variance);
+}
+
+} // namespace scipp::core::element
+

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -22,4 +22,3 @@ template <class T> void zero(const core::ValueAndVariance<span<T>> &data) {
 }
 
 } // namespace scipp::core::element
-

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -16,7 +16,7 @@ std::string to_string(const Dimensions &dims) {
   if (dims.empty())
     return "{}";
   std::string s = "{{";
-  for (int32_t i = 0; i < dims.shape().size(); ++i)
+  for (int32_t i = 0; i < scipp::size(dims.shape()); ++i)
     s += to_string(dims.labels()[i]) + ", " + std::to_string(dims.shape()[i]) +
          "}, {";
   s.resize(s.size() - 3);

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -72,7 +72,10 @@ template <class Types, class Op, class... Var>
 ///    (first) argument is the "out" argument, as used in `transform_in_place`.
 /// 3. The tuple of supported type combinations must include the type of the out
 ///    argument as the first type in the inner tuples. The output type must be
-///    passed at runtime as the first argument.
+///    passed at runtime as the first argument. `transform_subspan` DOES NOT
+///    DEFAULT INITIALIZE the output array, i.e., `Op` must take care of
+///    initializating the respective subspans. This is done for improved
+///    performance, avoiding streaming/writing to memory twice.
 /// 4. The output type and the type of non-events inputs that depend on `dim`
 ///    must be specified as `span<T>`. The user-provided lambda is called with a
 ///    span of values for these arguments.

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -46,10 +46,10 @@ template <class Types, class Op, class... Var>
        (var.hasVariances() || ...));
   Variable out =
       variance ? Variable(type, dims,
-                          Values{dims.volume(), core::default_init_elements},
-                          Variances{dims.volume(), core::default_init_elements})
+                          Values(dims.volume(), core::default_init_elements),
+                          Variances(dims.volume(), core::default_init_elements))
                : Variable(type, dims,
-                          Values{dims.volume(), core::default_init_elements});
+                          Values(dims.volume(), core::default_init_elements));
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -44,8 +44,12 @@ template <class Types, class Op, class... Var>
       (std::is_base_of_v<
            core::transform_flags::expect_in_variance_if_out_variance_t, Op> &&
        (var.hasVariances() || ...));
-  Variable out = variance ? Variable(type, dims, Values{}, Variances{})
-                          : Variable(type, dims);
+  Variable out =
+      variance ? Variable(type, dims,
+                          Values{dims.volume(), core::default_init_elements},
+                          Variances{dims.volume(), core::default_init_elements})
+               : Variable(type, dims,
+                          Values{dims.volume(), core::default_init_elements});
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -117,7 +117,7 @@ Variable filter(const Variable &var, const Variable &filter) {
   // Note: Could copy larger chunks of applicable for better(?) performance.
   // Note: This implementation is inefficient, since we need to cast to concrete
   // type for *every* slice. Should be combined into a single virtual call.
-  for (scipp::index iIn = 0; iIn < mask.size(); ++iIn)
+  for (scipp::index iIn = 0; iIn < scipp::size(mask); ++iIn)
     if (mask[iIn])
       out.data().copy(var.data(), dim, iOut++, iIn, iIn + 1);
   return out;


### PR DESCRIPTION
- Cleanup: see commits.
- Avoid large array init in `transform_subspan`. Previously the output was default-initialized, and later overwritten. This implies writting a large array twice. The impact of this depends on the exact parameters (e.g., how many input and outputs bins in `rebin`, or how many events in `histogram`). For the histogram benchmarks I observe between 0% and 20% speedup.