### PR TITLE
Skip geometry conversion via keyword argument

### DIFF
--- a/docs/scipp-neutron/instrument-view.ipynb
+++ b/docs/scipp-neutron/instrument-view.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample = sn.load(filename='PG3_4871_event.nxs')"
+    "sample = sn.load(filename='PG3_4871_event.nxs', advanced_geometry=True)"
    ]
   },
   {


### PR DESCRIPTION
The full geometry conversion (including pixel rotations and shapes) from Mantud to Scipp is very time consuming.

By default, we now skip this step and fall back to only having the detector positions.

Note that the instrument view defaults to `Fast` rendering since information on the detector shapes/orientations is no longer present.
