### PR TITLE
Use Mantid's extractY() and extractE() for 2D data

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -176,8 +176,8 @@ template <class... Ts> class as_ElementArrayViewImpl {
               typename std::remove_reference_t<decltype(view_)>::value_type;
           if constexpr (std::is_trivial_v<T>) {
             auto &data = obj.cast<const py::array_t<T>>();
-            bool except = (dims.shape().size() != data.ndim());
-            for (int i = 0; i < dims.shape().size(); ++i)
+            bool except = (scipp::size(dims.shape()) != data.ndim());
+            for (scipp::index i = 0; i < scipp::size(dims.shape()); ++i)
               except |= (dims.shape()[i] != data.shape()[i]);
             if (except)
               throw except::DimensionError("The shape of the provided data "

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -460,10 +460,12 @@ def convert_Workspace2D_to_data_array(ws, **ignored):
 
     coords_labs_data = _convert_MatrixWorkspace_info(ws)
     _, data_unit = validate_and_get_unit(ws.YUnit(), allow_empty=True)
+    stddev2 = ws.extractE()
+    np.power(stddev2, 2, out=stddev2)
     coords_labs_data["data"] = sc.Variable([spec_dim, dim],
                                            unit=data_unit,
                                            values=ws.extractY(),
-                                           variances=ws.extractE())
+                                           variances=stddev2)
     array = detail.move_to_data_array(**coords_labs_data)
 
     if ws.hasAnyMaskedBins():
@@ -839,7 +841,7 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
 
     assert len(y.shape) == 2, "Currently can only handle 2D data."
 
-    e = e if e is not None else np.sqrt(y)
+    e = np.sqrt(e) if e is not None else np.sqrt(y)
 
     unitX = validate_dim_and_get_mantid_string(coord_dim)
 

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -57,15 +57,6 @@ def make_sample(ws):
     return sc.Variable(value=deepcopy(ws.sample()))
 
 
-def make_bin_masks(common_bins, spec_dim, dim, num_bins, num_spectra):
-    if common_bins:
-        return sc.Variable([dim], shape=(num_bins, ), dtype=sc.dtype.bool)
-    else:
-        return sc.Variable([spec_dim, dim],
-                           shape=(num_spectra, num_bins),
-                           dtype=sc.dtype.bool)
-
-
 def make_component_info(ws):
     component_info = ws.componentInfo()
 
@@ -470,13 +461,16 @@ def convert_Workspace2D_to_data_array(ws, **ignored):
 
     if ws.hasAnyMaskedBins():
         array.masks["bin"] = detail.move(
-            make_bin_masks(common_bins, spec_dim, dim, ws.blocksize(),
-                           ws.getNumberHistograms()))
+                sc.Variable(dims=array.dims,
+                           shape=array.shape,
+                           dtype=sc.dtype.bool))
         bin_masks = array.masks["bin"]
-        if common_bins:
-            set_common_bins_masks(bin_masks, dim, ws.maskedBinsIndices(0))
-        else:
-            for i in range(ws.getNumberHistograms()):
+        #if common_bins:
+        #    set_common_bins_masks(bin_masks, dim, ws.maskedBinsIndices(0))
+        #else:
+        for i in range(ws.getNumberHistograms()):
+             # maskedBinsIndices throws instead of returning empty list
+            if ws.hasMaskedBins(i):
                 set_bin_masks(bin_masks, dim, i, ws.maskedBinsIndices(i))
 
     # Avoid creating dimensions that are not required since this mostly an

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -440,7 +440,6 @@ def convert_monitors_ws(ws, converter, **ignored):
 
 
 def convert_Workspace2D_to_data_array(ws, **ignored):
-    common_bins = ws.isCommonBins()
     dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit().unitID())
     spec_dim, spec_coord = init_spec_axis(ws)
 
@@ -456,10 +455,10 @@ def convert_Workspace2D_to_data_array(ws, **ignored):
 
     if ws.hasAnyMaskedBins():
         bin_mask = sc.Variable(dims=array.dims,
-                           shape=array.shape,
-                           dtype=sc.dtype.bool)
+                               shape=array.shape,
+                               dtype=sc.dtype.bool)
         for i in range(ws.getNumberHistograms()):
-             # maskedBinsIndices throws instead of returning empty list
+            # maskedBinsIndices throws instead of returning empty list
             if ws.hasMaskedBins(i):
                 set_bin_masks(bin_mask, dim, i, ws.maskedBinsIndices(i))
         common_mask = sc.all(bin_mask, 'spectrum')

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -51,6 +51,9 @@ class TestMantidConversion(unittest.TestCase):
             "2012-05-21T15:14:56.279289666",
         )
         self.assertEqual(d.data.unit, sc.units.counts)
+        for i in range(ws.getNumberHistograms()):
+            assert np.all(np.equal(d.values[i], ws.readY(i)))
+            assert np.all(np.equal(d.variances[i], np.power(ws.readE(i), 2)))
 
     def test_EventWorkspace(self):
         import mantid.simpleapi as mantid
@@ -524,7 +527,8 @@ def test_to_workspace_2d(param_dim):
     for i in range(expected_number_spectra):
         np.testing.assert_array_equal(ws.readX(i), x['spectrum', i])
         np.testing.assert_array_equal(ws.readY(i), y['spectrum', i])
-        np.testing.assert_array_equal(ws.readE(i), y['spectrum', i].variances)
+        np.testing.assert_array_equal(ws.readE(i),
+                                      np.sqrt(y['spectrum', i].variances))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Faster by avoiding loops and small numpy arrays.
- Less and cleaner code.
- Fix missing sqrt in convertion *TO* Mantid.
- Fix ignored bin masks if workspace has common bins (bin masking may differ, even if there are common bins).
- Test uncertainty conversions.