### PR TITLE
Handle special FP vals in masks

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   element_histogram_test.cpp
   element_trigonometry_test.cpp
   element_unary_operations_test.cpp
+  element_util_test.cpp
   value_and_variance_test.cpp
   view_index_test.cpp
 )

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+
+#include "scipp/core/element/util.h"
+#include "scipp/units/except.h"
+#include "scipp/units/unit.h"
+
+#include "fix_typed_test_suite_warnings.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+using namespace scipp::core::element;
+
+TEST(ElementUtilTest, convertMaskedToZero_masks_special_vals) {
+  EXPECT_EQ(convertMaskedToZero(1.0, true), 0.0);
+  EXPECT_EQ(convertMaskedToZero(std::numeric_limits<double>::quiet_NaN(), true),
+            0.0);
+  EXPECT_EQ(convertMaskedToZero(std::numeric_limits<double>::infinity(), true),
+            0.0);
+  EXPECT_EQ(convertMaskedToZero(1.0, false), 1.0);
+}
+
+TEST(ElementUtilTest, convertMaskedToZero_ignores_unmasked) {
+  EXPECT_TRUE(std::isnan(
+      convertMaskedToZero(std::numeric_limits<double>::quiet_NaN(), false)));
+
+  EXPECT_TRUE(std::isinf(
+      convertMaskedToZero(std::numeric_limits<double>::infinity(), false)));
+}
+
+TEST(ElementUtilTest, convertMaskedToZero_handles_units) {
+  const auto dimensionless = scipp::units::dimensionless;
+
+  for (const auto &unit :
+       {scipp::units::m, scipp::units::dimensionless, scipp::units::s}) {
+
+    // Unit 'a' should always be preserved
+    EXPECT_EQ(convertMaskedToZero(unit, dimensionless), unit);
+  }
+}
+
+TEST(ElementUtilTest, convertMaskedToZero_rejects_units_with_dim) {
+  const auto seconds = scipp::units::s;
+
+  for (const auto &unit :
+       {scipp::units::m, scipp::units::kg, scipp::units::s}) {
+    // Unit 'b' should always be dimensionless as its a mask
+    EXPECT_THROW(convertMaskedToZero(seconds, unit), scipp::except::UnitError);
+  }
+}
+
+TEST(ElementUtilTest, convertMaskedToZero_accepts_all_types) {
+  static_assert(
+      std::is_same_v<decltype(convertMaskedToZero(bool{}, true)), bool>);
+  static_assert(
+      std::is_same_v<decltype(convertMaskedToZero(double{}, true)), double>);
+  static_assert(
+      std::is_same_v<decltype(convertMaskedToZero(float{}, true)), float>);
+  static_assert(
+      std::is_same_v<decltype(convertMaskedToZero(int32_t{}, true)), int32_t>);
+  static_assert(
+      std::is_same_v<decltype(convertMaskedToZero(int64_t{}, true)), int64_t>);
+}

--- a/dataset/test/sum_test.cpp
+++ b/dataset/test/sum_test.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
-#include <gtest/gtest.h>
-#include <vector>
-
 #include "scipp/dataset/dataset.h"
+
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
 
 using namespace scipp;
 using namespace scipp::dataset;
@@ -23,6 +24,25 @@ TEST(SumTest, masked_data_array) {
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
   EXPECT_FALSE(sum(a, Dim::X).masks().contains("mask"));
   EXPECT_TRUE(sum(a, Dim::Y).masks().contains("mask"));
+}
+
+TEST(SumTest, masked_data_with_special_vals) {
+  const auto var = makeVariable<double>(
+      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, units::m,
+      Values{1.0, std::numeric_limits<double>::quiet_NaN(), 3.0, 4.0});
+  const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
+                                       Values{false, true, false, false});
+
+  DataArray a(var);
+  a.masks().set("mask", mask);
+
+  const auto sumX =
+      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 7.0});
+  const auto sumY =
+      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{4.0, 4.0});
+
+  EXPECT_EQ(sum(a, Dim::X).data(), sumX);
+  EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
 }
 
 TEST(SumTest, masked_data_array_two_masks) {


### PR DESCRIPTION
Handles special floating point values in masks, such as `NaN` by transforming the to zero where `mask == true`

This resolves issues where masked `NaN` bins were propagating through a sum, turning the entire dataset into `NaN` values

Fixes: #1145 