### PR TITLE
Collection of misc fixes

### DIFF
--- a/docs/data/fetch_neutron_data.py
+++ b/docs/data/fetch_neutron_data.py
@@ -7,7 +7,8 @@ import subprocess as sp
 
 
 def download_file(source, destination):
-    command = "wget -O {} {}".format(destination, source)
+    print(f"Downloading: {source}")
+    command = "wget -nv -O {} {}".format(destination, source)
     status = sp.run(command, shell=True).returncode
     if status != 0:
         raise RuntimeError("Can't load {} to {}.".format(source, destination))

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -107,3 +107,13 @@ To run the Python tests, run (in the ``python/`` directory):
 
   cd python
   PYTHONPATH=$PYTHONPATH:./install python3 -m pytest
+
+Building Documentation
+----------------------
+
+- Run ``python3 data/fetch_neutron_data.py``
+- cd to a directory where the docs should be built (e.g. ``mkdir -p build/docs && cd build/docs``)
+- Activate a conda environment with Mantid or ensure Mantid is in your ``PYTHONPATH``
+- If Mantid is unavailable (e.g. on Windows) edit ``docs/conf.py`` and include
+``nbsphinx_allow_errors = True``. Take care to not commit this change though.
+- Run ``sphinx-build scipp/src/docs .``

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -924,7 +924,7 @@ def fit(ws, function, workspace_index, start_x, end_x):
     with run_mantid_alg('Fit',
                         Function=function,
                         InputWorkspace=ws,
-                        WorkspaceIndex=workspace_index,
+                        WorkspaceIndex=int(workspace_index),
                         StartX=start_x,
                         EndX=end_x,
                         CreateOutput=True) as fit:


### PR DESCRIPTION
Multiple misc fixes / improvements I've gathered in my repo:

- Force conversion to int for `WorkspaceIndex` in the compat layer, since Mantid will only state a parameter has no registered type converter for a parameter (but not which parameter was broken) rather than attempt float->int. This means that for users it either works or gives a sane error from Python's cast to int

- Reduce the verbosity of downloading data, whilst local devs can't see the bar scroll anymore it makes it much easier to spot what is going wrong in the docs CI step. We use `-nv` to allow wget to still print out information and errors (`--quiet` would suppress this too)

- Add some instructions on how to build docs locally in the getting started pages, this is so devs don't have to look at the CI job to figure it out