### PR TITLE
Speed up MSVC Compilation

### DIFF
--- a/CMake/IPO.cmake
+++ b/CMake/IPO.cmake
@@ -1,0 +1,40 @@
+include(CheckIPOSupported)
+check_ipo_supported(RESULT result OUTPUT output)
+if(result)
+  if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
+        TRUE
+        CACHE BOOL "Link-time optimization: ON/OFF" FORCE
+    )
+  endif()
+  message("IPO set to ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}")
+else()
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
+      FALSE
+      CACHE BOOL "Link-time optimization: ON/OFF" FORCE
+  )
+  message(WARNING "IPO is not supported: ${output}")
+endif()
+
+if(MSVC)
+  # CMake IPO does not include LTCG flag, causing the linker to restart
+  add_link_options($<$<BOOL:${CMAKE_INTERPROCEDURAL_OPTIMIZATION}>:/LTCG>)
+endif()
+
+# See https://github.com/pybind/pybind11/issues/1604
+set(INTERPROCEDURAL_OPTIMIZATION_TESTS FALSE)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
+  if(APPLE)
+    add_compile_definitions(_APPLE_CLANG_)
+  else()
+    # For some reason clang6 on ubuntu18 can't link parts with different
+    # INTERPROCEDURAL_OPTIMIZATION flag.
+    set(INTERPROCEDURAL_OPTIMIZATION_TESTS
+        ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}
+    )
+  endif()
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  # Reduces binary size of, e.g., libscipp-core.so by several MB.
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later Copyright (c) 2019 Scipp
 # contributors (https://github.com/scipp)
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.13)
 project(scipp)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -50,6 +50,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake"
 
 find_package(Sanitizers REQUIRED)
 
+# MP : Parallel compile, add before any targets so all use it
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:-MP>)
+
 include(GTest)
 include(boost)
 include(Eigen)
@@ -98,41 +101,7 @@ option(WITH_CTEST "Enable ctest integration of tests" ON)
 option(DYNAMIC_LIB "Build shared libraries" OFF)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT result OUTPUT output)
-if(result)
-  if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
-        TRUE
-        CACHE BOOL "Link-time optimization: ON/OFF" FORCE
-    )
-  endif()
-  message("IPO set to ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}")
-else()
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
-      FALSE
-      CACHE BOOL "Link-time optimization: ON/OFF" FORCE
-  )
-  message(WARNING "IPO is not supported: ${output}")
-endif()
-
-# See https://github.com/pybind/pybind11/issues/1604
-set(INTERPROCEDURAL_OPTIMIZATION_TESTS FALSE)
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
-  if(APPLE)
-    add_compile_definitions(_APPLE_CLANG_)
-  else()
-    # For some reason clang6 on ubuntu18 can't link parts with different
-    # INTERPROCEDURAL_OPTIMIZATION flag.
-    set(INTERPROCEDURAL_OPTIMIZATION_TESTS
-        ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}
-    )
-  endif()
-  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-  # Reduces binary size of, e.g., libscipp-core.so by several MB.
-  set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
-endif()
+include(IPO)
 
 # Optimization flags
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
@@ -171,10 +140,12 @@ if(NOT WIN32)
     $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
     $<$<COMPILE_LANGUAGE:CXX>:-fno-operator-names>
   )
-
 endif(NOT WIN32)
 # This is currently causing to many warnings, reenable when appropriate.
 # add_compile_options ( -Wconversion )
+
+# permissive- : Std compilant parsing, warnings (W3) set by CMake defaults
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:-permissive->)
 
 enable_testing()
 

--- a/docs/developer/tooling.rst
+++ b/docs/developer/tooling.rst
@@ -6,8 +6,10 @@ This is a list of the tooling (i.e. compilers, static analysis, etc.) that are u
 Misc
 ~~~~
 
-- CMake
+- CMake >= 3.13
 - Conda
+
+Note: Ubuntu users can use the `Kitware Repo <https://apt.kitware.com/>`_ to obtain the latest version.
 
 Compilers
 ~~~~~~~~~


### PR DESCRIPTION
Some fixes for MSVC I completed whilst working on another PR on the same platform:

- Compile using all cores available instead of 1, we should see compile times drop significantly on CI now
- Pass LTCG flag since the linker would start, realise we needed IPO then restart wasting ~5 seconds per target
- Bump CMake to 3.13 (this is for the above)
- Move IPO handling into its own CMake file, since the logic was slowly growing in the main CMake file
- ~Update CI to use Kitware APT repo as 3.10 is the latest available from the Ubuntu repo~ Azure uses 3.16 by default so we don't need to do this

Edit:

The following have been moved to their own issue and PR:

- Replace `Rebin` and the logical ops implicit conversions to static_cast (ensuring it's safe) reducing some warning noise. See commits for more details.
- Handle `bool` types specially in Rebin (since we were doing +=), this prevents an extremely unlikely bug where the int could wrap back up to 0 and turn into false and removes some warnings

Fixes: #1153 