### PR TITLE
Switch to logical comparitors

### DIFF
--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -39,7 +39,6 @@ static constexpr auto rebin = overloaded{
           const auto delta = std::min<double>(xn_high, xo_high) -
                              std::max<double>(xn_low, xo_low);
           const auto owidth = xo_high - xo_low;
-
           const auto scale = delta / owidth;
           if constexpr (is_ValueAndVariance_v<
                             std::decay_t<decltype(data_old)>>) {

--- a/variable/logical.cpp
+++ b/variable/logical.cpp
@@ -15,27 +15,27 @@ using namespace scipp::core;
 namespace scipp::variable {
 
 static constexpr auto or_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ || other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ | other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto or_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ = var_ || other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ |= other_; },
                dimensionless_unit_check};
 
 static constexpr auto and_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ && other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ & other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto and_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ = var_ && other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ &= other_; },
                dimensionless_unit_check};
 
 static constexpr auto xor_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ != other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ ^ other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto xor_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ = var_ != other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ ^= other_; },
                dimensionless_unit_check};
 
 template <class T1, class T2> T1 &or_equals(T1 &variable, const T2 &other) {

--- a/variable/logical.cpp
+++ b/variable/logical.cpp
@@ -15,27 +15,27 @@ using namespace scipp::core;
 namespace scipp::variable {
 
 static constexpr auto or_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ | other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ || other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto or_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ |= other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ = var_ || other_; },
                dimensionless_unit_check};
 
 static constexpr auto and_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ & other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ && other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto and_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ &= other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ = var_ && other_; },
                dimensionless_unit_check};
 
 static constexpr auto xor_op_ = overloaded{
-    [](const auto &var_, const auto &other_) -> bool { return var_ ^ other_; },
+    [](const auto &var_, const auto &other_) -> bool { return var_ != other_; },
     dimensionless_unit_check_return};
 
 static constexpr auto xor_equals_ =
-    overloaded{[](auto &var_, const auto &other_) { var_ ^= other_; },
+    overloaded{[](auto &var_, const auto &other_) { var_ = var_ != other_; },
                dimensionless_unit_check};
 
 template <class T1, class T2> T1 &or_equals(T1 &variable, const T2 &other) {

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -104,7 +104,7 @@ Variable filter(const Variable &var, const Variable &filter) {
   const auto dim = filter.dims().labels()[0];
   auto mask = filter.values<bool>();
 
-  const scipp::index removed = std::count(mask.begin(), mask.end(), 0);
+  const scipp::index removed = std::count(mask.begin(), mask.end(), false);
   if (removed == 0)
     return var;
 


### PR DESCRIPTION
Switch to logical comparators from bitmasks which compare the pointer instead of the underlying type as described in the original issue

Fixes: #1156 

- Use logical comparators rather than bitwise so T& works correctly (rather than comparing the pointer)
- Resolves a warning where we were scaling `bool` types in rebin, which in a very rare set of circumstances could have the underlying representation overflow