### PR TITLE
Fix groupby.sum with 2D coords

### DIFF
--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -70,9 +70,9 @@ static constexpr auto make_value = [](auto &&view) -> decltype(auto) {
 ///
 /// For dimension-coords, this is the same as the key, for non-dimension-coords
 /// (labels) we adopt the convention that they are "label" their inner
-/// dimension.
+/// dimension. Returns Dim::Invalid for 0-D var or var containing event lists.
 template <class T, class Key> Dim dim_of_coord(const T &var, const Key &key) {
-  if (contains_events(var))
+  if (contains_events(var) || var.dims().ndim() == 0)
     return Dim::Invalid;
   if constexpr (std::is_same_v<Key, Dim>) {
     const bool is_dimension_coord = var.dims().contains(key);

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -129,16 +129,6 @@ UnalignedData sum(Dimensions dims, const DataArrayConstView &unaligned,
   dims.erase(dim);
   return {dims, flatten(unaligned, dim)};
 }
-
-UnalignedData mean(Dimensions, const DataArrayConstView &, const Dim,
-                   const MasksConstView &) {
-  throw std::runtime_error("Mean for realigned data not implemented yet.");
-}
-
-UnalignedData rebin(Dimensions, const DataArrayConstView &, const Dim,
-                    const VariableConstView &, const VariableConstView &) {
-  throw std::runtime_error("Rebin for realigned data not implemented yet.");
-}
 } // namespace
 
 DataArray sum(const DataArrayConstView &a, const Dim dim) {
@@ -157,7 +147,9 @@ Dataset sum(const DatasetConstView &d, const Dim dim) {
 
 DataArray mean(const DataArrayConstView &a, const Dim dim) {
   return apply_to_data_and_drop_dim(
-      a, [](auto &&... _) { return mean(_...); }, dim, a.masks());
+      a,
+      overloaded{no_realigned_support, [](auto &&... _) { return mean(_...); }},
+      dim, a.masks());
 }
 
 Dataset mean(const DatasetConstView &d, const Dim dim) {
@@ -168,7 +160,10 @@ Dataset mean(const DatasetConstView &d, const Dim dim) {
 DataArray rebin(const DataArrayConstView &a, const Dim dim,
                 const VariableConstView &coord) {
   auto rebinned = apply_to_data_and_drop_dim(
-      a, [](auto &&... _) { return rebin(_...); }, dim, a.coords()[dim], coord);
+      a,
+      overloaded{no_realigned_support,
+                 [](auto &&... _) { return rebin(_...); }},
+      dim, a.coords()[dim], coord);
 
   for (auto &&[name, mask] : a.masks()) {
     if (mask.dims().contains(dim))
@@ -186,9 +181,10 @@ Dataset rebin(const DatasetConstView &d, const Dim dim,
 }
 
 namespace {
-Dimensions resize(Dimensions dims, const Dim dim, const scipp::index size) {
+UnalignedData resize(Dimensions dims, const DataArrayConstView &unaligned,
+                     const Dim dim, const scipp::index size) {
   dims.resize(dim, size);
-  return dims;
+  return {dims, resize(unaligned, dim, size)};
 }
 } // namespace
 

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -103,7 +103,7 @@ Dataset concatenate(const DatasetConstView &a, const DatasetConstView &b,
 }
 
 DataArray flatten(const DataArrayConstView &a, const Dim dim) {
-  return apply_or_copy_dim(
+  return apply_to_data_and_drop_dim(
       a,
       overloaded{no_realigned_support,
                  [](const auto &x, const Dim dim_, const auto &mask_) {
@@ -190,7 +190,7 @@ UnalignedData resize(Dimensions dims, const DataArrayConstView &unaligned,
 
 DataArray resize(const DataArrayConstView &a, const Dim dim,
                  const scipp::index size) {
-  return apply_or_copy_dim(
+  return apply_to_data_and_drop_dim(
       a, [](auto &&... _) { return resize(_...); }, dim, size);
 }
 

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -65,6 +65,13 @@ TEST_F(GroupbyTest, copy) {
   EXPECT_EQ(two_groups.copy(1), d.slice({Dim::X, 2, 3}));
 }
 
+TEST_F(GroupbyTest, fail_2d_coord) {
+  d.setCoord(Dim("2d"), makeVariable<float>(Dims{Dim::X, Dim::Z}, Shape{2, 2}));
+  EXPECT_NO_THROW(groupby(d, Dim("labels2")));
+  EXPECT_THROW(groupby(d, Dim("labels2")).sum(Dim::X),
+               except::CoordMismatchError);
+}
+
 TEST_F(GroupbyTest, dataset_1d_and_2d) {
   Dataset expected;
   Dim dim("labels2");
@@ -140,7 +147,7 @@ TEST_F(GroupbyMaskedTest, sum) {
   EXPECT_EQ(result, expected);
 }
 
-TEST_F(GroupbyMaskedTest, sum_irrelvant_mask) {
+TEST_F(GroupbyMaskedTest, sum_irrelevant_mask) {
   Dataset expected;
   const Dim dim("labels2");
   expected.setData("a", makeVariable<double>(Dimensions{dim, 2}, units::m,


### PR DESCRIPTION
Solves the first bug in #1148. `groupby.sum` now throws as it should if a 2D coord is present.

- Added missing unit test.
- The bug was in a near-duplicate piece of code which I finally managed to unify. I am still unhappy with the branching in `apply_or_copy_dim_impl`, but for now I did not find a way to get away from this.