### PR TITLE
Add realign option to neutron.convert

### DIFF
--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -43,6 +43,11 @@ template <class T>
 MismatchError(const core::Dimensions &, const T &)
     -> MismatchError<core::Dimensions>;
 
+using TypeMismatchError = MismatchError<core::DType>;
+
+template <class T>
+MismatchError(const core::DType &, const T &) -> MismatchError<core::DType>;
+
 struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
   DimensionError(const std::string &msg);
   DimensionError(scipp::index expectedDim, scipp::index userDim);

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -120,14 +120,22 @@ DataArray apply_to_items(const DataArrayConstView &d, Func func,
   return func(d, std::forward<Args>(args)...);
 }
 
+template <class... Args>
+bool copy_attr(const VariableConstView &attr, const Dim dim, const Args &...) {
+  return !attr.dims().contains(dim);
+}
+template <class... Args>
+bool copy_attr(const VariableConstView &, const Args &...) {
+  return true;
+}
+
 template <class Func, class... Args>
-Dataset apply_to_items(const DatasetConstView &d, Func func, const Dim dim,
-                       Args &&... args) {
+Dataset apply_to_items(const DatasetConstView &d, Func func, Args &&... args) {
   Dataset result;
   for (const auto &data : d)
-    result.setData(data.name(), func(data, dim, std::forward<Args>(args)...));
+    result.setData(data.name(), func(data, std::forward<Args>(args)...));
   for (auto &&[name, attr] : d.attrs())
-    if (!attr.dims().contains(dim))
+    if (copy_attr(attr, args...))
       result.setAttr(name, attr);
   return result;
 }

--- a/dataset/event.cpp
+++ b/dataset/event.cpp
@@ -107,7 +107,8 @@ DataArray filter(const DataArrayConstView &array, const Dim dim,
                                                  : copy(array.data()),
                    std::move(coords), array.masks(),
                    attrPolicy == AttrPolicy::Keep ? array.attrs()
-                                                  : empty.attrs()};
+                                                  : empty.attrs(),
+                   array.name()};
 }
 
 Variable map(const DataArrayConstView &function, const VariableConstView &x,

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -191,10 +191,7 @@ DataArray histogram(const DataArrayConstView &realigned) {
 }
 
 Dataset histogram(const DatasetConstView &realigned) {
-  Dataset out;
-  for (const auto &item : realigned)
-    out.setData(item.name(), histogram(item));
-  return out;
+  return apply_to_items(realigned, [](auto &item) { return histogram(item); });
 }
 
 } // namespace scipp::dataset

--- a/neutron/include/scipp/neutron/convert.h
+++ b/neutron/include/scipp/neutron/convert.h
@@ -10,13 +10,19 @@
 
 namespace scipp::neutron {
 
-SCIPP_NEUTRON_EXPORT dataset::DataArray convert(dataset::DataArray d,
-                                                const Dim from, const Dim to);
+enum class ConvertRealign { None, Linear };
+
 SCIPP_NEUTRON_EXPORT dataset::DataArray
-convert(const dataset::DataArrayConstView &d, const Dim from, const Dim to);
-SCIPP_NEUTRON_EXPORT dataset::Dataset convert(dataset::Dataset d,
-                                              const Dim from, const Dim to);
+convert(dataset::DataArray d, const Dim from, const Dim to,
+        const ConvertRealign realign = ConvertRealign::None);
+SCIPP_NEUTRON_EXPORT dataset::DataArray
+convert(const dataset::DataArrayConstView &d, const Dim from, const Dim to,
+        const ConvertRealign realign = ConvertRealign::None);
 SCIPP_NEUTRON_EXPORT dataset::Dataset
-convert(const dataset::DatasetConstView &d, const Dim from, const Dim to);
+convert(dataset::Dataset d, const Dim from, const Dim to,
+        const ConvertRealign realign = ConvertRealign::None);
+SCIPP_NEUTRON_EXPORT dataset::Dataset
+convert(const dataset::DatasetConstView &d, const Dim from, const Dim to,
+        const ConvertRealign realign = ConvertRealign::None);
 
 } // namespace scipp::neutron

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -53,7 +53,7 @@ class TestMantidConversion(unittest.TestCase):
         self.assertEqual(d.data.unit, sc.units.counts)
         for i in range(ws.getNumberHistograms()):
             assert np.all(np.equal(d.values[i], ws.readY(i)))
-            assert np.all(np.equal(d.variances[i], np.power(ws.readE(i), 2)))
+            assert np.all(np.equal(d.variances[i], ws.readE(i) * ws.readE(i)))
 
     def test_EventWorkspace(self):
         import mantid.simpleapi as mantid

--- a/python/tests/neutron/test_neutron.py
+++ b/python/tests/neutron/test_neutron.py
@@ -36,7 +36,6 @@ def make_dataset_with_beamline():
 
 def test_neutron_convert():
     d = make_dataset_with_beamline()
-
     dspacing = sc.neutron.convert(d, 'tof', 'd-spacing')
     # Detailed testing done on the C++ side
     assert dspacing.coords['d-spacing'].unit == sc.units.angstrom
@@ -44,8 +43,28 @@ def test_neutron_convert():
 
 def test_neutron_convert_out_arg():
     d = make_dataset_with_beamline()
-
     dspacing = sc.neutron.convert(d, 'tof', 'd-spacing', out=d)
+    assert dspacing.coords['d-spacing'].unit == sc.units.angstrom
+    assert dspacing is d
+
+
+def test_neutron_convert_realign():
+    d = make_dataset_with_beamline()
+    # note that on the C++ side the request for realignment will be
+    # ignored since this is not realigned event data.
+    dspacing = sc.neutron.convert(d, 'tof', 'd-spacing', realign='linear')
+    assert dspacing.coords['d-spacing'].unit == sc.units.angstrom
+
+
+def test_neutron_convert_out_arg_realign():
+    d = make_dataset_with_beamline()
+    # note that on the C++ side the request for realignment will be
+    # ignored since this is not realigned event data.
+    dspacing = sc.neutron.convert(d,
+                                  'tof',
+                                  'd-spacing',
+                                  out=d,
+                                  realign='linear')
     assert dspacing.coords['d-spacing'].unit == sc.units.angstrom
     assert dspacing is d
 

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -17,6 +17,7 @@ set(INC_FILES
     include/scipp/variable/transform.h
     include/scipp/variable/transform_subspan.h
     include/scipp/variable/trigonometry.h
+    include/scipp/variable/util.h
     include/scipp/variable/variable_concept.h
     include/scipp/variable/variable.h
     include/scipp/variable/variable_keyword_arg_constructor.h
@@ -38,6 +39,7 @@ set(SRC_FILES
     subspan_view.cpp
     trigonometry.cpp
     type_conversion.cpp
+    util.cpp
     variable_concept.cpp
     variable.cpp
     variable_instantiate_basic.cpp

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp-variable_export.h"
+#include "scipp/variable/variable.h"
+
+namespace scipp::variable {
+
+SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
+                                        const VariableConstView &stop,
+                                        const Dim dim, const scipp::index num);
+
+} // namespace scipp::variable

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
   subspan_view_test.cpp
   transform_test.cpp
   trigonometry_test.cpp
+  util_test.cpp
   variable_concept_test.cpp
   variable_custom_type_test.cpp
   variable_keyword_args_constructor_test.cpp

--- a/variable/test/util_test.cpp
+++ b/variable/test/util_test.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/except.h"
+#include "scipp/variable/arithmetic.h"
+#include "scipp/variable/util.h"
+
+using namespace scipp;
+
+TEST(LinspaceTest, dim_mismatch) {
+  EXPECT_THROW(
+      linspace(1.0 * units::one,
+               makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::one), Dim::X,
+               4),
+      except::DimensionMismatchError);
+}
+
+TEST(LinspaceTest, unit_mismatch) {
+  EXPECT_THROW(linspace(1.0 * units::one, 4.0 * units::m, Dim::X, 4),
+               except::UnitMismatchError);
+}
+
+TEST(LinspaceTest, dtype_mismatch) {
+  EXPECT_THROW(linspace(1.0 * units::one, 4.0f * units::one, Dim::X, 4),
+               except::TypeMismatchError);
+}
+
+TEST(LinspaceTest, non_float_fail) {
+  EXPECT_THROW(linspace(1 * units::one, 4 * units::one, Dim::X, 4),
+               except::TypeError);
+}
+
+TEST(LinspaceTest, variances_fail) {
+  const auto a = 1.0 * units::one;
+  const auto b = makeVariable<double>(Values{1}, Variances{1});
+  EXPECT_THROW(linspace(a, b, Dim::X, 4), except::VariancesError);
+  EXPECT_THROW(linspace(b, a, Dim::X, 4), except::VariancesError);
+  EXPECT_THROW(linspace(b, b, Dim::X, 4), except::VariancesError);
+}
+
+TEST(LinspaceTest, increasing) {
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  EXPECT_EQ(linspace(1.0 * units::one, 4.0 * units::one, Dim::X, 4), expected);
+}
+
+TEST(LinspaceTest, increasing_float) {
+  const auto expected =
+      makeVariable<float>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  EXPECT_EQ(linspace(1.0f * units::one, 4.0f * units::one, Dim::X, 4),
+            expected);
+}
+
+TEST(LinspaceTest, with_unit) {
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{4}, units::m,
+                                             Values{1, 2, 3, 4});
+  EXPECT_EQ(linspace(1.0 * units::m, 4.0 * units::m, Dim::X, 4), expected);
+}
+
+TEST(LinspaceTest, fractional) {
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{4}, units::m, Values{0.1, 0.1 + 0.1, 0.1 + 0.2, 0.4});
+  EXPECT_EQ(linspace(0.1 * units::m, 0.4 * units::m, Dim::X, 4), expected);
+}
+
+TEST(LinspaceTest, decreasing) {
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{4, 3, 2, 1});
+  EXPECT_EQ(linspace(4.0 * units::one, 1.0 * units::one, Dim::X, 4), expected);
+}
+
+TEST(LinspaceTest, increasing_2d) {
+  const auto expected = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
+                                             Values{1, 2, 3, 10, 20, 30});
+  EXPECT_EQ(linspace(expected.slice({Dim::X, 0}), expected.slice({Dim::X, 2}),
+                     Dim::X, 3),
+            expected);
+}

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -3,10 +3,10 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/variable/util.h"
+#include "scipp/core/except.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/except.h"
 #include "scipp/variable/misc_operations.h"
-#include "scipp/variable/transform_subspan.h"
 
 using namespace scipp::core;
 
@@ -14,14 +14,27 @@ namespace scipp::variable {
 
 Variable linspace(const VariableConstView &start, const VariableConstView &stop,
                   const Dim dim, const scipp::index num) {
+  // Th implementation here is slightly verbose and explicit. It could be
+  // improved if we were to introduce new variants of `transform`, similar to
+  // `std::generate`.
   core::expect::equals(start.dims(), stop.dims());
   core::expect::equals(start.unit(), stop.unit());
+  core::expect::equals(start.dtype(), stop.dtype());
+  if (start.dtype() != dtype<double> && start.dtype() != dtype<float>)
+    throw except::TypeError(
+        "Cannot create linspace with non-floating-point start and/or stop.");
+  if (start.hasVariances() || stop.hasVariances())
+    throw except::VariancesError(
+        "Cannot create linspace with start and/or stop containing variances.");
   auto dims = start.dims();
   dims.addInner(dim, num);
-  Variable out = broadcast(start, dims);
+  Variable out(start, dims);
   const auto range = stop - start;
-  for (scipp::index i = 1; i < num - 1; ++i)
-    out.slice({dim, i}) += (static_cast<double>(i) / num * units::one) * range;
+  for (scipp::index i = 0; i < num - 1; ++i)
+    out.slice({dim, i}).assign(
+        start +
+        astype(static_cast<double>(i) / (num - 1) * units::one, start.dtype()) *
+            range);
   out.slice({dim, num - 1}).assign(stop); // endpoint included
   return out;
 }

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/variable/util.h"
+#include "scipp/variable/arithmetic.h"
+#include "scipp/variable/except.h"
+#include "scipp/variable/misc_operations.h"
+#include "scipp/variable/transform_subspan.h"
+
+using namespace scipp::core;
+
+namespace scipp::variable {
+
+Variable linspace(const VariableConstView &start, const VariableConstView &stop,
+                  const Dim dim, const scipp::index num) {
+  core::expect::equals(start.dims(), stop.dims());
+  core::expect::equals(start.unit(), stop.unit());
+  auto dims = start.dims();
+  dims.addInner(dim, num);
+  Variable out = broadcast(start, dims);
+  const auto range = stop - start;
+  for (scipp::index i = 1; i < num - 1; ++i)
+    out.slice({dim, i}) += (static_cast<double>(i) / num * units::one) * range;
+  out.slice({dim, num - 1}).assign(stop); // endpoint included
+  return out;
+}
+
+} // namespace scipp::variable


### PR DESCRIPTION
Fixes #1148.

- Add `realign` option to `neutron.convert`. Only supporting `'linear'` for now, `'log'` would probably also be useful at some point.
- Added `linspace` as a helper.

TODO:
- [x] I'd like some advice on testing this. Just looking at the "small" modifications made to `convert_generic`, we have at least 4 new cases to test (`None`, `any_aligned`, increasing coord, decreasing coord). It feels like brute-forcing this is not going to lead to maintainable code? -> done using tests against histogrammed data.