### PR TITLE
Coerce spectrum float64 to int64 for spectrum coord

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -350,9 +350,12 @@ def get_detector_properties(ws,
                             dtype=sc.dtype.vector_3_float64))
 
 
-def _get_dtype_from_values(values):
+def _get_dtype_from_values(values, coerce_floats_to_ints):
     if hasattr(values, 'dtype'):
-        dtype = values.dtype
+        if coerce_floats_to_ints and np.all(np.mod(values, 1.0) == 0.0):
+            dtype = sc.dtype.int64
+        else:
+            dtype = values.dtype
     else:
         if len(values) > 0:
             dtype = type(values[0])
@@ -375,7 +378,7 @@ def init_spec_axis(ws):
     axis = ws.getAxis(1)
     dim, unit = validate_and_get_unit(axis.getUnit().unitID())
     values = axis.extractValues()
-    dtype = _get_dtype_from_values(values)
+    dtype = _get_dtype_from_values(values, dim == 'spectrum')
     return dim, sc.Variable([dim], values=values, unit=unit, dtype=dtype)
 
 

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -351,11 +351,10 @@ def get_detector_properties(ws,
 
 
 def _get_dtype_from_values(values, coerce_floats_to_ints):
-    if hasattr(values, 'dtype'):
-        if coerce_floats_to_ints and np.all(np.mod(values, 1.0) == 0.0):
-            dtype = sc.dtype.int64
-        else:
-            dtype = values.dtype
+    if coerce_floats_to_ints and np.all(np.mod(values, 1.0) == 0.0):
+        dtype = sc.dtype.int64
+    elif hasattr(values, 'dtype'):
+        dtype = values.dtype
     else:
         if len(values) > 0:
             dtype = type(values[0])

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -352,7 +352,7 @@ def get_detector_properties(ws,
 
 def _get_dtype_from_values(values, coerce_floats_to_ints):
     if coerce_floats_to_ints and np.all(np.mod(values, 1.0) == 0.0):
-        dtype = sc.dtype.int64
+        dtype = sc.dtype.int32
     elif hasattr(values, 'dtype'):
         dtype = values.dtype
     else:

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -54,7 +54,7 @@ class TestMantidConversion(unittest.TestCase):
         for i in range(ws.getNumberHistograms()):
             assert np.all(np.equal(d.values[i], ws.readY(i)))
             assert np.all(np.equal(d.variances[i], np.power(ws.readE(i), 2)))
-        self.assertEqual(d.coords['spectrum'].dtype, sc.dtype.int64)
+        self.assertEqual(d.coords['spectrum'].dtype, sc.dtype.int32)
         self.assertEqual(d.coords['tof'].dtype, sc.dtype.float64)
 
     def test_EventWorkspace(self):

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -54,6 +54,8 @@ class TestMantidConversion(unittest.TestCase):
         for i in range(ws.getNumberHistograms()):
             assert np.all(np.equal(d.values[i], ws.readY(i)))
             assert np.all(np.equal(d.variances[i], np.power(ws.readE(i), 2)))
+        self.assertEqual(d.coords['spectrum'].dtype, sc.dtype.int64)
+        self.assertEqual(d.coords['tof'].dtype, sc.dtype.float64)
 
     def test_EventWorkspace(self):
         import mantid.simpleapi as mantid


### PR DESCRIPTION
Additional check that this is the spectrum axis. May be undesirable behaviour if representing other dimensions.

Fixes #1111