### PR TITLE
Handle single spec in to_workspace_2d

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -880,13 +880,26 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
             "as detailed in the installation instructions (https://scipp."
             "github.io/getting-started/installation.html)")
 
-    assert len(y.shape) == 2, "Currently can only handle 2D data."
+    assert (len(y.shape) == 2 or len(y.shape) == 1), \
+        "Currently can only handle 2D data."
 
     e = np.sqrt(e) if e is not None else np.sqrt(y)
+
+    # Convert a single array (e.g. single spectra) into 2d format
+    if len(y.shape) == 1:
+        y = np.array([y])
+
+    if len(e.shape) == 1:
+        e = np.array([e])
 
     unitX = validate_dim_and_get_mantid_string(coord_dim)
 
     nspec = y.shape[0]
+    if len(x.shape) == 1:
+        # SCIPP is using a  1:n spectra coord mapping, Mantid needs
+        # a 1:1 mapping so expand this out
+        x = np.broadcast_to(x, shape=(nspec, len(x)))
+
     nbins = x.shape[1]
     nitems = y.shape[1]
 


### PR DESCRIPTION
Handles single spectra data converting to 2d, such as when Dim.Spectrum has been summed. This means the caller side does not have to
include boilerplate to figure out if they need to add an extra outer dim
to satisfy the 2d requirements

This work was originally done with the imaging notebooks, but I hadn't pushed up the changes. It's required for the imaging notebook to run correctly as we pass through single spectra and 2d data