### PR TITLE
Exclude googlebenchmark from all so it does not end up in conda pkg

### DIFF
--- a/CMake/GoogleBenchmark.cmake
+++ b/CMake/GoogleBenchmark.cmake
@@ -31,6 +31,5 @@ endif()
 
 add_subdirectory(
   ${CMAKE_BINARY_DIR}/googlebenchmark-src
-  ${CMAKE_BINARY_DIR}/googlebenchmark-build
-  EXCLUDE_FROM_ALL
+  ${CMAKE_BINARY_DIR}/googlebenchmark-build EXCLUDE_FROM_ALL
 )

--- a/CMake/GoogleBenchmark.cmake
+++ b/CMake/GoogleBenchmark.cmake
@@ -32,4 +32,5 @@ endif()
 add_subdirectory(
   ${CMAKE_BINARY_DIR}/googlebenchmark-src
   ${CMAKE_BINARY_DIR}/googlebenchmark-build
+  EXCLUDE_FROM_ALL
 )


### PR DESCRIPTION
Fixes #1057.