### PR TITLE
Add -p to mkdir in case dir already exists

### DIFF
--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -54,7 +54,7 @@ stages:
               conda env create -f scipp-developer.yml
               # TODO: source activate does not work (see https://github.com/conda/conda/issues/9566)
               echo "##vso[task.prependpath]$CONDA/envs/scipp-developer/bin"
-              mkdir "$(build_dir)" "$(install_dir)" "$(docs_build_dir)"
+              mkdir -p  "$(build_dir)" "$(install_dir)" "$(docs_build_dir)"
             displayName: 'Configure build environment'
           - bash: |
               set -ex
@@ -101,7 +101,7 @@ stages:
               set -ex
               cd docs
               python data/fetch_neutron_data.py
-              mkdir "$HOME/.mantid"
+              mkdir -p  "$HOME/.mantid"
               echo -e "usagereports.enabled=0\ndatasearch.directories=$(pwd)/data" > "$HOME/.mantid/Mantid.user.properties"
               # Build documentation, redirecting doctrees to avoid size bloat in build documentation
               PYTHONPATH="$PYTHONPATH:$(install_dir)" sphinx-build -d $(mktemp -d) . "$(docs_build_dir)"
@@ -138,7 +138,7 @@ stages:
               conda env create -f scipp-developer-no-mantid.yml
               # TODO: source activate does not work (see https://github.com/conda/conda/issues/9566)
               echo "##vso[task.prependpath]$CONDA/envs/scipp-developer/bin"
-              mkdir "$(build_dir)" "$(install_dir)"
+              mkdir -p  "$(build_dir)" "$(install_dir)"
             displayName: 'Configure build environment'
           - bash: |
               set -ex
@@ -192,7 +192,7 @@ stages:
               set -ex
               conda --version
               conda env create -f scipp-developer-no-mantid.yml
-              mkdir "$(build_dir)" "$(install_dir)"
+              mkdir -p  "$(build_dir)" "$(install_dir)"
             displayName: 'Configure build environment'
           - bash: |
               set -ex

--- a/.azure-pipelines/templates/documentation_build.yml
+++ b/.azure-pipelines/templates/documentation_build.yml
@@ -36,7 +36,7 @@ jobs:
           cd docs
           source activate scipp-developer
           python data/fetch_neutron_data.py
-          mkdir $HOME/.mantid
+          mkdir -p  $HOME/.mantid
           echo -e "usagereports.enabled=0\ndatasearch.directories=$(pwd)/data" > $HOME/.mantid/Mantid.user.properties
           # Build documentation, redirecting doctrees to avoid size bloat in build documentation
           sphinx-build -d "$(mktemp -d)" . "$(docs_build_dir)"


### PR DESCRIPTION
CI has failed for $HOME/.mantid since the dir already exists from
Python importing the framework. For the sake of simplicity use -p so we
know that folder creation just works as the CI VMs are reset between
each pass anyway

This is currently blocking: #1171 