### PR TITLE
Convert coord to attrs in non-range slices, instead of dropping

### DIFF
--- a/dataset/CMakeLists.txt
+++ b/dataset/CMakeLists.txt
@@ -4,14 +4,23 @@ set(TARGET_NAME "scipp-dataset")
 set(INC_FILES
     include/scipp/dataset/choose.h
     include/scipp/dataset/counts.h
+    include/scipp/dataset/dataset_access.h
     include/scipp/dataset/dataset.h
     include/scipp/dataset/dataset_index.h
+    include/scipp/dataset/dataset_util.h
+    include/scipp/dataset/event.h
     include/scipp/dataset/except.h
+    include/scipp/dataset/groupby.h
+    include/scipp/dataset/histogram.h
+    include/scipp/dataset/map_view_forward.h
+    include/scipp/dataset/map_view.h
     include/scipp/dataset/math.h
     include/scipp/dataset/rebin.h
     include/scipp/dataset/reduction.h
     include/scipp/dataset/shape.h
     include/scipp/dataset/sort.h
+    include/scipp/dataset/string.h
+    include/scipp/dataset/unaligned.h
 )
 
 set(SRC_FILES

--- a/dataset/arithmetic.cpp
+++ b/dataset/arithmetic.cpp
@@ -147,6 +147,8 @@ auto apply_with_broadcast(const Op &op, const A &a,
   Dataset res;
   for (const auto &item : a)
     res.setData(item.name(), op(item, b));
+  for (auto &[name, attr] : intersection(a.attrs(), b.attrs()))
+    res.setAttr(name, std::move(attr));
   return res;
 }
 
@@ -156,6 +158,8 @@ auto apply_with_broadcast(const Op &op, const DataArrayConstView &a,
   Dataset res;
   for (const auto &item : b)
     res.setData(item.name(), op(a, item));
+  for (auto &[name, attr] : intersection(a.attrs(), b.attrs()))
+    res.setAttr(name, std::move(attr));
   return res;
 }
 

--- a/dataset/arithmetic.cpp
+++ b/dataset/arithmetic.cpp
@@ -6,6 +6,8 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/variable/transform.h"
 
+#include "dataset_operations_common.h"
+
 using namespace scipp::core;
 
 namespace scipp::dataset {
@@ -134,6 +136,8 @@ auto apply_with_broadcast(const Op &op, const A &a, const B &b) {
   for (const auto &item : b)
     if (const auto it = a.find(item.name()); it != a.end())
       res.setData(item.name(), op(*it, item));
+  for (auto &[name, attr] : intersection(a.attrs(), b.attrs()))
+    res.setAttr(name, std::move(attr));
   return res;
 }
 

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -317,14 +317,6 @@ DataArray &DataArray::operator/=(const VariableConstView &other) {
   return *this;
 }
 
-auto intersection(const AttrsConstView &a, const AttrsConstView &b) {
-  std::map<std::string, Variable> out;
-  for (const auto &[key, item] : a)
-    if (const auto it = b.find(key); it != b.end() && it->second == item)
-      out.emplace(key, item);
-  return out;
-}
-
 DataArray operator+(const DataArrayConstView &a, const DataArrayConstView &b) {
   if (a.hasData() && b.hasData()) {
     return DataArray(a.data() + b.data(), union_(a.coords(), b.coords()),

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -767,20 +767,17 @@ CoordsView DatasetView::coords() const noexcept {
 
 /// Return a const view to all attributes of the dataset slice.
 AttrsConstView DatasetConstView::attrs() const noexcept {
-  auto items = makeViewItems<AttrsConstView>(dimensions(), m_dataset->m_attrs);
-  addAttrsFromCoords(items, m_dataset->dimensions(), dimensions(),
-                     m_dataset->m_coords);
-  return AttrsConstView(std::move(items), slices());
+  return AttrsConstView(
+      makeViewItems<AttrsConstView>(dimensions(), m_dataset->m_attrs),
+      slices());
 }
 
 /// Return a view to all attributes of the dataset slice.
 AttrsView DatasetView::attrs() const noexcept {
-  auto items =
-      makeViewItems<AttrsConstView>(dimensions(), m_mutableDataset->m_attrs);
-  addAttrsFromCoords(items, m_dataset->dimensions(), dimensions(),
-                     m_mutableDataset->m_coords);
-  return AttrsView(AttrAccess(slices().empty() ? m_mutableDataset : nullptr),
-                   std::move(items), slices());
+  return AttrsView(
+      AttrAccess(slices().empty() ? m_mutableDataset : nullptr),
+      makeViewItems<AttrsConstView>(dimensions(), m_mutableDataset->m_attrs),
+      slices());
 }
 /// Return a const view to all masks of the dataset slice.
 MasksConstView DatasetConstView::masks() const noexcept {

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -25,6 +25,16 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
   return out;
 }
 
+/// Return intersection of maps, i.e., all items with matching names that
+/// have matching content.
+template <class Map> auto intersection(const Map &a, const Map &b) {
+  std::map<std::string, Variable> out;
+  for (const auto &[key, item] : a)
+    if (const auto it = b.find(key); it != b.end() && it->second == item)
+      out.emplace(key, item);
+  return out;
+}
+
 /// Return a copy of map-like objects such as CoordView.
 template <class T> auto copy_map(const T &map) {
   std::map<typename T::key_type, typename T::mapped_type> out;

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -164,15 +164,19 @@ DataArray histogram(const DataArrayConstView &realigned) {
                                   return realigned_dims.count(item.first);
                                 }),
                  bounds.end());
+    DataArray out;
     if (bounds.empty())
-      return histogram(realigned.unaligned(),
-                       unaligned::realigned_event_coord(realigned));
+      out = histogram(realigned.unaligned(),
+                      unaligned::realigned_event_coord(realigned));
     else {
       // Copy to drop events out of slice bounds
       DataArray sliced(realigned);
-      return histogram(sliced.unaligned(),
-                       unaligned::realigned_event_coord(realigned));
+      out = histogram(sliced.unaligned(),
+                      unaligned::realigned_event_coord(realigned));
     }
+    for (const auto &[name, attr] : realigned.attrs())
+      out.attrs().set(name, std::move(attr));
+    return out;
   }
   std::optional<DataArray> filtered;
   // If `realigned` is sliced we need to copy the unaligned content to "apply"

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -95,6 +95,7 @@ public:
   const detail::slice_list &slices() const noexcept { return m_slices; }
 
   auto &underlying() const { return m_data->second; }
+  Dimensions parentDims() const noexcept;
 
   std::vector<std::pair<Dim, Variable>> slice_bounds() const;
 

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -23,12 +23,12 @@ using slice_list =
 template <class T> void do_make_slice(T &slice, const slice_list &slices) {
   for (const auto &[params, extent] : slices) {
     if (slice.dims().contains(params.dim())) {
-      const auto new_end = params.end() + slice.dims()[params.dim()] - extent;
-      const auto pointSlice = (new_end == -1);
-      if (pointSlice) {
-        slice = slice.slice(Slice{params.dim(), params.begin()});
+      if (slice.dims()[params.dim()] == extent) {
+        slice = slice.slice(params);
       } else {
-        slice = slice.slice(Slice{params.dim(), params.begin(), new_end});
+        slice = slice.slice(
+            Slice{params.dim(), params.begin(),
+                  params.end() == -1 ? params.begin() + 2 : params.end() + 1});
       }
     }
   }

--- a/dataset/shape.cpp
+++ b/dataset/shape.cpp
@@ -57,8 +57,6 @@ auto concat(const T1 &a, const T2 &b, const Dim dim, const DimT &dimsA,
 
 DataArray concatenate(const DataArrayConstView &a, const DataArrayConstView &b,
                       const Dim dim) {
-  if (!a.dims().contains(dim) && a == b)
-    return DataArray{a};
   return DataArray(a.hasData() || b.hasData()
                        ? concatenate(a.data(), b.data(), dim)
                        : Variable{},

--- a/dataset/shape.cpp
+++ b/dataset/shape.cpp
@@ -72,8 +72,12 @@ Dataset concatenate(const DatasetConstView &a, const DatasetConstView &b,
       concat(a.masks(), b.masks(), dim, a.dimensions(), b.dimensions()),
       std::map<std::string, Variable>());
   for (const auto &item : a)
-    if (b.contains(item.name()))
-      result.setData(item.name(), concatenate(item, b[item.name()], dim));
+    if (b.contains(item.name())) {
+      if (!item.dims().contains(dim) && item == b[item.name()])
+        result.setData(item.name(), item);
+      else
+        result.setData(item.name(), concatenate(item, b[item.name()], dim));
+    }
   return result;
 }
 

--- a/dataset/test/attributes_test.cpp
+++ b/dataset/test/attributes_test.cpp
@@ -76,13 +76,6 @@ TEST_F(AttributesTest, dataset_events_item_attrs) {
   ASSERT_EQ(d["events"].attrs().size(), 0);
 }
 
-TEST_F(AttributesTest, dataset_item_attrs_dimensions_exceeding_data) {
-  Dataset d;
-  d.setData("scalar", scalar);
-  EXPECT_THROW(d["scalar"].attrs().set("x", varX), except::DimensionError);
-  ASSERT_FALSE(d["scalar"].attrs().contains("x"));
-}
-
 TEST_F(AttributesTest, slice_dataset_item_attrs) {
   Dataset d;
   d.setData("a", varZX);

--- a/dataset/test/attributes_test.cpp
+++ b/dataset/test/attributes_test.cpp
@@ -246,7 +246,13 @@ TEST_F(AttributesTest, unaligned_not_mapped_into_aligned) {
   EXPECT_TRUE(d["a"].unaligned().attrs().empty());
 }
 
-TEST_F(AttributesTest, unaligned_set_via_aligned_fails) {
+// We have removed the check in Dataset::setAttr preventing insertion of attrs
+// exceeding data dims. This is now more in line with how coords are handled,
+// and is required for storing edges of a single bin created from a non-range
+// slice. However, it leaves this peculiarity of allowing insertion of an
+// attribute that depends on an dimension of unaligned content, without implying
+// actual relation, i.e., extents are unrelated.
+TEST_F(AttributesTest, DISABLED_unaligned_set_via_aligned_fails) {
   auto d = testdata::make_dataset_realigned_x_to_y();
   EXPECT_ANY_THROW(
       d["a"].attrs().set("x", makeVariable<double>(Dims{Dim::X}, Shape{3})));

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -267,7 +267,14 @@ INSTANTIATE_TEST_SUITE_P(AllPositions, Dataset3DTest_slice_events,
 
 TEST_P(Dataset3DTest_slice_x, slice) {
   const auto pos = GetParam();
-  EXPECT_EQ(dataset.slice({Dim::X, pos}), reference(pos));
+  auto expected = reference(pos);
+  // Non-range slice converts coord to attr
+  for (const auto &name :
+       {"values_x", "data_x", "data_xy", "data_zyx", "data_xyz"})
+    for (const auto &attr : {"x", "labels_x"})
+      expected[name].attrs().set(
+          attr, dataset.coords()[Dim(attr)].slice({Dim::X, pos}));
+  EXPECT_EQ(dataset.slice({Dim::X, pos}), expected);
 }
 
 TEST_P(Dataset3DTest_slice_events, slice) {
@@ -321,6 +328,10 @@ TEST_P(Dataset3DTest_slice_y, slice) {
                     dataset["data_zyx"].data().slice({Dim::Y, pos}));
   reference.setData("data_xyz",
                     dataset["data_xyz"].data().slice({Dim::Y, pos}));
+  for (const auto &name : {"data_xy", "data_zyx", "data_xyz"})
+    for (const auto &attr : {"y", "labels_xy"})
+      reference[name].attrs().set(
+          attr, dataset.coords()[Dim(attr)].slice({Dim::Y, pos}));
 
   EXPECT_EQ(dataset.slice({Dim::Y, pos}), reference);
 }
@@ -341,6 +352,10 @@ TEST_P(Dataset3DTest_slice_z, slice) {
                     dataset["data_zyx"].data().slice({Dim::Z, pos}));
   reference.setData("data_xyz",
                     dataset["data_xyz"].data().slice({Dim::Z, pos}));
+  for (const auto &name : {"data_zyx", "data_xyz"})
+    for (const auto &attr : {"z", "labels_z"})
+      reference[name].attrs().set(
+          attr, dataset.coords()[Dim(attr)].slice({Dim::Z, pos}));
 
   EXPECT_EQ(dataset.slice({Dim::Z, pos}), reference);
 }

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -306,9 +306,17 @@ TEST_P(Dataset3DTest_slice_x, slice_bin_edges) {
   const auto pos = GetParam();
   auto datasetWithEdges = dataset;
   datasetWithEdges.setCoord(Dim::X, makeRandom({Dim::X, 5}));
-  EXPECT_EQ(datasetWithEdges.slice({Dim::X, pos}), reference(pos));
-  EXPECT_EQ(datasetWithEdges.slice({Dim::X, pos}),
-            dataset.slice({Dim::X, pos}));
+  auto expected = reference(pos);
+  // Non-range slice converts coord to attr
+  for (const auto &name :
+       {"values_x", "data_x", "data_xy", "data_zyx", "data_xyz"}) {
+    expected[name].attrs().set(
+        "labels_x",
+        datasetWithEdges.coords()[Dim("labels_x")].slice({Dim::X, pos}));
+    expected[name].attrs().set(
+        "x", datasetWithEdges.coords()[Dim("x")].slice({Dim::X, pos, pos + 2}));
+  }
+  EXPECT_EQ(datasetWithEdges.slice({Dim::X, pos}), expected);
 }
 
 TEST_P(Dataset3DTest_slice_y, slice) {

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -744,9 +744,7 @@ template <class T> void test_dataset_coord_to_attr_mapping(T &o) {
             3.0 * units::one);
 }
 
-TEST_F(CoordToAttrMappingTest, DataArrayView) {
-  test_coord_to_attr_mapping(a);
-}
+TEST_F(CoordToAttrMappingTest, DataArrayView) { test_coord_to_attr_mapping(a); }
 
 TEST_F(CoordToAttrMappingTest, DataArrayConstView) {
   const DataArray &const_a = a;

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -707,6 +707,20 @@ template <class T> void test_coord_to_attr_mapping(T &o) {
             3.0 * units::one);
 }
 
+template <class T> void test_dataset_coord_to_attr_mapping(T &o) {
+  EXPECT_FALSE(o.attrs().contains("x"));
+  EXPECT_FALSE(o.slice({Dim::X, 2, 3}).attrs().contains("x"));
+  // No mapping to attrs of *dataset*
+  EXPECT_FALSE(o.slice({Dim::X, 2}).attrs().contains("x"));
+  // Mapped "aligned" coord of dataset to attr (unaligned coord) of item
+  EXPECT_TRUE(o.slice({Dim::X, 2})["a"].attrs().contains("x"));
+  EXPECT_EQ(o.slice({Dim::X, 2})["a"].attrs()["x"], 3.0 * units::one);
+  EXPECT_TRUE(
+      o.slice({Dim::X, 2, 3}).slice({Dim::X, 0})["a"].attrs().contains("x"));
+  EXPECT_EQ(o.slice({Dim::X, 2, 3}).slice({Dim::X, 0})["a"].attrs()["x"],
+            3.0 * units::one);
+}
+
 TEST_F(CoordToAttrMappingTest, DataArrayView) {
   test_coord_to_attr_mapping(a);
 }
@@ -718,10 +732,10 @@ TEST_F(CoordToAttrMappingTest, DataArrayConstView) {
 
 TEST_F(CoordToAttrMappingTest, DatasetView) {
   Dataset d({{"a", a}});
-  test_coord_to_attr_mapping(d);
+  test_dataset_coord_to_attr_mapping(d);
 }
 
 TEST_F(CoordToAttrMappingTest, DatasetConstView) {
   const Dataset d({{"a", a}});
-  test_coord_to_attr_mapping(d);
+  test_dataset_coord_to_attr_mapping(d);
 }

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include <set>
+
 #include "scipp/core/element/arg_list.h"
 
 #include "scipp/variable/event.h"
@@ -190,11 +192,11 @@ T convert_impl(T d, const Dim from, const Dim to,
 namespace {
 template <class T>
 T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
-  auto fields = {"position", "source-position", "sample-position"};
-  // TODO Add `extract` methods to do this in one step and avoid copies?
-  if (from == Dim::Tof) {
-    for (const auto &field : fields) {
-      if (x.coords().contains(Dim(field))) {
+  const auto to_attr = [&](const auto field) {
+    if (!x.coords().contains(Dim(field)))
+      return;
+    if constexpr (std::is_same_v<std::decay_t<T>, Dataset>)
+      for (const auto &item : iter(x))
         // TODO This is an unfortunate duplication of attributes. It is
         // (currently?) required due to a limitation of handling attributes of
         // Dataset and its items *independently* (no mapping of dataset
@@ -203,27 +205,35 @@ T swap_tof_related_labels_and_attrs(T &&x, const Dim from, const Dim to) {
         // a subsequent unit conversion of an item on its own would not be
         // possible. It needs to be determined if there is a better way to
         // handle attributes so this can be avoided.
-        if constexpr (std::is_same_v<std::decay_t<T>, Dataset>)
-          for (const auto &item : iter(x))
-            item.attrs().set(field, x.coords()[Dim(field)]);
-        x.attrs().set(field, x.coords()[Dim(field)]);
-        x.coords().erase(Dim(field));
+        item.attrs().set(field, x.coords()[Dim(field)]);
+    x.attrs().set(field, x.coords()[Dim(field)]);
+    x.coords().erase(Dim(field));
+  };
+  const auto to_coord = [&](const auto field) {
+    if (!x.attrs().contains(field))
+      return;
+    x.coords().set(Dim(field), x.attrs()[field]);
+    x.attrs().erase(field);
+    if constexpr (std::is_same_v<std::decay_t<T>, Dataset>) {
+      for (const auto &item : iter(x)) {
+        core::expect::equals(x.coords()[Dim(field)], item.attrs()[field]);
+        item.attrs().erase(field);
       }
     }
-  }
-  if (to == Dim::Tof) {
-    for (const auto &field : fields) {
-      if (x.attrs().contains(field)) {
-        x.coords().set(Dim(field), x.attrs()[field]);
-        x.attrs().erase(field);
-        if constexpr (std::is_same_v<std::decay_t<T>, Dataset>) {
-          for (const auto &item : iter(x)) {
-            core::expect::equals(x.coords()[Dim(field)], item.attrs()[field]);
-            item.attrs().erase(field);
-          }
-        }
-      }
-    }
+  };
+  // Will be replaced by explicit flag
+  bool scatter = x.coords().contains(Dim("sample-position"));
+  if (scatter) {
+    std::set<Dim> pos_invariant{Dim::DSpacing, Dim::Q};
+    if (pos_invariant.count(to))
+      to_attr("position");
+    if (pos_invariant.count(from))
+      to_coord("position");
+  } else {
+    if (to == Dim::Tof)
+      to_coord("position");
+    else
+      to_attr("position");
   }
   return std::move(x);
 }

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -200,9 +200,9 @@ TEST_P(ConvertTest, Tof_to_DSpacing) {
   }
 
   ASSERT_EQ(dspacing.attrs()["position"], tof.coords()[Dim("position")]);
-  ASSERT_EQ(dspacing.attrs()["source-position"],
+  ASSERT_EQ(dspacing.coords()[Dim("source-position")],
             tof.coords()[Dim("source-position")]);
-  ASSERT_EQ(dspacing.attrs()["sample-position"],
+  ASSERT_EQ(dspacing.coords()[Dim("sample-position")],
             tof.coords()[Dim("sample-position")]);
 }
 
@@ -315,11 +315,8 @@ TEST_P(ConvertTest, Tof_to_Wavelength) {
     EXPECT_NEAR(d1[2], 3956.0 / (1e6 * 11.0 / tof1[2]), d1[2] * 1e-3);
   }
 
-  ASSERT_EQ(wavelength.attrs()["position"], tof.coords()[Dim("position")]);
-  ASSERT_EQ(wavelength.attrs()["source-position"],
-            tof.coords()[Dim("source-position")]);
-  ASSERT_EQ(wavelength.attrs()["sample-position"],
-            tof.coords()[Dim("sample-position")]);
+  for (const auto &name : {"position", "source-position", "sample-position"})
+    ASSERT_EQ(wavelength.coords()[Dim(name)], tof.coords()[Dim(name)]);
 }
 
 TEST_P(ConvertTest, Wavelength_to_Tof) {
@@ -462,11 +459,8 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
                 e1[2] * 1e-3);
   }
 
-  ASSERT_EQ(energy.attrs()["position"], tof.coords()[Dim("position")]);
-  ASSERT_EQ(energy.attrs()["source-position"],
-            tof.coords()[Dim("source-position")]);
-  ASSERT_EQ(energy.attrs()["sample-position"],
-            tof.coords()[Dim("sample-position")]);
+  for (const auto &name : {"position", "source-position", "sample-position"})
+    ASSERT_EQ(energy.coords()[Dim(name)], tof.coords()[Dim(name)]);
 }
 
 TEST_P(ConvertTest, Energy_to_Tof_Elastic) {

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -402,8 +402,7 @@ def _convert_MatrixWorkspace_info(ws, advanced_geometry=False):
     info = {
         "coords": {
             dim: coord,
-            spec_dim: spec_coord,
-            "position": pos
+            spec_dim: spec_coord
         },
         "masks": {},
         "attrs": {
@@ -419,6 +418,9 @@ def _convert_MatrixWorkspace_info(ws, advanced_geometry=False):
 
     if advanced_geometry:
         info["coords"]["detector_info"] = make_detector_info(ws)
+
+    if not np.all(np.isnan(pos.values)):
+        info["coords"].update({"position": pos})
 
     if rot is not None and shp is not None and not np.all(np.isnan(
             pos.values)):

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -273,7 +273,10 @@ def test_slice():
             'b': sc.Variable(1.0)
         },
         coords={'x': sc.Variable(dims=['x'], values=np.arange(10.0))})
-    expected = sc.Dataset({'a': sc.Variable(1.0)})
+    expected = sc.Dataset({
+        'a':
+        sc.DataArray(1.0 * sc.units.one, attrs={'x': 1.0 * sc.units.one})
+    })
 
     assert d['x', 1] == expected
     assert 'a' in d['x', 1]
@@ -281,6 +284,9 @@ def test_slice():
 
 
 def test_chained_slicing():
+    x = sc.Variable(dims=['x'], values=np.arange(11.0))
+    y = sc.Variable(dims=['y'], values=np.arange(11.0))
+    z = sc.Variable(dims=['z'], values=np.arange(11.0))
     d = sc.Dataset(
         {
             'a':
@@ -291,9 +297,9 @@ def test_chained_slicing():
                         values=np.arange(0.0, 10.0, 0.1).reshape(10, 10))
         },
         coords={
-            'x': sc.Variable(dims=['x'], values=np.arange(11.0)),
-            'y': sc.Variable(dims=['y'], values=np.arange(11.0)),
-            'z': sc.Variable(dims=['z'], values=np.arange(11.0))
+            'x': x,
+            'y': y,
+            'z': z
         })
 
     expected = sc.Dataset()
@@ -301,6 +307,10 @@ def test_chained_slicing():
     expected['a'] = sc.Variable(dims=['y'],
                                 values=np.arange(501.0, 600.0, 10.0))
     expected['b'] = sc.Variable(1.5)
+    expected['a'].attrs['x'] = x['x', 1:3]
+    expected['b'].attrs['x'] = x['x', 1:3]
+    expected['a'].attrs['z'] = z['z', 5:7]
+    expected['b'].attrs['z'] = z['z', 5:7]
 
     assert d['x', 1]['z', 5] == expected
 


### PR DESCRIPTION
Possible solution to #1155, in particular the [last suggestion](https://github.com/scipp/scipp/issues/1155#issuecomment-638691295). This represents a (almost) non-breaking first step.

- Current attrs essentially behave like the "unaligned coords" we have discussed there, so the draft here simply maps sliced coords to attrs. This may actually be a good initial implementation/refactoring step, leaving all other interfaces intact.
- Propagate attrs in binary-ops. We had wanted to do this previously (and nothing prevented us), it had just not been done yet. Now it was required so, e.g., position attrs after unit conversion are carried.
- Unit conversion with better logic for coord -> attr conversion.

This works with the updated SANS direct-beam notebook in branch https://github.com/scipp/ess/tree/direct-beam-unaligned-coords.

Future work:
- Unify `coords` and `attrs` to aligned and unaligned coords.
- Provide mechanism to flag/unflag alignments.
- Convert (some?) attrs back to coord in `concatenate`?