### PR TITLE
Mantid compat updates

### DIFF
--- a/docs/scipp-neutron/overview.rst
+++ b/docs/scipp-neutron/overview.rst
@@ -40,6 +40,8 @@ Mantid Compatibility
    :toctree: ../generated
 
    from_mantid
+   to_mantid
+   fit
 
 Unit Conversion
 ~~~~~~~~~~~~~~~

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -867,7 +867,8 @@ def to_mantid(data, dim, instrument_file=None):
     :param dim: Coord to use for Mantid's first axis (X).
     :param instrument_file: Instrument file that will be
                             loaded into the workspace
-    :returns: Workspace containing converted data. The concrete workspace type may differ depending on the content of `data`.
+    :returns: Workspace containing converted data. The concrete workspace type
+              may differ depending on the content of `data`.
     """
     if not is_data_array(data):
         raise RuntimeError(

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -9,7 +9,9 @@ from contextlib import contextmanager
 import numpy as np
 
 from .. import detail
+from ..utils import is_data_array
 from .._scipp import core as sc
+from .._scipp.core import contains_events
 
 
 @contextmanager
@@ -855,33 +857,28 @@ def validate_dim_and_get_mantid_string(unit_dim):
         return known_units[user_k]
 
 
-def data_array_to_workspace_2d(data_array, dim, instrument_file=None):
-    return to_workspace_2d(x=data_array.coords[dim].values,
-                           y=data_array.values,
-                           e=data_array.variances,
-                           coord_dim=dim,
-                           instrument_file=instrument_file)
-
-
-def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
+def to_mantid(data, dim, instrument_file=None):
     """
-    Use the values provided to create a Mantid workspace.
+    Convert data to a Mantid workspace.
 
     The Mantid layout expect the spectra to be the Outer-most dimension,
     i.e. y.shape[0]. If that is not the case you might have to transpose
     your data to fit that, otherwise it will not be aligned correctly in the
     Mantid workspace.
 
-    :param x: Data to be used as X for the Mantid workspace.
-    :param y: Data to be used as Y for the Mantid workspace.
-    :param e: Data to be used as error for the Mantid workspace.
-              If `None` the np.sqrt of y will be used.
-    :param coord_dim: Dim of the coordinate, to be set as the equivalent
-                      UnitX on the Mantid workspace.
+    :param data: Data to be converted.
+    :param dim: Coord to use for Mantid's first axis (X).
     :param instrument_file: Instrument file that will be
                             loaded into the workspace
-    :returns: Workspace2D containing the data for X, Y and E
+    :returns: Workspace containing converted data. The concrete workspace type may differ depending on the content of `data`.
     """
+    if not is_data_array(data):
+        raise RuntimeError(
+            "Currently only data arrays can be converted to a Mantid workspace"
+        )
+    if data.data is None or contains_events(data):
+        raise RuntimeError(
+            "Currently only histogrammed data can be converted.")
     try:
         import mantid.simpleapi as mantid
     except ImportError:
@@ -889,6 +886,9 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
             "Mantid Python API was not found, please install Mantid framework "
             "as detailed in the installation instructions (https://scipp."
             "github.io/getting-started/installation.html)")
+    x = data.coords[dim].values
+    y = data.values
+    e = data.variances
 
     assert (len(y.shape) == 2 or len(y.shape) == 1), \
         "Currently can only handle 2D data."
@@ -902,7 +902,7 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
     if len(e.shape) == 1:
         e = np.array([e])
 
-    unitX = validate_dim_and_get_mantid_string(coord_dim)
+    unitX = validate_dim_and_get_mantid_string(dim)
 
     nspec = y.shape[0]
     if len(x.shape) == 1:
@@ -917,6 +917,8 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
                                         NVectors=nspec,
                                         XLength=nbins,
                                         YLength=nitems)
+    if data.unit != sc.units.counts:
+        ws.setDistribution(True)
 
     for i in range(nspec):
         ws.setX(i, x[i])
@@ -934,43 +936,54 @@ def to_workspace_2d(x, y, e, coord_dim, instrument_file=None):
     return ws
 
 
-def fit(ws, function, workspace_index, start_x, end_x):
+def _table_to_data_array(table, key, value, stddev):
+    stddevs = table[stddev].values
+    dim = 'parameter'
+    coord = table[key].data.copy()
+    coord.rename_dims({'row': dim})
+    return sc.DataArray(data=sc.Variable(dims=[dim],
+                                         values=table[value].values,
+                                         variances=stddevs * stddevs),
+                        coords={dim: coord})
+
+
+def _fit_workspace(ws, mantid_args):
     """
     Performs a fit on the workspace.
 
     :param ws: The workspace on which the fit will be performed
-    :param function: The function used for the fit. This is anything
-                     that mantid.Fit's Function parameter can handle.
-    :param workspace_index: Workspace index which will be fitted.
-    :param start_x: Start X for the fit
-    :param end_x: End X for the fit
     :returns: Dataset containing all of Fit's outputs
     """
     with run_mantid_alg('Fit',
-                        Function=function,
                         InputWorkspace=ws,
-                        WorkspaceIndex=int(workspace_index),
-                        StartX=start_x,
-                        EndX=end_x,
+                        **mantid_args,
                         CreateOutput=True) as fit:
-        ds = sc.Dataset(data={
-            'workspace':
-            sc.Variable(convert_Workspace2D_to_data_array(
-                fit.OutputWorkspace)),
-            'parameters':
-            sc.Variable(convert_TableWorkspace_to_dataset(
-                fit.OutputParameters)),
-            'normalised_covariance_matrix':
-            sc.Variable(
-                convert_TableWorkspace_to_dataset(
-                    fit.OutputNormalisedCovarianceMatrix)),
-        },
-                        attrs={
-                            'status': sc.Variable(fit.OutputStatus),
-                            'chi2_over_DoF':
-                            sc.Variable(fit.OutputChi2overDoF),
-                            'function': sc.Variable(str(fit.Function)),
-                            'cost_function': sc.Variable(fit.CostFunction)
-                        })
+        # This is assuming that all parameters are dimensionless. If this is
+        # not the case we should use a dataset with a scalar variable per
+        # parameter instead. Or better, a dict of scalar variables?
+        parameters = convert_TableWorkspace_to_dataset(fit.OutputParameters)
+        parameters = _table_to_data_array(parameters,
+                                          key='Name',
+                                          value='Value',
+                                          stddev='Error')
+        out = convert_Workspace2D_to_data_array(fit.OutputWorkspace)
+        data = sc.Dataset()
+        data['data'] = out['empty', 0]
+        data['calculated'] = out['empty', 1]
+        data['diff'] = out['empty', 2]
+        parameters.attrs['status'] = sc.Variable(fit.OutputStatus)
+        parameters.attrs['chi^2/d.o.f.'] = sc.Variable(fit.OutputChi2overDoF)
+        parameters.attrs['function'] = sc.Variable(str(fit.Function))
+        parameters.attrs['cost-function'] = sc.Variable(fit.CostFunction)
+        return parameters, data
 
-        return ds
+
+def fit(data, mantid_args):
+    if len(data.dims) != 1 or 'WorkspaceIndex' in mantid_args:
+        raise RuntimeError(
+            "Only 1D fitting is supported. Use scipp slicing and do not"
+            "provide a WorkspaceIndex.")
+    dim = data.dims[0]
+    ws = to_mantid(data, dim)
+    mantid_args['workspace_index'] = 0
+    return _fit_workspace(ws, mantid_args)

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -5,6 +5,7 @@
 import re
 from copy import deepcopy
 from contextlib import contextmanager
+import uuid
 
 import numpy as np
 
@@ -25,9 +26,8 @@ def run_mantid_alg(alg, *args, **kwargs):
             "as detailed in the installation instructions (https://scipp."
             "github.io/getting-started/installation.html)")
     # Deal with multiple calls to this function, which may have conflicting
-    # names in the global AnalysisDataService.
-    run_mantid_alg.workspace_id += 1
-    ws_name = f'scipp.run_mantid_alg.{run_mantid_alg.workspace_id}'
+    # names in the global AnalysisDataService by using uuid.
+    ws_name = f'scipp.run_mantid_alg.{uuid.uuid4()}'
     # Deal with non-standard ways to define the prefix of output workspaces
     if alg == 'Fit':
         kwargs['Output'] = ws_name
@@ -42,9 +42,6 @@ def run_mantid_alg(alg, *args, **kwargs):
         for name in AnalysisDataService.Instance().getObjectNames():
             if name.startswith(ws_name):
                 mantid.DeleteWorkspace(name)
-
-
-run_mantid_alg.workspace_id = 0
 
 
 def get_pos(pos):

--- a/python/src/scipp/neutron/__init__.py
+++ b/python/src/scipp/neutron/__init__.py
@@ -7,4 +7,4 @@
 from .._scipp.neutron import *
 from . import diffraction
 from .instrument_view import instrument_view
-from ..compat.mantid import from_mantid, load
+from ..compat.mantid import from_mantid, to_mantid, load, fit

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -31,6 +31,7 @@ def instrument_view(scipp_obj=None,
                     continuous_update=True,
                     dim="tof",
                     rendering="Full",
+                    pixel_size=0.0005,
                     background="#f0f0f0"):
     """
     Plot a 2D or 3D view of the instrument.
@@ -59,6 +60,7 @@ def instrument_view(scipp_obj=None,
                         continuous_update=continuous_update,
                         dim=dim,
                         rendering=rendering,
+                        pixel_size=pixel_size,
                         background=background)
 
     render_plot(widgets=iv.box, filename=filename)
@@ -81,7 +83,9 @@ class InstrumentView:
                  continuous_update=None,
                  dim=None,
                  rendering=None,
+                 pixel_size=0.0005,
                  background=None):
+        self._pixel_size = pixel_size
 
         # Delayed imports to avoid hard dependencies
         self.widgets = importlib.import_module("ipywidgets")
@@ -468,7 +472,7 @@ class InstrumentView:
                     [self.det_pos.shape[0], 3], dtype=np.float32))
             })
         points_material = self.p3.PointsMaterial(vertexColors='VertexColors',
-                                                 size=self.camera_pos * 0.05,
+                                                 size=self.camera_pos * self._pixel_size,
                                                  transparent=True)
         points = self.p3.Points(geometry=points_geometry,
                                 material=points_material)

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -472,7 +472,8 @@ class InstrumentView:
                     [self.det_pos.shape[0], 3], dtype=np.float32))
             })
         points_material = self.p3.PointsMaterial(vertexColors='VertexColors',
-                                                 size=self.camera_pos * self._pixel_size,
+                                                 size=self.camera_pos *
+                                                 self._pixel_size,
                                                  transparent=True)
         points = self.p3.Points(geometry=points_geometry,
                                 material=points_material)

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -409,9 +409,9 @@ class TestMantidConversion(unittest.TestCase):
                             expected_number_spectra * expected_bins,
                             dtype=np.float64).reshape(
                                 (expected_number_spectra, expected_bins)))
+        data = sc.DataArray(data=y, coords={param_dim: x})
 
-        ws = sc.compat.mantid.to_workspace_2d(x.values, y.values, None,
-                                              param_dim)
+        ws = sc.compat.mantid.to_mantid(data, param_dim)
 
         assert len(ws.readX(0)) == expected_bins
         assert ws.getNumberHistograms() == expected_number_spectra
@@ -424,7 +424,7 @@ class TestMantidConversion(unittest.TestCase):
             np.testing.assert_array_equal(ws.readE(i),
                                           np.sqrt(y['spectrum', i].values))
 
-    def test_fit_executes(self):
+    def test_fit(self):
         """
         Tests that the fit executes, and the outputs
         are moved into the dataset. Does not check the fit values.
@@ -432,21 +432,26 @@ class TestMantidConversion(unittest.TestCase):
         from mantid.simpleapi import Load, mtd
         mtd.clear()
 
-        ws = Load(MantidDataHelper.find_file("iris26176_graphite002_sqw.nxs"),
-                  StoreInADS=False)
+        data = sc.neutron.load(filename=MantidDataHelper.find_file(
+            "iris26176_graphite002_sqw.nxs"))
 
-        fit_ds = sc.compat.mantid.fit(ws, 'name=LinearBackground,A0=0,A1=1', 0,
-                                      0, 3)
+        params, diff = sc.compat.mantid.fit(
+            data['Q', 0],
+            mantid_args={
+                'Function': 'name=LinearBackground,A0=0,A1=1',
+                'StartX': 0,
+                'EndX': 3
+            })
 
         # check that no workspaces have been leaked in the ADS
-        self.assertEqual(len(mtd), 0, mtd.getObjectNames())
-        self.assertTrue("workspace" in fit_ds)
-        self.assertTrue("normalised_covariance_matrix" in fit_ds)
-        self.assertTrue("parameters" in fit_ds)
-        self.assertTrue("cost_function" in fit_ds.attrs)
-        self.assertTrue("function" in fit_ds.attrs)
-        self.assertTrue("status" in fit_ds.attrs)
-        self.assertTrue("chi2_over_DoF" in fit_ds.attrs)
+        assert len(mtd) == 0
+        assert 'data' in diff
+        assert 'calculated' in diff
+        assert 'diff' in diff
+        assert 'status' in params.attrs
+        assert 'function' in params.attrs
+        assert 'cost-function' in params.attrs
+        assert 'chi^2/d.o.f.' in params.attrs
 
     def test_set_run(self):
         import mantid.simpleapi as mantid
@@ -523,46 +528,6 @@ class TestMantidConversion(unittest.TestCase):
                 mantidcompat.validate_dim_and_get_mantid_string(i)
 
 
-@pytest.mark.skipif(not mantid_is_available(),
-                    reason='Mantid framework is unavailable')
-@pytest.mark.parametrize(
-    "param_dim",
-    ('tof', 'wavelength', 'E', 'd-spacing', 'Q', 'Q^2', 'Delta-E'))
-def test_data_array_to_ws(param_dim):
-    from mantid.simpleapi import mtd
-    mtd.clear()
-
-    data_len = 2
-    expected_bins = data_len + 1
-    expected_number_spectra = 10
-
-    y = sc.Variable(['spectrum', param_dim],
-                    values=np.random.rand(expected_number_spectra, data_len),
-                    variances=np.random.rand(expected_number_spectra,
-                                             data_len))
-
-    x = sc.Variable(['spectrum', param_dim],
-                    values=np.arange(expected_number_spectra * expected_bins,
-                                     dtype=np.float64).reshape(
-                                         (expected_number_spectra,
-                                          expected_bins)))
-
-    to_conv = sc.DataArray(data=y, coords={param_dim: x})
-
-    ws = sc.compat.mantid.data_array_to_workspace_2d(to_conv, param_dim)
-
-    assert len(ws.readX(0)) == expected_bins
-    assert ws.getNumberHistograms() == expected_number_spectra
-    # check that no workspaces have been leaked in the ADS
-    assert len(mtd) == 0, f"Workspaces present: {mtd.getObjectNames()}"
-
-    for i in range(expected_number_spectra):
-        np.testing.assert_array_equal(ws.readX(i), x['spectrum', i])
-        np.testing.assert_array_equal(ws.readY(i), y['spectrum', i])
-        np.testing.assert_array_equal(ws.readE(i),
-                                      np.sqrt(y['spectrum', i].variances))
-
-
 @pytest.mark.skipif(not memory_is_at_least_gb(16),
                     reason='Insufficient virtual memory')
 @pytest.mark.skipif(not mantid_is_available(),
@@ -588,9 +553,9 @@ def test_to_workspace_2d(param_dim):
                                      dtype=np.float64).reshape(
                                          (expected_number_spectra,
                                           expected_bins)))
+    data = sc.DataArray(data=y, coords={param_dim: x})
 
-    ws = sc.compat.mantid.to_workspace_2d(x.values, y.values, y.variances,
-                                          param_dim)
+    ws = sc.compat.mantid.to_mantid(data, param_dim)
 
     assert len(ws.readX(0)) == expected_bins
     assert ws.getNumberHistograms() == expected_number_spectra
@@ -616,9 +581,9 @@ def test_to_workspace_2d_handles_single_spectra():
 
     x = sc.Variable(['tof'], values=expected_x)
     y = sc.Variable(['tof'], values=expected_y, variances=expected_e)
+    data = sc.DataArray(data=y, coords={'tof': x})
 
-    ws = sc.compat.mantid.to_workspace_2d(x.values, y.values, y.variances,
-                                          "tof")
+    ws = sc.compat.mantid.to_mantid(data, "tof")
 
     assert ws.getNumberHistograms() == 1
 
@@ -641,9 +606,9 @@ def test_to_workspace_2d_handles_single_x_array():
     y = sc.Variable(['spectrum', 'tof'],
                     values=np.array(expected_y),
                     variances=np.array(expected_e))
+    data = sc.DataArray(data=y, coords={'tof': x})
 
-    ws = sc.compat.mantid.to_workspace_2d(x.values, y.values, y.variances,
-                                          "tof")
+    ws = sc.compat.mantid.to_mantid(data, "tof")
 
     assert ws.getNumberHistograms() == 2
     assert np.equal(ws.readX(0), expected_x).all()

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -429,7 +429,7 @@ class TestMantidConversion(unittest.TestCase):
         Tests that the fit executes, and the outputs
         are moved into the dataset. Does not check the fit values.
         """
-        from mantid.simpleapi import Load, mtd
+        from mantid.simpleapi import mtd
         mtd.clear()
 
         data = sc.neutron.load(filename=MantidDataHelper.find_file(


### PR DESCRIPTION
Several changes in compat layers. Needed for LoKI workflow, but all are general improvements.

- Can control pixel size in instrument view again.
- Rename conversion to Mantid to `to_mantid` and sanitize function signature (not accepting individual variables as inputs any more).
- `fit` wrapper now accepts data array instead of workspace.
- `fit` and `to_mantid` made part of `scipp.neutron`.
- Don't use counter to prevent ADS conflicts (had broken on me in the past when I used dask, i.e., this was not thread-safe).

@OwenArnold This will break the imaging notebooks I believe?