### PR TITLE
Instrument view: Fix pixel size and add related missing Python binding

### DIFF
--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -99,6 +99,9 @@ Geometric
 Group-by (split-apply-combine)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Reduction
+---------
+
 .. autosummary::
    :toctree: ../generated
 
@@ -117,6 +120,15 @@ Group-by (split-apply-combine)
    GroupByDataset.mean
    GroupByDataset.min
    GroupByDataset.sum
+
+Other
+-----
+
+.. autosummary::
+   :toctree: ../generated
+
+   GroupByDataArray.copy
+   GroupByDataset.copy
 
 Counts
 ~~~~~~

--- a/python/groupby.cpp
+++ b/python/groupby.cpp
@@ -111,6 +111,18 @@ template <class T> void bind_groupby(py::module &m, const std::string &name) {
   groupBy.def("max", &GroupBy<T>::max, py::arg("dim"),
               py::call_guard<py::gil_scoped_release>(),
               docstring_groupby<T>("max").c_str());
+
+  groupBy.def(
+      "copy",
+      [](const GroupBy<T> &self, const scipp::index &group) {
+        return self.copy(group);
+      },
+      py::arg("group"),
+      Docstring()
+          .description("Extract group as new data array or dataset.")
+          .rtype<T>()
+          .template param<scipp::index>("group", "Index of groupy to extract")
+          .c_str());
 }
 
 void init_groupby(py::module &m) {

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -32,6 +32,8 @@ def instrument_view(scipp_obj=None,
                     dim="tof",
                     rendering="Full",
                     pixel_size=0.02,
+                    camera_pos=None,
+                    look_at=None,
                     background="#f0f0f0"):
     """
     Plot a 2D or 3D view of the instrument.
@@ -61,6 +63,8 @@ def instrument_view(scipp_obj=None,
                         dim=dim,
                         rendering=rendering,
                         pixel_size=pixel_size,
+                        camera_pos=camera_pos,
+                        look_at=look_at,
                         background=background)
 
     render_plot(widgets=iv.box, filename=filename)
@@ -84,8 +88,12 @@ class InstrumentView:
                  dim=None,
                  rendering=None,
                  pixel_size=None,
+                 camera_pos=None,
+                 look_at=None,
                  background=None):
         self._pixel_size = pixel_size
+        self._camera_pos = camera_pos
+        self._look_at = look_at
 
         # Delayed imports to avoid hard dependencies
         self.widgets = importlib.import_module("ipywidgets")
@@ -386,7 +394,9 @@ class InstrumentView:
         self.change_rendering({"new": self.select_rendering.value})
 
         # Add camera controller
-        self.controller = self.p3.OrbitControls(controlling=self.camera)
+        self.controller = self.p3.OrbitControls(controlling=self.camera,
+                                                target=self._look_at)
+        self.camera.lookAt(self._look_at)
 
         # Render the scene into a widget
         self.renderer = self.p3.Renderer(camera=self.camera,
@@ -760,10 +770,14 @@ class InstrumentView:
                 new_cam_pos = [0, 0, self.camera_pos]
 
             self.camera.position = new_cam_pos
+            if self._camera_pos is not None:
+                self.camera.position = self._camera_pos
             self.renderer.controls = [
                 self.p3.OrbitControls(controlling=self.camera,
+                                      target=self._look_at,
                                       enableRotate=projection.startswith("3D"))
             ]
+            self.camera.lookAt(self._look_at)
 
         self.geometry.attributes["position"].array = xyz
 

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -394,9 +394,12 @@ class InstrumentView:
         self.change_rendering({"new": self.select_rendering.value})
 
         # Add camera controller
-        self.controller = self.p3.OrbitControls(controlling=self.camera,
-                                                target=self._look_at)
-        self.camera.lookAt(self._look_at)
+        if self._look_at is not None:
+            self.controller = self.p3.OrbitControls(controlling=self.camera,
+                                                    target=self._look_at)
+            self.camera.lookAt(self._look_at)
+        else:
+            self.controller = self.p3.OrbitControls(controlling=self.camera)
 
         # Render the scene into a widget
         self.renderer = self.p3.Renderer(camera=self.camera,
@@ -772,12 +775,20 @@ class InstrumentView:
             self.camera.position = new_cam_pos
             if self._camera_pos is not None:
                 self.camera.position = self._camera_pos
-            self.renderer.controls = [
-                self.p3.OrbitControls(controlling=self.camera,
-                                      target=self._look_at,
-                                      enableRotate=projection.startswith("3D"))
-            ]
-            self.camera.lookAt(self._look_at)
+            if self._look_at is not None:
+                self.renderer.controls = [
+                    self.p3.OrbitControls(
+                        controlling=self.camera,
+                        target=self._look_at,
+                        enableRotate=projection.startswith("3D"))
+                ]
+                self.camera.lookAt(self._look_at)
+            else:
+                self.renderer.controls = [
+                    self.p3.OrbitControls(
+                        controlling=self.camera,
+                        enableRotate=projection.startswith("3D"))
+                ]
 
         self.geometry.attributes["position"].array = xyz
 

--- a/python/src/scipp/neutron/instrument_view.py
+++ b/python/src/scipp/neutron/instrument_view.py
@@ -31,7 +31,7 @@ def instrument_view(scipp_obj=None,
                     continuous_update=True,
                     dim="tof",
                     rendering="Full",
-                    pixel_size=0.0005,
+                    pixel_size=0.02,
                     background="#f0f0f0"):
     """
     Plot a 2D or 3D view of the instrument.
@@ -83,7 +83,7 @@ class InstrumentView:
                  continuous_update=None,
                  dim=None,
                  rendering=None,
-                 pixel_size=0.0005,
+                 pixel_size=None,
                  background=None):
         self._pixel_size = pixel_size
 
@@ -472,8 +472,7 @@ class InstrumentView:
                     [self.det_pos.shape[0], 3], dtype=np.float32))
             })
         points_material = self.p3.PointsMaterial(vertexColors='VertexColors',
-                                                 size=self.camera_pos *
-                                                 self._pixel_size,
+                                                 size=self._pixel_size,
                                                  transparent=True)
         points = self.p3.Points(geometry=points_geometry,
                                 material=points_material)
@@ -798,7 +797,7 @@ class InstrumentView:
         return
 
     def generate_3d_axes_ticks(self):
-        tick_size = self.camera_pos * 0.05
+        tick_size = 10.0 * self._pixel_size
         axticks = self.p3.Group()
         axticks.add(self.make_axis_tick("0", [0, 0, 0], size=tick_size))
         for i in range(3):


### PR DESCRIPTION
- Previously I broke the (default) pixel size setting of the instrument view, leading to, e.g., tiny pixels in the docs. Now not camera dependent any more, hpefully works better for now.
- Smaller axis labels in instrument view. For LoKI these used to be as large as the detector itself, and happened to show at the same position.
- Configurable camera pos and target. Not documenting this for now, since it is just a quick hack. Maybe we should find the extents and center of mass of the detectors in the future to determine this automatically?
- Add Python binding for `groupby.copy`. This allows for (not interactive!) selection of which slice to show in the instrument view, as requested in the past and now by scientists:
  ```python
  from loki import LoKI
  sample.coords['layer'] = loki.layers()
  sc.neutron.instrument_view(sc.groupby(sample, 'layer').copy(1), bins=1, projection='3D Y', log=True, pixel_size=0.01)
  ```