### PR TITLE
Add support for variables with variances in comparisons

### DIFF
--- a/core/include/scipp/core/element/comparison.h
+++ b/core/include/scipp/core/element/comparison.h
@@ -17,8 +17,6 @@ namespace scipp::core::element {
 constexpr auto comparison = overloaded{
     arg_list<double, float, int64_t, int32_t, std::tuple<int64_t, int32_t>,
              std::tuple<int32_t, int64_t>>,
-    transform_flags::expect_no_variance_arg<0>,
-    transform_flags::expect_no_variance_arg<1>,
     [](const units::Unit &x, const units::Unit &y) {
       expect::equals(x, y);
       return units::dimensionless;

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -148,16 +148,93 @@ constexpr auto operator/(const T1 a, const ValueAndVariance<T2> b) noexcept {
                                            (b.value * b.value)};
 }
 
-template <class T>
-constexpr auto operator==(const ValueAndVariance<T> a,
-                          const ValueAndVariance<T> b) noexcept {
-  return a.value == b.value && a.variance == b.variance;
+// Comparison operators. Note that all of these IGNORE VARIANCES
+template <class A, class B>
+constexpr auto operator==(const ValueAndVariance<A> a,
+                          const ValueAndVariance<B> b) noexcept {
+  return a.value == b.value;
 }
-template <class T>
-constexpr auto operator!=(const ValueAndVariance<T> a,
-                          const ValueAndVariance<T> b) noexcept {
+template <class A, class B>
+constexpr auto operator==(const ValueAndVariance<A> a, const B b) noexcept {
+  return a.value == b;
+}
+template <class A, class B>
+constexpr auto operator==(const A a, const ValueAndVariance<B> b) noexcept {
+  return a == b.value;
+}
+
+template <class A, class B>
+constexpr auto operator!=(const ValueAndVariance<A> a,
+                          const ValueAndVariance<B> b) noexcept {
   return !(a == b);
 }
+
+template <class A, class B>
+constexpr auto operator!=(const ValueAndVariance<A> a, const B b) noexcept {
+  return !(a == b);
+}
+
+template <class A, class B>
+constexpr auto operator!=(const A a, const ValueAndVariance<B> b) noexcept {
+  return !(a == b);
+}
+
+template <class A, class B>
+constexpr auto operator<(const ValueAndVariance<A> a,
+                         const ValueAndVariance<B> b) noexcept {
+  return a.value < b.value;
+}
+template <class A, class B>
+constexpr auto operator<(const ValueAndVariance<A> a, const B b) noexcept {
+  return a.value < b;
+}
+template <class A, class B>
+constexpr auto operator<(const A a, const ValueAndVariance<B> b) noexcept {
+  return a < b.value;
+}
+
+template <class A, class B>
+constexpr auto operator<=(const ValueAndVariance<A> a,
+                          const ValueAndVariance<B> b) noexcept {
+  return a.value <= b.value;
+}
+template <class A, class B>
+constexpr auto operator<=(const ValueAndVariance<A> a, const B b) noexcept {
+  return a.value <= b;
+}
+template <class A, class B>
+constexpr auto operator<=(const A a, const ValueAndVariance<B> b) noexcept {
+  return a <= b.value;
+}
+
+template <class A, class B>
+constexpr auto operator>(const ValueAndVariance<A> a,
+                         const ValueAndVariance<B> b) noexcept {
+  return a.value > b.value;
+}
+template <class A, class B>
+constexpr auto operator>(const ValueAndVariance<A> a, const B b) noexcept {
+  return a.value > b;
+}
+template <class A, class B>
+constexpr auto operator>(const A a, const ValueAndVariance<B> b) noexcept {
+  return a > b.value;
+}
+
+template <class A, class B>
+constexpr auto operator>=(const ValueAndVariance<A> a,
+                          const ValueAndVariance<B> b) noexcept {
+  return a.value >= b.value;
+}
+template <class A, class B>
+constexpr auto operator>=(const ValueAndVariance<A> a, const B b) noexcept {
+  return a.value >= b;
+}
+template <class A, class B>
+constexpr auto operator>=(const A a, const ValueAndVariance<B> b) noexcept {
+  return a >= b.value;
+}
+// end comparison operators
 
 template <class T>
 constexpr auto min(const ValueAndVariance<T> a,

--- a/core/test/element_comparison_test.cpp
+++ b/core/test/element_comparison_test.cpp
@@ -31,17 +31,6 @@ TEST(ElementComparisonTest, unit) {
   EXPECT_THROW(comparison(rad, m), except::UnitError);
 }
 
-template <int T, typename Op> bool is_no_variance_arg() {
-  return std::is_base_of_v<core::transform_flags::expect_no_variance_arg_t<T>,
-                           Op>;
-}
-
-TEST(ElementComparisonTest, value_only_arguments) {
-  using Op = decltype(comparison);
-  EXPECT_TRUE((is_no_variance_arg<0, Op>())) << " y has variance ";
-  EXPECT_TRUE((is_no_variance_arg<1, Op>())) << " x has variance ";
-}
-
 TYPED_TEST(ElementLessTest, value) {
   using T = TypeParam;
   T y = 1;

--- a/core/test/value_and_variance_test.cpp
+++ b/core/test/value_and_variance_test.cpp
@@ -98,6 +98,108 @@ TEST(ValueAndVarianceTest, binary_divide_equals) {
             lhs.variance);
 }
 
+TEST(ValueAndVarianceTest, comparison) {
+  ValueAndVariance a1{1.0, 2.0};
+  ValueAndVariance a2{1.0, 3.0}; // same as a1 but difference variance
+  ValueAndVariance b{2.0, 2.0};
+
+  EXPECT_TRUE(a1 == a1);
+  EXPECT_TRUE(a1 == a2);
+  EXPECT_FALSE(a1 == b);
+
+  EXPECT_FALSE(a1 != a1);
+  EXPECT_FALSE(a1 != a2);
+  EXPECT_TRUE(a1 != b);
+
+  EXPECT_FALSE(a1 < a1);
+  EXPECT_FALSE(a1 < a2);
+  EXPECT_TRUE(a1 < b);
+  EXPECT_FALSE(b < a1);
+
+  EXPECT_FALSE(a1 > a1);
+  EXPECT_FALSE(a1 > a2);
+  EXPECT_FALSE(a1 > b);
+  EXPECT_TRUE(b > a1);
+
+  EXPECT_TRUE(a1 <= a1);
+  EXPECT_TRUE(a1 <= a2);
+  EXPECT_TRUE(a1 <= b);
+  EXPECT_FALSE(b <= a1);
+
+  EXPECT_TRUE(a1 >= a1);
+  EXPECT_TRUE(a1 >= a2);
+  EXPECT_FALSE(a1 >= b);
+  EXPECT_TRUE(b >= a1);
+}
+
+TEST(ValueAndVarianceTest, comparison_no_variance_lhs) {
+  ValueAndVariance a1{1.0, 2.0};
+  ValueAndVariance a2{1.0, 3.0}; // same as a1 but difference variance
+  ValueAndVariance b{2.0, 2.0};
+
+  EXPECT_TRUE(a1.value == a1);
+  EXPECT_TRUE(a1.value == a2);
+  EXPECT_FALSE(a1.value == b);
+
+  EXPECT_FALSE(a1.value != a1);
+  EXPECT_FALSE(a1.value != a2);
+  EXPECT_TRUE(a1.value != b);
+
+  EXPECT_FALSE(a1.value < a1);
+  EXPECT_FALSE(a1.value < a2);
+  EXPECT_TRUE(a1.value < b);
+  EXPECT_FALSE(b.value < a1);
+
+  EXPECT_FALSE(a1.value > a1);
+  EXPECT_FALSE(a1.value > a2);
+  EXPECT_FALSE(a1.value > b);
+  EXPECT_TRUE(b.value > a1);
+
+  EXPECT_TRUE(a1.value <= a1);
+  EXPECT_TRUE(a1.value <= a2);
+  EXPECT_TRUE(a1.value <= b);
+  EXPECT_FALSE(b.value <= a1);
+
+  EXPECT_TRUE(a1.value >= a1);
+  EXPECT_TRUE(a1.value >= a2);
+  EXPECT_FALSE(a1.value >= b);
+  EXPECT_TRUE(b.value >= a1);
+}
+
+TEST(ValueAndVarianceTest, comparison_no_variance_rhs) {
+  ValueAndVariance a1{1.0, 2.0};
+  ValueAndVariance a2{1.0, 3.0}; // same as a1 but difference variance
+  ValueAndVariance b{2.0, 2.0};
+
+  EXPECT_TRUE(a1 == a1.value);
+  EXPECT_TRUE(a1 == a2.value);
+  EXPECT_FALSE(a1 == b.value);
+
+  EXPECT_FALSE(a1 != a1.value);
+  EXPECT_FALSE(a1 != a2.value);
+  EXPECT_TRUE(a1 != b.value);
+
+  EXPECT_FALSE(a1 < a1.value);
+  EXPECT_FALSE(a1 < a2.value);
+  EXPECT_TRUE(a1 < b.value);
+  EXPECT_FALSE(b < a1.value);
+
+  EXPECT_FALSE(a1 > a1.value);
+  EXPECT_FALSE(a1 > a2.value);
+  EXPECT_FALSE(a1 > b.value);
+  EXPECT_TRUE(b > a1.value);
+
+  EXPECT_TRUE(a1 <= a1.value);
+  EXPECT_TRUE(a1 <= a2.value);
+  EXPECT_TRUE(a1 <= b.value);
+  EXPECT_FALSE(b <= a1.value);
+
+  EXPECT_TRUE(a1 >= a1.value);
+  EXPECT_TRUE(a1 >= a2.value);
+  EXPECT_FALSE(a1 >= b.value);
+  EXPECT_TRUE(b >= a1.value);
+}
+
 /* This test suite tests for equality between ValueAndVariance-scalar binary
  * operations and the equivalent ValueAndVariance-ValueAndVariance operation. */
 /* The assumption is made that ValueAndVariance-ValueAndVariance binary

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -46,6 +46,8 @@ General
 Comparison
 ~~~~~~~~~~
 
+Comparison operators compare element-wise and *ignore variances*.
+
 .. autosummary::
    :toctree: ../generated
 

--- a/python/comparison.cpp
+++ b/python/comparison.cpp
@@ -16,8 +16,11 @@ namespace py = pybind11;
 
 template <class T> Docstring docstring_comparison(const std::string op) {
   return Docstring()
-      .description("Comparison returning the truth value of " + op +
-                   " element-wise.")
+      .description(
+          "Comparison returning the truth value of " + op +
+          " element-wise.\n\nNote and warning: If one or both of the operators "
+          "have variances (uncertainties) there are ignored silently, i.e., "
+          "comparison is based exclusively on the values.")
       .raises("If the units of inputs are not the same, or if the dtypes of "
               "inputs are not double precision floats.")
       .returns("Booleans that are true if " + op + ".")


### PR DESCRIPTION
Fixes #1178. See there for discussion. This works if both or one of the operands have variances.