### PR TITLE
Fix comparison with variances and add "values" and "variances" helpers

### DIFF
--- a/core/include/scipp/core/element/comparison.h
+++ b/core/include/scipp/core/element/comparison.h
@@ -15,6 +15,7 @@
 namespace scipp::core::element {
 
 constexpr auto comparison = overloaded{
+    transform_flags::no_out_variance,
     arg_list<double, float, int64_t, int32_t, std::tuple<int64_t, int32_t>,
              std::tuple<int32_t, int64_t>>,
     [](const units::Unit &x, const units::Unit &y) {

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -7,6 +7,7 @@
 #include "scipp/common/overloaded.h"
 #include "scipp/common/span.h"
 #include "scipp/core/element/arg_list.h"
+#include "scipp/core/transform_common.h"
 #include "scipp/core/value_and_variance.h"
 #include "scipp/units/except.h"
 #include "scipp/units/unit.h"
@@ -40,5 +41,18 @@ template <class T> void zero(const core::ValueAndVariance<span<T>> &data) {
   zero(data.value);
   zero(data.variance);
 }
+
+constexpr auto values =
+    overloaded{core::element::arg_list<double, float>, [](const auto &x) {
+                 if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+                   return x.value;
+                 else
+                   return x;
+               }};
+
+constexpr auto variances = overloaded{core::element::arg_list<double, float>,
+                                      transform_flags::expect_variance_arg<0>,
+                                      [](const auto &x) { return x.variance; },
+                                      [](const units::Unit &u) { return u; }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -43,16 +43,23 @@ template <class T> void zero(const core::ValueAndVariance<span<T>> &data) {
 }
 
 constexpr auto values =
-    overloaded{core::element::arg_list<double, float>, [](const auto &x) {
+    overloaded{transform_flags::no_out_variance,
+               core::element::arg_list<double, float>, [](const auto &x) {
                  if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
                    return x.value;
                  else
                    return x;
                }};
 
-constexpr auto variances = overloaded{core::element::arg_list<double, float>,
-                                      transform_flags::expect_variance_arg<0>,
-                                      [](const auto &x) { return x.variance; },
-                                      [](const units::Unit &u) { return u; }};
+constexpr auto variances = overloaded{
+    transform_flags::no_out_variance, core::element::arg_list<double, float>,
+    transform_flags::expect_variance_arg<0>,
+    [](const auto &x) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+        return x.variance;
+      else
+        return x; // unreachable but required for instantiation
+    },
+    [](const units::Unit &u) { return u * u; }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -67,6 +67,11 @@ static constexpr auto dimensionless_unit_check_return =
 /// operator.
 namespace transform_flags {
 /// Add this to overloaded operator to indicate that the operation does not
+/// return data with variances, regardless of whether inputs have variances.
+static constexpr auto no_out_variance = []() {};
+using no_out_variance_t = decltype(no_out_variance);
+
+/// Add this to overloaded operator to indicate that the operation does not
 /// support variances in the specified argument.
 template <int N> static constexpr auto expect_no_variance_arg = []() {};
 template <int N>

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <vector>
 
+using namespace scipp;
 using namespace scipp::core::element;
 
 TEST(ElementUtilTest, convertMaskedToZero_masks_special_vals) {
@@ -62,4 +63,13 @@ TEST(ElementUtilTest, convertMaskedToZero_accepts_all_types) {
       std::is_same_v<decltype(convertMaskedToZero(int32_t{}, true)), int32_t>);
   static_assert(
       std::is_same_v<decltype(convertMaskedToZero(int64_t{}, true)), int64_t>);
+}
+
+TEST(ElementUtilTest, values_variances) {
+  ValueAndVariance x{1.0, 2.0};
+  EXPECT_EQ(values(units::m), units::m);
+  EXPECT_EQ(values(x), 1.0);
+  EXPECT_EQ(values(1.2), 1.2);
+  EXPECT_EQ(variances(units::m), units::m);
+  EXPECT_EQ(variances(x), 2.0);
 }

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -70,6 +70,6 @@ TEST(ElementUtilTest, values_variances) {
   EXPECT_EQ(values(units::m), units::m);
   EXPECT_EQ(values(x), 1.0);
   EXPECT_EQ(values(1.2), 1.2);
-  EXPECT_EQ(variances(units::m), units::m);
+  EXPECT_EQ(variances(units::m), units::m * units::m);
   EXPECT_EQ(variances(x), 2.0);
 }

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -42,6 +42,8 @@ General
    reshape
    sort
    sqrt
+   values
+   variances
 
 Comparison
 ~~~~~~~~~~

--- a/python/operations.cpp
+++ b/python/operations.cpp
@@ -9,6 +9,7 @@
 #include "scipp/dataset/shape.h"
 #include "scipp/dataset/sort.h"
 #include "scipp/variable/operations.h"
+#include "scipp/variable/util.h"
 
 using namespace scipp;
 using namespace scipp::variable;
@@ -133,4 +134,18 @@ void init_operations(py::module &m) {
 
   bind_contains_events<Variable>(m);
   bind_contains_events<DataArray>(m);
+
+  m.def("values", variable::values,
+        Docstring()
+            .description("Return the variable without variances.")
+            .seealso(":py:func:`scipp.variances`")
+            .c_str(),
+        py::call_guard<py::gil_scoped_release>());
+  m.def("variances", variable::variances,
+        Docstring()
+            .description("Return variable containing the variances of the "
+                         "input as values.")
+            .seealso(":py:func:`scipp.values`")
+            .c_str(),
+        py::call_guard<py::gil_scoped_release>());
 }

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -647,6 +647,11 @@ def test_sqrt_out():
     assert_export(sc.sqrt, var, var)
 
 
+def test_values_variances():
+    assert_export(sc.values, sc.Variable())
+    assert_export(sc.variances, sc.Variable())
+
+
 def test_sum():
     var = sc.Variable(dims=['x', 'y'],
                       values=np.array([[0.1, 0.3], [0.2, 0.6]]),

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -301,7 +301,9 @@ struct TransformEvents {
   constexpr auto operator()(const Op &op, const Ts &... args) const {
     event_list<std::invoke_result_t<Op, core::detail::element_type_t<Ts>...>>
         vals(check_and_get_size(args...));
-    if constexpr ((has_variances_v<Ts> || ...)) {
+    if constexpr (!std::is_base_of_v<core::transform_flags::no_out_variance_t,
+                                     Op> &&
+                  (has_variances_v<Ts> || ...)) {
       auto vars(vals);
       ValuesAndVariances out{vals, vars};
       transform_elements(op, out, maybe_broadcast(args)...);
@@ -332,7 +334,10 @@ static void do_transform(Op op, Out &&out, Tuple &&processed) {
         if constexpr (check_all_or_none_variances<Op, decltype(args)...>) {
           throw except::VariancesError(
               "Expected either all or none of inputs to have variances.");
-        } else if constexpr ((is_ValuesAndVariances_v<
+        } else if constexpr (!std::is_base_of_v<
+                                 core::transform_flags::no_out_variance_t,
+                                 Op> &&
+                             (is_ValuesAndVariances_v<
                                   std::decay_t<std::decay_t<decltype(args)>>> ||
                               ...)) {
           auto out_var = out.variances();
@@ -397,9 +402,11 @@ template <class Op> struct Transform {
   template <class... Ts> Variable operator()(Ts &&... handles) const {
     const auto dims = merge(handles.dims()...);
     using Out = decltype(maybe_eval(op(handles.values()[0]...)));
+    constexpr bool out_variances =
+        !std::is_base_of_v<core::transform_flags::no_out_variance_t, Op>;
     auto volume = dims.volume();
     Variable out =
-        (handles.hasVariances() || ...)
+        out_variances && (handles.hasVariances() || ...)
             ? makeVariable<Out>(Dimensions{dims},
                                 Values(volume, core::default_init_elements),
                                 Variances(volume, core::default_init_elements))

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -13,4 +13,8 @@ SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
                                         const VariableConstView &stop,
                                         const Dim dim, const scipp::index num);
 
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+variances(const VariableConstView &x);
+
 } // namespace scipp::variable

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -72,12 +72,15 @@ TEST(ComparisonTest, tolerance_type_mismatch) {
   EXPECT_NO_THROW(is_approx(a, b, 0.0f));
 }
 
-TEST(ComparisonTest, less_variances_test) {
-  const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0},
-                                     Variances{1.0, 1.0});
-  const auto b = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{0.0, 3.0},
-                                     Variances{1.0, 1.0});
-  EXPECT_THROW(less(a, b), std::runtime_error);
+TEST(ComparisonTest, variances_test) {
+  const auto a = makeVariable<float>(Values{1.0}, Variances{1.0});
+  const auto b = makeVariable<float>(Values{2.0}, Variances{2.0});
+  EXPECT_EQ(less(a, b), true * units::one);
+  EXPECT_EQ(less_equal(a, b), true * units::one);
+  EXPECT_EQ(greater(a, b), false * units::one);
+  EXPECT_EQ(greater_equal(a, b), false * units::one);
+  EXPECT_EQ(equal(a, b), false * units::one);
+  EXPECT_EQ(not_equal(a, b), true * units::one);
 }
 
 TEST(ComparisonTest, less_dtypes_test) {

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -6,6 +6,8 @@
 #include "make_events.h"
 #include "test_macros.h"
 
+#include "scipp/core/element/arg_list.h"
+
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/variable.h"
@@ -990,6 +992,15 @@ TEST(TransformFlagsTest, variance_on_arg) {
                except::VariancesError);
   EXPECT_NO_THROW((out = transform<std::tuple<double>>(
                        var_no_variance, var_no_variance, all_args_with_flag)));
+}
+
+TEST(TransformFlagsTest, no_out_variance) {
+  constexpr auto op =
+      overloaded{transform_flags::no_out_variance, element::arg_list<double>,
+                 [](const auto) { return true; },
+                 [](const units::Unit &) { return units::one; }};
+  const auto var = makeVariable<double>(Values{1.0}, Variances{1.0});
+  EXPECT_EQ(transform(var, op), true * units::one);
 }
 
 TEST(TransformFlagsTest, variance_on_arg_in_place) {

--- a/variable/test/util_test.cpp
+++ b/variable/test/util_test.cpp
@@ -77,3 +77,9 @@ TEST(LinspaceTest, increasing_2d) {
                      Dim::X, 3),
             expected);
 }
+
+TEST(UtilTest, values_variances) {
+  const auto var = makeVariable<double>(Values{1}, Variances{2});
+  EXPECT_EQ(values(var), 1.0 * units::one);
+  EXPECT_EQ(variances(var), 2.0 * units::one);
+}

--- a/variable/test/util_test.cpp
+++ b/variable/test/util_test.cpp
@@ -79,7 +79,7 @@ TEST(LinspaceTest, increasing_2d) {
 }
 
 TEST(UtilTest, values_variances) {
-  const auto var = makeVariable<double>(Values{1}, Variances{2});
-  EXPECT_EQ(values(var), 1.0 * units::one);
-  EXPECT_EQ(variances(var), 2.0 * units::one);
+  const auto var = makeVariable<double>(Values{1}, Variances{2}, units::m);
+  EXPECT_EQ(values(var), 1.0 * units::m);
+  EXPECT_EQ(variances(var), 2.0 * (units::m * units::m));
 }

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -3,10 +3,12 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/variable/util.h"
+#include "scipp/core/element/util.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/except.h"
 #include "scipp/variable/misc_operations.h"
+#include "scipp/variable/transform.h"
 
 using namespace scipp::core;
 
@@ -37,6 +39,13 @@ Variable linspace(const VariableConstView &start, const VariableConstView &stop,
             range);
   out.slice({dim, num - 1}).assign(stop); // endpoint included
   return out;
+}
+
+Variable values(const VariableConstView &x) {
+  return transform(x, element::values);
+}
+Variable variances(const VariableConstView &x) {
+  return transform(x, element::variances);
 }
 
 } // namespace scipp::variable


### PR DESCRIPTION
Recently added support for comparing with variances in #1215 was actually broken. This is fixed here by adding a new flag for transform to disable variances in the output. Ideally we would like to detect this automatically, but in practice this is really tricky with combinations of generic lambdas, event lists, manually disabled or required variances on inputs, ...

With this change to `transform` it was finally possible to also fix #1182, adding `sc.values` and `sc.variances` as two useful helpers.