### PR TITLE
Expose scipp.and and scipp.all for all dimensions

### DIFF
--- a/python/reduction.cpp
+++ b/python/reduction.cpp
@@ -155,24 +155,17 @@ template <class T> void bind_max(py::module &m) {
           .c_str());
 }
 
-template <class T> Docstring docstring_bool_dim(const std::string op) {
+template <class T> Docstring docstring_bool(const std::string op) {
   return Docstring()
-      .description("Element-wise " + op + " over the specified dimension.")
-      .raises("If the dimension does not exist, or if the dtype is not bool.")
+      .description(
+          "Element-wise " + op +
+          " over the specified dimension or all dimensions if not provided.")
+      .raises("If the input dimension to reduce (optional) does not exist, or "
+              "if the dtype is not bool.")
       .returns("The " + op + " combination of the input values.")
       .rtype<T>()
       .template param<T>("x", "Data to reduce.")
-      .param("dim", "Dimension to reduce.", "Dim");
-}
-
-template <class T> Docstring docstring_bool(const std::string op) {
-  return Docstring()
-      .description("Element-wise " + op +
-                   " over all of the input's dimensions.")
-      .raises("If the dtype has no " + op + ", e.g., if it is a string.")
-      .returns("The " + op + " combination of the input values.")
-      .rtype<T>()
-      .template param<T>("x", "Data to reduce.");
+      .param("dim", "Dimension to reduce (optional).", "Dim");
 }
 
 template <class T> void bind_all(py::module &m) {
@@ -186,7 +179,7 @@ template <class T> void bind_all(py::module &m) {
         return all(x, dim);
       },
       py::arg("all"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool_dim<T>("AND").c_str());
+      docstring_bool<T>("AND").c_str());
 }
 
 template <class T> void bind_any(py::module &m) {
@@ -200,7 +193,7 @@ template <class T> void bind_any(py::module &m) {
         return any(x, dim);
       },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool_dim<T>("OR").c_str());
+      docstring_bool<T>("OR").c_str());
 }
 
 void init_reduction(py::module &m) {

--- a/python/reduction.cpp
+++ b/python/reduction.cpp
@@ -178,7 +178,7 @@ template <class T> void bind_all(py::module &m) {
       [](const typename T::const_view_type &x, const Dim dim) {
         return all(x, dim);
       },
-      py::arg("all"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
       docstring_bool<T>("AND").c_str());
 }
 

--- a/python/reduction.cpp
+++ b/python/reduction.cpp
@@ -155,7 +155,7 @@ template <class T> void bind_max(py::module &m) {
           .c_str());
 }
 
-template <class T> Docstring docstring_bool(const std::string op) {
+template <class T> Docstring docstring_bool_dim(const std::string op) {
   return Docstring()
       .description("Element-wise " + op + " over the specified dimension.")
       .raises("If the dimension does not exist, or if the dtype is not bool.")
@@ -165,24 +165,42 @@ template <class T> Docstring docstring_bool(const std::string op) {
       .param("dim", "Dimension to reduce.", "Dim");
 }
 
+template <class T> Docstring docstring_bool(const std::string op) {
+  return Docstring()
+      .description("Element-wise " + op +
+                   " over all of the input's dimensions.")
+      .raises("If the dtype has no " + op + ", e.g., if it is a string.")
+      .returns("The " + op + " combination of the input values.")
+      .rtype<T>()
+      .template param<T>("x", "Data to reduce.");
+}
+
 template <class T> void bind_all(py::module &m) {
+  m.def(
+      "all", [](const typename T::const_view_type &x) { return all(x); },
+      py::arg("x"), py::call_guard<py::gil_scoped_release>(),
+      docstring_bool<T>("AND").c_str());
   m.def(
       "all",
       [](const typename T::const_view_type &x, const Dim dim) {
         return all(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("AND").c_str());
+      py::arg("all"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_bool_dim<T>("AND").c_str());
 }
 
 template <class T> void bind_any(py::module &m) {
+  m.def(
+      "any", [](const typename T::const_view_type &x) { return any(x); },
+      py::arg("x"), py::call_guard<py::gil_scoped_release>(),
+      docstring_bool<T>("OR").c_str());
   m.def(
       "any",
       [](const typename T::const_view_type &x, const Dim dim) {
         return any(x, dim);
       },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("OR").c_str());
+      docstring_bool_dim<T>("OR").c_str());
 }
 
 void init_reduction(py::module &m) {

--- a/python/tests/test_variable_reduction.py
+++ b/python/tests/test_variable_reduction.py
@@ -3,16 +3,34 @@
 # @file
 # @author Simon Heybrock
 import scipp as sc
+import numpy as np
 
 
 def test_all():
-    var = sc.Variable(['x'], values=[True, False, True])
-    assert sc.all(var, 'x') == sc.Variable(value=False)
+    var = sc.Variable(['x', 'y'],
+                      values=np.array([True, True, True, False]).reshape(2, 2))
+    assert sc.all(var) == sc.Variable(value=False)
+
+
+def test_all_with_dim():
+    var = sc.Variable(['x', 'y'],
+                      values=np.array([True, True, True, False]).reshape(2, 2))
+    assert sc.all(var, 'x') == sc.Variable(dims=['y'], values=[True, False])
+    assert sc.all(var, 'y') == sc.Variable(dims=['x'], values=[True, False])
 
 
 def test_any():
-    var = sc.Variable(['x'], values=[True, False, True])
-    assert sc.any(var, 'x') == sc.Variable(value=True)
+    var = sc.Variable(['x', 'y'],
+                      values=np.array([True, True, True, False]).reshape(2, 2))
+    assert sc.any(var) == sc.Variable(value=True)
+
+
+def test_any_with_dim():
+    var = sc.Variable(['x', 'y'],
+                      values=np.array([True, True, False,
+                                       False]).reshape(2, 2))
+    assert sc.any(var, 'x') == sc.Variable(dims=['y'], values=[True, True])
+    assert sc.any(var, 'y') == sc.Variable(dims=['x'], values=[True, False])
 
 
 def test_min():


### PR DESCRIPTION
Brings these functions inline with `max` and `min` of reduction in terms of behaviour.