### PR TITLE
Fix is_linspace

### DIFF
--- a/common/include/scipp/common/numeric.h
+++ b/common/include/scipp/common/numeric.h
@@ -21,8 +21,8 @@ template <class Range> bool is_linspace(const Range &range) {
   using T = typename Range::value_type;
   const T delta = (range.back() - range.front()) / (scipp::size(range) - 1);
   constexpr int32_t ulp = 4;
-  const T epsilon =
-      std::numeric_limits<T>::epsilon() * (range.front() + range.back()) * ulp;
+  const T epsilon = std::numeric_limits<T>::epsilon() *
+                    (std::abs(range.front()) + std::abs(range.back())) * ulp;
 
   return std::adjacent_find(range.begin(), range.end(),
                             [epsilon, delta](const auto &a, const auto &b) {

--- a/common/test/is_linspace_test.cpp
+++ b/common/test/is_linspace_test.cpp
@@ -49,6 +49,11 @@ TEST(IsLinspaceTest, size_3) {
   ASSERT_TRUE(is_linspace(std::vector<int32_t>({1, 2, 3})));
 }
 
+TEST(IsLinspaceTest, negative_front) {
+  ASSERT_TRUE(
+      is_linspace(std::vector<double>({-3.0, -2.0, -1.0, 0.0, 1.0, 2.0})));
+}
+
 TEST(IsLinspaceTest, std_iota) {
   std::vector<double> range(1e5);
   std::iota(range.begin(), range.end(), 1e-9);


### PR DESCRIPTION
`is_linspace` would fail when `front` was negative and had a larger magnitude than `back`, thus causing `epsilon` to be negative.
In turn, this meant that the test in the `adjacent_find` would fail on the first element.

We add absolute values to make sure `epsilon` is always positive.