### PR TITLE
To and from dict

### DIFF
--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -146,3 +146,12 @@ This can be converted into a counts (frequency) density, e.g., for visualization
 
    counts_to_density
    density_to_counts
+
+Compatibility
+~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../generated
+
+   to_dict
+   from_dict

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -21,7 +21,7 @@ from .extend_units import *
 from .table_html import to_html, make_html
 from .object_list import _repr_html_
 from ._utils import collapse, slices
-from .compat.dict import to_dict
+from .compat.dict import to_dict, from_dict
 
 setattr(Variable, '_repr_html_', make_html)
 setattr(VariableConstView, '_repr_html_', make_html)

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -21,6 +21,7 @@ from .extend_units import *
 from .table_html import to_html, make_html
 from .object_list import _repr_html_
 from ._utils import collapse, slices
+from .compat.dict import to_dict
 
 setattr(Variable, '_repr_html_', make_html)
 setattr(VariableConstView, '_repr_html_', make_html)

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -12,7 +12,7 @@ def to_dict(scipp_obj):
 
     :param scipp_obj: A Variable, DataArray or Dataset to be converted to a
                       python dict.
-    :type scipp_obj: Union[Variable, DataArray, Dataset]
+    :type scipp_obj: Variable, DataArray, or Dataset
     :return: A dict containing all the information necessary to fully define
              the supplied scipp object.
     :rtype: dict
@@ -88,7 +88,7 @@ def from_dict(dict_obj):
     :param dict_obj: A python dict to be converted to a scipp object.
     :type dict_obj: dict
     :return: A scipp Variable, DataArray or Dataset.
-    :rtype: Union[Variable, DataArray, Dataset]
+    :rtype: Variable, DataArray, or Dataset
     """
     if {"coords", "data"}.issubset(set(dict_obj.keys())):
         # Case of a DataArray-like dict (most-likely)

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -7,29 +7,46 @@ from .._scipp import core as sc
 
 
 def to_dict(scipp_obj):
-
+    """
+    Convert a scipp object (Variable, DataArray or Dataset) to a Python dict.
+    """
     if su.is_variable(scipp_obj):
         return _variable_to_dict(scipp_obj)
     elif su.is_data_array(scipp_obj):
         return _data_array_to_dict(scipp_obj)
     elif su.is_dataset(scipp_obj):
         # TODO: This currently duplicates all coordinates that would otherwise
-        # be at the Dataset level onto the individual DataArrays. Since we are
-        # only copying references to the same object, this should not use more
-        # memory.
-        return {name: _data_array_to_dict(item) for name, item in scipp_obj.items()}
+        # be at the Dataset level onto the individual DataArrays. We are also
+        # manually duplicating all attributes, since these are not carried when
+        # accessing items of a Dataset.
+        out = {}
+        copy_attrs = len(scipp_obj.attrs.keys()) > 0
+        for name, item in scipp_obj.items():
+            out[name] = _data_array_to_dict(item)
+            if copy_attrs:
+                for key, attr in scipp_obj.attrs.items():
+                    out[name]["attrs"][key] = _variable_to_dict(attr)
+        return out
 
 
 def _variable_to_dict(v):
-    return {"dims": _dims_to_strings(v.dims),
-            "shape": v.shape,
-            "values": v.values,
-            "variances": v.variances,
-            "unit": v.unit,
-            "dtype": v.dtype}
+    """
+    Convert a scipp Variable to a Python dict.
+    """
+    return {
+        "dims": _dims_to_strings(v.dims),
+        "shape": v.shape,
+        "values": v.values,
+        "variances": v.variances,
+        "unit": v.unit,
+        "dtype": v.dtype
+    }
 
 
 def _data_array_to_dict(da):
+    """
+    Convert a scipp DataArray to a Python dict.
+    """
     out = {"coords": {}, "masks": {}, "attrs": {}}
     for key in out.keys():
         for name, item in getattr(da, key).items():
@@ -46,42 +63,52 @@ def _data_array_to_dict(da):
 
 
 def _dims_to_strings(dims):
+    """
+    Convert dims that may or may not be strings to strings.
+    """
     return [str(dim) for dim in dims]
 
 
 def from_dict(dict_obj):
-    if "unit" not in dict_obj:
+    """
+    Convert a Python dict to a scipp Variable, DataArray or Dataset.
+    """
+    if {"coords", "data"}.issubset(set(dict_obj.keys())):
+        # Case of a DataArray-like dict (most-likely)
+        return _dict_to_data_array(dict_obj)
+    elif {"dims", "values"}.issubset(set(dict_obj.keys())):
+        # Case of a Variable-like dict (most-likely)
+        return _dict_to_variable(dict_obj)
+    else:
         # Case of a Dataset-like dict
         out = sc.Dataset()
         for key, item in dict_obj.items():
             out[key] = _dict_to_data_array(item)
         return out
-    elif "coords" in dict_obj:
-        # Case of a DataArray-like dict
-        return _dict_to_data_array(dict_obj)
-    else:
-        return sc.Variable(**dict_obj)
+
+
+def _dict_to_variable(d):
+    """
+    Convert a Python dict to a scipp Variable.
+    """
+    out = {}
+    for key, item in d.items():
+        if key != "shape":
+            out[key] = item
+    return sc.Variable(**out)
 
 
 def _dict_to_data_array(d):
+    """
+    Convert a Python dict to a scipp DataArray.
+    """
     out = {"coords": {}, "masks": {}, "attrs": {}}
     for key in out.keys():
-        for name, item in getattr(d, key).items():
-            out[key][name] = sc.Variable(**item)
-    # out["data"] = _variable_to_dict(da.data)
-    # out["values"] = da.values
-    # out["variances"] = da.variances
-    # out["dims"] = _dims_to_strings(da.dims)
-    # out["shape"] = da.shape
-    # out["name"] = da.name
-    # out["unit"] = str(da.unit)
-    # out["dtype"] = str(da.dtype)
+        if key in d:
+            for name, item in d[key].items():
+                out[key][name] = _dict_to_variable(item)
 
-    return sc.DataArray(data=sc.Variable(**d["data"]),
-        coords=out["coords"],
-        masks=out["masks"],
-        attrs=out["attrs"])
-
-
-    # if "dtype" in dict_obj:
-    #     # Case of a Variable
+    return sc.DataArray(data=_dict_to_variable(d["data"]),
+                        coords=out["coords"],
+                        masks=out["masks"],
+                        attrs=out["attrs"])

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Neil Vaytet
+
+from .. import _utils as su
+
+
+def to_dict(scipp_obj):
+
+    if su.is_variable(scipp_obj):
+        return _variable_to_dict(scipp_obj)
+    elif su.is_data_array(scipp_obj):
+        return _data_array_to_dict(scipp_obj)
+    elif su.is_dataset(scipp_obj):
+        return {name: _data_array_to_dict(item) for name, item in scipp_obj.items()}
+
+
+def _variable_to_dict(v):
+    return {"dims": _dims_to_strings(v.dims),
+            "shape": v.shape,
+            "values": v.values,
+            "variances": v.variances,
+            "unit": str(v.unit),
+            "dtype": str(v.dtype)}
+
+
+def _data_array_to_dict(da):
+    out = {"coords": {}, "masks": {}, "attrs": {}}
+    for key in out.keys():
+        for name, item in getattr(da, key).items():
+            out[key][str(name)] = _variable_to_dict(item)
+    out["data"] = _variable_to_dict(da.data)
+    out["values"] = da.values
+    out["variances"] = da.variances
+    out["dims"] = _dims_to_strings(da.dims)
+    out["shape"] = da.shape
+    out["name"] = da.name
+    out["unit"] = da.unit
+    return out
+
+
+def _dims_to_strings(dims):
+    return [str(dim) for dim in dims]

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -3,6 +3,7 @@
 # @author Neil Vaytet
 
 from .. import _utils as su
+from .._scipp import core as sc
 
 
 def to_dict(scipp_obj):
@@ -12,6 +13,10 @@ def to_dict(scipp_obj):
     elif su.is_data_array(scipp_obj):
         return _data_array_to_dict(scipp_obj)
     elif su.is_dataset(scipp_obj):
+        # TODO: This currently duplicates all coordinates that would otherwise
+        # be at the Dataset level onto the individual DataArrays. Since we are
+        # only copying references to the same object, this should not use more
+        # memory.
         return {name: _data_array_to_dict(item) for name, item in scipp_obj.items()}
 
 
@@ -20,8 +25,8 @@ def _variable_to_dict(v):
             "shape": v.shape,
             "values": v.values,
             "variances": v.variances,
-            "unit": str(v.unit),
-            "dtype": str(v.dtype)}
+            "unit": v.unit,
+            "dtype": v.dtype}
 
 
 def _data_array_to_dict(da):
@@ -36,8 +41,47 @@ def _data_array_to_dict(da):
     out["shape"] = da.shape
     out["name"] = da.name
     out["unit"] = da.unit
+    out["dtype"] = da.dtype
     return out
 
 
 def _dims_to_strings(dims):
     return [str(dim) for dim in dims]
+
+
+def from_dict(dict_obj):
+    if "unit" not in dict_obj:
+        # Case of a Dataset-like dict
+        out = sc.Dataset()
+        for key, item in dict_obj.items():
+            out[key] = _dict_to_data_array(item)
+        return out
+    elif "coords" in dict_obj:
+        # Case of a DataArray-like dict
+        return _dict_to_data_array(dict_obj)
+    else:
+        return sc.Variable(**dict_obj)
+
+
+def _dict_to_data_array(d):
+    out = {"coords": {}, "masks": {}, "attrs": {}}
+    for key in out.keys():
+        for name, item in getattr(d, key).items():
+            out[key][name] = sc.Variable(**item)
+    # out["data"] = _variable_to_dict(da.data)
+    # out["values"] = da.values
+    # out["variances"] = da.variances
+    # out["dims"] = _dims_to_strings(da.dims)
+    # out["shape"] = da.shape
+    # out["name"] = da.name
+    # out["unit"] = str(da.unit)
+    # out["dtype"] = str(da.dtype)
+
+    return sc.DataArray(data=sc.Variable(**d["data"]),
+        coords=out["coords"],
+        masks=out["masks"],
+        attrs=out["attrs"])
+
+
+    # if "dtype" in dict_obj:
+    #     # Case of a Variable

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -8,7 +8,14 @@ from .._scipp import core as sc
 
 def to_dict(scipp_obj):
     """
-    Convert a scipp object (Variable, DataArray or Dataset) to a Python dict.
+    Convert a scipp object (Variable, DataArray or Dataset) to a python dict.
+
+    :param scipp_obj: A Variable, DataArray or Dataset to be converted to a
+                      python dict.
+    :type scipp_obj: Union[Variable, DataArray, Dataset]
+    :return: A dict containing all the information necessary to fully define
+             the supplied scipp object.
+    :rtype: dict
     """
     if su.is_variable(scipp_obj):
         return _variable_to_dict(scipp_obj)
@@ -31,7 +38,7 @@ def to_dict(scipp_obj):
 
 def _variable_to_dict(v):
     """
-    Convert a scipp Variable to a Python dict.
+    Convert a scipp Variable to a python dict.
     """
     return {
         "dims": _dims_to_strings(v.dims),
@@ -45,7 +52,7 @@ def _variable_to_dict(v):
 
 def _data_array_to_dict(da):
     """
-    Convert a scipp DataArray to a Python dict.
+    Convert a scipp DataArray to a python dict.
     """
     out = {"coords": {}, "masks": {}, "attrs": {}}
     for key in out.keys():
@@ -71,7 +78,17 @@ def _dims_to_strings(dims):
 
 def from_dict(dict_obj):
     """
-    Convert a Python dict to a scipp Variable, DataArray or Dataset.
+    Convert a python dict to a scipp Variable, DataArray or Dataset.
+    If the input keys contain both `'coords'` and `'data'`, then a DataArray is
+    returned.
+    If the input keys contain both `'dims'` and `'values'`, as Variable is
+    returned.
+    Otherwise, a Dataset is returned.
+
+    :param dict_obj: A python dict to be converted to a scipp object.
+    :type dict_obj: dict
+    :return: A scipp Variable, DataArray or Dataset.
+    :rtype: Union[Variable, DataArray, Dataset]
     """
     if {"coords", "data"}.issubset(set(dict_obj.keys())):
         # Case of a DataArray-like dict (most-likely)
@@ -89,7 +106,7 @@ def from_dict(dict_obj):
 
 def _dict_to_variable(d):
     """
-    Convert a Python dict to a scipp Variable.
+    Convert a python dict to a scipp Variable.
     """
     out = {}
     for key, item in d.items():
@@ -100,7 +117,7 @@ def _dict_to_variable(d):
 
 def _dict_to_data_array(d):
     """
-    Convert a Python dict to a scipp DataArray.
+    Convert a python dict to a scipp DataArray.
     """
     out = {"coords": {}, "masks": {}, "attrs": {}}
     for key in out.keys():

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 # @author Neil Vaytet
 
+from .. import detail
 from .. import _utils as su
 from .._scipp import core as sc
 
@@ -215,9 +216,12 @@ def _dict_to_data_array(d):
         if key in d:
             for name, item in d[key].items():
                 out[key][name] = _dict_to_variable(item)
+    unaligned = None
     if "unaligned" in d:
-        out["unaligned"] = _dict_to_data_array(d["unaligned"])
+        unaligned = _dict_to_data_array(d["unaligned"])
     else:
         out["data"] = _dict_to_variable(d["data"])
-
-    return sc.DataArray(**out)
+    da = detail.move_to_data_array(**out)
+    if unaligned is not None:
+        da.unaligned = detail.move(unaligned)
+    return da

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -87,12 +87,12 @@ def from_dict(dict_obj):
     :return: A scipp Variable, DataArray or Dataset.
     :rtype: Variable, DataArray, or Dataset
     """
-    if ({"coords", "data"}.issubset(set(dict_obj.keys())) or
-        {"coords", "unaligned"}.issubset(set(dict_obj.keys()))):
+    if ({"coords", "data"}.issubset(set(dict_obj.keys()))
+            or {"coords", "unaligned"}.issubset(set(dict_obj.keys()))):
         # Case of a DataArray-like dict (most-likely)
         return _dict_to_data_array(dict_obj)
-    elif ({"dims", "values"}.issubset(set(dict_obj.keys())) or
-          {"dims", "shape"}.issubset(set(dict_obj.keys()))):
+    elif ({"dims", "values"}.issubset(set(dict_obj.keys()))
+          or {"dims", "shape"}.issubset(set(dict_obj.keys()))):
         # Case of a Variable-like dict (most-likely)
         return _dict_to_variable(dict_obj)
     else:

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -124,7 +124,7 @@ def _dict_to_data_array(d):
     Convert a python dict to a scipp DataArray.
     """
     if ("data" not in d) and ("unaligned" not in d):
-        raise KeyError("To create a Dataset, the supplied dict must contain "
+        raise KeyError("To create a DataArray, the supplied dict must contain "
                        "either 'data' or 'unaligned'. "
                        "Got {}.".format(d.keys()))
     out = {"coords": {}, "masks": {}, "attrs": {}}

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -5,6 +5,10 @@
 from .. import _utils as su
 from .._scipp import core as sc
 
+import numpy as np
+from collections import defaultdict
+from itertools import product
+
 
 def to_dict(scipp_obj):
     """
@@ -36,18 +40,53 @@ def to_dict(scipp_obj):
         return out
 
 
+def _vec_parser(x, shp):
+    """
+    Parse vector_3_float to 2D numpy array
+    """
+    return np.array(x)
+
+
+def _event_parser(x, shp):
+    """
+    Parse event list data to numpy array of numpy arrays
+    """
+    return np.reshape([np.array(x[i]) for i in range(len(x))], shp)
+
+
 def _variable_to_dict(v):
     """
     Convert a scipp Variable to a python dict.
     """
-    return {
+    out = {
         "dims": _dims_to_strings(v.dims),
         "shape": v.shape,
-        "values": v.values,
-        "variances": v.variances,
         "unit": v.unit,
         "dtype": v.dtype
     }
+
+    # Use defaultdict to return the raw values/variances by default
+    dtype_parser = defaultdict(lambda: lambda x, y: x)
+    # Using raw dtypes as dict keys doesn't appear to work, so we need to
+    # convert to strings.
+    dtype_parser.update({
+        str(sc.dtype.vector_3_float64): _vec_parser,
+        str(sc.dtype.matrix_3_float64): _vec_parser,
+        str(sc.dtype.string): _vec_parser,
+        str(sc.dtype.event_list_float32): _event_parser,
+        str(sc.dtype.event_list_float64): _event_parser
+    })
+
+    str_dtype = str(v.dtype)
+
+    # Check if variable is 0D:
+    suffix = "s" if len(out["dims"]) > 0 else ""
+    out["value" + suffix] = dtype_parser[str_dtype](getattr(
+        v, "value" + suffix), v.shape)
+    var = getattr(v, "variance" + suffix)
+    out["variance" + suffix] = dtype_parser[str_dtype](
+        var, v.shape) if var is not None else None
+    return out
 
 
 def _data_array_to_dict(da):
@@ -87,12 +126,15 @@ def from_dict(dict_obj):
     :return: A scipp Variable, DataArray or Dataset.
     :rtype: Variable, DataArray, or Dataset
     """
-    if ({"coords", "data"}.issubset(set(dict_obj.keys()))
-            or {"coords", "unaligned"}.issubset(set(dict_obj.keys()))):
+    keys_as_set = set(dict_obj.keys())
+    if ({"coords", "data"}.issubset(keys_as_set)
+            or {"coords", "unaligned"}.issubset(keys_as_set)):
         # Case of a DataArray-like dict (most-likely)
         return _dict_to_data_array(dict_obj)
-    elif ({"dims", "values"}.issubset(set(dict_obj.keys()))
-          or {"dims", "shape"}.issubset(set(dict_obj.keys()))):
+    elif (keys_as_set.issubset(
+        {"dims", "values", "variances", "unit", "dtype", "shape"})
+          or keys_as_set.issubset(
+              {"value", "variance", "unit", "dtype", "shape", "dims"})):
         # Case of a Variable-like dict (most-likely)
         return _dict_to_variable(dict_obj)
     else:
@@ -107,16 +149,57 @@ def _dict_to_variable(d):
     """
     Convert a python dict to a scipp Variable.
     """
-    out = {}
     # The Variable constructor does not accept both `shape` and `values`. If
-    # `values` is present, remove `shape` from the list.
+    # `values` is present, remove `shape` from the list. Also remove `dims` in
+    # the case of a 0D variable.
     keylist = list(d.keys())
+    if "value" in keylist:
+        if "shape" in keylist:
+            keylist.remove("shape")
+        if "dims" in keylist:
+            keylist.remove("dims")
     if "values" in keylist and "shape" in keylist:
         keylist.remove("shape")
+    out = {}
 
-    for key in keylist:
-        out[key] = d[key]
-    return sc.Variable(**out)
+    is_event_data = False
+    if "dtype" in keylist:
+        is_event_data = str(d["dtype"]).startswith("event_list_float")
+
+    # TODO: maybe this constructor would be worth adding to the scipp module
+    # itself?
+    if is_event_data:
+        if "shape" not in d:
+            shp = d["values"].shape
+        else:
+            shp = d["shape"]
+
+        var = sc.Variable(dims=d["dims"],
+                          shape=shp,
+                          dtype=getattr(sc.dtype, str(d["dtype"])))
+
+        ndim = len(d["dims"])
+        indices = tuple()
+        for i in range(ndim):
+            indices += range(shp[i]),
+        # Now construct all indices combinations using itertools
+        for ind in product(*indices):
+            # And for each indices combination, slice the original data
+            vslice = var
+            aslice = d["values"]
+            for i in range(ndim):
+                vslice = vslice[d["dims"][i], ind[i]]
+                aslice = aslice[ind[i]]
+            vslice.values = aslice
+        return var
+
+    else:
+        for key in keylist:
+            if key == "dtype" and isinstance(d[key], str):
+                out[key] = getattr(sc.dtype, d[key])
+            else:
+                out[key] = d[key]
+        return sc.Variable(**out)
 
 
 def _dict_to_data_array(d):

--- a/python/tests/compat/test_dict.py
+++ b/python/tests/compat/test_dict.py
@@ -151,16 +151,15 @@ def test_variable_matrix_from_dict():
     assert var.dtype == sc.dtype.matrix_3_float64
 
 
-def test_variable_matrix_from_dict():
+def test_variable_0D_matrix_from_dict():
     var_dict = {
-        "dims": ['x'],
-        "values": np.arange(18).reshape(2, 3, 3),
+        "value": np.arange(9).reshape(3, 3),
         "dtype": "matrix_3_float64"
     }
     var = sc.from_dict(var_dict)
-    assert var.dims == var_dict["dims"]
-    assert var.shape == [2]
-    assert np.array_equal(np.array(var.values), var_dict["values"])
+    assert var.dims == []
+    assert var.shape == []
+    assert np.array_equal(np.array(var.value), var_dict["value"])
     assert var.unit == sc.units.one
     assert var.dtype == sc.dtype.matrix_3_float64
 

--- a/python/tests/compat/test_dict.py
+++ b/python/tests/compat/test_dict.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Neil Vaytet
+
+import numpy as np
+import scipp as sc
+
+
+def test_variable_to_dict():
+    var = sc.Variable(dims=["x"],
+                      values=np.arange(10.),
+                      variances=np.random.random(10),
+                      unit=sc.units.m)
+    var_dict = sc.to_dict(var)
+    assert var_dict["dims"] == var.dims
+    assert var_dict["shape"] == var.shape
+    assert np.array_equal(var_dict["values"], var.values)
+    assert np.array_equal(var_dict["variances"], var.variances)
+    assert var_dict["unit"] == var.unit
+    assert var_dict["dtype"] == var.dtype
+
+
+def test_variable_from_dict():
+    var_dict = {
+        "dims": ['x'],
+        "values": np.arange(10.),
+        "variances": np.random.random(10)
+    }
+    var = sc.from_dict(var_dict)
+    assert var.dims == var_dict["dims"]
+    assert var.shape == [10]
+    assert np.array_equal(var.values, var_dict["values"])
+    assert np.array_equal(var.variances, var_dict["variances"])
+    assert var.unit == sc.units.one
+
+
+def test_variable_round_trip():
+    var = sc.Variable(dims=["x"],
+                      values=np.arange(10.),
+                      variances=np.random.random(10),
+                      unit=sc.units.m)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_data_array_to_dict():
+    da = sc.DataArray(
+        coords={
+            "x": sc.Variable(dims=["x"], values=np.arange(10.)),
+            "y": sc.Variable(dims=["y"], values=np.arange(5), unit=sc.units.m),
+        },
+        masks={
+            "amask":
+            sc.Variable(dims=["y"], values=[True, True, False, True, False])
+        },
+        attrs={"attr1": sc.Variable(dims=["x"], values=np.random.random(10))},
+        data=sc.Variable(dims=["y", "x"], values=np.random.random([5, 10])))
+    da_dict = sc.to_dict(da)
+    assert da_dict["dims"] == da.dims
+    assert da_dict["shape"] == da.shape
+    assert np.array_equal(da_dict["values"], da.values)
+    assert np.array_equal(da_dict["variances"], da.variances)
+    assert da_dict["unit"] == da.unit
+    assert da_dict["dtype"] == da.dtype
+    assert sc.from_dict(da_dict["coords"]["x"]) == da.coords["x"]
+    assert sc.from_dict(da_dict["coords"]["y"]) == da.coords["y"]
+    assert sc.from_dict(da_dict["masks"]["amask"]) == da.masks["amask"]
+    assert sc.from_dict(da_dict["attrs"]["attr1"]) == da.attrs["attr1"]
+
+
+def test_data_array_from_dict():
+    da_dict = {
+        "coords": {
+            "x": {
+                "dims": ["x"],
+                "values": np.arange(10)
+            },
+            "y": {
+                "dims": ["y"],
+                "values": np.arange(5),
+                "unit": sc.units.m
+            },
+        },
+        "masks": {
+            "amask": {
+                "dims": ["y"],
+                "values": [True, True, False, True, False]
+            }
+        },
+        "attrs": {
+            "attr1": {
+                "dims": ["x"],
+                "values": np.random.random(10)
+            }
+        },
+        "data": {
+            "dims": ["y", "x"],
+            "values": np.random.random([5, 10])
+        }
+    }
+    da = sc.from_dict(da_dict)
+    assert da.coords["x"] == sc.from_dict(da_dict["coords"]["x"])
+    assert da.coords["y"] == sc.from_dict(da_dict["coords"]["y"])
+    assert da.masks["amask"] == sc.from_dict(da_dict["masks"]["amask"])
+    assert da.attrs["attr1"] == sc.from_dict(da_dict["attrs"]["attr1"])
+    assert da.data == sc.from_dict(da_dict["data"])
+
+
+def test_data_array_round_trip():
+    da = sc.DataArray(coords={
+        "x":
+        sc.Variable(dims=["x"], values=np.arange(10.)),
+        "y":
+        sc.Variable(dims=["y"], values=np.arange(5), unit=sc.units.m),
+    },
+                      masks={
+                          "amask":
+                          sc.Variable(dims=["y"],
+                                      values=[True, True, False, True, False])
+                      },
+                      data=sc.Variable(dims=["y", "x"],
+                                       values=np.random.random([5, 10])))
+    assert da == sc.from_dict(sc.to_dict(da))
+
+
+def test_dataset_to_dict():
+    ds = sc.Dataset()
+    ds.coords["x"] = sc.Variable(dims=["x"], values=np.arange(10))
+    ds.coords["y"] = sc.Variable(dims=["y"],
+                                 values=np.arange(5),
+                                 unit=sc.units.m)
+    ds["a"] = sc.Variable(dims=["y", "x"], values=np.random.random([5, 10]))
+    ds["b"] = sc.Variable(dims=["y", "x"],
+                          values=np.random.random([5, 10]),
+                          variances=np.random.random([5, 10]),
+                          unit=sc.units.s)
+    ds.masks["amask"] = sc.Variable(dims=["y"],
+                                    values=[True, True, False, True, False])
+    # Note that attributes complicate things here, as they are duplicated in
+    # each entry during the conversion to dict. So for now, we leave attributes
+    # out.
+    ds_dict = sc.to_dict(ds)
+    assert sc.from_dict(ds_dict["a"]) == ds["a"]
+    assert sc.from_dict(ds_dict["b"]) == ds["b"]
+
+
+def test_dataset_from_dict():
+    ds_dict = {
+        "a": {
+            "coords": {
+                "x": {
+                    "dims": ["x"],
+                    "values": np.arange(10)
+                },
+                "y": {
+                    "dims": ["y"],
+                    "values": np.arange(5),
+                    "unit": sc.units.m
+                },
+            },
+            "masks": {
+                "amask": {
+                    "dims": ["y"],
+                    "values": [True, True, False, True, False]
+                }
+            },
+            "data": {
+                "dims": ["y", "x"],
+                "values": np.random.random([5, 10])
+            }
+        },
+        "b": {
+            "coords": {
+                "x": {
+                    "dims": ["x"],
+                    "values": np.arange(10)
+                },
+                "y": {
+                    "dims": ["y"],
+                    "values": np.arange(5),
+                    "unit": sc.units.m
+                },
+            },
+            "masks": {
+                "amask": {
+                    "dims": ["y"],
+                    "values": [True, True, False, True, False]
+                }
+            },
+            "data": {
+                "dims": ["y", "x"],
+                "values": np.random.random([5, 10]),
+                "variances": np.random.random([5, 10])
+            }
+        }
+    }
+    ds = sc.from_dict(ds_dict)
+    assert ds["a"] == sc.from_dict(ds_dict["a"])
+    assert ds["b"] == sc.from_dict(ds_dict["b"])
+
+
+def test_dataset_round_trip():
+    ds = sc.Dataset()
+    ds.coords["x"] = sc.Variable(dims=["x"], values=np.arange(10))
+    ds.coords["y"] = sc.Variable(dims=["y"],
+                                 values=np.arange(5),
+                                 unit=sc.units.m)
+    ds["a"] = sc.Variable(dims=["y", "x"], values=np.random.random([5, 10]))
+    ds["b"] = sc.Variable(dims=["y", "x"],
+                          values=np.random.random([5, 10]),
+                          variances=np.random.random([5, 10]),
+                          unit=sc.units.s)
+    ds.masks["amask"] = sc.Variable(dims=["y"],
+                                    values=[True, True, False, True, False])
+    # Note that round trip would not work if attrs are present, since they get
+    # become a per-item attribute during the conversion to dict.
+    assert ds == sc.from_dict(sc.to_dict(ds))

--- a/python/tests/compat/test_dict.py
+++ b/python/tests/compat/test_dict.py
@@ -21,10 +21,78 @@ def test_variable_to_dict():
     assert var_dict["dtype"] == var.dtype
 
 
+def test_variable_0D_to_dict():
+    var = 12.0 * sc.units.one
+    var_dict = sc.to_dict(var)
+    assert var_dict["dims"] == []
+    assert var_dict["shape"] == []
+    assert var_dict["value"] == 12.0
+
+
+def test_variable_vector_to_dict():
+    var = sc.Variable(['x'],
+                      values=np.random.random([10, 3]),
+                      dtype=sc.dtype.vector_3_float64)
+    var_dict = sc.to_dict(var)
+    assert var_dict["dims"] == ['x']
+    assert var_dict["shape"] == [10]
+    assert var_dict["values"].shape == (10, 3)
+    assert var_dict["dtype"] == sc.dtype.vector_3_float64
+
+
+def test_variable_0D_vector_to_dict():
+    var = sc.Variable(value=[1, 2, 3], dtype=sc.dtype.vector_3_float64)
+    var_dict = sc.to_dict(var)
+    assert var_dict["dims"] == []
+    assert var_dict["shape"] == []
+    assert np.array_equal(var_dict["value"], [1, 2, 3])
+    assert var_dict["dtype"] == sc.dtype.vector_3_float64
+
+
+def test_variable_matrix_to_dict():
+    data = np.array([
+        np.arange(9.0).reshape(3, 3),
+        np.arange(5.0, 14.0).reshape(3, 3),
+        np.arange(1.0, 10.0).reshape(3, 3),
+        np.arange(2.0, 11.0).reshape(3, 3)
+    ])
+    var = sc.Variable(['x'],
+                      values=data,
+                      unit=sc.units.m,
+                      dtype=sc.dtype.matrix_3_float64)
+    var_dict = sc.to_dict(var)
+    assert var_dict["shape"] == [4]
+    assert var_dict["values"].shape == (4, 3, 3)
+    assert var_dict["dtype"] == sc.dtype.matrix_3_float64
+
+
+def test_variable_0D_matrix_to_dict():
+    var = sc.Variable(value=np.arange(1, 10).reshape(3, 3),
+                      dtype=sc.dtype.matrix_3_float64)
+    var_dict = sc.to_dict(var)
+    assert var_dict["dims"] == []
+    assert var_dict["shape"] == []
+    assert np.array_equal(var_dict["value"], [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert var_dict["dtype"] == sc.dtype.matrix_3_float64
+
+
+def test_variable_event_to_dict():
+    var = sc.Variable(dims=['x'], shape=[4], dtype=sc.dtype.event_list_float64)
+    var['x', 1].values.append(42)
+    var['x', 0].values.extend(np.ones(3))
+    var['x', 3].values = np.ones(6)
+    var_dict = sc.to_dict(var)
+    assert var_dict["shape"] == [4]
+    assert np.array_equal(var_dict["values"][0], [1, 1, 1])
+    assert np.array_equal(var_dict["values"][1], [42])
+    assert len(var_dict["values"][2]) == 0
+    assert np.array_equal(var_dict["values"][3], [1, 1, 1, 1, 1, 1])
+
+
 def test_variable_from_dict():
     var_dict = {
         "dims": ['x'],
-        "values": np.arange(10.),
+        "values": np.random.random(10),
         "variances": np.random.random(10)
     }
     var = sc.from_dict(var_dict)
@@ -35,11 +103,143 @@ def test_variable_from_dict():
     assert var.unit == sc.units.one
 
 
+def test_variable_0D_from_dict():
+    var_dict = {"value": 17., "variance": 0.2}
+    var = sc.from_dict(var_dict)
+    assert var.dims == []
+    assert var.shape == []
+    assert var.value == 17.0
+    assert var.variance == 0.2
+    assert var.unit == sc.units.one
+
+
+def test_variable_vector_from_dict():
+    var_dict = {
+        "dims": ['x'],
+        "values": np.arange(6).reshape(2, 3),
+        "dtype": "vector_3_float64"
+    }
+    var = sc.from_dict(var_dict)
+    assert var.dims == var_dict["dims"]
+    assert var.shape == [2]
+    assert np.array_equal(np.array(var.values), [[0, 1, 2], [3, 4, 5]])
+    assert var.unit == sc.units.one
+    assert var.dtype == sc.dtype.vector_3_float64
+
+
+def test_variable_0D_vector_from_dict():
+    var_dict = {"value": [1, 2, 3], "dtype": "vector_3_float64"}
+    var = sc.from_dict(var_dict)
+    assert var.dims == []
+    assert var.shape == []
+    assert np.array_equal(np.array(var.values), [1, 2, 3])
+    assert var.unit == sc.units.one
+    assert var.dtype == sc.dtype.vector_3_float64
+
+
+def test_variable_matrix_from_dict():
+    var_dict = {
+        "dims": ['x'],
+        "values": np.arange(18).reshape(2, 3, 3),
+        "dtype": "matrix_3_float64"
+    }
+    var = sc.from_dict(var_dict)
+    assert var.dims == var_dict["dims"]
+    assert var.shape == [2]
+    assert np.array_equal(np.array(var.values), var_dict["values"])
+    assert var.unit == sc.units.one
+    assert var.dtype == sc.dtype.matrix_3_float64
+
+
+def test_variable_matrix_from_dict():
+    var_dict = {
+        "dims": ['x'],
+        "values": np.arange(18).reshape(2, 3, 3),
+        "dtype": "matrix_3_float64"
+    }
+    var = sc.from_dict(var_dict)
+    assert var.dims == var_dict["dims"]
+    assert var.shape == [2]
+    assert np.array_equal(np.array(var.values), var_dict["values"])
+    assert var.unit == sc.units.one
+    assert var.dtype == sc.dtype.matrix_3_float64
+
+
+def test_variable_event_from_dict():
+    var_dict = {
+        'dims': ['x'],
+        'dtype':
+        'event_list_float64',
+        'values':
+        np.array([
+            np.array([1., 1., 1.]),
+            np.array([42.]),
+            np.array([]),
+            np.array([1., 1., 1., 1., 1., 1.])
+        ])
+    }
+    var = sc.from_dict(var_dict)
+    assert var.dims == ['x']
+    assert var.shape == [4]
+    assert np.array_equal(var['x', 0].values, [1., 1., 1.])
+    assert np.array_equal(var['x', 1].values, [42.])
+    assert len(var['x', 2].values) == 0
+    assert np.array_equal(var['x', 3].values, [1., 1., 1., 1., 1., 1.])
+    assert var.unit == sc.units.one
+    assert var.dtype == sc.dtype.event_list_float64
+
+
 def test_variable_round_trip():
     var = sc.Variable(dims=["x"],
                       values=np.arange(10.),
                       variances=np.random.random(10),
                       unit=sc.units.m)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_0D_round_trip():
+    var = 12.0 * sc.units.one
+    print(sc.to_dict(var))
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_vector_round_trip():
+    var = sc.Variable(['x'],
+                      values=np.random.random([10, 3]),
+                      dtype=sc.dtype.vector_3_float64)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_0D_vector_round_trip():
+    var = sc.Variable(value=[1, 2, 3], dtype=sc.dtype.vector_3_float64)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_matrix_round_trip():
+    data = np.array([
+        np.arange(9.0).reshape(3, 3),
+        np.arange(5.0, 14.0).reshape(3, 3),
+        np.arange(1.0, 10.0).reshape(3, 3),
+        np.arange(2.0, 11.0).reshape(3, 3)
+    ])
+    var = sc.Variable(['x'],
+                      values=data,
+                      unit=sc.units.m,
+                      dtype=sc.dtype.matrix_3_float64)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_0D_matrix_round_trip():
+    var = sc.Variable(value=np.arange(1, 10).reshape(3, 3),
+                      dtype=sc.dtype.matrix_3_float64)
+    assert var == sc.from_dict(sc.to_dict(var))
+
+
+def test_variable_event_round_trip():
+    var = sc.Variable(dims=['x'], shape=[4], dtype=sc.dtype.event_list_float64)
+    var['x', 1].values.append(42)
+    var['x', 0].values.extend(np.ones(3))
+    var['x', 3].values = np.ones(6)
     assert var == sc.from_dict(sc.to_dict(var))
 
 

--- a/python/tests/compat/test_dict.py
+++ b/python/tests/compat/test_dict.py
@@ -56,16 +56,54 @@ def test_data_array_to_dict():
         attrs={"attr1": sc.Variable(dims=["x"], values=np.random.random(10))},
         data=sc.Variable(dims=["y", "x"], values=np.random.random([5, 10])))
     da_dict = sc.to_dict(da)
-    assert da_dict["dims"] == da.dims
-    assert da_dict["shape"] == da.shape
-    assert np.array_equal(da_dict["values"], da.values)
-    assert np.array_equal(da_dict["variances"], da.variances)
-    assert da_dict["unit"] == da.unit
-    assert da_dict["dtype"] == da.dtype
+    assert da_dict["data"]["dims"] == da.dims
+    assert da_dict["data"]["shape"] == da.shape
+    assert np.array_equal(da_dict["data"]["values"], da.values)
+    assert np.array_equal(da_dict["data"]["variances"], da.variances)
+    assert da_dict["data"]["unit"] == da.unit
+    assert da_dict["data"]["dtype"] == da.dtype
     assert sc.from_dict(da_dict["coords"]["x"]) == da.coords["x"]
     assert sc.from_dict(da_dict["coords"]["y"]) == da.coords["y"]
     assert sc.from_dict(da_dict["masks"]["amask"]) == da.masks["amask"]
     assert sc.from_dict(da_dict["attrs"]["attr1"]) == da.attrs["attr1"]
+
+
+def test_data_array_unaligned_to_dict():
+    N = 50
+    values = 10 * np.random.rand(N)
+    da = sc.DataArray(data=sc.Variable(dims=['position'],
+                                       unit=sc.units.counts,
+                                       values=values,
+                                       variances=values),
+                      coords={
+                          'position':
+                          sc.Variable(
+                              dims=['position'],
+                              values=['site-{}'.format(i) for i in range(N)]),
+                          'x':
+                          sc.Variable(dims=['position'],
+                                      unit=sc.units.m,
+                                      values=np.random.rand(N)),
+                          'y':
+                          sc.Variable(dims=['position'],
+                                      unit=sc.units.m,
+                                      values=np.random.rand(N))
+                      })
+    xbins = sc.Variable(dims=['x'], unit=sc.units.m, values=[0.1, 0.5, 0.9])
+    ybins = sc.Variable(dims=['y'],
+                        unit=sc.units.m,
+                        values=[0.1, 0.3, 0.5, 0.7, 0.9])
+    realigned = sc.realign(da, {'y': ybins, 'x': xbins})
+
+    da_dict = sc.to_dict(realigned)
+    assert "unaligned" in da_dict
+    assert "data" not in da_dict
+    assert sc.from_dict(da_dict["coords"]["x"]) == xbins
+    assert sc.from_dict(da_dict["coords"]["y"]) == ybins
+    assert sc.from_dict(
+        da_dict["unaligned"]["coords"]["x"]) == realigned.unaligned.coords["x"]
+    assert sc.from_dict(
+        da_dict["unaligned"]["coords"]["y"]) == realigned.unaligned.coords["y"]
 
 
 def test_data_array_from_dict():


### PR DESCRIPTION
This allows to convert between scipp objects (`Variable`, `DataArray` and `Dataset`) and python `dict`.
See the unit tests for some use examples.

Fixes #954 