### PR TITLE
Fix superplot when nans are present in values and variances

### DIFF
--- a/python/tests/plot/test_plot_1d.py
+++ b/python/tests/plot/test_plot_1d.py
@@ -109,6 +109,19 @@ def test_plot_sliceviewer_with_1d_projection():
     plot(d, projection="1d")
 
 
+def test_plot_sliceviewer_with_1d_projection_with_nans():
+    d = make_dense_dataset(ndim=3, binedges=True, variances=True)
+    d['Sample'].values = np.where(d['Sample'].values < -0.8, np.nan,
+                                  d['Sample'].values)
+    d['Sample'].variances = np.where(d['Sample'].values < 0., np.nan,
+                                     d['Sample'].variances)
+    p = plot(d, projection='1d')
+    # Move the sliders
+    p['tof.x.y.counts']['widgets']['sliders']['tof'].value = 10
+    p['tof.x.y.counts']['widgets']['sliders']['x'].value = 10
+    p['tof.x.y.counts']['widgets']['sliders']['y'].value = 10
+
+
 def test_plot_1d_events_data_with_bool_bins():
     d = make_events_dataset(ndim=1)
     plot(d, bins={'tof': True})


### PR DESCRIPTION
When NaNs were present in either the values or variances of the data when plotting N-D data with `projection='1d'`, a (not so clear) error was thrown when moving the sliders.

It turns out that when you plot errorbars on 20 points, but 5 of them have a NaN y-value, when you retrieve the segments from the errorbar object with `get_segments()` it only returns the segments for the non-NaN points.

I fixed it by re-generating all segments from the x and y coordinates, instead of starting from the segments given by `get_segments()`.

I also fixed a bug when searching for the y limits, which went wrong when all errorbars were NaN.

**Additional notes**:
- I think i fixed a bug in the errorbars when using the sliders: it seems i was taking the square root twice: see
  - here: https://github.com/scipp/scipp/blob/master/python/src/scipp/plot/plot_1d.py#L396
  - and here: https://github.com/scipp/scipp/blob/master/python/src/scipp/plot/plot_1d.py#L475

Please check!

You can check it works with the following example:
```Py
N = 54
M = 12
L = 9
xx = np.arange(N+1, dtype=np.float64)
yy = np.arange(M, dtype=np.int32)
zz = np.arange(L+1, dtype=np.float64)
z, y, x = np.meshgrid(zz[:-1], yy, xx[:-1], indexing='ij')
b = N/20.0
c = M/2.0
d = L/2.0
r = np.sqrt(((x-c)/b)**2 + ((y-c)/b)**2 + ((z-d)/b)**2)
a = np.sin(r)
d = sc.Dataset()
d.coords['x'] = sc.Variable(['x'], values=xx)
d.coords['y'] = sc.Variable(['y'], values=yy)
d.coords['z'] = sc.Variable(['z'], values=zz)
d['Some3Ddata'] = sc.Variable(['z', 'y', 'x'], values=np.where(a < -0.8, np.nan, a),
                              variances=np.log10(np.random.normal(a * 10.0, 0.05)))
plot(d['Some3Ddata'], projection="1d")
```

Fixes #1222 