### PR TITLE
Edge handling fixes and simplifications

### DIFF
--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -134,18 +134,15 @@ void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
     dims[dim] = isCoord ? extents::makeUnknownEdgeState(extent) : extent;
   } else {
     auto &heldExtent = it->second;
-    if (extents::isUnknownEdgeState(heldExtent)) {
-      if (extent == decodeExtent(heldExtent)) {
-        if (!isCoord)
-          heldExtent = extent;
-      } else if (extent == decodeExtent(heldExtent) + 1 && isCoord) {
-        heldExtent = decodeExtent(heldExtent);
-      } else if (extent == decodeExtent(heldExtent) - 1) {
-        heldExtent = extent;
-      } else {
-        throw except::DimensionError(heldExtent, extent);
-      }
-    } else if (extent != heldExtent && !(isCoord && extent == heldExtent + 1)) {
+    if (extent == decodeExtent(heldExtent) && !isCoord)
+      heldExtent = decodeExtent(heldExtent); // switch to known
+    if (extent == decodeExtent(heldExtent) + 1 && isCoord)
+      heldExtent = decodeExtent(heldExtent); // switch to known
+    if (extent == decodeExtent(heldExtent) - 1 &&
+        extents::isUnknownEdgeState(heldExtent))
+      heldExtent = extent;
+    if (extent != decodeExtent(heldExtent) &&
+        !(isCoord && extent == decodeExtent(heldExtent) + 1)) {
       throw except::DimensionError(heldExtent, extent);
     }
   }

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -121,21 +121,11 @@ namespace extents {
 scipp::index makeUnknownEdgeState(const scipp::index extent) {
   return -extent - 1;
 }
-scipp::index shrink(const scipp::index extent) { return extent - 1; }
 bool isUnknownEdgeState(const scipp::index extent) { return extent < 0; }
 scipp::index decodeExtent(const scipp::index extent) {
   if (isUnknownEdgeState(extent))
     return -extent - 1;
   return extent;
-}
-bool isSame(const scipp::index extent, const scipp::index reference) {
-  return reference == -extent - 1;
-}
-bool oneLarger(const scipp::index extent, const scipp::index reference) {
-  return extent == -reference - 1 + 1;
-}
-bool oneSmaller(const scipp::index extent, const scipp::index reference) {
-  return extent == -reference - 1 - 1;
 }
 void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
                const scipp::index extent, const bool isCoord) {
@@ -145,12 +135,12 @@ void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
   } else {
     auto &heldExtent = it->second;
     if (extents::isUnknownEdgeState(heldExtent)) {
-      if (extents::isSame(extent, heldExtent)) {
+      if (extent == decodeExtent(heldExtent)) {
         if (!isCoord)
           heldExtent = extent;
-      } else if (extents::oneLarger(extent, heldExtent) && isCoord) {
-        heldExtent = extents::shrink(extent);
-      } else if (extents::oneSmaller(extent, heldExtent)) {
+      } else if (extent == decodeExtent(heldExtent) + 1 && isCoord) {
+        heldExtent = decodeExtent(heldExtent);
+      } else if (extent == decodeExtent(heldExtent) - 1) {
         heldExtent = extent;
       } else {
         throw except::DimensionError(heldExtent, extent);

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -141,7 +141,7 @@ void setExtent(std::unordered_map<Dim, scipp::index> &dims, const Dim dim,
   if (extent == decode(current) - 1 && isUnknownEdgeState(current))
     current = extent; // shrink by 1 and switch to known
   if (extent != decode(current) && !(isCoord && extent == decode(current) + 1))
-    throw except::DimensionError(current, extent);
+    throw except::DimensionError(decode(current), extent);
 }
 } // namespace extents
 

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -127,6 +127,13 @@ TEST(DatasetTest, setCoord_shrink) {
   ASSERT_NO_THROW(d.setCoord(Dim::Y, var3));
 }
 
+TEST(DatasetTest, setCoord_fail_events_on_edges) {
+  const auto events = makeVariable<event_list<double>>(Dims{Dim::X}, Shape{4});
+  Dataset d;
+  d.setData("a", makeVariable<double>(Dims{Dim::X}, Shape{3}));
+  ASSERT_THROW(d.setCoord(Dim::Y, events), except::DimensionError);
+}
+
 TEST(DatasetTest, set_item_mask) {
   Dataset d;
   d.setData("x", makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}));

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -111,6 +111,22 @@ TEST(DatasetTest, setCoord) {
   ASSERT_EQ(d.coords().size(), 2);
 }
 
+TEST(DatasetTest, setCoord_grow) {
+  const auto var3 = makeVariable<double>(Dims{Dim::X}, Shape{3});
+  const auto var4 = makeVariable<double>(Dims{Dim::X}, Shape{4});
+  Dataset d;
+  ASSERT_NO_THROW(d.setCoord(Dim::X, var3));
+  ASSERT_NO_THROW(d.setCoord(Dim::Y, var4));
+}
+
+TEST(DatasetTest, setCoord_shrink) {
+  const auto var3 = makeVariable<double>(Dims{Dim::X}, Shape{3});
+  const auto var4 = makeVariable<double>(Dims{Dim::X}, Shape{4});
+  Dataset d;
+  ASSERT_NO_THROW(d.setCoord(Dim::X, var4));
+  ASSERT_NO_THROW(d.setCoord(Dim::Y, var3));
+}
+
 TEST(DatasetTest, set_item_mask) {
   Dataset d;
   d.setData("x", makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}));

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -69,7 +69,7 @@ TEST_F(GroupbyTest, copy) {
 }
 
 TEST_F(GroupbyTest, fail_2d_coord) {
-  d.setCoord(Dim("2d"), makeVariable<float>(Dims{Dim::X, Dim::Z}, Shape{2, 2}));
+  d.setCoord(Dim("2d"), makeVariable<float>(Dims{Dim::X, Dim::Z}, Shape{3, 2}));
   EXPECT_NO_THROW(groupby(d, Dim("labels2")));
   EXPECT_THROW(groupby(d, Dim("labels2")).sum(Dim::X), except::DimensionError);
 }

--- a/dataset/test/self_assignment_test.cpp
+++ b/dataset/test/self_assignment_test.cpp
@@ -35,7 +35,7 @@ TEST_F(SelfAssignmentTest, dataset_item) {
 
   // Code that checks for self-assignment might erroneously not check for
   // presence of slices.
-  dataset.setData("a", dataset["a"].slice({Dim::X, 0, 1}));
+  dataset.setData("a", dataset["a"].slice({Dim::X, 0}));
   EXPECT_NE(dataset["a"], expected);
   EXPECT_NE(dataset["a"].values<double>().data(), expected_ptr);
 }

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -726,8 +726,8 @@ def test_correct_temporaries():
     N = 6
     M = 4
     d1 = sc.Dataset()
-    d1['x'] = sc.Variable(['x'], values=np.arange(N + 1).astype(np.float64))
-    d1['y'] = sc.Variable(['y'], values=np.arange(M + 1).astype(np.float64))
+    d1['x'] = sc.Variable(['x'], values=np.arange(N).astype(np.float64))
+    d1['y'] = sc.Variable(['y'], values=np.arange(M).astype(np.float64))
     arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
     d1['A'] = sc.Variable(['x', 'y'], values=arr1)
     d1 = d1['x', 1:2]

--- a/python/tests/test_datasetslice.py
+++ b/python/tests/test_datasetslice.py
@@ -70,10 +70,8 @@ class TestDatasetSlice:
         N = 6
         M = 4
         d1 = sc.Dataset()
-        d1['x'] = sc.Variable(['x'],
-                              values=np.arange(N + 1).astype(np.float64))
-        d1['y'] = sc.Variable(['y'],
-                              values=np.arange(M + 1).astype(np.float64))
+        d1['x'] = sc.Variable(['x'], values=np.arange(N).astype(np.float64))
+        d1['y'] = sc.Variable(['y'], values=np.arange(M).astype(np.float64))
         arr1 = np.arange(N * M).reshape(N, M).astype(np.float64) + 1
         d1['a'] = sc.Variable(['x', 'y'], values=arr1)
         d1 = d1['x', 1:2]


### PR DESCRIPTION
- Only support coords (not data or masks) on edges. This simplifies things conceptually. We do not have a use for data on the edges and likely many other things would fail (we are never unit-testing any of our operations for this).
- Fixes #1190.
- Support non-dimension coords that are edges, even if no corresponding dim coord on the edges exists.
- Simplify code around edge state handling.
- Add a couple more unit tests.

Based on #1261.
