### PR TITLE
Arithmetic type conversion/support fixes

### DIFF
--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -16,7 +16,10 @@ constexpr auto add_inplace_types =
     arg_list<double, float, int64_t, int32_t, Eigen::Vector3d,
              std::tuple<scipp::core::time_point, int64_t>,
              std::tuple<scipp::core::time_point, int32_t>,
-             std::tuple<double, float>, std::tuple<int64_t, int32_t>,
+             std::tuple<double, float>, std::tuple<float, double>,
+             std::tuple<int64_t, int32_t>, std::tuple<int32_t, int64_t>,
+             std::tuple<double, int64_t>, std::tuple<double, int32_t>,
+             std::tuple<float, int64_t>, std::tuple<float, int32_t>,
              std::tuple<int64_t, bool>>;
 
 constexpr auto plus_equals =

--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -46,8 +46,8 @@ TEST_F(ElementArithmeticTest, unary_minus) { EXPECT_EQ(unary_minus(a), -a); }
 
 TEST(ElementArithmeticIntegerDivisionTest, truediv) {
   // 32 bit ints gives double not float, consistent with numpy
-  EXPECT_TRUE(std::is_same_v<decltype(divide(int32_t{}, int32_t{})), double>);
-  EXPECT_TRUE(std::is_same_v<decltype(divide(int64_t{}, int64_t{})), double>);
+  EXPECT_TRUE((std::is_same_v<decltype(divide(int32_t{}, int32_t{})), double>));
+  EXPECT_TRUE((std::is_same_v<decltype(divide(int64_t{}, int64_t{})), double>));
 }
 
 TEST(ElementArithmeticIntegerDivisionTest, truediv_32bit) {

--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -44,10 +44,15 @@ TEST_F(ElementArithmeticTest, non_in_place) {
 
 TEST_F(ElementArithmeticTest, unary_minus) { EXPECT_EQ(unary_minus(a), -a); }
 
+TEST(ElementArithmeticIntegerDivisionTest, truediv) {
+  // 32 bit ints gives double not float, consistent with numpy
+  EXPECT_TRUE(std::is_same_v<decltype(divide(int32_t{}, int32_t{}), double>);
+  EXPECT_TRUE(std::is_same_v<decltype(divide(int64_t{}, int64_t{}), double>);
+}
+
 TEST(ElementArithmeticIntegerDivisionTest, truediv_32bit) {
   const int32_t a = 2;
   const int32_t b = 3;
-  // 32 bit ints give double not float, consistent with numpy
   EXPECT_EQ(divide(a, b), 2.0 / 3.0);
 }
 

--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -46,8 +46,8 @@ TEST_F(ElementArithmeticTest, unary_minus) { EXPECT_EQ(unary_minus(a), -a); }
 
 TEST(ElementArithmeticIntegerDivisionTest, truediv) {
   // 32 bit ints gives double not float, consistent with numpy
-  EXPECT_TRUE(std::is_same_v<decltype(divide(int32_t{}, int32_t{}), double>);
-  EXPECT_TRUE(std::is_same_v<decltype(divide(int64_t{}, int64_t{}), double>);
+  EXPECT_TRUE(std::is_same_v<decltype(divide(int32_t{}, int32_t{})), double>);
+  EXPECT_TRUE(std::is_same_v<decltype(divide(int64_t{}, int64_t{})), double>);
 }
 
 TEST(ElementArithmeticIntegerDivisionTest, truediv_32bit) {

--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -43,3 +43,30 @@ TEST_F(ElementArithmeticTest, non_in_place) {
 }
 
 TEST_F(ElementArithmeticTest, unary_minus) { EXPECT_EQ(unary_minus(a), -a); }
+
+TEST(ElementArithmeticIntegerDivisionTest, truediv_32bit) {
+  const int32_t a = 2;
+  const int32_t b = 3;
+  // 32 bit ints give double not float, consistent with numpy
+  EXPECT_EQ(divide(a, b), 2.0 / 3.0);
+}
+
+TEST(ElementArithmeticIntegerDivisionTest, truediv_64bit) {
+  const int64_t a = 2;
+  const int64_t b = 3;
+  EXPECT_EQ(divide(a, b), 2.0 / 3.0);
+}
+
+template <class T> struct int_as_first_arg : std::false_type {};
+template <> struct int_as_first_arg<int64_t> : std::true_type {};
+template <> struct int_as_first_arg<int32_t> : std::true_type {};
+template <class A, class B>
+struct int_as_first_arg<std::tuple<A, B>> : int_as_first_arg<A> {};
+
+template <class... Ts> auto no_int_as_first_arg(const std::tuple<Ts...> &) {
+  return !(int_as_first_arg<Ts>::value || ...);
+}
+
+TEST(ElementArithmeticIntegerDivisionTest, inplace_truediv_not_supported) {
+  EXPECT_TRUE(no_int_as_first_arg(decltype(divide_equals)::types{}));
+}

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -144,7 +144,7 @@ def test_in_place_binary_with_dataarray():
 
 
 def test_in_place_binary_with_scalar():
-    a = sc.DataArray(data=sc.Variable(['x'], values=[10]),
+    a = sc.DataArray(data=sc.Variable(['x'], values=[10.0]),
                      coords={'x': sc.Variable(['x'], values=[10])})
     copy = a.copy()
 
@@ -170,7 +170,7 @@ def test_binary_with_broadcast():
 
 
 def test_view_in_place_binary_with_scalar():
-    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10])},
+    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10.0])},
                    coords={'x': sc.Variable(dims=['x'], values=[10])})
     copy = d.copy()
 

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -594,7 +594,7 @@ def test_binary_of_item_with_variable():
 
 
 def test_in_place_binary_with_scalar():
-    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10])},
+    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10.0])},
                    coords={'x': sc.Variable(dims=['x'], values=[10])})
     copy = d.copy()
 
@@ -606,7 +606,7 @@ def test_in_place_binary_with_scalar():
 
 
 def test_view_in_place_binary_with_scalar():
-    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10])},
+    d = sc.Dataset({'data': sc.Variable(dims=['x'], values=[10.0])},
                    coords={'x': sc.Variable(dims=['x'], values=[10])})
     copy = d.copy()
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -589,7 +589,7 @@ def test_binary_xor():
 
 
 def test_in_place_binary_with_scalar():
-    v = sc.Variable(dims=['x'], values=[10])
+    v = sc.Variable(dims=['x'], values=[10.0])
     copy = v.copy()
 
     v += 2
@@ -1037,5 +1037,5 @@ def test_rmul_int():
 
 def test_rtruediv_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var / 1).dtype == var.dtype
-    assert (1 / var).dtype == var.dtype
+    assert (var / 1).dtype == sc.dtype.float64
+    assert (1 / var).dtype == sc.dtype.float64

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -43,8 +43,14 @@ TYPED_TEST(VariableScalarOperatorTest, times_equals) {
 }
 
 TYPED_TEST(VariableScalarOperatorTest, divide_equals) {
-  this->variable /= this->scalar * units::one;
-  EXPECT_EQ(this->value(), 5);
+  if (this->variable.dtype() == dtype<double> ||
+      this->variable.dtype() == dtype<float>) {
+    this->variable /= this->scalar * units::one;
+    EXPECT_EQ(this->value(), 5);
+  } else {
+    EXPECT_THROW(this->variable /= this->scalar * units::one,
+                 except::TypeError);
+  }
 }
 
 TEST(Variable, operator_unary_minus) {
@@ -145,7 +151,7 @@ TEST(Variable, operator_minus_equal_time_type) {
 TEST(Variable, operator_plus_equal_different_variables_different_element_type) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.0});
   auto b = makeVariable<int64_t>(Dims{Dim::X}, Shape{1}, Values{2});
-  EXPECT_THROW(a += b, except::TypeError);
+  EXPECT_NO_THROW(a += b);
 }
 
 TEST(Variable, operator_plus_equal_different_variables_same_element_type) {
@@ -411,9 +417,9 @@ TEST(Variable, operator_allowed_types) {
   EXPECT_NO_THROW(i64 += i32);
   EXPECT_NO_THROW(d += f);
 
-  /* Can not operate on lower precision from higher precision */
-  EXPECT_ANY_THROW(i32 += i64);
-  EXPECT_ANY_THROW(f += d);
+  /* Can operate on lower precision from higher precision */
+  EXPECT_NO_THROW(i32 += i64);
+  EXPECT_NO_THROW(f += d);
 
   /* Expect promotion to double if one parameter is double */
   EXPECT_EQ(dtype<double>, (f + d).dtype());


### PR DESCRIPTION
The overall approach is to be consistent with Python 3 and numpy (in particular `truediv`). This implies that the behavior on the C++ side is unusual, but in practice this should not be an issue. Note that we are not 100% numpy compliant yet, e.g., numpy int32/float32 gives float64, whereas scipp still gives float32.

- Fixes #1265.
- Fixes #1114.