### PR TITLE
Various plotting fixes

### DIFF
--- a/core/include/scipp/core/element/comparison.h
+++ b/core/include/scipp/core/element/comparison.h
@@ -16,8 +16,8 @@ namespace scipp::core::element {
 
 constexpr auto comparison = overloaded{
     transform_flags::no_out_variance,
-    arg_list<double, float, int64_t, int32_t, std::tuple<int64_t, int32_t>,
-             std::tuple<int32_t, int64_t>>,
+    arg_list<double, float, int64_t, int32_t, bool,
+             std::tuple<int64_t, int32_t>, std::tuple<int32_t, int64_t>>,
     [](const units::Unit &x, const units::Unit &y) {
       expect::equals(x, y);
       return units::dimensionless;
@@ -49,7 +49,7 @@ constexpr auto not_equal =
     overloaded{comparison, [](const auto &x, const auto &y) { return x != y; }};
 
 constexpr auto max_equals =
-    overloaded{arg_list<double, float, int64_t, int32_t>,
+    overloaded{arg_list<double, float, int64_t, int32_t, bool>,
                transform_flags::expect_in_variance_if_out_variance,
                [](auto &&a, const auto &b) {
                  using std::max;
@@ -57,7 +57,7 @@ constexpr auto max_equals =
                }};
 
 constexpr auto min_equals =
-    overloaded{arg_list<double, float, int64_t, int32_t>,
+    overloaded{arg_list<double, float, int64_t, int32_t, bool>,
                transform_flags::expect_in_variance_if_out_variance,
                [](auto &&a, const auto &b) {
                  using std::min;

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -74,4 +74,61 @@ static constexpr auto rebin = overloaded{
     transform_flags::expect_no_variance_arg<1>,
     transform_flags::expect_no_variance_arg<3>};
 
+static constexpr auto rebin_descending = overloaded{
+    [](const auto &data_new, const auto &xnew, const auto &data_old,
+       const auto &xold) {
+      zero(data_new);
+      const auto oldSize = scipp::size(xold) - 1;
+      const auto newSize = scipp::size(xnew) - 1;
+      scipp::index iold = 0;
+      scipp::index inew = 0;
+      while ((iold < oldSize) && (inew < newSize)) {
+        const auto xo_low = xold[iold];
+        const auto xo_high = xold[iold + 1];
+        const auto xn_low = xnew[inew];
+        const auto xn_high = xnew[inew + 1];
+        if (xn_high >= xo_low)
+          inew++; // old and new bins do not overlap
+        else if (xo_high >= xn_low)
+          iold++; // old and new bins do not overlap
+        else {
+          // delta is the overlap of the bins on the x axis
+          const auto delta = std::min<double>(xn_low, xo_low) -
+                             std::max<double>(xn_high, xo_high);
+          const auto owidth = xo_low - xo_high;
+          const auto scale = delta / owidth;
+          if constexpr (is_ValueAndVariance_v<
+                            std::decay_t<decltype(data_old)>>) {
+            data_new.value[inew] += data_old.value[iold] * scale;
+            data_new.variance[inew] += data_old.variance[iold] * scale;
+          } else if constexpr (std::is_same_v<typename std::decay_t<decltype(
+                                                  data_new)>::value_type,
+                                              bool>) {
+            static_cast<void>(scale);
+            data_new[inew] = data_new[inew] || data_old[iold];
+          } else {
+            data_new[inew] += data_old[iold] * scale;
+          }
+          if (xn_high < xo_high) {
+            iold++;
+          } else {
+            inew++;
+          }
+        }
+      }
+    },
+    [](const units::Unit &target_edges, const units::Unit &data,
+       const units::Unit &edges) {
+      if (target_edges != edges)
+        throw except::UnitError(
+            "Input and output bin edges must have the same unit.");
+      if (data != units::counts && data != units::one)
+        throw except::UnitError("Only count-data (units::counts or "
+                                "units::dimensionless) can be rebinned.");
+      return data;
+    },
+    transform_flags::expect_in_variance_if_out_variance,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<3>};
+
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -17,6 +17,74 @@
 
 namespace scipp::core::element {
 
+struct AscendingRebin {};
+struct DescendingRebin {};
+
+namespace {
+void rebin_error() {
+  throw std::runtime_error(
+      "Unknown type of rebin operation. "
+      "Possible branches are AscendingRebin and DescendingRebin.");
+}
+} // namespace
+
+template <class RebinType, class OldType, class NewType>
+bool compare_new_high_with_old_low(const NewType xn_high,
+                                   const OldType xo_low) {
+  if constexpr (std::is_same_v<RebinType, AscendingRebin>)
+    return xn_high <= xo_low;
+  else if constexpr (std::is_same_v<RebinType, DescendingRebin>)
+    return xn_high >= xo_low;
+  else
+    rebin_error();
+}
+
+template <class RebinType, class OldType, class NewType>
+bool compare_old_high_with_new_low(const OldType xo_high,
+                                   const NewType xn_low) {
+  if constexpr (std::is_same_v<RebinType, AscendingRebin>)
+    return xo_high <= xn_low;
+  else if constexpr (std::is_same_v<RebinType, DescendingRebin>)
+    return xo_high >= xn_low;
+  else
+    rebin_error();
+}
+
+template <class RebinType, class OldType, class NewType>
+double compute_delta(const NewType xn_high, const OldType xo_high,
+                     const NewType xn_low, const OldType xo_low) {
+  if constexpr (std::is_same_v<RebinType, AscendingRebin>)
+    return std::min<double>(xn_high, xo_high) -
+           std::max<double>(xn_low, xo_low);
+  else if constexpr (std::is_same_v<RebinType, DescendingRebin>)
+    return std::min<double>(xn_low, xo_low) -
+           std::max<double>(xn_high, xo_high);
+  else
+    rebin_error();
+}
+
+template <class RebinType, class OldType>
+double compute_owidth(const OldType xo_high, const OldType xo_low) {
+  if constexpr (std::is_same_v<RebinType, AscendingRebin>)
+    return xo_high - xo_low;
+  else if constexpr (std::is_same_v<RebinType, DescendingRebin>)
+    return xo_low - xo_high;
+  else
+    rebin_error();
+}
+
+template <class RebinType, class OldType, class NewType>
+bool compare_new_high_with_old_high(const NewType xn_high,
+                                    const OldType xo_high) {
+  if constexpr (std::is_same_v<RebinType, AscendingRebin>)
+    return xn_high > xo_high;
+  else if constexpr (std::is_same_v<RebinType, DescendingRebin>)
+    return xn_high < xo_high;
+  else
+    rebin_error();
+}
+
+template <class T>
 static constexpr auto rebin = overloaded{
     [](const auto &data_new, const auto &xnew, const auto &data_old,
        const auto &xold) {
@@ -30,15 +98,14 @@ static constexpr auto rebin = overloaded{
         const auto xo_high = xold[iold + 1];
         const auto xn_low = xnew[inew];
         const auto xn_high = xnew[inew + 1];
-        if (xn_high <= xo_low)
+        if (compare_old_high_with_new_low<T>(xn_high, xo_low))
           inew++; // old and new bins do not overlap
-        else if (xo_high <= xn_low)
+        else if (compare_old_high_with_new_low<T>(xo_high, xn_low))
           iold++; // old and new bins do not overlap
         else {
           // delta is the overlap of the bins on the x axis
-          const auto delta = std::min<double>(xn_high, xo_high) -
-                             std::max<double>(xn_low, xo_low);
-          const auto owidth = xo_high - xo_low;
+          const auto delta = compute_delta<T>(xn_high, xo_high, xn_low, xo_low);
+          const auto owidth = compute_owidth<T>(xo_high, xo_low);
           const auto scale = delta / owidth;
           if constexpr (is_ValueAndVariance_v<
                             std::decay_t<decltype(data_old)>>) {
@@ -52,64 +119,7 @@ static constexpr auto rebin = overloaded{
           } else {
             data_new[inew] += data_old[iold] * scale;
           }
-          if (xn_high > xo_high) {
-            iold++;
-          } else {
-            inew++;
-          }
-        }
-      }
-    },
-    [](const units::Unit &target_edges, const units::Unit &data,
-       const units::Unit &edges) {
-      if (target_edges != edges)
-        throw except::UnitError(
-            "Input and output bin edges must have the same unit.");
-      if (data != units::counts && data != units::one)
-        throw except::UnitError("Only count-data (units::counts or "
-                                "units::dimensionless) can be rebinned.");
-      return data;
-    },
-    transform_flags::expect_in_variance_if_out_variance,
-    transform_flags::expect_no_variance_arg<1>,
-    transform_flags::expect_no_variance_arg<3>};
-
-static constexpr auto rebin_descending = overloaded{
-    [](const auto &data_new, const auto &xnew, const auto &data_old,
-       const auto &xold) {
-      zero(data_new);
-      const auto oldSize = scipp::size(xold) - 1;
-      const auto newSize = scipp::size(xnew) - 1;
-      scipp::index iold = 0;
-      scipp::index inew = 0;
-      while ((iold < oldSize) && (inew < newSize)) {
-        const auto xo_low = xold[iold];
-        const auto xo_high = xold[iold + 1];
-        const auto xn_low = xnew[inew];
-        const auto xn_high = xnew[inew + 1];
-        if (xn_high >= xo_low)
-          inew++; // old and new bins do not overlap
-        else if (xo_high >= xn_low)
-          iold++; // old and new bins do not overlap
-        else {
-          // delta is the overlap of the bins on the x axis
-          const auto delta = std::min<double>(xn_low, xo_low) -
-                             std::max<double>(xn_high, xo_high);
-          const auto owidth = xo_low - xo_high;
-          const auto scale = delta / owidth;
-          if constexpr (is_ValueAndVariance_v<
-                            std::decay_t<decltype(data_old)>>) {
-            data_new.value[inew] += data_old.value[iold] * scale;
-            data_new.variance[inew] += data_old.variance[iold] * scale;
-          } else if constexpr (std::is_same_v<typename std::decay_t<decltype(
-                                                  data_new)>::value_type,
-                                              bool>) {
-            static_cast<void>(scale);
-            data_new[inew] = data_new[inew] || data_old[iold];
-          } else {
-            data_new[inew] += data_old[iold] * scale;
-          }
-          if (xn_high < xo_high) {
+          if (compare_new_high_with_old_high<T>(xn_high, xo_high)) {
             iold++;
           } else {
             inew++;

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -98,14 +98,15 @@ static constexpr auto rebin = overloaded{
         const auto xo_high = xold[iold + 1];
         const auto xn_low = xnew[inew];
         const auto xn_high = xnew[inew + 1];
-        if (compare_old_high_with_new_low<T>(xn_high, xo_low))
+        if (T{}(xo_low, xn_high))
           inew++; // old and new bins do not overlap
-        else if (compare_old_high_with_new_low<T>(xo_high, xn_low))
+        else if (T{}(xn_low, xo_high))
           iold++; // old and new bins do not overlap
         else {
           // delta is the overlap of the bins on the x axis
-          const auto delta = compute_delta<T>(xn_high, xo_high, xn_low, xo_low);
-          const auto owidth = compute_owidth<T>(xo_high, xo_low);
+          const auto delta = std::abs(std::max<double>(xn_high, xo_high, T{}) -
+                                      std::min<double>(xn_low, xo_low, T{}));
+          const auto owidth = std::abs(xo_high - xo_low);
           const auto scale = delta / owidth;
           if constexpr (is_ValueAndVariance_v<
                             std::decay_t<decltype(data_old)>>) {
@@ -119,7 +120,7 @@ static constexpr auto rebin = overloaded{
           } else {
             data_new[inew] += data_old[iold] * scale;
           }
-          if (compare_new_high_with_old_high<T>(xn_high, xo_high)) {
+          if (T{}(xn_high, xo_high)) {
             iold++;
           } else {
             inew++;

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -63,8 +63,9 @@ constexpr auto variances = overloaded{
     [](const units::Unit &u) { return u * u; }};
 
 constexpr auto is_sorted_common = overloaded{
-    core::element::arg_list<std::tuple<bool, double, double>,
-                            std::tuple<bool, float, float>>,
+    core::element::arg_list<
+        std::tuple<bool, double, double>, std::tuple<bool, float, float>,
+        std::tuple<bool, int64_t, int64_t>, std::tuple<bool, int32_t, int32_t>>,
     transform_flags::expect_no_variance_arg<1>,
     [](units::Unit &out, const units::Unit &left, const units::Unit &right) {
       core::expect::equals(left, right);

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -62,4 +62,23 @@ constexpr auto variances = overloaded{
     },
     [](const units::Unit &u) { return u * u; }};
 
+constexpr auto is_sorted_common = overloaded{
+    core::element::arg_list<std::tuple<bool, double, double>,
+                            std::tuple<bool, float, float>>,
+    transform_flags::expect_no_variance_arg<1>,
+    [](units::Unit &out, const units::Unit &left, const units::Unit &right) {
+      core::expect::equals(left, right);
+      out = units::dimensionless;
+    }};
+
+constexpr auto is_sorted_ascending = overloaded{
+    is_sorted_common, [](bool &out, const auto left, const auto right) {
+      out = out && (left < right);
+    }};
+
+constexpr auto is_sorted_descending = overloaded{
+    is_sorted_common, [](bool &out, const auto left, const auto right) {
+      out = out && (left > right);
+    }};
+
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -65,7 +65,8 @@ constexpr auto variances = overloaded{
 constexpr auto is_sorted_common = overloaded{
     core::element::arg_list<
         std::tuple<bool, double, double>, std::tuple<bool, float, float>,
-        std::tuple<bool, int64_t, int64_t>, std::tuple<bool, int32_t, int32_t>>,
+        std::tuple<bool, int64_t, int64_t>, std::tuple<bool, int32_t, int32_t>,
+        std::tuple<bool, std::string, std::string>>,
     transform_flags::expect_no_variance_arg<1>,
     [](units::Unit &out, const units::Unit &left, const units::Unit &right) {
       core::expect::equals(left, right);
@@ -73,12 +74,12 @@ constexpr auto is_sorted_common = overloaded{
     }};
 
 constexpr auto is_sorted_nondescending = overloaded{
-    is_sorted_common, [](bool &out, const auto left, const auto right) {
+    is_sorted_common, [](bool &out, const auto &left, const auto &right) {
       out = out && (left <= right);
     }};
 
 constexpr auto is_sorted_nonascending = overloaded{
-    is_sorted_common, [](bool &out, const auto left, const auto right) {
+    is_sorted_common, [](bool &out, const auto &left, const auto &right) {
       out = out && (left >= right);
     }};
 

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -71,14 +71,14 @@ constexpr auto is_sorted_common = overloaded{
       out = units::dimensionless;
     }};
 
-constexpr auto is_sorted_ascending = overloaded{
+constexpr auto is_sorted_nondescending = overloaded{
     is_sorted_common, [](bool &out, const auto left, const auto right) {
-      out = out && (left < right);
+      out = out && (left <= right);
     }};
 
-constexpr auto is_sorted_descending = overloaded{
+constexpr auto is_sorted_nonascending = overloaded{
     is_sorted_common, [](bool &out, const auto left, const auto right) {
-      out = out && (left > right);
+      out = out && (left >= right);
     }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/histogram.h
+++ b/core/include/scipp/core/histogram.h
@@ -28,3 +28,20 @@ template <class T> void sorted_edges(const T &edges) {
 } // namespace expect::histogram
 
 } // namespace scipp::core
+
+
+
+// template <class T> bool sorted_edges_ascending(const T &edges) {
+//   return std::is_sorted(edges.begin(), edges.end());
+// }
+
+// template <class T> bool sorted_edges_descending(const T &edges) {
+//   return std::is_sorted(edges.begin(), edges.end(),
+//                         std::greater<typename T::value_type>());
+// }
+
+// template <class T> void sorted_edges(const T &edges) {
+//   if (!sorted_edges_ascending(edges) && !sorted_edges_descending(edges))
+//     throw except::BinEdgeError("Bin edges of histogram must be sorted in "
+//                                "either ascending or descending order.");
+// }

--- a/core/include/scipp/core/histogram.h
+++ b/core/include/scipp/core/histogram.h
@@ -28,18 +28,3 @@ template <class T> void sorted_edges(const T &edges) {
 } // namespace expect::histogram
 
 } // namespace scipp::core
-
-// template <class T> bool sorted_edges_ascending(const T &edges) {
-//   return std::is_sorted(edges.begin(), edges.end());
-// }
-
-// template <class T> bool sorted_edges_descending(const T &edges) {
-//   return std::is_sorted(edges.begin(), edges.end(),
-//                         std::greater<typename T::value_type>());
-// }
-
-// template <class T> void sorted_edges(const T &edges) {
-//   if (!sorted_edges_ascending(edges) && !sorted_edges_descending(edges))
-//     throw except::BinEdgeError("Bin edges of histogram must be sorted in "
-//                                "either ascending or descending order.");
-// }

--- a/core/include/scipp/core/histogram.h
+++ b/core/include/scipp/core/histogram.h
@@ -29,8 +29,6 @@ template <class T> void sorted_edges(const T &edges) {
 
 } // namespace scipp::core
 
-
-
 // template <class T> bool sorted_edges_ascending(const T &edges) {
 //   return std::is_sorted(edges.begin(), edges.end());
 // }

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -73,3 +73,30 @@ TEST(ElementUtilTest, values_variances) {
   EXPECT_EQ(variances(units::m), units::m * units::m);
   EXPECT_EQ(variances(x), 2.0);
 }
+
+namespace {
+constexpr auto test_is_sorted = [](const auto sorted, const bool order) {
+  const auto expect_sorted_eq = [&sorted](const auto a, const auto b,
+                                          const auto expected) {
+    bool out = true;
+    sorted(out, a, b);
+    EXPECT_EQ(out, expected);
+  };
+  expect_sorted_eq(1.0, 2.0, order);
+  expect_sorted_eq(-1.0, 1.0, order);
+  expect_sorted_eq(-2.0, -1.0, order);
+  expect_sorted_eq(1.0, 1.0, false);
+  expect_sorted_eq(2.0, 1.0, !order);
+  expect_sorted_eq(1.0, -1.0, !order);
+  expect_sorted_eq(-1.0, -2.0, !order);
+  units::Unit unit = units::one;
+  sorted(unit, units::m, units::m);
+  EXPECT_EQ(unit, units::one);
+  EXPECT_THROW(sorted(unit, units::m, units::s), except::UnitError);
+};
+}
+
+TEST(ElementUtilTest, is_sorted) {
+  test_is_sorted(is_sorted_ascending, true);
+  test_is_sorted(is_sorted_descending, false);
+}

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -85,7 +85,7 @@ constexpr auto test_is_sorted = [](const auto sorted, const bool order) {
   expect_sorted_eq(1.0, 2.0, order);
   expect_sorted_eq(-1.0, 1.0, order);
   expect_sorted_eq(-2.0, -1.0, order);
-  expect_sorted_eq(1.0, 1.0, false);
+  expect_sorted_eq(1.0, 1.0, true);
   expect_sorted_eq(2.0, 1.0, !order);
   expect_sorted_eq(1.0, -1.0, !order);
   expect_sorted_eq(-1.0, -2.0, !order);
@@ -97,6 +97,6 @@ constexpr auto test_is_sorted = [](const auto sorted, const bool order) {
 }
 
 TEST(ElementUtilTest, is_sorted) {
-  test_is_sorted(is_sorted_ascending, true);
-  test_is_sorted(is_sorted_descending, false);
+  test_is_sorted(is_sorted_nondescending, true);
+  test_is_sorted(is_sorted_nonascending, false);
 }

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -35,6 +35,7 @@ General
    dot
    filter
    histogram
+   is_sorted
    merge
    nan_to_num
    norm

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -372,26 +372,17 @@ class Slicer2d(Slicer):
         """
         self.xlim_updated = False
         self.ylim_updated = False
-        xylims = {
-            "x": np.array(self.ax.get_xlim()),
-            "y": np.array(self.ax.get_ylim())
-        }
-
+        xylims = {}
         # Make sure we don't overrun the original array bounds
-        xylims["x"][0] = max(
-            xylims["x"][0],
-            self.slider_xlims[self.name][self.button_dims[1]][0])
-        xylims["x"][1] = min(
-            xylims["x"][1],
-            self.slider_xlims[self.name][self.button_dims[1]][1])
-        xylims["y"][0] = max(
-            xylims["y"][0],
-            self.slider_xlims[self.name][self.button_dims[0]][0])
-        xylims["y"][1] = min(
-            xylims["y"][1],
-            self.slider_xlims[self.name][self.button_dims[0]][1])
-        dx = self.current_lims["x"][1] - self.current_lims["x"][0]
-        dy = self.current_lims["y"][1] - self.current_lims["y"][0]
+        xylims["x"] = np.clip(
+            self.ax.get_xlim(),
+            *sorted(self.slider_xlims[self.name][self.button_dims[1]]))
+        xylims["y"] = np.clip(
+            self.ax.get_ylim(),
+            *sorted(self.slider_xlims[self.name][self.button_dims[0]]))
+
+        dx = np.abs(self.current_lims["x"][1] - self.current_lims["x"][0])
+        dy = np.abs(self.current_lims["y"][1] - self.current_lims["y"][0])
         diffx = np.abs(self.current_lims["x"] - xylims["x"]) / dx
         diffy = np.abs(self.current_lims["y"] - xylims["y"]) / dy
         diff = diffx.sum() + diffy.sum()

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -223,9 +223,6 @@ class Slicer2d(Slicer):
         for xy, param in self.axparams.items():
             # Create coordinate axes for resampled array to be used as image
             offset = 2 * (xy == "y")
-            # # Flip the axis if the coordinate is descending
-            # i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
-            # i2 = (i1 + 1) % 2
             self.xyrebin[xy] = sc.Variable(
                 dims=[param["dim"]],
                 values=np.linspace(extent_array[0 + offset],
@@ -292,12 +289,10 @@ class Slicer2d(Slicer):
         """
         Pixel widths used for scaling before rebin step
         """
-        self.xywidth[xy] = (self.xyedges[xy][dim, 1:] -
-                            self.xyedges[xy][dim, :-1]) / (
-                                self.xyrebin[xy][dim, 1] -
-                                self.xyrebin[xy][dim, 0])
+        self.xywidth[xy] = (
+            self.xyedges[xy][dim, 1:] - self.xyedges[xy][dim, :-1]) / (
+                self.xyrebin[xy][dim, 1] - self.xyrebin[xy][dim, 0])
         self.xywidth[xy].unit = sc.units.one
-
 
     def slice_coords(self):
         """
@@ -322,11 +317,6 @@ class Slicer2d(Slicer):
                     sc.dtype.float64)
             # Pixel widths used for scaling before rebin step
             self.compute_bin_widths(xy, param["dim"])
-            # self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
-            #                     self.xyedges[xy][param["dim"], :-1]) / (
-            #                         self.xyrebin[xy][param["dim"], 1] -
-            #                         self.xyrebin[xy][param["dim"], 0])
-            # self.xywidth[xy].unit = sc.units.one
 
     def slice_data(self):
         """
@@ -411,9 +401,6 @@ class Slicer2d(Slicer):
         if diff > 0.1:
             self.current_lims = xylims
             for xy, param in self.axparams.items():
-                # # Flip the axis if the coordinate is descending
-                # i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
-                # i2 = (i1 + 1) % 2
                 # Create coordinate axes for resampled image array
                 self.xyrebin[xy] = sc.Variable(
                     dims=[param["dim"]],
@@ -423,11 +410,6 @@ class Slicer2d(Slicer):
 
                 # Pixel widths used for scaling before rebin step
                 self.compute_bin_widths(xy, param["dim"])
-                # self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
-                #                     self.xyedges[xy][param["dim"], :-1]) / (
-                #                         self.xyrebin[xy][param["dim"], 1] -
-                #                         self.xyrebin[xy][param["dim"], 0])
-                # self.xywidth[xy].unit = sc.units.one
 
             self.update_image(extent=np.array(list(xylims.values())).flatten())
 
@@ -470,19 +452,10 @@ class Slicer2d(Slicer):
         xy = "yx"
         if len(dslice.coords[self.button_dims[1]].dims) > 1:
             xy = "xy"
-        print("dslice", dslice)
-        print('self.xyrebin[x]', self.xyrebin['x'])
-        # print('self.xyrebin[y]', self.xyrebin['y'])
         dslice = sc.rebin(dslice, self.xyrebin[xy[0]].dims[0],
                           self.xyrebin[xy[0]])
-        # print(np.flip(self.xyrebin[xy[1]].values))
-        # print("dslice.values", dslice.values)
-        # self.xyrebin[xy[1]].values = np.flip(self.xyrebin[xy[1]].values).copy()
-        # print('self.xyrebin[x]', self.xyrebin['x'].values[:100])
-        print('self.xyrebin[x]', self.xyrebin['x'])
         dslice = sc.rebin(dslice, self.xyrebin[xy[1]].dims[0],
                           self.xyrebin[xy[1]])
-        # print("dslice.values", dslice.values)
 
         # Use Scipp's automatic transpose to match the image x/y axes
         # TODO: once transpose is available for DataArrays,

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -223,13 +223,13 @@ class Slicer2d(Slicer):
         for xy, param in self.axparams.items():
             # Create coordinate axes for resampled array to be used as image
             offset = 2 * (xy == "y")
-            # Flip the axis if the coordinate is descending
-            i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
-            i2 = (i1 + 1) % 2
+            # # Flip the axis if the coordinate is descending
+            # i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
+            # i2 = (i1 + 1) % 2
             self.xyrebin[xy] = sc.Variable(
                 dims=[param["dim"]],
-                values=np.linspace(extent_array[i1 + offset],
-                                   extent_array[i2 + offset],
+                values=np.linspace(extent_array[0 + offset],
+                                   extent_array[1 + offset],
                                    self.image_resolution[xy] + 1),
                 unit=self.slider_coord[self.name][param["dim"]].unit)
 
@@ -411,13 +411,13 @@ class Slicer2d(Slicer):
         if diff > 0.1:
             self.current_lims = xylims
             for xy, param in self.axparams.items():
-                # Flip the axis if the coordinate is descending
-                i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
-                i2 = (i1 + 1) % 2
+                # # Flip the axis if the coordinate is descending
+                # i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
+                # i2 = (i1 + 1) % 2
                 # Create coordinate axes for resampled image array
                 self.xyrebin[xy] = sc.Variable(
                     dims=[param["dim"]],
-                    values=np.linspace(xylims[xy][i1], xylims[xy][i2],
+                    values=np.linspace(xylims[xy][0], xylims[xy][1],
                                        self.image_resolution[xy] + 1),
                     unit=self.slider_coord[self.name][param["dim"]].unit)
 
@@ -446,7 +446,8 @@ class Slicer2d(Slicer):
                 self.xyrebin[self.dim_to_xy[self.vslice.dims[1]]].dims[0]
             ],
                              values=self.vslice.values,
-                             unit=sc.units.counts))
+                             unit=sc.units.counts,
+                             dtype=sc.dtype.float64))
 
         # Also include the masks
         if self.params["masks"][self.name]["show"]:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -450,8 +450,15 @@ class Slicer2d(Slicer):
         xy = "yx"
         if len(dslice.coords[self.button_dims[1]].dims) > 1:
             xy = "xy"
+        print(dslice)
+        print('self.xyrebin[x]', self.xyrebin['x'].values)
+        print('self.xyrebin[y]', self.xyrebin['y'])
         dslice = sc.rebin(dslice, self.xyrebin[xy[0]].dims[0],
                           self.xyrebin[xy[0]])
+        print(np.flip(self.xyrebin[xy[1]].values))
+        self.xyrebin[xy[1]].values = np.flip(self.xyrebin[xy[1]].values).copy()
+        # print('self.xyrebin[x]', self.xyrebin['x'].values[:100])
+        print('self.xyrebin[x]', self.xyrebin['x'].values)
         dslice = sc.rebin(dslice, self.xyrebin[xy[1]].dims[0],
                           self.xyrebin[xy[1]])
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -223,10 +223,13 @@ class Slicer2d(Slicer):
         for xy, param in self.axparams.items():
             # Create coordinate axes for resampled array to be used as image
             offset = 2 * (xy == "y")
+            # Flip the axis if the coordinate is descending
+            i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
+            i2 = (i1 + 1) % 2
             self.xyrebin[xy] = sc.Variable(
                 dims=[param["dim"]],
-                values=np.linspace(extent_array[0 + offset],
-                                   extent_array[1 + offset],
+                values=np.linspace(extent_array[i1 + offset],
+                                   extent_array[i2 + offset],
                                    self.image_resolution[xy] + 1),
                 unit=self.slider_coord[self.name][param["dim"]].unit)
 
@@ -285,6 +288,17 @@ class Slicer2d(Slicer):
 
         return
 
+    def compute_bin_widths(self, xy, dim):
+        """
+        Pixel widths used for scaling before rebin step
+        """
+        self.xywidth[xy] = (self.xyedges[xy][dim, 1:] -
+                            self.xyedges[xy][dim, :-1]) / (
+                                self.xyrebin[xy][dim, 1] -
+                                self.xyrebin[xy][dim, 0])
+        self.xywidth[xy].unit = sc.units.one
+
+
     def slice_coords(self):
         """
         Recursively slice the coords along the dimensions of active sliders.
@@ -307,11 +321,12 @@ class Slicer2d(Slicer):
                 self.xyedges[xy] = self.cslice[param["dim"]].astype(
                     sc.dtype.float64)
             # Pixel widths used for scaling before rebin step
-            self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
-                                self.xyedges[xy][param["dim"], :-1]) / (
-                                    self.xyrebin[xy][param["dim"], 1] -
-                                    self.xyrebin[xy][param["dim"], 0])
-            self.xywidth[xy].unit = sc.units.one
+            self.compute_bin_widths(xy, param["dim"])
+            # self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
+            #                     self.xyedges[xy][param["dim"], :-1]) / (
+            #                         self.xyrebin[xy][param["dim"], 1] -
+            #                         self.xyrebin[xy][param["dim"], 0])
+            # self.xywidth[xy].unit = sc.units.one
 
     def slice_data(self):
         """
@@ -396,19 +411,23 @@ class Slicer2d(Slicer):
         if diff > 0.1:
             self.current_lims = xylims
             for xy, param in self.axparams.items():
+                # Flip the axis if the coordinate is descending
+                i1 = (0 + self.contains_decreasing_coord[self.name][param["dim"]]) % 2
+                i2 = (i1 + 1) % 2
                 # Create coordinate axes for resampled image array
                 self.xyrebin[xy] = sc.Variable(
                     dims=[param["dim"]],
-                    values=np.linspace(xylims[xy][0], xylims[xy][1],
+                    values=np.linspace(xylims[xy][i1], xylims[xy][i2],
                                        self.image_resolution[xy] + 1),
                     unit=self.slider_coord[self.name][param["dim"]].unit)
 
                 # Pixel widths used for scaling before rebin step
-                self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
-                                    self.xyedges[xy][param["dim"], :-1]) / (
-                                        self.xyrebin[xy][param["dim"], 1] -
-                                        self.xyrebin[xy][param["dim"], 0])
-                self.xywidth[xy].unit = sc.units.one
+                self.compute_bin_widths(xy, param["dim"])
+                # self.xywidth[xy] = (self.xyedges[xy][param["dim"], 1:] -
+                #                     self.xyedges[xy][param["dim"], :-1]) / (
+                #                         self.xyrebin[xy][param["dim"], 1] -
+                #                         self.xyrebin[xy][param["dim"], 0])
+                # self.xywidth[xy].unit = sc.units.one
 
             self.update_image(extent=np.array(list(xylims.values())).flatten())
 
@@ -450,17 +469,19 @@ class Slicer2d(Slicer):
         xy = "yx"
         if len(dslice.coords[self.button_dims[1]].dims) > 1:
             xy = "xy"
-        print(dslice)
-        print('self.xyrebin[x]', self.xyrebin['x'].values)
-        print('self.xyrebin[y]', self.xyrebin['y'])
+        print("dslice", dslice)
+        print('self.xyrebin[x]', self.xyrebin['x'])
+        # print('self.xyrebin[y]', self.xyrebin['y'])
         dslice = sc.rebin(dslice, self.xyrebin[xy[0]].dims[0],
                           self.xyrebin[xy[0]])
-        print(np.flip(self.xyrebin[xy[1]].values))
-        self.xyrebin[xy[1]].values = np.flip(self.xyrebin[xy[1]].values).copy()
+        # print(np.flip(self.xyrebin[xy[1]].values))
+        # print("dslice.values", dslice.values)
+        # self.xyrebin[xy[1]].values = np.flip(self.xyrebin[xy[1]].values).copy()
         # print('self.xyrebin[x]', self.xyrebin['x'].values[:100])
-        print('self.xyrebin[x]', self.xyrebin['x'].values)
+        print('self.xyrebin[x]', self.xyrebin['x'])
         dslice = sc.rebin(dslice, self.xyrebin[xy[1]].dims[0],
                           self.xyrebin[xy[1]])
+        # print("dslice.values", dslice.values)
 
         # Use Scipp's automatic transpose to match the image x/y axes
         # TODO: once transpose is available for DataArrays,

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -337,6 +337,7 @@ class Slicer:
 
         underlying_dim = dim
         non_dimension_coord = False
+        var = None
 
         if dim in data_array.coords:
 
@@ -373,11 +374,16 @@ class Slicer:
             elif dim != dim_coord_dim:
                 # non-dimension coordinate
                 non_dimension_coord = True
-                var = data_array.coords[dim_coord_dim]
+                if dim_coord_dim in data_array.coords:
+                    var = data_array.coords[dim_coord_dim]
+                else:
+                    var = make_fake_coord(dim_coord_dim, dim_to_shape[dim_coord_dim])
                 underlying_dim = dim_coord_dim
+                # form = ticker.FuncFormatter(lambda val, pos: value_to_string(
+                #     data_array.coords[dim].values[np.abs(data_array.coords[
+                #         dim_coord_dim].values - val).argmin()]))
                 form = ticker.FuncFormatter(lambda val, pos: value_to_string(
-                    data_array.coords[dim].values[np.abs(data_array.coords[
-                        dim_coord_dim].values - val).argmin()]))
+                    data_array.coords[dim].values[np.abs(var.values - val).argmin()]))
                 formatter.update({False: form, True: form})
 
             else:

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -75,7 +75,7 @@ class Slicer:
         self.slider_axlocator = {}
 
         self.contains_multid_coord = {}
-        self.contains_decreasing_coord = {}
+        # self.contains_decreasing_coord = {}
 
         for name, array in self.scipp_obj_dict.items():
 
@@ -119,7 +119,7 @@ class Slicer:
             self.histograms[name] = {}
 
             self.contains_multid_coord[name] = False
-            self.contains_decreasing_coord[name] = {}
+            # self.contains_decreasing_coord[name] = {}
 
             # Process axes dimensions
             if axes is None:
@@ -145,6 +145,8 @@ class Slicer:
                 # The limits for each dimension
                 self.slider_xlims[name][dim] = np.array(
                     [sc.min(var).value, sc.max(var).value], dtype=np.float)
+                if sc.is_sorted_descending(var, dim):
+                    self.slider_xlims[name][dim] = np.flip(self.slider_xlims[name][dim]).copy()
                 # The tick formatter and locator
                 self.slider_axformatter[name][dim] = formatter
                 self.slider_axlocator[name][dim] = locator
@@ -182,7 +184,8 @@ class Slicer:
                 if len(self.slider_coord[name][dim].dims) > 1:
                     self.contains_multid_coord[name] = True
 
-                self.contains_decreasing_coord[name][dim] = sc.is_sorted_descending(var, dim)
+                # self.contains_decreasing_coord[name][dim] = sc.is_sorted_descending
+                # (var, dim)
 
 
 

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -73,9 +73,8 @@ class Slicer:
         self.slider_axformatter = {}
         # Axes tick locators
         self.slider_axlocator = {}
-
+        # Save if some dims contain multi-dimensional coords
         self.contains_multid_coord = {}
-        # self.contains_decreasing_coord = {}
 
         for name, array in self.scipp_obj_dict.items():
 
@@ -117,9 +116,8 @@ class Slicer:
             self.slider_axlocator[name] = {}
             # Save information on histograms
             self.histograms[name] = {}
-
+            # Save if some dims contain multi-dimensional coords
             self.contains_multid_coord[name] = False
-            # self.contains_decreasing_coord[name] = {}
 
             # Process axes dimensions
             if axes is None:
@@ -146,7 +144,8 @@ class Slicer:
                 self.slider_xlims[name][dim] = np.array(
                     [sc.min(var).value, sc.max(var).value], dtype=np.float)
                 if sc.is_sorted_descending(var, dim):
-                    self.slider_xlims[name][dim] = np.flip(self.slider_xlims[name][dim]).copy()
+                    self.slider_xlims[name][dim] = np.flip(
+                        self.slider_xlims[name][dim]).copy()
                 # The tick formatter and locator
                 self.slider_axformatter[name][dim] = formatter
                 self.slider_axlocator[name][dim] = locator
@@ -183,11 +182,6 @@ class Slicer:
 
                 if len(self.slider_coord[name][dim].dims) > 1:
                     self.contains_multid_coord[name] = True
-
-                # self.contains_decreasing_coord[name][dim] = sc.is_sorted_descending
-                # (var, dim)
-
-
 
         # Initialise list for VBox container
         self.vbox = []
@@ -386,13 +380,12 @@ class Slicer:
                 if dim_coord_dim in data_array.coords:
                     var = data_array.coords[dim_coord_dim]
                 else:
-                    var = make_fake_coord(dim_coord_dim, dim_to_shape[dim_coord_dim])
+                    var = make_fake_coord(dim_coord_dim,
+                                          dim_to_shape[dim_coord_dim])
                 underlying_dim = dim_coord_dim
-                # form = ticker.FuncFormatter(lambda val, pos: value_to_string(
-                #     data_array.coords[dim].values[np.abs(data_array.coords[
-                #         dim_coord_dim].values - val).argmin()]))
-                form = ticker.FuncFormatter(lambda val, pos: value_to_string(
-                    data_array.coords[dim].values[np.abs(var.values - val).argmin()]))
+                form = ticker.FuncFormatter(
+                    lambda val, pos: value_to_string(data_array.coords[
+                        dim].values[np.abs(var.values - val).argmin()]))
                 formatter.update({False: form, True: form})
 
             else:

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -143,7 +143,7 @@ class Slicer:
                 # The limits for each dimension
                 self.slider_xlims[name][dim] = np.array(
                     [sc.min(var).value, sc.max(var).value], dtype=np.float)
-                if sc.is_sorted_descending(var, dim):
+                if sc.is_sorted(var, dim, order='descending'):
                     self.slider_xlims[name][dim] = np.flip(
                         self.slider_xlims[name][dim]).copy()
                 # The tick formatter and locator

--- a/python/src/scipp/plot/slicer.py
+++ b/python/src/scipp/plot/slicer.py
@@ -75,6 +75,7 @@ class Slicer:
         self.slider_axlocator = {}
 
         self.contains_multid_coord = {}
+        self.contains_decreasing_coord = {}
 
         for name, array in self.scipp_obj_dict.items():
 
@@ -118,6 +119,7 @@ class Slicer:
             self.histograms[name] = {}
 
             self.contains_multid_coord[name] = False
+            self.contains_decreasing_coord[name] = {}
 
             # Process axes dimensions
             if axes is None:
@@ -179,6 +181,10 @@ class Slicer:
 
                 if len(self.slider_coord[name][dim].dims) > 1:
                     self.contains_multid_coord[name] = True
+
+                self.contains_decreasing_coord[name][dim] = sc.is_sorted_descending(var, dim)
+
+
 
         # Initialise list for VBox container
         self.vbox = []

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -103,7 +103,7 @@ def parse_params(params=None,
 
 
 def make_fake_coord(dim, size, unit=None):
-    args = {"values": np.arange(size)}
+    args = {"values": np.arange(size, dtype=np.float64)}
     if unit is not None:
         args["unit"] = unit
     return sc.Variable(dims=[dim], **args)

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -38,8 +38,8 @@ def to_bin_edges(x, dim):
         center = to_bin_centers(x, dim)
         # Note: use range of 0:1 to keep dimension dim in the slice to avoid
         # switching round dimension order in concatenate step.
-        left = center[dim, 0:1] - (center[dim, 1] - center[dim, 0])
-        right = center[dim, -1] + (center[dim, -1] - center[dim, -2])
+        left = center[dim, 0:1] - (x[dim, 1] - x[dim, 0])
+        right = center[dim, -1] + (x[dim, -1] - x[dim, -2])
         return sc.concatenate(sc.concatenate(left, center, dim), right, dim)
 
 

--- a/python/tests/plot/test_plot_2d.py
+++ b/python/tests/plot/test_plot_2d.py
@@ -184,6 +184,15 @@ def test_plot_2d_with_dimension_of_size_1():
     plot(d["b"])
 
 
+def test_plot_2d_with_dimension_of_size_2():
+    a = sc.DataArray(data=sc.Variable(dims=['y', 'x'], shape=[2, 4]),
+                     coords={
+                         'x': sc.Variable(dims=['x'], values=[1, 2, 3, 4]),
+                         'y': sc.Variable(dims=['y'], values=[1, 2])
+                     })
+    plot(a)
+
+
 def test_plot_realigned_2d():
     d = make_events_dataset(ndim=1)
     tbins = sc.Variable(dims=['tof'], unit=sc.units.us, values=np.arange(100.))
@@ -272,3 +281,27 @@ def test_plot_2d_ragged_coord_with_masks():
                                values=np.where(z < 0.5, True, False),
                                dtype=bool)
     plot(d)
+
+
+def test_plot_2d_with_labels_but_no_dimension_coord():
+    N = 50
+    M = 10
+    y = np.arange(M).astype(np.float)
+    z = np.random.random([M, N])
+    d = sc.Dataset()
+    d.coords['y'] = sc.Variable(['y'], values=y, unit=sc.units.m)
+    d['Signal'] = sc.Variable(['y', 'x'], values=z, unit=sc.units.kg)
+    d.coords['somelabels'] = sc.Variable(['x'],
+                                         values=np.linspace(101., 155., N),
+                                         unit=sc.units.s)
+    plot(d, axes=['y', 'somelabels'])
+
+
+def test_plot_2d_with_decreasing_edges():
+    a = sc.DataArray(data=sc.Variable(dims=['y', 'x'],
+                                      values=np.arange(12).reshape(3, 4)),
+                     coords={
+                         'x': sc.Variable(dims=['x'], values=[4, 3, 2, 1]),
+                         'y': sc.Variable(dims=['y'], values=[1, 2, 3])
+                     })
+    plot(a)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -340,7 +340,7 @@ Mostly equivalent to Variable, see there for details.)");
   m.def(
       "is_sorted_ascending",
       [](const VariableConstView &x, const Dim dim) {
-          return is_sorted_ascending(x, dim);
+        return is_sorted_ascending(x, dim);
       },
       py::call_guard<py::gil_scoped_release>(),
       Docstring()
@@ -354,7 +354,7 @@ Mostly equivalent to Variable, see there for details.)");
   m.def(
       "is_sorted_descending",
       [](const VariableConstView &x, const Dim dim) {
-          return is_sorted_descending(x, dim);
+        return is_sorted_descending(x, dim);
       },
       py::call_guard<py::gil_scoped_release>(),
       Docstring()

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -338,30 +338,29 @@ Mostly equivalent to Variable, see there for details.)");
           .c_str());
 
   m.def(
-      "is_sorted_ascending",
-      [](const VariableConstView &x, const Dim dim) {
-        return is_sorted_ascending(x, dim);
+      "is_sorted",
+      [](const VariableConstView &x, const Dim dim, const std::string &order) {
+        if (order == "ascending")
+          return is_sorted(x, dim, variable::SortOrder::Ascending);
+        else if (order == "descending")
+          return is_sorted(x, dim, variable::SortOrder::Descending);
+        else
+          throw std::runtime_error(
+              "Sort order must be 'ascending' or 'descending'");
       },
+      py::arg("x"), py::arg("dim"), py::arg("order") = "ascending",
       py::call_guard<py::gil_scoped_release>(),
       Docstring()
           .description("Check if the values of a variable are sorted in "
-                       "ascending order.")
+                       "ascending/descending order.")
+          .param("x", "Variable to check.", "Variable")
+          .param("dim", "Dimension along which order is checked.", "Dim")
+          .param("order",
+                 "Sorted order. Valid options are 'ascending' and "
+                 "'descending'. Default is 'ascending'.",
+                 "str")
           .returns("Returns True if the variable values are monotonously "
                    "ascending, False otherwise.")
-          .rtype("bool")
-          .c_str());
-
-  m.def(
-      "is_sorted_descending",
-      [](const VariableConstView &x, const Dim dim) {
-        return is_sorted_descending(x, dim);
-      },
-      py::call_guard<py::gil_scoped_release>(),
-      Docstring()
-          .description("Check if the values of a variable are sorted in "
-                       "descending order.")
-          .returns("Returns True if the variable values are monotonously "
-                   "descending, False otherwise.")
           .rtype("bool")
           .c_str());
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -14,6 +14,7 @@
 #include "scipp/variable/comparison.h"
 #include "scipp/variable/operations.h"
 #include "scipp/variable/transform.h"
+#include "scipp/variable/util.h"
 #include "scipp/variable/variable.h"
 
 #include "scipp/dataset/dataset.h"
@@ -333,6 +334,34 @@ Mostly equivalent to Variable, see there for details.)");
           .description("Check if the values of a variable are evenly spaced.")
           .returns("Returns True if the variable contains regularly spaced "
                    "values, False otherwise.")
+          .rtype("bool")
+          .c_str());
+
+  m.def(
+      "is_sorted_ascending",
+      [](const VariableConstView &x, const Dim dim) {
+          return is_sorted_ascending(x, dim);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      Docstring()
+          .description("Check if the values of a variable are sorted in "
+                       "ascending order.")
+          .returns("Returns True if the variable values are monotonously "
+                   "ascending, False otherwise.")
+          .rtype("bool")
+          .c_str());
+
+  m.def(
+      "is_sorted_descending",
+      [](const VariableConstView &x, const Dim dim) {
+          return is_sorted_descending(x, dim);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      Docstring()
+          .description("Check if the values of a variable are sorted in "
+                       "descending order.")
+          .returns("Returns True if the variable values are monotonously "
+                   "descending, False otherwise.")
           .rtype("bool")
           .c_str());
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -351,8 +351,10 @@ Mostly equivalent to Variable, see there for details.)");
       py::arg("x"), py::arg("dim"), py::arg("order") = "ascending",
       py::call_guard<py::gil_scoped_release>(),
       Docstring()
-          .description("Check if the values of a variable are sorted in "
-                       "ascending/descending order.")
+          .description("Check if the values of a variable are sorted in.\n\nIf "
+                       "'order' is 'ascending' checks if values are "
+                       "non-decreasing along 'dim'. If 'order' is 'descending' "
+                       "checks if values are non-increasing along 'dim'.")
           .param("x", "Variable to check.", "Variable")
           .param("dim", "Dimension along which order is checked.", "Dim")
           .param("order",

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -16,9 +16,10 @@ SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 variances(const VariableConstView &x);
+
+enum class SortOrder { Ascending, Descending };
+
 [[nodiscard]] SCIPP_VARIABLE_EXPORT bool
-is_sorted_ascending(const VariableConstView &x, const Dim dim);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT bool
-is_sorted_descending(const VariableConstView &x, const Dim dim);
+is_sorted(const VariableConstView &x, const Dim dim, const SortOrder order);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -16,5 +16,7 @@ SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 variances(const VariableConstView &x);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT bool is_sorted_ascending(const VariableConstView &x, const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT bool is_sorted_descending(const VariableConstView &x, const Dim dim);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -16,7 +16,9 @@ SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 variances(const VariableConstView &x);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT bool is_sorted_ascending(const VariableConstView &x, const Dim dim);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT bool is_sorted_descending(const VariableConstView &x, const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT bool
+is_sorted_ascending(const VariableConstView &x, const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT bool
+is_sorted_descending(const VariableConstView &x, const Dim dim);
 
 } // namespace scipp::variable

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -106,10 +106,10 @@ Variable rebin(const VariableConstView &var, const Dim dim,
       args<float, double, float, double>, args<float, float, float, double>,
       args<bool, double, bool, double>>;
 
-  const bool ascending =
-      is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim);
-  if (!ascending && !(is_sorted_descending(oldCoord, dim) &&
-                      is_sorted_descending(newCoord, dim)))
+  const bool ascending = is_sorted(oldCoord, dim, SortOrder::Ascending) &&
+                         is_sorted(newCoord, dim, SortOrder::Ascending);
+  if (!ascending && !(is_sorted(oldCoord, dim, SortOrder::Descending) &&
+                      is_sorted(newCoord, dim, SortOrder::Descending)))
     throw except::BinEdgeError(
         "Rebin: The old or new bin edges are not sorted.");
   if (var.dims().inner() == dim) {

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -9,6 +9,7 @@
 #include "scipp/variable/except.h"
 #include "scipp/variable/misc_operations.h"
 #include "scipp/variable/transform_subspan.h"
+#include "scipp/variable/util.h"
 
 namespace scipp::variable {
 
@@ -65,6 +66,54 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
   }
 }
 
+template <typename T>
+void rebin_non_inner_descending(const Dim dim, const VariableConstView &oldT,
+                     Variable &newT, const VariableConstView &oldCoordT,
+                     const VariableConstView &newCoordT) {
+  const auto oldSize = oldT.dims()[dim];
+  const auto newSize = newT.dims()[dim];
+
+  const auto *xold = oldCoordT.values<T>().data();
+  const auto *xnew = newCoordT.values<T>().data();
+  // This function assumes that dimensions between coord and data
+  // coord is 1D.
+  int iold = 0;
+  int inew = 0;
+  // TODO: Using dtype<bool> does not seem to compile on Windows. It is not
+  // clear why that is, since dtype<double> is working below.
+  // We use the longer syntax below which compiles instead of:
+  // const bool is_bool = newT.dtype() == dtype<bool>;
+  const bool is_bool = newT.dtype().index == std::type_index(typeid(bool));
+  while ((iold < oldSize) && (inew < newSize)) {
+    auto xo_low = xold[iold];
+    auto xo_high = xold[iold + 1];
+    auto xn_low = xnew[inew];
+    auto xn_high = xnew[inew + 1];
+
+    if (xn_high >= xo_low)
+      inew++; /* old and new bins do not overlap */
+    else if (xo_high >= xn_low)
+      iold++; /* old and new bins do not overlap */
+    else {
+      if (is_bool) {
+        newT.slice({dim, inew}) |= oldT.slice({dim, iold});
+      } else {
+        // delta is the overlap of the bins on the x axis
+        auto delta = std::min(xn_low, xo_low) - std::max(xn_high, xo_high);
+        auto owidth = xo_low - xo_high;
+        newT.slice({dim, inew}) +=
+            astype(oldT.slice({dim, iold}) * ((delta / owidth) * units::one),
+                   newT.dtype());
+      }
+      if (xn_high < xo_high) {
+        iold++;
+      } else {
+        inew++;
+      }
+    }
+  }
+}
+
 namespace rebin_inner_detail {
 template <class Out, class OutEdge, class In, class InEdge>
 using args = std::tuple<span<Out>, span<const OutEdge>, span<const In>,
@@ -81,15 +130,27 @@ Variable rebin(const VariableConstView &var, const Dim dim,
   if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");
+  std::string sorted_error = "Rebin: The old or new coordinates are not sorted.";
 
   if (var.dims().inner() == dim) {
     using namespace rebin_inner_detail;
-    return transform_subspan<std::tuple<
-        args<double, double, double, double>, args<float, float, float, float>,
-        args<float, double, float, double>, args<float, float, float, double>,
-        args<bool, double, bool, double>>>(var.dtype(), dim,
-                                           newCoord.dims()[dim] - 1, newCoord,
-                                           var, oldCoord, core::element::rebin);
+    if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim)) {
+      return transform_subspan<std::tuple<
+          args<double, double, double, double>, args<float, float, float, float>,
+          args<float, double, float, double>, args<float, float, float, double>,
+          args<bool, double, bool, double>>>(var.dtype(), dim,
+                                             newCoord.dims()[dim] - 1, newCoord,
+                                             var, oldCoord, core::element::rebin);
+    } else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim)) {
+      return transform_subspan<std::tuple<
+          args<double, double, double, double>, args<float, float, float, float>,
+          args<float, double, float, double>, args<float, float, float, double>,
+          args<bool, double, bool, double>>>(var.dtype(), dim,
+                                             newCoord.dims()[dim] - 1, newCoord,
+                                             var, oldCoord, core::element::rebin_descending);
+    } else {
+      throw except::BinEdgeError(sorted_error);
+    }
 
   } else {
     auto dims = var.dims();
@@ -99,9 +160,19 @@ Variable rebin(const VariableConstView &var, const Dim dim,
       throw std::runtime_error(
           "Not inner rebin works only for 1d coordinates for now.");
     if (oldCoord.dtype() == dtype<double>)
-      rebin_non_inner<double>(dim, var, rebinned, oldCoord, newCoord);
+      if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim))
+        rebin_non_inner<double>(dim, var, rebinned, oldCoord, newCoord);
+      else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim))
+        rebin_non_inner_descending<double>(dim, var, rebinned, oldCoord, newCoord);
+      else
+        throw except::BinEdgeError(sorted_error);
     else if (oldCoord.dtype() == dtype<float>)
-      rebin_non_inner<float>(dim, var, rebinned, oldCoord, newCoord);
+      if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim))
+        rebin_non_inner<float>(dim, var, rebinned, oldCoord, newCoord);
+      else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim))
+        rebin_non_inner_descending<float>(dim, var, rebinned, oldCoord, newCoord);
+      else
+        throw except::BinEdgeError(sorted_error);
     else
       throw std::runtime_error(
           "Rebinning is possible only for double and float types.");

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -68,8 +68,9 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
 
 template <typename T>
 void rebin_non_inner_descending(const Dim dim, const VariableConstView &oldT,
-                     Variable &newT, const VariableConstView &oldCoordT,
-                     const VariableConstView &newCoordT) {
+                                Variable &newT,
+                                const VariableConstView &oldCoordT,
+                                const VariableConstView &newCoordT) {
   const auto oldSize = oldT.dims()[dim];
   const auto newSize = newT.dims()[dim];
 
@@ -130,24 +131,27 @@ Variable rebin(const VariableConstView &var, const Dim dim,
   if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");
-  std::string sorted_error = "Rebin: The old or new coordinates are not sorted.";
+  std::string sorted_error =
+      "Rebin: The old or new coordinates are not sorted.";
 
   if (var.dims().inner() == dim) {
     using namespace rebin_inner_detail;
-    if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim)) {
+    if (is_sorted_ascending(oldCoord, dim) &&
+        is_sorted_ascending(newCoord, dim)) {
       return transform_subspan<std::tuple<
-          args<double, double, double, double>, args<float, float, float, float>,
-          args<float, double, float, double>, args<float, float, float, double>,
-          args<bool, double, bool, double>>>(var.dtype(), dim,
-                                             newCoord.dims()[dim] - 1, newCoord,
-                                             var, oldCoord, core::element::rebin);
-    } else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim)) {
+          args<double, double, double, double>,
+          args<float, float, float, float>, args<float, double, float, double>,
+          args<float, float, float, double>, args<bool, double, bool, double>>>(
+          var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
+          core::element::rebin);
+    } else if (is_sorted_descending(oldCoord, dim) &&
+               is_sorted_descending(newCoord, dim)) {
       return transform_subspan<std::tuple<
-          args<double, double, double, double>, args<float, float, float, float>,
-          args<float, double, float, double>, args<float, float, float, double>,
-          args<bool, double, bool, double>>>(var.dtype(), dim,
-                                             newCoord.dims()[dim] - 1, newCoord,
-                                             var, oldCoord, core::element::rebin_descending);
+          args<double, double, double, double>,
+          args<float, float, float, float>, args<float, double, float, double>,
+          args<float, float, float, double>, args<bool, double, bool, double>>>(
+          var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
+          core::element::rebin_descending);
     } else {
       throw except::BinEdgeError(sorted_error);
     }
@@ -160,17 +164,23 @@ Variable rebin(const VariableConstView &var, const Dim dim,
       throw std::runtime_error(
           "Not inner rebin works only for 1d coordinates for now.");
     if (oldCoord.dtype() == dtype<double>)
-      if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim))
+      if (is_sorted_ascending(oldCoord, dim) &&
+          is_sorted_ascending(newCoord, dim))
         rebin_non_inner<double>(dim, var, rebinned, oldCoord, newCoord);
-      else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim))
-        rebin_non_inner_descending<double>(dim, var, rebinned, oldCoord, newCoord);
+      else if (is_sorted_descending(oldCoord, dim) &&
+               is_sorted_descending(newCoord, dim))
+        rebin_non_inner_descending<double>(dim, var, rebinned, oldCoord,
+                                           newCoord);
       else
         throw except::BinEdgeError(sorted_error);
     else if (oldCoord.dtype() == dtype<float>)
-      if (is_sorted_ascending(oldCoord, dim) && is_sorted_ascending(newCoord, dim))
+      if (is_sorted_ascending(oldCoord, dim) &&
+          is_sorted_ascending(newCoord, dim))
         rebin_non_inner<float>(dim, var, rebinned, oldCoord, newCoord);
-      else if (is_sorted_descending(oldCoord, dim) && is_sorted_descending(newCoord, dim))
-        rebin_non_inner_descending<float>(dim, var, rebinned, oldCoord, newCoord);
+      else if (is_sorted_descending(oldCoord, dim) &&
+               is_sorted_descending(newCoord, dim))
+        rebin_non_inner_descending<float>(dim, var, rebinned, oldCoord,
+                                          newCoord);
       else
         throw except::BinEdgeError(sorted_error);
     else

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -76,6 +76,18 @@ using args = std::tuple<span<Out>, span<const OutEdge>, span<const In>,
                         span<const InEdge>>;
 }
 
+struct Greater {
+  template <class A, class B> bool operator()(const A a, const B b) {
+    return a > b;
+  }
+};
+
+struct Less {
+  template <class A, class B> bool operator()(const A a, const B b) {
+    return a < b;
+  }
+};
+
 Variable rebin(const VariableConstView &var, const Dim dim,
                const VariableConstView &oldCoord,
                const VariableConstView &newCoord) {
@@ -100,12 +112,12 @@ Variable rebin(const VariableConstView &var, const Dim dim,
         is_sorted_ascending(newCoord, dim)) {
       return transform_subspan<transform_args>(
           var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
-          core::element::rebin<AscendingRebin>);
+          core::element::rebin<Greater>);
     } else if (is_sorted_descending(oldCoord, dim) &&
                is_sorted_descending(newCoord, dim)) {
       return transform_subspan<transform_args>(
           var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
-          core::element::rebin<DescendingRebin>);
+          core::element::rebin<Less>);
     } else {
       throw except::BinEdgeError(sorted_error);
     }

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -22,16 +22,20 @@ TEST(Variable, rebin) {
 }
 
 TEST(Variable, rebin_descending) {
-  auto var = makeVariable<double>(Dims{Dim::X}, Shape{10}, Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
+  auto var = makeVariable<double>(
+      Dims{Dim::X}, Shape{10},
+      Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
   var.setUnit(units::counts);
-  const auto oldEdge =
-      makeVariable<double>(Dims{Dim::X}, Shape{11}, Values{10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0});
-  const auto newEdge =
-      makeVariable<double>(Dims{Dim::X}, Shape{6}, Values{11.0, 7.5, 6.0, 4.5, 2.0, 0.0});
+  const auto oldEdge = makeVariable<double>(
+      Dims{Dim::X}, Shape{11},
+      Values{10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0});
+  const auto newEdge = makeVariable<double>(
+      Dims{Dim::X}, Shape{6}, Values{11.0, 7.5, 6.0, 4.5, 2.0, 0.0});
   auto rebinned = rebin(var, Dim::X, oldEdge, newEdge);
 
- auto expected = makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{4.5, 5.5, 8.0, 18.0, 19.0});
- expected.setUnit(units::counts);
+  auto expected = makeVariable<double>(Dims{Dim::X}, Shape{5},
+                                       Values{4.5, 5.5, 8.0, 18.0, 19.0});
+  expected.setUnit(units::counts);
 
   ASSERT_EQ(rebinned, expected);
 }

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -21,6 +21,20 @@ TEST(Variable, rebin) {
   EXPECT_EQ(rebinned.values<double>()[0], 3.0);
 }
 
+TEST(Variable, rebin_descending) {
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
+  var.setUnit(units::counts);
+  const auto oldEdge =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{3.0, 2.0, 1.0});
+  const auto newEdge =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{3.0, 1.0});
+  auto rebinned = rebin(var, Dim::X, oldEdge, newEdge);
+  ASSERT_EQ(rebinned.dims().shape().size(), 1);
+  ASSERT_EQ(rebinned.dims().volume(), 1);
+  ASSERT_EQ(rebinned.values<double>().size(), 1);
+  EXPECT_EQ(rebinned.values<double>()[0], 3.0);
+}
+
 TEST(Variable, rebin_outer) {
   auto var = makeVariable<double>(Dimensions{{Dim::Y, 6}, {Dim::X, 2}},
                                   Values{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -22,17 +22,18 @@ TEST(Variable, rebin) {
 }
 
 TEST(Variable, rebin_descending) {
-  auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{10}, Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
   var.setUnit(units::counts);
   const auto oldEdge =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{3.0, 2.0, 1.0});
+      makeVariable<double>(Dims{Dim::X}, Shape{11}, Values{10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0});
   const auto newEdge =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{3.0, 1.0});
+      makeVariable<double>(Dims{Dim::X}, Shape{6}, Values{11.0, 7.5, 6.0, 4.5, 2.0, 0.0});
   auto rebinned = rebin(var, Dim::X, oldEdge, newEdge);
-  ASSERT_EQ(rebinned.dims().shape().size(), 1);
-  ASSERT_EQ(rebinned.dims().volume(), 1);
-  ASSERT_EQ(rebinned.values<double>().size(), 1);
-  EXPECT_EQ(rebinned.values<double>()[0], 3.0);
+
+ auto expected = makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{4.5, 5.5, 8.0, 18.0, 19.0});
+ expected.setUnit(units::counts);
+
+  ASSERT_EQ(rebinned, expected);
 }
 
 TEST(Variable, rebin_outer) {

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -53,21 +53,23 @@ Variable variances(const VariableConstView &x) {
 /// Return True if variable values are monotonously increasing along given dim.
 bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
-  if (size < 2)
-    return true;
-  return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
-                     Variable(x.dtype(), x.unit(), Values{0.0})))
-      .value<bool>();
+  auto out = makeVariable<bool>(Values{true});
+  if (size > 1)
+    accumulate_in_place(out, x.slice({dim, 0, size - 1}),
+                        x.slice({dim, 1, size}),
+                        core::element::is_sorted_ascending);
+  return out.value<bool>();
 }
 
 /// Return True if variable values are monotonously decreasing along given dim.
 bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
-  if (size < 2)
-    return false;
-  return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
-                  Variable(x.dtype(), x.unit(), Values{0.0})))
-      .value<bool>();
+  auto out = makeVariable<bool>(Values{true});
+  if (size > 1)
+    accumulate_in_place(out, x.slice({dim, 0, size - 1}),
+                        x.slice({dim, 1, size}),
+                        core::element::is_sorted_descending);
+  return out.value<bool>();
 }
 
 } // namespace scipp::variable

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -50,31 +50,19 @@ Variable variances(const VariableConstView &x) {
   return transform(x, element::variances);
 }
 
-
-// template <class T> struct MakeIsSorted {
-//   static auto apply(const VariableConstView &key) {
-//     const auto &values = key.values<T>();
-//     return std::is_sorted(values.begin(), values.end());
-//   }
-// };
-
-// static auto make_is_sorted(const VariableConstView &x, const bool ascending = true) {
-//   if (ascending)
-//       return core::CallDType<double, float, int64_t, int32_t, bool,
-//                          std::string>::apply<MakeIsSorted>(x.dtype(), x);
-//   else
-//     return core::CallDType<double, float, int64_t, int32_t, bool,
-//                          std::string>::apply<MakeIsSorted>(x.dtype(), x);
-// }
-
 bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
-  return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size-1}), makeVariable<double>(Values{0.0}, x.unit()))).value<bool>();
+  return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
+                     Variable(x.dtype(), x.unit(), Values{0.0})
+                            ))
+      .value<bool>();
 }
 
 bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
-  return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size-1}), makeVariable<double>(Values{0.0}, x.unit()))).value<bool>();
+  return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
+                  Variable(x.dtype(), x.unit(), Values{0.0})))
+      .value<bool>();
 }
 
 } // namespace scipp::variable

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -53,6 +53,8 @@ Variable variances(const VariableConstView &x) {
 /// Return True if variable values are monotonously increasing along given dim.
 bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
+  if (size < 2)
+    return true;
   return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
                      Variable(x.dtype(), x.unit(), Values{0.0})))
       .value<bool>();
@@ -61,6 +63,8 @@ bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
 /// Return True if variable values are monotonously decreasing along given dim.
 bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
+  if (size < 2)
+    return false;
   return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
                   Variable(x.dtype(), x.unit(), Values{0.0})))
       .value<bool>();

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -18,7 +18,7 @@ namespace scipp::variable {
 
 Variable linspace(const VariableConstView &start, const VariableConstView &stop,
                   const Dim dim, const scipp::index num) {
-  // Th implementation here is slightly verbose and explicit. It could be
+  // The implementation here is slightly verbose and explicit. It could be
   // improved if we were to introduce new variants of `transform`, similar to
   // `std::generate`.
   core::expect::equals(start.dims(), stop.dims());
@@ -50,14 +50,15 @@ Variable variances(const VariableConstView &x) {
   return transform(x, element::variances);
 }
 
+/// Return True if variable values are monotonously increasing along given dim.
 bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
   return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),
-                     Variable(x.dtype(), x.unit(), Values{0.0})
-                            ))
+                     Variable(x.dtype(), x.unit(), Values{0.0})))
       .value<bool>();
 }
 
+/// Return True if variable values are monotonously decreasing along given dim.
 bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
   const auto size = x.dims()[dim];
   return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size - 1}),

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -50,8 +50,10 @@ Variable variances(const VariableConstView &x) {
   return transform(x, element::variances);
 }
 
-/// Return true if variable values are monotonously increasing/decreasing (for
-/// Ascending/Descending order, respectively) along given dim.
+/// Return true if variable values are sorted along given dim.
+///
+/// If `order` is SortOrder::Ascending, checks if values are non-decreasing.
+/// If `order` is SortOrder::Descending, checks if values are non-increasing.
 bool is_sorted(const VariableConstView &x, const Dim dim,
                const SortOrder order) {
   const auto size = x.dims()[dim];
@@ -61,11 +63,11 @@ bool is_sorted(const VariableConstView &x, const Dim dim,
   if (order == SortOrder::Ascending)
     accumulate_in_place(out, x.slice({dim, 0, size - 1}),
                         x.slice({dim, 1, size}),
-                        core::element::is_sorted_ascending);
+                        core::element::is_sorted_nondescending);
   else
     accumulate_in_place(out, x.slice({dim, 0, size - 1}),
                         x.slice({dim, 1, size}),
-                        core::element::is_sorted_descending);
+                        core::element::is_sorted_nonascending);
   return out.value<bool>();
 }
 

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -6,8 +6,10 @@
 #include "scipp/core/element/util.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/comparison.h"
 #include "scipp/variable/except.h"
 #include "scipp/variable/misc_operations.h"
+#include "scipp/variable/reduction.h"
 #include "scipp/variable/transform.h"
 
 using namespace scipp::core;
@@ -46,6 +48,33 @@ Variable values(const VariableConstView &x) {
 }
 Variable variances(const VariableConstView &x) {
   return transform(x, element::variances);
+}
+
+
+// template <class T> struct MakeIsSorted {
+//   static auto apply(const VariableConstView &key) {
+//     const auto &values = key.values<T>();
+//     return std::is_sorted(values.begin(), values.end());
+//   }
+// };
+
+// static auto make_is_sorted(const VariableConstView &x, const bool ascending = true) {
+//   if (ascending)
+//       return core::CallDType<double, float, int64_t, int32_t, bool,
+//                          std::string>::apply<MakeIsSorted>(x.dtype(), x);
+//   else
+//     return core::CallDType<double, float, int64_t, int32_t, bool,
+//                          std::string>::apply<MakeIsSorted>(x.dtype(), x);
+// }
+
+bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
+  const auto size = x.dims()[dim];
+  return all(greater(x.slice({dim, 1, size}) - x.slice({dim, 0, size-1}), makeVariable<double>(Values{0.0}, x.unit()))).value<bool>();
+}
+
+bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
+  const auto size = x.dims()[dim];
+  return all(less(x.slice({dim, 1, size}) - x.slice({dim, 0, size-1}), makeVariable<double>(Values{0.0}, x.unit()))).value<bool>();
 }
 
 } // namespace scipp::variable

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -50,22 +50,19 @@ Variable variances(const VariableConstView &x) {
   return transform(x, element::variances);
 }
 
-/// Return True if variable values are monotonously increasing along given dim.
-bool is_sorted_ascending(const VariableConstView &x, const Dim dim) {
+/// Return true if variable values are monotonously increasing/decreasing (for
+/// Ascending/Descending order, respectively) along given dim.
+bool is_sorted(const VariableConstView &x, const Dim dim,
+               const SortOrder order) {
   const auto size = x.dims()[dim];
+  if (size < 2)
+    return true;
   auto out = makeVariable<bool>(Values{true});
-  if (size > 1)
+  if (order == SortOrder::Ascending)
     accumulate_in_place(out, x.slice({dim, 0, size - 1}),
                         x.slice({dim, 1, size}),
                         core::element::is_sorted_ascending);
-  return out.value<bool>();
-}
-
-/// Return True if variable values are monotonously decreasing along given dim.
-bool is_sorted_descending(const VariableConstView &x, const Dim dim) {
-  const auto size = x.dims()[dim];
-  auto out = makeVariable<bool>(Values{true});
-  if (size > 1)
+  else
     accumulate_in_place(out, x.slice({dim, 0, size - 1}),
                         x.slice({dim, 1, size}),
                         core::element::is_sorted_descending);


### PR DESCRIPTION
Fixed 3 things:

1. Plotting with non-dim coord when dim coord is **not** present:
```Py
N = 50
M = 10
x = np.arange(N).astype(np.float)
y = np.arange(M).astype(np.float)
z = np.random.random([M, N])
d1 = sc.Dataset()
d1.coords['y'] = sc.Variable(['y'], values=y, unit=sc.units.m)
d1['Signal'] = sc.Variable(['y', 'x'], values=z, unit=sc.units.kg)
d1.coords['somelabels'] = sc.Variable(['x'],
                                      values=np.linspace(101., 155., N),
                                      unit=sc.units.s)
plot(d1, axes=['y', 'somelabels'])
```

2. Plotting with an array of shape 2:
```Py
a = sc.DataArray(
    data=sc.Variable(dims=['y','x'], shape=[2,4]),
    coords={'x':sc.Variable(dims=['x'], values=[1,2,3,4]),
            'y':sc.Variable(dims=['y'], values=[1,2])})
plot(a)
```

3. Plotting 2D data with decreasing coordinates:
```Py
a = sc.DataArray(
    data=sc.Variable(dims=['y','x'], values=np.arange(12).reshape(3,4)),
    coords={'x':sc.Variable(dims=['x'], values=[4,3,2,1]),
            'y':sc.Variable(dims=['y'], values=[1,2,3])})
plot(a)
```

Item 3. has required a modification of `rebin`, which checks if the coordinates are sorted in ascending or descending order.
As a result, a small but noticeable performance loss is felt when interacting (zooming/panning) with the 2D plot.
We should discuss whether this is the correct way to go.
I tried to make as much of the branching at compile time as possible, but I believe the bottleneck is scanning the old and new edges every time `rebin` is called.