### PR TITLE
Python wrappers to avoid duplicate docstrings and support better out args

### DIFF
--- a/python/comparison.cpp
+++ b/python/comparison.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include "docstring.h"
 #include "pybind11.h"
 
 #include "scipp/core/string.h"
@@ -15,28 +14,12 @@ using namespace scipp::dataset;
 
 namespace py = pybind11;
 
-template <class T> Docstring docstring_comparison(const std::string op) {
-  return Docstring()
-      .description(
-          "Comparison returning the truth value of " + op +
-          " element-wise.\n\nNote and warning: If one or both of the operators "
-          "have variances (uncertainties) there are ignored silently, i.e., "
-          "comparison is based exclusively on the values.")
-      .raises("If the units of inputs are not the same, or if the dtypes of "
-              "inputs are not double precision floats.")
-      .returns("Booleans that are true if " + op + ".")
-      .rtype<T>()
-      .template param<T>("x", "Input left operand.")
-      .template param<T>("y", "Input right operand.");
-}
-
 template <typename T> void bind_less(py::module &m) {
   m.def(
       "less",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return less(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x < y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_greater(py::module &m) {
@@ -44,8 +27,7 @@ template <typename T> void bind_greater(py::module &m) {
       "greater",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return greater(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x > y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_less_equal(py::module &m) {
@@ -53,8 +35,7 @@ template <typename T> void bind_less_equal(py::module &m) {
       "less_equal",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return less_equal(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x <= y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_greater_equal(py::module &m) {
@@ -62,8 +43,7 @@ template <typename T> void bind_greater_equal(py::module &m) {
       "greater_equal",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return greater_equal(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x >= y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_equal(py::module &m) {
@@ -71,8 +51,7 @@ template <typename T> void bind_equal(py::module &m) {
       "equal",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return equal(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x == y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_not_equal(py::module &m) {
@@ -80,8 +59,7 @@ template <typename T> void bind_not_equal(py::module &m) {
       "not_equal",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return not_equal(x, y); },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      docstring_comparison<T>("(x != y)").c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_is_equal(py::module &m) {
@@ -89,15 +67,7 @@ template <typename T> void bind_is_equal(py::module &m) {
       "is_equal",
       [](const typename T::const_view_type &x,
          const typename T::const_view_type &y) { return x == y; },
-      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>(),
-      Docstring()
-          .description("Variable level equals. Returns True if x and y "
-                       "considered equal.")
-          .returns("True if x and y are considered equal")
-          .rtype<T>()
-          .template param<T>("x", "Input left operand.")
-          .template param<T>("y", "Input right operand.")
-          .c_str());
+      py::arg("x"), py::arg("y"), py::call_guard<py::gil_scoped_release>());
 }
 
 void init_comparison(py::module &m) {

--- a/python/reduction.cpp
+++ b/python/reduction.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include "docstring.h"
 #include "pybind11.h"
 
 #include "scipp/dataset/reduction.h"
@@ -18,40 +17,7 @@ template <class T> void bind_flatten(py::module &m) {
   m.def("flatten",
         py::overload_cast<const typename T::const_view_type &, const Dim>(
             &flatten),
-        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-        Docstring()
-            .description("Flatten the specified dimension into event lists, "
-                         "equivalent to summing dense data.")
-            .raises("If the dimension does not exist, or if x does not contain "
-                    "event lists.")
-            .seealso(":py:func:`scipp.sum`")
-            .returns("The flattened data.")
-            .rtype<T>()
-            .template param<T>("x", "Data container to flatten.")
-            .param("dim", "Dimension over which to flatten.", "Dim")
-            .c_str());
-}
-
-template <class T> Docstring docstring_mean() {
-  return Docstring()
-      .description(R"(
-Element-wise mean over the specified dimension, if variances are present,
-the new variance is computated as standard-deviation of the mean.
-
-If the input has variances, the variances stored in the ouput are based on
-the "standard deviation of the mean", i.e.,
-:math:`\sigma_{mean} = \sigma / \sqrt{N}`.
-:math:`N` is the length of the input dimension.
-:math:`sigma` is estimated as the average of the standard deviations of
-the input elements along that dimension.
-
-This assumes that elements follow a normal distribution.)")
-      .raises("If the dimension does not exist, or the dtype cannot be summed, "
-              "e.g., if it is a string.")
-      .returns("The mean of the input values.")
-      .rtype<T>()
-      .template param<T>("x", "Data to calculate mean of.")
-      .param("dim", "Dimension along which to calculate the mean.", "Dim");
+        py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_mean(py::module &m) {
@@ -60,8 +26,7 @@ template <class T> void bind_mean(py::module &m) {
       [](const typename T::const_view_type &x, const Dim dim) {
         return mean(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_mean<T>().c_str());
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_mean_out(py::module &m) {
@@ -70,21 +35,7 @@ template <class T> void bind_mean_out(py::module &m) {
       [](const typename T::const_view_type &x, const Dim dim,
          typename T::view_type out) { return mean(x, dim, out); },
       py::arg("x"), py::arg("dim"), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>(),
-      docstring_mean<typename T::view_type>()
-          .template param<T>("out", "Output buffer.")
-          .c_str());
-}
-
-template <class T> Docstring docstring_sum() {
-  return Docstring()
-      .description("Element-wise sum over the specified dimension.")
-      .raises("If the dimension does not exist, or the dtype cannot be summed, "
-              "e.g., if it is a string.")
-      .returns("The sum of the input values.")
-      .rtype<T>()
-      .template param<T>("x", "Data to calculate sum of.")
-      .param("dim", "Dimension along which to calculate the sum.", "Dim");
+      py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_sum(py::module &m) {
@@ -93,8 +44,7 @@ template <class T> void bind_sum(py::module &m) {
       [](const typename T::const_view_type &x, const Dim dim) {
         return sum(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_sum<T>().c_str());
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_sum_out(py::module &m) {
@@ -103,97 +53,55 @@ template <class T> void bind_sum_out(py::module &m) {
       [](const typename T::const_view_type &x, const Dim dim,
          const typename T::view_type &out) { return sum(x, dim, out); },
       py::arg("x"), py::arg("dim"), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>(),
-      docstring_sum<typename T::view_type>()
-          .template param<T>("out", "Output buffer.")
-          .c_str());
-}
-
-template <class T> Docstring docstring_minmax(const std::string minmax) {
-  return Docstring()
-      .description("Element-wise " + minmax +
-                   " over all of the input's dimensions.")
-      .raises("If the dtype has no " + minmax + ", e.g., if it is a string.")
-      .seealso(std::string(":py:func:`scipp.") +
-               (minmax == "min" ? "max" : "min") + "`")
-      .returns("The " + minmax + " of the input values.")
-      .rtype<T>()
-      .template param<T>("x", "Data to calculate " + minmax + " of.");
+      py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_min(py::module &m) {
-  auto doc = docstring_minmax<T>("min");
   m.def(
       "min", [](const typename T::const_view_type &x) { return min(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "min",
       [](const typename T::const_view_type &x, const Dim dim) {
         return min(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      doc.description("Element-wise min over the specified dimension.")
-          .raises(" If the dimension does not exist.", true)
-          .param("dim", "Dimension over which to calculate the min.", "Dim")
-          .c_str());
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_max(py::module &m) {
-  auto doc = docstring_minmax<T>("max");
   m.def(
       "max", [](const typename T::const_view_type &x) { return max(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "max",
       [](const typename T::const_view_type &x, const Dim dim) {
         return max(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      doc.description("Element-wise min over the specified dimension.")
-          .raises(" If the dimension does not exist", true)
-          .param("dim", "Dimension over which to calculate the min.", "Dim")
-          .c_str());
-}
-
-template <class T> Docstring docstring_bool(const std::string op) {
-  return Docstring()
-      .description(
-          "Element-wise " + op +
-          " over the specified dimension or all dimensions if not provided.")
-      .raises("If the input dimension to reduce (optional) does not exist, or "
-              "if the dtype is not bool.")
-      .returns("The " + op + " combination of the input values.")
-      .rtype<T>()
-      .template param<T>("x", "Data to reduce.")
-      .param("dim", "Dimension to reduce (optional).", "Dim");
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_all(py::module &m) {
   m.def(
       "all", [](const typename T::const_view_type &x) { return all(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("AND").c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "all",
       [](const typename T::const_view_type &x, const Dim dim) {
         return all(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("AND").c_str());
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_any(py::module &m) {
   m.def(
       "any", [](const typename T::const_view_type &x) { return any(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("OR").c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "any",
       [](const typename T::const_view_type &x, const Dim dim) {
         return any(x, dim);
       },
-      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
-      docstring_bool<T>("OR").c_str());
+      py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 void init_reduction(py::module &m) {
@@ -212,10 +120,7 @@ void init_reduction(py::module &m) {
   bind_sum_out<Variable>(m);
 
   bind_min<Variable>(m);
-
   bind_max<Variable>(m);
-
   bind_all<Variable>(m);
-
   bind_any<Variable>(m);
 }

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -27,6 +27,7 @@ from .io import data_array_to_hdf5
 # Wrappers for free functions from _scipp.core
 from ._comparison import *
 from ._math import *
+from ._reduction import *
 from ._trigonometry import *
 
 setattr(Variable, '_repr_html_', make_html)

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -24,6 +24,9 @@ from ._utils import collapse, slices
 from .compat.dict import to_dict, from_dict
 from .io import data_array_to_hdf5
 
+# Wrappers for free functions from _scipp.core
+from .math import *
+
 setattr(Variable, '_repr_html_', make_html)
 setattr(VariableConstView, '_repr_html_', make_html)
 setattr(DataArray, '_repr_html_', make_html)

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -25,7 +25,9 @@ from .compat.dict import to_dict, from_dict
 from .io import data_array_to_hdf5
 
 # Wrappers for free functions from _scipp.core
-from .math import *
+from ._comparison import *
+from ._math import *
+from ._trigonometry import *
 
 setattr(Variable, '_repr_html_', make_html)
 setattr(VariableConstView, '_repr_html_', make_html)

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -14,7 +14,7 @@ def less(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a < b`.
     """
@@ -30,7 +30,7 @@ def greater(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a > b`.
     """
@@ -46,7 +46,7 @@ def less_equal(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a <= b`.
     """
@@ -62,7 +62,7 @@ def greater_equal(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a >= b`.
     """
@@ -78,7 +78,7 @@ def equal(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a == b`.
     """
@@ -94,7 +94,7 @@ def not_equal(x, y):
 
     :param x: Left input.
     :param y: Right input.
-    :raises: If the units of inputs are not the same, or if the dtypes of 
+    :raises: If the units of inputs are not the same, or if the dtypes of
              inputs cannot be compared.
     :return: Booleans that are true if `a != b`.
     """

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+
+
+def less(x, y):
+    """Element-wise '<' (less).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a < b`.
+    """
+    return _call_cpp_func(_cpp.less, x, y)
+
+
+def greater(x, y):
+    """Element-wise '>' (greater).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a > b`.
+    """
+    return _call_cpp_func(_cpp.greater, x, y)
+
+
+def less_equal(x, y):
+    """Element-wise '<=' (less_equal).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a <= b`.
+    """
+    return _call_cpp_func(_cpp.less_equal, x, y)
+
+
+def greater_equal(x, y):
+    """Element-wise '>=' (greater_equal).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a >= b`.
+    """
+    return _call_cpp_func(_cpp.greater_equal, x, y)
+
+
+def equal(x, y):
+    """Element-wise '==' (equal).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a == b`.
+    """
+    return _call_cpp_func(_cpp.equal, x, y)
+
+
+def not_equal(x, y):
+    """Element-wise '!=' (not_equal).
+
+    Warning: If one or both of the operators have variances (uncertainties)
+    there are ignored silently, i.e., comparison is based exclusively on
+    the values.
+
+    :param x: Left input.
+    :param y: Right input.
+    :raises: If the units of inputs are not the same, or if the dtypes of 
+             inputs cannot be compared.
+    :return: Booleans that are true if `a != b`.
+    """
+    return _call_cpp_func(_cpp.not_equal, x, y)
+
+
+def is_equal(x, y):
+    """Full comparison of x and y.
+
+    :param x: Left input.
+    :param y: Right input.
+    :return: True if x and y have identical values, variances, dtypes, units,
+             dims, shapes, coords, and masks. Else False.
+    """
+    return _call_cpp_func(_cpp.is_equal, x, y)

--- a/python/src/scipp/_cpp_wrapper_util.py
+++ b/python/src/scipp/_cpp_wrapper_util.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+
+
+def call_func(func, *args, out=None, **kwargs):
+    if out is None:
+        return func(*args, **kwargs)
+    else:
+        return func(*args, **kwargs, out=out)

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -25,7 +25,7 @@ def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
     The function allows replacements to be separately specified for nan, inf
     or -inf values.
     You can choose to replace a subset of those special values by providing
-    just the required key word arguments.
+    just the required keyword arguments.
     If the replacement is value-only and the input has variances, the variance
     at the element(s) undergoing replacement are also replaced with the
     replacement value.

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -1,11 +1,8 @@
-from ._scipp import core as sc
-
-
-def _call_cpp_func(func, *args, out=None, **kwargs):
-    if out is None:
-        return func(*args, **kwargs)
-    else:
-        return func(*args, **kwargs, out=out)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
 def abs(x, out=None):
@@ -15,9 +12,9 @@ def abs(x, out=None):
     :param out: Optional output buffer.
     :raises: If the dtype has no absolute value, e.g., if it is a string.
     :return: The absolute values of the input.
-    :seealso: `scipp.norm` for vector-like dtype.
+    :seealso: :py:func:`scipp.norm` for vector-like dtype.
     """
-    return _call_cpp_func(sc.abs, x, out=out)
+    return _call_cpp_func(_cpp.abs, x, out=out)
 
 
 def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
@@ -44,7 +41,7 @@ def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
     :raises: If the types of input and replacement do not match.
     :return: Input elements are replaced in output with specified subsitutions.
     """
-    return _call_cpp_func(sc.nan_to_num, x, nan, posinf, neginf, out=out)
+    return _call_cpp_func(_cpp.nan_to_num, x, nan, posinf, neginf, out=out)
 
 
 def norm(x):
@@ -54,7 +51,7 @@ def norm(x):
     :raises: If the dtype has no norm, i.e., if it is not a vector.
     :return: Scalar elements computed as the norm values of the input elements.
     """
-    return _call_cpp_func(sc.norm, x, out=None)
+    return _call_cpp_func(_cpp.norm, x, out=None)
 
 
 def reciprocal(x, out=None):
@@ -65,7 +62,7 @@ def reciprocal(x, out=None):
     :raises: If the dtype has no reciprocal, e.g., if it is a string.
     :return: The reciprocal values of the input.
     """
-    return _call_cpp_func(sc.reciprocal, x, out=out)
+    return _call_cpp_func(_cpp.reciprocal, x, out=out)
 
 
 def sqrt(x, out=None):
@@ -76,4 +73,4 @@ def sqrt(x, out=None):
     :raises: If the dtype has no square-root, e.g., if it is a string.
     :return: The square-root values of the input.
     """
-    return _call_cpp_func(sc.sqrt, x, out=out)
+    return _call_cpp_func(_cpp.sqrt, x, out=out)

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+
+
+def flatten(x, dim):
+    """Flatten the specified dimension into event lists equivalent to
+    summing dense data.
+
+    :param x: Input data.
+    :param dim: Dimension to flatten over.
+    :raises: If the dimension does not exist, or if x does not contain event
+             lists.
+    :return: The flattened data.
+    :seealso: :py:func:`scipp.sum` for regular dense data.
+    """
+    return _call_cpp_func(_cpp.flatten, x)
+
+
+def mean(x, dim, out=None):
+    """Element-wise mean over the specified dimension, if variances are
+    present, the new variance is computated as standard-deviation of the mean.
+
+    If the input has variances, the variances stored in the ouput are based on
+    the "standard deviation of the mean", i.e.,
+    :math:`\\sigma_{mean} = \\sigma / \\sqrt{N}`.
+    :math:`N` is the length of the input dimension.
+    :math:`sigma` is estimated as the average of the standard deviations of
+    the input elements along that dimension.
+
+    :param x: Input data.
+    :param dim: Dimension along which to calculate the mean.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The mean of the input values.
+    """
+    return _call_cpp_func(_cpp.mean, x, dim, out=out)
+
+
+def sum(x, dim, out=None):
+    """Element-wise sum over the specified dimension.
+
+    :param x: Input data.
+    :param dim: Dimension along which to calculate the sum.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The sum of the input values.
+    """
+    return _call_cpp_func(_cpp.sum, x, dim, out=out)
+
+
+def min(x, dim=None, out=None):
+    """Element-wise min over the specified dimension or all dimensions if not
+    provided.
+
+    :param x: Input data.
+    :param dim: Optional dimension along which to calculate the min. If not
+                given, the min over all dimensions is calculated.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The min of the input values.
+    """
+    if dim is None:
+        return _call_cpp_func(_cpp.min, x, out=out)
+    else:
+        return _call_cpp_func(_cpp.min, x, dim=dim, out=out)
+
+
+def max(x, dim=None, out=None):
+    """Element-wise max over the specified dimension or all dimensions if not
+    provided.
+
+    :param x: Input data.
+    :param dim: Optional dimension along which to calculate the max. If not
+                given, the max over all dimensions is calculated.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The max of the input values.
+    """
+    if dim is None:
+        return _call_cpp_func(_cpp.max, x, out=out)
+    else:
+        return _call_cpp_func(_cpp.max, x, dim=dim, out=out)
+
+
+def all(x, dim=None, out=None):
+    """Element-wise AND over the specified dimension or all dimensions if not
+    provided.
+
+    :param x: Input data.
+    :param dim: Optional dimension along which to calculate the AND. If not
+                given, the AND over all dimensions is calculated.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The AND of the input values.
+    """
+    if dim is None:
+        return _call_cpp_func(_cpp.all, x, out=out)
+    else:
+        return _call_cpp_func(_cpp.all, x, dim=dim, out=out)
+
+
+def any(x, dim=None, out=None):
+    """Element-wise AND over the specified dimension or all dimensions if not
+    provided.
+
+    :param x: Input data.
+    :param dim: Optional dimension along which to calculate the AND. If not
+                given, the AND over all dimensions is calculated.
+    :param out: Optional output buffer.
+    :raises: If the dimension does not exist, or the dtype cannot be summed,
+             e.g., if it is a string.
+    :return: The AND of the input values.
+    """
+    if dim is None:
+        return _call_cpp_func(_cpp.any, x, out=out)
+    else:
+        return _call_cpp_func(_cpp.any, x, dim=dim, out=out)

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -108,16 +108,16 @@ def all(x, dim=None, out=None):
 
 
 def any(x, dim=None, out=None):
-    """Element-wise AND over the specified dimension or all dimensions if not
+    """Element-wise OR over the specified dimension or all dimensions if not
     provided.
 
     :param x: Input data.
-    :param dim: Optional dimension along which to calculate the AND. If not
-                given, the AND over all dimensions is calculated.
+    :param dim: Optional dimension along which to calculate the OR. If not
+                given, the OR over all dimensions is calculated.
     :param out: Optional output buffer.
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
-    :return: The AND of the input values.
+    :return: The OR of the input values.
     """
     if dim is None:
         return _call_cpp_func(_cpp.any, x, out=out)

--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -42,44 +42,44 @@ def tan(x, out=None):
 
 
 def asin(x, out=None):
-    """Element-wise asin.
+    """Element-wise inverse sin.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The asin values of the input.
+    :return: The inverse sin values of the input.
     """
     return _call_cpp_func(_cpp.asin, x, out=out)
 
 
 def acos(x, out=None):
-    """Element-wise acos.
+    """Element-wise inverse cos.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The acos values of the input.
+    :return: The inverse cos values of the input.
     """
     return _call_cpp_func(_cpp.acos, x, out=out)
 
 
 def atan(x, out=None):
-    """Element-wise atan.
+    """Element-wise inverse tan.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The atan values of the input.
+    :return: The inverse tan values of the input.
     """
     return _call_cpp_func(_cpp.atan, x, out=out)
 
 
 def atan2(y, x, out=None):
-    """Element-wise atan2.
+    """Element-wise inverse tan providing signed angle.
 
     :param y: Input y values.
     :param x: Input x values.
     :param out: Optional output buffer.
-    :return: The atan2 values of the inputs.
+    :return: The signed inverse tan values of the inputs.
     """
     return _call_cpp_func(_cpp.atan, x, out=out)

--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+
+
+def sin(x, out=None):
+    """Element-wise sin.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not a plane-angle unit, or if the sin cannot be
+             computed on the dtype, e.g., if it is an integer.
+    :return: The sin values of the input.
+    """
+    return _call_cpp_func(_cpp.sin, x, out=out)
+
+
+def cos(x, out=None):
+    """Element-wise cos.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not a plane-angle unit, or if the cos cannot be
+             computed on the dtype, e.g., if it is an integer.
+    :return: The cos values of the input.
+    """
+    return _call_cpp_func(_cpp.cos, x, out=out)
+
+
+def tan(x, out=None):
+    """Element-wise tan.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not a plane-angle unit, or if the tan cannot be
+             computed on the dtype, e.g., if it is an integer.
+    :return: The tan values of the input.
+    """
+    return _call_cpp_func(_cpp.tan, x, out=out)
+
+
+def asin(x, out=None):
+    """Element-wise asin.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not dimensionless.
+    :return: The asin values of the input.
+    """
+    return _call_cpp_func(_cpp.asin, x, out=out)
+
+
+def acos(x, out=None):
+    """Element-wise acos.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not dimensionless.
+    :return: The acos values of the input.
+    """
+    return _call_cpp_func(_cpp.acos, x, out=out)
+
+
+def atan(x, out=None):
+    """Element-wise atan.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the unit is not dimensionless.
+    :return: The atan values of the input.
+    """
+    return _call_cpp_func(_cpp.atan, x, out=out)
+
+
+def atan2(y, x, out=None):
+    """Element-wise atan2.
+
+    :param y: Input y values.
+    :param x: Input x values.
+    :param out: Optional output buffer.
+    :return: The atan2 values of the inputs.
+    """
+    return _call_cpp_func(_cpp.atan, x, out=out)

--- a/python/src/scipp/math.py
+++ b/python/src/scipp/math.py
@@ -1,0 +1,79 @@
+from ._scipp import core as sc
+
+
+def _call_cpp_func(func, *args, out=None, **kwargs):
+    if out is None:
+        return func(*args, **kwargs)
+    else:
+        return func(*args, **kwargs, out=out)
+
+
+def abs(x, out=None):
+    """Element-wise absolute value.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the dtype has no absolute value, e.g., if it is a string.
+    :return: The absolute values of the input.
+    :seealso: `scipp.norm` for vector-like dtype.
+    """
+    return _call_cpp_func(sc.abs, x, out=out)
+
+
+def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
+    """Element-wise special value replacement.
+
+    All elements in the output are identical to input except in the presence
+    of a NaN, Inf or -Inf.
+    The function allows replacements to be separately specified for nan, inf
+    or -inf values.
+    You can choose to replace a subset of those special values by providing
+    just the required key word arguments.
+    If the replacement is value-only and the input has variances, the variance
+    at the element(s) undergoing replacement are also replaced with the
+    replacement value.
+    If the replacement has a variance and the input has variances, the
+    variance at the element(s) undergoing replacement are also replaced with
+    the replacement variance.
+
+    :param x: Input data.
+    :param nan: Replacement values for NaN in the input.
+    :param posinf: Replacement values for Inf in the input.
+    :param neginf: Replacement values for -Inf in the input.
+    :param out: Optional output buffer.
+    :raises: If the types of input and replacement do not match.
+    :return: Input elements are replaced in output with specified subsitutions.
+    """
+    return _call_cpp_func(sc.nan_to_num, x, nan, posinf, neginf, out=out)
+
+
+def norm(x):
+    """Element-wise norm.
+
+    :param x: Input data.
+    :raises: If the dtype has no norm, i.e., if it is not a vector.
+    :return: Scalar elements computed as the norm values of the input elements.
+    """
+    return _call_cpp_func(sc.norm, x, out=None)
+
+
+def reciprocal(x, out=None):
+    """Element-wise reciprocal.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the dtype has no reciprocal, e.g., if it is a string.
+    :return: The reciprocal values of the input.
+    """
+    return _call_cpp_func(sc.reciprocal, x, out=out)
+
+
+def sqrt(x, out=None):
+    """Element-wise square-root.
+
+    :param x: Input data.
+    :param out: Optional output buffer.
+    :raises: If the dtype has no square-root, e.g., if it is a string.
+    :return: The square-root values of the input.
+    """
+    return _call_cpp_func(sc.sqrt, x, out=out)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -899,7 +899,7 @@ def test_variable_data_array_binary_ops():
     assert sc.is_equal(a / var, var / a)
 
 
-def test_num_to_nan():
+def test_nan_to_num():
     a = sc.Variable(dims=['x'], values=np.array([1, np.nan]))
     replace = sc.Variable(value=0.0)
     b = sc.nan_to_num(a, replace)
@@ -942,7 +942,7 @@ def test_nan_to_nan_with_multiple_special_replacements():
     assert sc.is_equal(b, expected)
 
 
-def test_num_to_nan_out():
+def test_nan_to_num_out():
     a = sc.Variable(dims=['x'], values=np.array([1, np.nan]))
     out = sc.Variable(dims=['x'], values=np.zeros(2))
     replace = sc.Variable(value=0.0)
@@ -951,7 +951,7 @@ def test_num_to_nan_out():
     assert sc.is_equal(out, expected)
 
 
-def test_num_to_nan_out_with_multiple_special_replacements():
+def test_nan_to_num_out_with_multiple_special_replacements():
     a = sc.Variable(dims=['x'], values=np.array([1, np.inf, -np.inf, np.nan]))
     out = sc.Variable(dims=['x'], values=np.zeros(4))
     replace = sc.Variable(value=0.0)

--- a/python/trigonometry.cpp
+++ b/python/trigonometry.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Neil Vaytet
-#include "docstring.h"
 #include "pybind11.h"
 
 #include "scipp/variable/trigonometry.h"
@@ -12,137 +11,85 @@ using namespace scipp::variable;
 
 namespace py = pybind11;
 
-template <class T> Docstring docstring_trig(const std::string &op) {
-  return Docstring()
-      .description("Element-wise " + op + ".")
-      .raises("If the unit is not a plane-angle unit, or if the " + op +
-              " function cannot be computed on the dtype, e.g., if it is an "
-              "integer.")
-      .returns("The " + op + " values of the input.")
-      .rtype<T>()
-      .template param<T>("x", "Input data.");
-}
-
 template <class T> void bind_sin(py::module &m) {
-  auto doc = docstring_trig<T>("sin");
   m.def(
       "sin", [](const typename T::const_view_type &x) { return sin(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "sin",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return sin(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_asin(py::module &m) {
-  auto doc =
-      docstring_trig<T>("asin").raises("If the unit is not dimensionless.");
   m.def(
       "asin", [](const typename T::const_view_type &x) { return asin(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "asin",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return asin(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_cos(py::module &m) {
-  auto doc = docstring_trig<T>("cos");
   m.def(
       "cos", [](const typename T::const_view_type &x) { return cos(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "cos",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return cos(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_acos(py::module &m) {
-  auto doc =
-      docstring_trig<T>("acos").raises("If the unit is not dimensionless.");
   m.def(
       "acos", [](const typename T::const_view_type &x) { return acos(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "acos",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return acos(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_tan(py::module &m) {
-  auto doc = docstring_trig<T>("tan");
   m.def(
       "tan", [](const typename T::const_view_type &x) { return tan(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "tan",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return tan(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_atan(py::module &m) {
-  auto doc =
-      docstring_trig<T>("atan").raises("If the unit is not dimensionless.");
   m.def(
       "atan", [](const typename T::const_view_type &x) { return atan(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "atan",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return atan(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_atan2(py::module &m) {
-  auto doc =
-      Docstring()
-          .description("Element-wise atan2.")
-          .raises("If the unit is not a plane-angle unit, or if the atan2 "
-                  "function cannot be computed on the dtype, e.g., if it is an "
-                  "integer.")
-          .returns("The atan2 values of the input.")
-          .rtype<T>()
-          .template param<T>("y", "Input y values.")
-          .template param<T>("x", "Input x values.");
   m.def(
       "atan2",
       [](const typename T::const_view_type &y,
          const typename T::const_view_type &x) { return atan2(y, x); },
-      py::arg("y"), py::arg("x"), py::call_guard<py::gil_scoped_release>(),
-      doc.c_str());
+      py::arg("y"), py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "atan2",
       [](const typename T::const_view_type &y,
          const typename T::const_view_type &x,
          typename T::view_type out) { return atan2(y, x, out); },
       py::arg("y"), py::arg("x"), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer")
-          .c_str());
+      py::call_guard<py::gil_scoped_release>());
 }
 
 void init_trigonometry(py::module &m) {

--- a/python/unary.cpp
+++ b/python/unary.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include "docstring.h"
 #include "pybind11.h"
 
 #include "scipp/dataset/dataset.h"
@@ -15,114 +14,46 @@ using namespace scipp::dataset;
 namespace py = pybind11;
 
 template <typename T> void bind_abs(py::module &m) {
-  auto doc =
-      Docstring()
-          .description("Element-wise absolute value.")
-          .raises(
-              "If the dtype has no absolute value, e.g., if it is a string.")
-          .seealso(":py:func:`scipp.norm` for vector-like dtype.")
-          .returns("The absolute values of the input.")
-          .rtype<T>()
-          .template param<T>("x", "Input data.");
   m.def(
       "abs", [](const typename T::const_view_type &x) { return abs(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "abs",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return abs(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer.")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_sqrt(py::module &m) {
-  auto doc =
-      Docstring()
-          .description("Element-wise square-root.")
-          .raises("If the dtype has no square-root, e.g., if it is a string.")
-          .returns("The square-root values of the input.")
-          .rtype<T>()
-          .template param<T>("x", "Input data.");
   m.def(
       "sqrt", [](const typename T::const_view_type &x) { return sqrt(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "sqrt",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return sqrt(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer.")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_norm(py::module &m) {
-  auto doc =
-      Docstring()
-          .description("Element-wise norm.")
-          .raises("If the dtype has no norm, i.e., if it is not a vector.")
-          .returns("Scalar elements computed as the norm values of the input "
-                   "elements.")
-          .rtype<T>()
-          .template param<T>("x", "Input data.");
   m.def(
       "norm", [](const typename T::const_view_type &x) { return norm(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_reciprocal(py::module &m) {
-  auto doc =
-      Docstring()
-          .description("Element-wise reciprocal.")
-          .raises("If the dtype has no reciprocal, e.g., if it is a string.")
-          .returns("The reciprocal values of the input.")
-          .rtype<T>()
-          .template param<T>("x", "Input data.");
   m.def(
       "reciprocal",
       [](const typename T::const_view_type &x) { return reciprocal(x); },
-      py::arg("x"), py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::arg("x"), py::call_guard<py::gil_scoped_release>());
   m.def(
       "reciprocal",
       [](const typename T::const_view_type &x,
          const typename T::view_type &out) { return reciprocal(x, out); },
-      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>(),
-      doc.template rtype<typename T::view_type>()
-          .template param<T>("out", "Output buffer.")
-          .c_str());
+      py::arg("x"), py::arg("out"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <typename T> void bind_nan_to_num(py::module &m) {
-  auto doc =
-      Docstring()
-          .description(
-              R"(Element-wise special value replacement
-
-All elements in the output are identical to input except in the presence
-of a NaN, Inf or -Inf.
-The function allows replacements to be separately specified for nan, inf
-or -inf values.
-You can choose to replace a subset of those special values by providing
-just the required key word arguments.
-If the replacement is value-only and the input has variances,
-the variance at the element(s) undergoing replacement are also replaced
-with the replacement value.
-If the replacement has a variance and the input has variances,
-the variance at the element(s) undergoing replacement are also replaced
-with the replacement variance.)")
-          .raises("If the types of input and replacement do not match.")
-          .returns("Input elements are replaced in output with specified "
-                   "subsitutions.")
-          .rtype<T>()
-          .template param<T>("x", "Input data.")
-          .param("nan", "Replacement values for NaN in the input.", "Variable")
-          .param("posinf", "Replacement values for Inf in the input.",
-                 "Variable")
-          .param("neginf", "Replacement values for -Inf in the input.",
-                 "Variable");
-
   m.def(
       "nan_to_num",
       [](const typename T::const_view_type &x,
@@ -141,7 +72,7 @@ with the replacement variance.)")
       py::arg("x"), py::arg("nan") = std::optional<VariableConstView>(),
       py::arg("posinf") = std::optional<VariableConstView>(),
       py::arg("neginf") = std::optional<VariableConstView>(),
-      py::call_guard<py::gil_scoped_release>(), doc.c_str());
+      py::call_guard<py::gil_scoped_release>());
 
   m.def(
       "nan_to_num",
@@ -161,10 +92,7 @@ with the replacement variance.)")
       py::arg("x"), py::arg("nan") = std::optional<VariableConstView>(),
       py::arg("posinf") = std::optional<VariableConstView>(),
       py::arg("neginf") = std::optional<VariableConstView>(), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>(),
-      doc.template param<T>("out", "Output buffer.")
-          .template rtype<typename T::view_type>()
-          .c_str());
+      py::call_guard<py::gil_scoped_release>());
 }
 
 void init_unary(py::module &m) {


### PR DESCRIPTION
See issue descriptions:
- Fixes #1184.
- Fixes #1149.

Essentially this is adding Python wrappers for free functions. I did the main ones, but there is more to do (left for future PRs).