### PR TITLE
Update 2D plotting page with new collapse syntax

### DIFF
--- a/docs/visualization/plotting-2d-data.ipynb
+++ b/docs/visualization/plotting-2d-data.ipynb
@@ -144,7 +144,7 @@
    "source": [
     "## Collapsing dimensions\n",
     "\n",
-    "Sometimes it is useful to collapse one or more of the data's dimensions, if for instance most detector pixels contain noise, but one specific channel contains a strong signal. This is done by specifying the dimension to be displayed along the x axis as a keyword argument. All other dimensions will be collapsed."
+    "Sometimes it is useful to collapse one or more of the data's dimensions, if for instance most detector pixels contain noise, but one specific channel contains a strong signal. This is done by specifying the dimension to be displayed along the x axis as a keyword argument to `sc.collapse`. All other dimensions will be collapsed."
    ]
   },
   {
@@ -166,7 +166,7 @@
     "d2['sample'] = sc.Variable(['x', 'tof'], values=a,\n",
     "                           variances=0.1*np.random.rand(M, N))\n",
     "plot(d2)\n",
-    "plot(d2, collapse='tof')"
+    "plot(sc.collapse(d2['sample'], keep='tof'))"
    ]
   },
   {

--- a/python/src/scipp/plot/dispatch.py
+++ b/python/src/scipp/plot/dispatch.py
@@ -8,7 +8,6 @@ from .._utils import histogram_events_data
 def dispatch(scipp_obj_dict,
              ndim=0,
              name=None,
-             collapse=None,
              bins=None,
              projection=None,
              mpl_line_params=None,

--- a/python/tests/plot/test_plot_1d.py
+++ b/python/tests/plot/test_plot_1d.py
@@ -101,7 +101,7 @@ def test_plot_1d_with_masks():
 
 def test_plot_collapse():
     d = make_dense_dataset(ndim=2)
-    plot(d, collapse='tof')
+    plot(sc.collaps(d, keep='tof'))
 
 
 def test_plot_sliceviewer_with_1d_projection():

--- a/python/tests/plot/test_plot_1d.py
+++ b/python/tests/plot/test_plot_1d.py
@@ -101,7 +101,7 @@ def test_plot_1d_with_masks():
 
 def test_plot_collapse():
     d = make_dense_dataset(ndim=2)
-    plot(sc.collaps(d, keep='tof'))
+    plot(sc.collapse(d["Sample"], keep='tof'))
 
 
 def test_plot_sliceviewer_with_1d_projection():


### PR DESCRIPTION
After #1233 this option was ignored. Use sc.collapse.