### PR TITLE
Up to 30x speedup for 2D plotting

### DIFF
--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -364,7 +364,7 @@ class Slicer2d(Slicer):
             self.vslice = sc.histogram(self.vslice)
             self.autoscale_cbar = True
         else:
-            self.vslice = self.vslice.copy()
+            self.vslice = self.vslice.astype(sc.dtype.float32)
             self.autoscale_cbar = False
         self.vslice.variances = None
         self.vslice.unit = sc.units.counts
@@ -445,12 +445,14 @@ class Slicer2d(Slicer):
         return
 
     def select_bins(self, coord, dim, start, end):
-        if len(coord.dims) != 1:
+        if len(coord.dims) != 1: # TODO find combined min/max
             return dim, slice(0, -1)
         bins = coord.shape[0]
         # scipp treats bins as closed on left and open on right: [left, right)
         first = sc.sum(coord <= start, dim).value - 1
         last = bins - sc.sum(coord > end, dim).value
+        if first >= last: # TODO better handling for decreasing
+            return dim, slice(0, -1)
         first = max(0, first)
         last = min(bins - 1, last)
         return dim, slice(first, last + 1)

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -16,24 +16,6 @@ import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import warnings
 
-import os
-import time
-
-
-def timeit(method):
-    def timed(*args, **kw):
-        ts = time.time()
-        result = method(*args, **kw)
-        te = time.time()
-        if 'log_time' in kw:
-            name = kw.get('log_name', method.__name__.upper())
-            kw['log_time'][name] = int((te - ts) * 1000)
-        else:
-            os.write(1, f'{method.__name__}  {(te - ts) * 1000} ms\n'.encode())
-        return result
-
-    return timed
-
 
 def plot_2d(scipp_obj_dict=None,
             axes=None,
@@ -213,7 +195,6 @@ class Slicer2d(Slicer):
         self.update_axes()
         return
 
-    @timeit
     def update_axes(self):
         # Go through the buttons and select the right coordinates for the axes
         for dim, button in self.buttons.items():
@@ -304,7 +285,6 @@ class Slicer2d(Slicer):
 
         return
 
-    @timeit
     def compute_bin_widths(self, xy, dim):
         """
         Pixel widths used for scaling before rebin step
@@ -313,7 +293,6 @@ class Slicer2d(Slicer):
                             self.xyedges[xy][dim, :-1])
         self.xywidth[xy].unit = sc.units.one
 
-    @timeit
     def slice_coords(self):
         """
         Recursively slice the coords along the dimensions of active sliders.
@@ -338,7 +317,6 @@ class Slicer2d(Slicer):
             # Pixel widths used for scaling before rebin step
             self.compute_bin_widths(xy, param["dim"])
 
-    @timeit
     def slice_data(self):
         """
         Recursively slice the data along the dimensions of active sliders.
@@ -378,7 +356,6 @@ class Slicer2d(Slicer):
         self.vslice *= self.xywidth["x"]
         self.vslice *= self.xywidth["y"]
 
-    @timeit
     def update_slice(self, change=None):
         """
         Slice data according to new slider value and update the image.
@@ -408,7 +385,6 @@ class Slicer2d(Slicer):
         if self.xlim_updated:
             self.update_bins_from_axes_limits()
 
-    @timeit
     def update_bins_from_axes_limits(self):
         """
         Update the axis limits and resample the image according to new viewport
@@ -457,7 +433,6 @@ class Slicer2d(Slicer):
         last = min(bins - 1, last)
         return dim, slice(first, last + 1)
 
-    @timeit
     def resample_image(self):
         dim = self.xyrebin['x'].dims[0]
         slicex = self.select_bins(self.xyedges['x'], dim,
@@ -499,7 +474,6 @@ class Slicer2d(Slicer):
         arr /= self.xyrebin['y'].values[1] - self.xyrebin['y'].values[0]
         return arr
 
-    @timeit
     def update_image(self, extent=None):
         dslice = self.resample_image()
         if self.params["masks"][self.name]["show"]:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -427,7 +427,7 @@ class Slicer2d(Slicer):
     def select_bins(self, coord, dim, start, end):
         bins = coord.shape[-1]
         if len(coord.dims) != 1:  # TODO find combined min/max
-            return dim, slice(0, bins-1)
+            return dim, slice(0, bins - 1)
         # scipp treats bins as closed on left and open on right: [left, right)
         first = sc.sum(coord <= start, dim).value - 1
         last = bins - sc.sum(coord > end, dim).value

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -441,18 +441,18 @@ class Slicer2d(Slicer):
         last = bins - sc.sum(coord > end, dim).value
         first = max(0, first)
         last = min(bins - 1, last)
-        return (dim, slice(first, last + 1)), (dim, slice(first, last + 2))
+        return dim, slice(first, last + 1)
 
     @timeit
     def resample_image(self):
         dim = self.xyrebin['x'].dims[0]
-        slicex, binslicex = self.select_bins(self.xyedges["x"], dim,
-                                             self.xyrebin['x'][dim, 0],
-                                             self.xyrebin['x'][dim, -1])
+        slicex = self.select_bins(self.xyedges["x"], dim,
+                                  self.xyrebin['x'][dim, 0],
+                                  self.xyrebin['x'][dim, -1])
         dim = self.xyrebin['y'].dims[0]
-        slicey, binslicey = self.select_bins(self.xyedges["y"], dim,
-                                             self.xyrebin['y'][dim, 0],
-                                             self.xyrebin['y'][dim, -1])
+        slicey = self.select_bins(self.xyedges["y"], dim,
+                                  self.xyrebin['y'][dim, 0],
+                                  self.xyrebin['y'][dim, -1])
 
         # Make a new slice with bin edges and counts for using in rebin.
         dslice = self.vslice[slicex][slicey]

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -473,7 +473,10 @@ class Slicer2d(Slicer):
             dslice.masks["all"] = mslice
 
         # Scale by bin width and then rebin in both directions
-        dslice *= self.xywidth["x"][slicex] * self.xywidth["y"][slicey]
+        # Note that this has to be written as 2 inplace operations to avoid
+        # creation of large 2D temporary from broadcast
+        dslice *= self.xywidth["x"][slicex]
+        dslice *= self.xywidth["y"][slicey]
         # The order of the dimensions that are rebinned matters if 2D coords
         # are present. We must rebin the base dimension of the 2D coord first.
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -358,6 +358,7 @@ class Slicer2d(Slicer):
                         self.name]["show"] and dim in self.mslice.dims:
                     self.mslice = self.mslice[val.dim, val.value]
         self.vslice = self.vslice.copy()
+        self.vslice.variances = None
         self.vslice.coords[self.xyrebin["x"].dims[0]] = self.xyedges["x"]
         self.vslice.coords[self.xyrebin["y"].dims[0]] = self.xyedges["y"]
         if self.params["masks"][self.name]["show"]:
@@ -491,12 +492,8 @@ class Slicer2d(Slicer):
                                             dtype=dslice.dtype,
                                             unit=sc.units.one))
         arr *= dslice
-        arr /= self.xyrebin['x'][self.xyrebin["x"].dims[0],
-                                 1] - self.xyrebin['x'][
-                                     self.xyrebin["x"].dims[0], 0]
-        arr /= self.xyrebin['y'][self.xyrebin["y"].dims[0],
-                                 1] - self.xyrebin['y'][
-                                     self.xyrebin["y"].dims[0], 0]
+        arr /= self.xyrebin['x'].values[1] - self.xyrebin['x'].values[0]
+        arr /= self.xyrebin['y'].values[1] - self.xyrebin['y'].values[0]
         return arr
 
     @timeit

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -359,6 +359,7 @@ class Slicer2d(Slicer):
                     self.mslice = self.mslice[val.dim, val.value]
         self.vslice = self.vslice.copy()
         self.vslice.variances = None
+        self.vslice.unit = sc.units.counts
         self.vslice.coords[self.xyrebin["x"].dims[0]] = self.xyedges["x"]
         self.vslice.coords[self.xyrebin["y"].dims[0]] = self.xyedges["y"]
         if self.params["masks"][self.name]["show"]:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -425,14 +425,14 @@ class Slicer2d(Slicer):
         return
 
     def select_bins(self, coord, dim, start, end):
+        bins = coord.shape[-1]
         if len(coord.dims) != 1:  # TODO find combined min/max
-            return dim, slice(0, -1)
-        bins = coord.shape[0]
+            return dim, slice(0, bins-1)
         # scipp treats bins as closed on left and open on right: [left, right)
         first = sc.sum(coord <= start, dim).value - 1
         last = bins - sc.sum(coord > end, dim).value
         if first >= last:  # TODO better handling for decreasing
-            return dim, slice(0, -1)
+            return dim, slice(0, bins - 1)
         first = max(0, first)
         last = min(bins - 1, last)
         return dim, slice(first, last + 1)

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -9,6 +9,7 @@ from .slicer import Slicer
 from .tools import to_bin_edges, parse_params
 from .._utils import name_with_unit
 from .._scipp import core as sc
+from .. import detail
 
 # Other imports
 import numpy as np
@@ -341,11 +342,14 @@ class Slicer2d(Slicer):
         if self.vslice.unaligned is not None:
             self.vslice = sc.histogram(self.vslice)
             self.autoscale_cbar = True
+            self.vslice.variances = None
         else:
-            self.vslice = self.vslice.astype(sc.dtype.float32)
+            self.vslice = detail.move_to_data_array(
+                data=sc.Variable(dims=self.vslice.dims,
+                                 unit=sc.units.counts,
+                                 values=self.vslice.values,
+                                 dtype=sc.dtype.float32))
             self.autoscale_cbar = False
-        self.vslice.variances = None
-        self.vslice.unit = sc.units.counts
         self.vslice.coords[self.xyrebin["x"].dims[0]] = self.xyedges["x"]
         self.vslice.coords[self.xyrebin["y"].dims[0]] = self.xyedges["y"]
         if self.params["masks"][self.name]["show"]:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -445,6 +445,8 @@ class Slicer2d(Slicer):
         return
 
     def select_bins(self, coord, dim, start, end):
+        if len(coord.dims) != 1:
+            return dim, slice(0, -1)
         bins = coord.shape[0]
         # scipp treats bins as closed on left and open on right: [left, right)
         first = sc.sum(coord <= start, dim).value - 1
@@ -456,11 +458,11 @@ class Slicer2d(Slicer):
     @timeit
     def resample_image(self):
         dim = self.xyrebin['x'].dims[0]
-        slicex = self.select_bins(self.xyedges["x"], dim,
+        slicex = self.select_bins(self.xyedges['x'], dim,
                                   self.xyrebin['x'][dim, 0],
                                   self.xyrebin['x'][dim, -1])
         dim = self.xyrebin['y'].dims[0]
-        slicey = self.select_bins(self.xyedges["y"], dim,
+        slicey = self.select_bins(self.xyedges['y'], dim,
                                   self.xyrebin['y'][dim, 0],
                                   self.xyrebin['y'][dim, -1])
 

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -16,6 +16,24 @@ import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import warnings
 
+import os
+import time
+
+
+def timeit(method):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method.__name__.upper())
+            kw['log_time'][name] = int((te - ts) * 1000)
+        else:
+            os.write(1, f'{method.__name__}  {(te - ts) * 1000} ms\n'.encode())
+        return result
+
+    return timed
+
 
 def plot_2d(scipp_obj_dict=None,
             axes=None,
@@ -195,6 +213,7 @@ class Slicer2d(Slicer):
         self.update_axes()
         return
 
+    @timeit
     def update_axes(self):
         # Go through the buttons and select the right coordinates for the axes
         for dim, button in self.buttons.items():
@@ -318,6 +337,7 @@ class Slicer2d(Slicer):
             # Pixel widths used for scaling before rebin step
             self.compute_bin_widths(xy, param["dim"])
 
+    @timeit
     def slice_data(self):
         """
         Recursively slice the data along the dimensions of active sliders.
@@ -337,6 +357,7 @@ class Slicer2d(Slicer):
                         self.name]["show"] and dim in self.mslice.dims:
                     self.mslice = self.mslice[val.dim, val.value]
 
+    @timeit
     def update_slice(self, change=None):
         """
         Slice data according to new slider value and update the image.
@@ -366,6 +387,7 @@ class Slicer2d(Slicer):
         if self.xlim_updated:
             self.update_bins_from_axes_limits()
 
+    @timeit
     def update_bins_from_axes_limits(self):
         """
         Update the axis limits and resample the image according to new viewport
@@ -415,6 +437,7 @@ class Slicer2d(Slicer):
         last = min(bins - 1, last)
         return (dim, slice(first, last + 1)), (dim, slice(first, last + 2))
 
+    @timeit
     def resample_image(self):
         dim = self.xyrebin['x'].dims[0]
         slicex, binslicex = self.select_bins(self.xyedges["x"], dim,
@@ -479,6 +502,7 @@ class Slicer2d(Slicer):
         arr *= dslice
         return arr
 
+    @timeit
     def update_image(self, extent=None):
 
         # In the case of unaligned data, we may want to auto-scale the colorbar

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -341,15 +341,15 @@ class Slicer2d(Slicer):
         # but not shrink.
         if self.vslice.unaligned is not None:
             self.vslice = sc.histogram(self.vslice)
-            self.autoscale_cbar = True
             self.vslice.variances = None
+            self.autoscale_cbar = True
         else:
-            self.vslice = detail.move_to_data_array(
-                data=sc.Variable(dims=self.vslice.dims,
-                                 unit=sc.units.counts,
-                                 values=self.vslice.values,
-                                 dtype=sc.dtype.float32))
             self.autoscale_cbar = False
+        self.vslice = detail.move_to_data_array(
+            data=sc.Variable(dims=self.vslice.dims,
+                             unit=sc.units.counts,
+                             values=self.vslice.values,
+                             dtype=sc.dtype.float32))
         self.vslice.coords[self.xyrebin["x"].dims[0]] = self.xyedges["x"]
         self.vslice.coords[self.xyrebin["y"].dims[0]] = self.xyedges["y"]
         if self.params["masks"][self.name]["show"]:

--- a/python/src/scipp/plot/plot_2d.py
+++ b/python/src/scipp/plot/plot_2d.py
@@ -460,7 +460,7 @@ class Slicer2d(Slicer):
             ],
                              values=self.vslice[slicex][slicey].values,
                              unit=sc.units.counts,
-                             dtype=sc.dtype.float64))
+                             dtype=sc.dtype.float32))
 
         # Also include the masks
         if self.params["masks"][self.name]["show"]:

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -58,8 +58,7 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
                                     std::max<double>(xn_low, xo_low, less));
         const auto owidth = std::abs(xo_high - xo_low);
         newT.slice({dim, inew}) +=
-            astype(oldT.slice({dim, iold}) * ((delta / owidth) * units::one),
-                   newT.dtype());
+            oldT.slice({dim, iold}) * ((delta / owidth) * units::one);
       }
       if (less(xo_high, xn_high)) {
         iold++;

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -24,6 +24,8 @@ bool isBinEdge(const Dim dim, Dimensions edges, const Dimensions &toMatch) {
   return edges[dim] == toMatch[dim];
 }
 
+bool is_dtype_bool(const Variable &var) { return var.dtype() == dtype<bool>; }
+
 template <typename T, class Less>
 void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
                      Variable &newT, const VariableConstView &oldCoordT,
@@ -54,7 +56,7 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
     if (begin == oldSize + 1 || end == 0)
       return;
     begin = std::max(scipp::index(0), begin - 1);
-    if (newT.dtype() == dtype<bool>) {
+    if (is_dtype_bool(newT)) {
       slice |= any(oldT.slice({dim, begin, end}), dim);
     } else {
       add_from_bin(slice, xn_low, xn_high, begin);

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -57,8 +57,11 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
         const auto delta = std::abs(std::min<double>(xn_high, xo_high, less) -
                                     std::max<double>(xn_low, xo_low, less));
         const auto owidth = std::abs(xo_high - xo_low);
-        newT.slice({dim, inew}) +=
-            oldT.slice({dim, iold}) * ((delta / owidth) * units::one);
+        if (delta == owidth) // 2x speedup for many-to-1 rebin
+          newT.slice({dim, inew}) += oldT.slice({dim, iold});
+        else
+          newT.slice({dim, inew}) +=
+              oldT.slice({dim, iold}) * ((delta / owidth) * units::one);
       }
       if (less(xo_high, xn_high)) {
         iold++;

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -66,7 +66,7 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
       if (is_bool)
         slice |= any(oldT.slice({dim, begin, end - 1}), dim);
       else
-        slice += sum(oldT.slice({dim, begin, end - 1}), dim);
+        sum(oldT.slice({dim, begin, end - 1}), dim, slice);
     }
     if (begin != end && end < oldSize + 1)
       add_from_bin(slice, xn_low, xn_high, end - 1);

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -3,7 +3,6 @@
 /// @file
 /// @author Simon Heybrock, Igor Gudich
 #include "scipp/core/element/rebin.h"
-#include "scipp/core/dtype.h"
 #include "scipp/core/parallel.h"
 #include "scipp/units/except.h"
 #include "scipp/variable/apply.h"
@@ -14,7 +13,6 @@
 #include "scipp/variable/transform_subspan.h"
 #include "scipp/variable/util.h"
 
-using namespace scipp::core;
 using namespace scipp::core::element;
 
 namespace scipp::variable {
@@ -24,6 +22,7 @@ bool isBinEdge(const Dim dim, Dimensions edges, const Dimensions &toMatch) {
   return edges[dim] == toMatch[dim];
 }
 
+// Workaround VS C7526 (undefined inline variable) with dtype<> in template.
 bool is_dtype_bool(const Variable &var) { return var.dtype() == dtype<bool>; }
 
 template <typename T, class Less>

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock, Igor Gudich
 #include "scipp/core/element/rebin.h"
+#include "scipp/core/dtype.h"
 #include "scipp/core/parallel.h"
 #include "scipp/units/except.h"
 #include "scipp/variable/apply.h"
@@ -13,6 +14,7 @@
 #include "scipp/variable/transform_subspan.h"
 #include "scipp/variable/util.h"
 
+using namespace scipp::core;
 using namespace scipp::core::element;
 
 namespace scipp::variable {

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -61,7 +61,7 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
       add_from_bin(slice, xn_low, xn_high, begin);
       if (begin < end - 1)
         sum(oldT.slice({dim, begin + 1, end - 1}), dim, slice);
-      if (begin != end && end < oldSize + 1)
+      if (begin != end - 1 && end < oldSize + 1)
         add_from_bin(slice, xn_low, xn_high, end - 1);
     }
   };

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace scipp;
 
-TEST(Variable, rebin) {
+TEST(RebinTest, inner) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   var.setUnit(units::counts);
   const auto oldEdge =
@@ -21,7 +21,7 @@ TEST(Variable, rebin) {
   EXPECT_EQ(rebinned.values<double>()[0], 3.0);
 }
 
-TEST(Variable, rebin_descending) {
+TEST(RebinTest, inner_descending) {
   auto var = makeVariable<double>(
       Dims{Dim::X}, Shape{10},
       Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
@@ -40,7 +40,7 @@ TEST(Variable, rebin_descending) {
   ASSERT_EQ(rebinned, expected);
 }
 
-TEST(Variable, rebin_outer) {
+TEST(RebinTest, outer) {
   auto var = makeVariable<double>(Dimensions{{Dim::Y, 6}, {Dim::X, 2}},
                                   Values{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
   var.setUnit(units::counts);
@@ -57,6 +57,41 @@ TEST(Variable, rebin_outer) {
   expected.setUnit(units::counts);
 
   ASSERT_EQ(rebinned, expected);
+}
+
+TEST(RebinTest, outer2) {
+  const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
+                                        Values{1, 2, 3, 4}, units::counts);
+  constexpr auto varY = [](const auto... vals) {
+    return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
+                                Values{vals...});
+  };
+  const auto oldY = varY(0, 1, 2, 3, 4);
+  constexpr auto var1x1 = [](const double value) {
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
+                                Values{value}, units::counts);
+  };
+  // full range
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
+  // aligned old/bew edges
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 4)), var1x1(10));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 2)), var1x1(3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1, 3)), var1x1(5));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 4)), var1x1(7));
+  // crossing 0 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 0.3)), var1x1((0.3 - 0.1) * 1));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 1.3)), var1x1((1.3 - 1.1) * 2));
+  // crossing 1 bin bound
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.0)), var1x1(0.9 * 1 + 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 1.3)),
+            var1x1((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 2.3)),
+            var1x1((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
+  // crossing 2 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.3)),
+            var1x1((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 3.3)),
+            var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
 }
 
 class RebinMask1DTest : public ::testing::Test {


### PR DESCRIPTION
### Example:
```python
import scipp as sc
import numpy as np
# This is roughly LoKI with full pixel count, but bins might also be 1000 in a worse case
data = sc.DataArray(data=sc.Variable(dims=['x','y'], values=np.random.rand(1000000,100)))
data.masks['m'] = data.data['x',0] < data.data['x',1]
```
```python
%%time
sc.plot.plot(data)
```

Compiled with TBB.

### Before

- `35 s` for the plot to show up.
- `1 s` to `3 s` for zoom into fewer pixels
- `1 s` to `3 s` for pan in zoomed-in state

### After

- `1 s` for the plot to show up (there must be extra overhead outside the 2d plotting code, the update takes only `200 ms`).
- `50 ms` for zoom into fewer pixels
- `50 ms` for pan in zoomed-in state

### How?

- Copy slice once, early, instead of once for every update.
- Optimize algorithm in `rebin_non_inner`.
- Multi-threading in `rebin_non_inner`.
- Slice before rebinning to avoid rebinning areas that are not required.

