### PR TITLE
Sort by values

### DIFF
--- a/python/operations.cpp
+++ b/python/operations.cpp
@@ -9,6 +9,8 @@
 #include "scipp/dataset/sort.h"
 #include "scipp/variable/operations.h"
 #include "scipp/variable/util.h"
+#include "scipp/variable/sort.h"
+#include "scipp/variable/variable.h"
 
 using namespace scipp;
 using namespace scipp::variable;
@@ -93,6 +95,7 @@ void init_operations(py::module &m) {
   bind_sort<Variable>(m);
   bind_sort<DataArray>(m);
   bind_sort<Dataset>(m);
+  bind_sort_dim<Variable>(m);
   bind_sort_dim<DataArray>(m);
   bind_sort_dim<Dataset>(m);
 

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -15,6 +15,7 @@ set(INC_FILES
     include/scipp/variable/rebin.h
     include/scipp/variable/reduction.h
     include/scipp/variable/shape.h
+    include/scipp/variable/sort.h
     include/scipp/variable/string.h
     include/scipp/variable/subspan_view.h
     include/scipp/variable/transform.h
@@ -40,6 +41,7 @@ set(SRC_FILES
     rebin.cpp
     reduction.cpp
     shape.cpp
+    sort.cpp
     string.cpp
     subspan_view.cpp
     trigonometry.cpp

--- a/variable/include/scipp/variable/sort.h
+++ b/variable/include/scipp/variable/sort.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Thibault Chatel
+#pragma once
+
+#include <vector>
+
+#include "scipp-variable_export.h"
+#include "scipp/variable/variable.h"
+
+namespace scipp::variable {
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sort(const VariableConstView &var,
+                                   const Dim &key);
+
+} // namespace scipp::variable

--- a/variable/sort.cpp
+++ b/variable/sort.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Thibault Chatel
+#include <numeric>
+
+#include "scipp/core/tag_util.h"
+#include "scipp/variable/sort.h"
+#include "scipp/variable/indexed_slice_view.h"
+
+using scipp::variable::IndexedSliceView;
+
+namespace scipp::variable {
+
+template <class T> struct MakeSort {
+  static auto apply(const VariableConstView &var, const Dim &key) {
+  if (var.dims().ndim() == 1) {
+    const auto &values = var.values<T>();
+    std::vector<scipp::index> permutation(values.size());
+    std::iota(permutation.begin(), permutation.end(), 0);
+    std::sort(
+          permutation.begin(), permutation.end(),
+          [&](scipp::index i, scipp::index j) { return values[i] < values[j]; });
+    return concatenate(
+          IndexedSliceView{var, key, permutation});
+  } else {
+    scipp::index good_index = 0;
+    Variable for_taille = Variable(var, var.dims());
+    scipp::index taille = for_taille.dims().shape()[good_index];
+    Dim y = var.dims().label(good_index);
+    VariableConstView pre_viewtest(var, y, 0);
+    Variable sorted = apply(pre_viewtest, key);
+    for (scipp::index i = 1; i<taille; i++) {
+      VariableConstView viewtest(var, y, i);
+      Variable viewtest_trie = apply(viewtest, key);
+      sorted = concatenate(sorted, viewtest_trie, y);
+    }
+    sorted.setDims(var.dims());
+
+    return sorted;
+  }
+}
+};
+
+
+Variable sort(const VariableConstView &var, const Dim &key) {
+  uint16_t ndim = var.dims().ndim();
+  VariableConstView input = var;
+  if (ndim>1) {
+    scipp::index key_one = 0;
+    for (scipp::index i = 0; i<ndim; i++) {
+      if (key == (var.dims().label(i))) { key_one = i; }
+    }
+    if (key_one != (ndim-1)) {
+      std::vector<Dim> for_transpose = {};
+      for (scipp::index i = 0; i<ndim; i++) {
+        if (i==key_one) { for_transpose.push_back(var.dims().label(ndim-1)); }
+        else if (i==ndim-1) { for_transpose.push_back(var.dims().label(key_one)); }
+        else { for_transpose.push_back(var.dims().label(i)); }
+      }
+      input = var.transpose(for_transpose);
+    }
+  }
+  return core::CallDType<double, float, int64_t, int32_t, bool,
+                         std::string>::apply<MakeSort>(input.dtype(), input, key);
+}
+
+
+
+} // namespace scipp::variable

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
   reduce_logical_test.cpp
   reduce_various_test.cpp
   subspan_view_test.cpp
+  sort_test.cpp
   transform_test.cpp
   trigonometry_test.cpp
   util_test.cpp

--- a/variable/test/sort_test.cpp
+++ b/variable/test/sort_test.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/variable/sort.h"
+#include "scipp/variable/variable.h"
+
+using namespace scipp;
+using namespace scipp::variable;
+
+TEST(Variable, sort1d) {
+    auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1.0, 3.0, 2.0});
+    EXPECT_EQ(sort(var), makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1.0, 2.0, 3.0}));
+}
+
+TEST(Variable, sort2d_x) {
+    auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 3}}, Values{1.0,3.0,2.0,4.0,0.0,5.0});
+    EXPECT_EQ(sort(var), makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 3}}, Values{1.0,2.0,3.0,0.0,4.0,5.0}));
+}
+
+TEST(Variable, sort2d_y) {
+    auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 3}}, Values{1.0,3.0,2.0,4.0,0.0,5.0});
+    EXPECT_EQ(sort(var), makeVariable<double>(Dimensions{{Dim::X,3}, {Dim::Y,2}}, Values{1.0,4.0,0.0,3.0,2.0,5.0}));
+}


### PR DESCRIPTION
I added the possibility to sort a Variable instance according to its values along a specified dimension.
An example of use could be : `v = sc.Variable(['y','x'], values=np.array([[1,3,2],[4,0,5]]))` `sc.sort(v,'x')`
which would produce a Variable with values : [[1,2,3],[0,4,5]]. 
Note : the specified dimension is always swapped to the last place if necessary because of my recursive approch to perform the sort. It means that `sc.sort(sc.Variable(['y','x'], values=np.array([[1,3,2],[4,0,5]])), 'y')` will produce a Variable with values : [[1,4],[0,3],[2,5]] .

