### PR TITLE
Python bindings for "bucket" variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .clangd/
 .idea/
 .vscode/
+*.ipynb_checkpoints

--- a/core/element_array_view.cpp
+++ b/core/element_array_view.cpp
@@ -43,9 +43,9 @@ element_array_view::element_array_view(const scipp::index offset,
 /// broadcasting the slice.
 element_array_view::element_array_view(const element_array_view &other,
                                        const Dimensions &iterDims)
-    : m_offset(other.m_offset), m_iterDims(iterDims) {
+    : m_offset(other.m_offset), m_iterDims(iterDims),
+      m_dataDims(other.m_dataDims) {
   expectCanBroadcastFromTo(other.m_iterDims, m_iterDims);
-  m_dataDims = other.m_dataDims;
   // See implementation of ViewIndex regarding this relabeling.
   for (const auto label : m_dataDims.labels())
     if (label != Dim::Invalid && !other.m_iterDims.contains(label))

--- a/core/include/scipp/core/bucket.h
+++ b/core/include/scipp/core/bucket.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+#include <utility>
+
+#include "scipp-core_export.h"
+#include "scipp/common/index.h"
+
+namespace scipp::core {
+
+struct bucket_base {
+  using range_type = std::pair<scipp::index, scipp::index>;
+};
+template <class T> struct bucket : bucket_base {
+  using element_type = typename T::view_type;
+  using const_element_type = typename T::const_view_type;
+};
+
+} // namespace scipp::core
+
+namespace scipp {
+using core::bucket;
+}

--- a/core/include/scipp/core/bucket_array_view.h
+++ b/core/include/scipp/core/bucket_array_view.h
@@ -6,17 +6,10 @@
 
 #include <boost/iterator/transform_iterator.hpp>
 
+#include "scipp/core/bucket.h"
 #include "scipp/core/element_array_view.h"
 
 namespace scipp::core {
-
-struct bucket_base {
-  using range_type = std::pair<scipp::index, scipp::index>;
-};
-template <class T> struct bucket : bucket_base {
-  using element_type = typename T::view_type;
-  using const_element_type = typename T::const_view_type;
-};
 
 template <class T>
 class bucket_array_view
@@ -69,6 +62,8 @@ private:
 /// example, a VariableView in case of T=Variable.
 template <class T>
 class ElementArrayView<bucket<T>> : public bucket_array_view<T> {
+public:
+  using value_type = typename T::view_type;
   using bucket_array_view<T>::bucket_array_view;
 };
 
@@ -78,11 +73,9 @@ class ElementArrayView<bucket<T>> : public bucket_array_view<T> {
 /// example, a VariableConstView in case of T=Variable.
 template <class T>
 class ElementArrayView<const bucket<T>> : public bucket_array_view<const T> {
+public:
+  using value_type = typename T::const_view_type;
   using bucket_array_view<const T>::bucket_array_view;
 };
 
 } // namespace scipp::core
-
-namespace scipp {
-using core::bucket;
-}

--- a/core/include/scipp/core/element_array_view.h
+++ b/core/include/scipp/core/element_array_view.h
@@ -137,3 +137,6 @@ private:
 namespace scipp {
 using core::ElementArrayView;
 }
+
+// Specializations of ElementArrayView:
+#include "scipp/core/bucket_array_view.h"

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -71,7 +71,6 @@ element_to_string(const T &item,
     return {'"' + item + "\", "};
   else if constexpr (std::is_same_v<T, bool>)
     return core::to_string(item) + ", ";
-
   else if constexpr (std::is_same_v<T, scipp::core::time_point>) {
     return core::to_string(to_iso_date(item, unit.value())) + ", ";
   } else if constexpr (std::is_same_v<T, Eigen::Vector3d>)

--- a/core/slice.cpp
+++ b/core/slice.cpp
@@ -26,7 +26,7 @@ void validate_begin(const scipp::index begin_) {
 Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_)
     : m_dim(dim_), m_begin(begin_), m_end(end_) {
   validate_begin(begin_);
-  if (begin_ > end_)
+  if (end_ != -1 && begin_ > end_)
     throw except::SliceError("end must be >= begin. Given begin " +
                              std::to_string(begin_) + " end " +
                              std::to_string(end_));

--- a/dataset/CMakeLists.txt
+++ b/dataset/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SRC_FILES
     sort.cpp
     string.cpp
     unaligned.cpp
+    variable_instantiate_bucket_elements.cpp
     variable_instantiate_dataset.cpp
     variable_reduction.cpp
 )

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -393,6 +393,7 @@ public:
   Dataset &operator/=(const DatasetConstView &other);
 
   std::unordered_map<Dim, scipp::index> dimensions() const;
+  std::unordered_map<Dim, scipp::index> dims() const { return dimensions(); }
 
 private:
   friend class DatasetConstView;
@@ -498,6 +499,7 @@ public:
   bool operator!=(const Dataset &other) const;
   bool operator!=(const DatasetConstView &other) const;
   std::unordered_map<Dim, scipp::index> dimensions() const;
+  std::unordered_map<Dim, scipp::index> dims() const { return dimensions(); }
 
 protected:
   explicit DatasetConstView() : m_dataset(nullptr) {}

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -810,4 +810,6 @@ using dataset::DataArrayView;
 using dataset::Dataset;
 using dataset::DatasetConstView;
 using dataset::DatasetView;
+template <> struct is_view<DataArrayView> : std::true_type {};
+template <> struct is_view<DatasetView> : std::true_type {};
 } // namespace scipp

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -9,8 +9,8 @@
 
 namespace scipp::variable {
 
-INSTANTIATE_BUCKET_VARIABLE(bucket_Dataset, bucket<Dataset>)
-INSTANTIATE_BUCKET_VARIABLE(bucket_DataArray, bucket<DataArray>)
+INSTANTIATE_BUCKET_VARIABLE(DatasetView, bucket<Dataset>)
+INSTANTIATE_BUCKET_VARIABLE(DataArrayView, bucket<DataArray>)
 
 } // namespace scipp::variable
 

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/string.h"
+#include "scipp/variable/bucket_variable.tcc"
+#include "scipp/variable/string.h"
+
+namespace scipp::variable {
+
+INSTANTIATE_BUCKET_VARIABLE(bucket_Dataset, bucket<Dataset>)
+INSTANTIATE_BUCKET_VARIABLE(bucket_DataArray, bucket<DataArray>)
+
+} // namespace scipp::variable
+
+namespace scipp::dataset {
+namespace {
+auto register_dataset_types(
+    (variable::formatterRegistry().emplace(
+         dtype<bucket<Dataset>>,
+         std::make_unique<variable::Formatter<bucket<Dataset>>>()),
+     variable::formatterRegistry().emplace(
+         dtype<bucket<DataArray>>,
+         std::make_unique<variable::Formatter<bucket<DataArray>>>()),
+     0));
+} // namespace
+} // namespace scipp::dataset

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,6 +4,7 @@ pybind11_add_module(
   _scipp
   SHARED
   SYSTEM
+  buckets.cpp
   choose.cpp
   comparison.cpp
   counts.cpp

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -19,12 +19,6 @@
 namespace py = pybind11;
 using namespace scipp;
 
-template <class T> struct is_view : std::false_type {};
-template <> struct is_view<VariableView> : std::true_type {};
-template <> struct is_view<DataArrayView> : std::true_type {};
-template <> struct is_view<DatasetView> : std::true_type {};
-template <class T> inline constexpr bool is_view_v = is_view<T>::value;
-
 template <class T> void remove_variances(T &obj) {
   if constexpr (std::is_same_v<T, DataArray> ||
                 std::is_same_v<T, DataArrayView>)

--- a/python/buckets.cpp
+++ b/python/buckets.cpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Hezbrock
-#include "docstring.h"
 #include "pybind11.h"
+#include "scipp/core/except.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/bucket_model.h"
 #include "scipp/variable/shape.h"
@@ -20,15 +20,31 @@ template <class T> void bind_buckets(pybind11::module &m) {
       "to_buckets",
       [](const VariableConstView &begin, const VariableConstView &end,
          const Dim dim, const typename T::const_view_type &data) {
-        // if(!begin && !end)
-        element_array<std::pair<scipp::index, scipp::index>> buckets(
-            begin.dims().volume());
-        const auto &begin_ = begin.values<int64_t>();
-        const auto &end_ = end.values<int64_t>();
-        for (scipp::index i = 0; i < buckets.size(); ++i)
-          buckets.data()[i] = {begin_[i], end_[i]};
+        element_array<std::pair<scipp::index, scipp::index>> buckets;
+        Dimensions dims;
+        if (begin) {
+          buckets.resize(begin.dims().volume());
+          dims = begin.dims();
+          const auto &begin_ = begin.values<int64_t>();
+          if (end) {
+            core::expect::equals(begin.dims(), end.dims());
+            const auto &end_ = end.values<int64_t>();
+            for (scipp::index i = 0; i < buckets.size(); ++i)
+              buckets.data()[i] = {begin_[i], end_[i]};
+          } else {
+            for (scipp::index i = 0; i < buckets.size(); ++i)
+              buckets.data()[i] = {begin_[i], -1};
+          }
+        } else if (!end) {
+          buckets.resize(data.dims()[dim]);
+          dims = Dimensions(dim, buckets.size());
+          for (scipp::index i = 0; i < buckets.size(); ++i)
+            buckets.data()[i] = {i, -1};
+        } else {
+          throw std::runtime_error("`end` given but not `begin`");
+        }
         return Variable(std::make_unique<variable::DataModel<bucket<T>>>(
-            begin.dims(), std::move(buckets), dim, T(data)));
+            dims, std::move(buckets), dim, T(data)));
       },
       py::arg("begin") = VariableConstView{},
       py::arg("end") = VariableConstView{}, py::arg("dim"), py::arg("data"),

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -69,10 +69,10 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
   else
     view.def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
                                [[maybe_unused]] const T value) {
-      if constexpr (std::is_same_v<decltype(self[i]), T>)
-        self[i] = value;
-      else
+      if constexpr (is_view_v<decltype(self[i])>)
         throw std::runtime_error("Setting items of this type is not possible.");
+      else
+        self[i] = value;
     });
 }
 

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -56,8 +56,6 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
           [](const ElementArrayView<T> &self) { return array_to_string(self); })
       .def("__getitem__", &ElementArrayView<T>::operator[],
            py::return_value_policy::reference)
-      .def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
-                             const T value) { self[i] = value; })
       .def("__len__", &ElementArrayView<T>::size)
       .def("__iter__", [](const ElementArrayView<T> &self) {
         return py::make_iterator(self.begin(), self.end());
@@ -68,6 +66,14 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
                 const std::vector<typename T::value_type> &value) {
                self[i].assign(value.begin(), value.end());
              });
+  else
+    view.def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
+                               const T value) {
+      if constexpr (std::is_same_v<decltype(self[i]), T>)
+        self[i] = value;
+      else
+        throw std::runtime_error("Setting items of this type is not possible.");
+    });
 }
 
 void init_element_array_view(py::module &m) {
@@ -106,4 +112,7 @@ void init_element_array_view(py::module &m) {
   declare_ElementArrayView<event_list<scipp::core::time_point>>(m,
                                                                 "time_point");
   declare_ElementArrayView<Eigen::Matrix3d>(m, "Eigen_Matrix3d");
+  declare_ElementArrayView<bucket<Variable>>(m, "bucket_Variable");
+  declare_ElementArrayView<bucket<DataArray>>(m, "bucket_DataArray");
+  declare_ElementArrayView<bucket<Dataset>>(m, "bucket_Dataset");
 }

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -68,7 +68,7 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
              });
   else
     view.def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
-                               const T value) {
+                               [[maybe_unused]] const T value) {
       if constexpr (std::is_same_v<decltype(self[i]), T>)
         self[i] = value;
       else

--- a/python/scipp.cpp
+++ b/python/scipp.cpp
@@ -6,6 +6,7 @@
 
 namespace py = pybind11;
 
+void init_buckets(py::module &);
 void init_choose(py::module &);
 void init_comparison(py::module &);
 void init_counts(py::module &);
@@ -33,6 +34,7 @@ void init_core(py::module &m) {
   init_eigen(core);
   init_dtype(core);
   init_variable(core);
+  init_buckets(core);
   init_choose(core);
   init_counts(core);
   init_dataset(core);

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -24,6 +24,7 @@ from ._utils import collapse, slices
 from .compat.dict import to_dict, from_dict
 
 # Wrappers for free functions from _scipp.core
+from ._buckets import *
 from ._comparison import *
 from ._math import *
 from ._reduction import *

--- a/python/src/scipp/_buckets.py
+++ b/python/src/scipp/_buckets.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+
+
+def to_buckets(data, dim, begin=None, end=None):
+    """Create variable with elements defined as slices of `data` along `dim`.
+
+    The elements of the returned variable are "buckets", defined as views into
+    `data`. The returned variable keeps and manages a copy of `data` internally.
+
+    The variables `begin` and `end` must have the same dims and shape and
+    `dtype=sc.dtype.int64`. The output dims and shape are given by `begin`.
+    If only `begin` is given, each bucket is a slice containing a non-range
+    slice of `data` at the given indices. If neither `begin` nor `end` are
+    given, the output has `dims=[dim]` and contains all non-range slices along
+    that dimension.
+
+    :param data: Variable, DataArray, or Dataset to map into buckets.
+    :param dim: Dimension for selecting slices of `data`.
+    :param begin: Variable with begin-indices for slicing `data` (optional).
+    :param end: Variable with end-indices for slicing `data` (optional).
+    :return: Variable with elements that are view into `data`.
+    """
+    return _call_cpp_func(_cpp.to_buckets,
+                          dim=dim,
+                          data=data,
+                          begin=begin,
+                          end=end)

--- a/python/src/scipp/_buckets.py
+++ b/python/src/scipp/_buckets.py
@@ -9,7 +9,8 @@ def to_buckets(data, dim, begin=None, end=None):
     """Create variable with elements defined as slices of `data` along `dim`.
 
     The elements of the returned variable are "buckets", defined as views into
-    `data`. The returned variable keeps and manages a copy of `data` internally.
+    `data`. The returned variable keeps and manages a copy of `data`
+    internally.
 
     The variables `begin` and `end` must have the same dims and shape and
     `dtype=sc.dtype.int64`. The output dims and shape are given by `begin`.

--- a/python/tests/test_buckets.py
+++ b/python/tests/test_buckets.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import pytest
+import scipp as sc
+
+
+def test_to_buckets_default_begin_end():
+    data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    var = sc.to_buckets(dim='x', data=data)
+    assert var.dims == data.dims
+    assert var.shape == data.shape
+    for i in range(4):
+        assert sc.is_equal(var['x', i].value, data['x', i])
+
+
+def test_to_buckets_default_end():
+    data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    begin = sc.Variable(dims=['y'], values=[1, 3])
+    var = sc.to_buckets(begin=begin, dim='x', data=data)
+    assert var.dims == begin.dims
+    assert var.shape == begin.shape
+    assert sc.is_equal(var['y', 0].value, data['x', 1])
+    assert sc.is_equal(var['y', 1].value, data['x', 3])
+
+
+def test_to_buckets_fail_only_end():
+    data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    end = sc.Variable(dims=['y'], values=[1, 3])
+    with pytest.raises(RuntimeError):
+        sc.to_buckets(end=end, dim='x', data=data)
+
+
+def test_to_buckets():
+    data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    begin = sc.Variable(dims=['y'], values=[0, 2])
+    end = sc.Variable(dims=['y'], values=[2, 4])
+    var = sc.to_buckets(begin=begin, end=end, dim='x', data=data)
+    assert var.dims == begin.dims
+    assert var.shape == begin.shape
+    assert sc.is_equal(var['y', 0].value, data['x', 0:2])
+    assert sc.is_equal(var['y', 1].value, data['x', 2:4])

--- a/python/tests/test_buckets.py
+++ b/python/tests/test_buckets.py
@@ -16,7 +16,7 @@ def test_to_buckets_default_begin_end():
 
 def test_to_buckets_default_end():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    begin = sc.Variable(dims=['y'], values=[1, 3])
+    begin = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.dtype.int64)
     var = sc.to_buckets(begin=begin, dim='x', data=data)
     assert var.dims == begin.dims
     assert var.shape == begin.shape
@@ -26,15 +26,15 @@ def test_to_buckets_default_end():
 
 def test_to_buckets_fail_only_end():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    end = sc.Variable(dims=['y'], values=[1, 3])
+    end = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.dtype.int64)
     with pytest.raises(RuntimeError):
         sc.to_buckets(end=end, dim='x', data=data)
 
 
 def test_to_buckets():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    begin = sc.Variable(dims=['y'], values=[0, 2])
-    end = sc.Variable(dims=['y'], values=[2, 4])
+    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
+    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
     var = sc.to_buckets(begin=begin, end=end, dim='x', data=data)
     assert var.dims == begin.dims
     assert var.shape == begin.shape

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -25,7 +25,7 @@ public:
             const Dim dim, T buffer)
       : VariableConcept(dimensions), m_buckets(std::move(buckets)), m_dim(dim),
         m_buffer(std::move(buffer)) {
-    if (!get_dims(m_buffer).count(m_dim))
+    if (!m_buffer.dims().count(m_dim))
       throw except::DimensionError("Buffer must contain bucket slicing dim.");
     if (this->dims().volume() != scipp::size(m_buckets))
       throw except::DimensionError(
@@ -93,12 +93,6 @@ public:
   }
 
 private:
-  auto get_dims(const T &obj) const {
-    if constexpr (std::is_same_v<T, dataset::Dataset>)
-      return obj.dimensions();
-    else
-      return obj.dims();
-  }
   element_array<range_type> m_buckets;
   Dim m_dim;
   T m_buffer;

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -48,12 +48,9 @@ public:
 
   VariableConceptHandle
   makeDefaultFromParent(const Dimensions &dims) const override {
-    if constexpr (std::is_same_v<T, Variable>)
-      return std::make_unique<DataModel>(
-          dims, element_array<range_type>(dims.volume()), m_dim,
-          T(m_buffer, get_dims(m_buffer)));
-    throw std::runtime_error(
-        "makeDefaultFromParent not implemented yet for this bucket type");
+    return std::make_unique<DataModel>(dims,
+                                       element_array<range_type>(dims.volume()),
+                                       m_dim, T{m_buffer.slice({m_dim, 0, 0})});
   }
 
   static DType static_dtype() noexcept { return scipp::dtype<bucket<T>>; }

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -249,6 +249,7 @@ public:
   Variable operator-() const;
 
   auto &underlying() const { return *m_variable; }
+  bool is_trivial() const noexcept;
 
 protected:
   const Variable *m_variable{nullptr};

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -342,4 +342,8 @@ using variable::Variable;
 using variable::VariableConstView;
 using variable::VariableView;
 using variable::Variances;
+template <class T> struct is_view : std::false_type {};
+template <class T> inline constexpr bool is_view_v = is_view<T>::value;
+template <> struct is_view<VariableConstView> : std::true_type {};
+template <> struct is_view<VariableView> : std::true_type {};
 } // namespace scipp

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -19,54 +19,54 @@ using Model = DataModel<bucket<Variable>>;
 class BucketModelTest : public ::testing::Test {
 protected:
   Dimensions dims{Dim::Y, 2};
-  element_array<std::pair<scipp::index, scipp::index>> buckets{{0, 2}, {2, 4}};
+  element_array<std::pair<scipp::index, scipp::index>> indices{{0, 2}, {2, 4}};
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
 };
 
 TEST_F(BucketModelTest, construct) {
-  Model model(dims, buckets, Dim::X, buffer);
-  EXPECT_THROW(Model(dims, buckets, Dim::Y, buffer), except::DimensionError);
+  Model model(dims, indices, Dim::X, buffer);
+  EXPECT_THROW(Model(dims, indices, Dim::Y, buffer), except::DimensionError);
 }
 
 TEST_F(BucketModelTest, dtype) {
-  Model model(dims, buckets, Dim::X, buffer);
+  Model model(dims, indices, Dim::X, buffer);
   EXPECT_NE(model.dtype(), buffer.dtype());
   EXPECT_EQ(model.dtype(), dtype<bucket<Variable>>);
 }
 
 TEST_F(BucketModelTest, variances) {
-  Model model(dims, buckets, Dim::X, buffer);
+  Model model(dims, indices, Dim::X, buffer);
   EXPECT_FALSE(model.hasVariances());
   EXPECT_THROW(model.setVariances(Variable(buffer)), except::VariancesError);
   EXPECT_FALSE(model.hasVariances());
 }
 
 TEST_F(BucketModelTest, comparison) {
-  EXPECT_EQ(Model(dims, buckets, Dim::X, buffer),
-            Model(dims, buckets, Dim::X, buffer));
-  EXPECT_NE(Model(dims, buckets, Dim::X, buffer),
-            Model({{Dim::X, Dim::Y}, {2, 1}}, buckets, Dim::X, buffer));
-  auto buckets2 = buckets;
-  buckets2.data()[0] = {0, 1};
-  EXPECT_NE(Model(dims, buckets, Dim::X, buffer),
-            Model(dims, buckets2, Dim::X, buffer));
+  EXPECT_EQ(Model(dims, indices, Dim::X, buffer),
+            Model(dims, indices, Dim::X, buffer));
+  EXPECT_NE(Model(dims, indices, Dim::X, buffer),
+            Model({{Dim::X, Dim::Y}, {2, 1}}, indices, Dim::X, buffer));
+  auto indices2 = indices;
+  indices2.data()[0] = {0, 1};
+  EXPECT_NE(Model(dims, indices, Dim::X, buffer),
+            Model(dims, indices2, Dim::X, buffer));
   auto buffer2 = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                       Values{1, 2, 3, 4});
-  EXPECT_NE(Model(dims, buckets, Dim::X, buffer2),
-            Model(dims, buckets, Dim::Y, buffer2));
-  EXPECT_NE(Model(dims, buckets, Dim::X, buffer),
-            Model(dims, buckets, Dim::X, buffer2));
+  EXPECT_NE(Model(dims, indices, Dim::X, buffer2),
+            Model(dims, indices, Dim::Y, buffer2));
+  EXPECT_NE(Model(dims, indices, Dim::X, buffer),
+            Model(dims, indices, Dim::X, buffer2));
 }
 
 TEST_F(BucketModelTest, clone) {
-  Model model(dims, buckets, Dim::X, buffer);
+  Model model(dims, indices, Dim::X, buffer);
   const auto copy = model.clone();
   EXPECT_EQ(dynamic_cast<const Model &>(*copy), model);
 }
 
 TEST_F(BucketModelTest, values) {
-  Model model(dims, buckets, Dim::X, buffer);
+  Model model(dims, indices, Dim::X, buffer);
   EXPECT_EQ(*(model.values().begin() + 0), buffer.slice({Dim::X, 0, 2}));
   EXPECT_EQ(*(model.values().begin() + 1), buffer.slice({Dim::X, 2, 4}));
   (*model.values().begin()) += 2.0 * units::one;
@@ -74,7 +74,7 @@ TEST_F(BucketModelTest, values) {
 }
 
 TEST_F(BucketModelTest, values_const) {
-  const Model model(dims, buckets, Dim::X, buffer);
+  const Model model(dims, indices, Dim::X, buffer);
   EXPECT_EQ(*(model.values().begin() + 0), buffer.slice({Dim::X, 0, 2}));
   EXPECT_EQ(*(model.values().begin() + 1), buffer.slice({Dim::X, 2, 4}));
 }

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -12,10 +12,10 @@ using Model = variable::DataModel<bucket<Variable>>;
 class VariableBucketTest : public ::testing::Test {
 protected:
   Dimensions dims{Dim::Y, 2};
-  element_array<std::pair<scipp::index, scipp::index>> buckets{{0, 2}, {2, 4}};
+  element_array<std::pair<scipp::index, scipp::index>> indices{{0, 2}, {2, 4}};
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
-  Variable var{std::make_unique<Model>(dims, buckets, Dim::X, buffer)};
+  Variable var{std::make_unique<Model>(dims, indices, Dim::X, buffer)};
 };
 
 TEST_F(VariableBucketTest, comparison) {

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -63,3 +63,8 @@ TEST_F(VariableBucketTest, view) {
   EXPECT_EQ(vals.size(), 1);
   EXPECT_EQ(vals[0], buffer.slice({Dim::X, 2, 4}));
 }
+
+TEST_F(VariableBucketTest, construct_from_view) {
+  Variable copy{VariableView(var)};
+  EXPECT_EQ(copy, var);
+}

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -10,11 +10,17 @@
 
 namespace scipp::variable {
 
+// TODO Is there a bug here? Checking dims of underlying not enough, need to
+// also check data dims?
 Variable::Variable(const VariableConstView &slice)
-    : Variable(slice ? Variable(slice, slice.dims()) : Variable()) {
+    : Variable(slice ? slice.dims() == slice.underlying().dims()
+                           ? Variable(slice.underlying())
+                           : Variable(slice, slice.dims())
+                     : Variable()) {
   // There is a bug in the implementation of MultiIndex used in ElementArrayView
   // in case one of the dimensions has extent 0.
-  if (slice && dims().volume() != 0)
+  if (slice && slice.dims() != slice.underlying().dims() &&
+      dims().volume() != 0)
     data().copy(slice, *this);
 }
 

--- a/variable/variable_instantiate_bucket_elements.cpp
+++ b/variable/variable_instantiate_bucket_elements.cpp
@@ -6,6 +6,6 @@
 
 namespace scipp::variable {
 
-INSTANTIATE_BUCKET_VARIABLE(bucket_Variable, bucket<Variable>)
+INSTANTIATE_BUCKET_VARIABLE(VariableView, bucket<Variable>)
 
 } // namespace scipp::variable


### PR DESCRIPTION
Part of #1281.

- Add `sc.to_buckets`. Works for variables, data arrays, and datasets.
- Fixes #1211, at least to a large extent.