### PR TITLE
Preparations for supporting buckets in transform

### DIFF
--- a/core/include/scipp/core/element_array_view.h
+++ b/core/include/scipp/core/element_array_view.h
@@ -66,6 +66,7 @@ public:
 
   scipp::index size() const { return m_iterDims.volume(); }
   constexpr const Dimensions &dims() const noexcept { return m_iterDims; }
+  constexpr const Dimensions &dataDims() const noexcept { return m_dataDims; }
 
   bool overlaps(const element_array_view &other) const {
     // TODO We could be less restrictive here and use a more sophisticated check

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -9,13 +9,6 @@
 
 namespace scipp::core {
 
-template <class T> scipp::index to_linear(const T &coord, const T &shape) {
-  scipp::index linear = coord.front();
-  for (scipp::index d = 1; d < scipp::size(coord); ++d)
-    linear = shape[d] * linear + coord[d];
-  return linear;
-}
-
 /// Strides in dataDims when iterating iterDims.
 inline auto get_strides(const Dimensions &iterDims,
                         const Dimensions &dataDims) {

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -63,8 +63,31 @@ public:
     ++m_iter_index;
   }
 
+  constexpr void advance(const scipp::index offset) noexcept {
+    m_iter_index += offset;
+    auto remainder{m_iter_index};
+    for (scipp::index d = 0; d < NDIM_MAX; ++d) {
+      if (m_shape[d] == 0)
+        continue;
+      m_coord[d] = remainder % m_shape[d];
+      remainder /= m_shape[d];
+    }
+    for (scipp::index data = 0; data < N; ++data) {
+      m_data_index[data] = 0;
+      for (scipp::index d = 0; d < NDIM_MAX; ++d)
+        m_data_index[data] += m_stride[data][d] * m_coord[d];
+    }
+  }
+
   constexpr auto get() const noexcept { return m_data_index; }
   constexpr scipp::index index() const noexcept { return m_iter_index; }
+
+  constexpr bool operator==(const MultiIndex &other) const noexcept {
+    return m_iter_index == other.m_iter_index;
+  }
+  constexpr bool operator!=(const MultiIndex &other) const noexcept {
+    return m_iter_index != other.m_iter_index;
+  }
 
   scipp::index end_sentinel() const noexcept { return m_end_sentinel; }
 

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp-core_export.h"
+#include "scipp/core/dimensions.h"
+
+namespace scipp::core {
+
+template <class T> scipp::index to_linear(const T &coord, const T &shape) {
+  scipp::index linear = coord.front();
+  for (scipp::index d = 1; d < scipp::size(coord); ++d)
+    linear = shape[d] * linear + coord[d];
+  return linear;
+}
+
+/// Strides in dataDims when iterating iterDims.
+auto get_strides(const Dimensions &iterDims, const Dimensions &dataDims) {
+  std::array<scipp::index, NDIM_MAX> strides = {};
+  scipp::index d = iterDims.ndim() - 1;
+  for (const auto dim : iterDims.labels()) {
+    if (dataDims.contains(dim))
+      strides[d--] = dataDims.offset(dim);
+    else
+      strides[d--] = 0;
+  }
+  return strides;
+}
+
+template <class... DataDims> class SCIPP_CORE_EXPORT MultiIndex {
+public:
+  constexpr static scipp::index N = sizeof...(DataDims);
+  MultiIndex(const Dimensions &iterDims, const DataDims &... dataDims) {
+    scipp::index d = iterDims.ndim() - 1;
+    for (const auto size : iterDims.shape())
+      m_shape[d--] = size;
+    m_stride = std::array<std::array<scipp::index, NDIM_MAX>, N>{
+        get_strides(iterDims, dataDims)...};
+  }
+
+  constexpr void increment_outer() noexcept {
+    scipp::index d = 0;
+    while ((m_coord[d] == m_shape[d]) && (d < NDIM_MAX - 1)) {
+      for (scipp::index data = 0; data < N; ++data)
+        m_data_index[data] +=
+            m_stride[data][d + 1] - m_coord[d] * m_stride[data][d];
+      ++m_coord[d + 1];
+      m_coord[d] = 0;
+      ++d;
+    }
+  }
+
+  constexpr void increment() noexcept {
+    for (scipp::index data = 0; data < N; ++data)
+      m_data_index[data] += m_stride[data][0];
+    ++m_coord[0];
+    if (m_coord[0] == m_shape[0])
+      increment_outer();
+    ++m_iter_index;
+  }
+
+  constexpr auto get() const noexcept { return m_data_index; }
+  constexpr scipp::index index() const noexcept { return m_iter_index; }
+
+  constexpr bool operator==(const MultiIndex &other) const noexcept {
+    return m_iter_index == other.m_iter_index;
+  }
+  constexpr bool operator!=(const MultiIndex &other) const noexcept {
+    return m_iter_index != other.m_iter_index;
+  }
+
+private:
+  std::array<scipp::index, N> m_data_index = {};
+  scipp::index m_iter_index{0};
+  std::array<std::array<scipp::index, NDIM_MAX>, N> m_stride = {};
+  std::array<scipp::index, NDIM_MAX> m_coord = {};
+  std::array<scipp::index, NDIM_MAX> m_shape = {};
+};
+
+} // namespace scipp::core

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -34,8 +34,10 @@ public:
   constexpr static scipp::index N = sizeof...(DataDims);
   MultiIndex(const Dimensions &iterDims, const DataDims &... dataDims) {
     scipp::index d = iterDims.ndim() - 1;
-    for (const auto size : iterDims.shape())
+    for (const auto size : iterDims.shape()) {
       m_shape[d--] = size;
+      m_end_sentinel *= size;
+    }
     m_stride = std::array<std::array<scipp::index, NDIM_MAX>, N>{
         get_strides(iterDims, dataDims)...};
   }
@@ -64,12 +66,7 @@ public:
   constexpr auto get() const noexcept { return m_data_index; }
   constexpr scipp::index index() const noexcept { return m_iter_index; }
 
-  constexpr bool operator==(const MultiIndex &other) const noexcept {
-    return m_iter_index == other.m_iter_index;
-  }
-  constexpr bool operator!=(const MultiIndex &other) const noexcept {
-    return m_iter_index != other.m_iter_index;
-  }
+  scipp::index end_sentinel() const noexcept { return m_end_sentinel; }
 
 private:
   std::array<scipp::index, N> m_data_index = {};
@@ -77,6 +74,7 @@ private:
   std::array<std::array<scipp::index, NDIM_MAX>, N> m_stride = {};
   std::array<scipp::index, NDIM_MAX> m_coord = {};
   std::array<scipp::index, NDIM_MAX> m_shape = {};
+  scipp::index m_end_sentinel{1};
 };
 
 } // namespace scipp::core

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -17,7 +17,8 @@ template <class T> scipp::index to_linear(const T &coord, const T &shape) {
 }
 
 /// Strides in dataDims when iterating iterDims.
-auto get_strides(const Dimensions &iterDims, const Dimensions &dataDims) {
+inline auto get_strides(const Dimensions &iterDims,
+                        const Dimensions &dataDims) {
   std::array<scipp::index, NDIM_MAX> strides = {};
   scipp::index d = iterDims.ndim() - 1;
   for (const auto dim : iterDims.labels()) {

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   element_special_values_test.cpp
   element_trigonometry_test.cpp
   element_util_test.cpp
+  multi_index_test.cpp
   string_test.cpp
   time_point_test.cpp
   value_and_variance_test.cpp

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "scipp/core/multi_index.h"
+
+using namespace scipp;
+using namespace scipp::core;
+
+class MultiIndexTest : public ::testing::Test {
+protected:
+  void check(MultiIndex<Dimensions> i,
+             const std::vector<scipp::index> &indices) const {
+    for (const auto index : indices) {
+      EXPECT_EQ(i.get(), (std::array<scipp::index, 1>{index}));
+      i.increment();
+    }
+  }
+  void check(MultiIndex<Dimensions, Dimensions> i,
+             const std::vector<scipp::index> &indices0,
+             const std::vector<scipp::index> &indices1) const {
+    for (scipp::index n = 0; n < scipp::size(indices0); ++n) {
+      EXPECT_EQ(i.get(), (std::array{indices0[n], indices1[n]}));
+      i.increment();
+    }
+  }
+  Dimensions x{{Dim::X}, {2}};
+  Dimensions yx{{Dim::Y, Dim::X}, {3, 2}};
+  Dimensions xy{{Dim::X, Dim::Y}, {2, 3}};
+  Dimensions xz{{Dim::X, Dim::Z}, {2, 4}};
+  Dimensions xyz{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
+};
+
+TEST_F(MultiIndexTest, to_linear) {
+  EXPECT_EQ(to_linear(std::vector{0}, std::vector{2}), 0);
+  EXPECT_EQ(to_linear(std::vector{1}, std::vector{2}), 1);
+  EXPECT_EQ(to_linear(std::vector{0, 0}, std::vector{1, 1}), 0);
+  EXPECT_EQ(to_linear(std::vector{0, 1}, std::vector{2, 2}), 1);
+  EXPECT_EQ(to_linear(std::vector{1, 0}, std::vector{2, 2}), 2);
+  EXPECT_EQ(to_linear(std::vector{1, 1}, std::vector{2, 2}), 3);
+}
+
+namespace {
+constexpr static auto check_strides =
+    [](const Dimensions &iter, const Dimensions &data,
+       const std::vector<scipp::index> &expected) {
+      std::array<scipp::index, NDIM_MAX> array = {};
+      std::copy_n(expected.begin(), expected.size(), array.begin());
+      EXPECT_EQ(get_strides(iter, data), array);
+    };
+}
+
+TEST_F(MultiIndexTest, get_strides) {
+  check_strides({Dim::X, 1}, {Dim::X, 1}, {1});
+  check_strides({Dim::X, 2}, {Dim::X, 2}, {1});
+  // Y sliced out, broadcast slice to X
+  check_strides({Dim::X, 2}, {Dim::Y, 2}, {0});
+  // Note that internally order is reversed
+  check_strides(yx, yx, {1, 2});
+  check_strides(xy, yx, {2, 1});
+}
+
+TEST_F(MultiIndexTest, broadcast_inner) { check({xy, x}, {0, 0, 0, 1, 1, 1}); }
+
+TEST_F(MultiIndexTest, broadcast_outer) { check({yx, x}, {0, 1, 0, 1, 0, 1}); }
+
+TEST_F(MultiIndexTest, slice_inner) { check({x, xy}, {0, 3}); }
+
+TEST_F(MultiIndexTest, slice_middle) {
+  check({xz, xyz}, {0, 1, 2, 3, 12, 13, 14, 15});
+}
+
+TEST_F(MultiIndexTest, slice_outer) { check({x, yx}, {0, 1}); }
+
+TEST_F(MultiIndexTest, 2d) { check({xy, xy}, {0, 1, 2, 3, 4, 5}); }
+
+TEST_F(MultiIndexTest, 2d_transpose) { check({yx, xy}, {0, 3, 1, 4, 2, 5}); }
+
+TEST_F(MultiIndexTest, slice_and_broadcast) {
+  check({xz, yx}, {0, 0, 0, 0, 1, 1, 1, 1});
+  check({xz, xy}, {0, 0, 0, 0, 3, 3, 3, 3});
+  check({yx, xz}, {0, 4, 0, 4, 0, 4});
+}
+
+TEST_F(MultiIndexTest, multiple_data_indices) {
+  check({xy, yx, xy}, {0, 2, 4, 1, 3, 5}, {0, 1, 2, 3, 4, 5});
+  check({yx, yx, xy}, {0, 1, 2, 3, 4, 5}, {0, 3, 1, 4, 2, 5});
+}

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -27,6 +27,7 @@ protected:
     }
   }
   Dimensions x{{Dim::X}, {2}};
+  Dimensions y{{Dim::Y}, {3}};
   Dimensions yx{{Dim::Y, Dim::X}, {3, 2}};
   Dimensions xy{{Dim::X, Dim::Y}, {2, 3}};
   Dimensions xz{{Dim::X, Dim::Z}, {2, 4}};
@@ -85,6 +86,8 @@ TEST_F(MultiIndexTest, slice_and_broadcast) {
 }
 
 TEST_F(MultiIndexTest, multiple_data_indices) {
+  check({yx, x, y}, {0, 1, 0, 1, 0, 1}, {0, 0, 1, 1, 2, 2});
+  check({xy, x, y}, {0, 0, 0, 1, 1, 1}, {0, 1, 2, 0, 1, 2});
   check({xy, yx, xy}, {0, 2, 4, 1, 3, 5}, {0, 1, 2, 3, 4, 5});
   check({yx, yx, xy}, {0, 1, 2, 3, 4, 5}, {0, 3, 1, 4, 2, 5});
 }

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -17,6 +17,7 @@ protected:
       EXPECT_EQ(i.get(), (std::array<scipp::index, 1>{index}));
       i.increment();
     }
+    EXPECT_EQ(i.index(), i.end_sentinel());
   }
   void check(MultiIndex<Dimensions, Dimensions> i,
              const std::vector<scipp::index> &indices0,
@@ -25,6 +26,7 @@ protected:
       EXPECT_EQ(i.get(), (std::array{indices0[n], indices1[n]}));
       i.increment();
     }
+    EXPECT_EQ(i.index(), i.end_sentinel());
   }
   Dimensions x{{Dim::X}, {2}};
   Dimensions y{{Dim::Y}, {3}};

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -49,15 +49,6 @@ protected:
   Dimensions xyz{{Dim::X, Dim::Y, Dim::Z}, {2, 3, 4}};
 };
 
-TEST_F(MultiIndexTest, to_linear) {
-  EXPECT_EQ(to_linear(std::vector{0}, std::vector{2}), 0);
-  EXPECT_EQ(to_linear(std::vector{1}, std::vector{2}), 1);
-  EXPECT_EQ(to_linear(std::vector{0, 0}, std::vector{1, 1}), 0);
-  EXPECT_EQ(to_linear(std::vector{0, 1}, std::vector{2, 2}), 1);
-  EXPECT_EQ(to_linear(std::vector{1, 0}, std::vector{2, 2}), 2);
-  EXPECT_EQ(to_linear(std::vector{1, 1}, std::vector{2, 2}), 3);
-}
-
 namespace {
 constexpr static auto check_strides =
     [](const Dimensions &iter, const Dimensions &data,

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -392,6 +392,8 @@ public:
   Dataset &operator*=(const DatasetConstView &other);
   Dataset &operator/=(const DatasetConstView &other);
 
+  // TODO dims() required for generic code. Need proper equivalent to class
+  // Dimensions that does not imply dimension order.
   std::unordered_map<Dim, scipp::index> dimensions() const;
   std::unordered_map<Dim, scipp::index> dims() const { return dimensions(); }
 

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -245,6 +245,10 @@ template <class... Ts> class as_ElementArrayViewImpl {
               // goes out of scope.
               return data[0].to_pybind();
             } else if constexpr (is_view_v<std::decay_t<decltype(data[0])>>) {
+              // Views such as VariableView are returned by value and require
+              // separate handling to avoid the
+              // py::return_value_policy::reference_internal in the default case
+              // below.
               auto ret = py::cast(data[0], py::return_value_policy::move);
               pybind11::detail::keep_alive_impl(ret, obj);
               return ret;

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -274,7 +274,7 @@ static void transform_elements(Op op, Out &&out, Ts &&... other) {
       auto indices = begin;
       indices.advance(range.begin());
       auto end = begin;
-      end.advance(range.end() - range.begin());
+      end.advance(range.end());
       run(indices, end);
     };
     core::parallel::parallel_for(core::parallel::blocked_range(0, out.size()),
@@ -622,7 +622,7 @@ template <bool dry_run> struct in_place {
           auto indices = begin_;
           indices.advance(range.begin());
           auto end = begin_;
-          end.advance(range.end() - range.begin());
+          end.advance(range.end());
           run_(indices, end);
         };
         core::parallel::parallel_for(


### PR DESCRIPTION
- Add `MultiIndex`, to replace `ViewIndex` in `transform`. Instead of having multiple indices (one for each transform argument) this will handle all indices in one. This is slightly more efficient, but the main reason is simplification for the next step, where we will need to load subrange indices for buckets in the inner iteration (to replace iteration over each `event_list`).
- Partially use `MultiIndex` in `transform`. A full replacement is not possible at this point, since `event_list` iteration in the nested iteration step cannot be handled by `MultiIndex`. The resulting duplication is temporary and will be removed once we remove support for `event_list`, i.e., once we can fully handle all operations with buckets.
- Thanks to `MultiIndex` we actually appear to regain some performance that was lost in a previous preparatory refactor step. This may not be sustained once we introduce bucket handling.

Note also that eventually we would like to remove `ViewIndex`, which for now is a near-duplicate of `MultiIndex`. However, `ViewIndex` is not just used by `transform`, but also when accessing value or variances arrays directly using the Python or C++ API. It is not clear whether this could or should also be implemented using `MultiIndex`.