### PR TITLE
Add optional precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,5 @@ repos:
       rev: v0.30.0
       hooks:
         - id: yapf
+          args: ["-i", "-r"]
+          files: "python"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  -   repo: https://github.com/pycqa/flake8
+      rev: 3.8.3
+      hooks:
+        - id: flake8
+  -   repo: https://github.com/pre-commit/mirrors-yapf
+      rev: v0.30.0
+      hooks:
+        - id: yapf

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -116,3 +116,13 @@ Building Documentation
 - Activate a conda environment with Mantid or ensure Mantid is in your ``PYTHONPATH``
 - If Mantid is unavailable (e.g. on Windows) edit ``docs/conf.py`` and include ``nbsphinx_allow_errors = True``. Take care to not commit this change though.
 - Run ``sphinx-build scipp/src/docs .``
+
+Precommit Hooks
+---------------
+
+If you wish, you can install precommit hooks for flake8 and yapf. In the source directory run:
+
+.. code-block:: bash
+
+  pre-commit install
+  pre-commit run --all-files

--- a/scipp-developer-no-mantid.yml
+++ b/scipp-developer-no-mantid.yml
@@ -31,6 +31,11 @@ dependencies:
   - psutil
   - pytest
 
+  # Formatting & static analysis
+  - pre-commit
+  - yapf
+  - flake8
+
   # Docs
   - ipython=7.2.0
   - pandoc

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -32,6 +32,11 @@ dependencies:
   - psutil
   - pytest
 
+  # Formatting & static analysis
+  - pre-commit
+  - yapf
+  - flake8
+
   # Docs
   - ipython=7.2.0
   - pandoc


### PR DESCRIPTION
Adds optionally installable precommit hooks for `flake8` and `yapf` and documents this in the developer documentation.
