### PR TITLE
Convert Mantid Run to native data structures

### DIFF
--- a/.azure-pipelines/templates/code_quality_checks.yml
+++ b/.azure-pipelines/templates/code_quality_checks.yml
@@ -74,7 +74,7 @@ stages:
               versionSpec: '3.x'
               addToPath: true
               architecture: 'x64'
-          - bash: pip install flake8 yapf==0.29.0
+          - bash: pip install flake8 yapf==0.30.0
             displayName: 'Install tooling'
           - bash: |
               set -ex

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -71,12 +71,14 @@ def make_variables_from_run_logs(ws):
     lookup_units.update(additional_unit_mapping)
     for property_name in ws.run().keys():
         units_string = ws.run()[property_name].units
-        unit = lookup_units.get(units_string, sc.units.one)
+        unit = lookup_units.get(units_string, None)
         values = deepcopy(ws.run()[property_name].value)
 
-        if units_string and unit == sc.units.one:
+        if units_string and unit is None:
             warnings.warn(f"Workspace run log '{property_name}' "
                           f"has unrecognised units: '{units_string}'")
+        if unit is None:
+            unit = sc.units.one
 
         try:
             times = deepcopy(ws.run()[property_name].times)

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -53,10 +53,24 @@ def make_run(ws):
     return sc.Variable(value=deepcopy(ws.run()))
 
 
+additional_unit_mapping = {
+    "Kelvin": sc.units.K,
+    "microsecond": sc.units.us,
+    "nanosecond": sc.units.ns,
+    "second": sc.units.s,
+    "Angstrom": sc.units.angstrom,
+    "Hz": sc.units.dimensionless / sc.units.s,
+    "degree": sc.units.deg,
+}
+# Alternatively we could make use of a library for this,
+# for example pint (https://pint.readthedocs.io)
+
+
 def make_variables_from_run_logs(ws):
     lookup_units = dict(
         zip([str(unit) for unit in sc.units.supported_units()],
             sc.units.supported_units()))
+    lookup_units.update(additional_unit_mapping)
     for property_name in ws.run().keys():
         units_string = ws.run()[property_name].units
         units = lookup_units.get(units_string, None)
@@ -101,8 +115,8 @@ def make_variables_from_run_logs(ws):
                                                       unit=sc.units.ns)
                                       })
             yield property_name, sc.Variable(data_array)
-
-        yield property_name, property_data
+        else:
+            yield property_name, property_data
 
 
 def make_sample(ws):

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -62,8 +62,6 @@ additional_unit_mapping = {
     "Hz": sc.units.dimensionless / sc.units.s,
     "degree": sc.units.deg,
 }
-# Alternatively we could make use of a library for this,
-# for example pint (https://pint.readthedocs.io)
 
 
 def make_variables_from_run_logs(ws):
@@ -77,9 +75,8 @@ def make_variables_from_run_logs(ws):
         values = deepcopy(ws.run()[property_name].value)
 
         if units_string and units is None:
-            warnings.warn(
-                f"Workspace run log '{property_name}' has units which are "
-                f"unrecognised by scipp: '{units_string}'")
+            warnings.warn(f"Workspace run log '{property_name}' "
+                          f"has unrecognised units: '{units_string}'")
 
         try:
             times = deepcopy(ws.run()[property_name].times)

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -74,7 +74,7 @@ def make_variables_from_run_logs(ws):
         unit = lookup_units.get(units_string, sc.units.one)
         values = deepcopy(ws.run()[property_name].value)
 
-        if units_string and unit is None:
+        if units_string and unit == sc.units.one:
             warnings.warn(f"Workspace run log '{property_name}' "
                           f"has unrecognised units: '{units_string}'")
 

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -464,11 +464,11 @@ class TestMantidConversion(unittest.TestCase):
         # after
         self.assertTrue(target.run().hasProperty("test_property"))
 
-    def test_convert_run_logs_to_unaligned_coords(self):
+    def test_convert_array_run_log_to_unaligned_coords(self):
         # Given a Mantid workspace with a run log
         import mantid.simpleapi as mantid
         target = mantid.CloneWorkspace(self.base_event_ws)
-        log_name = "proton_charge"
+        log_name = "SampleTemp"
         self.assertTrue(
             target.run().hasProperty(log_name),
             f"Expected input workspace to have a {log_name} run log")
@@ -480,8 +480,32 @@ class TestMantidConversion(unittest.TestCase):
         self.assertTrue(
             np.allclose(target.run()[log_name].value,
                         d.unaligned_coords[log_name].values),
-            "Expected values in the unaligned coord to match the original run log from the Mantid workspace"
-        )
+            "Expected values in the unaligned coord to match "
+            "the original run log from the Mantid workspace")
+        self.assertEqual(d.unaligned_coords[log_name].units, sc.units.K)
+        self.assertTrue(
+            np.allclose(target.run()[log_name].times,
+                        d.unaligned_coords[log_name].coords["times"].values),
+            "Expected times in the unaligned coord to match "
+            "the original run log from the Mantid workspace")
+
+    def test_convert_scalar_run_log_to_unaligned_coords(self):
+        # Given a Mantid workspace with a run log
+        import mantid.simpleapi as mantid
+        target = mantid.CloneWorkspace(self.base_event_ws)
+        log_name = "start_time"
+        self.assertTrue(
+            target.run().hasProperty(log_name),
+            f"Expected input workspace to have a {log_name} run log")
+
+        # When the workspace is converted to a scipp data array
+        d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
+
+        # Then the data array contains the run log as an unaligned coord
+        self.assertEqual(
+            target.run()[log_name].value, d.unaligned_coords[log_name].value,
+            "Expected value of the unaligned coord to match "
+            "the original run log from the Mantid workspace")
 
     def test_set_sample(self):
         import mantid.simpleapi as mantid

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -478,8 +478,8 @@ class TestMantidConversion(unittest.TestCase):
 
         # Then the data array contains the run log as an unaligned coord
         self.assertTrue(
-            np.allclose(target.run().getProperty(log_name).value,
-                        d.unaligned_coords[log_name].value),
+            np.allclose(target.run()[log_name].value,
+                        d.unaligned_coords[log_name].values),
             "Expected values in the unaligned coord to match the original run log from the Mantid workspace"
         )
 

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -1,6 +1,7 @@
 # Tests in this file work only with a working Mantid installation available in
 # PYTHONPATH.
 import unittest
+import warnings
 
 import numpy as np
 import pytest
@@ -507,6 +508,19 @@ class TestMantidConversion(unittest.TestCase):
             target.run()[log_name].value, d.unaligned_coords[log_name].value,
             "Expected value of the unaligned coord to match "
             "the original run log from the Mantid workspace")
+
+    def test_warning_raised_when_convert_run_log_with_unrecognised_units(self):
+        import mantid.simpleapi as mantid
+        target = mantid.CloneWorkspace(self.base_event_ws)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            mantidcompat.convert_EventWorkspace_to_data_array(target, False)
+            self.assertGreater(
+                len(caught_warnings), 0,
+                "Expected warnings due to some run logs"
+                "having unrecognised units strings")
+            self.assertTrue(
+                any("unrecognised units" in str(caught_warning.message)
+                    for caught_warning in caught_warnings))
 
     def test_set_sample(self):
         import mantid.simpleapi as mantid

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -48,7 +48,7 @@ class TestMantidConversion(unittest.TestCase):
         ws = mantid.Rebin(eventWS, 10000, PreserveEvents=False)
         d = mantidcompat.convert_Workspace2D_to_data_array(ws)
         self.assertEqual(
-            d.coords["run"].value.getProperty("run_start").value,
+            d.coords["run_start"].value,
             "2012-05-21T15:14:56.279289666",
         )
         self.assertEqual(d.data.unit, sc.units.counts)
@@ -86,10 +86,8 @@ class TestMantidConversion(unittest.TestCase):
             eventWS, realign_events=False, load_pulse_times=False)
         d.realign({'tof': realigned.coords['tof']})
 
-        # Removing run and sample due to missing comparison operators
-        del d.unaligned_coords['run']
+        # Removing sample due to missing comparison operators
         del d.unaligned_coords['sample']
-        del realigned.unaligned_coords['run']
         del realigned.unaligned_coords['sample']
         assert sc.is_equal(realigned, d)
 
@@ -301,7 +299,6 @@ class TestMantidConversion(unittest.TestCase):
             # Absence of the following is not crucial, but currently there is
             # no need for these, and it avoid duplication:
             assert 'detector-info' not in monitor.coords
-            assert 'run' not in monitor.coords
             assert 'sample' not in monitor.coords
 
     def test_mdhisto_workspace_q(self):
@@ -453,17 +450,6 @@ class TestMantidConversion(unittest.TestCase):
         assert 'function' in params.coords
         assert 'cost-function' in params.coords
         assert 'chi^2/d.o.f.' in params.coords
-
-    def test_set_run(self):
-        import mantid.simpleapi as mantid
-        target = mantid.CloneWorkspace(self.base_event_ws)
-        d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
-        d.unaligned_coords["run"].value.addProperty("test_property", 1, True)
-        # before
-        self.assertFalse(target.run().hasProperty("test_property"))
-        target.setRun(d.unaligned_coords["run"].value)
-        # after
-        self.assertTrue(target.run().hasProperty("test_property"))
 
     def test_convert_array_run_log_to_unaligned_coords(self):
         # Given a Mantid workspace with a run log

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -297,9 +297,11 @@ class TestMantidConversion(unittest.TestCase):
             # from sample:
             assert 'sample-position' not in monitor.coords
             # Absence of the following is not crucial, but currently there is
-            # no need for these, and it avoid duplication:
+            # no need for these, and it avoids duplication:
             assert 'detector-info' not in monitor.coords
             assert 'sample' not in monitor.coords
+            assert 'SampleTemp' not in monitor.coords,\
+                "Expect run logs not be duplicated in monitor workspaces"
 
     def test_mdhisto_workspace_q(self):
         from mantid.simpleapi import (CreateMDWorkspace, FakeMDEventData,
@@ -473,7 +475,7 @@ class TestMantidConversion(unittest.TestCase):
         self.assertTrue(
             np.array_equal(
                 target.run()[log_name].times.astype(np.int64),
-                d.unaligned_coords[log_name].values.coords["times"].values),
+                d.unaligned_coords[log_name].values.coords["time"].values),
             "Expected times in the unaligned coord to match "
             "the original run log from the Mantid workspace")
 

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -464,6 +464,25 @@ class TestMantidConversion(unittest.TestCase):
         # after
         self.assertTrue(target.run().hasProperty("test_property"))
 
+    def test_convert_run_logs_to_unaligned_coords(self):
+        # Given a Mantid workspace with a run log
+        import mantid.simpleapi as mantid
+        target = mantid.CloneWorkspace(self.base_event_ws)
+        log_name = "proton_charge"
+        self.assertTrue(
+            target.run().hasProperty(log_name),
+            f"Expected input workspace to have a {log_name} run log")
+
+        # When the workspace is converted to a scipp data array
+        d = mantidcompat.convert_EventWorkspace_to_data_array(target, False)
+
+        # Then the data array contains the run log as an unaligned coord
+        self.assertTrue(
+            np.allclose(target.run().getProperty(log_name).value,
+                        d.unaligned_coords[log_name].value),
+            "Expected values in the unaligned coord to match the original run log from the Mantid workspace"
+        )
+
     def test_set_sample(self):
         import mantid.simpleapi as mantid
         target = mantid.CloneWorkspace(self.base_event_ws)

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -479,13 +479,14 @@ class TestMantidConversion(unittest.TestCase):
         # Then the data array contains the run log as an unaligned coord
         self.assertTrue(
             np.allclose(target.run()[log_name].value,
-                        d.unaligned_coords[log_name].values),
+                        d.unaligned_coords[log_name].values.data.values),
             "Expected values in the unaligned coord to match "
             "the original run log from the Mantid workspace")
-        self.assertEqual(d.unaligned_coords[log_name].units, sc.units.K)
+        self.assertEqual(d.unaligned_coords[log_name].values.unit, sc.units.K)
         self.assertTrue(
-            np.allclose(target.run()[log_name].times,
-                        d.unaligned_coords[log_name].coords["times"].values),
+            np.array_equal(
+                target.run()[log_name].times.astype(np.int64),
+                d.unaligned_coords[log_name].values.coords["times"].values),
             "Expected times in the unaligned coord to match "
             "the original run log from the Mantid workspace")
 

--- a/tools/cppcheck.Dockerfile
+++ b/tools/cppcheck.Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux
 
-RUN pacman -Sy --noconfirm cppcheck && \
+RUN pacman -Syu --noconfirm cppcheck && \
     mkdir -p '/data/'
 
 VOLUME ['/data']


### PR DESCRIPTION
Closes #1303 

Instead of copying the Mantid `Run` object when converting from a Mantid workspace, run logs are converted to scipp `Variable`s and, in the case of time series logs, `DataArray`s.

An attempt is made to convert units strings to scipp units, a warning is raised whenever the unit string is not recognised. This is implemented using a lookup table with scipp's string representations of units, supplemented with a few extra mappings for unit strings that are common in our example files, for example "Hz" -> "s^-1". This is not particularly satisfactory; for example it will currently fail on these strings in one of the SNS files used in the tests:
"picoCoulombs", "millimetres", "uA.hours".

When loading monitor workspaces with a data workspace the run logs are not loaded for the monitor workspaces. This avoids the overhead of loading many times only to delete the duiplicates, and also avoids duplicate warnings for unrecognised unit strings.

Not implemented:
- The goniometer is in the Mantid `Run` object and is currently ignored (not converted).
- `to_mantid` makes no attempt to populate the `Run` object in the created workspace. This is not a change to the current situation, however it was previously possible to call `set_run()` on the workspace with the copied `Run` object.