### PR TITLE
Improve "show" svg in case where there are many 0D Variables

### DIFF
--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -213,30 +213,27 @@ class VariableDrawer():
 
         def make_label(dim, extent, axis):
             if axis == 2:
-                return '<text x="{}" y="{}" text-anchor="middle" fill="dim-color" \
-                        style="font-size:#smaller-font">{}</text>'.format(
-                    dx + self._margin + 0.5 * extent,
-                    dy + view_height - self._margin + _smaller_font, dim)
+                x_pos = dx + self._margin + 0.5 * extent
+                y_pos = dy + view_height - self._margin + _smaller_font
+                return f'<text x="{x_pos}" y="{y_pos}" text-anchor="middle" \
+                         fill="dim-color" \
+                         style="font-size:#smaller-font">{dim}</text>'
+
             if axis == 1:
-                return '<text x="x_pos" y="y_pos" text-anchor="middle" \
+                x_pos = dx + self._margin - 0.3 * _smaller_font
+                y_pos = dy + view_height - self._margin - 0.5 * extent
+                return f'<text x="{x_pos}" y="{y_pos}" text-anchor="middle" \
                     fill="dim-color" style="font-size:#smaller-font" \
-                    transform="rotate(-90, x_pos, y_pos)">{}</text>'.replace(
-                    'x_pos',
-                    str(dx + self._margin - 0.3 * _smaller_font)).replace(
-                        'y_pos',
-                        str(dy + view_height - self._margin -
-                            0.5 * extent)).format(dim)
+                    transform="rotate(-90, {x_pos}, {y_pos})">{dim}</text>'
+
             if axis == 0:
-                return '<text x="x_pos" y="y_pos" text-anchor="middle" \
+                x_pos = dx + self._margin + 0.3 * 0.5 * extent - \
+                        0.2 * _smaller_font
+                y_pos = dy + view_height - self._margin - self._extents(
+                )[-2] - 0.3 * 0.5 * extent - 0.2 * _smaller_font
+                return f'<text x="{x_pos}" y="{y_pos}" text-anchor="middle" \
                     fill="dim-color" style="font-size:#smaller-font" \
-                    transform="rotate(-45, x_pos, y_pos)">{}</text>'.replace(
-                    'x_pos',
-                    str(dx + self._margin + 0.3 * 0.5 * extent -
-                        0.2 * _smaller_font)).replace(
-                            'y_pos',
-                            str(dy + view_height - self._margin -
-                                self._extents()[-2] - 0.3 * 0.5 * extent -
-                                0.2 * _smaller_font)).format(dim)
+                    transform="rotate(-45, {x_pos}, {y_pos})">{dim}</text>'
 
         extents = self._extents()
         for dim in self._variable.dims:
@@ -254,16 +251,18 @@ class VariableDrawer():
         details = 'dims={}, shape={}, unit={}, variances={}'.format(
             self._variable.dims, self._variable.shape, unit,
             self._variable.variances is not None)
+        x_pos = offset[0] + 0
+        y_pos = offset[10] + 0.6
         if title is not None:
-            svg = '<text x="{}" y="{}" \
-                    style="font-size:#normal-font">{}</text>'.format(
-                offset[0] + 0, offset[1] + 0.6, title)
-            svg += '<title>{}</title>'.format(details)
+            svg = f'<text x="{x_pos}" y="{y_pos}" \
+                    style="font-size:#normal-font">{title}</text>'
+
+            svg += f'<title>{details}</title>'
         else:
-            svg = '<text x="{}" y="{}" \
+            svg = f'<text x="{x_pos}" y="{y_pos}" \
                     style="font-size:#small-font">\
-                    {}\
-                    </text>'.format(offset[0] + 0, offset[1] + 0.6, details)
+                    {details}</text>'
+
         return svg
 
     def draw(self, color, offset=np.zeros(2), title=None):

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -8,8 +8,6 @@ import numpy as np
 from ._scipp import core as sc
 from . import config
 from ._utils import is_data_array
-from dataclasses import dataclass
-from typing import Any
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.
@@ -56,14 +54,7 @@ def _color_variants(hex_color):
     return [hex_color, top, side]
 
 
-@dataclass
-class Item:
-    name: str
-    data: Any
-    color: str
-
-
-class VariableDrawer():
+class VariableDrawer:
     def __init__(self, variable, margin=1.0, target_dims=None):
         self._margin = margin
         self._variable = variable
@@ -257,6 +248,11 @@ class VariableDrawer():
         y_pos = offset[1] + 0.6
         if title is not None:
             # Apply a small rotation to avoid long titles overlapping
+            # and truncate really long ones
+            max_title_length = 13
+            title = str(title)
+            title = (title[:max_title_length] +
+                     '..') if len(title) > max_title_length else title
             svg = f'<text x="{x_pos}" y="{y_pos}" \
                     style="font-size:#normal-font" \
                     transform="rotate(-12, {x_pos}, {y_pos})"> \
@@ -317,7 +313,7 @@ class VariableDrawer():
                 self.size()[1], self.draw(color=config.colors['data'])))
 
 
-class DatasetDrawer():
+class DatasetDrawer:
     def __init__(self, dataset):
         self._dataset = dataset
 

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -451,7 +451,7 @@ class DatasetDrawer():
                 return offset
 
             def _append_dot(content, offset, layout_direction):
-                dot = f'<circle cx="{offset[0]+0.15}" cy="{offset[1]+1.5}" r="0.1" fill="black" />'  # noqa #501
+                dot = f'<circle cx="{offset[0]+0.15}" cy="{offset[1]+1.9}" r="0.1" fill="black" />'  # noqa #501
                 content += dot
                 offset = _pad_dot(offset, layout_direction)
                 return content, offset

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -144,7 +144,7 @@ class VariableDrawer():
     def size(self):
         """Return the size (width and height) of the rendered output"""
         width = 2 * self._margin
-        height = 3 * self._margin  # double margin on top for title space
+        height = 4 * self._margin  # double margin on top for title space
         shape = self._extents()
 
         if shape[-1] == self._events_flag:
@@ -251,16 +251,22 @@ class VariableDrawer():
         details = 'dims={}, shape={}, unit={}, variances={}'.format(
             self._variable.dims, self._variable.shape, unit,
             self._variable.variances is not None)
-        x_pos = offset[0] + 0
-        y_pos = offset[10] + 0.6
+        # Small addition to horizontal offset avoids clipping part of the
+        # first letter on the left edge of the image (due to its rotation)
+        x_pos = offset[0] + 0.1
+        y_pos = offset[1] + 0.6
         if title is not None:
+            # Apply a small rotation to avoid long titles overlapping
             svg = f'<text x="{x_pos}" y="{y_pos}" \
-                    style="font-size:#normal-font">{title}</text>'
+                    style="font-size:#normal-font" \
+                    transform="rotate(-12, {x_pos}, {y_pos})"> \
+                    {title}</text>'
 
             svg += f'<title>{details}</title>'
         else:
             svg = f'<text x="{x_pos}" y="{y_pos}" \
-                    style="font-size:#small-font">\
+                    style="font-size:#small-font" \
+                    transform="rotate(-12, {x_pos}, {y_pos})"> \
                     {details}</text>'
 
         return svg

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -55,6 +55,12 @@ def _color_variants(hex_color):
     return [hex_color, top, side]
 
 
+def _truncate_long_string(long_string: str) -> str:
+    max_title_length = 13
+    return (long_string[:max_title_length] +
+            '..') if len(long_string) > max_title_length else long_string
+
+
 class VariableDrawer:
     def __init__(self, variable, margin=1.0, target_dims=None):
         self._margin = margin
@@ -248,22 +254,16 @@ class VariableDrawer:
         x_pos = offset[0] + 0.1
         y_pos = offset[1] + 0.6
         if title is not None:
-            # Apply a small rotation to avoid long titles overlapping
-            # and truncate really long ones
-            max_title_length = 13
-            title = str(title)
-            title = (title[:max_title_length] +
-                     '..') if len(title) > max_title_length else title
+            title = _truncate_long_string(str(title))
             svg = f'<text x="{x_pos}" y="{y_pos}" \
-                    style="font-size:#normal-font" \
-                    transform="rotate(-12, {x_pos}, {y_pos})"> \
+                    style="font-size:#normal-font"> \
                     {title}</text>'
 
             svg += f'<title>{details}</title>'
         else:
+            details = _truncate_long_string(str(details))
             svg = f'<text x="{x_pos}" y="{y_pos}" \
-                    style="font-size:#small-font" \
-                    transform="rotate(-12, {x_pos}, {y_pos})"> \
+                    style="font-size:#small-font"> \
                     {details}</text>'
 
         return svg

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -249,9 +249,7 @@ class VariableDrawer:
         details = 'dims={}, shape={}, unit={}, variances={}'.format(
             self._variable.dims, self._variable.shape, unit,
             self._variable.variances is not None)
-        # Small addition to horizontal offset avoids clipping part of the
-        # first letter on the left edge of the image (due to its rotation)
-        x_pos = offset[0] + 0.1
+        x_pos = offset[0]
         y_pos = offset[1] + 0.6
         if title is not None:
             title = _truncate_long_string(str(title))
@@ -261,7 +259,6 @@ class VariableDrawer:
 
             svg += f'<title>{details}</title>'
         else:
-            details = _truncate_long_string(str(details))
             svg = f'<text x="{x_pos}" y="{y_pos}" \
                     style="font-size:#small-font"> \
                     {details}</text>'

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -18,6 +18,7 @@ _cubes_in_full_width = 24
 # We are effectively rescaling our svg by setting an explicit viewport size.
 # Here we compute relative font sizes, based on a cube width of "1" (px).
 _svg_em = _cubes_in_full_width / _svg_width
+_large_font = round(1.6 * _svg_em, 2)
 _normal_font = round(_svg_em, 2)
 _small_font = round(0.8 * _svg_em, 2)
 _smaller_font = round(0.6 * _svg_em, 2)
@@ -335,29 +336,14 @@ class EllipsisItem:
     @staticmethod
     def append_to_svg(content, width, height, offset, layout_direction,
                       *unused):
-        def _pad_dot(offset, layout_direction):
-            if layout_direction == 'x':
-                offset[0] += 0.3
-            else:
-                offset[1] += 0.3
-            return offset
-
-        def _append_dot(content, offset, layout_direction):
-            dot = f'<circle cx="{offset[0]+0.15}" cy="{offset[1]+1.9}" r="0.1" fill="black" />'  # noqa #501
-            content += dot
-            offset = _pad_dot(offset, layout_direction)
-            return content, offset
-
-        offset = _pad_dot(offset, layout_direction)
-        content, offset = _append_dot(content, offset, layout_direction)
-        content, offset = _append_dot(content, offset, layout_direction)
-        content, offset = _append_dot(content, offset, layout_direction)
-        _pad_dot(offset, layout_direction)
+        x_pos = offset[0] + 0.3
+        y_pos = offset[1] + 2.0
+        content += f'<text x="{x_pos}" y="{y_pos}" \
+                    style="font-size:{_large_font}px"> ... </text>'
 
         ellipsis_size = [1.5, 2.0]
         width, height, offset = _new_size_and_offset(ellipsis_size, width,
                                                      height, layout_direction)
-
         return content, width, height, offset
 
 


### PR DESCRIPTION
Closes #1310 

Changes:
- If there are more than 5 0D Variables then only the first and last are drawn as "drawers" and an ellipsis shows that some were omitted.
- Titles longer than 13 characters are truncated to 13 characters and ".." appended.

![Screenshot_20200914_160418](https://user-images.githubusercontent.com/13455433/93104627-052c1300-f6a6-11ea-9cfd-3c887bdfd8a2.png)
