### PR TITLE
Bind slicing by value to DataArray

### DIFF
--- a/dataset/include/scipp/dataset/slice.h
+++ b/dataset/include/scipp/dataset/slice.h
@@ -16,4 +16,11 @@ slice(const DataArrayConstView &data, const Dim dim,
 slice(const DataArrayConstView &data, const Dim dim,
       const VariableConstView begin, const VariableConstView end);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArrayView
+slice(const DataArrayView &data, const Dim dim, const VariableConstView value);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArrayView
+slice(const DataArrayView &data, const Dim dim, const VariableConstView begin,
+      const VariableConstView end);
+
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/slice.h
+++ b/dataset/include/scipp/dataset/slice.h
@@ -23,4 +23,11 @@ slice(const DataArrayView &data, const Dim dim, const VariableConstView value);
 slice(const DataArrayView &data, const Dim dim, const VariableConstView begin,
       const VariableConstView end);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArrayView
+slice(DataArray &data, const Dim dim, const VariableConstView value);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArrayView
+slice(DataArray &data, const Dim dim, const VariableConstView begin,
+      const VariableConstView end);
+
 } // namespace scipp::dataset

--- a/dataset/slice.cpp
+++ b/dataset/slice.cpp
@@ -110,4 +110,15 @@ DataArrayView slice(const DataArrayView &data, const Dim dim,
                     const VariableConstView end) {
   return slice<DataArrayView>(data, dim, begin, end);
 }
+
+DataArrayView slice(DataArray &data, const Dim dim,
+                    const VariableConstView value) {
+  return slice(DataArrayView(data), dim, value);
+}
+
+DataArrayView slice(DataArray &data, const Dim dim,
+                    const VariableConstView begin,
+                    const VariableConstView end) {
+  return slice(DataArrayView(data), dim, begin, end);
+}
 } // namespace scipp::dataset

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -96,20 +96,21 @@ template <class T> struct slicer {
                   std::is_same_v<T, DataArrayView>) {
       try {
         auto step = py::getattr(py_slice, "step");
-        if (step.is_none()) {
-          std::runtime_error(
+        if (!step.is_none()) {
+          throw std::runtime_error(
               "Step cannot be specified for value based slicing.");
         }
         auto start = py::getattr(py_slice, "start");
         auto stop = py::getattr(py_slice, "stop");
         auto start_var =
             start.is_none()
-                ? Variable{}
+                ? VariableConstView{}
                 : py::getattr(py_slice, "start").cast<VariableConstView>();
         auto stop_var =
             stop.is_none()
-                ? Variable{}
+                ? VariableConstView{}
                 : py::getattr(py_slice, "stop").cast<VariableConstView>();
+
         return slice(self, dim, start_var, stop_var);
       } catch (const py::cast_error &) {
       }

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -101,3 +101,22 @@ class TestSliceByValue:
         with pytest.raises(RuntimeError):
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless] = self._d['b']['x', 0:-2]
+
+    def test_range_slice_with_step_throws(self):
+        with pytest.raises(RuntimeError) as e_info:
+            self._d['a']['x', 1.5 * sc.units.m:4.5 * sc.units.m:4]
+        assert str(e_info.value) == 'dimensionless expected to be equal to m'
+
+    def test_range_start_only(self):
+        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless:]
+        by_index = self._d['a']['x', 1:]
+        assert sc.is_equal(by_value, by_index)
+
+    def test_range_end_only(self):
+        by_value = self._d['a']['x', :2.5 * sc.units.dimensionless]
+        by_index = self._d['a']['x', :2]
+        assert sc.is_equal(by_value, by_index)
+
+    def test_range_all(self):
+        by_value = self._d['a']['x', :]
+        assert sc.is_equal(by_value, self._d['a'])

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Matthew Andrew
+import scipp as sc
+import numpy as np
+from .common import assert_export
+
+class TestSliceByValue:
+    def setup_method(self):
+        var = sc.Variable(['x'], values=np.arange(5, dtype=np.float) + 0.5)
+        values_a = sc.Variable(dims=['x'], values=[1.0,1.1,1.2,1.3,1.4], unit=sc.units.m)
+        self._d = sc.Dataset(data={'a': values_a, 'b': var}, coords={'x': var})
+
+    def test_slice_by_single_value(self):
+        by_value = self._d['a']['x', 1.5*sc.units.dimensionless]
+        by_index = self._d['a']['x', 1]
+        assert sc.is_equal(by_value, by_index)
+
+    def test_assigning_to_slice_by_value(self):
+        self._d['a']['x', 1.5*sc.units.dimensionless] = 5.7 * sc.units.m
+        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        assert slice == np.array(5.7)
+
+    def test_modifying_slice_in_place(self):
+        self._d['a']['x', 1.5*sc.units.dimensionless] *= 2.5
+        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        assert slice == np.array(2.75)
+
+        self._d['a']['x', 1.5*sc.units.dimensionless] += 2.25 * sc.units.m
+        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        assert slice == np.array(5.0)
+
+        self._d['a']['x', 1.5*sc.units.dimensionless] -= 3.0 * sc.units.m
+        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        assert slice == np.array(2.0)
+
+        self._d['a']['x', 1.5*sc.units.dimensionless] /= 2.0
+        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        assert slice == np.array(1.0)
+

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -4,38 +4,101 @@
 # @author Matthew Andrew
 import scipp as sc
 import numpy as np
-from .common import assert_export
+import pytest
+
 
 class TestSliceByValue:
     def setup_method(self):
         var = sc.Variable(['x'], values=np.arange(5, dtype=np.float) + 0.5)
-        values_a = sc.Variable(dims=['x'], values=[1.0,1.1,1.2,1.3,1.4], unit=sc.units.m)
-        self._d = sc.Dataset(data={'a': values_a, 'b': var}, coords={'x': var})
+        values_a = sc.Variable(dims=['x'],
+                               values=[1.0, 1.1, 1.2, 1.3, 1.4],
+                               unit=sc.units.m)
+        values_b = sc.Variable(dims=['x'],
+                               values=[1.0, 2.0, 3.0, 4.0, 5.0],
+                               unit=sc.units.m)
+        self._d = sc.Dataset(data={
+            'a': values_a,
+            'b': values_b
+        },
+                             coords={'x': var})
 
     def test_slice_by_single_value(self):
-        by_value = self._d['a']['x', 1.5*sc.units.dimensionless]
+        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless]
         by_index = self._d['a']['x', 1]
         assert sc.is_equal(by_value, by_index)
 
     def test_assigning_to_slice_by_value(self):
-        self._d['a']['x', 1.5*sc.units.dimensionless] = 5.7 * sc.units.m
-        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        self._d['a']['x', 1.5 * sc.units.dimensionless] = 5.7 * sc.units.m
+        slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(5.7)
 
     def test_modifying_slice_in_place(self):
-        self._d['a']['x', 1.5*sc.units.dimensionless] *= 2.5
-        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        self._d['a']['x', 1.5 * sc.units.dimensionless] *= 2.5
+        slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(2.75)
 
-        self._d['a']['x', 1.5*sc.units.dimensionless] += 2.25 * sc.units.m
-        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        self._d['a']['x', 1.5 * sc.units.dimensionless] += 2.25 * sc.units.m
+        slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(5.0)
 
-        self._d['a']['x', 1.5*sc.units.dimensionless] -= 3.0 * sc.units.m
-        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        self._d['a']['x', 1.5 * sc.units.dimensionless] -= 3.0 * sc.units.m
+        slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(2.0)
 
-        self._d['a']['x', 1.5*sc.units.dimensionless] /= 2.0
-        slice = self._d['a']['x', 1.5*sc.units.dimensionless].values
+        self._d['a']['x', 1.5 * sc.units.dimensionless] /= 2.0
+        slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(1.0)
 
+    def test_slice_with_range(self):
+        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless,
+                                4.5 * sc.units.dimensionless]
+        by_index = self._d['a']['x', 1:-1]
+        assert sc.is_equal(by_value, by_index)
+
+    def test_assign_variable_to_range(self):
+        self._d['a']['x', 1.5 * sc.units.dimensionless,
+                     4.5 * sc.units.dimensionless] = sc.Variable(
+                         dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
+
+        assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
+
+    def test_modify_range_in_place_from_variable(self):
+        self._d['a']['x', 1.5 * sc.units.dimensionless,
+                     4.5 * sc.units.dimensionless] += sc.Variable(
+                         dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
+
+        assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
+
+    def test_assign_dataarray_to_range(self):
+        self._d['a']['x', 1.5 * sc.units.dimensionless,
+                     4.5 * sc.units.dimensionless] = self._d['b']['x', 1:-1]
+
+        assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
+
+    def test_modify_range_in_place_from_dataarray(self):
+        self._d['a']['x', 1.5 * sc.units.dimensionless,
+                     4.5 * sc.units.dimensionless] += self._d['b']['x', 1:-1]
+
+        assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]
+
+    def test_slice_by_incorrect_unit_throws(self):
+        with pytest.raises(RuntimeError) as e_info:
+            self._d['a']['x', 1.5 * sc.units.m]
+        assert str(e_info.value) == 'dimensionless expected to be equal to m'
+
+    def test_out_of_range_throws(self):
+        with pytest.raises(IndexError):
+            self._d['a']['x', 5.0 * sc.units.dimensionless]
+
+    def test_assign_incompatable_variable_throws(self):
+        with pytest.raises(RuntimeError) as e_info:
+            self._d['a']['x', 1.5 * sc.units.dimensionless,
+                         4.5 * sc.units.dimensionless] = sc.Variable(
+                             dims=['x'], values=[6.0, 6.0], unit=sc.units.m)
+        assert str(e_info.value) == '{{x, 3}} expected to be equal to {{x, 2}}'
+
+    def test_assign_incompatible_dataarray(self):
+        with pytest.raises(RuntimeError):
+            self._d['a']['x', 1.5 * sc.units.dimensionless,
+                         4.5 * sc.units.dimensionless] = self._d['b']['x',
+                                                                      0:-2]

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -50,34 +50,34 @@ class TestSliceByValue:
         assert slice == np.array(1.0)
 
     def test_slice_with_range(self):
-        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless,
-                                4.5 * sc.units.dimensionless]
+        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                                sc.units.dimensionless]
         by_index = self._d['a']['x', 1:-1]
         assert sc.is_equal(by_value, by_index)
 
     def test_assign_variable_to_range(self):
-        self._d['a']['x', 1.5 * sc.units.dimensionless,
-                     4.5 * sc.units.dimensionless] = sc.Variable(
+        self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                     sc.units.dimensionless] = sc.Variable(
                          dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
 
     def test_modify_range_in_place_from_variable(self):
-        self._d['a']['x', 1.5 * sc.units.dimensionless,
-                     4.5 * sc.units.dimensionless] += sc.Variable(
+        self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                     sc.units.dimensionless] += sc.Variable(
                          dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
 
     def test_assign_dataarray_to_range(self):
-        self._d['a']['x', 1.5 * sc.units.dimensionless,
-                     4.5 * sc.units.dimensionless] = self._d['b']['x', 1:-1]
+        self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                     sc.units.dimensionless] = self._d['b']['x', 1:-1]
 
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
     def test_modify_range_in_place_from_dataarray(self):
-        self._d['a']['x', 1.5 * sc.units.dimensionless,
-                     4.5 * sc.units.dimensionless] += self._d['b']['x', 1:-1]
+        self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                     sc.units.dimensionless] += self._d['b']['x', 1:-1]
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]
 
@@ -92,13 +92,12 @@ class TestSliceByValue:
 
     def test_assign_incompatable_variable_throws(self):
         with pytest.raises(RuntimeError) as e_info:
-            self._d['a']['x', 1.5 * sc.units.dimensionless,
-                         4.5 * sc.units.dimensionless] = sc.Variable(
+            self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                         sc.units.dimensionless] = sc.Variable(
                              dims=['x'], values=[6.0, 6.0], unit=sc.units.m)
         assert str(e_info.value) == '{{x, 3}} expected to be equal to {{x, 2}}'
 
     def test_assign_incompatible_dataarray(self):
         with pytest.raises(RuntimeError):
-            self._d['a']['x', 1.5 * sc.units.dimensionless,
-                         4.5 * sc.units.dimensionless] = self._d['b']['x',
-                                                                      0:-2]
+            self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                         sc.units.dimensionless] = self._d['b']['x', 0:-2]

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -105,7 +105,8 @@ class TestSliceByValue:
     def test_range_slice_with_step_throws(self):
         with pytest.raises(RuntimeError) as e_info:
             self._d['a']['x', 1.5 * sc.units.m:4.5 * sc.units.m:4]
-        assert str(e_info.value) == 'dimensionless expected to be equal to m'
+        assert str(e_info.value
+                   ) == "Step cannot be specified for value based slicing."
 
     def test_range_start_only(self):
         by_value = self._d['a']['x', 1.5 * sc.units.dimensionless:]


### PR DESCRIPTION
This binds the C++ free functions defined in #1133 to DataArray on the python side. The current syntax for this is `dataArray['dim', 1.5*sc.units...]` or `dataArray['dim', 1.5*sc.units: 45.*sc.units]`. The units are required to unambiguously resolve the overload with index based slicing. 