### PR TITLE
Dataset Slice by Value

### DIFF
--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -118,22 +118,23 @@ Dim edge_dimension(const DataArrayConstView &a) {
   return *dims.begin();
 }
 
-/// Return true if the data array represents a histogram for given dim.
-bool is_histogram(const DataArrayConstView &a, const Dim dim) {
+namespace {
+template <typename T> bool is_histogram_impl(const T &a, const Dim dim) {
   const auto dims = a.dims();
   const auto coords = a.coords();
-  return dims.contains(dim) && coords.contains(dim) &&
+  return dims.count(dim) == 1 && coords.contains(dim) &&
          coords[dim].dims().contains(dim) &&
-         coords[dim].dims()[dim] == dims[dim] + 1;
+         coords[dim].dims()[dim] == dims.at(dim) + 1;
+}
+} // namespace
+/// Return true if the data array represents a histogram for given dim.
+bool is_histogram(const DataArrayConstView &a, const Dim dim) {
+  return is_histogram_impl(a, dim);
 }
 
 /// Return true if the dataset represents a histogram for given dim.
 bool is_histogram(const DatasetConstView &a, const Dim dim) {
-  const auto dims = a.dims();
-  const auto coords = a.coords();
-  return dims.find(dim) != dims.end() && coords.contains(dim) &&
-         coords[dim].dims().contains(dim) &&
-         coords[dim].dims()[dim] == dims.at(dim) + 1;
+  return is_histogram_impl(a, dim);
 }
 
 namespace {

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -118,13 +118,22 @@ Dim edge_dimension(const DataArrayConstView &a) {
   return *dims.begin();
 }
 
-/// Return true if the data array respresents a histogram for given dim.
+/// Return true if the data array represents a histogram for given dim.
 bool is_histogram(const DataArrayConstView &a, const Dim dim) {
   const auto dims = a.dims();
   const auto coords = a.coords();
   return dims.contains(dim) && coords.contains(dim) &&
          coords[dim].dims().contains(dim) &&
          coords[dim].dims()[dim] == dims[dim] + 1;
+}
+
+/// Return true if the dataset represents a histogram for given dim.
+bool is_histogram(const DatasetConstView &a, const Dim dim) {
+  const auto dims = a.dims();
+  const auto coords = a.coords();
+  return dims.find(dim) != dims.end() && coords.contains(dim) &&
+         coords[dim].dims().contains(dim) &&
+         coords[dim].dims()[dim] == dims.at(dim) + 1;
 }
 
 namespace {

--- a/dataset/include/scipp/dataset/histogram.h
+++ b/dataset/include/scipp/dataset/histogram.h
@@ -23,5 +23,7 @@ SCIPP_DATASET_EXPORT std::set<Dim> edge_dimensions(const DataArrayConstView &a);
 SCIPP_DATASET_EXPORT Dim edge_dimension(const DataArrayConstView &a);
 SCIPP_DATASET_EXPORT bool is_histogram(const DataArrayConstView &a,
                                        const Dim dim);
+SCIPP_DATASET_EXPORT bool is_histogram(const DatasetConstView &a,
+                                       const Dim dim);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/slice.h
+++ b/dataset/include/scipp/dataset/slice.h
@@ -30,4 +30,7 @@ slice(DataArray &data, const Dim dim, const VariableConstView value);
 slice(DataArray &data, const Dim dim, const VariableConstView begin,
       const VariableConstView end);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetConstView
+slice(const DatasetConstView &ds, const Dim dim, const VariableConstView value);
+
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/slice.h
+++ b/dataset/include/scipp/dataset/slice.h
@@ -33,4 +33,8 @@ slice(DataArray &data, const Dim dim, const VariableConstView begin,
 [[nodiscard]] SCIPP_DATASET_EXPORT DatasetConstView
 slice(const DatasetConstView &ds, const Dim dim, const VariableConstView value);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetConstView
+slice(const DatasetConstView &ds, const Dim dim, const VariableConstView begin,
+      const VariableConstView end);
+
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/slice.h
+++ b/dataset/include/scipp/dataset/slice.h
@@ -33,8 +33,22 @@ slice(DataArray &data, const Dim dim, const VariableConstView begin,
 [[nodiscard]] SCIPP_DATASET_EXPORT DatasetConstView
 slice(const DatasetConstView &ds, const Dim dim, const VariableConstView value);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetView
+slice(const DatasetView &ds, const Dim dim, const VariableConstView value);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetView
+slice(Dataset &ds, const Dim dim, const VariableConstView value);
+
 [[nodiscard]] SCIPP_DATASET_EXPORT DatasetConstView
 slice(const DatasetConstView &ds, const Dim dim, const VariableConstView begin,
+      const VariableConstView end);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetView
+slice(const DatasetView &ds, const Dim dim, const VariableConstView begin,
+      const VariableConstView end);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT DatasetView
+slice(Dataset &ds, const Dim dim, const VariableConstView begin,
       const VariableConstView end);
 
 } // namespace scipp::dataset

--- a/dataset/slice.cpp
+++ b/dataset/slice.cpp
@@ -125,10 +125,27 @@ DatasetConstView slice(const DatasetConstView &ds, const Dim dim,
                        const VariableConstView value) {
   return slice<DatasetConstView>(ds, dim, value);
 }
+DatasetView slice(const DatasetView &ds, const Dim dim,
+                  const VariableConstView value) {
+  return slice<DatasetView>(ds, dim, value);
+}
+DatasetView slice(Dataset &ds, const Dim dim, const VariableConstView value) {
+  return slice(DatasetView(ds), dim, value);
+}
 
 DatasetConstView slice(const DatasetConstView &ds, const Dim dim,
                        const VariableConstView begin,
                        const VariableConstView end) {
   return slice<DatasetConstView>(ds, dim, begin, end);
+}
+
+DatasetView slice(const DatasetView &ds, const Dim dim,
+                  const VariableConstView begin, const VariableConstView end) {
+  return slice<DatasetView>(ds, dim, begin, end);
+}
+
+DatasetView slice(Dataset &ds, const Dim dim, const VariableConstView begin,
+                  const VariableConstView end) {
+  return slice(DatasetView(ds), dim, begin, end);
 }
 } // namespace scipp::dataset

--- a/dataset/slice.cpp
+++ b/dataset/slice.cpp
@@ -125,4 +125,10 @@ DatasetConstView slice(const DatasetConstView &ds, const Dim dim,
                        const VariableConstView value) {
   return slice<DatasetConstView>(ds, dim, value);
 }
+
+DatasetConstView slice(const DatasetConstView &ds, const Dim dim,
+                       const VariableConstView begin,
+                       const VariableConstView end) {
+  return slice<DatasetConstView>(ds, dim, begin, end);
+}
 } // namespace scipp::dataset

--- a/dataset/slice.cpp
+++ b/dataset/slice.cpp
@@ -32,7 +32,7 @@ scipp::index get_index(const VariableConstView &coord, const Dim dim,
   return std::clamp<scipp::index>(0, i, coord.dims()[dim]);
 }
 
-auto get_1d_coord(const DataArrayConstView &data, const Dim dim) {
+template <typename T> auto get_1d_coord(const T &data, const Dim dim) {
   const auto &coord = data.coords()[dim];
   if (coord.dims().ndim() != 1)
     throw except::DimensionError(
@@ -40,7 +40,7 @@ auto get_1d_coord(const DataArrayConstView &data, const Dim dim) {
   return coord;
 }
 
-auto get_coord(const DataArrayConstView &data, const Dim dim) {
+template <typename T> auto get_coord(const T &data, const Dim dim) {
   const auto &coord = get_1d_coord(data, dim);
   const bool ascending = is_sorted(coord, dim, variable::SortOrder::Ascending);
   const bool descending =
@@ -120,5 +120,9 @@ DataArrayView slice(DataArray &data, const Dim dim,
                     const VariableConstView begin,
                     const VariableConstView end) {
   return slice(DataArrayView(data), dim, begin, end);
+}
+DatasetConstView slice(const DatasetConstView &ds, const Dim dim,
+                       const VariableConstView value) {
+  return slice<DatasetConstView>(ds, dim, value);
 }
 } // namespace scipp::dataset

--- a/dataset/test/histogram_test.cpp
+++ b/dataset/test/histogram_test.cpp
@@ -54,6 +54,10 @@ TEST_F(HistogramHelpersTest, is_histogram) {
   const auto histX = DataArray(dataX, {{Dim::X, edgesX}});
   EXPECT_TRUE(is_histogram(histX, Dim::X));
   EXPECT_FALSE(is_histogram(histX, Dim::Y));
+  // Also for Dataset
+  const auto ds_histX = Dataset{DataArrayConstView{histX}};
+  EXPECT_TRUE(is_histogram(ds_histX, Dim::X));
+  EXPECT_FALSE(is_histogram(ds_histX, Dim::Y));
 
   const auto histX2d = DataArray(dataXY, {{Dim::X, edgesX}});
   EXPECT_TRUE(is_histogram(histX2d, Dim::X));

--- a/dataset/test/slice_by_value_test.cpp
+++ b/dataset/test/slice_by_value_test.cpp
@@ -193,3 +193,30 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_duplicate) {
   auto da = make_histogram(3, 4, 4, 5);
   EXPECT_EQ(slice(da, Dim::X, 4.0 * units::m), da.slice({Dim::X, 2}));
 }
+
+TEST(SliceByValueTest, test_point_on_point_coord_1D_dataset) {
+  auto da = make_points(1, 3, 5, 4, 2);
+  auto ds =
+      Dataset{{{"a", DataArrayConstView{da}}, {"b", DataArrayConstView{da}}}};
+  EXPECT_EQ(slice(ds, Dim::X, 1.0 * units::m), ds.slice({Dim::X, 0}));
+  EXPECT_EQ(slice(ds, Dim::X, 3.0 * units::m), ds.slice({Dim::X, 1}));
+  EXPECT_EQ(slice(ds, Dim::X, 4.0 * units::m), ds.slice({Dim::X, 3}));
+  EXPECT_EQ(slice(ds, Dim::X, 2.0 * units::m), ds.slice({Dim::X, 4}));
+}
+TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_dataset) {
+  auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+  auto ds =
+      Dataset{{{"a", DataArrayConstView{da}}, {"b", DataArrayConstView{da}}}};
+  // Test start on left boundary (closed on left), so includes boundary
+  EXPECT_EQ(slice(ds, Dim::X, 3.0 * units::m), ds.slice({Dim::X, 0}));
+  // Same as above, takes lower bounds of bin so same bin
+  EXPECT_EQ(slice(ds, Dim::X, 3.5 * units::m), ds.slice({Dim::X, 0}));
+  // Next bin
+  EXPECT_EQ(slice(ds, Dim::X, 4.0 * units::m), ds.slice({Dim::X, 1}));
+  // Last bin
+  EXPECT_EQ(slice(ds, Dim::X, 11.9 * units::m), ds.slice({Dim::X, 8}));
+  // (closed on right) so out of bounds
+  EXPECT_THROW(slice(ds, Dim::X, 12.0 * units::m), except::SliceError);
+  // out of bounds for left for completeness
+  EXPECT_THROW(slice(ds, Dim::X, 2.99 * units::m), except::SliceError);
+}

--- a/dataset/test/slice_by_value_test.cpp
+++ b/dataset/test/slice_by_value_test.cpp
@@ -26,197 +26,249 @@ constexpr auto make_points = make_array_common<0>;
 constexpr auto make_histogram = make_array_common<1>;
 
 TEST(SliceByValueTest, test_dimension_not_found) {
+  auto test = [](const auto &sliceable) {
+    EXPECT_THROW(auto s = slice(sliceable, Dim::Y, {}, {}),
+                 except::NotFoundError);
+  };
+
   auto var =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1.0, 2.0, 3.0, 4.0});
   DataArray da{var, {{Dim::X, var}}};
-  EXPECT_THROW(auto s = slice(da, Dim::Y, {}, {}), except::NotFoundError);
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_no_multi_dimensional_coords) {
+  auto test = [](const auto &sliceable) {
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, {}, {}),
+                 except::DimensionError);
+  };
+
   auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});
   DataArray da{var, {{Dim::X, var}}};
-  EXPECT_THROW(auto s = slice(da, Dim::X, {}, {}), except::DimensionError);
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_unsorted_coord_throws) {
+  auto test = [](const auto &sliceable) {
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, {}, {}), std::runtime_error);
+  };
   auto unsorted =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1.0, 2.0, 3.0, 1.5});
   DataArray da{unsorted, {{Dim::X, unsorted}}};
-  EXPECT_THROW(auto s = slice(da, Dim::X, {}, {}), std::runtime_error);
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_begin_end_not_0D_throws) {
   auto da = make_points(0, 1, 2, 3);
   auto one_d = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1.0});
-  EXPECT_THROW(auto s = slice(da, Dim::X, one_d, {}),
-               except::MismatchError<Dimensions>);
-  EXPECT_THROW(auto s = slice(da, Dim::X, {}, one_d),
-               except::MismatchError<Dimensions>);
+  auto test = [&](const auto &sliceable) {
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, one_d, {}),
+                 except::MismatchError<Dimensions>);
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, {}, one_d),
+                 except::MismatchError<Dimensions>);
+  };
+
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slicing_defaults_ascending) {
   auto da = make_points(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-  EXPECT_EQ(da, slice(da, Dim::X, {}, 13.0 * units::m));
-  EXPECT_EQ(da, slice(da, Dim::X, {}, {}));
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 13.0 * units::m));
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, {}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slicing_defaults_descending) {
   auto da = make_points(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
-  EXPECT_EQ(da, slice(da, Dim::X, {}, 2.0 * units::m));
-  EXPECT_EQ(da, slice(da, Dim::X, {}, {}));
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 2.0 * units::m));
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, {}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_ascending) {
   auto da = make_points(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-  // No effect slicing
-  auto out = slice(da, Dim::X, 3.0 * units::m, 13.0 * units::m);
-  EXPECT_EQ(da, out);
-  // Test start on left boundary (closed on left), so includes boundary
-  out = slice(da, Dim::X, 3.0 * units::m, 4.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test start out of bounds on left truncated
-  out = slice(da, Dim::X, 2.0 * units::m, 4.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test inner values
-  out = slice(da, Dim::X, 3.5 * units::m, 5.5 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 1, 3}));
-  // Test end on right boundary (open on right), so does not include boundary
-  out = slice(da, Dim::X, 11.0 * units::m, 12.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 9}));
-  // Test end out of bounds on right truncated
-  out = slice(da, Dim::X, 11.0 * units::m, 13.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 10}));
+  auto test = [](const auto &sliceable) {
+    // No effect slicing
+    auto out = slice(sliceable, Dim::X, 3.0 * units::m, 13.0 * units::m);
+    EXPECT_EQ(sliceable, out);
+    // Test start on left boundary (closed on left), so includes boundary
+    out = slice(sliceable, Dim::X, 3.0 * units::m, 4.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test start out of bounds on left truncated
+    out = slice(sliceable, Dim::X, 2.0 * units::m, 4.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test inner values
+    out = slice(sliceable, Dim::X, 3.5 * units::m, 5.5 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
+    // Test end on right boundary (open on right), so does not include boundary
+    out = slice(sliceable, Dim::X, 11.0 * units::m, 12.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
+    // Test end out of bounds on right truncated
+    out = slice(sliceable, Dim::X, 11.0 * units::m, 13.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 10}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_descending) {
   auto da = make_points(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
-  // No effect slicing
-  auto out = slice(da, Dim::X, 12.0 * units::m, 2.0 * units::m);
-  EXPECT_EQ(da, out);
-  // Test start on left boundary (closed on left), so includes boundary
-  out = slice(da, Dim::X, 12.0 * units::m, 11.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test start out of bounds on left truncated
-  out = slice(da, Dim::X, 13.0 * units::m, 11.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test inner values
-  out = slice(da, Dim::X, 11.5 * units::m, 9.5 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 1, 3}));
-  // Test end on right boundary (open on right), so does not include boundary
-  out = slice(da, Dim::X, 4.0 * units::m, 3.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 9}));
-  // Test end out of bounds on right truncated
-  out = slice(da, Dim::X, 4.0 * units::m, 1.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 10}));
+  auto test = [](const auto &sliceable) {
+    // No effect slicing
+    auto out = slice(sliceable, Dim::X, 12.0 * units::m, 2.0 * units::m);
+    EXPECT_EQ(sliceable, out);
+    // Test start on left boundary (closed on left), so includes boundary
+    out = slice(sliceable, Dim::X, 12.0 * units::m, 11.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test start out of bounds on left truncated
+    out = slice(sliceable, Dim::X, 13.0 * units::m, 11.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test inner values
+    out = slice(sliceable, Dim::X, 11.5 * units::m, 9.5 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
+    // Test end on right boundary (open on right), so does not include boundary
+    out = slice(sliceable, Dim::X, 4.0 * units::m, 3.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
+    // Test end out of bounds on right truncated
+    out = slice(sliceable, Dim::X, 4.0 * units::m, 1.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 10}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_range_on_edge_coord_1D_ascending) {
   auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-  // No effect slicing
-  auto out = slice(da, Dim::X, 3.0 * units::m, 13.0 * units::m);
-  EXPECT_EQ(out, da);
-  // Test start on left boundary (closed on left), so includes boundary
-  out = slice(da, Dim::X, 3.0 * units::m, 4.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test slicing with range boundary inside edge, same result as above expected
-  out = slice(da, Dim::X, 3.1 * units::m, 4.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test slicing with range lower boundary on upper edge of bin (open on right
-  // test)
-  out = slice(da, Dim::X, 4.0 * units::m, 6.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 1, 3}));
-  // Test end on right boundary (open on right), so does not include boundary
-  out = slice(da, Dim::X, 11.0 * units::m, 12.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 9}));
+  const auto test = [](const auto &sliceable) {
+    // No effect slicing
+    auto out = slice(sliceable, Dim::X, 3.0 * units::m, 13.0 * units::m);
+    EXPECT_EQ(out, sliceable);
+    // Test start on left boundary (closed on left), so includes boundary
+    out = slice(sliceable, Dim::X, 3.0 * units::m, 4.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test slicing with range boundary inside edge, same result as above
+    // expected
+    out = slice(sliceable, Dim::X, 3.1 * units::m, 4.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test slicing with range lower boundary on upper edge of bin (open on
+    // right test)
+    out = slice(sliceable, Dim::X, 4.0 * units::m, 6.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
+    // Test end on right boundary (open on right), so does not include boundary
+    out = slice(sliceable, Dim::X, 11.0 * units::m, 12.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_range_on_edge_coord_1D_descending) {
   auto da = make_histogram(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
   // No effect slicing
-  auto out = slice(da, Dim::X, 12.0 * units::m, 2.0 * units::m);
-  EXPECT_EQ(out, da);
-  // Test start on left boundary (closed on left), so includes boundary
-  out = slice(da, Dim::X, 12.0 * units::m, 11.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test slicing with range boundary inside edge, same result as above expected
-  out = slice(da, Dim::X, 11.9 * units::m, 11.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 0, 1}));
-  // Test slicing with range lower boundary on upper edge of bin (open on right
-  // test)
-  out = slice(da, Dim::X, 11.0 * units::m, 9.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 1, 3}));
-  // Test end on right boundary (open on right), so does not include boundary
-  out = slice(da, Dim::X, 4.0 * units::m, 3.0 * units::m);
-  EXPECT_EQ(out, da.slice({Dim::X, 8, 9}));
+  auto test = [](const auto &sliceable) {
+    auto out = slice(sliceable, Dim::X, 12.0 * units::m, 2.0 * units::m);
+    EXPECT_EQ(out, sliceable);
+    // Test start on left boundary (closed on left), so includes boundary
+    out = slice(sliceable, Dim::X, 12.0 * units::m, 11.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test slicing with range boundary inside edge, same result as above
+    // expected
+    out = slice(sliceable, Dim::X, 11.9 * units::m, 11.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
+    // Test slicing with range lower boundary on upper edge of bin (open on
+    // right test)
+    out = slice(sliceable, Dim::X, 11.0 * units::m, 9.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
+    // Test end on right boundary (open on right), so does not include boundary
+    out = slice(sliceable, Dim::X, 4.0 * units::m, 3.0 * units::m);
+    EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_point_on_point_coord_1D) {
   auto da = make_points(1, 3, 5, 4, 2);
-  EXPECT_EQ(slice(da, Dim::X, 1.0 * units::m), da.slice({Dim::X, 0}));
-  EXPECT_EQ(slice(da, Dim::X, 3.0 * units::m), da.slice({Dim::X, 1}));
-  EXPECT_EQ(slice(da, Dim::X, 4.0 * units::m), da.slice({Dim::X, 3}));
-  EXPECT_EQ(slice(da, Dim::X, 2.0 * units::m), da.slice({Dim::X, 4}));
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * units::m),
+              sliceable.slice({Dim::X, 0}));
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::m),
+              sliceable.slice({Dim::X, 1}));
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::m),
+              sliceable.slice({Dim::X, 3}));
+    EXPECT_EQ(slice(sliceable, Dim::X, 2.0 * units::m),
+              sliceable.slice({Dim::X, 4}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_point_on_point_coord_1D_not_unique) {
   auto da = make_points(1, 3, 5, 3, 2);
-  EXPECT_EQ(slice(da, Dim::X, 1.0 * units::m), da.slice({Dim::X, 0}));
-  EXPECT_THROW(slice(da, Dim::X, 3.0 * units::m), except::SliceError);
-  EXPECT_THROW(slice(da, Dim::X, 4.0 * units::m), except::SliceError);
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * units::m),
+              sliceable.slice({Dim::X, 0}));
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 3.0 * units::m),
+                 except::SliceError);
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 4.0 * units::m),
+                 except::SliceError);
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D) {
   auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-  // Test start on left boundary (closed on left), so includes boundary
-  EXPECT_EQ(slice(da, Dim::X, 3.0 * units::m), da.slice({Dim::X, 0}));
-  // Same as above, takes lower bounds of bin so same bin
-  EXPECT_EQ(slice(da, Dim::X, 3.5 * units::m), da.slice({Dim::X, 0}));
-  // Next bin
-  EXPECT_EQ(slice(da, Dim::X, 4.0 * units::m), da.slice({Dim::X, 1}));
-  // Last bin
-  EXPECT_EQ(slice(da, Dim::X, 11.9 * units::m), da.slice({Dim::X, 8}));
-  // (closed on right) so out of bounds
-  EXPECT_THROW(slice(da, Dim::X, 12.0 * units::m), except::SliceError);
-  // out of bounds for left for completeness
-  EXPECT_THROW(slice(da, Dim::X, 2.99 * units::m), except::SliceError);
+  const auto test = [](const auto &sliceable) {
+    // Test start on left boundary (closed on left), so includes boundary
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::m),
+              sliceable.slice({Dim::X, 0}));
+    // Same as above, takes lower bounds of bin so same bin
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.5 * units::m),
+              sliceable.slice({Dim::X, 0}));
+    // Next bin
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::m),
+              sliceable.slice({Dim::X, 1}));
+    // Last bin
+    EXPECT_EQ(slice(sliceable, Dim::X, 11.9 * units::m),
+              sliceable.slice({Dim::X, 8}));
+    // (closed on right) so out of bounds
+    EXPECT_THROW(slice(sliceable, Dim::X, 12.0 * units::m), except::SliceError);
+    // out of bounds for left for completeness
+    EXPECT_THROW(slice(sliceable, Dim::X, 2.99 * units::m), except::SliceError);
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_duplicate) {
   auto da = make_points(3, 4, 4, 5);
-  EXPECT_EQ(slice(da, Dim::X, 4.0 * units::m, 4.6 * units::m),
-            da.slice({Dim::X, 1, 3}));
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::m, 4.6 * units::m),
+              sliceable.slice({Dim::X, 1, 3}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }
 
 TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_duplicate) {
   // [4,4) is empty bin, 4 is in [4,5)
   auto da = make_histogram(3, 4, 4, 5);
-  EXPECT_EQ(slice(da, Dim::X, 4.0 * units::m), da.slice({Dim::X, 2}));
-}
-
-TEST(SliceByValueTest, test_point_on_point_coord_1D_dataset) {
-  auto da = make_points(1, 3, 5, 4, 2);
-  auto ds =
-      Dataset{{{"a", DataArrayConstView{da}}, {"b", DataArrayConstView{da}}}};
-  EXPECT_EQ(slice(ds, Dim::X, 1.0 * units::m), ds.slice({Dim::X, 0}));
-  EXPECT_EQ(slice(ds, Dim::X, 3.0 * units::m), ds.slice({Dim::X, 1}));
-  EXPECT_EQ(slice(ds, Dim::X, 4.0 * units::m), ds.slice({Dim::X, 3}));
-  EXPECT_EQ(slice(ds, Dim::X, 2.0 * units::m), ds.slice({Dim::X, 4}));
-}
-TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_dataset) {
-  auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-  auto ds =
-      Dataset{{{"a", DataArrayConstView{da}}, {"b", DataArrayConstView{da}}}};
-  // Test start on left boundary (closed on left), so includes boundary
-  EXPECT_EQ(slice(ds, Dim::X, 3.0 * units::m), ds.slice({Dim::X, 0}));
-  // Same as above, takes lower bounds of bin so same bin
-  EXPECT_EQ(slice(ds, Dim::X, 3.5 * units::m), ds.slice({Dim::X, 0}));
-  // Next bin
-  EXPECT_EQ(slice(ds, Dim::X, 4.0 * units::m), ds.slice({Dim::X, 1}));
-  // Last bin
-  EXPECT_EQ(slice(ds, Dim::X, 11.9 * units::m), ds.slice({Dim::X, 8}));
-  // (closed on right) so out of bounds
-  EXPECT_THROW(slice(ds, Dim::X, 12.0 * units::m), except::SliceError);
-  // out of bounds for left for completeness
-  EXPECT_THROW(slice(ds, Dim::X, 2.99 * units::m), except::SliceError);
+  const auto test = [](const auto &sliceable) {
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::m),
+              sliceable.slice({Dim::X, 2}));
+  };
+  test(da);                              // Test for DataArray
+  test(Dataset{DataArrayConstView{da}}); // Test for Dataset
 }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -104,16 +104,19 @@ template <class T> struct slicer {
         }
         auto start = py::getattr(py_slice, "start");
         auto stop = py::getattr(py_slice, "stop");
-        auto start_var =
-            start.is_none()
-                ? VariableConstView{}
-                : py::getattr(py_slice, "start").cast<VariableConstView>();
-        auto stop_var =
-            stop.is_none()
-                ? VariableConstView{}
-                : py::getattr(py_slice, "stop").cast<VariableConstView>();
+        if (!start.is_none() || !stop.is_none()) { // Means default slice : is
+                                                   // treated as index slice
+          auto start_var =
+              start.is_none()
+                  ? VariableConstView{}
+                  : py::getattr(py_slice, "start").cast<VariableConstView>();
+          auto stop_var =
+              stop.is_none()
+                  ? VariableConstView{}
+                  : py::getattr(py_slice, "stop").cast<VariableConstView>();
 
-        return slice(self, dim, start_var, stop_var);
+          return slice(self, dim, start_var, stop_var);
+        }
       } catch (const py::cast_error &) {
       }
     }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -183,5 +183,6 @@ void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
     c.def("__getitem__", &slicer<T>::get_by_value, py::keep_alive<0, 1>());
     c.def("__setitem__", &slicer<T>::template set<DatasetView>);
     c.def("__setitem__", &slicer<T>::template set_range<DatasetView>);
+    c.def("__setitem__", &slicer<T>::template set_by_value<DatasetView>);
   }
 }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -93,7 +93,9 @@ template <class T> struct slicer {
                         const std::tuple<Dim, const py::slice> &index) {
     auto [dim, py_slice] = index;
     if constexpr (std::is_same_v<T, DataArray> ||
-                  std::is_same_v<T, DataArrayView>) {
+                  std::is_same_v<T, DataArrayView> ||
+                  std::is_same_v<T, Dataset> ||
+                  std::is_same_v<T, DatasetView>) {
       try {
         auto step = py::getattr(py_slice, "step");
         if (!step.is_none()) {
@@ -178,6 +180,7 @@ void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
     c.def("__setitem__", &slicer<T>::template set_by_value<DataArrayView>);
   }
   if constexpr (std::is_same_v<T, Dataset> || std::is_same_v<T, DatasetView>) {
+    c.def("__getitem__", &slicer<T>::get_by_value, py::keep_alive<0, 1>());
     c.def("__setitem__", &slicer<T>::template set<DatasetView>);
     c.def("__setitem__", &slicer<T>::template set_range<DatasetView>);
   }

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -45,17 +45,25 @@ class TestSliceByValue:
         self._d['a']['x', 1.5 * sc.units.dimensionless] *= 2.5
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(2.75)
+        slice = self._d['x', 1.5 * sc.units.dimensionless]['a'].values
+        assert slice == np.array(2.75)
 
         self._d['a']['x', 1.5 * sc.units.dimensionless] += 2.25 * sc.units.m
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
+        assert slice == np.array(5.0)
+        slice = self._d['x', 1.5 * sc.units.dimensionless]['a'].values
         assert slice == np.array(5.0)
 
         self._d['a']['x', 1.5 * sc.units.dimensionless] -= 3.0 * sc.units.m
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(2.0)
+        slice = self._d['x', 1.5 * sc.units.dimensionless]['a'].values
+        assert slice == np.array(2.0)
 
         self._d['a']['x', 1.5 * sc.units.dimensionless] /= 2.0
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
+        assert slice == np.array(1.0)
+        slice = self._d['x', 1.5 * sc.units.dimensionless]['a'].values
         assert slice == np.array(1.0)
 
     def test_slice_with_range(self):
@@ -71,15 +79,29 @@ class TestSliceByValue:
 
     def test_assign_variable_to_range(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
-                     sc.units.dimensionless] = sc.Variable(
+                     sc.units.dimensionless].data = sc.Variable(
                          dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
 
+        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                sc.units.dimensionless]['a'].data = sc.Variable(
+                    dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
+
+        assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
+
     def test_modify_range_in_place_from_variable(self):
+        orig = self._d.copy()
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
-                     sc.units.dimensionless] += sc.Variable(
+                     sc.units.dimensionless].data += sc.Variable(
                          dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
+
+        assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
+
+        self._d = orig
+        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                sc.units.dimensionless]['a'].data += sc.Variable(
+                    dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
 
@@ -89,10 +111,21 @@ class TestSliceByValue:
 
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
+        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                sc.units.dimensionless]['a'] = self._d['b']['x', 1:-1]
+
+        assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
+
     def test_modify_range_in_place_from_dataarray(self):
+        orig = self._d.copy()
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                      sc.units.dimensionless] += self._d['b']['x', 1:-1]
 
+        assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]
+
+        self._d = orig
+        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                sc.units.dimensionless]['a'] += self._d['b']['x', 1:-1]
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]
 
     def test_slice_by_incorrect_unit_throws(self):
@@ -127,11 +160,15 @@ class TestSliceByValue:
         by_index = self._d['a']['x', 1:]
         assert sc.is_equal(by_value, by_index)
 
+        by_value = self._d['x', 1.5 * sc.units.dimensionless:]
+        by_index = self._d['x', 1:]
+        assert sc.is_equal(by_value, by_index)
+
     def test_range_end_only(self):
         by_value = self._d['a']['x', :2.5 * sc.units.dimensionless]
         by_index = self._d['a']['x', :2]
         assert sc.is_equal(by_value, by_index)
 
-    def test_range_all(self):
-        by_value = self._d['a']['x', :]
-        assert sc.is_equal(by_value, self._d['a'])
+        by_value = self._d['x', :2.5 * sc.units.dimensionless]
+        by_index = self._d['x', :2]
+        assert sc.is_equal(by_value, by_index)

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -31,11 +31,12 @@ class TestSliceByValue:
         test(self._d['a'])
         test(self._d)
 
-    def test_assigning_to_slice_by_value(self):
+    def test_assigning_to_slice_by_value_dataarray(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless] = 5.7 * sc.units.m
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(5.7)
 
+    def test_assigning_to_slice_by_value_dataset(self):
         self._d['x',
                 0.5 * sc.units.dimensionless] = self._d['x', 1.5 *
                                                         sc.units.dimensionless]
@@ -77,53 +78,53 @@ class TestSliceByValue:
         test(self._d['a'])
         test(self._d)
 
-    def test_assign_variable_to_range(self):
+    def test_assign_variable_to_range_dataarray(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                      sc.units.dimensionless].data = sc.Variable(
                          dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
 
+    def test_assign_variable_to_range_dataset(self):
         self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                 sc.units.dimensionless]['a'].data = sc.Variable(
                     dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
 
-    def test_modify_range_in_place_from_variable(self):
-        orig = self._d.copy()
+    def test_on_dataarray_modify_range_in_place_from_variable(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                      sc.units.dimensionless].data += sc.Variable(
                          dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
 
-        self._d = orig
+    def test_on_dataset_modify_range_in_place_from_variable(self):
         self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                 sc.units.dimensionless]['a'].data += sc.Variable(
                     dims=['x'], values=[2.0, 2.0, 2.0], unit=sc.units.m)
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 3.2, 3.3, 1.4]
 
-    def test_assign_dataarray_to_range(self):
+    def test_on_dataarray_assign_dataarray_to_range(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                      sc.units.dimensionless] = self._d['b']['x', 1:-1]
 
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
+    def test_on_dataset_assign_dataarray_to_range(self):
         self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                 sc.units.dimensionless]['a'] = self._d['b']['x', 1:-1]
 
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
-    def test_modify_range_in_place_from_dataarray(self):
-        orig = self._d.copy()
+    def test_on_dataarray_modify_range_in_place_from_dataarray(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                      sc.units.dimensionless] += self._d['b']['x', 1:-1]
 
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]
 
-        self._d = orig
+    def test_on_dataset_modify_range_in_place_from_dataarray(self):
         self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                 sc.units.dimensionless]['a'] += self._d['b']['x', 1:-1]
         assert self._d['a'].data.values.tolist() == [1.0, 3.1, 4.2, 5.3, 1.4]

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -36,6 +36,11 @@ class TestSliceByValue:
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values
         assert slice == np.array(5.7)
 
+        self._d['x',
+                0.5 * sc.units.dimensionless] = self._d['x', 1.5 *
+                                                        sc.units.dimensionless]
+        assert self._d['x', 0]['a'].value == self._d['x', 1]['a'].value
+
     def test_modifying_slice_in_place(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless] *= 2.5
         slice = self._d['a']['x', 1.5 * sc.units.dimensionless].values

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -23,9 +23,13 @@ class TestSliceByValue:
                              coords={'x': var})
 
     def test_slice_by_single_value(self):
-        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless]
-        by_index = self._d['a']['x', 1]
-        assert sc.is_equal(by_value, by_index)
+        def test(sliceable):
+            by_value = sliceable['x', 1.5 * sc.units.dimensionless]
+            by_index = sliceable['x', 1]
+            assert sc.is_equal(by_value, by_index)
+
+        test(self._d['a'])
+        test(self._d)
 
     def test_assigning_to_slice_by_value(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless] = 5.7 * sc.units.m
@@ -50,10 +54,15 @@ class TestSliceByValue:
         assert slice == np.array(1.0)
 
     def test_slice_with_range(self):
-        by_value = self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
-                                sc.units.dimensionless]
-        by_index = self._d['a']['x', 1:-1]
-        assert sc.is_equal(by_value, by_index)
+        def test(sliceable):
+
+            by_value = sliceable['x', 1.5 * sc.units.dimensionless:4.5 *
+                                 sc.units.dimensionless]
+            by_index = sliceable['x', 1:-1]
+            assert sc.is_equal(by_value, by_index)
+
+        test(self._d['a'])
+        test(self._d)
 
     def test_assign_variable_to_range(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *


### PR DESCRIPTION
Currently missing so we have a mismatch in functionality between index slicing and value slicing. 

This feature is required for introduction of value based slicing into the wavelength slicing used in the SANS notebooks.