### PR TITLE
Bucket concat and append

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,6 +7,10 @@ add_executable(groupby_benchmark EXCLUDE_FROM_ALL groupby_benchmark.cpp)
 add_dependencies(all-benchmarks groupby_benchmark)
 target_link_libraries(groupby_benchmark LINK_PRIVATE scipp-dataset benchmark)
 
+add_executable(buckets_benchmark EXCLUDE_FROM_ALL buckets_benchmark.cpp)
+add_dependencies(all-benchmarks buckets_benchmark)
+target_link_libraries(buckets_benchmark LINK_PRIVATE scipp-dataset benchmark)
+
 add_executable(slice_benchmark EXCLUDE_FROM_ALL slice_benchmark.cpp)
 add_dependencies(all-benchmarks slice_benchmark)
 target_link_libraries(slice_benchmark LINK_PRIVATE scipp-dataset benchmark)

--- a/benchmark/buckets_benchmark.cpp
+++ b/benchmark/buckets_benchmark.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+#include <benchmark/benchmark.h>
+
+#include "scipp/dataset/bucket.h"
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/shape.h"
+#include "scipp/variable/bucket_model.h"
+#include "scipp/variable/operations.h"
+
+using namespace scipp;
+
+auto make_buckets(const scipp::index size, const scipp::index count) {
+  using Model = variable::DataModel<bucket<DataArray>>;
+  Dimensions dims{Dim::Y, size};
+  Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(dims);
+  scipp::index current = 0;
+  for (auto &range : indices.values<std::pair<scipp::index, scipp::index>>()) {
+    range.first = current;
+    current += count / size;
+    range.second = current;
+  }
+  Variable data = makeVariable<double>(Dims{Dim::X}, Shape{count});
+  DataArray buffer = DataArray(data, {{Dim::X, data + data}});
+  return Variable{
+      std::make_unique<Model>(std::move(indices), Dim::X, std::move(buffer))};
+}
+
+static void BM_buckets_concatenate(benchmark::State &state) {
+  const scipp::index nBucket = state.range(0);
+  const scipp::index nEvent = state.range(1);
+  auto events = make_buckets(nBucket, nEvent);
+  for (auto _ : state) {
+    auto var = dataset::buckets::concatenate(events, events);
+    state.PauseTiming();
+    var = Variable();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(state.iterations() * 2 * nEvent);
+  int read_and_write = 2;
+  int data_and_coord = 2;
+  state.SetBytesProcessed(state.iterations() * 2 * nEvent * sizeof(double) *
+                          read_and_write * data_and_coord);
+  state.counters["events"] = nEvent;
+  state.counters["buckets"] = nBucket;
+}
+BENCHMARK(BM_buckets_concatenate)
+    ->RangeMultiplier(4)
+    ->Ranges({{64, 1e6}, {2 << 20, 1e9}});
+
+BENCHMARK_MAIN();

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -203,21 +203,4 @@ Dimensions transpose(const Dimensions &dims, std::vector<Dim> labels) {
   return {labels, shape};
 }
 
-Dimensions concatenate(const Dimensions &a, const Dimensions &b,
-                       const Dim dim) {
-  auto out = a;
-  if (a.contains(dim)) {
-    if (b.contains(dim))
-      out.resize(dim, a[dim] + b[dim]);
-    else
-      out.resize(dim, a[dim] + 1);
-  } else if (b.contains(dim)) {
-    out = b;
-    out.resize(dim, b[dim] + 1);
-  } else {
-    out.add(dim, 2);
-  }
-  return out;
-}
-
 } // namespace scipp::core

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -203,4 +203,21 @@ Dimensions transpose(const Dimensions &dims, std::vector<Dim> labels) {
   return {labels, shape};
 }
 
+Dimensions concatenate(const Dimensions &a, const Dimensions &b,
+                       const Dim dim) {
+  auto out = a;
+  if (a.contains(dim)) {
+    if (b.contains(dim))
+      out.resize(dim, a[dim] + b[dim]);
+    else
+      out.resize(dim, a[dim] + 1);
+  } else if (b.contains(dim)) {
+    out = b;
+    out.resize(dim, b[dim] + 1);
+  } else {
+    out.add(dim, 2);
+  }
+  return out;
+}
+
 } // namespace scipp::core

--- a/core/element_array_view.cpp
+++ b/core/element_array_view.cpp
@@ -25,6 +25,8 @@ void expectCanBroadcastFromTo(const Dimensions &source,
 /// @param offset Start offset from beginning of array.
 /// @param iterDims Dimensions to use for iteration.
 /// @param dataDims Dimensions of array to iterate.
+/// @param bucketParams Optional, in case of view onto bucket-variable this
+/// holds parameters for accessing individual buckets.
 ///
 /// The parameter `iterDims` can be used to remove, slice, broadcast, or
 /// transpose `dataDims`.

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -144,9 +144,6 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
 SCIPP_CORE_EXPORT Dimensions transpose(const Dimensions &dims,
                                        std::vector<Dim> labels = {});
 
-SCIPP_CORE_EXPORT Dimensions concatenate(const Dimensions &a,
-                                         const Dimensions &b, const Dim dim);
-
 } // namespace scipp::core
 
 namespace scipp {

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -144,6 +144,9 @@ Dimensions merge(const Dimensions &a, const Dimensions &b,
 SCIPP_CORE_EXPORT Dimensions transpose(const Dimensions &dims,
                                        std::vector<Dim> labels = {});
 
+SCIPP_CORE_EXPORT Dimensions concatenate(const Dimensions &a,
+                                         const Dimensions &b, const Dim dim);
+
 } // namespace scipp::core
 
 namespace scipp {

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -83,4 +83,23 @@ constexpr auto is_sorted_nonascending = overloaded{
       out = out && (left >= right);
     }};
 
+constexpr auto zip =
+    overloaded{arg_list<scipp::index>,
+               transform_flags::no_event_list_handling,
+               transform_flags::expect_no_variance_arg<0>,
+               transform_flags::expect_no_variance_arg<1>,
+               [](const units::Unit &first, const units::Unit &second) {
+                 expect::equals(first, second);
+                 return first;
+               },
+               [](const auto first, const auto second) {
+                 return std::pair{first, second};
+               }};
+
+template <int N>
+constexpr auto get = overloaded{arg_list<std::pair<scipp::index, scipp::index>>,
+                                transform_flags::expect_no_variance_arg<0>,
+                                [](const auto &x) { return std::get<N>(x); },
+                                [](const units::Unit &u) { return u; }};
+
 } // namespace scipp::core::element

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -100,3 +100,22 @@ TEST(ElementUtilTest, is_sorted) {
   test_is_sorted(is_sorted_nondescending, true);
   test_is_sorted(is_sorted_nonascending, false);
 }
+
+TEST(ElementUtilTest, zip) {
+  EXPECT_EQ(zip(1, 2), (std::pair{1, 2}));
+  EXPECT_EQ(zip(3, 4), (std::pair{3, 4}));
+  EXPECT_EQ(zip(units::m, units::m), units::m);
+  EXPECT_EQ(zip(units::s, units::s), units::s);
+  EXPECT_THROW(zip(units::m, units::s), except::UnitError);
+}
+
+TEST(ElementUtilTest, get) {
+  EXPECT_EQ(core::element::get<0>(std::pair{1, 2}), 1);
+  EXPECT_EQ(core::element::get<1>(std::pair{1, 2}), 2);
+  EXPECT_EQ(core::element::get<0>(std::pair{3, 4}), 3);
+  EXPECT_EQ(core::element::get<1>(std::pair{3, 4}), 4);
+  EXPECT_EQ(core::element::get<0>(units::m), units::m);
+  EXPECT_EQ(core::element::get<0>(units::s), units::s);
+  EXPECT_EQ(core::element::get<1>(units::m), units::m);
+  EXPECT_EQ(core::element::get<1>(units::s), units::s);
+}

--- a/dataset/CMakeLists.txt
+++ b/dataset/CMakeLists.txt
@@ -2,6 +2,7 @@
 # contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-dataset")
 set(INC_FILES
+    include/scipp/dataset/bucket.h
     include/scipp/dataset/choose.h
     include/scipp/dataset/counts.h
     include/scipp/dataset/dataset_access.h
@@ -26,6 +27,7 @@ set(INC_FILES
 
 set(SRC_FILES
     arithmetic.cpp
+    bucket.cpp
     counts.cpp
     data_array.cpp
     dataset_access.cpp

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -18,7 +18,6 @@
 #include "scipp/variable/transform.h"
 #include "scipp/variable/util.h"
 
-
 namespace scipp::dataset::buckets {
 
 namespace {

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -90,12 +90,16 @@ void copy(const DataArrayConstView &src, const DataArrayView &dst,
           const Dim dim, const VariableConstView &srcIndices,
           const VariableConstView &dstIndices) {
   copy(src.data(), dst.data(), dim, srcIndices, dstIndices);
+  const auto copy_or_match = [&](const auto &a, const auto &b) {
+    if (a.dims().contains(dim))
+      copy(a, b, dim, srcIndices, dstIndices);
+    else
+      core::expect::equals(a, b);
+  };
   for (const auto &[name, coord] : src.coords())
-    if (coord.dims().contains(dim))
-      copy(coord, dst.coords()[name], dim, srcIndices, dstIndices);
+    copy_or_match(coord, dst.coords()[name]);
   for (const auto &[name, mask] : src.masks())
-    if (mask.dims().contains(dim))
-      copy(mask, dst.masks()[name], dim, srcIndices, dstIndices);
+    copy_or_match(mask, dst.masks()[name]);
 }
 
 auto resize_buffer(const VariableConstView &parent, const Dim dim,

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -16,56 +16,12 @@
 #include "scipp/variable/shape.h"
 #include "scipp/variable/subspan_view.h"
 #include "scipp/variable/transform.h"
+#include "scipp/variable/util.h"
 
-namespace scipp::core::element::bucket {
 
-constexpr auto zip =
-    overloaded{element::arg_list<scipp::index>,
-               transform_flags::no_event_list_handling,
-               transform_flags::expect_no_variance_arg<0>,
-               transform_flags::expect_no_variance_arg<1>,
-               [](const units::Unit &first, const units::Unit &second) {
-                 expect::equals(first, second);
-                 return first;
-               },
-               [](const auto first, const auto second) {
-                 return std::pair{first, second};
-               }};
-
-template <int N>
-constexpr auto get =
-    overloaded{element::arg_list<core::bucket_base::range_type>,
-               transform_flags::expect_no_variance_arg<0>,
-               [](const auto &x) { return std::get<N>(x); },
-               [](const units::Unit &u) { return u; }};
-
-constexpr auto copy = overloaded{
-    element::arg_list<std::tuple<span<double>, span<const double>>>,
-    transform_flags::expect_all_or_none_have_variance,
-    [](units::Unit &a, const units::Unit &b) { expect::equals(a, b); },
-    [](auto &dst, const auto &src) {
-      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(dst)>>) {
-        std::copy(src.value.begin(), src.value.end(), dst.value.begin());
-        std::copy(src.variance.begin(), src.variance.end(),
-                  dst.variance.begin());
-      } else {
-        std::copy(src.begin(), src.end(), dst.begin());
-      }
-    }};
-} // namespace scipp::core::element::bucket
-
-namespace scipp::dataset {
-
-namespace buckets {
+namespace scipp::dataset::buckets {
 
 namespace {
-auto zip(const VariableConstView &first, const VariableConstView &second) {
-  return transform(first, second, core::element::bucket::zip);
-}
-auto unzip(const VariableConstView &var) {
-  return std::pair{transform(var, core::element::bucket::get<0>),
-                   transform(var, core::element::bucket::get<1>)};
-}
 
 auto sizes_to_begin(const VariableConstView &sizes) {
   Variable begin(sizes);
@@ -78,12 +34,25 @@ auto sizes_to_begin(const VariableConstView &sizes) {
   return std::tuple{begin, size};
 }
 
+constexpr auto copy_spans = overloaded{
+    core::element::arg_list<std::tuple<span<double>, span<const double>>>,
+    core::transform_flags::expect_all_or_none_have_variance,
+    [](units::Unit &a, const units::Unit &b) { core::expect::equals(a, b); },
+    [](auto &dst, const auto &src) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(dst)>>) {
+        std::copy(src.value.begin(), src.value.end(), dst.value.begin());
+        std::copy(src.variance.begin(), src.variance.end(),
+                  dst.variance.begin());
+      } else {
+        std::copy(src.begin(), src.end(), dst.begin());
+      }
+    }};
+
 void copy(const VariableConstView &src, const VariableView &dst, const Dim dim,
           const VariableConstView &srcIndices,
           const VariableConstView &dstIndices) {
   transform_in_place(subspan_view(dst, dim, dstIndices),
-                     subspan_view(src, dim, srcIndices),
-                     core::element::bucket::copy);
+                     subspan_view(src, dim, srcIndices), copy_spans);
 }
 
 void copy(const DataArrayConstView &src, const DataArrayView &dst,
@@ -165,5 +134,4 @@ void append(const VariableView &var0, const VariableConstView &var1) {
     var0.replace_model(combine<DataArray>(var0, var1));
 }
 
-} // namespace buckets
-} // namespace scipp::dataset
+} // namespace scipp::dataset::buckets

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <algorithm>
+
+#include "scipp/common/overloaded.h"
+#include "scipp/core/bucket.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/except.h"
+#include "scipp/dataset/bucket.h"
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/shape.h"
+#include "scipp/variable/arithmetic.h"
+#include "scipp/variable/bucket_model.h"
+#include "scipp/variable/subspan_view.h"
+#include "scipp/variable/transform.h"
+
+namespace scipp::core::element::bucket {
+
+constexpr auto sizes =
+    overloaded{element::arg_list<core::bucket_base::range_type>,
+               transform_flags::expect_no_variance_arg<0>,
+               [](const units::Unit &u) {
+                 expect::equals(u, units::one);
+                 return units::one;
+               },
+               [](const auto &range) { return range.second - range.first; }};
+
+constexpr auto zip =
+    overloaded{element::arg_list<scipp::index>,
+               transform_flags::no_event_list_handling,
+               transform_flags::expect_no_variance_arg<0>,
+               transform_flags::expect_no_variance_arg<1>,
+               [](const units::Unit &first, const units::Unit &second) {
+                 expect::equals(first, second);
+                 return first;
+               },
+               [](const auto first, const auto second) {
+                 return std::pair{first, second};
+               }};
+
+constexpr auto add_to_component = overloaded{
+    element::arg_list<std::tuple<core::bucket_base::range_type, int64_t>>,
+    transform_flags::expect_no_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    [](units::Unit &a, const units::Unit &b) { a += b; }};
+constexpr auto add_to_first =
+    overloaded{add_to_component, [](auto &a, const auto &b) { a.first += b; }};
+constexpr auto add_to_second =
+    overloaded{add_to_component, [](auto &a, const auto &b) { a.second += b; }};
+
+constexpr auto copy = overloaded{
+    element::arg_list<std::tuple<span<double>, span<const double>>>,
+    transform_flags::expect_all_or_none_have_variance,
+    [](units::Unit &a, const units::Unit &b) { expect::equals(a, b); },
+    [](auto &dst, const auto &src) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(dst)>>) {
+        std::copy(src.value.begin(), src.value.end(), dst.value.begin());
+        std::copy(src.variance.begin(), src.variance.end(),
+                  dst.variance.begin());
+      } else {
+        std::copy(src.begin(), src.end(), dst.begin());
+      }
+    }};
+} // namespace scipp::core::element::bucket
+
+namespace scipp::dataset {
+
+namespace buckets {
+
+/// TODO A number of these functions would be redundant if we used an inner
+/// extra dim of size 2 instead of a pair.
+auto sizes(const VariableConstView &indices) {
+  return transform(indices, core::element::bucket::sizes);
+}
+auto zip(const VariableConstView &first, const VariableConstView &second) {
+  return transform(first, second, core::element::bucket::zip);
+}
+void add_to_first(const VariableView &a, const VariableConstView &b) {
+  transform_in_place(a, b, core::element::bucket::add_to_first);
+}
+void add_to_second(const VariableView &a, const VariableConstView &b) {
+  transform_in_place(a, b, core::element::bucket::add_to_second);
+}
+
+auto sizes_to_indices(const VariableConstView &sizes) {
+  auto indices = zip(sizes * makeVariable<scipp::index>(Values{0}), sizes);
+  scipp::index size = 0;
+  for (auto &range : indices.values<core::bucket_base::range_type>()) {
+    range.second += size - range.first;
+    range.first = size;
+    size = range.second;
+  }
+  return std::tuple{indices, size};
+}
+
+void copy(const VariableConstView &src, const VariableView &dst, const Dim dim,
+          const VariableConstView &srcIndices,
+          const VariableConstView &dstIndices) {
+  transform_in_place(subspan_view(dst, dim, dstIndices),
+                     subspan_view(src, dim, srcIndices),
+                     core::element::bucket::copy);
+}
+
+void copy(const DataArrayConstView &src, const DataArrayView &dst,
+          const Dim dim, const VariableConstView &srcIndices,
+          const VariableConstView &dstIndices) {
+  copy(src.data(), dst.data(), dim, srcIndices, dstIndices);
+  for (const auto &[name, coord] : src.coords())
+    if (coord.dims().contains(dim))
+      copy(coord, dst.coords()[name], dim, srcIndices, dstIndices);
+  for (const auto &[name, mask] : src.masks())
+    if (mask.dims().contains(dim))
+      copy(mask, dst.masks()[name], dim, srcIndices, dstIndices);
+}
+
+Variable concatenate(const VariableConstView &var0,
+                     const VariableConstView &var1) {
+  const auto &[ranges0, dim0, buffer0] = var0.constituents<bucket<DataArray>>();
+  const auto &[ranges1, dim1, buffer1] = var1.constituents<bucket<DataArray>>();
+  core::expect::equals(ranges0.dims(), ranges1.dims());
+  // core::expect::equals(dim0, dim1);
+  const Dim dim = dim0;
+  // const auto dims = concatenate(buffer0.dims(), buffer1.dims(), dim);
+  // TODO This copies, but is later overwritten, should be avoided
+  auto buffer = dataset::concatenate(buffer0, buffer1, dim);
+  const auto sizes0 = sizes(ranges0);
+  const auto sizes1 = sizes(ranges1);
+  const auto [indices, size] = sizes_to_indices(sizes0 + sizes1);
+  auto target0 = indices;
+  auto target1 = indices;
+  add_to_second(target0, -sizes1);
+  add_to_first(target1, sizes0);
+  copy(buffer0, buffer, dim, ranges0, target0);
+  copy(buffer1, buffer, dim, ranges1, target1);
+  return Variable{std::make_unique<variable::DataModel<bucket<DataArray>>>(
+      indices, dim, std::move(buffer))};
+}
+
+} // namespace buckets
+} // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/dataset/dataset.h"
+
+namespace scipp::dataset::buckets {
+
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+concatenate(const VariableConstView &var0, const VariableConstView &var1);
+
+} // namespace scipp::dataset::buckets

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -11,4 +11,7 @@ namespace scipp::dataset::buckets {
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 concatenate(const VariableConstView &var0, const VariableConstView &var1);
 
+SCIPP_DATASET_EXPORT void append(const VariableView &var0,
+                                 const VariableConstView &var1);
+
 } // namespace scipp::dataset::buckets

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_dependencies(all-tests ${TARGET_NAME})
 add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
   attributes_test.cpp
+  buckets_test.cpp
   choose_test.cpp
   concatenate_test.cpp
   coords_view_test.cpp

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/dataset/bucket.h"
+#include "scipp/dataset/dataset.h"
+#include "scipp/variable/bucket_model.h"
+#include "scipp/variable/operations.h"
+
+using namespace scipp;
+using namespace scipp::dataset;
+
+using Model = variable::DataModel<bucket<DataArray>>;
+
+class DataArrayBucketTest : public ::testing::Test {
+protected:
+  Dimensions dims{Dim::Y, 2};
+  Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+      dims, Values{std::pair{0, 2}, std::pair{2, 4}});
+  Variable column =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  DataArray buffer = DataArray(column, {{Dim::X, column + column}});
+  Variable var{std::make_unique<Model>(indices, Dim::X, buffer)};
+};
+
+TEST_F(DataArrayBucketTest, concatenate) {
+  const auto result = buckets::concatenate(var, var);
+  Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+      dims, Values{std::pair{0, 4}, std::pair{4, 8}});
+  Variable column = makeVariable<double>(Dims{Dim::X}, Shape{8},
+                                         Values{1, 2, 1, 2, 3, 4, 3, 4});
+  DataArray buffer = DataArray(column, {{Dim::X, column + column}});
+  EXPECT_EQ(result, Variable(std::make_unique<Model>(indices, Dim::X, buffer)));
+}

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -17,18 +17,21 @@ protected:
   Dimensions dims{Dim::Y, 2};
   Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       dims, Values{std::pair{0, 2}, std::pair{2, 4}});
-  Variable column =
+  Variable data =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
-  DataArray buffer = DataArray(column, {{Dim::X, column + column}});
+  DataArray buffer = DataArray(data, {{Dim::X, data + data}});
   Variable var{std::make_unique<Model>(indices, Dim::X, buffer)};
 };
 
 TEST_F(DataArrayBucketTest, concatenate) {
-  const auto result = buckets::concatenate(var, var);
-  Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+  const auto result = buckets::concatenate(var, var * (3.0 * units::one));
+  Variable out_indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       dims, Values{std::pair{0, 4}, std::pair{4, 8}});
-  Variable column = makeVariable<double>(Dims{Dim::X}, Shape{8},
-                                         Values{1, 2, 1, 2, 3, 4, 3, 4});
-  DataArray buffer = DataArray(column, {{Dim::X, column + column}});
-  EXPECT_EQ(result, Variable(std::make_unique<Model>(indices, Dim::X, buffer)));
+  Variable out_data = makeVariable<double>(Dims{Dim::X}, Shape{8},
+                                           Values{1, 2, 3, 6, 3, 4, 9, 12});
+  Variable out_x = makeVariable<double>(Dims{Dim::X}, Shape{8},
+                                        Values{2, 4, 2, 4, 6, 8, 6, 8});
+  DataArray out_buffer = DataArray(out_data, {{Dim::X, out_x}});
+  EXPECT_EQ(result,
+            Variable(std::make_unique<Model>(out_indices, Dim::X, out_buffer)));
 }

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -11,7 +11,6 @@
 using namespace scipp;
 using namespace scipp::dataset;
 
-
 class DataArrayBucketTest : public ::testing::Test {
 protected:
   using Model = variable::DataModel<bucket<DataArray>>;

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -34,4 +34,32 @@ TEST_F(DataArrayBucketTest, concatenate) {
   DataArray out_buffer = DataArray(out_data, {{Dim::X, out_x}});
   EXPECT_EQ(result,
             Variable(std::make_unique<Model>(out_indices, Dim::X, out_buffer)));
+
+  // "in-place" append gives same as concatenate
+  buckets::append(var, var * (3.0 * units::one));
+  EXPECT_EQ(result, var);
+  buckets::append(var, -var);
+}
+
+TEST_F(DataArrayBucketTest, concatenate_with_broadcast) {
+  auto var2 = var;
+  var2.rename(Dim::Y, Dim::Z);
+  var2 *= 3.0 * units::one;
+  const auto result = buckets::concatenate(var, var2);
+  Variable out_indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+      Dims{Dim::Y, Dim::Z}, Shape{2, 2},
+      Values{std::pair{0, 4}, std::pair{4, 8}, std::pair{8, 12},
+             std::pair{12, 16}});
+  Variable out_data = makeVariable<double>(
+      Dims{Dim::X}, Shape{16},
+      Values{1, 2, 3, 6, 1, 2, 9, 12, 3, 4, 3, 6, 3, 4, 9, 12});
+  Variable out_x = makeVariable<double>(
+      Dims{Dim::X}, Shape{16},
+      Values{2, 4, 2, 4, 2, 4, 6, 8, 6, 8, 2, 4, 6, 8, 6, 8});
+  DataArray out_buffer = DataArray(out_data, {{Dim::X, out_x}});
+  EXPECT_EQ(result,
+            Variable(std::make_unique<Model>(out_indices, Dim::X, out_buffer)));
+
+  // Broadcast not possible for in-place append
+  EXPECT_THROW(buckets::append(var, var2), except::DimensionMismatchError);
 }

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -39,6 +39,16 @@ private:
   VariableView data(const VariableView &var) const override {
     return std::get<2>(var.constituents<bucket<DataArray>>()).data();
   }
+  core::element_array_view
+  array_params(const VariableConstView &var) const override {
+    const auto &[indices, dim, buffer] = var.constituents<bucket<DataArray>>();
+    auto params = var.array_params();
+    return {0, // no offset required in buffer since access via indices
+            params.dims(),
+            params.dataDims(),
+            {dim, buffer.dims(),
+             indices.values<std::pair<scipp::index, scipp::index>>().data()}};
+  }
 };
 
 namespace {

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -24,7 +24,8 @@ private:
                         const bool variances) const override {
     const auto &source = std::get<2>(parent.constituents<bucket<DataArray>>());
     if (parent.dims() !=
-        dims) // would need to select and copy slices from source coords
+        indices
+            .dims()) // would need to select and copy slices from source coords
       throw std::runtime_error(
           "Shape changing operations with bucket<DataArray> not supported yet");
     auto buffer = DataArray(

--- a/variable/include/scipp/variable/reduction.h
+++ b/variable/include/scipp/variable/reduction.h
@@ -15,6 +15,8 @@ SCIPP_VARIABLE_EXPORT VariableView mean(const VariableConstView &var,
                                         const Dim dim, const VariableView &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 flatten(const VariableConstView &var, const Dim dim);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const VariableConstView &var,
                                                  const Dim dim);
 SCIPP_VARIABLE_EXPORT VariableView sum(const VariableConstView &var,

--- a/variable/include/scipp/variable/subspan_view.h
+++ b/variable/include/scipp/variable/subspan_view.h
@@ -8,10 +8,19 @@
 
 namespace scipp::variable {
 
-SCIPP_VARIABLE_EXPORT Variable subspan_view(Variable &var, const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable subspan_view(const VariableView &var,
-                                            const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable subspan_view(const VariableConstView &var,
-                                            const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable subspan_view(Variable &var,
+                                                          const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+subspan_view(const VariableView &var, const Dim dim);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+subspan_view(const VariableConstView &var, const Dim dim);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+subspan_view(Variable &var, const Dim dim, const VariableConstView &indices);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable subspan_view(
+    const VariableView &var, const Dim dim, const VariableConstView &indices);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+subspan_view(const VariableConstView &var, const Dim dim,
+             const VariableConstView &indices);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -870,7 +870,9 @@ Variable transform(std::tuple<Ts...> &&, Op op, const Vars &... vars) {
   auto unit = op(vars.unit()...);
   Variable out;
   try {
-    if constexpr ((is_any_events<Ts>::value || ...) || sizeof...(Vars) > 2) {
+    if constexpr (std::is_base_of_v<
+                      core::transform_flags::no_event_list_handling_t, Op> ||
+                  (is_any_events<Ts>::value || ...) || sizeof...(Vars) > 2) {
       out = visit_impl<Ts...>::apply(Transform{op}, vars...);
     } else {
       out =

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -22,4 +22,9 @@ enum class SortOrder { Ascending, Descending };
 [[nodiscard]] SCIPP_VARIABLE_EXPORT bool
 is_sorted(const VariableConstView &x, const Dim dim, const SortOrder order);
 
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+zip(const VariableConstView &first, const VariableConstView &second);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT std::pair<Variable, Variable>
+unzip(const VariableConstView &var);
+
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -11,8 +11,6 @@
 
 #include <Eigen/Dense>
 
-#include "variable_concept.h"
-
 #include "scipp-variable_export.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
@@ -26,6 +24,7 @@
 #include "scipp/core/slice.h"
 #include "scipp/core/tag_util.h"
 
+#include "scipp/variable/variable_concept.h"
 #include "scipp/variable/variable_keyword_arg_constructor.h"
 
 namespace scipp::dataset {
@@ -332,6 +331,8 @@ public:
   template <class T>
   std::tuple<VariableConstView, Dim, typename T::element_type>
   constituents() const;
+
+  template <class T> void replace_model(T model) const;
 
 private:
   friend class dataset::DataArrayConstView;

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -48,6 +48,14 @@ template <class T> ElementArrayView<T> VariableView::variances() const {
   return cast<T>(*m_mutableVariable).variances(array_params());
 }
 
+template <class T> void VariableView::replace_model(T model) const {
+  core::expect::equals(dims(),
+                       m_mutableVariable->dims()); // trivial view (no slice)
+  core::expect::equals(dims(),
+                       model.dims()); // shape change would break DataArray
+  requireT<T>(m_mutableVariable->data()) = std::move(model);
+}
+
 #define INSTANTIATE_VARIABLE_BASE(name, ...)                                   \
   namespace {                                                                  \
   auto register_dtype_name_##name(                                             \
@@ -57,7 +65,9 @@ template <class T> ElementArrayView<T> VariableView::variances() const {
   template ElementArrayView<__VA_ARGS__> Variable::values();                   \
   template ElementArrayView<const __VA_ARGS__> VariableConstView::values()     \
       const;                                                                   \
-  template ElementArrayView<__VA_ARGS__> VariableView::values() const;
+  template ElementArrayView<__VA_ARGS__> VariableView::values() const;         \
+  template void VariableView::replace_model<DataModel<__VA_ARGS__>>(           \
+      DataModel<__VA_ARGS__>) const;
 
 /// Macro for instantiating classes and functions required for support a new
 /// dtype in Variable.

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -190,6 +190,11 @@ Variable nanmin(const VariableConstView &var, const Dim dim) {
   return reduce_idempotent(var, dim, core::element::nanmin_equals);
 }
 
+/// Return the sum along all dimensions.
+Variable sum(const VariableConstView &var) {
+  return reduce_all_dims(var, [](auto &&... _) { return sum(_...); });
+}
+
 /// Return the maximum along all dimensions.
 Variable max(const VariableConstView &var) {
   return reduce_all_dims(var, [](auto &&... _) { return max(_...); });

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -7,6 +7,8 @@
 
 namespace scipp::variable {
 
+namespace {
+
 /// Helper returning vector of subspans from begin to end
 template <class T>
 auto make_subspans(const ElementArrayView<T> &first,
@@ -17,6 +19,41 @@ auto make_subspans(const ElementArrayView<T> &first,
   for (scipp::index i = 0; i < len; ++i)
     spans.emplace_back(scipp::span(&first[i], &last[i] + 1));
   return spans;
+}
+
+template <class T>
+auto make_subspans(T *base, const VariableConstView &indices,
+                   const scipp::index stride) {
+  const auto &offset = indices.values<core::bucket_base::range_type>();
+  const auto len = offset.size();
+  std::vector<span<T>> spans;
+  spans.reserve(len);
+  for (scipp::index i = 0; i < len; ++i)
+    spans.emplace_back(scipp::span(base + stride * offset[i].first,
+                                   base + stride * offset[i].second));
+  return spans;
+}
+
+template <class T, class Var, class ValuesMaker, class VariancesMaker>
+Variable make_subspan_view(Var &var, const Dimensions &dims,
+                           ValuesMaker make_values,
+                           VariancesMaker make_variances) {
+  std::conditional_t<std::is_const_v<T>, const Var, Var> &var_ref = var;
+  using MaybeConstT =
+      std::conditional_t<std::is_const_v<Var> &&
+                             !std::is_same_v<std::decay_t<Var>, VariableView>,
+                         std::add_const_t<T>, T>;
+  auto valuesView = make_values(var_ref);
+  if (var.hasVariances()) {
+    auto variancesView = make_variances(var_ref);
+    return makeVariable<span<MaybeConstT>>(
+        Dimensions{dims}, var.unit(),
+        Values(valuesView.begin(), valuesView.end()),
+        Variances(variancesView.begin(), variancesView.end()));
+  } else
+    return makeVariable<span<MaybeConstT>>(
+        Dimensions{dims}, var.unit(),
+        Values(valuesView.begin(), valuesView.end()));
 }
 
 /// Return Variable containing spans over given dimension as elements.
@@ -30,6 +67,8 @@ template <class T, class Var> Variable subspan_view(Var &var, const Dim dim) {
         "View over subspan can only be created for contiguous "
         "range of data.");
 
+  auto dims = var.dims();
+  dims.erase(dim);
   const auto values_view = [dim, len](auto &v) {
     return make_subspans(v.slice({dim, 0}).template values<E>(),
                          v.slice({dim, len - 1}).template values<E>());
@@ -38,23 +77,24 @@ template <class T, class Var> Variable subspan_view(Var &var, const Dim dim) {
     return make_subspans(v.slice({dim, 0}).template variances<E>(),
                          v.slice({dim, len - 1}).template variances<E>());
   };
+  return make_subspan_view<T>(var, dims, values_view, variances_view);
+}
 
-  auto dims = var.dims();
-  dims.erase(dim);
-  std::conditional_t<std::is_const_v<T>, const Var, Var> &var_ref = var;
-  using MaybeConstT =
-      std::conditional_t<std::is_const_v<Var>, std::add_const_t<T>, T>;
-  auto valuesView = values_view(var_ref);
-  if (var.hasVariances()) {
-    auto variancesView = variances_view(var_ref);
-    return makeVariable<span<MaybeConstT>>(
-        Dimensions{dims}, var.unit(),
-        Values(valuesView.begin(), valuesView.end()),
-        Variances(variancesView.begin(), variancesView.end()));
-  } else
-    return makeVariable<span<MaybeConstT>>(
-        Dimensions{dims}, var.unit(),
-        Values(valuesView.begin(), valuesView.end()));
+/// Return Variable containing spans with extents given by indices over given
+/// dimension as elements.
+template <class T, class Var>
+Variable subspan_view(Var &var, const Dim dim,
+                      const VariableConstView &indices) {
+  using E = std::remove_const_t<T>;
+  const auto values_view = [dim, &indices](auto &v) {
+    return make_subspans(v.template values<E>().data(), indices,
+                         v.dims().offset(dim));
+  };
+  const auto variances_view = [dim, &indices](auto &v) {
+    return make_subspans(v.template variances<E>().data(), indices,
+                         v.dims().offset(dim));
+  };
+  return make_subspan_view<T>(var, indices.dims(), values_view, variances_view);
 }
 
 template <class... Ts, class... Args>
@@ -68,10 +108,13 @@ auto invoke_subspan_view(const DType dtype, Args &&... args) {
   return ret;
 }
 
-template <class Var> Variable subspan_view_impl(Var &var, const Dim dim) {
-  return invoke_subspan_view<double, float, int64_t, int32_t, bool>(var.dtype(),
-                                                                    var, dim);
+template <class Var, class... Args>
+Variable subspan_view_impl(Var &var, Args &&... args) {
+  return invoke_subspan_view<double, float, int64_t, int32_t, bool>(
+      var.dtype(), var, args...);
 }
+
+} // namespace
 
 /// Return Variable containing mutable spans over given dimension as elements.
 Variable subspan_view(Variable &var, const Dim dim) {
@@ -84,6 +127,19 @@ Variable subspan_view(const VariableView &var, const Dim dim) {
 /// Return Variable containing const spans over given dimension as elements.
 Variable subspan_view(const VariableConstView &var, const Dim dim) {
   return subspan_view_impl(var, dim);
+}
+
+Variable subspan_view(Variable &var, const Dim dim,
+                      const VariableConstView &indices) {
+  return subspan_view_impl(var, dim, indices);
+}
+Variable subspan_view(const VariableView &var, const Dim dim,
+                      const VariableConstView &indices) {
+  return subspan_view_impl(var, dim, indices);
+}
+Variable subspan_view(const VariableConstView &var, const Dim dim,
+                      const VariableConstView &indices) {
+  return subspan_view_impl(var, dim, indices);
 }
 
 } // namespace scipp::variable

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -71,4 +71,16 @@ bool is_sorted(const VariableConstView &x, const Dim dim,
   return out.value<bool>();
 }
 
+/// Zip elements of two variables into a variable where each element is a pair.
+Variable zip(const VariableConstView &first, const VariableConstView &second) {
+  return transform(first, second, core::element::zip);
+}
+
+/// For an input where elements are pairs, return two variables containing the
+/// first and second components of the input pairs.
+std::pair<Variable, Variable> unzip(const VariableConstView &var) {
+  return {transform(var, core::element::get<0>),
+          transform(var, core::element::get<1>)};
+}
+
 } // namespace scipp::variable


### PR DESCRIPTION
This provides the equivalent of addition (or subtraction) for data arrays containing realigned event data. See https://scipp.github.io/event-data/overview.html#Addition for the old mechanism.

With buckets, the suggestion is to *not* do this in `+` or `-` operations. Elements of buckets are, e.g., `DataArrayView`. It would be *surprising behavior* if `+` and `-` would concatenate these elements instead of simply adding/subtracting the element (given that data arrays can be added and subtracted). Instead, I propose to provide named functions for these (as done in this PR). I am not clear yet on how to do this on the Python side, suggestions welcome. For example, we will want to append to event lists of a dataset item:
```python
# slightly odd? Is there a better syntax?
sc.buckets.append(dataset['sample17'], more_events)
```

Main additions in this PR:
- `subspan_view` can no be used for non-rectangular subspans, i.e., it can be created from a bucket variable to reference subspan in the internal buffer. This will allow for reuse of various other functionality. There are some potential options opening here for simplication/generalization: Our old subspan-views are actually very similar to bucket variable. The main difference is that subspan-views do not own the buffer, but reference ranges in another variable. I will need to think a bit more about this, but ultimately unifying both concepts might be ideal.
- `concatenate` and `append` for bucket variables.