### PR TITLE
Histogramming for bucketed data

### DIFF
--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -217,31 +217,6 @@ auto apply_op_events_dense(const Coord &coord, const Edges &edges,
     return out_vals;
 }
 
-namespace events_dense_op_impl_detail {
-template <class Coord, class Edge, class Weight>
-using args =
-    std::tuple<event_list<Coord>, span<const Edge>, span<const Weight>>;
-} // namespace events_dense_op_impl_detail
-
-Variable events_dense_op_impl(const VariableConstView &eventsCoord_,
-                              const VariableConstView &edges_,
-                              const VariableConstView &weights_,
-                              const Dim dim) {
-  using namespace events_dense_op_impl_detail;
-  return variable::transform<
-      std::tuple<args<double, double, double>, args<float, double, double>,
-                 args<float, float, float>, args<double, float, float>>>(
-      eventsCoord_, subspan_view(edges_, dim), subspan_view(weights_, dim),
-      overloaded{[](const auto &... a) { return apply_op_events_dense(a...); },
-                 core::transform_flags::expect_no_variance_arg<0>,
-                 core::transform_flags::expect_no_variance_arg<1>,
-                 [](const units::Unit &events, const units::Unit &edges,
-                    const units::Unit &weights) {
-                   core::expect::equals(events, edges);
-                   return weights;
-                 }});
-}
-
 namespace {
 bool is_self_append(const DataArrayConstView &a, const DataArrayConstView &b) {
   return &a.underlying() == &b.underlying();

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -14,4 +14,7 @@ concatenate(const VariableConstView &var0, const VariableConstView &var1);
 SCIPP_DATASET_EXPORT void append(const VariableView &var0,
                                  const VariableConstView &var1);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+histogram(const VariableConstView &data, const VariableConstView &binEdges);
+
 } // namespace scipp::dataset::buckets

--- a/variable/include/scipp/variable/transform_subspan.h
+++ b/variable/include/scipp/variable/transform_subspan.h
@@ -6,6 +6,7 @@
 
 #include "scipp/variable/subspan_view.h"
 #include "scipp/variable/transform.h"
+#include "scipp/variable/variable_factory.h"
 
 namespace scipp::variable {
 
@@ -44,12 +45,7 @@ template <class Types, class Op, class... Var>
       (std::is_base_of_v<
            core::transform_flags::expect_in_variance_if_out_variance_t, Op> &&
        (var.hasVariances() || ...));
-  Variable out =
-      variance ? Variable(type, dims,
-                          Values(dims.volume(), core::default_init_elements),
-                          Variances(dims.volume(), core::default_init_elements))
-               : Variable(type, dims,
-                          Values(dims.volume(), core::default_init_elements));
+  Variable out = variableFactory().create(type, dims, variance);
 
   const auto keep_subspan_vars_alive = std::array{maybe_subspan(var, dim)...};
 


### PR DESCRIPTION
Support histogramming for `bucket<DataArray>`, i.e., what will be used for replacing the current use of `event_list` and histogramming thereof.

The semantics of the relation between bucketing of a dimension and histogramming the same dimension are still a bit unclear. The best analogue to think of is Mantid's `EventWorkspace`, which, by default, has only a single "bin" for each spectrum, containing all events. It can then be histogrammed to a different resolution/bin-edges. The bin edges stored on the event workspace would be ignored, similar to how we are here ignoring the coord and bucketing of the data array containing the event data in buckets.