### PR TITLE
Scale and map operations for bucket data

### DIFF
--- a/core/include/scipp/core/element/event_operations.h
+++ b/core/include/scipp/core/element/event_operations.h
@@ -136,6 +136,77 @@ constexpr auto map = overloaded{
         return out_vals;
     }};
 
+namespace map_in_place_detail {
+template <class Coord, class Edge, class Weight>
+using args = std::tuple<span<Weight>, span<const Coord>, span<const Edge>,
+                        span<const Weight>>;
+} // namespace map_in_place_detail
+
+// TODO This is a temporary near-duplicate of map (above). The latter should
+// probably be removable once support for event lists is removed.
+constexpr auto map_in_place = overloaded{
+    element::arg_list<map_in_place_detail::args<int64_t, int64_t, double>,
+                      map_in_place_detail::args<int64_t, int64_t, float>,
+                      map_in_place_detail::args<int32_t, int32_t, double>,
+                      map_in_place_detail::args<int32_t, int32_t, float>,
+                      map_in_place_detail::args<int64_t, double, double>,
+                      map_in_place_detail::args<int64_t, double, float>,
+                      map_in_place_detail::args<int32_t, double, double>,
+                      map_in_place_detail::args<int32_t, double, float>,
+                      map_in_place_detail::args<double, double, double>,
+                      map_in_place_detail::args<float, double, double>,
+                      map_in_place_detail::args<float, float, float>,
+                      map_in_place_detail::args<double, float, float>>,
+    transform_flags::expect_in_variance_if_out_variance,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<2>,
+    [](units::Unit &out, const units::Unit &x, const units::Unit &edges,
+       const units::Unit &weights) {
+      expect::equals(x, edges);
+      out = weights;
+    },
+    [](const auto &out, const auto &coord, const auto &edges,
+       const auto &weights) {
+      using W = std::decay_t<decltype(weights)>;
+      constexpr bool vars = is_ValueAndVariance_v<W>;
+      constexpr auto get = [](const auto &x, const scipp::index i) {
+        if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+          return ValueAndVariance{x.value[i], x.variance[i]};
+        else
+          return x[i];
+      };
+      using w_type = decltype(get(weights, 0));
+      constexpr w_type out_of_bounds(0.0);
+      if (scipp::numeric::is_linspace(edges)) {
+        const auto [offset, nbin, scale] = linear_edge_params(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          const auto bin = (coord[i] - offset) * scale;
+          w_type w =
+              bin < 0.0 || bin >= nbin ? out_of_bounds : get(weights, bin);
+          if constexpr (vars) {
+            out.value[i] = w.value;
+            out.variance[i] = w.variance;
+          } else {
+            out[i] = w;
+          }
+        }
+      } else {
+        expect::histogram::sorted_edges(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          auto it = std::upper_bound(edges.begin(), edges.end(), coord[i]);
+          w_type w = (it == edges.end() || it == edges.begin())
+                         ? out_of_bounds
+                         : get(weights, --it - edges.begin());
+          if constexpr (vars) {
+            out.value[i] = w.value;
+            out.variance[i] = w.variance;
+          } else {
+            out[i] = w;
+          }
+        }
+      }
+    }};
+
 namespace make_select_detail {
 template <class T> using args = std::tuple<event_list<T>, span<const T>>;
 }

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -17,4 +17,10 @@ SCIPP_DATASET_EXPORT void append(const VariableView &var0,
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 histogram(const VariableConstView &data, const VariableConstView &binEdges);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+map(const DataArrayConstView &function, const VariableConstView &x,
+    Dim hist_dim);
+
+void scale(const DataArrayView &data, const DataArrayConstView &histogram);
+
 } // namespace scipp::dataset::buckets

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -825,6 +825,15 @@ void transform_in_place(Var &&var, const VariableConstView &var1,
                                            var2);
 }
 
+/// Transform the data elements of a variable in-place.
+template <class... TypePairs, class Var, class Op>
+void transform_in_place(Var &&var, const VariableConstView &var1,
+                        const VariableConstView &var2,
+                        const VariableConstView &var3, Op op) {
+  in_place<false>::transform<TypePairs...>(op, std::forward<Var>(var), var1,
+                                           var2, var3);
+}
+
 /// Accumulate data elements of a variable in-place.
 ///
 /// This is equivalent to `transform_in_place`, with the only difference that


### PR DESCRIPTION
- Add equivalent to https://scipp.github.io/event-data/overview.html#Multiplication-and-division
- Add equivalent to https://scipp.github.io/event-data/filtering.html#Step-2:-Map-time-stamps

Note that Python bindings have not been added yet. Event filtering cannot be done in its entirety yet, since `filter` for bucket is not available yet.