### PR TITLE
Fix atan2 wrapper

### DIFF
--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -82,4 +82,4 @@ def atan2(y, x, out=None):
     :param out: Optional output buffer.
     :return: The signed inverse tan values of the inputs.
     """
-    return _call_cpp_func(_cpp.atan, x, out=out)
+    return _call_cpp_func(_cpp.atan2, y, x, out=out)


### PR DESCRIPTION
Bad internal call made for `atan2` introduced [here](https://github.com/scipp/scipp/commit/35484dbd15e59cda770941d3517d7a12b46ea889#diff-e4c337be0727d7bd6f0836fc398b7624) silently failed. Discovered while investigating #1227 but does not completely fix that issue.