### PR TITLE
Bucket unit conversion

### DIFF
--- a/core/include/scipp/core/bucket.h
+++ b/core/include/scipp/core/bucket.h
@@ -14,6 +14,7 @@ struct bucket_base {
   using range_type = std::pair<scipp::index, scipp::index>;
 };
 template <class T> struct bucket : bucket_base {
+  using buffer_type = T;
   using element_type = typename T::view_type;
   using const_element_type = typename T::const_view_type;
 };

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -302,4 +302,20 @@ DataArray sum(const DataArrayConstView &data) {
           data.unaligned_coords()};
 }
 
+template <class T>
+Variable from_constituents_impl(Variable &&indices, const Dim dim, T &&buffer) {
+  return {std::make_unique<variable::DataModel<bucket<T>>>(
+      std::move(indices), dim, std::move(buffer))};
+}
+
+Variable from_constituents(Variable &&indices, const Dim dim,
+                           Variable &&buffer) {
+  return from_constituents_impl(std::move(indices), dim, std::move(buffer));
+}
+
+Variable from_constituents(Variable &&indices, const Dim dim,
+                           DataArray &&buffer) {
+  return from_constituents_impl(std::move(indices), dim, std::move(buffer));
+}
+
 } // namespace scipp::dataset::buckets

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -45,12 +45,16 @@ const VariableView &DataArrayView::data() const { return m_view; }
 
 DataArrayConstView DataArray::get() const {
   requireValid(*this);
-  return *m_holder.begin();
+  auto view = *m_holder.begin();
+  view.m_isItem = false;
+  return view;
 }
 
 DataArrayView DataArray::get() {
   requireValid(*this);
-  return *m_holder.begin();
+  auto view = *m_holder.begin();
+  view.m_isItem = false;
+  return view;
 }
 
 /// Return true if the dataset proxies have identical content.

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -261,29 +261,34 @@ void DataArrayView::setData(Variable data) const {
 }
 
 template <class Key, class Val>
-void Dataset::erase_from_map(std::unordered_map<Key, Val> &map,
-                             const Key &key) {
+Val Dataset::extract_from_map(std::unordered_map<Key, Val> &map,
+                              const Key &key) {
   using core::to_string;
   if (!map.count(key))
     throw except::NotFoundError("Cannot erase " + to_string(key) +
                                 " -- not found.");
+  auto value = std::move(map.at(key));
   map.erase(key);
   rebuildDims();
+  return value;
 }
 
-/// Removes the coordinate for the given dimension.
-void Dataset::eraseCoord(const Dim dim) { erase_from_map(m_coords, dim); }
-
-/// Removes unaligned coord with given name from the given item.
-void Dataset::eraseCoord(const std::string &name, const Dim dim) {
-  scipp::expect::contains(*this, name);
-  erase_from_map(m_data[name].coords, dim);
+/// Remove and return the coordinate for the given dimension.
+Variable Dataset::extractCoord(const Dim dim) {
+  return extract_from_map(m_coords, dim);
 }
 
-/// Remove mask with given mask name from the given item.
-void Dataset::eraseMask(const std::string &name, const std::string &maskName) {
+/// Remove and return unaligned coord with given name from the given item.
+Variable Dataset::extractCoord(const std::string &name, const Dim dim) {
   scipp::expect::contains(*this, name);
-  erase_from_map(m_data[name].masks, maskName);
+  return extract_from_map(m_data[name].coords, dim);
+}
+
+/// Remove and return mask with given mask name from the given item.
+Variable Dataset::extractMask(const std::string &name,
+                              const std::string &maskName) {
+  scipp::expect::contains(*this, name);
+  return extract_from_map(m_data[name].masks, maskName);
 }
 
 /// Return const slice of the dataset along given dimension with given extents.

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -485,9 +485,11 @@ CoordsConstView DataArrayConstView::coords() const noexcept {
 
 /// Return a view to all coordinates of the data view.
 CoordsView DataArrayView::coords() const noexcept {
-  // Typically view of item of data array, therefore:
+  // Typically view of item of dataset, therefore:
   // ds['a'].coords['x'] = x # inserts unaligned coord
-  return make_coords(*this, CoordCategory::All);
+  // Views created from DataArray set m_isItem = false, so aligned coords can be
+  // inserted.
+  return make_coords(*this, CoordCategory::All, m_isItem);
 }
 
 /// Return a const view to all coordinates of the data array.

--- a/dataset/dataset_access.cpp
+++ b/dataset/dataset_access.cpp
@@ -22,24 +22,27 @@ void CoordAccess::set(const Dim &key, Variable var) const {
   } else
     m_parent->setCoord(key, std::move(var));
 }
-void CoordAccess::erase(const Dim &key) const {
+void CoordAccess::erase(const Dim &key) const { extract(key); }
+Variable CoordAccess::extract(const Dim &key) const {
   expectValidParent(m_parent);
   if (m_name) {
     if (!m_isItem && m_parent->coords().contains(key))
-      m_parent->eraseCoord(key); // this is a DataArray, may delete aligned
+      return m_parent->extractCoord(
+          key); // this is a DataArray, may delete aligned
     else
-      m_parent->eraseCoord(*m_name, key);
+      return m_parent->extractCoord(*m_name, key);
   } else
-    m_parent->eraseCoord(key);
+    return m_parent->extractCoord(key);
 }
 
 void MaskAccess::set(const std::string &key, Variable var) const {
   expectValidParent(m_parent);
   m_parent->setMask(*m_name, key, std::move(var));
 }
-void MaskAccess::erase(const std::string &key) const {
+void MaskAccess::erase(const std::string &key) const { extract(key); }
+Variable MaskAccess::extract(const std::string &key) const {
   expectValidParent(m_parent);
-  m_parent->eraseMask(*m_name, key);
+  return m_parent->extractMask(*m_name, key);
 }
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -31,4 +31,9 @@ void scale(const DataArrayView &data, const DataArrayConstView &histogram);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 sum(const DataArrayConstView &data);
 
+[[nodiscard]] Variable from_constituents(Variable &&indices, const Dim dim,
+                                         Variable &&buffer);
+[[nodiscard]] Variable from_constituents(Variable &&indices, const Dim dim,
+                                         DataArray &&buffer);
+
 } // namespace scipp::dataset::buckets

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -105,11 +105,16 @@ protected:
   // VariableView. The interface guarantees that the invalid mutable view is
   // not accessible. This wrapping avoids inefficient duplication of the view in
   // the child class DataArrayView.
-  VariableView m_view; // empty if the array has no (aligned) data
+  VariableView m_view; // empty if the array has no data
+  // Flag required to allow for removal/addition of coords from DataArray via a
+  // view. This may be another indicator that the current implementation of
+  // DataArray based on Dataset should be refactored.
+  bool m_isItem{true};
 
 private:
   friend class DatasetConstView;
   friend class DatasetView;
+  friend class DataArray;
 
   const Dataset *m_dataset{nullptr};
   const detail::dataset_item_map::value_type *m_data{nullptr};

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -352,9 +352,11 @@ public:
     setData(name, Variable(data), attrPolicy);
   }
 
-  void eraseCoord(const Dim dim);
-  void eraseCoord(const std::string &name, const Dim dim);
-  void eraseMask(const std::string &name, const std::string &maskName);
+  [[maybe_unused]] Variable extractCoord(const Dim dim);
+  [[maybe_unused]] Variable extractCoord(const std::string &name,
+                                         const Dim dim);
+  [[maybe_unused]] Variable extractMask(const std::string &name,
+                                        const std::string &maskName);
 
   DatasetConstView slice(const Slice s) const &;
   DatasetView slice(const Slice s) &;
@@ -400,7 +402,7 @@ private:
   void rebuildDims();
 
   template <class Key, class Val>
-  void erase_from_map(std::unordered_map<Key, Val> &map, const Key &key);
+  Val extract_from_map(std::unordered_map<Key, Val> &map, const Key &key);
 
   void setData_impl(const std::string &name, detail::DatasetData &&data,
                     const AttrPolicy attrPolicy);

--- a/dataset/include/scipp/dataset/dataset_access.h
+++ b/dataset/include/scipp/dataset/dataset_access.h
@@ -26,6 +26,7 @@ public:
 
   void set(const Dim &key, variable::Variable var) const;
   void erase(const Dim &key) const;
+  [[maybe_unused]] variable::Variable extract(const Dim &key) const;
 
 private:
   Dataset *m_parent;
@@ -40,6 +41,7 @@ public:
 
   void set(const std::string &key, variable::Variable var) const;
   void erase(const std::string &key) const;
+  [[maybe_unused]] variable::Variable extract(const std::string &key) const;
 
 private:
   Dataset *m_parent;

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -242,6 +242,7 @@ public:
   }
 
   void erase(const typename Base::key_type &key) const;
+  typename Base::mapped_type extract(const typename Base::key_type &key) const;
 
   const Access &access() const { return m_access; }
 };

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -73,6 +73,13 @@ void MutableView<Base, Access>::erase(
   m_access.erase(key);
 }
 
+template <class Base, class Access>
+typename Base::mapped_type
+MutableView<Base, Access>::extract(const typename Base::key_type &key) const {
+  scipp::expect::contains(*this, key);
+  return m_access.extract(key);
+}
+
 template class ConstView<ViewId::Coords, Dim, variable::Variable>;
 template class MutableView<CoordsConstView, CoordAccess>;
 template class ConstView<ViewId::Masks, std::string, variable::Variable>;

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -54,7 +54,9 @@ TEST(DatasetTest, extract) {
   auto dataset = factory.make();
   Dataset reference(dataset);
 
+  auto ptr = dataset["data_xyz"].values<double>().data();
   auto array = dataset.extract("data_xyz");
+  EXPECT_EQ(array.values<double>().data(), ptr);
 
   ASSERT_FALSE(dataset.contains("data_xyz"));
   EXPECT_EQ(array, reference["data_xyz"]);
@@ -383,12 +385,14 @@ TEST(DatasetTest, sum_and_mean) {
                except::TypeError);
 }
 
-TEST(DatasetTest, erase_coord) {
+TEST(DatasetTest, extract_coord) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
   Dataset ds(ref);
   auto coord = Variable(ds.coords()[Dim::X]);
-  ds.eraseCoord(Dim::X);
+  auto ptr = ds.coords()[Dim::X].values<double>().data();
+  auto var = ds.extractCoord(Dim::X);
+  EXPECT_EQ(var.values<double>().data(), ptr);
   EXPECT_FALSE(ds.coords().contains(Dim::X));
   ds.setCoord(Dim::X, coord);
   EXPECT_EQ(ref, ds);
@@ -408,12 +412,12 @@ TEST(DatasetTest, erase_item_coord_cannot_erase_coord) {
   EXPECT_THROW(ds["data_x"].coords().erase(Dim::X), except::NotFoundError);
 }
 
-TEST(DatasetTest, erase_labels) {
+TEST(DatasetTest, extract_labels) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
   Dataset ds(ref);
   auto labels = Variable(ds.coords()[Dim("labels_x")]);
-  ds.eraseCoord(Dim("labels_x"));
+  ds.extractCoord(Dim("labels_x"));
   EXPECT_FALSE(ds.coords().contains(Dim("labels_x")));
   ds.setCoord(Dim("labels_x"), labels);
   EXPECT_EQ(ref, ds);

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -4,10 +4,10 @@
 #include <gtest/gtest.h>
 
 #include "scipp/core/dimensions.h"
+#include "scipp/dataset/bucket.h"
 #include "scipp/dataset/counts.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/histogram.h"
-#include "scipp/dataset/unaligned.h"
 #include "scipp/neutron/convert.h"
 #include "scipp/variable/operations.h"
 
@@ -60,6 +60,19 @@ Dataset makeTofDatasetEvents() {
                                    Values{1, 1}, Variances{1, 1}));
 
   return tof;
+}
+
+Variable makeTofBucketedEvents() {
+  Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+      Dims{Dim::Spectrum}, Shape{2}, Values{std::pair{0, 4}, std::pair{4, 7}});
+  Variable tofs =
+      makeVariable<double>(Dims{Dim::Event}, Shape{7}, units::us,
+                           Values{1000, 3000, 2000, 4000, 5000, 6000, 3000});
+  Variable weights =
+      makeVariable<double>(Dims{Dim::Event}, Shape{7}, Values{}, Variances{});
+  DataArray buffer = DataArray(weights, {{Dim::Tof, tofs}});
+  return dataset::buckets::from_constituents(std::move(indices), Dim::Event,
+                                             std::move(buffer));
 }
 
 Variable makeCountDensityData(const units::Unit &unit) {
@@ -513,6 +526,32 @@ TEST_P(ConvertTest, convert_with_factor_type_promotion) {
 
     res = convert(res, d, Dim::Tof);
     EXPECT_EQ(res.coords()[Dim::Tof].dtype(), core::dtype<float>);
+  }
+}
+
+TEST(ConvertBucketsTest, events_converted) {
+  Dataset tof = makeTofDataset();
+  // Standard dense coord for comparison purposes. The final 0 is a dummy.
+  const auto coord = makeVariable<double>(
+      Dims{Dim::Spectrum, Dim::Tof}, Shape{2, 4}, units::us,
+      Values{1000, 3000, 2000, 4000, 5000, 6000, 3000, 0});
+  tof.coords().set(Dim::Tof, coord);
+  tof.setData("bucketed", makeTofBucketedEvents());
+  for (auto &&d : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
+    auto res = convert(tof, Dim::Tof, d);
+    auto values = res["bucketed"].values<bucket<DataArray>>();
+    Variable expected(
+        res.coords()[d].slice({Dim::Spectrum, 0}).slice({d, 0, 4}));
+    expected.rename(d, Dim::Event);
+    EXPECT_FALSE(values[0].coords().contains(Dim::Tof));
+    EXPECT_TRUE(values[0].coords().contains(d));
+    EXPECT_EQ(values[0].coords()[d], expected);
+    expected =
+        Variable(res.coords()[d].slice({Dim::Spectrum, 1}).slice({d, 0, 3}));
+    expected.rename(d, Dim::Event);
+    EXPECT_FALSE(values[1].coords().contains(Dim::Tof));
+    EXPECT_TRUE(values[1].coords().contains(d));
+    EXPECT_EQ(values[1].coords()[d], expected);
   }
 }
 

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -14,6 +14,7 @@ std::unordered_map<std::string, Dim::Id> Dim::builtin_ids{
     {"d-spacing", Dim::DSpacing},
     {"E", Dim::Energy},
     {"Delta-E", Dim::EnergyTransfer},
+    {"event", Dim::Event},
     {"group", Dim::Group},
     {"<invalid>", Dim::Invalid},
     {"position", Dim::Position},

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -18,6 +18,7 @@ public:
     DSpacing,
     Energy,
     EnergyTransfer,
+    Event,
     Group,
     Position,
     PulseTime,
@@ -43,6 +44,7 @@ public:
   constexpr static auto DSpacing = Id::DSpacing;
   constexpr static auto Energy = Id::Energy;
   constexpr static auto EnergyTransfer = Id::EnergyTransfer;
+  constexpr static auto Event = Id::Event;
   constexpr static auto Group = Id::Group;
   constexpr static auto Invalid = Id::Invalid;
   constexpr static auto Position = Id::Position;

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -62,9 +62,12 @@ public:
   void assign(const VariableConcept &other) override;
 
   Dim dim() const noexcept { return m_dim; }
+  // TODO Should the mutable version return a view to prevent risk of clients
+  // breaking invariants of variable?
   const T &buffer() const noexcept { return m_buffer; }
   T &buffer() noexcept { return m_buffer; }
   const Variable &indices() const { return m_indices; }
+  Variable &indices() { return m_indices; }
 
   ElementArrayView<bucket<T>> values(const core::element_array_view &base) {
     return {index_values(base), m_dim, m_buffer};

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -10,6 +10,14 @@
 namespace scipp::variable {
 
 template <class T>
+std::tuple<Variable, Dim, typename T::buffer_type> Variable::to_constituents() {
+  Variable tmp;
+  std::swap(*this, tmp);
+  auto &model = requireT<DataModel<T>>(tmp.data());
+  return {std::move(model.indices()), model.dim(), std::move(model.buffer())};
+}
+
+template <class T>
 std::tuple<VariableConstView, Dim, typename T::const_element_type>
 VariableConstView::constituents() const {
   auto view = *this;
@@ -86,6 +94,8 @@ public:
 /// bucket dtype in Variable.
 #define INSTANTIATE_BUCKET_VARIABLE(name, ...)                                 \
   INSTANTIATE_VARIABLE_BASE(name, __VA_ARGS__)                                 \
+  template std::tuple<Variable, Dim, typename __VA_ARGS__::buffer_type>        \
+  Variable::to_constituents<__VA_ARGS__>();                                    \
   template std::tuple<VariableConstView, Dim,                                  \
                       typename __VA_ARGS__::element_type>                      \
   VariableView::constituents<__VA_ARGS__>() const;                             \

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -85,6 +85,10 @@ public:
   units::Unit elem_unit(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<T>>()).unit();
   }
+  void set_elem_unit(const VariableView &var,
+                     const units::Unit &u) const override {
+    return std::get<2>(var.constituents<bucket<T>>()).setUnit(u);
+  }
   bool hasVariances(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<T>>()).hasVariances();
   }

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -790,8 +790,8 @@ template <bool dry_run> struct in_place {
   static void transform(Op op, Var &&var, const Other &... other) {
     using namespace detail;
     (scipp::expect::contains(var.dims(), other.dims()), ...);
-    auto unit = var.unit();
-    op(unit, other.unit()...);
+    auto unit = variableFactory().elem_unit(var);
+    op(unit, variableFactory().elem_unit(other)...);
     // Stop early in bad cases of changing units (if `var` is a slice):
     var.expectCanSetUnit(unit);
     // Wrapped implementation to convert multiple tuples into a parameter pack.
@@ -799,7 +799,7 @@ template <bool dry_run> struct in_place {
                    other...);
     if constexpr (dry_run)
       return;
-    var.setUnit(unit);
+    variableFactory().set_elem_unit(var, unit);
   }
 };
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -139,6 +139,9 @@ public:
     return {0, dims(), dims(), {}};
   }
 
+  template <class T>
+  std::tuple<Variable, Dim, typename T::buffer_type> to_constituents();
+
 private:
   template <class... Ts, class... Args>
   static Variable construct(const DType &type, Args &&... args);

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -25,6 +25,8 @@ public:
          const std::vector<VariableConstView> &parents) const = 0;
   virtual DType elem_dtype(const VariableConstView &var) const = 0;
   virtual units::Unit elem_unit(const VariableConstView &var) const = 0;
+  virtual void set_elem_unit(const VariableView &var,
+                             const units::Unit &u) const = 0;
   virtual bool hasVariances(const VariableConstView &var) const = 0;
   virtual VariableConstView data(const VariableConstView &) const {
     throw unreachable();
@@ -56,6 +58,10 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   }
   units::Unit elem_unit(const VariableConstView &var) const override {
     return var.unit();
+  }
+  void set_elem_unit(const VariableView &var,
+                     const units::Unit &u) const override {
+    var.setUnit(u);
   }
   bool hasVariances(const VariableConstView &var) const override {
     return var.hasVariances();
@@ -96,6 +102,7 @@ public:
   }
   DType elem_dtype(const VariableConstView &var) const;
   units::Unit elem_unit(const VariableConstView &var) const;
+  void set_elem_unit(const VariableView &var, const units::Unit &u) const;
   bool hasVariances(const VariableConstView &var) const;
   template <class T, class Var> auto values(Var &&var) const {
     if (!is_buckets(var))

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -112,3 +112,16 @@ TEST_F(VariableBucketTest, binary_operation_with_dense_broadcast) {
   EXPECT_EQ(var.slice({Dim::Y, 1}) + dense, expected.slice({Dim::Y, 1}));
   EXPECT_EQ(dense + var, expected);
 }
+
+TEST_F(VariableBucketTest, to_constituents) {
+  auto [idx0, dim0, buf0] = VariableView(var).constituents<bucket<Variable>>();
+  auto idx_ptr = idx0.values<std::pair<scipp::index, scipp::index>>().data();
+  auto buf_ptr = buf0.values<double>().data();
+  auto [idx1, dim1, buf1] = var.to_constituents<bucket<Variable>>();
+  EXPECT_EQ((idx1.values<std::pair<scipp::index, scipp::index>>().data()),
+            idx_ptr);
+  EXPECT_EQ(buf1.values<double>().data(), buf_ptr);
+  EXPECT_EQ(idx1, indices);
+  EXPECT_EQ(dim1, Dim::X);
+  EXPECT_EQ(buf1, buffer);
+}

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -118,6 +118,7 @@ TEST_F(VariableBucketTest, to_constituents) {
   auto idx_ptr = idx0.values<std::pair<scipp::index, scipp::index>>().data();
   auto buf_ptr = buf0.values<double>().data();
   auto [idx1, dim1, buf1] = var.to_constituents<bucket<Variable>>();
+  EXPECT_FALSE(var);
   EXPECT_EQ((idx1.values<std::pair<scipp::index, scipp::index>>().data()),
             idx_ptr);
   EXPECT_EQ(buf1.values<double>().data(), buf_ptr);

--- a/variable/variable_factory.cpp
+++ b/variable/variable_factory.cpp
@@ -22,6 +22,11 @@ units::Unit VariableFactory::elem_unit(const VariableConstView &var) const {
   return m_makers.at(var.dtype())->elem_unit(var);
 }
 
+void VariableFactory::set_elem_unit(const VariableView &var,
+                                    const units::Unit &u) const {
+  m_makers.at(var.dtype())->set_elem_unit(var, u);
+}
+
 bool VariableFactory::hasVariances(const VariableConstView &var) const {
   return m_makers.at(var.dtype())->hasVariances(var);
 }


### PR DESCRIPTION
Add support for converting the coords of a bucket variable (containing data arrays) in unit conversion. This correspondings to converting not just the bin edges but also the TOF values of each event.

It is a bit odd to modify details of of data entry elements (the coords of the individual "event lists", i.e., buckets). Maybe this should only be done explicitly? We have similar conceptual haze in `histogram`, which, as of #1337, can histogram buckets elements. Something to think about once we have all the basics working and move towards consolidation.

Also fixed a number of related issues:
- `transform_in_place` did not update unit of buffer in bucket variables (see previous change to `transform` which accomplished this).
- `DataArrayView` of a `DataArray` to support addition/extraction of coords. Previously this did not work because it was assumed that `DataArrayView` generally refers to a dataset item so *unaligned* coord removal/insertion was attempted.