### PR TITLE
Add "bucketby"

### DIFF
--- a/core/element_array_view.cpp
+++ b/core/element_array_view.cpp
@@ -56,4 +56,9 @@ element_array_view::element_array_view(const element_array_view &other,
       m_dataDims.relabel(m_dataDims.index(label), Dim::Invalid);
 }
 
+void element_array_view::requireContiguous() const {
+  if (m_iterDims != m_dataDims || m_bucketParams)
+    throw std::runtime_error("Data is not contiguous");
+}
+
 } // namespace scipp::core

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -91,4 +91,42 @@ static constexpr auto histogram = overloaded{
     transform_flags::expect_variance_arg<2>,
     transform_flags::expect_no_variance_arg<3>};
 
+template <class T>
+using bin_index_arg =
+    std::tuple<span<scipp::index>, span<const T>, span<const T>>;
+
+static constexpr auto bin_index = overloaded{
+    element::arg_list<bin_index_arg<double>, bin_index_arg<float>>,
+    [](const auto &index, const auto &coord, const auto &edges) {
+      // Special faster implementation for linear bins.
+      if (scipp::numeric::is_linspace(edges)) {
+        const auto [offset, nbin, scale] = core::linear_edge_params(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          const auto x = coord[i];
+          const double bin = (x - offset) * scale;
+          if (bin < 0.0 || bin >= nbin)
+            index[i] = -1;
+          else
+            index[i] = bin;
+        }
+      } else {
+        core::expect::histogram::sorted_edges(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          const auto x = coord[i];
+          auto it = std::upper_bound(edges.begin(), edges.end(), x);
+          if (it == edges.begin() || it == edges.end())
+            index[i] = -1;
+          else
+            index[i] = --it - edges.begin();
+        }
+      }
+    },
+    [](units::Unit &index, const units::Unit &coord, const units::Unit &edges) {
+      expect::equals(coord, edges);
+      index = units::one;
+    },
+    transform_flags::expect_no_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<2>};
+
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/permute.h
+++ b/core/include/scipp/core/element/permute.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/common/overloaded.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/time_point.h"
+#include "scipp/core/transform_common.h"
+#include "scipp/core/value_and_variance.h"
+
+namespace scipp::core::element {
+
+constexpr auto permute = overloaded{
+    transform_flags::expect_no_variance_arg<1>,
+    arg_list<std::tuple<scipp::span<const double>, scipp::index>,
+             std::tuple<scipp::span<const float>, scipp::index>,
+             std::tuple<scipp::span<const int64_t>, scipp::index>,
+             std::tuple<scipp::span<const int32_t>, scipp::index>,
+             std::tuple<scipp::span<const bool>, scipp::index>,
+             std::tuple<scipp::span<const time_point>, scipp::index>,
+             std::tuple<scipp::span<const std::string>, scipp::index>>,
+    [](const auto &data, const auto &i) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(data)>>)
+        return ValueAndVariance{data.value[i], data.variance[i]};
+      else
+        return data[i];
+    },
+    [](const units::Unit &data, const units::Unit &i) {
+      expect::equals(i, units::one);
+      return data;
+    }};
+
+} // namespace scipp::core::element

--- a/core/include/scipp/core/element_array_view.h
+++ b/core/include/scipp/core/element_array_view.h
@@ -88,6 +88,7 @@ public:
   }
 
 protected:
+  void requireContiguous() const;
   scipp::index m_offset{0};
   Dimensions m_iterDims;
   Dimensions m_dataDims;
@@ -133,6 +134,16 @@ public:
 
   const T *data() const { return m_buffer + m_offset; }
   T *data() { return m_buffer + m_offset; }
+
+  auto as_span() const {
+    requireContiguous();
+    return scipp::span(data(), data() + size());
+  }
+
+  auto as_span() {
+    requireContiguous();
+    return scipp::span(data(), data() + size());
+  }
 
   bool operator==(const ElementArrayView<T> &other) const {
     if (dims() != other.dims())

--- a/core/include/scipp/core/parallel-fallback.h
+++ b/core/include/scipp/core/parallel-fallback.h
@@ -4,6 +4,8 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include <algorithm>
+
 #include "scipp/common/index.h"
 
 /// Fallback wrappers without actual threading, in case TBB is not available.
@@ -26,6 +28,10 @@ private:
 
 template <class Op> void parallel_for(const blocked_range &range, Op &&op) {
   op(range);
+}
+
+template <class... Args> void parallel_sort(Args &&... args) {
+  std::sort(std::forward<Args>(args)...);
 }
 
 } // namespace scipp::core::parallel

--- a/core/include/scipp/core/parallel-tbb.h
+++ b/core/include/scipp/core/parallel-tbb.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_sort.h>
 
 #include "scipp/common/index.h"
 #cmakedefine ENABLE_THREAD_LIMIT
@@ -37,6 +38,10 @@ template <class... Args> void parallel_for(Args &&... args) {
 #else
   tbb::parallel_for(std::forward<Args>(args)...);
 #endif
+}
+
+template <class... Args> void parallel_sort(Args &&... args) {
+  tbb::parallel_sort(std::forward<Args>(args)...);
 }
 
 } // namespace scipp::core::parallel

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -91,8 +91,8 @@ protected:
     check(swapped, expected1, expected0);
   }
 
-  Dimensions x{{Dim::X}, {2}};
-  Dimensions y{{Dim::Y}, {3}};
+  Dimensions x{Dim::X, 2};
+  Dimensions y{Dim::Y, 3};
   Dimensions yx{{Dim::Y, Dim::X}, {3, 2}};
   Dimensions xy{{Dim::X, Dim::Y}, {2, 3}};
   Dimensions xz{{Dim::X, Dim::Z}, {2, 4}};
@@ -172,7 +172,7 @@ TEST_F(MultiIndexTest, advance_slice_and_broadcast) {
 
 TEST_F(MultiIndexTest, 1d_array_of_1d_buckets) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {7}}; // 1d cut into two sections
+  Dimensions buf{dim, 7}; // 1d cut into two sections
   // natural order no gaps
   check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, x, x, {0, 1, 2, 3, 4, 5, 6});
   // gap between
@@ -198,7 +198,7 @@ TEST_F(MultiIndexTest, 1d_array_of_2d_buckets) {
 
 TEST_F(MultiIndexTest, 2d_array_of_1d_buckets) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {12}}; // 1d cut into xy=2x3 sections
+  Dimensions buf{dim, 12}; // 1d cut into xy=2x3 sections
   check_with_buckets(buf, dim,
                      {{0, 2}, {2, 4}, {4, 6}, {6, 8}, {8, 10}, {10, 12}}, xy,
                      xy, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -221,7 +221,7 @@ TEST_F(MultiIndexTest, 2d_array_of_1d_buckets) {
 
 TEST_F(MultiIndexTest, 1d_array_of_1d_buckets_and_dense) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {7}}; // 1d cut into two sections
+  Dimensions buf{dim, 7}; // 1d cut into two sections
   // natural order no gaps
   check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, Dimensions{}, Dim::Invalid, {},
                      x, x, x, {0, 1, 2, 3, 4, 5, 6}, {0, 0, 0, 1, 1, 1, 1});
@@ -241,8 +241,8 @@ TEST_F(MultiIndexTest, 1d_array_of_1d_buckets_and_dense) {
 
 TEST_F(MultiIndexTest, 1d_array_of_1d_buckets_and_dense_with_empty_buckets) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {7}};
-  Dimensions x1{{Dim::X}, {1}};
+  Dimensions buf{dim, 7};
+  Dimensions x1{Dim::X, 1};
   check_with_buckets(buf, dim, {{0, 0}}, Dimensions{}, Dim::Invalid, {}, x1, x1,
                      x1, {}, {});
   check_with_buckets(buf, dim, {{1, 1}, {0, 0}}, Dimensions{}, Dim::Invalid, {},
@@ -257,7 +257,7 @@ TEST_F(MultiIndexTest, 1d_array_of_1d_buckets_and_dense_with_empty_buckets) {
 
 TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {1}};
+  Dimensions buf{dim, 1};
   check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, buf, dim, {{4, 7}, {0, 4}}, x,
                      x, x, {0, 1, 2, 3, 4, 5, 6}, {4, 5, 6, 0, 1, 2, 3});
   // slice inner
@@ -275,7 +275,7 @@ TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets) {
 
 TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets_bucket_size_mismatch) {
   const Dim dim = Dim::Row;
-  Dimensions buf{{dim}, {7}};
+  Dimensions buf{dim, 7};
   EXPECT_THROW(check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, buf, dim,
                                   {{0, 4}, {3, 7}}, x, x, x,
                                   {0, 1, 2, 3, 4, 5, 6}, {0, 1, 2, 3, 4, 5, 6}),

--- a/dataset/CMakeLists.txt
+++ b/dataset/CMakeLists.txt
@@ -2,6 +2,7 @@
 # contributors (https://github.com/scipp)
 set(TARGET_NAME "scipp-dataset")
 set(INC_FILES
+    include/scipp/dataset/bucketby.h
     include/scipp/dataset/bucket.h
     include/scipp/dataset/choose.h
     include/scipp/dataset/counts.h
@@ -26,6 +27,7 @@ set(INC_FILES
 
 set(SRC_FILES
     arithmetic.cpp
+    bucketby.cpp
     bucket.cpp
     counts.cpp
     data_array.cpp

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -29,9 +29,8 @@
 
 namespace scipp::dataset::buckets {
 
-namespace {
-
-auto sizes_to_begin(const VariableConstView &sizes) {
+std::tuple<Variable, scipp::index>
+sizes_to_begin(const VariableConstView &sizes) {
   Variable begin(sizes);
   scipp::index size = 0;
   for (auto &i : begin.values<scipp::index>()) {
@@ -39,8 +38,10 @@ auto sizes_to_begin(const VariableConstView &sizes) {
     size += i;
     i = old_size;
   }
-  return std::tuple{begin, size};
+  return {begin, size};
 }
+
+namespace {
 
 constexpr auto copy_spans = overloaded{
     core::element::arg_list<std::tuple<span<double>, span<const double>>>,

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -175,9 +175,10 @@ DataArray bucketby(const DataArrayConstView &array,
     if (indices) {
       if (bucket_dim != coord.dims().inner())
         throw except::DimensionError(
-            "Coords of data to be bucketed have inconsistent dimensions. Data "
-            "that can be bucketed should generally resemble a table, with a "
-            "coord column for each bucketed dimension.");
+            "Coords of data to be bucketed have inconsistent dimensions " +
+            to_string(bucket_dim) + " and " + to_string(coord.dims().inner()) +
+            ". Data that can be bucketed should generally resemble a table, "
+            "with a coord column for each bucketed dimension.");
       indices = variable::transform<scipp::index>(
           indices, inner_indices,
           overloaded{[](const units::Unit &, const units::Unit &) {

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <numeric>
+
+#include "scipp/core/element/permute.h"
+#include "scipp/core/parallel.h"
+#include "scipp/core/tag_util.h"
+
+#include "scipp/variable/subspan_view.h"
+#include "scipp/variable/transform.h"
+#include "scipp/variable/util.h"
+
+#include "scipp/dataset/bucket.h"
+#include "scipp/dataset/bucketby.h"
+
+#include "dataset_operations_common.h"
+
+namespace scipp::dataset {
+
+
+namespace {
+static void expectValidGroupbyKey(const VariableConstView &key) {
+  if (key.dims().ndim() != 1)
+    throw except::DimensionError("Group-by key must be 1-dimensional");
+  if (key.hasVariances())
+    throw except::VariancesError("Group-by key cannot have variances");
+}
+
+template <class T> auto edge_indices(const T &x, const T &edges) {
+  const auto size = scipp::size(edges);
+  element_array<scipp::index> indices(size, core::default_init_elements);
+  scipp::index current = 0;
+  for (scipp::index i = 0; i < scipp::size(x); ++i) {
+    while (current < size && x[i] >= edges[current])
+      indices.data()[current++] = i;
+  }
+  for (; current < size; ++current)
+    indices.data()[current] = scipp::size(x);
+  return indices;
+}
+
+template <class T> auto find_sorting_permutation(const T &key) {
+  element_array<scipp::index> p(key.size(), core::default_init_elements);
+  std::iota(p.begin(), p.end(), 0);
+  core::parallel::parallel_sort(
+      p.begin(), p.end(), [&](auto i, auto j) { return key[i] < key[j]; });
+  return p;
+}
+
+Variable permute(const VariableConstView &var, const Dim dim,
+                 const VariableConstView &permutation) {
+  return variable::transform(subspan_view(var, dim), permutation,
+                             core::element::permute);
+}
+
+template <class T> struct BoundIndices {
+  static auto apply(const VariableConstView &x,
+                    const VariableConstView &edges) {
+    // Using span over data since random access via ElementArrayView is slow.
+    const auto x_ = scipp::span(x.values<T>().data(), x.dims().volume());
+    const auto edges_ =
+        scipp::span(edges.values<T>().data(), edges.dims().volume());
+    return makeVariable<scipp::index>(edges.dims(),
+                                      Values(edge_indices(x_, edges_)));
+  }
+};
+
+template <class T> struct MakePermutation {
+  static auto apply(const VariableConstView &key) {
+    expectValidGroupbyKey(key);
+    // Using span over data since random access via ElementArrayView is slow.
+    const auto range = scipp::span(key.values<T>().data(), key.dims().volume());
+    return makeVariable<scipp::index>(key.dims(),
+                                      Values(find_sorting_permutation(range)));
+  }
+};
+
+auto permute(const DataArrayConstView &data, const Dim dim,
+             const VariableConstView &permutation) {
+  return dataset::transform(data, [dim, permutation](const auto &var) {
+    return var.dims().contains(dim) ? permute(var, dim, permutation)
+                                    : copy(var);
+  });
+}
+} // namespace
+
+
+auto edge_indices(const VariableConstView &x, const VariableConstView &edges) {
+  return core::CallDType<double, float, int64_t, int32_t, bool,
+                         std::string>::apply<BoundIndices>(x.dtype(), x, edges);
+}
+
+template <class T>
+auto call_bucketby(const T &array, const VariableConstView &key) {
+  return permute(
+      array, key.dims().inner(),
+      core::CallDType<double, float, int64_t, int32_t, bool,
+                      std::string>::apply<MakePermutation>(key.dtype(), key));
+}
+
+
+DataArray sortby(const DataArrayConstView &array, const Dim dim) {
+  const auto &key = array.coords()[dim];
+  return call_bucketby(array, key);
+}
+
+Variable bucketby(const DataArrayConstView &array, const Dim dim,
+                  const VariableConstView &bins) {
+  auto sorted = sortby(array, dim);
+  const auto &key = sorted.coords()[dim];
+  auto indices = edge_indices(key, bins);
+  const auto &dims = bins.dims();
+  const auto bin_dim = dims.inner();
+  const auto nbin = dims[bin_dim] - 1;
+  // Note that data outside bin bounds is *not* dropped. Should it?
+  return buckets::from_constituents(zip(indices.slice({bin_dim, 0, nbin}),
+                                        indices.slice({bin_dim, 1, nbin + 1})),
+                                    key.dims().inner(), std::move(sorted));
+}
+
+} // namespace scipp::dataset

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -17,18 +17,13 @@
 
 #include "scipp/dataset/bucket.h"
 #include "scipp/dataset/bucketby.h"
+#include "scipp/dataset/except.h"
 
 #include "dataset_operations_common.h"
 
 namespace scipp::dataset {
 
 namespace {
-static void expectValidGroupbyKey(const VariableConstView &key) {
-  if (key.dims().ndim() != 1)
-    throw except::DimensionError("Group-by key must be 1-dimensional");
-  if (key.hasVariances())
-    throw except::VariancesError("Group-by key cannot have variances");
-}
 
 template <class T> auto find_sorting_permutation(const T &key) {
   element_array<scipp::index> p(key.size(), core::default_init_elements);
@@ -130,7 +125,7 @@ Variable permute(const VariableConstView &var, const Dim dim,
 
 template <class T> struct MakePermutation {
   static auto apply(const VariableConstView &key) {
-    expectValidGroupbyKey(key);
+    expect::isKey(key);
     // Using span over data since random access via ElementArrayView is slow.
     return makeVariable<scipp::index>(
         key.dims(), Values(find_sorting_permutation(scipp::span(

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -57,8 +57,8 @@ Variable bin_sizes(const VariableConstView &indices,
   for (const auto &item : edges)
     dims = merge(dims, shrink(item.dims()));
   Variable sizes = makeVariable<scipp::index>(dims);
-  const auto s = sizes.values<scipp::index>();
-  for (const auto i : indices.values<scipp::index>())
+  const auto s = sizes.values<scipp::index>().as_span();
+  for (const auto i : indices.values<scipp::index>().as_span())
     if (i >= 0)
       ++s[i];
   return sizes;
@@ -74,14 +74,14 @@ template <class T> struct Bin {
     dims.resize(dims.inner(), total_size);
     auto binned = variable::variableFactory().create(
         var.dtype(), dims, var.unit(), var.hasVariances());
-    const auto indices_ = indices.values<scipp::index>();
-    const auto values = var.values<T>();
-    const auto binned_values = binned.values<T>();
-    const auto current = begin.values<scipp::index>();
+    const auto indices_ = indices.values<scipp::index>().as_span();
+    const auto values = var.values<T>().as_span();
+    const auto binned_values = binned.values<T>().as_span();
+    const auto current = begin.values<scipp::index>().as_span();
     const auto size = scipp::size(values);
     if (var.hasVariances()) {
-      const auto variances = var.variances<T>();
-      const auto binned_variances = binned.variances<T>();
+      const auto variances = var.variances<T>().as_span();
+      const auto binned_variances = binned.variances<T>().as_span();
       for (scipp::index i = 0; i < size; ++i) {
         const auto i_bin = indices_[i];
         if (i_bin < 0)
@@ -128,8 +128,8 @@ template <class T> struct MakePermutation {
     expect::isKey(key);
     // Using span over data since random access via ElementArrayView is slow.
     return makeVariable<scipp::index>(
-        key.dims(), Values(find_sorting_permutation(scipp::span(
-                        key.values<T>().data(), key.dims().volume()))));
+        key.dims(),
+        Values(find_sorting_permutation(key.values<T>().as_span())));
   }
 };
 

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -180,7 +180,7 @@ DataArray bucketby(const DataArrayConstView &array,
             "coord column for each bucketed dimension.");
       indices = variable::transform<scipp::index>(
           indices, inner_indices,
-          overloaded{[](const units::Unit &u0, const units::Unit &u1) {
+          overloaded{[](const units::Unit &, const units::Unit &) {
                        return units::one;
                      },
                      [nbin](const auto i0, const auto i1) {

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -181,8 +181,7 @@ DataArray bucketby(const DataArrayConstView &array,
                      },
                      [nbin](const auto i0, const auto i1) {
                        return i0 < 0 || i1 < 0 ? -1 : i0 * nbin + i1;
-                     }} // namespace scipp::dataset
-      );
+                     }});
     } else {
       indices = inner_indices;
     }

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -153,6 +153,22 @@ Dataset apply_to_items(const DatasetConstView &d, Func func, Args &&... args) {
   return result;
 }
 
+/// Return a copy of map-like objects such as CoordView with `func` applied to
+/// each item.
+template <class T, class Func> auto transform_map(const T &map, Func func) {
+  std::map<typename T::key_type, typename T::mapped_type> out;
+  for (const auto &[key, item] : map)
+    out.emplace(key, func(item));
+  return out;
+}
+
+template <class Func>
+DataArray transform(const DataArrayConstView &a, Func func) {
+  return DataArray(func(a.data()), transform_map(a.aligned_coords(), func),
+                   transform_map(a.masks(), func),
+                   transform_map(a.unaligned_coords(), func), a.name());
+}
+
 // Helpers for reductions for DataArray and Dataset, which include masks.
 [[nodiscard]] Variable mean(const VariableConstView &var, const Dim dim,
                             const MasksConstView &masks);

--- a/dataset/except.cpp
+++ b/dataset/except.cpp
@@ -15,4 +15,13 @@ void coordsAreSuperset(const DataArrayConstView &a,
       throw except::CoordMismatchError(*a_coords.find(b_coord.first), b_coord);
 }
 
+void isKey(const VariableConstView &key) {
+  if (key.dims().ndim() != 1)
+    throw except::DimensionError(
+        "Coord for binning or grouping must be 1-dimensional");
+  if (key.hasVariances())
+    throw except::VariancesError(
+        "Coord for binning or grouping cannot have variances");
+}
+
 } // namespace scipp::dataset::expect

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -236,16 +236,9 @@ template <class T> T GroupBy<T>::mean(const Dim reductionDim) const {
   return out;
 }
 
-static void expectValidGroupbyKey(const VariableConstView &key) {
-  if (key.dims().ndim() != 1)
-    throw except::DimensionError("Group-by key must be 1-dimensional");
-  if (key.hasVariances())
-    throw except::VariancesError("Group-by key cannot have variances");
-}
-
 template <class T> struct MakeGroups {
   static auto apply(const VariableConstView &key, const Dim targetDim) {
-    expectValidGroupbyKey(key);
+    expect::isKey(key);
     const auto &values = key.values<T>();
 
     const auto dim = key.dims().inner();
@@ -280,7 +273,7 @@ template <class T> struct MakeGroups {
 template <class T> struct MakeBinGroups {
   static auto apply(const VariableConstView &key,
                     const VariableConstView &bins) {
-    expectValidGroupbyKey(key);
+    expect::isKey(key);
     if (bins.dims().ndim() != 1)
       throw except::DimensionError("Group-by bins must be 1-dimensional");
     if (key.unit() != bins.unit())

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -121,18 +121,17 @@ static constexpr auto flatten = [](const DataArrayView &out, const auto &in,
   }
 };
 
-static constexpr auto sum = [](const DataArrayView &out,
-                               const auto &data_container,
-                               const GroupByGrouping::group &group,
-                               const Dim reductionDim, const Variable &mask) {
-  for (const auto &slice : group) {
-    const auto data_slice = data_container.slice(slice);
-    if (mask)
-      sum_impl(out.data(), data_slice.data() * mask.slice(slice));
-    else
-      sum_impl(out.data(), data_slice.data());
-  }
-};
+static constexpr auto sum =
+    [](const DataArrayView &out, const auto &data_container,
+       const GroupByGrouping::group &group, const Dim, const Variable &mask) {
+      for (const auto &slice : group) {
+        const auto data_slice = data_container.slice(slice);
+        if (mask)
+          sum_impl(out.data(), data_slice.data() * mask.slice(slice));
+        else
+          sum_impl(out.data(), data_slice.data());
+      }
+    };
 
 template <void (*Func)(const VariableView &, const VariableConstView &)>
 // The msvc compiler was failing to pass the templated function correctly

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -8,6 +8,9 @@
 
 namespace scipp::dataset::buckets {
 
+[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Variable, scipp::index>
+sizes_to_begin(const VariableConstView &sizes);
+
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 concatenate(const VariableConstView &var0, const VariableConstView &var1);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray

--- a/dataset/include/scipp/dataset/bucketby.h
+++ b/dataset/include/scipp/dataset/bucketby.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <scipp/dataset/dataset.h>
+
+namespace scipp::dataset {
+
+SCIPP_DATASET_EXPORT DataArray sortby(const DataArrayConstView &data,
+                                      const Dim dim);
+SCIPP_DATASET_EXPORT Variable bucketby(const DataArrayConstView &data,
+                                       const Dim dim,
+                                       const VariableConstView &bins);
+
+} // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucketby.h
+++ b/dataset/include/scipp/dataset/bucketby.h
@@ -12,6 +12,6 @@ SCIPP_DATASET_EXPORT DataArray sortby(const DataArrayConstView &data,
                                       const Dim dim);
 SCIPP_DATASET_EXPORT DataArray
 bucketby(const DataArrayConstView &array,
-         const std::map<Dim, VariableConstView> &edges);
+         const std::vector<VariableConstView> &edges);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucketby.h
+++ b/dataset/include/scipp/dataset/bucketby.h
@@ -13,5 +13,10 @@ SCIPP_DATASET_EXPORT DataArray sortby(const DataArrayConstView &data,
 SCIPP_DATASET_EXPORT Variable bucketby(const DataArrayConstView &data,
                                        const Dim dim,
                                        const VariableConstView &bins);
+SCIPP_DATASET_EXPORT Variable bucketby(const DataArrayConstView &data,
+                                       const Dim dim0,
+                                       const VariableConstView &bins0,
+                                       const Dim dim1,
+                                       const VariableConstView &bins1);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucketby.h
+++ b/dataset/include/scipp/dataset/bucketby.h
@@ -10,13 +10,8 @@ namespace scipp::dataset {
 
 SCIPP_DATASET_EXPORT DataArray sortby(const DataArrayConstView &data,
                                       const Dim dim);
-SCIPP_DATASET_EXPORT DataArray bucketby(const DataArrayConstView &data,
-                                        const Dim dim,
-                                        const VariableConstView &bins);
-SCIPP_DATASET_EXPORT DataArray bucketby(const DataArrayConstView &data,
-                                        const Dim dim0,
-                                        const VariableConstView &bins0,
-                                        const Dim dim1,
-                                        const VariableConstView &bins1);
+SCIPP_DATASET_EXPORT DataArray
+bucketby(const DataArrayConstView &array,
+         const std::map<Dim, VariableConstView> &edges);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bucketby.h
+++ b/dataset/include/scipp/dataset/bucketby.h
@@ -10,13 +10,13 @@ namespace scipp::dataset {
 
 SCIPP_DATASET_EXPORT DataArray sortby(const DataArrayConstView &data,
                                       const Dim dim);
-SCIPP_DATASET_EXPORT Variable bucketby(const DataArrayConstView &data,
-                                       const Dim dim,
-                                       const VariableConstView &bins);
-SCIPP_DATASET_EXPORT Variable bucketby(const DataArrayConstView &data,
-                                       const Dim dim0,
-                                       const VariableConstView &bins0,
-                                       const Dim dim1,
-                                       const VariableConstView &bins1);
+SCIPP_DATASET_EXPORT DataArray bucketby(const DataArrayConstView &data,
+                                        const Dim dim,
+                                        const VariableConstView &bins);
+SCIPP_DATASET_EXPORT DataArray bucketby(const DataArrayConstView &data,
+                                        const Dim dim0,
+                                        const VariableConstView &bins0,
+                                        const Dim dim1,
+                                        const VariableConstView &bins1);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/except.h
+++ b/dataset/include/scipp/dataset/except.h
@@ -49,7 +49,9 @@ MismatchError(const std::pair<std::string, VariableConstView> &, const T &)
 
 namespace scipp::dataset::expect {
 
-void SCIPP_DATASET_EXPORT coordsAreSuperset(const DataArrayConstView &a,
+SCIPP_DATASET_EXPORT void coordsAreSuperset(const DataArrayConstView &a,
                                             const DataArrayConstView &b);
+
+SCIPP_DATASET_EXPORT void isKey(const VariableConstView &key);
 
 } // namespace scipp::dataset::expect

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_dependencies(all-tests ${TARGET_NAME})
 add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
   attributes_test.cpp
+  bucketby_test.cpp
   buckets_test.cpp
   choose_test.cpp
   concatenate_test.cpp

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -47,7 +47,7 @@ TEST_F(DataArrayBucketByTest, 1d) {
       DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
                 {{"mask", sorted_mask}});
 
-  const auto bucketed = bucketby(table, {{Dim::X, edges_x}});
+  const auto bucketed = bucketby(table, {edges_x});
 
   EXPECT_EQ(bucketed.dims(), Dimensions({Dim::X}, {2}));
   EXPECT_EQ(bucketed.coords()[Dim::X], edges_x);
@@ -77,7 +77,7 @@ TEST_F(DataArrayBucketByTest, 2d) {
       {{Dim::X, sorted_x}, {Dim::Y, sorted_y}, {Dim("scalar"), scalar}},
       {{"mask", sorted_mask}});
 
-  const auto bucketed = bucketby(table, {{Dim::X, edges_x}, {Dim::Y, edges_y}});
+  const auto bucketed = bucketby(table, {edges_x, edges_y});
 
   EXPECT_EQ(bucketed.dims(), Dimensions({Dim::X, Dim::Y}, {2, 2}));
   EXPECT_EQ(bucketed.coords()[Dim::X], edges_x);

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -47,7 +47,7 @@ TEST_F(DataArrayBucketByTest, 1d) {
       DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
                 {{"mask", sorted_mask}});
 
-  const auto bucketed = bucketby(table, Dim::X, edges_x);
+  const auto bucketed = bucketby(table, {{Dim::X, edges_x}});
 
   EXPECT_EQ(bucketed.dims(), Dimensions({Dim::X}, {2}));
   EXPECT_EQ(bucketed.coords()[Dim::X], edges_x);
@@ -77,7 +77,7 @@ TEST_F(DataArrayBucketByTest, 2d) {
       {{Dim::X, sorted_x}, {Dim::Y, sorted_y}, {Dim("scalar"), scalar}},
       {{"mask", sorted_mask}});
 
-  const auto bucketed = bucketby(table, Dim::X, edges_x, Dim::Y, edges_y);
+  const auto bucketed = bucketby(table, {{Dim::X, edges_x}, {Dim::Y, edges_y}});
 
   EXPECT_EQ(bucketed.dims(), Dimensions({Dim::X, Dim::Y}, {2, 2}));
   EXPECT_EQ(bucketed.coords()[Dim::X], edges_x);

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -13,7 +13,7 @@ protected:
   Variable data = makeVariable<double>(
       Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 3, 2, 4});
   Variable x =
-      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{4, 3, 2, 1});
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{3, 2, 4, 1});
   Variable mask = makeVariable<bool>(Dims{Dim::Event}, Shape{4},
                                      Values{true, false, false, false});
   Variable scalar = makeVariable<double>(Values{1.1});
@@ -23,18 +23,30 @@ protected:
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0, 2, 4});
 };
 
-TEST_F(DataArrayBucketByTest, 1d) {
+TEST_F(DataArrayBucketByTest, sort_1d) {
   Variable sorted_data = makeVariable<double>(
-      Dims{Dim::Event}, Shape{4}, Values{4, 3, 2, 1}, Variances{4, 2, 3, 1});
+      Dims{Dim::Event}, Shape{4}, Values{4, 2, 1, 3}, Variances{4, 3, 1, 2});
   Variable sorted_x =
       makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4});
   Variable sorted_mask = makeVariable<bool>(Dims{Dim::Event}, Shape{4},
-                                            Values{false, false, false, true});
+                                            Values{false, false, true, false});
+  DataArray sorted_table =
+      DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
+                {{"mask", sorted_mask}});
+  EXPECT_EQ(sortby(table, Dim::X), sorted_table);
+}
+
+TEST_F(DataArrayBucketByTest, 1d) {
+  Variable sorted_data = makeVariable<double>(
+      Dims{Dim::Event}, Shape{3}, Values{4, 1, 2}, Variances{4, 1, 3});
+  Variable sorted_x =
+      makeVariable<double>(Dims{Dim::Event}, Shape{3}, Values{1, 3, 2});
+  Variable sorted_mask = makeVariable<bool>(Dims{Dim::Event}, Shape{3},
+                                            Values{false, true, false});
   DataArray sorted_table =
       DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
                 {{"mask", sorted_mask}});
 
-  EXPECT_EQ(sortby(table, Dim::X), sorted_table);
   const auto bucketed = bucketby(table, Dim::X, edges_x);
   EXPECT_EQ(bucketed.values<bucket<DataArray>>()[0],
             sorted_table.slice({Dim::Event, 0, 1}));

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/dataset/bucketby.h"
+#include "scipp/dataset/string.h"
+
+using namespace scipp;
+using namespace scipp::dataset;
+
+class DataArrayBucketByTest : public ::testing::Test {
+protected:
+  Variable data = makeVariable<double>(
+      Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 3, 2, 4});
+  Variable x =
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{4, 3, 2, 1});
+  Variable mask = makeVariable<bool>(Dims{Dim::Event}, Shape{4},
+                                     Values{true, false, false, false});
+  Variable scalar = makeVariable<double>(Values{1.1});
+  DataArray table =
+      DataArray(data, {{Dim::X, x}, {Dim("scalar"), scalar}}, {{"mask", mask}});
+  Variable edges =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0, 2, 4});
+};
+
+TEST_F(DataArrayBucketByTest, 1d) {
+  Variable sorted_data = makeVariable<double>(
+      Dims{Dim::Event}, Shape{4}, Values{4, 3, 2, 1}, Variances{4, 2, 3, 1});
+  Variable sorted_x =
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4});
+  Variable sorted_mask = makeVariable<bool>(Dims{Dim::Event}, Shape{4},
+                                            Values{false, false, false, true});
+  DataArray sorted_table =
+      DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
+                {{"mask", sorted_mask}});
+
+  EXPECT_EQ(sortby(table, Dim::X), sorted_table);
+  const auto bucketed = bucketby(table, Dim::X, edges);
+  EXPECT_EQ(bucketed.values<bucket<DataArray>>()[0],
+            sorted_table.slice({Dim::Event, 0, 1}));
+  EXPECT_EQ(bucketed.values<bucket<DataArray>>()[1],
+            sorted_table.slice({Dim::Event, 1, 3}));
+}

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -49,7 +49,7 @@ TEST_F(DataArrayBucketByTest, 1d) {
 
   const auto bucketed = bucketby(table, {edges_x});
 
-  EXPECT_EQ(bucketed.dims(), Dimensions({Dim::X}, {2}));
+  EXPECT_EQ(bucketed.dims(), Dimensions(Dim::X, 2));
   EXPECT_EQ(bucketed.coords()[Dim::X], edges_x);
   EXPECT_EQ(bucketed.values<bucket<DataArray>>()[0],
             sorted_table.slice({Dim::Event, 0, 1}));

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -366,7 +366,8 @@ protected:
   void check_fail() {
     Variable var0{std::make_unique<Model>(indices, Dim::X, buffer0)};
     Variable var1{std::make_unique<Model>(indices, Dim::X, buffer1)};
-    EXPECT_ANY_THROW(buckets::concatenate(var0, var1));
+    EXPECT_ANY_THROW([[maybe_unused]] auto joined =
+                         buckets::concatenate(var0, var1));
   }
 };
 

--- a/dataset/test/dataset_test_common.cpp
+++ b/dataset/test/dataset_test_common.cpp
@@ -20,10 +20,6 @@ std::vector<bool> make_bools(const scipp::index size,
 std::vector<bool> make_bools(const scipp::index size, bool pattern) {
   return make_bools(size, std::initializer_list<bool>{pattern});
 }
-Variable makeRandom(const Dimensions &dims) {
-  Random rand;
-  return makeVariable<double>(Dimensions{dims}, Values(rand(dims.volume())));
-}
 
 DatasetFactory3D::DatasetFactory3D(const scipp::index lx_,
                                    const scipp::index ly_,

--- a/dataset/test/dataset_test_common.h
+++ b/dataset/test/dataset_test_common.h
@@ -16,8 +16,6 @@ std::vector<bool> make_bools(const scipp::index size,
                              std::initializer_list<bool> pattern);
 std::vector<bool> make_bools(const scipp::index size, bool pattern);
 
-Variable makeRandom(const Dimensions &dims);
-
 /// Factory for creating datasets for testing. For a given instance, `make()`
 /// will return datasets with identical coords, such that they are compatible in
 /// binary operations.

--- a/dataset/test/mean_test.cpp
+++ b/dataset/test/mean_test.cpp
@@ -60,7 +60,8 @@ TEST(MeanTest, in_place_fail_output_dtype) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                         units::m, Values{1.0, 2.0, 3.0, 4.0});
   auto out = makeVariable<int>(Dims{Dim::Y}, Shape{2}, units::m);
-  EXPECT_THROW(const auto view = mean(var, Dim::X, out), except::UnitError);
+  EXPECT_THROW([[maybe_unused]] const auto view = mean(var, Dim::X, out),
+               except::UnitError);
 }
 
 TEST(MeanTest, masked_data_array) {

--- a/dataset/test/slice_by_value_test.cpp
+++ b/dataset/test/slice_by_value_test.cpp
@@ -244,9 +244,13 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D) {
     EXPECT_EQ(slice(sliceable, Dim::X, 11.9 * units::m),
               sliceable.slice({Dim::X, 8}));
     // (closed on right) so out of bounds
-    EXPECT_THROW(slice(sliceable, Dim::X, 12.0 * units::m), except::SliceError);
+    EXPECT_THROW([[maybe_unused]] auto view =
+                     slice(sliceable, Dim::X, 12.0 * units::m),
+                 except::SliceError);
     // out of bounds for left for completeness
-    EXPECT_THROW(slice(sliceable, Dim::X, 2.99 * units::m), except::SliceError);
+    EXPECT_THROW([[maybe_unused]] auto view =
+                     slice(sliceable, Dim::X, 2.99 * units::m),
+                 except::SliceError);
   };
   test(da);                              // Test for DataArray
   test(Dataset{DataArrayConstView{da}}); // Test for Dataset

--- a/docs/user-guide/buckets.ipynb
+++ b/docs/user-guide/buckets.ipynb
@@ -18,8 +18,7 @@
     "\n",
     "The key feature here is that *bucketing does not actually histogram or resample data*.\n",
     "Data is kept in its original form.\n",
-    "Bucketing just adds a wrapper with a coordinate system more adequate for working with the scientific data.\n",
-    "Where possible, operations with the realigned wrapper are supported \"as if\" working with dense histogrammed data.\n",
+    "Bucketing provides a wrapper with a coordinate system more adequate for working with the scientific data.\n",
     "\n",
     "## From unaligned to bucketed data\n",
     "\n",
@@ -120,7 +119,7 @@
     "This shows the distribution in space, but for real datasets with millions of points this may not be convenient.\n",
     "Furthermore, operating with scattered data is often inconvenient and may require knowledge of the underlying representation.\n",
     "\n",
-    "We can now use `scipp.to_buckets` to provide a more accessible wrapper for our data:"
+    "We can now use `scipp.bucketby` to provide a more accessible wrapper for our data:"
    ]
   },
   {
@@ -131,11 +130,7 @@
    "source": [
     "xbins = sc.Variable(dims=['x'], unit=sc.units.m, values=[0.1,0.5,0.9])\n",
     "ybins = sc.Variable(dims=['y'], unit=sc.units.m, values=[0.1,0.3,0.5,0.7,0.9])\n",
-    "# TODO Would actually need to sort `data` first\n",
-    "begin = sc.Variable(dims=['y','x'], values=np.linspace(0,40,num=8).astype(np.int64).reshape(4,2))\n",
-    "end = begin + 5\n",
-    "realigned = sc.to_buckets(dim='position', begin=begin, end=end, data=data)\n",
-    "buckets = sc.DataArray(data=realigned, coords={'y':ybins,'x':xbins})\n",
+    "buckets = sc.bucketby(data, [ybins, xbins])\n",
     "buckets"
    ]
   },
@@ -286,10 +281,10 @@
    "outputs": [],
    "source": [
     "# In general npos != N since positions out of bounds are dropped by `realign`\n",
-    "#npos = len(realigned.unaligned.coords['position'].values)\n",
+    "npos = len(sc.buckets.get_buffer(buckets.data).coords['position'].values)\n",
     "position_mask = sc.Variable(\n",
     "    dims=['position'],\n",
-    "    values=[False if i>N/4 else True for i in range(N)]\n",
+    "    values=[False if i>npos/4 else True for i in range(npos)]\n",
     ")\n",
     "x_y_mask = sc.Variable(\n",
     "    dims=buckets.dims,\n",
@@ -354,7 +349,7 @@
     "**Warning**\n",
     "    \n",
     "The support for realigned data is being removed and will be replaced by bucket variables.\n",
-    "This section is therefore currently incomplete and disabled.\n",
+    "The on-the-fly sum over buckets required for plotting is currently not yet being performance automatically.\n",
     "\n",
     "</div>"
    ]
@@ -375,8 +370,8 @@
     "        'y':sc.Variable(dims=['position'], unit=sc.units.m, values=np.random.rand(N)),\n",
     "        'z':sc.Variable(dims=['position'], unit=sc.units.m, values=np.random.rand(N))})\n",
     "zbins = sc.Variable(dims=['z'], unit=sc.units.m, values=np.linspace(0.1, 0.9, 20))\n",
-    "#realigned = sc.realign(data3d, {'z':zbins,'y':ybins,'x':xbins})\n",
-    "#plot(realigned)"
+    "buckets = sc.bucketby(data3d, [zbins, ybins, xbins])\n",
+    "plot(sc.buckets.sum(buckets))"
    ]
   },
   {
@@ -390,22 +385,6 @@
     "In this case, since the histogramming is performed on-the-fly for every slice through the data cube, the colorscale limits cannot be known in advance. They will then grow automatically as we navigate through the cube, but will not shink if the range of displayed values gets smaller again, to give a better feel of the relative values contained in different slices.\n",
     "\n",
     "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The automatic histogramming also works in a 1-dimensional projection: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#plot(realigned, projection=\"1d\")"
    ]
   },
   {

--- a/docs/user-guide/buckets.ipynb
+++ b/docs/user-guide/buckets.ipynb
@@ -349,7 +349,7 @@
     "**Warning**\n",
     "    \n",
     "The support for realigned data is being removed and will be replaced by bucket variables.\n",
-    "The on-the-fly sum over buckets required for plotting is currently not yet being performance automatically.\n",
+    "The on-the-fly sum over buckets required for plotting is currently not yet being performed automatically.\n",
     "\n",
     "</div>"
    ]

--- a/python/buckets.cpp
+++ b/python/buckets.cpp
@@ -5,6 +5,7 @@
 #include "pybind11.h"
 #include "scipp/core/except.h"
 #include "scipp/dataset/bucket.h"
+#include "scipp/dataset/bucketby.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/bucket_model.h"
 #include "scipp/variable/shape.h"
@@ -119,4 +120,7 @@ void init_buckets(py::module &m) {
       return get_buffer<Dataset>(obj);
     return py::none();
   });
+
+  m.def("bucketby", dataset::bucketby,
+        py::call_guard<py::gil_scoped_release>());
 }

--- a/test/random.h
+++ b/test/random.h
@@ -8,6 +8,8 @@
 #include <random>
 #include <vector>
 
+#include "scipp/variable/variable.h"
+
 class Random {
   std::mt19937 mt{std::random_device()()};
   std::uniform_real_distribution<double> dist;
@@ -35,3 +37,9 @@ public:
   }
   void seed(const uint32_t value) { mt.seed(value); }
 };
+
+inline scipp::Variable makeRandom(const scipp::Dimensions &dims) {
+  using namespace scipp;
+  Random rand;
+  return makeVariable<double>(Dimensions{dims}, Values(rand(dims.volume())));
+}

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -40,7 +40,7 @@ TEST(UnitTest, cancellation) {
   EXPECT_EQ(units::deg * Unit(units::rad / units::deg), units::rad);
 }
 
-TEST(UnitTest, construct) { ASSERT_NO_THROW(Unit u{units::dimensionless}); }
+TEST(UnitTest, construct) { ASSERT_NO_THROW(Unit{units::dimensionless}); }
 
 TEST(UnitTest, construct_default) {
   Unit u;

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -110,8 +110,8 @@ auto invoke_subspan_view(const DType dtype, Args &&... args) {
 
 template <class Var, class... Args>
 Variable subspan_view_impl(Var &var, Args &&... args) {
-  return invoke_subspan_view<double, float, int64_t, int32_t, bool>(
-      var.dtype(), var, args...);
+  return invoke_subspan_view<double, float, int64_t, int32_t, bool,
+                             std::string>(var.dtype(), var, args...);
 }
 
 } // namespace

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
-#include "test_macros.h"
+// clang-format off
 #include <gtest/gtest.h>
-
-#include "fix_typed_test_suite_warnings.h"
+#include "test_macros.h"
+// clang-format on
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
 

--- a/variable/test/subspan_view_test.cpp
+++ b/variable/test/subspan_view_test.cpp
@@ -20,12 +20,15 @@ protected:
 
 TEST_F(SubspanViewTest, fail_events) {
   auto events = makeVariable<event_list<double>>(Dims{Dim::Y}, Shape{2});
-  EXPECT_THROW(subspan_view(events, Dim::X), except::TypeError);
-  EXPECT_THROW(subspan_view(events, Dim::Y), except::TypeError);
+  EXPECT_THROW([[maybe_unused]] auto view = subspan_view(events, Dim::X),
+               except::TypeError);
+  EXPECT_THROW([[maybe_unused]] auto view = subspan_view(events, Dim::Y),
+               except::TypeError);
 }
 
 TEST_F(SubspanViewTest, fail_not_inner) {
-  EXPECT_THROW(subspan_view(var, Dim::Y), except::DimensionError);
+  EXPECT_THROW([[maybe_unused]] auto view = subspan_view(var, Dim::Y),
+               except::DimensionError);
 }
 
 TEST_F(SubspanViewTest, values) {

--- a/variable/variable_instantiate_view_elements.cpp
+++ b/variable/variable_instantiate_view_elements.cpp
@@ -20,6 +20,9 @@ INSTANTIATE_VARIABLE(span_int64, span<int64_t>)
 INSTANTIATE_VARIABLE(span_int32, span<int32_t>)
 INSTANTIATE_VARIABLE(span_const_bool, span<const bool>)
 INSTANTIATE_VARIABLE(span_bool, span<bool>)
+INSTANTIATE_VARIABLE(span_const_time_point, span<const core::time_point>)
+INSTANTIATE_VARIABLE(span_time_point, span<core::time_point>)
+INSTANTIATE_VARIABLE(span_const_string, span<const std::string>)
 INSTANTIATE_VARIABLE(span_string, span<std::string>)
 
 } // namespace scipp::variable


### PR DESCRIPTION
This adds `bucketby`. The current naming is inspired by `groupby`, which does essentially the same except for not executing the reorder into group (instead `groupby` keeps indices of all group contributions). There is a multitude of applications for this:

- Convert raw loaded event data to the "standard" event data layout with data sorted according to pixel ids (this is not really supported yet, would need to add a variant that works with a normal (integer) coord instead of bins, similar to the two variants we have for `groupby`).
- Group event data by pulse-time or TOF.
- Create the equivalent of a Mantid `MDEventWorkspace`.

The performance of this inial implementation is likely very poor. This is a vast number of ooptions for improving this, both in terms of improving the current algorithm, as well as using completely different algorithms. Since the targe applications vary so widely and the use is to important, it may eventually even be necessary to have multiple optimized implementations internally.

Reviewers:
- Check that the plot for bucketed data is back to how it looked before (screenshot kindly provided by Neil: https://github.com/scipp/scipp/pull/1337#discussion_r503855604).
- Try it out. Note that most sanity checks are missing right now, and testing is nearly non-existant, will add those in PR updates or follow-up PRs.
- Maybe focus on the bigger picture for now (docs working again?), internals are likely to be rewritten as missing variants are added and performance gets improved.
- `sortby` was a failed first attempt for implementing this, but may be useful for other things. Should it be kept?