### PR TITLE
Bucket "flatten"

### DIFF
--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -27,15 +27,14 @@ constexpr auto plus_equals =
 constexpr auto minus_equals =
     overloaded{add_inplace_types, [](auto &&a, const auto &b) { a -= b; }};
 
-constexpr auto mul_inplace_types =
-    arg_list<double, float, int64_t, int32_t, std::tuple<double, float>,
-             std::tuple<float, double>, std::tuple<int64_t, int32_t>,
-             std::tuple<int32_t, int64_t>, std::tuple<double, int64_t>,
-             std::tuple<double, int32_t>, std::tuple<float, int64_t>,
-             std::tuple<float, int32_t>, std::tuple<Eigen::Vector3d, double>,
-             std::tuple<Eigen::Vector3d, float>,
-             std::tuple<Eigen::Vector3d, int64_t>,
-             std::tuple<Eigen::Vector3d, int32_t>>;
+constexpr auto mul_inplace_types = arg_list<
+    double, float, int64_t, int32_t, std::tuple<double, float>,
+    std::tuple<float, double>, std::tuple<int64_t, int32_t>,
+    std::tuple<int64_t, bool>, std::tuple<int32_t, int64_t>,
+    std::tuple<double, int64_t>, std::tuple<double, int32_t>,
+    std::tuple<float, int64_t>, std::tuple<float, int32_t>,
+    std::tuple<Eigen::Vector3d, double>, std::tuple<Eigen::Vector3d, float>,
+    std::tuple<Eigen::Vector3d, int64_t>, std::tuple<Eigen::Vector3d, int32_t>>;
 
 // Note that we do *not* support any integer type as left-hand-side, to match
 // Python 3 and numpy "truediv" behavior. If "floordiv" is required it should be

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -202,6 +202,14 @@ Variable concatenate(const VariableConstView &var, const Dim dim) {
     return concatenate_impl<Dataset>(var, dim);
 }
 
+/// Reduce a dimension by concatenating all elements along the dimension.
+///
+/// This is the analogue to summing non-bucket data.
+DataArray concatenate(const DataArrayConstView &array, const Dim dim) {
+  return {buckets::concatenate(array.data(), dim), array.aligned_coords(),
+          array.masks(), array.unaligned_coords()};
+}
+
 void append(const VariableView &var0, const VariableConstView &var1) {
   if (var0.dtype() == dtype<bucket<Variable>>)
     var0.replace_model(combine<Variable>(var0, var1));

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -146,28 +146,49 @@ auto concatenate_impl(const VariableConstView &var0,
 }
 
 template <class T>
-auto concatenate_impl(const VariableConstView &var, const Dim dim) {
+auto concatenate_impl(const VariableConstView &var, const Dim dim,
+                      const VariableConstView &mask) {
   const auto &[indices, buffer_dim, buffer] = var.constituents<bucket<T>>();
-  const auto [begin, end] = unzip(indices);
+  auto [begin, end] = unzip(indices);
+  if (mask) {
+    begin *= ~mask;
+    end *= ~mask;
+  }
+  const auto masked_indices = zip(begin, end);
   const auto sizes = end - begin;
   const auto out_sizes = sum(sizes, dim);
   const auto [out_begin, size] = sizes_to_begin(out_sizes);
   const auto out_end = out_begin + out_sizes;
-  auto out_buffer = resize_buffer(buffer, dim, size);
-  const auto nslice = indices.dims()[dim];
+  auto out_buffer = resize_default_init(buffer, dim, size);
+  const auto nslice = masked_indices.dims()[dim];
   auto out_current = out_begin;
   auto out_next = out_current;
+  // For now we use a relatively inefficient implementation, copying the
+  // contents of every slice of input buckets to the same output bucket. A more
+  // efficient solution might be to use `transform` directly. Masking is taken
+  // care of by setting indidces (and begin/end indices) to {0,0} for masked
+  // input buckets.
   for (scipp::index i = 0; i < nslice; ++i) {
-    const auto slice_indices = indices.slice({dim, i});
+    const auto slice_indices = masked_indices.slice({dim, i});
     const auto [slice_begin, slice_end] = unzip(slice_indices);
     out_next += slice_end;
     out_next -= slice_begin;
-    copy(buffer, out_buffer, buffer_dim, slice_indices,
-         zip(out_current, out_next));
+    copy_slices(buffer, out_buffer, buffer_dim, slice_indices,
+                zip(out_current, out_next));
     out_current = out_next;
   }
   return Variable{std::make_unique<variable::DataModel<bucket<T>>>(
       zip(out_begin, out_end), buffer_dim, std::move(out_buffer))};
+}
+
+Variable concatenate_untyped(const VariableConstView &var, const Dim dim,
+                             const VariableConstView &mask = {}) {
+  if (var.dtype() == dtype<bucket<Variable>>)
+    return concatenate_impl<Variable>(var, dim, mask);
+  else if (var.dtype() == dtype<bucket<DataArray>>)
+    return concatenate_impl<DataArray>(var, dim, mask);
+  else
+    return concatenate_impl<Dataset>(var, dim, mask);
 }
 
 } // namespace
@@ -194,20 +215,15 @@ DataArray concatenate(const DataArrayConstView &a,
 ///
 /// This is the analogue to summing non-bucket data.
 Variable concatenate(const VariableConstView &var, const Dim dim) {
-  if (var.dtype() == dtype<bucket<Variable>>)
-    return concatenate_impl<Variable>(var, dim);
-  else if (var.dtype() == dtype<bucket<DataArray>>)
-    return concatenate_impl<DataArray>(var, dim);
-  else
-    return concatenate_impl<Dataset>(var, dim);
+  return concatenate_untyped(var, dim);
 }
 
 /// Reduce a dimension by concatenating all elements along the dimension.
 ///
 /// This is the analogue to summing non-bucket data.
 DataArray concatenate(const DataArrayConstView &array, const Dim dim) {
-  return {buckets::concatenate(array.data(), dim), array.aligned_coords(),
-          array.masks(), array.unaligned_coords()};
+  return apply_to_data_and_drop_dim(array, concatenate_untyped, dim,
+                                    irreducible_mask(array.masks(), dim));
 }
 
 void append(const VariableView &var0, const VariableConstView &var1) {

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -33,6 +33,8 @@ concatenate(const DataArrayConstView &var0, const DataArrayConstView &var1);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 concatenate(const VariableConstView &var, const Dim dim);
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArray
+concatenate(const DataArrayConstView &var, const Dim dim);
 
 SCIPP_DATASET_EXPORT void append(const VariableView &var0,
                                  const VariableConstView &var1);

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -31,6 +31,9 @@ concatenate(const VariableConstView &var0, const VariableConstView &var1);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 concatenate(const DataArrayConstView &var0, const DataArrayConstView &var1);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+concatenate(const VariableConstView &var, const Dim dim);
+
 SCIPP_DATASET_EXPORT void append(const VariableView &var0,
                                  const VariableConstView &var1);
 SCIPP_DATASET_EXPORT void append(const DataArrayView &a,

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -33,6 +33,19 @@ TEST_F(DataArrayBucketTest, concatenate_dim_1d) {
   EXPECT_EQ(buckets::concatenate(var, Dim::Y), expected);
 }
 
+TEST_F(DataArrayBucketTest, concatenate_dim_1d_masked) {
+  const auto y = makeVariable<double>(dims);
+  const auto scalar = makeVariable<double>(Values{1.2});
+  const auto mask = makeVariable<bool>(dims, Values{true, false});
+  const auto scalar_mask = makeVariable<bool>(Values{false});
+  DataArray a(var, {{Dim::Y, y}, {Dim("scalar"), scalar}},
+              {{"mask", mask}, {"scalar", scalar_mask}});
+  auto expected = copy(a.slice({Dim::Y, 1}));
+  expected.coords().erase(Dim::Y);
+  expected.masks().erase("mask");
+  EXPECT_EQ(buckets::concatenate(a, Dim::Y), expected);
+}
+
 TEST(DataArrayBucket2dTest, concatenate_dim_2d) {
   using Model = variable::DataModel<bucket<DataArray>>;
   Variable indicesZY = makeVariable<std::pair<scipp::index, scipp::index>>(

--- a/python/buckets.cpp
+++ b/python/buckets.cpp
@@ -86,6 +86,18 @@ void init_buckets(py::module &m) {
       },
       py::call_guard<py::gil_scoped_release>());
   buckets.def(
+      "concatenate",
+      [](const VariableConstView &var, const Dim dim) {
+        return dataset::buckets::concatenate(var, dim);
+      },
+      py::call_guard<py::gil_scoped_release>());
+  buckets.def(
+      "concatenate",
+      [](const DataArrayConstView &array, const Dim dim) {
+        return dataset::buckets::concatenate(array, dim);
+      },
+      py::call_guard<py::gil_scoped_release>());
+  buckets.def(
       "append",
       [](const VariableView &a, const VariableConstView &b) {
         return dataset::buckets::append(a, b);


### PR DESCRIPTION
- Is there a better name than `concatenate`?
- Will need to add the same to replace `groupby.flatten`