### PR TITLE
Bucket filtering and other cleanup

### DIFF
--- a/benchmark/buckets_benchmark.cpp
+++ b/benchmark/buckets_benchmark.cpp
@@ -8,6 +8,7 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/operations.h"
 
 #include "../test/random.h"

--- a/benchmark/transform_benchmark.cpp
+++ b/benchmark/transform_benchmark.cpp
@@ -7,6 +7,7 @@
 #include <random>
 
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/variable.h"
 

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -264,11 +264,14 @@ Variable map(const DataArrayConstView &function, const VariableConstView &x,
   // size, even if `x` is a slice and only subsections of the buffer are needed.
   auto out = variable::variableFactory().create(
       function.dtype(), buffer.dims(), units::one, function.hasVariances());
+  // TODO "bug" here: subspan_view creates a new variable, so out unit not set!
   transform_in_place(subspan_view(out, dim, indices),
                      subspan_view(buffer.coords()[hist_dim], dim, indices),
                      subspan_view(function.coords()[hist_dim], hist_dim),
                      subspan_view(mask ? masked : function.data(), hist_dim),
                      core::element::event::map_in_place);
+  // TODO Workaround, see comment above
+  out.setUnit(function.unit());
   return Variable{std::make_unique<variable::DataModel<bucket<Variable>>>(
       indices, dim, std::move(out))};
 }

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -268,6 +268,10 @@ DataArray sum(const DataArrayConstView &data) {
           data.unaligned_coords()};
 }
 
+Dataset sum(const DatasetConstView &d) {
+  return apply_to_items(d, [](auto &&... _) { return buckets::sum(_...); });
+}
+
 template <class T>
 Variable from_constituents_impl(Variable &&indices, const Dim dim, T &&buffer) {
   return {std::make_unique<variable::DataModel<bucket<T>>>(

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -70,7 +70,6 @@ void copy_slices(const DatasetConstView &src, const DatasetView &dst,
   }
 }
 
-
 namespace {
 constexpr auto copy_or_resize = [](const auto &var, const Dim dim,
                                    const scipp::index size) {

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -10,6 +10,7 @@
 #include "scipp/core/tag_util.h"
 
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/subspan_view.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/util.h"
@@ -69,7 +70,7 @@ template <class T> struct Bin {
   static auto apply(const VariableConstView &var,
                     const VariableConstView &indices,
                     const VariableConstView &sizes) {
-    auto [begin, total_size] = buckets::sizes_to_begin(sizes);
+    auto [begin, total_size] = sizes_to_begin(sizes);
     auto dims = var.dims();
     // Output may be smaller since values outside bins are dropped.
     dims.resize(dims.inner(), total_size);
@@ -191,7 +192,7 @@ DataArray bucketby_impl(const DataArrayConstView &array,
     bucket_dim = coord.dims().inner();
   }
   const auto sizes = bin_sizes(indices, dims, edges);
-  const auto [begin, total_size] = buckets::sizes_to_begin(sizes);
+  const auto [begin, total_size] = sizes_to_begin(sizes);
   const auto end = begin + sizes;
   auto binned = bin(array, indices, sizes);
   std::map<Dim, Variable> coords;

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -207,6 +207,13 @@ DataArray bucketby_impl(const DataArrayConstView &array,
 DataArray bucketby(const DataArrayConstView &array,
                    const std::vector<VariableConstView> &edges) {
   if (array.dtype() == dtype<bucket<DataArray>>) {
+    // TODO The need for this check may be an indicator that we should support
+    // adding another bucketed dimension via a separate function instead of
+    // having this dual-purpose `bucketby`.
+    for (const auto &edge : edges)
+      if (array.dims().contains(edge.dims().inner()))
+        throw std::runtime_error(
+            "Recursive buckets cannot be created with bucketby.");
     const auto &[begin_end, dim, buffer] =
         array.data().constituents<bucket<DataArray>>();
     auto indices =

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -821,4 +821,11 @@ void union_or_in_place(const MasksView &currentMasks,
     }
   }
 }
+
+void copy_metadata(const DataArrayConstView &a, const DataArrayView &b) {
+  copy_items(a.aligned_coords(), b.aligned_coords());
+  copy_items(a.masks(), b.masks());
+  copy_items(a.unaligned_coords(), b.unaligned_coords());
+}
+
 } // namespace scipp::dataset

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -153,6 +153,12 @@ Dataset apply_to_items(const DatasetConstView &d, Func func, Args &&... args) {
   return result;
 }
 
+/// Copy all map items from `a` and insert them into `b`.
+template <class A, class B> auto copy_items(const A &a, const B &b) {
+  for (const auto &[key, item] : a)
+    b.set(key, item);
+}
+
 /// Return a copy of map-like objects such as CoordView with `func` applied to
 /// each item.
 template <class T, class Func> auto transform_map(const T &map, Func func) {
@@ -168,6 +174,8 @@ DataArray transform(const DataArrayConstView &a, Func func) {
                    transform_map(a.masks(), func),
                    transform_map(a.unaligned_coords(), func), a.name());
 }
+
+void copy_metadata(const DataArrayConstView &a, const DataArrayView &b);
 
 // Helpers for reductions for DataArray and Dataset, which include masks.
 [[nodiscard]] Variable mean(const VariableConstView &var, const Dim dim,

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -17,12 +17,14 @@ SCIPP_DATASET_EXPORT void copy_slices(const DatasetConstView &src,
                                       const VariableConstView &srcIndices,
                                       const VariableConstView &dstIndices);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArray resize_default_init(
+    const DataArrayConstView &parent, const Dim dim, const scipp::index size);
+[[nodiscard]] SCIPP_DATASET_EXPORT Dataset resize_default_init(
+    const DatasetConstView &parent, const Dim dim, const scipp::index size);
+
 } // namespace scipp::dataset
 
 namespace scipp::dataset::buckets {
-
-[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Variable, scipp::index>
-sizes_to_begin(const VariableConstView &sizes);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 concatenate(const VariableConstView &var0, const VariableConstView &var1);

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -48,6 +48,7 @@ void scale(const DataArrayView &data, const DataArrayConstView &histogram);
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable sum(const VariableConstView &data);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 sum(const DataArrayConstView &data);
+[[nodiscard]] SCIPP_DATASET_EXPORT Dataset sum(const DatasetConstView &data);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 from_constituents(Variable &&indices, const Dim dim, Variable &&buffer);

--- a/dataset/include/scipp/dataset/bucket.h
+++ b/dataset/include/scipp/dataset/bucket.h
@@ -6,6 +6,19 @@
 
 #include "scipp/dataset/dataset.h"
 
+namespace scipp::dataset {
+
+SCIPP_DATASET_EXPORT void copy_slices(const DataArrayConstView &src,
+                                      const DataArrayView &dst, const Dim dim,
+                                      const VariableConstView &srcIndices,
+                                      const VariableConstView &dstIndices);
+SCIPP_DATASET_EXPORT void copy_slices(const DatasetConstView &src,
+                                      const DatasetView &dst, const Dim dim,
+                                      const VariableConstView &srcIndices,
+                                      const VariableConstView &dstIndices);
+
+} // namespace scipp::dataset
+
 namespace scipp::dataset::buckets {
 
 [[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Variable, scipp::index>
@@ -34,9 +47,11 @@ void scale(const DataArrayView &data, const DataArrayConstView &histogram);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 sum(const DataArrayConstView &data);
 
-[[nodiscard]] Variable from_constituents(Variable &&indices, const Dim dim,
-                                         Variable &&buffer);
-[[nodiscard]] Variable from_constituents(Variable &&indices, const Dim dim,
-                                         DataArray &&buffer);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+from_constituents(Variable &&indices, const Dim dim, Variable &&buffer);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+from_constituents(Variable &&indices, const Dim dim, DataArray &&buffer);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+from_constituents(Variable &&indices, const Dim dim, Dataset &&buffer);
 
 } // namespace scipp::dataset::buckets

--- a/dataset/test/bucketby_test.cpp
+++ b/dataset/test/bucketby_test.cpp
@@ -89,4 +89,6 @@ TEST_F(DataArrayBucketByTest, 2d) {
   EXPECT_EQ(bucketed.values<bucket<DataArray>>()[2], empty_bucket);
   EXPECT_EQ(bucketed.values<bucket<DataArray>>()[3],
             sorted_table.slice({Dim::Event, 1, 3}));
+
+  EXPECT_EQ(bucketby(bucketby(table, {edges_x}), {edges_y}), bucketed);
 }

--- a/dataset/test/buckets_test.cpp
+++ b/dataset/test/buckets_test.cpp
@@ -7,6 +7,7 @@
 #include "scipp/dataset/histogram.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/operations.h"
 
 using namespace scipp;

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/dataset/bucket.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/string.h"
 #include "scipp/variable/bucket_variable.tcc"

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -6,6 +6,7 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/string.h"
 #include "scipp/variable/bucket_variable.tcc"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/string.h"
 
 namespace scipp::variable {

--- a/docs/event-data/filtering.ipynb
+++ b/docs/event-data/filtering.ipynb
@@ -4,20 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**Note**\n",
-    "    \n",
-    "The support for realigned data is being removed and will be replaced by bucket variables.\n",
-    "Documentation will be updated in the near future.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Filtering\n",
     "\n",
     "Event filtering refers to the process of removing or extracting a subset of events based on some criterion such as the temperature of the measured sample at the time an event was detected.\n",
@@ -69,40 +55,36 @@
     "tof_max = 10000\n",
     "width = tof_max/20\n",
     "sizes = 4*np.array([7000, 3333, 3000, 5000])\n",
-    "data = sc.Variable(dims=['x'],\n",
-    "                   shape=[4],\n",
-    "                   variances=True,\n",
-    "                   dtype=sc.dtype.event_list_float64)\n",
+    "size = np.sum(sizes)\n",
+    "data = sc.Variable(dims=['event'],\n",
+    "                   values=np.ones(size),\n",
+    "                   variances=np.ones(size))\n",
     "x = sc.Variable(dims=['x'], unit=sc.units.m, values=np.linspace(0, 1, num=4))\n",
-    "time = sc.Variable(dims=['x'],\n",
-    "                   shape=[4],\n",
-    "                   unit=sc.units.s,\n",
-    "                   dtype=sc.dtype.event_list_int64)\n",
+    "time = sc.Variable(dims=['event'], unit=sc.units.s, dtype=sc.dtype.int64, shape=[size])\n",
     "# time-of-flight in a neutron-scattering experiment\n",
-    "tof = sc.Variable(dims=['x'],\n",
-    "                   shape=[4],\n",
-    "                   unit=sc.units.us,\n",
-    "                   dtype=sc.dtype.event_list_float64)\n",
-    "for i, size in enumerate(sizes):\n",
-    "    vals = np.random.rand(size)\n",
-    "    data['x', i].values = np.ones(size)\n",
-    "    data['x', i].variances = np.ones(size)\n",
-    "    time['x', i].values = np.linspace(0, end_time, num=size)\n",
-    "    tof['x', i].values = np.concatenate(\n",
-    "        (np.concatenate(\n",
-    "            (7*width + width*np.random.randn(size//4),\n",
-    "            13*width + width*np.random.randn(size//4))),\n",
-    "        10*width + width*np.random.randn(size//2)))\n",
+    "tof = sc.Variable(dims=['event'], unit=sc.units.us, dtype=sc.dtype.float64, shape=[size])\n",
+    "table = sc.DataArray(data=data, coords={'time':time, 'tof':tof})\n",
+    "table\n",
     "\n",
     "ntemp = 100\n",
     "sample_temperature = sc.DataArray(\n",
     "    data=sc.Variable(dims=['time'], unit=sc.units.K, values=5*np.random.rand(100)+np.linspace(100, 120, num=ntemp)),\n",
     "    coords={'time':sc.Variable(dims=['time'], unit=sc.units.s, values=np.linspace(0, end_time, num=ntemp))})\n",
-    "    \n",
+    "  \n",
+    "end = sc.Variable(dims=['x'], values=np.cumsum(sizes))\n",
+    "begin = end.copy()\n",
+    "begin.values -= sizes\n",
     "events = sc.DataArray(\n",
-    "    data,\n",
-    "    coords={'x':x, 'time':time, 'tof':tof},\n",
-    "    unaligned_coords={'sample_temperature': sc.Variable(value=sample_temperature)})"
+    "    data=sc.to_buckets(begin=begin, end=end, dim='event', data=table),\n",
+    "    coords={'x':x},\n",
+    "    unaligned_coords={'sample_temperature': sc.Variable(value=sample_temperature)})\n",
+    "for size, bucket in zip(sizes, events.values):\n",
+    "    bucket.coords['time'].values = np.linspace(0, end_time, num=size)\n",
+    "    bucket.coords['tof'].values = np.concatenate(\n",
+    "        (np.concatenate(\n",
+    "            (7*width + width*np.random.randn(size//4),\n",
+    "             13*width + width*np.random.randn(size//4))),\n",
+    "         10*width + width*np.random.randn(size//2)))"
    ]
   },
   {
@@ -178,7 +160,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events.coords['temperature'] = sc.map(temperature, events.coords['time'])"
+    "# Note: The API for this is work-in-progress and will be made more convenient\n",
+    "event_temp = sc.buckets.map(temperature, events.data, 'time')\n",
+    "sc.buckets.get_buffer(events.data).coords['temperature'] = sc.buckets.get_buffer(event_temp)"
    ]
   },
   {
@@ -194,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events"
+    "events.values[0]"
    ]
   },
   {
@@ -204,7 +188,7 @@
     "## Step 3: Filter\n",
     "\n",
     "The temperature coordinate create in the previous step can now be used for the actual filtering step.\n",
-    "There are two options, `scipp.filter` and `scipp.realign` in combination with slicing.\n",
+    "There are two options, `scipp.filter` and `scipp.bucketby` in combination with slicing.\n",
     "\n",
     "### Option 1: `scipp.filter`\n",
     "\n",
@@ -213,15 +197,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note**\n",
+    "    \n",
+    "The support for realigned data is being removed and will be replaced by bucket variables.\n",
+    "`filter` is not yet available for bucketed data.\n",
+    "Documentation will be updated in the near future.\n",
+    "See next subsection for a solution that works right now.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "filtered = sc.filter(\n",
-    "    data=events,\n",
-    "    filter='temperature',\n",
-    "    interval=sc.Variable(dims=['temperature'], unit=sc.units.K, values=[115.0, 119.0]))"
+    "#filtered = sc.filter(\n",
+    "#    data=events,\n",
+    "#    filter='temperature',\n",
+    "#    interval=sc.Variable(dims=['temperature'], unit=sc.units.K, values=[115.0, 119.0]))"
    ]
   },
   {
@@ -239,16 +239,16 @@
    },
    "outputs": [],
    "source": [
-    "plot(filtered, bins={'tof':100})"
+    "#plot(filtered, bins={'tof':100})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Option 2: `scipp.realign`\n",
+    "### Option 2: `scipp.bucketby`\n",
     "\n",
-    "With a `temperature` coordinate stored in `events` it is possible to use `scipp.realign` with temperature bins:"
+    "With a `temperature` coordinate stored in th buckets of `events` it is possible to use `scipp.bucketby` with temperature bins:"
    ]
   },
   {
@@ -259,14 +259,15 @@
    "source": [
     "tof_bins = sc.Variable(dims=['tof'], unit=sc.units.us, values=np.linspace(0,tof_max,num=100))\n",
     "temp_bins = sc.Variable(dims=['temperature'], unit=sc.units.K, values=np.linspace(100.0, 130.0, num=6))\n",
-    "realigned = sc.realign(events, {'temperature':temp_bins, 'tof':tof_bins})"
+    "bucketed_events = sc.bucketby(events, [temp_bins, tof_bins])\n",
+    "bucketed_events"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Filtering is then performed by slicing and copying:"
+    "Filtering is then performed by slicing (and copying):"
    ]
   },
   {
@@ -275,7 +276,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filtered = realigned['temperature', 0:3].copy()"
+    "filtered_view = bucketed_events['temperature', 0:3] # view containing only relevant events\n",
+    "filtered = bucketed_events['temperature', 0:3].copy() # extract only relevant events by copying"
    ]
   },
   {
@@ -291,8 +293,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(sc.histogram(realigned['temperature', 1]))\n",
-    "plot(sc.histogram(realigned['temperature', 3]))"
+    "plot(sc.buckets.sum(bucketed_events['temperature', 1]))\n",
+    "plot(sc.buckets.sum(bucketed_events['temperature', 3]))"
    ]
   },
   {
@@ -309,16 +311,16 @@
    "outputs": [],
    "source": [
     "d = sc.Dataset()\n",
-    "d['below_T_c'] = realigned['temperature', 1]\n",
-    "d['above_T_c'] = realigned['temperature', 3]\n",
-    "plot(sc.sum(sc.histogram(d), 'x'))"
+    "d['below_T_c'] = bucketed_events['temperature', 1]\n",
+    "d['above_T_c'] = bucketed_events['temperature', 3]\n",
+    "plot(sc.sum(sc.buckets.sum(d), 'x'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also realign without the time-of-flight coordinate to obtain that temperature dependence of the total event count, e.g., for normalization purposes:"
+    "We can also bucket without the time-of-flight coordinate to obtain that temperature dependence of the total event count, e.g., for normalization purposes:"
    ]
   },
   {
@@ -329,8 +331,8 @@
    },
    "outputs": [],
    "source": [
-    "realigned = sc.realign(events, {'temperature':temp_bins})\n",
-    "plot(realigned)"
+    "bucketed_events = sc.bucketby(events, [temp_bins])\n",
+    "plot(sc.buckets.sum(bucketed_events))"
    ]
   }
  ],
@@ -351,9 +353,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.2"
-  },
-  "nbsphinx": {
-   "execute": "never"
   }
  },
  "nbformat": 4,

--- a/docs/event-data/overview.ipynb
+++ b/docs/event-data/overview.ipynb
@@ -284,7 +284,7 @@
    "outputs": [],
    "source": [
     "time_bins = sc.Variable(dims=['time'], unit=sc.units.us, values=[0.0, 3.0, 6.0])\n",
-    "sc.buckets.scale(a, sc.histogram(a, time_bins))\n",
+    "sc.buckets.scale(a, sc.reciprocal(sc.histogram(a, time_bins)))\n",
     "plot(sc.histogram(a, time_bins))"
    ]
   }

--- a/python/buckets.cpp
+++ b/python/buckets.cpp
@@ -109,6 +109,9 @@ void init_buckets(py::module &m) {
       "sum",
       [](const DataArrayConstView &x) { return dataset::buckets::sum(x); },
       py::call_guard<py::gil_scoped_release>());
+  buckets.def(
+      "sum", [](const DatasetConstView &x) { return dataset::buckets::sum(x); },
+      py::call_guard<py::gil_scoped_release>());
   buckets.def("get_buffer", [](py::object &obj) -> py::object {
     auto &var = obj.cast<const VariableView &>();
     if (var.dtype() == dtype<bucket<Variable>>)

--- a/python/buckets.cpp
+++ b/python/buckets.cpp
@@ -7,7 +7,6 @@
 #include "scipp/dataset/bucket.h"
 #include "scipp/dataset/bucketby.h"
 #include "scipp/dataset/shape.h"
-#include "scipp/variable/bucket_model.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/variable.h"
 
@@ -47,10 +46,10 @@ template <class T> void bind_buckets(pybind11::module &m) {
         } else {
           throw std::runtime_error("`end` given but not `begin`");
         }
-        return Variable(std::make_unique<variable::DataModel<bucket<T>>>(
+        return dataset::buckets::from_constituents(
             makeVariable<std::pair<scipp::index, scipp::index>>(
                 dims, Values(std::move(indices))),
-            dim, T(data)));
+            dim, T(data));
       },
       py::arg("begin") = py::none(), py::arg("end") = py::none(),
       py::arg("dim"), py::arg("data")); // do not release GIL since using

--- a/units/include/scipp/units/except.h
+++ b/units/include/scipp/units/except.h
@@ -18,5 +18,7 @@ using UnitMismatchError = MismatchError<units::Unit>;
 // mismatch and VariableView mismatch are the same type.
 template <class T>
 MismatchError(const units::Unit &, const T &) -> MismatchError<units::Unit>;
+template <class T>
+MismatchError(const units::Dim &, const T &) -> MismatchError<units::Dim>;
 
 } // namespace scipp::except

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TARGET_NAME "scipp-variable")
 set(INC_FILES
     include/scipp/variable/apply.h
     include/scipp/variable/arithmetic.h
+    include/scipp/variable/buckets.h
     include/scipp/variable/comparison.h
     include/scipp/variable/event.h
     include/scipp/variable/except.h
@@ -32,6 +33,7 @@ set(INC_FILES
 
 set(SRC_FILES
     arithmetic.cpp
+    buckets.cpp
     comparison.cpp
     event.cpp
     except.cpp

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -16,8 +16,11 @@
 namespace scipp::variable {
 
 namespace {
+template <class T> using copy_spans_args = std::tuple<span<T>, span<const T>>;
 constexpr auto copy_spans = overloaded{
-    core::element::arg_list<std::tuple<span<double>, span<const double>>>,
+    core::element::arg_list<copy_spans_args<double>, copy_spans_args<float>,
+                            copy_spans_args<int64_t>, copy_spans_args<int32_t>,
+                            copy_spans_args<bool>>,
     core::transform_flags::expect_all_or_none_have_variance,
     [](units::Unit &a, const units::Unit &b) { a = b; },
     [](auto &dst, const auto &src) {

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -32,7 +32,7 @@ constexpr auto copy_spans = overloaded{
         std::copy(src.begin(), src.end(), dst.begin());
       }
     }};
-}
+} // namespace
 
 void copy_slices(const VariableConstView &src, const VariableView &dst,
                  const Dim dim, const VariableConstView &srcIndices,

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/element/arg_list.h"
+
+#include "scipp/variable/arithmetic.h"
+#include "scipp/variable/buckets.h"
+#include "scipp/variable/comparison.h"
+#include "scipp/variable/reduction.h"
+#include "scipp/variable/shape.h"
+#include "scipp/variable/subspan_view.h"
+#include "scipp/variable/transform.h"
+#include "scipp/variable/util.h"
+
+namespace scipp::variable {
+
+namespace {
+constexpr auto copy_spans = overloaded{
+    core::element::arg_list<std::tuple<span<double>, span<const double>>>,
+    core::transform_flags::expect_all_or_none_have_variance,
+    [](units::Unit &a, const units::Unit &b) { a = b; },
+    [](auto &dst, const auto &src) {
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(dst)>>) {
+        std::copy(src.value.begin(), src.value.end(), dst.value.begin());
+        std::copy(src.variance.begin(), src.variance.end(),
+                  dst.variance.begin());
+      } else {
+        std::copy(src.begin(), src.end(), dst.begin());
+      }
+    }};
+}
+
+void copy_slices(const VariableConstView &src, const VariableView &dst,
+                 const Dim dim, const VariableConstView &srcIndices,
+                 const VariableConstView &dstIndices) {
+  const auto [begin0, end0] = unzip(srcIndices);
+  const auto [begin1, end1] = unzip(dstIndices);
+  const auto sizes0 = end0 - begin0;
+  const auto sizes1 = end1 - begin1;
+  // May broadcast `src` but not `dst` since that would result in
+  // multiple/conflicting writes to same bucket.
+  expect::contains(sizes1.dims(), sizes0.dims());
+  core::expect::equals(all(equal(sizes0, sizes1)),
+                       makeVariable<bool>(Values{true}));
+  transform_in_place(subspan_view(dst, dim, dstIndices),
+                     subspan_view(src, dim, srcIndices), copy_spans);
+}
+
+} // namespace scipp::variable

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -47,4 +47,27 @@ void copy_slices(const VariableConstView &src, const VariableView &dst,
                      subspan_view(src, dim, srcIndices), copy_spans);
 }
 
+Variable resize_default_init(const VariableConstView &var, const Dim dim,
+                             const scipp::index size) {
+  auto dims = var.dims();
+  if (dims.contains(dim))
+    dims.resize(dim, size);
+  // Using variableFactory instead of variable::resize for creating
+  // _uninitialized_ variable.
+  return variable::variableFactory().create(var.dtype(), dims, var.unit(),
+                                            var.hasVariances());
+}
+
+std::tuple<Variable, scipp::index>
+sizes_to_begin(const VariableConstView &sizes) {
+  Variable begin(sizes);
+  scipp::index size = 0;
+  for (auto &i : begin.values<scipp::index>()) {
+    const auto old_size = size;
+    size += i;
+    i = old_size;
+  }
+  return {begin, size};
+}
+
 } // namespace scipp::variable

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -20,7 +20,8 @@ template <class T> using copy_spans_args = std::tuple<span<T>, span<const T>>;
 constexpr auto copy_spans = overloaded{
     core::element::arg_list<copy_spans_args<double>, copy_spans_args<float>,
                             copy_spans_args<int64_t>, copy_spans_args<int32_t>,
-                            copy_spans_args<bool>>,
+                            copy_spans_args<bool>, copy_spans_args<std::string>,
+                            copy_spans_args<core::time_point>>,
     core::transform_flags::expect_all_or_none_have_variance,
     [](units::Unit &a, const units::Unit &b) { a = b; },
     [](auto &dst, const auto &src) {

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -8,8 +8,10 @@
 #include "scipp/core/bucket_array_view.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/except.h"
+#include "scipp/variable/arithmetic.h"
 #include "scipp/variable/data_model.h"
 #include "scipp/variable/except.h"
+#include "scipp/variable/util.h"
 
 namespace scipp::variable {
 
@@ -132,9 +134,14 @@ template <class T>
 void DataModel<bucket<T>>::copy(const VariableConstView &src,
                                 const VariableView &dst) const {
   const auto &[indices0, dim0, buffer0] = src.constituents<bucket<T>>();
-  const auto &[indices1, dim1, buffer1] = dst.constituents<bucket<T>>();
-  core::expect::equals(dim0, dim1);
+  const auto [begin0, end0] = unzip(indices0);
+  const auto sizes1 = end0 - begin0;
+  auto [begin1, size1] = sizes_to_begin(sizes1);
+  auto indices1 = zip(begin1, begin1 + sizes1);
+  auto buffer1 = resize_default_init(buffer0, dim0, size1);
   copy_slices(buffer0, buffer1, dim0, indices0, indices1);
+  dst.replace_model(
+      DataModel<bucket<T>>{std::move(indices1), dim0, std::move(buffer1)});
 }
 
 template <class T>

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -129,13 +129,12 @@ bool DataModel<bucket<T>>::equals(const VariableConstView &a,
 }
 
 template <class T>
-void DataModel<bucket<T>>::copy(const VariableConstView &,
-                                const VariableView &) const {
-  // Need to rethink the entire mechanism of shape-changing operations such as
-  // `concatenate` since we cannot just copy indices but need to manage the
-  // buffer as well.
-  throw std::runtime_error(
-      "Shape-related operations for bucketed data are not supported yet.");
+void DataModel<bucket<T>>::copy(const VariableConstView &src,
+                                const VariableView &dst) const {
+  const auto &[indices0, dim0, buffer0] = src.constituents<bucket<T>>();
+  const auto &[indices1, dim1, buffer1] = dst.constituents<bucket<T>>();
+  core::expect::equals(dim0, dim1);
+  copy_slices(buffer0, buffer1, dim0, indices0, indices1);
 }
 
 template <class T>

--- a/variable/include/scipp/variable/buckets.h
+++ b/variable/include/scipp/variable/buckets.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/variable/variable.h"
+
+namespace scipp::variable {
+
+SCIPP_VARIABLE_EXPORT void copy_slices(const VariableConstView &src,
+                                       const VariableView &dst, const Dim dim,
+                                       const VariableConstView &srcIndices,
+                                       const VariableConstView &dstIndices);
+
+} // namespace scipp::variable

--- a/variable/include/scipp/variable/buckets.h
+++ b/variable/include/scipp/variable/buckets.h
@@ -13,4 +13,10 @@ SCIPP_VARIABLE_EXPORT void copy_slices(const VariableConstView &src,
                                        const VariableConstView &srcIndices,
                                        const VariableConstView &dstIndices);
 
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable resize_default_init(
+    const VariableConstView &var, const Dim dim, const scipp::index size);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT std::tuple<Variable, scipp::index>
+sizes_to_begin(const VariableConstView &sizes);
+
 } // namespace scipp::variable

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -4,6 +4,7 @@
 
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 
 using namespace scipp;
 using namespace scipp::variable;

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -10,6 +10,7 @@
 
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/variable.h"
 

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "scipp/variable/bucket_model.h"
+#include "scipp/variable/buckets.h"
 #include "scipp/variable/operations.h"
 
 using namespace scipp;

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -35,6 +35,12 @@ TEST_F(VariableBucketTest, assign) {
   EXPECT_EQ(copy, var);
 }
 
+TEST_F(VariableBucketTest, copy_view) {
+  EXPECT_EQ(Variable(var.slice({Dim::Y, 0, 2})), var);
+  EXPECT_EQ(Variable(var.slice({Dim::Y, 0, 1})), var.slice({Dim::Y, 0, 1}));
+  EXPECT_EQ(Variable(var.slice({Dim::Y, 1, 2})), var.slice({Dim::Y, 1, 2}));
+}
+
 TEST_F(VariableBucketTest, shape_operations) {
   // Not supported yet, not to ensure this fails instead of returning garbage.
   EXPECT_ANY_THROW(concatenate(var, var, Dim::Y));

--- a/variable/variable_instantiate_bucket_elements.cpp
+++ b/variable/variable_instantiate_bucket_elements.cpp
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/variable/bucket_variable.tcc"
+#include "scipp/variable/buckets.h"
 
 namespace scipp::variable {
 


### PR DESCRIPTION
- Re-enable filtering docs page. Note that not everything is supported yet.
- Copying slices of bucket variables works now. This can provide an intuitive way of filtering.
- `bucketby` can now be "chained". Main application could be to add TOF or pulse-time buckets to an "event workspace", i.e., data with events for every spectrum in a bucket. Subsequent `bucketby` calls split the existing buckets. Note also comments in code regarding whether this makes sense as the same function, or if it should be different?
- Start some cleanup, moving code to more sensible places. A lot more to do in future PRs.
- Work around "bug" (or rather unintented use) with unit not being set if `subspan_view` is used as an output. This can't really be fixed directly, rather we need to find a way to accomplish the same without `subspan` view. I am still thinking about a better solution, this will not be included in this PR, since it would likely have wider-reaching consequences (most likely involving changes to `transform.h`).