### PR TITLE
Better plot interface

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -390,8 +390,12 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly(
       "dims",
       [](const T &self) {
-        const auto &dims = self.dims();
-        return std::vector<Dim>(dims.labels().begin(), dims.labels().end());
+        const auto &dims_ = self.dims();
+        std::vector<std::string> dims;
+        for (const auto &dim : dims_.labels()) {
+          dims.push_back(dim.name());
+        }
+        return dims;
       },
       "Dimension labels of the data (read-only).",
       py::return_value_policy::move);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -149,9 +149,9 @@ void bind_dataset_view_methods(py::class_<T, Ignored...> &c) {
   c.def_property_readonly(
       "dims",
       [](const T &self) {
-        std::vector<Dim> dims;
+        std::vector<std::string> dims;
         for (const auto &dim : self.dimensions()) {
-          dims.push_back(dim.first);
+          dims.push_back(dim.first.name());
         }
         return dims;
       },

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -4,6 +4,7 @@
 # @author Neil Vaytet
 
 from .plot import plot as _plot
+import warnings
 
 # If we are running inside a notebook, then make plot interactive by default.
 # From: https://stackoverflow.com/a/22424821
@@ -28,10 +29,18 @@ try:
         # If we are in an IPython kernel, select widget backend
         if "IPKernelApp" in ipy.config and not is_doc_build:
             mpl.use('module://ipympl.backend_nbagg')
-            # Hide the figure header:
-            # see https://github.com/matplotlib/ipympl/issues/229
-            from ipympl.backend_nbagg import Canvas
-            Canvas.header_visible.default_value = False
+            try:
+                # Hide the figure header:
+                # see https://github.com/matplotlib/ipympl/issues/229
+                from ipympl.backend_nbagg import Canvas
+                Canvas.header_visible.default_value = False
+            except ImportError:
+                warnings.warn(
+                    "The ipympl backend, which is required for "
+                    "interactive plots in Jupyter, was not found. "
+                    "Falling back to a static backend. Visit "
+                    "https://github.com/matplotlib/ipympl for "
+                    "instructions on how to install ipympl.", ImportWarning)
     import matplotlib.pyplot as plt
 
 except ImportError:
@@ -45,7 +54,7 @@ def _is_interactive():
     """
     Determine if we are using a static or interactive backend
     """
-    return mpl.get_backend().lower().endswith('nbagg')
+    return not mpl.get_backend().lower().endswith('inline')
 
 
 def plot(*args, **kwargs):

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -44,9 +44,8 @@ if ipy is not None:
             warnings.warn(
                 "The ipympl backend, which is required for "
                 "interactive plots in Jupyter, was not found. "
-                "Falling back to a static backend. Visit "
-                "https://github.com/matplotlib/ipympl for "
-                "instructions on how to install ipympl.", UserWarning)
+                "Falling back to a static backend. Use "
+                "conda install -c conda-forge ipympl to install ipympl.")
 
 try:
     import matplotlib.pyplot as plt

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -124,6 +124,7 @@ class PlotController:
         self.initialise_model()
         if self.profile is not None:
             self.initialise_profile()
+            self.connect_profile()
 
         self.connect_widgets()
         self.connect_view()
@@ -248,6 +249,12 @@ class PlotController:
         Dummy connect for `PlotPanel`.
         """
         return
+
+    def connect_profile(self):
+        """
+        Connect callbacks to the `PlotWidgets` interface.
+        """
+        self.profile.connect()
 
     def lock_update_data(self):
         self.update_data_lock = True

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -45,6 +45,7 @@ class PlotController:
 
         self.name = name
         self.dim_to_shape = dim_to_shape
+        self.update_data_lock = False
         self.axparams = {}
 
         self.profile_axparams = {}
@@ -192,7 +193,9 @@ class PlotController:
             "update_data": self.update_data,
             "update_axes": self.update_axes,
             "toggle_mask": self.toggle_mask.
-            "get_dim_shape": self.get_dim_shape
+            "get_dim_shape": self.get_dim_shape,
+            "lock_update_data": self.lock_update_data,
+            "unlock_update_data": self.unlock_update_data
         })
 
     def connect_view(self):
@@ -211,6 +214,12 @@ class PlotController:
         Dummy connect for `panel`.
         """
         return
+
+    def lock_update_data(self):
+        self.update_data_lock = True
+
+    def unlock_update_data(self):
+        self.update_data_lock = False
 
     def rescale_to_data(self, button=None):
         """
@@ -262,6 +271,9 @@ class PlotController:
         called when update_axes is called since the displayed data needs to be
         updated when the axes have changed.
         """
+
+        if self.update_data_lock:
+            return
 
         active_sliders = self.widgets.get_active_slider_values()
 

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -44,6 +44,7 @@ class PlotController:
         self.view = view
 
         self.name = name
+        self.dim_to_shape = dim_to_shape
         self.axparams = {}
 
         self.profile_axparams = {}
@@ -86,7 +87,7 @@ class PlotController:
                 # stored as dicts, with one key per dimension of the coordinate
                 self.histograms[key][dim] = {}
                 for i, d in enumerate(coord.dims):
-                    self.histograms[key][dim][d] = dim_to_shape[key][
+                    self.histograms[key][dim][d] = self.dim_to_shape[key][
                         d] == coord_shapes[key][dim][i] - 1
 
                 # The limits for each dimension
@@ -120,6 +121,9 @@ class PlotController:
         self.connect_view()
         if self.panel is not None:
             self.connect_panel()
+
+    def get_dim_shape(self, dim):
+        return self.dim_to_shape[dim]
 
     def initialise_widgets(self, dim_to_shape):
         """
@@ -187,7 +191,8 @@ class PlotController:
             "toggle_profile_view": self.toggle_profile_view,
             "update_data": self.update_data,
             "update_axes": self.update_axes,
-            "toggle_mask": self.toggle_mask
+            "toggle_mask": self.toggle_mask.
+            "get_dim_shape": self.get_dim_shape
         })
 
     def connect_view(self):

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -300,8 +300,11 @@ class PlotController:
         self.scale[dim] = "log" if change["new"] else "linear"
         self.update_axes()
 
-    def toggle_norm(self, owner):
-        return
+    def toggle_norm(self, change):
+        self.norm = "log" if change["new"] else "linear"
+        vmin, vmax = self.model.rescale_to_data()
+        vmin, vmax = check_log_limits(vmin=vmin, vmax=vmax, scale=self.norm)
+        self.view.toggle_norm(self.norm, vmin, vmax)
 
     def swap_dimensions(self, index, old_dim, new_dim):
         """

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -203,7 +203,7 @@ class PlotController:
         }
         figure_callbacks = {
             "rescale_to_data": self.rescale_to_data,
-            "swap_axes": self.swap_axes,
+            "transpose": self.transpose,
             "toggle_xaxis_scale": self.toggle_xaxis_scale,
             "toggle_yaxis_scale": self.toggle_yaxis_scale,
             "toggle_norm": self.toggle_norm,
@@ -257,9 +257,9 @@ class PlotController:
                                        vmax=vmax,
                                        mask_info=self.get_masks_info())
 
-    def swap_axes(self, owner=None):
+    def transpose(self, owner=None):
         """
-        Roll the order of the displayed axes.
+        Transpose the displayed axes.
         """
         xyz = self._get_xyz_axes()
         dims = [self.axes[key] for key in xyz]

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -36,7 +36,8 @@ class PlotController:
                  model=None,
                  panel=None,
                  profile=None,
-                 view=None):
+                 view=None,
+                 initial_update=True):
 
         self.widgets = widgets
         self.model = model
@@ -125,6 +126,11 @@ class PlotController:
         self.connect_view()
         if self.panel is not None:
             self.connect_panel()
+
+        # Call axes once to make the initial plot
+        if initial_update:
+            self.update_axes()
+            self.update_log_axes_buttons()
 
     def get_dim_shape(self, dim, name=None):
         if name is None:

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -274,8 +274,9 @@ class PlotController:
         """
         Roll the order of the displayed axes.
         """
-        dims = [self.axes[key] for key in sorted(self.axes.keys())]
-        keys = list(np.roll(self._get_xyz_axes(), 1))
+        xyz = self._get_xyz_axes()
+        dims = [self.axes[key] for key in xyz]
+        keys = list(np.roll(xyz, 1))
         for i in range(len(dims)):
             self.axes[keys[i]] = dims[i]
         self.update_axes()

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -110,7 +110,7 @@ class PlotController:
 
                 self.labels[key][dim] = name_with_unit(var=coord)
 
-        self.initialise_widgets(dim_to_shape[self.name])
+        # self.initialise_widgets(dim_to_shape[self.name])
         self.initialise_view(axes)
         self.initialise_model()
         if self.profile is not None:

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -192,7 +192,7 @@ class PlotController:
             "toggle_profile_view": self.toggle_profile_view,
             "update_data": self.update_data,
             "update_axes": self.update_axes,
-            "toggle_mask": self.toggle_mask.
+            "toggle_mask": self.toggle_mask,
             "get_dim_shape": self.get_dim_shape,
             "lock_update_data": self.lock_update_data,
             "unlock_update_data": self.unlock_update_data

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -55,7 +55,7 @@ class PlotController:
         self.vmax = vmax
         self.norm = norm
 
-        print(self.axes, self.axes.values())
+        # print(self.axes, self.axes.values())
         self.scale = {dim: "linear" for dim in self.axes.values()}
         if scale is not None:
             for dim, item in scale.items():
@@ -117,7 +117,7 @@ class PlotController:
                 self.coord_labels[key][dim] = name_with_unit(var=coord)
                 self.coord_units[key][dim] = name_with_unit(var=coord, name="")
 
-        print(self.histograms)
+        # print(self.histograms)
 
         self.initialise_widgets(dim_to_shape[self.name])
         self.initialise_view()
@@ -275,11 +275,14 @@ class PlotController:
         # Find position of new dim in axes values
         # pos = list(self.axes.values()).index(new_dim)
         # print(self._get_xyz_axes())
-        keys = np.roll(self._get_xyz_axes(), 1)
         dims = list(self.axes.values())
+        # keys = list(np.roll(self._get_xyz_axes(), 1))
+        keys = self._get_xyz_axes()
         # print(keys)
         # print(dims)
+        # print(zip(keys, dims))
         for ax, dim in zip(keys, dims):
+            # print(ax, dim, self.axes)
             self.axes[ax] = dim
         # print("after", self.axes)
         self.update_axes()
@@ -307,6 +310,8 @@ class PlotController:
         and sends it over to the view for display.
         """
 
+        print("controller update_axes")
+        print(self.axes)
         self.axparams = self._get_axes_parameters()
         other_params = self.model.update_axes(self.axparams)
         if other_params is not None:
@@ -333,7 +338,7 @@ class PlotController:
 
         # slider_params = self.widgets.get_slider_dims_and_values()
         slices = self.widgets.get_slider_bounds()
-        print(slices)
+        # print(slices)
 
         if change is not None:
             owner_dim = self.widgets.get_index_dim(change["owner"].index)

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -235,7 +235,11 @@ class PlotController:
             "remove_line": self.remove_line
         }
         figure_callbacks = {"rescale_to_data": self.rescale_to_data,
-                            "swap_axes": self.swap_axes}
+                            "swap_axes": self.swap_axes,
+                            "toggle_xaxis_scale": self.toggle_xaxis_scale,
+                            "toggle_yaxis_scale": self.toggle_yaxis_scale,
+                            "toggle_norm": self.toggle_norm,
+                            }
         self.view.connect(view_callbacks=view_callbacks,
                           figure_callbacks=figure_callbacks)
 
@@ -280,6 +284,24 @@ class PlotController:
         for i in range(len(dims)):
             self.axes[keys[i]] = dims[i]
         self.update_axes()
+
+    def toggle_xaxis_scale(self, change):
+        dim = self.axes["x"]
+        self.scale[dim] = "log" if change["new"] else "linear"
+        self.update_axes()
+
+    def toggle_yaxis_scale(self, change):
+        dim = self.axes["y"]
+        self.scale[dim] = "log" if change["new"] else "linear"
+        self.update_axes()
+
+    def toggle_zaxis_scale(self, change):
+        dim = self.axes["z"]
+        self.scale[dim] = "log" if change["new"] else "linear"
+        self.update_axes()
+
+    def toggle_norm(self, owner):
+        return
 
     def swap_dimensions(self, index, old_dim, new_dim):
         """

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -65,7 +65,8 @@ class PlotController:
         # Store coordinate min and max limits
         self.xlims = {}
         # Store labels for sliders
-        self.labels = {}
+        self.coord_labels = {}
+        self.coord_units = {}
         # Record which variables are histograms along which dimension
         self.histograms = {}
         # Keep track if a coordinate with more than one dimension is present
@@ -74,7 +75,8 @@ class PlotController:
         for key in self.model.get_data_names():
 
             self.xlims[key] = {}
-            self.labels[key] = {}
+            self.coord_labels[key] = {}
+            self.coord_units[key] = {}
             self.histograms[key] = {}
 
             # Iterate through axes and collect dimensions
@@ -111,7 +113,8 @@ class PlotController:
                                                    values=self.xlims[key][dim],
                                                    unit=coord.unit)
 
-                self.labels[key][dim] = name_with_unit(var=coord)
+                self.coord_labels[key][dim] = name_with_unit(var=coord)
+                self.coord_units[key][dim] = name_with_unit(var=coord, name="")
 
         self.initialise_widgets(dim_to_shape[self.name])
         self.initialise_view()
@@ -128,6 +131,12 @@ class PlotController:
         if name is None:
             name = self.name
         return self.dim_to_shape[name][dim]
+
+    def get_coord_unit(self, dim, name=None):
+        if name is None:
+            name = self.name
+        return self.coord_units[name][dim]
+
 
     def initialise_widgets(self, dim_to_shape):
         """
@@ -159,7 +168,15 @@ class PlotController:
 
         # # self.widgets.initialise(parameters=parameters,
         # #                         multid_coord=self.multid_coord)
-        self.widgets.initialise(dim_to_shape)
+
+        
+        # for dim, bounds in self.widgets.get_slider_bounds().items():
+        # lower, upper = self.model.get_slice_coord_bounds(
+        #         self.name, owner_dim, slices[owner_dim])
+        #     self.widgets.update_slider_readout(change["owner"].index,
+        #         lower, upper, slices[owner_dim], owner_dim == self.multid_coord)
+        self.widgets.initialise(dim_to_shape, self.xlims[self.name],
+            self.coord_units[self.name])
 
     def initialise_view(self):
         """
@@ -200,7 +217,8 @@ class PlotController:
             "get_dim_shape": self.get_dim_shape,
             "lock_update_data": self.lock_update_data,
             "unlock_update_data": self.unlock_update_data,
-            "swap_axes": self.swap_axes
+            "swap_axes": self.swap_axes,
+            "get_coord_unit": self.get_coord_unit
         })
 
     def connect_view(self):
@@ -362,7 +380,7 @@ class PlotController:
                     for name in self.histograms
                 },
                 "dim": dim,
-                "label": self.labels[self.name][dim]
+                "label": self.coord_labels[self.name][dim]
             }
             # Safety check for log axes
             axparams[ax]["lims"] = check_log_limits(
@@ -446,7 +464,7 @@ class PlotController:
                             for name in self.histograms
                         },
                         "dim": self.profile_dim,
-                        "label": self.labels[self.name][self.profile_dim]
+                        "label": self.coord_labels[self.name][self.profile_dim]
                     }
                 }
 

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -31,6 +31,7 @@ class PlotController:
                  scale=None,
                  dim_to_shape=None,
                  coord_shapes=None,
+                 multid_coord=None,
                  widgets=None,
                  model=None,
                  panel=None,
@@ -70,7 +71,7 @@ class PlotController:
         # Record which variables are histograms along which dimension
         self.histograms = {}
         # Keep track if a coordinate with more than one dimension is present
-        self.multid_coord = None
+        self.multid_coord = multid_coord
 
         for key in self.model.get_data_names():
 
@@ -83,9 +84,6 @@ class PlotController:
             for dim in self.axes.values():
 
                 coord = self.model.get_data_coord(name, dim)
-
-                if len(coord.dims) > 1:
-                    self.multid_coord = dim
 
                 # To allow for 2D coordinates, the histograms are
                 # stored as dicts, with one key per dimension of the coordinate

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -291,24 +291,25 @@ class PlotController:
         for i in range(len(dims)):
             self.axes[keys[i]] = dims[i]
         self.update_axes()
+        self.update_log_axes_buttons()
 
-    def toggle_xaxis_scale(self, change):
+    def toggle_xaxis_scale(self, owner):
         dim = self.axes["x"]
-        self.scale[dim] = "log" if change["new"] else "linear"
+        self.scale[dim] = "log" if owner.value else "linear"
         self.update_axes()
 
-    def toggle_yaxis_scale(self, change):
+    def toggle_yaxis_scale(self, owner):
         dim = self.axes["y"]
-        self.scale[dim] = "log" if change["new"] else "linear"
+        self.scale[dim] = "log" if owner.value else "linear"
         self.update_axes()
 
-    def toggle_zaxis_scale(self, change):
+    def toggle_zaxis_scale(self, owner):
         dim = self.axes["z"]
-        self.scale[dim] = "log" if change["new"] else "linear"
+        self.scale[dim] = "log" if owner.value else "linear"
         self.update_axes()
 
-    def toggle_norm(self, change):
-        self.norm = "log" if change["new"] else "linear"
+    def toggle_norm(self, owner):
+        self.norm = "log" if owner.value else "linear"
         vmin, vmax = self.model.rescale_to_data()
         vmin, vmax = check_log_limits(vmin=vmin, vmax=vmax, scale=self.norm)
         self.view.toggle_norm(self.norm, vmin, vmax)
@@ -317,11 +318,18 @@ class PlotController:
         """
         Swap one dimension for another in the displayed axes.
         """
+        print(self.scale)
         pos = list(self.axes.values()).index(new_dim)
         key = list(self.axes.keys())[pos]
         self.axes[key] = old_dim
         self.axes[index] = new_dim
         self.update_axes()
+        # axes_scales = _get_xyz_axes
+        self.update_log_axes_buttons()
+
+    def update_log_axes_buttons(self):
+        self.view.update_log_axes_buttons({ax: self.scale[self.axes[ax]] for
+            ax in self._get_xyz_axes()})
 
     def update_axes(self, change=None):
         """

--- a/python/src/scipp/plot/controller.py
+++ b/python/src/scipp/plot/controller.py
@@ -271,31 +271,23 @@ class PlotController:
                                        mask_info=self.get_masks_info())
 
     def swap_axes(self, owner=None):
-        # print("before", self.axes)
-        # Find position of new dim in axes values
-        # pos = list(self.axes.values()).index(new_dim)
-        # print(self._get_xyz_axes())
-        dims = list(self.axes.values())
-        # keys = list(np.roll(self._get_xyz_axes(), 1))
-        keys = self._get_xyz_axes()
-        # print(keys)
-        # print(dims)
-        # print(zip(keys, dims))
-        for ax, dim in zip(keys, dims):
-            # print(ax, dim, self.axes)
-            self.axes[ax] = dim
-        # print("after", self.axes)
+        """
+        Roll the order of the displayed axes.
+        """
+        dims = [self.axes[key] for key in sorted(self.axes.keys())]
+        keys = list(np.roll(self._get_xyz_axes(), 1))
+        for i in range(len(dims)):
+            self.axes[keys[i]] = dims[i]
         self.update_axes()
 
-
     def swap_dimensions(self, index, old_dim, new_dim):
-        # print("before", self.axes)
-        # Find position of new dim in axes values
+        """
+        Swap one dimension for another in the displayed axes.
+        """
         pos = list(self.axes.values()).index(new_dim)
         key = list(self.axes.keys())[pos]
         self.axes[key] = old_dim
         self.axes[index] = new_dim
-        # print("after", self.axes)
         self.update_axes()
 
     def update_axes(self, change=None):
@@ -309,9 +301,6 @@ class PlotController:
         state to the model. If then gets the updated data back from the model
         and sends it over to the view for display.
         """
-
-        print("controller update_axes")
-        print(self.axes)
         self.axparams = self._get_axes_parameters()
         other_params = self.model.update_axes(self.axparams)
         if other_params is not None:
@@ -388,7 +377,7 @@ class PlotController:
                                      change["owner"].mask_name, change["new"])
 
     def _get_xyz_axes(self):
-        return list(set(['x', 'y', 'z']) & set(self.axes.keys()))
+        return sorted(list(set(['x', 'y', 'z']) & set(self.axes.keys())))
 
     def _get_axes_parameters(self):
         """

--- a/python/src/scipp/plot/controller2d.py
+++ b/python/src/scipp/plot/controller2d.py
@@ -27,4 +27,5 @@ class PlotController2d(PlotController):
         Connect the view interface to callbacks.
         """
         super().connect_view()
-        self.view.connect(view_callbacks={"update_viewport": self.update_viewport})
+        self.view.connect(
+            view_callbacks={"update_viewport": self.update_viewport})

--- a/python/src/scipp/plot/controller3d.py
+++ b/python/src/scipp/plot/controller3d.py
@@ -126,6 +126,10 @@ class PlotController3d(PlotController):
         self.view.update_data(new_values)
 
     def toggle_norm(self, change):
+        """
+        When toggling the color normalization, we need to get values from
+        the model to update the colors in 3d plots.
+        """
         super().toggle_norm(change)
         new_values = self.model.get_slice_values(
             mask_info=self.get_masks_info())

--- a/python/src/scipp/plot/controller3d.py
+++ b/python/src/scipp/plot/controller3d.py
@@ -14,14 +14,9 @@ class PlotController3d(PlotController):
     It handles some additional events from the cut surface panel, compared to
     the base class controller.
     """
-    def __init__(self,
-                 *args,
-                 pixel_size=None,
-                 positions=None,
-                 initial_update=False,
-                 **kwargs):
+    def __init__(self, *args, pixel_size=None, positions=None, **kwargs):
 
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, initial_update=False, **kwargs)
 
         self.positions = positions
         self.pos_axparams = {}

--- a/python/src/scipp/plot/controller3d.py
+++ b/python/src/scipp/plot/controller3d.py
@@ -14,7 +14,12 @@ class PlotController3d(PlotController):
     It handles some additional events from the cut surface panel, compared to
     the base class controller.
     """
-    def __init__(self, *args, pixel_size=None, positions=None, **kwargs):
+    def __init__(self,
+                 *args,
+                 pixel_size=None,
+                 positions=None,
+                 initial_update=False,
+                 **kwargs):
 
         super().__init__(*args, **kwargs)
 
@@ -30,6 +35,10 @@ class PlotController3d(PlotController):
                     "lims": ex["lims"],
                     "label": name_with_unit(1.0 * ex["unit"], name=xyz.upper())
                 }
+
+        # Call axes once to make the initial plot
+        self.update_axes()
+        self.update_log_axes_buttons()
 
     def initialise_model(self):
         """

--- a/python/src/scipp/plot/controller3d.py
+++ b/python/src/scipp/plot/controller3d.py
@@ -124,3 +124,9 @@ class PlotController3d(PlotController):
         new_values = self.model.get_slice_values(
             mask_info=self.get_masks_info())
         self.view.update_data(new_values)
+
+    def toggle_norm(self, change):
+        super().toggle_norm(change)
+        new_values = self.model.get_slice_values(
+            mask_info=self.get_masks_info())
+        self.view.update_data(new_values)

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -111,7 +111,8 @@ class PlotFigure:
                     integer=True)
 
     def connect(self, callbacks):
-        self.toolbar.connect(callbacks)
+        if self.toolbar is not None:
+            self.toolbar.connect(callbacks)
 
     def draw(self):
         """

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -38,8 +38,8 @@ class PlotFigure:
                 padding = config.plot.padding
             self.fig.tight_layout(rect=padding)
             if self.is_widget():
-                self.toolbar = PlotToolbar(canvas=self.fig.canvas,
-                    ndim=ndim)
+                # We create a custom toolbar
+                self.toolbar = PlotToolbar(canvas=self.fig.canvas, ndim=ndim)
                 self.fig.canvas.toolbar_visible = False
         else:
             self.own_axes = False
@@ -75,18 +75,12 @@ class PlotFigure:
     def _to_widget(self):
         """
         Convert the Matplotlib figure to a widget. If the ipympl (widget)
-        backend is in use, just return the figure canvas.
+        backend is in use, return the custom toolbar and the figure canvas.
         If not, convert the plot to a png image and place inside an ipywidgets
         Image container.
         """
         if self.is_widget():
             return ipw.HBox([self.toolbar._to_widget(), self.fig.canvas])
-            # # print(self.fig.canvas.layout.width)
-            # # return ipw.HBox([ipw.ToggleButton(description="log", layout={"width": "40px"}), self.fig.canvas, ipw.VBox([ipw.ToggleButton(description="log2", layout={"width": "40px"})])],
-            # #      layout={"justify_items": "flex-start"})
-            # return ipw.HBox([self.toolbar._to_widget(),
-            #     ipw.VBox([ipw.HBox([ipw.Label(layout={"width": "50px"}), ipw.ToggleButton(description="log", layout={"width": "34px", "padding": '0px 0px 0px 0px'})]), self.fig.canvas]),
-            #     ipw.VBox([ipw.Label(layout={"height": "440px"}), ipw.ToggleButton(description="log", layout={"width": "34px", "padding": '0px 0px 0px 0px'})])])
         else:
             buf = io.BytesIO()
             self.fig.savefig(buf, format='png')

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -89,6 +89,12 @@ class PlotFigure:
                              width=config.plot.width,
                              height=config.plot.height)
 
+    def show(self):
+        """
+        Show the matplotlib figure.
+        """
+        self.fig.show()
+
     def initialise(self, axformatters=None):
         """
         Initialise figure parameters once the model has been created, since

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -111,6 +111,11 @@ class PlotFigure:
                     integer=True)
 
     def connect(self, callbacks):
+        """
+        Connect the toolbar to callback from the controller. This includes
+        rescaling the data norm, and change the scale (log or linear) on the
+        axes.
+        """
         if self.toolbar is not None:
             self.toolbar.connect(callbacks)
 
@@ -145,4 +150,9 @@ class PlotFigure:
             self.fig.canvas.mpl_disconnect(hover_connection)
 
     def update_log_axes_buttons(self, *args, **kwargs):
-        self.toolbar.update_log_axes_buttons(*args, **kwargs)
+        """
+        Update the state (value and color) of toolbar log axes buttons when
+        axes or dimensions are swapped.
+        """
+        if self.toolbar is not None:
+            self.toolbar.update_log_axes_buttons(*args, **kwargs)

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -20,7 +20,7 @@ class PlotFigure:
                  figsize=None,
                  title=None,
                  padding=None,
-                 swap_axes_button=False):
+                 ndim=1):
         self.fig = None
         self.ax = ax
         self.cax = cax
@@ -38,8 +38,8 @@ class PlotFigure:
                 padding = config.plot.padding
             self.fig.tight_layout(rect=padding)
             if self.is_widget():
-                self.toolbar = PlotToolbar(self.fig.canvas.toolbar,
-                    swap_axes_button)
+                self.toolbar = PlotToolbar(canvas=self.fig.canvas,
+                    ndim=ndim)
                 self.fig.canvas.toolbar_visible = False
         else:
             self.own_axes = False
@@ -81,6 +81,12 @@ class PlotFigure:
         """
         if self.is_widget():
             return ipw.HBox([self.toolbar._to_widget(), self.fig.canvas])
+            # # print(self.fig.canvas.layout.width)
+            # # return ipw.HBox([ipw.ToggleButton(description="log", layout={"width": "40px"}), self.fig.canvas, ipw.VBox([ipw.ToggleButton(description="log2", layout={"width": "40px"})])],
+            # #      layout={"justify_items": "flex-start"})
+            # return ipw.HBox([self.toolbar._to_widget(),
+            #     ipw.VBox([ipw.HBox([ipw.Label(layout={"width": "50px"}), ipw.ToggleButton(description="log", layout={"width": "34px", "padding": '0px 0px 0px 0px'})]), self.fig.canvas]),
+            #     ipw.VBox([ipw.Label(layout={"height": "440px"}), ipw.ToggleButton(description="log", layout={"width": "34px", "padding": '0px 0px 0px 0px'})])])
         else:
             buf = io.BytesIO()
             self.fig.savefig(buf, format='png')

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -19,7 +19,8 @@ class PlotFigure:
                  cax=None,
                  figsize=None,
                  title=None,
-                 padding=None):
+                 padding=None,
+                 swap_axes_button=False):
         self.fig = None
         self.ax = ax
         self.cax = cax
@@ -37,7 +38,8 @@ class PlotFigure:
                 padding = config.plot.padding
             self.fig.tight_layout(rect=padding)
             if self.is_widget():
-                self.toolbar = PlotToolbar(self.fig.canvas.toolbar)
+                self.toolbar = PlotToolbar(self.fig.canvas.toolbar,
+                    swap_axes_button)
                 self.fig.canvas.toolbar_visible = False
         else:
             self.own_axes = False

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -148,3 +148,6 @@ class PlotFigure:
             self.fig.canvas.mpl_disconnect(pick_connection)
         if hover_connection is not None:
             self.fig.canvas.mpl_disconnect(hover_connection)
+
+    def update_log_axes_buttons(self, *args, **kwargs):
+        self.toolbar.update_log_axes_buttons(*args, **kwargs)

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -62,7 +62,6 @@ class PlotFigure1d(PlotFigure):
         the horizontal axis is changed.
         """
         xparams = axparams["x"]
-        print(xparams)
 
         if self.own_axes:
             self.ax.clear()
@@ -323,5 +322,8 @@ class PlotFigure1d(PlotFigure):
             self.ax.get_legend_handles_labels()[1]) > 0
 
     def toggle_norm(self, norm=None, vmin=None, vmax=None):
+        """
+        Set yscale to either "log" or "linear", depending on norm.
+        """
         self.norm = norm
         self.ax.set_yscale("log" if self.norm == "log" else "linear")

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -321,3 +321,7 @@ class PlotFigure1d(PlotFigure):
         """
         return self.legend["show"] and len(
             self.ax.get_legend_handles_labels()[1]) > 0
+
+    def toggle_norm(self, norm=None, vmin=None, vmax=None):
+        self.norm = norm
+        self.ax.set_yscale("log" if self.norm == "log" else "linear")

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -62,6 +62,7 @@ class PlotFigure1d(PlotFigure):
         the horizontal axis is changed.
         """
         xparams = axparams["x"]
+        print(xparams)
 
         if self.own_axes:
             self.ax.clear()

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -28,7 +28,8 @@ class PlotFigure2d(PlotFigure):
                  masks=None,
                  resolution=None):
 
-        super().__init__(ax=ax, cax=cax, figsize=figsize, title=title)
+        super().__init__(ax=ax, cax=cax, figsize=figsize, title=title,
+          swap_axes_button=True)
 
         if aspect is None:
             aspect = config.plot.aspect

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -6,6 +6,7 @@ from .. import config
 from .figure import PlotFigure
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize, LogNorm
 import warnings
 
 
@@ -154,3 +155,9 @@ class PlotFigure2d(PlotFigure):
             if new_values["extent"] is not None:
                 self.mask_image[m].set_extent(new_values["extent"])
         self.draw()
+
+    def toggle_norm(self, norm=None, vmin=None, vmax=None):
+        new_norm = LogNorm(vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin, vmax=vmax)
+        self.image.set_norm(new_norm)
+        for m in self.mask_image:
+            self.mask_image[m].set_norm(new_norm)

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -29,8 +29,7 @@ class PlotFigure2d(PlotFigure):
                  masks=None,
                  resolution=None):
 
-        super().__init__(ax=ax, cax=cax, figsize=figsize, title=title,
-          ndim=2)
+        super().__init__(ax=ax, cax=cax, figsize=figsize, title=title, ndim=2)
 
         if aspect is None:
             aspect = config.plot.aspect
@@ -157,7 +156,9 @@ class PlotFigure2d(PlotFigure):
         self.draw()
 
     def toggle_norm(self, norm=None, vmin=None, vmax=None):
-        new_norm = LogNorm(vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin, vmax=vmax)
+        new_norm = LogNorm(
+            vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin,
+                                                                  vmax=vmax)
         self.image.set_norm(new_norm)
         for m in self.mask_image:
             self.mask_image[m].set_norm(new_norm)

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -29,7 +29,7 @@ class PlotFigure2d(PlotFigure):
                  resolution=None):
 
         super().__init__(ax=ax, cax=cax, figsize=figsize, title=title,
-          swap_axes_button=True)
+          ndim=2)
 
         if aspect is None:
             aspect = config.plot.aspect

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -394,3 +394,11 @@ void main() {
         self.masks_scalar_map.set_norm(new_norm)
         self.cbar.set_norm(new_norm)
         self.update_colorbar()
+
+    def update_log_axes_buttons(self, *args, **kwargs):
+        """
+        Update the state (value and color) of toolbar log axes buttons when
+        axes or dimensions are swapped.
+        """
+        if self.toolbar is not None:
+            self.toolbar.update_log_axes_buttons(*args, **kwargs)

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -360,6 +360,13 @@ void main() {
         """
         self.scalar_map.set_clim(vmin, vmax)
         self.cbar.set_clim(vmin, vmax)
+        self.update_colorbar()
+        # buf = io.BytesIO()
+        # self.cbar_fig.savefig(buf, format='png', bbox_inches='tight')
+        # buf.seek(0)
+        # self.cbar_image.value = buf.getvalue()
+
+    def update_colorbar(self):
         buf = io.BytesIO()
         self.cbar_fig.savefig(buf, format='png', bbox_inches='tight')
         buf.seek(0)
@@ -374,3 +381,5 @@ void main() {
         new_norm = LogNorm(vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin, vmax=vmax)
         self.scalar_map.set_norm(new_norm)
         self.masks_scalar_map.set_norm(new_norm)
+        self.cbar.set_norm(new_norm)
+        self.update_colorbar()

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -7,9 +7,10 @@ from .toolbar import PlotToolbar
 from .._utils import value_to_string
 import numpy as np
 import ipywidgets as ipw
-from matplotlib import cm
-import matplotlib as mpl
+from matplotlib import cm, ticker
+# import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize, LogNorm
 import pythreejs as p3
 from copy import copy
 import io
@@ -40,7 +41,7 @@ class PlotFigure3d:
             figsize = (config.plot.width, config.plot.height)
 
         # Figure toolbar
-        self.toolbar = PlotToolbar(swap_axes_button=True)
+        self.toolbar = PlotToolbar(ndim=3)
 
         # Prepare colormaps
         self.cmap = copy(cm.get_cmap(cmap))
@@ -258,7 +259,7 @@ void main() {
             ])
         ticks_and_labels = p3.Group()
         iden = np.identity(3, dtype=np.float32)
-        ticker = mpl.ticker.MaxNLocator(5)
+        ticker_ = ticker.MaxNLocator(5)
         offsets = {
             'x': [0, axparams['y']["lims"][0], axparams['z']["lims"][0]],
             'y': [axparams['x']["lims"][0], 0, axparams['z']["lims"][0]],
@@ -266,7 +267,7 @@ void main() {
         }
 
         for axis, x in enumerate('xyz'):
-            ticks = ticker.tick_values(axparams[x]["lims"][0],
+            ticks = ticker_.tick_values(axparams[x]["lims"][0],
                                        axparams[x]["lims"][1])
             for tick in ticks:
                 if tick >= axparams[x]["lims"][0] and tick <= axparams[x][
@@ -368,3 +369,8 @@ void main() {
         self.camera.position = self.camera_reset["position"]
         self.controls.target = self.camera_reset["lookat"]
         self.camera.lookAt(self.camera_reset["lookat"])
+
+    def toggle_norm(self, norm=None, vmin=None, vmax=None):
+        new_norm = LogNorm(vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin, vmax=vmax)
+        self.scalar_map.set_norm(new_norm)
+        self.masks_scalar_map.set_norm(new_norm)

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -95,7 +95,8 @@ class PlotFigure3d:
                                     width=figsize[0],
                                     height=figsize[1])
 
-        self.figure = ipw.HBox([self.toolbar._to_widget(), self.renderer, self.cbar_image])
+        self.figure = ipw.HBox(
+            [self.toolbar._to_widget(), self.renderer, self.cbar_image])
 
         return
 
@@ -127,6 +128,9 @@ class PlotFigure3d:
         return
 
     def connect(self, callbacks):
+        """
+        Connect the toolbar Home button to reset the camera position.
+        """
         callbacks.update({"home": self.reset_camera})
         self.toolbar.connect(callbacks)
 
@@ -268,7 +272,7 @@ void main() {
 
         for axis, x in enumerate('xyz'):
             ticks = ticker_.tick_values(axparams[x]["lims"][0],
-                                       axparams[x]["lims"][1])
+                                        axparams[x]["lims"][1])
             for tick in ticks:
                 if tick >= axparams[x]["lims"][0] and tick <= axparams[x][
                         "lims"][1]:
@@ -361,24 +365,31 @@ void main() {
         self.scalar_map.set_clim(vmin, vmax)
         self.cbar.set_clim(vmin, vmax)
         self.update_colorbar()
-        # buf = io.BytesIO()
-        # self.cbar_fig.savefig(buf, format='png', bbox_inches='tight')
-        # buf.seek(0)
-        # self.cbar_image.value = buf.getvalue()
 
     def update_colorbar(self):
+        """
+        Save the colorbar figure to png and update the image widget.
+        """
         buf = io.BytesIO()
         self.cbar_fig.savefig(buf, format='png', bbox_inches='tight')
         buf.seek(0)
         self.cbar_image.value = buf.getvalue()
 
     def reset_camera(self, owner=None):
+        """
+        Reset the camera position.
+        """
         self.camera.position = self.camera_reset["position"]
         self.controls.target = self.camera_reset["lookat"]
         self.camera.lookAt(self.camera_reset["lookat"])
 
     def toggle_norm(self, norm=None, vmin=None, vmax=None):
-        new_norm = LogNorm(vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin, vmax=vmax)
+        """
+        Toggle color normalization when toolbar button is clicked.
+        """
+        new_norm = LogNorm(
+            vmin=vmin, vmax=vmax) if norm == "log" else Normalize(vmin=vmin,
+                                                                  vmax=vmax)
         self.scalar_map.set_norm(new_norm)
         self.masks_scalar_map.set_norm(new_norm)
         self.cbar.set_norm(new_norm)

--- a/python/src/scipp/plot/model.py
+++ b/python/src/scipp/plot/model.py
@@ -242,8 +242,8 @@ class PlotModel:
         vmin = None
         vmax = None
         if self.dslice is not None:
-            vmin = sc.min(self.dslice.data).value
-            vmax = sc.max(self.dslice.data).value
+            vmin = sc.nanmin(self.dslice.data).value
+            vmax = sc.nanmax(self.dslice.data).value
         return vmin, vmax
 
     # def _slice_or_rebin(self, array, dim, dim_slice):
@@ -278,5 +278,11 @@ class PlotModel:
         # for dim in slices:
         for dim, [lower, upper] in slices.items():
             # data_slice = self._slice_or_rebin(data_slice, dim, slices[dim])
-            array = sc.sum(array[dim, lower:upper], dim)
+            # array = sc.sum(array[dim, lower:upper], dim)
+            array = array[dim, lower:upper]
+            # Here we rebin to a single bin instead of using sc.sum because the
+            # sum would apply the masks (i.e. zero the data values)
+            array = sc.rebin(array, dim,
+                sc.concatenate(array.coords[dim][dim, 0],
+                               array.coords[dim][dim, -1], dim))[dim, 0]
         return array

--- a/python/src/scipp/plot/model.py
+++ b/python/src/scipp/plot/model.py
@@ -209,13 +209,13 @@ class PlotModel:
         """
         for dim, [lower, upper] in slices.items():
             # TODO: Could this be optimized for performance?
-            array = array[dim, lower:upper]
             if (upper - lower) > 1:
+                array = array[dim, lower:upper]
                 array = sc.rebin(
                     array, dim,
                     sc.concatenate(array.coords[dim][dim, 0],
                                    array.coords[dim][dim, -1], dim))[dim, 0]
             else:
-                array = array[dim, 0]
+                array = array[dim, lower]
 
         return array

--- a/python/src/scipp/plot/model.py
+++ b/python/src/scipp/plot/model.py
@@ -169,15 +169,16 @@ class PlotModel:
         """
         return self.axformatter[name][dim]
 
-    def get_bin_coord_values(self, name, dim, ind):
+    def get_slice_coord_bounds(self, name, dim, bounds):
         """
         Return the left, center, and right coordinates for a bin index.
         """
-        left = self.data_arrays[name].coords[dim][dim, ind:ind + 1]
-        right = self.data_arrays[name].coords[dim][dim, ind + 1:ind + 2]
-        return left.values[0], to_bin_centers(
-            self.data_arrays[name].coords[dim][dim, ind:ind + 2],
-            dim).values[0], right.values[0]
+        # lower = self.data_arrays[name].coords[dim][dim, ind:ind + 1]
+        # right = self.data_arrays[name].coords[dim][dim, ind + 1:ind + 2]
+        # return left.values[0], to_bin_centers(
+        #     self.data_arrays[name].coords[dim][dim, ind:ind + 2],
+        #     dim).values[0], right.values[0]
+        return self.data_arrays[name].coords[dim][dim, bounds[0]].value, self.data_arrays[name].coords[dim][dim, bounds[1]].value
 
     def get_data_names(self):
         """
@@ -193,46 +194,46 @@ class PlotModel:
         """
         return self.data_arrays[name].coords[dim]
 
-    def _select_bins(self, coord, dim, start, end):
-        """
-        Method to speed up the finding of bin ranges
-        """
-        bins = coord.shape[-1]
-        if len(coord.dims) != 1:  # TODO find combined min/max
-            return dim, slice(0, bins - 1)
-        # scipp treats bins as closed on left and open on right: [left, right)
-        first = sc.sum(coord <= start, dim).value - 1
-        last = bins - sc.sum(coord > end, dim).value
-        if first >= last:  # TODO better handling for decreasing
-            return dim, slice(0, bins - 1)
-        first = max(0, first)
-        last = min(bins - 1, last)
-        return dim, slice(first, last + 1)
+    # def _select_bins(self, coord, dim, start, end):
+    #     """
+    #     Method to speed up the finding of bin ranges
+    #     """
+    #     bins = coord.shape[-1]
+    #     if len(coord.dims) != 1:  # TODO find combined min/max
+    #         return dim, slice(0, bins - 1)
+    #     # scipp treats bins as closed on left and open on right: [left, right)
+    #     first = sc.sum(coord <= start, dim).value - 1
+    #     last = bins - sc.sum(coord > end, dim).value
+    #     if first >= last:  # TODO better handling for decreasing
+    #         return dim, slice(0, bins - 1)
+    #     first = max(0, first)
+    #     last = min(bins - 1, last)
+    #     return dim, slice(first, last + 1)
 
-    def resample_data(self, array, rebin_edges):
-        """
-        Resample a DataArray according to new bin edges.
-        """
-        dslice = array
-        # Select bins to speed up rebinning
-        for dim in rebin_edges:
-            this_slice = self._select_bins(array.coords[dim], dim,
-                                           rebin_edges[dim][dim, 0],
-                                           rebin_edges[dim][dim, -1])
-            dslice = dslice[this_slice]
+    # def resample_data(self, array, rebin_edges):
+    #     """
+    #     Resample a DataArray according to new bin edges.
+    #     """
+    #     dslice = array
+    #     # Select bins to speed up rebinning
+    #     for dim in rebin_edges:
+    #         this_slice = self._select_bins(array.coords[dim], dim,
+    #                                        rebin_edges[dim][dim, 0],
+    #                                        rebin_edges[dim][dim, -1])
+    #         dslice = dslice[this_slice]
 
-        # Rebin the data
-        for dim, edges in rebin_edges.items():
-            dslice = sc.rebin(dslice, dim, edges)
+    #     # Rebin the data
+    #     for dim, edges in rebin_edges.items():
+    #         dslice = sc.rebin(dslice, dim, edges)
 
-        # Divide by pixel width
-        # TODO: can this loop be combined with the one above?
-        for dim, edges in rebin_edges.items():
-            div = edges[dim, 1:] - edges[dim, :-1]
-            div.unit = sc.units.one
-            dslice /= div
+    #     # Divide by pixel width
+    #     # TODO: can this loop be combined with the one above?
+    #     for dim, edges in rebin_edges.items():
+    #         div = edges[dim, 1:] - edges[dim, :-1]
+    #         div.unit = sc.units.one
+    #         dslice /= div
 
-        return dslice
+    #     return dslice
 
     def rescale_to_data(self):
         """
@@ -245,35 +246,37 @@ class PlotModel:
             vmax = sc.max(self.dslice.data).value
         return vmin, vmax
 
-    def _slice_or_rebin(self, array, dim, dim_slice):
-        """
-        The convetion is:
-        - if the slider thickness is zero, use index-based slicing
-        - otherwise, use `rebin`.
-        """
-        deltax = dim_slice["thickness"]
-        if deltax == 0.0:
-            array = array[dim, dim_slice["index"]]
-        else:
-            loc = dim_slice["bin_centre"]
-            array = self.resample_data(
-                array,
-                rebin_edges={
-                    dim:
-                    sc.Variable(
-                        [dim],
-                        values=[loc - 0.5 * deltax, loc + 0.5 * deltax],
-                        unit=array.coords[dim].unit)
-                })[dim, 0]
-            array *= (deltax * sc.units.one)
-        return array
+    # def _slice_or_rebin(self, array, dim, dim_slice):
+    #     """
+    #     The convetion is:
+    #     - if the slider thickness is zero, use index-based slicing
+    #     - otherwise, use `rebin`.
+    #     """
+    #     deltax = dim_slice["thickness"]
+    #     if deltax == 0.0:
+    #         array = array[dim, dim_slice["index"]]
+    #     else:
+    #         loc = dim_slice["bin_centre"]
+    #         array = self.resample_data(
+    #             array,
+    #             rebin_edges={
+    #                 dim:
+    #                 sc.Variable(
+    #                     [dim],
+    #                     values=[loc - 0.5 * deltax, loc + 0.5 * deltax],
+    #                     unit=array.coords[dim].unit)
+    #             })[dim, 0]
+    #         array *= (deltax * sc.units.one)
+    #     return array
 
     def slice_data(self, array, slices):
         """
         Slice the data array according to the dimensions and extents listed
         in slices.
         """
-        data_slice = array
-        for dim in slices:
-            data_slice = self._slice_or_rebin(data_slice, dim, slices[dim])
-        return data_slice
+        # data_slice = array
+        # for dim in slices:
+        for dim, [lower, upper] in slices.items():
+            # data_slice = self._slice_or_rebin(data_slice, dim, slices[dim])
+            array = sc.sum(array[dim, lower:upper], dim)
+        return array

--- a/python/src/scipp/plot/model.py
+++ b/python/src/scipp/plot/model.py
@@ -221,7 +221,10 @@ class PlotModel:
                     else:
                         array.coords[dim_] = coord
             for m, msk in aslice.masks.items():
-                array.masks[m] = sc.any(msk, dim)
+                if dim in msk.dims:
+                    array.masks[m] = sc.any(msk, dim)
+                else:
+                    array.masks[m] = msk
 
             # TODO: alternative here is to use rebin into a single bin with
             # array = sc.rebin(

--- a/python/src/scipp/plot/model1d.py
+++ b/python/src/scipp/plot/model1d.py
@@ -89,13 +89,14 @@ class PlotModel1d(PlotModel):
         Slice down all dimensions apart from the profile dimension, and send
         the data values, variances and masks back to the `PlotController`.
         """
+        # os.write(1, "model1d update_profile 1\n)
 
         profile_dim = axparams["x"]["dim"]
 
         new_values = {}
 
-        # Remove the current dim since it will be manually sliced below
-        del slices[self.dim]
+        # # Remove the current dim since it will be manually sliced below
+        # del slices[self.dim]
 
         # Find closest point to cursor
         # TODO: can we optimize this with new buckets?

--- a/python/src/scipp/plot/model1d.py
+++ b/python/src/scipp/plot/model1d.py
@@ -89,14 +89,9 @@ class PlotModel1d(PlotModel):
         Slice down all dimensions apart from the profile dimension, and send
         the data values, variances and masks back to the `PlotController`.
         """
-        # os.write(1, "model1d update_profile 1\n)
 
         profile_dim = axparams["x"]["dim"]
-
         new_values = {}
-
-        # # Remove the current dim since it will be manually sliced below
-        # del slices[self.dim]
 
         # Find closest point to cursor
         # TODO: can we optimize this with new buckets?

--- a/python/src/scipp/plot/model2d.py
+++ b/python/src/scipp/plot/model2d.py
@@ -250,10 +250,10 @@ class PlotModel2d(PlotModel):
                                                                  iy:iy + 2]
                                            })[dimx, 0][dimy, 0]
 
-        # Remove the current x and y dims since they will have been manually
-        # sliced above
-        del slices[dimx]
-        del slices[dimy]
+        # # Remove the current x and y dims since they will have been manually
+        # # sliced above
+        # del slices[dimx]
+        # del slices[dimy]
         # Slice the remaining dims
         profile_slice = self.slice_data(profile_slice, slices)
 

--- a/python/src/scipp/plot/model2d.py
+++ b/python/src/scipp/plot/model2d.py
@@ -87,6 +87,47 @@ class PlotModel2d(PlotModel):
         new_values = self.update_image(mask_info=mask_info)
         return new_values
 
+    def _select_bins(self, coord, dim, start, end):
+        """
+        Method to speed up the finding of bin ranges
+        """
+        bins = coord.shape[-1]
+        if len(coord.dims) != 1:  # TODO find combined min/max
+            return dim, slice(0, bins - 1)
+        # scipp treats bins as closed on left and open on right: [left, right)
+        first = sc.sum(coord <= start, dim).value - 1
+        last = bins - sc.sum(coord > end, dim).value
+        if first >= last:  # TODO better handling for decreasing
+            return dim, slice(0, bins - 1)
+        first = max(0, first)
+        last = min(bins - 1, last)
+        return dim, slice(first, last + 1)
+
+    def resample_data(self, array, rebin_edges):
+        """
+        Resample a DataArray according to new bin edges.
+        """
+        dslice = array
+        # Select bins to speed up rebinning
+        for dim in rebin_edges:
+            this_slice = self._select_bins(array.coords[dim], dim,
+                                           rebin_edges[dim][dim, 0],
+                                           rebin_edges[dim][dim, -1])
+            dslice = dslice[this_slice]
+
+        # Rebin the data
+        for dim, edges in rebin_edges.items():
+            dslice = sc.rebin(dslice, dim, edges)
+
+        # Divide by pixel width
+        # TODO: can this loop be combined with the one above?
+        for dim, edges in rebin_edges.items():
+            div = edges[dim, 1:] - edges[dim, :-1]
+            div.unit = sc.units.one
+            dslice /= div
+
+        return dslice
+
     def update_image(self, extent=None, mask_info=None):
         """
         Resample 2d images to a fixed resolution to handle very large images.

--- a/python/src/scipp/plot/model2d.py
+++ b/python/src/scipp/plot/model2d.py
@@ -250,10 +250,6 @@ class PlotModel2d(PlotModel):
                                                                  iy:iy + 2]
                                            })[dimx, 0][dimy, 0]
 
-        # # Remove the current x and y dims since they will have been manually
-        # # sliced above
-        # del slices[dimx]
-        # del slices[dimy]
         # Slice the remaining dims
         profile_slice = self.slice_data(profile_slice, slices)
 

--- a/python/src/scipp/plot/panel1d.py
+++ b/python/src/scipp/plot/panel1d.py
@@ -39,7 +39,7 @@ class PlotPanel1d(PlotPanel):
         col = ipw.ColorPicker(concise=True,
                               description='',
                               value=make_random_color(fmt='hex'),
-                              disabled=False)
+                              layout={'width': "40px"})
         # Make a unique id
         self.counter += 1
         line_id = self.counter

--- a/python/src/scipp/plot/panel3d.py
+++ b/python/src/scipp/plot/panel3d.py
@@ -194,7 +194,6 @@ class PlotPanel3d(PlotPanel):
             self.cut_surface_thickness.disabled = True
             self._update_opacity({"new": self.opacity_slider.value})
         else:
-            # self.points_material.depthTest = False
             self.interface["update_depth_test"](False)
             if change["old"] is None:
                 self.cut_slider.disabled = False

--- a/python/src/scipp/plot/panel3d.py
+++ b/python/src/scipp/plot/panel3d.py
@@ -47,7 +47,7 @@ class PlotPanel3d(PlotPanel):
         self.opacity_slider = ipw.FloatRangeSlider(
             min=0.0,
             max=1.0,
-            value=[0.01, 1],
+            value=[0.03, 1],
             step=0.01,
             description="Opacity slider: When no cut surface is active, the "
             "max value of the range slider controls the overall opacity, "

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -152,9 +152,9 @@ def plot(scipp_obj,
             if ndims == 1 or projection == "1d" or projection == "1D":
                 # Construct a key from the dimensions
                 if axes is not None:
-                    key = str(list(axes.values())[0])
+                    key = list(axes.values())[0]
                 else:
-                    key = str(var.dims[0])
+                    key = var.dims[0]
                 # Add unit to key
                 key = "{}.{}".format(key, str(var.unit))
                 line_count += 1

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -24,11 +24,21 @@ class Plot(dict):
         """
         IPython display representation for Jupyter notebooks.
         """
-        import ipywidgets as widgets
+        return self._to_widget()._ipython_display_()
+
+    def _to_widget(self):
+        """
+        Return plot contents into a single VBocx container
+        """
+        import ipywidgets as ipw
         contents = []
-        for key, val in self.items():
-            contents.append(val._to_widget())
-        return widgets.VBox(contents)._ipython_display_()
+        for item in self.values():
+            contents.append(item._to_widget())
+        return ipw.VBox(contents)
+
+    def show(self):
+        for item in self.values():
+            item.show()
 
     def as_static(self, *args, **kwargs):
         """

--- a/python/src/scipp/plot/plot1d.py
+++ b/python/src/scipp/plot/plot1d.py
@@ -66,7 +66,7 @@ class SciPlot1d(SciPlot):
                                    name=self.name,
                                    dim_to_shape=self.dim_to_shape,
                                    masks=self.masks,
-                                   button_options=['x'])
+                                   multid_coord=self.multid_coord)
 
         # The model which takes care of all heavy calculations
         self.model = PlotModel1d(scipp_obj_dict=scipp_obj_dict,

--- a/python/src/scipp/plot/plot1d.py
+++ b/python/src/scipp/plot/plot1d.py
@@ -124,6 +124,3 @@ class SciPlot1d(SciPlot):
             view=self.view,
             panel=self.panel,
             profile=self.profile)
-
-        # Call update_slice once to make the initial plot
-        self.controller.update_axes()

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -84,22 +84,22 @@ class SciPlot2d(SciPlot):
                                unit=self.params["values"][self.name]["unit"],
                                masks=self.masks[self.name])
 
-        # Profile view which displays an additional dimension as a 1d plot
-        if self.ndim > 2:
-            pad = config.plot.padding.copy()
-            pad[2] = 0.77
-            self.profile = ProfileView(
-                errorbars=self.errorbars,
-                ax=pax,
-                unit=self.params["values"][self.name]["unit"],
-                masks=self.masks,
-                figsize=(1.3 * config.plot.width / config.plot.dpi,
-                         0.6 * config.plot.height / config.plot.dpi),
-                padding=pad,
-                legend={
-                    "show": True,
-                    "loc": (1.02, 0.0)
-                })
+        # # Profile view which displays an additional dimension as a 1d plot
+        # if self.ndim > 2:
+        #     pad = config.plot.padding.copy()
+        #     pad[2] = 0.77
+        #     self.profile = ProfileView(
+        #         errorbars=self.errorbars,
+        #         ax=pax,
+        #         unit=self.params["values"][self.name]["unit"],
+        #         masks=self.masks,
+        #         figsize=(1.3 * config.plot.width / config.plot.dpi,
+        #                  0.6 * config.plot.height / config.plot.dpi),
+        #         padding=pad,
+        #         legend={
+        #             "show": True,
+        #             "loc": (1.02, 0.0)
+        #         })
 
         # The main controller module which connects and controls all the parts
         self.controller = PlotController2d(

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -115,6 +115,3 @@ class SciPlot2d(SciPlot):
             model=self.model,
             view=self.view,
             profile=self.profile)
-
-        # Call update_slice once to make the initial image
-        self.controller.update_axes()

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -61,7 +61,7 @@ class SciPlot2d(SciPlot):
                                    name=self.name,
                                    dim_to_shape=self.dim_to_shape,
                                    masks=self.masks,
-                                   button_options=['x', 'y'])
+                                   multid_coord=self.multid_coord)
 
         # The model which takes care of all heavy calculations
         self.model = PlotModel2d(scipp_obj_dict=scipp_obj_dict,

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -117,4 +117,4 @@ class SciPlot2d(SciPlot):
             profile=self.profile)
 
         # Call update_slice once to make the initial image
-        self.controller.update_axes()
+        # self.controller.update_axes()

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -117,4 +117,4 @@ class SciPlot2d(SciPlot):
             profile=self.profile)
 
         # Call update_slice once to make the initial image
-        # self.controller.update_axes()
+        self.controller.update_axes()

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -111,6 +111,3 @@ class SciPlot3d(SciPlot):
             view=self.view,
             panel=self.panel,
             profile=self.profile)
-
-        # Call update_slice once to make the initial image
-        self.controller.update_axes()

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -68,7 +68,7 @@ class SciPlot3d(SciPlot):
                                    dim_to_shape=self.dim_to_shape,
                                    masks=self.masks,
                                    positions=positions,
-                                   button_options=['x', 'y', 'z'])
+                                   multid_coord=self.multid_coord)
 
         # The model which takes care of all heavy calculations
         self.model = PlotModel3d(scipp_obj_dict=scipp_obj_dict,

--- a/python/src/scipp/plot/profile.py
+++ b/python/src/scipp/plot/profile.py
@@ -99,14 +99,14 @@ class PlotProfile(PlotFigure1d):
                 "toggle_norm": self.toggle_norm
             })
 
-    def toggle_xaxis_scale(self, change):
+    def toggle_xaxis_scale(self, owner):
         """
         Toggle x-axis scale from toolbar button signal.
         """
-        self.ax.set_xscale("log" if change["new"] else "linear")
+        self.ax.set_xscale("log" if owner.value else "linear")
 
-    def toggle_norm(self, change):
+    def toggle_norm(self, owner):
         """
         Toggle y-axis scale from toolbar button signal.
         """
-        self.ax.set_yscale("log" if change["new"] else "linear")
+        self.ax.set_yscale("log" if owner.value else "linear")

--- a/python/src/scipp/plot/profile.py
+++ b/python/src/scipp/plot/profile.py
@@ -93,10 +93,11 @@ class PlotProfile(PlotFigure1d):
         callbacks local to `PlotProfile`, since all we need to do is toggle
         the scale on the matplotlib axes.
         """
-        self.toolbar.connect({
-            "toggle_xaxis_scale": self.toggle_xaxis_scale,
-            "toggle_norm": self.toggle_norm
-        })
+        if self.toolbar is not None:
+            self.toolbar.connect({
+                "toggle_xaxis_scale": self.toggle_xaxis_scale,
+                "toggle_norm": self.toggle_norm
+            })
 
     def toggle_xaxis_scale(self, change):
         """

--- a/python/src/scipp/plot/profile.py
+++ b/python/src/scipp/plot/profile.py
@@ -76,9 +76,9 @@ class ProfileView(PlotFigure1d):
         """
         Show or hide profile view.
         """
-        # "on_widget_constructed" is an attribute specific to ipywidgets
-        if hasattr(self.fig.canvas, "on_widget_constructed"):
+        if self.is_widget():
             self.fig.canvas.layout.display = None if visible else 'none'
+            self.fig.toolbar.set_visible(visible)
         self.visible = visible
 
     def is_visible(self):

--- a/python/src/scipp/plot/profile.py
+++ b/python/src/scipp/plot/profile.py
@@ -88,11 +88,24 @@ class PlotProfile(PlotFigure1d):
         return self.visible
 
     def connect(self):
-        self.toolbar.connect({"toggle_xaxis_scale": self.toggle_xaxis_scale,
-            "toggle_norm": self.toggle_norm})
+        """
+        For the profile, we connect the log buttons of the toolbar directly to
+        callbacks local to `PlotProfile`, since all we need to do is toggle
+        the scale on the matplotlib axes.
+        """
+        self.toolbar.connect({
+            "toggle_xaxis_scale": self.toggle_xaxis_scale,
+            "toggle_norm": self.toggle_norm
+        })
 
     def toggle_xaxis_scale(self, change):
+        """
+        Toggle x-axis scale from toolbar button signal.
+        """
         self.ax.set_xscale("log" if change["new"] else "linear")
 
     def toggle_norm(self, change):
+        """
+        Toggle y-axis scale from toolbar button signal.
+        """
         self.ax.set_yscale("log" if change["new"] else "linear")

--- a/python/src/scipp/plot/profile.py
+++ b/python/src/scipp/plot/profile.py
@@ -86,3 +86,13 @@ class PlotProfile(PlotFigure1d):
         Get visible state of profile view.
         """
         return self.visible
+
+    def connect(self):
+        self.toolbar.connect({"toggle_xaxis_scale": self.toggle_xaxis_scale,
+            "toggle_norm": self.toggle_norm})
+
+    def toggle_xaxis_scale(self, change):
+        self.ax.set_xscale("log" if change["new"] else "linear")
+
+    def toggle_norm(self, change):
+        self.ax.set_yscale("log" if change["new"] else "linear")

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -222,7 +222,6 @@ class SciPlot:
 
         # Protect against having a multi-dimensional coord along a slider axis
         for ax, dim in self.axes.items():
-            print(ax, dim, self.multid_coord)
             if isinstance(ax, int) and (dim == self.multid_coord):
                 raise RuntimeError("A ragged coordinate cannot lie along "
                                    "a slider dimension, it must be one of "

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -157,6 +157,12 @@ class SciPlot:
                 widget_list.append(item._to_widget())
         return ipw.VBox(widget_list)
 
+    def show(self):
+        """
+        Call the show() method of a matplotlib figure.
+        """
+        self.view.show()
+
     def _process_axes_dimensions(self,
                                  array=None,
                                  axes=None,

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -57,6 +57,7 @@ class SciPlot:
         self.dim_to_shape = {}
         self.coord_shapes = {}
         self.dim_label_map = {}
+        self.multid_coord = None
 
         self.name = list(scipp_obj_dict.keys())[0]
         self._process_axes_dimensions(scipp_obj_dict[self.name],
@@ -107,10 +108,15 @@ class SciPlot:
 
             # Create a useful map from dim to shape
             self.dim_to_shape[name] = dict(zip(array_dims, array.shape))
-            self.coord_shapes[name] = {
-                str(dim): array.coords[dim].shape
-                for dim in array.coords
-            }
+            self.coord_shapes[name] = {}
+            for dim, coord in array.coords.items():
+                # TODO: this would no longer be necessary once coords.items()
+                # returns strings
+                dimstr = str(dim)
+                if len(coord.dims) > 1:
+                    self.multid_coord = dimstr
+                self.coord_shapes[name][dimstr] = coord.shape
+
             # Add shapes for dims that have no coord in the original data.
             # They will be replaced by fake coordinates in the model.
             for dim in array_dims:

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -180,15 +180,15 @@ class SciPlot:
 
         if axes is not None:
             # Axes can be incomplete
-            for key, ax in axes.items():
-                dim = sc.Dim(ax)
+            for key, dim in axes.items():
+                # dim = sc.Dim(ax)
                 dim_list = list(self.axes.values())
                 key_list = list(self.axes.keys())
-                if ax in dim_list:
-                    ind = dim_list.index(ax)
+                if dim in dim_list:
+                    ind = dim_list.index(dim)
                 else:
                     # Non-dimension coordinate
-                    underlying_dim = array.coords[ax].dims[-1]
+                    underlying_dim = array.coords[dim].dims[-1]
                     self.dim_label_map[underlying_dim] = dim
                     self.dim_label_map[dim] = underlying_dim
                     ind = dim_list.index(underlying_dim)
@@ -198,15 +198,15 @@ class SciPlot:
         # Replace positions in axes if positions set
         if positions is not None:
             if positions not in self.axes:
-                dim = sc.Dim(positions)
+                # dim = sc.Dim(positions)
                 underlying_dim = array.coords[positions].dims[-1]
-                self.dim_label_map[underlying_dim] = dim
-                self.dim_label_map[dim] = underlying_dim
+                self.dim_label_map[underlying_dim] = positions
+                self.dim_label_map[positions] = underlying_dim
                 dim_list = list(self.axes.values())
                 key_list = list(self.axes.keys())
                 ind = dim_list.index(underlying_dim)
                 self.axes[key_list[ind]] = self.axes[key]
-                self.axes[key] = dim
+                self.axes[key] = positions
 
         # Protect against duplicate entries in axes
         if len(self.axes) != len(set(self.axes)):

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -109,7 +109,7 @@ class SciPlot:
             # Create a useful map from dim to shape
             self.dim_to_shape[name] = dict(zip(array_dims, array.shape))
             self.coord_shapes[name] = {
-                dim: array.coords[dim].shape
+                str(dim): array.coords[dim].shape
                 for dim in array.coords
             }
             # Add shapes for dims that have no coord in the original data.

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -108,6 +108,8 @@ class SciPlot:
 
             # Create a useful map from dim to shape
             self.dim_to_shape[name] = dict(zip(array_dims, array.shape))
+            # TODO: once Dim has been replaced by strings, the str(dim) can
+            # then here be replaced by dim
             self.coord_shapes[name] = {
                 str(dim): coord.shape
                 for dim, coord in array.coords.items()

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Neil Vaytet
+
+import ipywidgets as ipw
+
+
+class PlotToolbar:
+    """
+    Custom toolbar with additional buttons.
+    """
+    def __init__(self, fig_toolbar):
+        self.members = {"original": fig_toolbar}
+        self.container = ipw.VBox(list(self.members.values()))
+        self.add_button("rescale", "arrows-v", "Rescale")
+
+
+    def _ipython_display_(self):
+        """
+        IPython display representation for Jupyter notebooks.
+        """
+        return self._to_widget()._ipython_display_()
+
+    def _to_widget(self):
+        """
+        """
+        return self.container
+
+    def set_visible(self, visible):
+        """
+        """
+        self.container.layout.display = None if visible else 'none'
+
+    def add_button(self, name, icon, tooltip=None):
+        """
+        """
+        self.members[name] = ipw.Button(icon=icon, layout={"width": "34px"}, tooltip=tooltip)
+        self.container.children = tuple(self.members.values())

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -13,7 +13,7 @@ class PlotToolbar:
         self.members = {"original": fig_toolbar}
         self.container = ipw.VBox(list(self.members.values()))
         self.add_button("rescale", "arrows-v", "Rescale")
-
+        self.add_button("swap", "exchange", "Swap axes")
 
     def _ipython_display_(self):
         """
@@ -39,3 +39,4 @@ class PlotToolbar:
 
     def connect(self, callbacks):
         self.members["rescale"].on_click(callbacks["rescale_to_data"])
+        self.members["swap"].on_click(callbacks["swap_axes"])

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -9,12 +9,18 @@ class PlotToolbar:
     """
     Custom toolbar with additional buttons.
     """
-    def __init__(self, fig_toolbar, swap_axes_button=False):
-        self.members = {"original": fig_toolbar}
-        self.container = ipw.VBox(list(self.members.values()))
-        self.add_button("rescale", "arrows-v", "Rescale")
+    def __init__(self, fig_toolbar=None, swap_axes_button=False):
+        self.container = ipw.VBox()
+        self.members = {}
+        if fig_toolbar is not None:
+            self.members["original"] = fig_toolbar
+        else:
+            self.add_button("menu", "navicon", "Menu")
+            self.add_button("home", "home", "Reset original view")
+        self.add_button("rescale_to_data", "arrows-v", "Rescale")
         if swap_axes_button:
-            self.add_button("swap", "exchange", "Swap axes")
+            self.add_button("swap_axes", "exchange", "Swap axes")
+        self._update_container()
 
     def _ipython_display_(self):
         """
@@ -36,9 +42,13 @@ class PlotToolbar:
         """
         """
         self.members[name] = ipw.Button(icon=icon, layout={"width": "34px"}, tooltip=tooltip)
-        self.container.children = tuple(self.members.values())
+        # self.container.children = tuple(self.members.values())
 
     def connect(self, callbacks):
-        self.members["rescale"].on_click(callbacks["rescale_to_data"])
-        if "swap" in self.members:
-            self.members["swap"].on_click(callbacks["swap_axes"])
+        for key in callbacks:
+            self.members[key].on_click(callbacks[key])
+        # if "swap" in self.members:
+        #     self.members["swap"].on_click(callbacks["swap_axes"])
+
+    def _update_container(self):
+        self.container.children = tuple(self.members.values())

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -28,13 +28,15 @@ class PlotToolbar:
         if ndim > 1:
             self.add_button(name="swap_axes", icon="exchange", tooltip="Swap axes")
 
-        self.add_togglebutton(name="toggle_xaxis_scale", description="logx", tooltip="Log(x)")
-        # In the case of a 1d plot, we connect the logy button to the
-        # toggle_norm function.
+        if ndim < 3:
+            self.add_togglebutton(name="toggle_xaxis_scale", description="logx", tooltip="Log(x)")
         if ndim == 1:
+            # In the case of a 1d plot, we connect the logy button to the
+            # toggle_norm function.
             self.add_togglebutton(name="toggle_norm", description="logy", tooltip="Log(y)")
         else:
-            self.add_togglebutton(name="toggle_yaxis_scale", description="logy", tooltip="Log(y)")
+            if ndim < 3:
+                self.add_togglebutton(name="toggle_yaxis_scale", description="logy", tooltip="Log(y)")
             self.add_togglebutton(name="toggle_norm", icon="signal", tooltip="Log(data)")
 
         self._update_container()

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -15,11 +15,12 @@ class PlotToolbar:
         if fig_toolbar is not None:
             self.members["original"] = fig_toolbar
         else:
-            self.add_button("menu", "navicon", "Menu")
-            self.add_button("home", "home", "Reset original view")
-        self.add_button("rescale_to_data", "arrows-v", "Rescale")
+            self.add_button(name="menu", icon="navicon", tooltip="Menu")
+            self.add_button(name="home", icon="home", tooltip="Reset original view")
+        self.add_button(name="rescale_to_data", icon="arrows-v", tooltip="Rescale")
+        self.add_togglebutton(name="logx", description="Logx", tooltip="Log(x)")
         if swap_axes_button:
-            self.add_button("swap_axes", "exchange", "Swap axes")
+            self.add_button(name="swap_axes", icon="exchange", tooltip="Swap axes")
         self._update_container()
 
     def _ipython_display_(self):
@@ -38,10 +39,25 @@ class PlotToolbar:
         """
         self.container.layout.display = None if visible else 'none'
 
-    def add_button(self, name, icon, tooltip=None):
+    def add_button(self, name, icon=None, description=None, tooltip=None):
         """
         """
-        self.members[name] = ipw.Button(icon=icon, layout={"width": "34px"}, tooltip=tooltip)
+        # args = {}
+        # if icon is not None:
+        #     args["icon"] = icon
+        # if description is not None:
+        #     args["description"] = description
+        # if tooltip is not None:
+        #     args["tooltip"] = tooltip
+        args = self._parse_button_args(icon=icon, description=description, tooltip=tooltip)
+        self.members[name] = ipw.Button(**args, layout={"width": "34px"})
+        # self.container.children = tuple(self.members.values())
+
+    def add_togglebutton(self, name, icon=None, description=None, tooltip=None):
+        """
+        """
+        args = self._parse_button_args(icon=icon, description=description, tooltip=tooltip)
+        self.members[name] = ipw.ToggleButton(value=False, layout={"width": "34px"}, **args)
         # self.container.children = tuple(self.members.values())
 
     def connect(self, callbacks):
@@ -53,3 +69,10 @@ class PlotToolbar:
 
     def _update_container(self):
         self.container.children = tuple(self.members.values())
+
+    def _parse_button_args(self, **kwargs):
+        args = {}
+        for key, value in kwargs.items():
+            if value is not None:
+                args[key] = value
+        return args

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -7,7 +7,8 @@ import ipywidgets as ipw
 
 class PlotToolbar:
     """
-    Custom toolbar with additional buttons and back/forward buttons removed.
+    Custom toolbar with additional buttons for controlling log scales and
+    normalization, and with back/forward buttons removed.
     """
     def __init__(self, canvas=None, ndim=1):
         # Prepare containers
@@ -17,27 +18,43 @@ class PlotToolbar:
         # Construct  toolbar
         if canvas is not None:
             old_tools = canvas.toolbar.toolitems
-            new_tools = [old_tools[0], old_tools[3], old_tools[4], old_tools[5]]
+            new_tools = [
+                old_tools[0], old_tools[3], old_tools[4], old_tools[5]
+            ]
             canvas.toolbar.toolitems = new_tools
             self.members["mpl_toolbar"] = canvas.toolbar
             canvas.toolbar_visible = False
         else:
             self.add_button(name="menu", icon="bars", tooltip="Menu")
-            self.add_button(name="home", icon="home", tooltip="Reset original view")
-        self.add_button(name="rescale_to_data", icon="arrows-v", tooltip="Rescale")
+            self.add_button(name="home",
+                            icon="home",
+                            tooltip="Reset original view")
+        self.add_button(name="rescale_to_data",
+                        icon="arrows-v",
+                        tooltip="Rescale")
         if ndim > 1:
-            self.add_button(name="swap_axes", icon="exchange", tooltip="Swap axes")
+            self.add_button(name="swap_axes",
+                            icon="exchange",
+                            tooltip="Swap axes")
 
         if ndim < 3:
-            self.add_togglebutton(name="toggle_xaxis_scale", description="logx", tooltip="Log(x)")
+            self.add_togglebutton(name="toggle_xaxis_scale",
+                                  description="logx",
+                                  tooltip="Log(x)")
         if ndim == 1:
             # In the case of a 1d plot, we connect the logy button to the
             # toggle_norm function.
-            self.add_togglebutton(name="toggle_norm", description="logy", tooltip="Log(y)")
+            self.add_togglebutton(name="toggle_norm",
+                                  description="logy",
+                                  tooltip="Log(y)")
         else:
             if ndim < 3:
-                self.add_togglebutton(name="toggle_yaxis_scale", description="logy", tooltip="Log(y)")
-            self.add_togglebutton(name="toggle_norm", description="log", tooltip="Log(data)")
+                self.add_togglebutton(name="toggle_yaxis_scale",
+                                      description="logy",
+                                      tooltip="Log(y)")
+            self.add_togglebutton(name="toggle_norm",
+                                  description="log",
+                                  tooltip="Log(data)")
 
         self._update_container()
 
@@ -49,16 +66,19 @@ class PlotToolbar:
 
     def _to_widget(self):
         """
+        Return the VBox container
         """
         return self.container
 
     def set_visible(self, visible):
         """
+        Need to hide/show the toolbar when a canvas is hidden/shown.
         """
         self.container.layout.display = None if visible else 'none'
 
     def add_button(self, name, **kwargs):
         """
+        Create a new button and add it to the toolbar members list.
         """
         args = self._parse_button_args(**kwargs)
         self.members[name] = ipw.Button(**args)
@@ -77,6 +97,9 @@ class PlotToolbar:
         self.members[name].on_click(self.toggle_button_color)
 
     def toggle_button_color(self, owner, value=None):
+        """
+        Change the color of the button to make it look like a ToggleButton.
+        """
         if value is None:
             owner.value = not owner.value
         else:
@@ -84,21 +107,24 @@ class PlotToolbar:
         owner.style.button_color = "#bdbdbd" if owner.value else "#eeeeee"
 
     def connect(self, callbacks):
+        """
+        Connect callbacks to button clicks.
+        """
         for key in callbacks:
             if key in self.members:
-                # if hasattr(self.members[key], "on_click"):
                 self.members[key].on_click(callbacks[key])
-                # else:
-                    # self.members[key].observe(callbacks[key], names="value")
 
     def _update_container(self):
-        # for group, item in self.containers.items():
+        """
+        Update the container's children according to the buttons in the
+        members.
+        """
         self.container.children = tuple(self.members.values())
 
     def _parse_button_args(self, layout=None, **kwargs):
-        # layout = {"width": "34px"}
-        # if "layout" in kwargs:
-        #     layout.update(kwargs["layout"])
+        """
+        Parse button arguments and add some default styling options.
+        """
         args = {"layout": {"width": "34px", "padding": "0px 0px 0px 0px"}}
         if layout is not None:
             args["layout"].update(layout)
@@ -108,10 +134,12 @@ class PlotToolbar:
         return args
 
     def update_log_axes_buttons(self, axes_scales):
-        # print("in toolbar clear_log_axes_buttons")
+        """
+        When axes are changed or swapped, update the value and color of the
+        custom togglebuttons without triggering a new update.
+        """
         for xyz, scale in axes_scales.items():
             key = "toggle_{}axis_scale".format(xyz)
             if key in self.members:
-                self.toggle_button_color(self.members[key], value=scale=="log")
-        # if "toggle_yaxis_scale" in self.members:
-        #     self.toggle_button_color(self.members["toggle_yaxis_scale"], value=False)
+                self.toggle_button_color(self.members[key],
+                                         value=scale == "log")

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -46,7 +46,8 @@ class PlotToolbar:
 
     def connect(self, callbacks):
         for key in callbacks:
-            self.members[key].on_click(callbacks[key])
+            if key in self.members:
+                self.members[key].on_click(callbacks[key])
         # if "swap" in self.members:
         #     self.members["swap"].on_click(callbacks["swap_axes"])
 

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -9,11 +9,12 @@ class PlotToolbar:
     """
     Custom toolbar with additional buttons.
     """
-    def __init__(self, fig_toolbar):
+    def __init__(self, fig_toolbar, swap_axes_button=False):
         self.members = {"original": fig_toolbar}
         self.container = ipw.VBox(list(self.members.values()))
         self.add_button("rescale", "arrows-v", "Rescale")
-        self.add_button("swap", "exchange", "Swap axes")
+        if swap_axes_button:
+            self.add_button("swap", "exchange", "Swap axes")
 
     def _ipython_display_(self):
         """
@@ -39,4 +40,5 @@ class PlotToolbar:
 
     def connect(self, callbacks):
         self.members["rescale"].on_click(callbacks["rescale_to_data"])
-        self.members["swap"].on_click(callbacks["swap_axes"])
+        if "swap" in self.members:
+            self.members["swap"].on_click(callbacks["swap_axes"])

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -32,10 +32,10 @@ class PlotToolbar:
         self.add_button(name="rescale_to_data",
                         icon="arrows-v",
                         tooltip="Rescale")
-        if ndim > 1:
-            self.add_button(name="swap_axes",
-                            icon="exchange",
-                            tooltip="Swap axes")
+        if ndim == 2:
+            self.add_button(name="transpose",
+                            icon="retweet",
+                            tooltip="Transpose")
 
         if ndim < 3:
             self.add_togglebutton(name="toggle_xaxis_scale",

--- a/python/src/scipp/plot/view.py
+++ b/python/src/scipp/plot/view.py
@@ -35,6 +35,12 @@ class PlotView:
         """
         return self.figure._to_widget()
 
+    def show(self):
+        """
+        Forward the call to show() to the figure.
+        """
+        self.figure.show()
+
     def savefig(self, *args, **kwargs):
         """
         Forward figure saving to the `figure`.

--- a/python/src/scipp/plot/view.py
+++ b/python/src/scipp/plot/view.py
@@ -97,4 +97,7 @@ class PlotView:
             self.profile_hover_connection = None
 
     def update_log_axes_buttons(self, *args, **kwargs):
+        """
+        Forward log buttons update to the `figure`.
+        """
         self.figure.update_log_axes_buttons(*args, **kwargs)

--- a/python/src/scipp/plot/view.py
+++ b/python/src/scipp/plot/view.py
@@ -95,3 +95,6 @@ class PlotView:
                                            self.profile_hover_connection)
             self.profile_pick_connection = None
             self.profile_hover_connection = None
+
+    def update_log_axes_buttons(self, *args, **kwargs):
+        self.figure.update_log_axes_buttons(*args, **kwargs)

--- a/python/src/scipp/plot/view.py
+++ b/python/src/scipp/plot/view.py
@@ -58,11 +58,17 @@ class PlotView:
         if figure_callbacks is not None:
             self.figure.connect(figure_callbacks)
 
-    def rescale_to_data(self, vmin=None, vmax=None):
+    def rescale_to_data(self, *args, **kwargs):
         """
         Forward rescaling to the `figure`.
         """
-        self.figure.rescale_to_data(vmin=vmin, vmax=vmax)
+        self.figure.rescale_to_data(*args, **kwargs)
+
+    def toggle_norm(self, *args, **kwargs):
+        """
+        Forward norm change to the `figure`.
+        """
+        self.figure.toggle_norm(*args, **kwargs)
 
     def update_axes(self, *args, **kwargs):
         """

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -21,26 +21,28 @@ class PlotWidgets:
                  masks=None,
                  button_options=None):
 
-        # self.rescale_button = ipw.Button(description="Rescale")
-        # if ndim == len(button_options):
-        #     self.rescale_button.layout.display = 'none'
         self.interface = {}
 
         # The container list to hold all widgets
-        # self.container = [self.rescale_button]
         self.container = []
 
-        # Initialise slider and label containers
+        # unit_labels: label to display slider coordinate unit
         self.unit_labels = {}
+        # slider: slider to slice along additional dimensions of the array
         self.slider = {}
+        # index_to_dim: map slider index to coordinate dim
         self.index_to_dim = {}
+        # slider_readout: label to display range currently covered by slider
         self.slider_readout = {}
+        # thickness_slider: slider to control thickness of slice
         self.thickness_slider = {}
+        # dim_buttons: buttons to control which dimension the slider controls
         self.dim_buttons = {}
+        # profile_button: button to show/hide a profile plot along selected dim
         self.profile_button = {}
-        self.showhide = {}
-        self.button_axis_to_dim = {}
+        # continuous_update: checkbox to turn on/off slider continuous update
         self.continuous_update = {}
+        # all_masks_button: button to hide/show all masks in a single click
         self.all_masks_button = None
 
         slider_dims = {}
@@ -50,25 +52,14 @@ class PlotWidgets:
         possible_dims = list(axes.values())
 
         # Now begin loop to construct sliders
-        # for ax, dim in axes.items():
         for index, (ax, dim) in enumerate(slider_dims.items()):
-
-            # # Determine if slider should be disabled or not:
-            # # In the case of 3d projection, disable sliders that are for
-            # # dims < 3, or sliders that contain vectors.
-            # disabled = False
-            # if positions is not None:
-            #     disabled = dim == positions
-            # elif string_ax:
-            #     disabled = True
 
             self.unit_labels[index] = ipw.Label(layout={"width": "60px"})
 
-            # Add a slider to slice along additional dimensions of the array
             self.slider[index] = ipw.IntSlider(step=1,
-                                             continuous_update=True,
-                                             readout=False,
-                                             layout={"width": "200px"})
+                                               continuous_update=True,
+                                               readout=False,
+                                               layout={"width": "200px"})
 
             self.continuous_update[index] = ipw.Checkbox(
                 value=True,
@@ -89,85 +80,36 @@ class PlotWidgets:
 
             self.slider_readout[index] = ipw.Label()
 
-            self.profile_button[index] = ipw.Button(description="Profile",
-                                                  button_style="",
-                                                  layout={"width": "initial"})
-
-            # if ndim == len(button_options):
-            #     self.slider[dim].layout.display = 'none'
-            #     self.slider_readout[dim].layout.display = 'none'
-            #     self.continuous_update[dim].layout.display = 'none'
-            #     self.thickness_slider[dim].layout.display = 'none'
-            #     self.profile_button[dim].layout.display = 'none'
+            self.profile_button[index] = ipw.Button(
+                description="Profile",
+                button_style="",
+                layout={"width": "initial"})
 
             # Add one set of buttons per dimension
             self.dim_buttons[index] = {}
             for dim_ in possible_dims:
-                # dstr = str(dim_)
                 self.dim_buttons[index][dim_] = ipw.Button(
-                description=dim_,
-                # value=dim == dim_,
-                button_style='info' if dim == dim_ else '',
-                # style={"button_width": "initial"}
-                disabled=((dim != dim_) and (dim_ in slider_dims.values())),
-                layout={"width":'initial'})
+                    description=dim_,
+                    button_style='info' if dim == dim_ else '',
+                    disabled=((dim != dim_)
+                              and (dim_ in slider_dims.values())),
+                    layout={"width": 'initial'})
                 # Add observer to buttons
-                # self.dim_buttons[index][dim_].on_msg(self.update_buttons)
                 self.dim_buttons[index][dim_].on_click(self.update_buttons)
                 setattr(self.dim_buttons[index][dim_], "index", index)
 
             self.index_to_dim[index] = dim
             self.index_to_dim[dim] = index
 
-            # if string_ax:
-            #     self.button_axis_to_dim[ax] = dim
-
-            # setattr(self.dim_buttons[index], "index", index)
-            # setattr(self.dim_buttons[index], "old_value", self.dim_buttons[index].value)
-            # setattr(self.slider[index], "dim", dim)
             setattr(self.slider[index], "index", index)
-            # setattr(self.continuous_update[index], "index", index)
-            # setattr(self.thickness_slider[index], "dim", dim)
             setattr(self.thickness_slider[index], "index", index)
             setattr(self.profile_button[index], "index", index)
 
-            # # Hide buttons and labels for 1d variables
-            # if ndim == 1:
-            #     self.buttons[dim].layout.display = 'none'
-            #     self.dim_labels[dim].layout.display = 'none'
-            #     self.thickness_slider[dim].layout.display = 'none'
-            #     self.profile_button[dim].layout.display = 'none'
-            #     self.continuous_update[dim].layout.display = 'none'
-
-            # # Hide buttons if positions are used
-            # if positions is not None:
-            #     self.buttons[dim].layout.display = 'none'
-            # # Hide profile picking for 3D plots for now
-            # if len(button_options) == 3:
-            #     self.profile_button[dim].layout.display = 'none'
-            # if dim == positions:
-            #     self.dim_labels[dim].layout.display = 'none'
-            #     self.slider[dim].layout.display = 'none'
-            #     self.continuous_update[dim].layout.display = 'none'
-            #     self.profile_button[dim].layout.display = 'none'
-            #     self.thickness_slider[dim].layout.display = 'none'
-
-            # Add observer to buttons
-            # self.dim_buttons[index].on_msg(self.update_buttons)
-            # Add the row of slider + buttons
-            # row = [
-            #     self.dim_labels[dim], self.slider[dim],
-            #     self.slider_readout[dim], self.continuous_update[dim],
-            #     self.buttons[dim], self.thickness_slider[dim],
-            #     self.profile_button[dim]
-            # ]
+            # Add the row of sliders + buttons
             row = list(self.dim_buttons[index].values()) + [
-                self.continuous_update[index],
-                self.slider[index],
-                self.slider_readout[index],
-                self.unit_labels[index],
-                self.thickness_slider[index],
-                self.profile_button[index]
+                self.continuous_update[index], self.slider[index],
+                self.slider_readout[index], self.unit_labels[index],
+                self.thickness_slider[index], self.profile_button[index]
             ]
             self.container.append(ipw.HBox(row))
 
@@ -235,20 +177,12 @@ class PlotWidgets:
                     [self.masks_lab, self.all_masks_button, self.masks_box])
             ]
 
-    # def update_buttons(self, owner=None, event=None, dummy=None):
     def update_buttons(self, owner=None):
         """
         Custom update for 2D grid of toggle buttons.
         """
         if owner.button_style == "info":
             return
-        # toggle_slider = False
-        # if not self.slider[owner.dim].disabled:
-        #     toggle_slider = True
-        #     self.slider[owner.dim].disabled = True
-        #     self.thickness_slider[owner.dim].disabled = True
-        #     self.profile_button[owner.dim].disabled = True
-        #     self.continuous_update[owner.dim].disabled = True
         new_ind = owner.index
         new_dim = owner.description
 
@@ -259,113 +193,68 @@ class PlotWidgets:
         for dim in self.dim_buttons[new_ind]:
             if self.dim_buttons[new_ind][dim].button_style == "info":
                 old_dim = self.dim_buttons[new_ind][dim].description
-            # if self.dim_buttons[owner.index][dim].description != owner.description:
             self.dim_buttons[new_ind][dim].button_style = ""
         owner.button_style = "info"
 
-        # self.slider[new_ind].dim = new_dim
-        # self.thickness_slider[new_ind].dim = new_dim
-
         # Update the slider max and value.
         self.update_thickness_slider_range({new_ind: new_dim})
-        # # Before we update the value, we need
-        # # to lock the data update which is linked to the slider.
-        # self.interface["lock_update_data"]()
-        # slider_max = self.interface["get_dim_shape"](new_dim) - 1
-        # if slider_max < self.slider[new_ind].value:
-        #     self.slider[new_ind].value = slider_max // 2
-        #     self.slider[new_ind].max = slider_max
-        # else:
-        #     self.slider[new_ind].max = slider_max
-        #     self.slider[new_ind].value = slider_max // 2
-        # self.interface["unlock_update_data"]()
-        # for dim in self.dim_buttons[owner.index]:
-        #     if self.dim_buttons[owner.index][dim].description != owner.description:
-        #         self.dim_buttons[owner.index][dim].button_style = ""
         for index in set(self.dim_buttons.keys()) - set([new_ind]):
             self.dim_buttons[index][new_dim].disabled = True
             self.dim_buttons[index][old_dim].disabled = False
 
-        # Update the axes
-
-
-        # for index in self.dim_buttons:
-        #     for dim in self.dim_buttons[index]:
-
-        #     if (button.value == owner.value) and (dim != owner.dim):
-        #         if self.slider[dim].disabled:
-        #             button.value = owner.old_value
-        #         else:
-        #             button.value = None
-        #         button.old_value = button.value
-        #         if toggle_slider:
-        #             self.slider[dim].disabled = False
-        #             self.thickness_slider[dim].disabled = False
-        #             self.profile_button[dim].disabled = False
-        #             self.continuous_update[dim].disabled = False
-        # owner.old_value = owner.value
-        self.unit_labels[new_ind].value = self.interface["get_coord_unit"](new_dim)
-
+        self.unit_labels[new_ind].value = self.interface["get_coord_unit"](
+            new_dim)
         self.interface["swap_dimensions"](new_ind, old_dim, new_dim)
-        # self.interface["update_axes"]()
-        return
 
     def get_index_dim(self, index):
+        """
+        Get the dimension corresponding to the supplied index.
+        """
         return self.index_to_dim[index]
 
-
     def update_slider_range(self, index, thickness, nmax, set_value=True):
+        """
+        When the thickness slider value is changed, we need to update the
+        bounds of the slice position slider so that it does no overrun the data
+        range. In short, the min and max of the position slider are
+        0.5*thickness and N - 0.5*thickness, respectively, where N is the size
+        of the slider dimension.
+        Since we are dealing with integers, when the thickness is an even
+        number, the range covered is shifted by 1 towards the right.
+        """
         sl_min = (thickness // 2) + (thickness % 2) - 1
         sl_max = nmax - (thickness // 2)
-        # print(sl_min, sl_mid, sl_max)
-        # print(self.slider[index].min, self.slider[index].value, self.slider[index].max)
         if sl_max < self.slider[index].min:
             self.slider[index].min = sl_min
             self.slider[index].max = sl_max
         else:
             self.slider[index].max = sl_max
             self.slider[index].min = sl_min
-        # self.slider[index].min = sl_min
-        # self.slider[index].max = sl_max
         if set_value:
-            # sl_mid = (sl_min + sl_max) // 2
             self.slider[index].value = (sl_min + sl_max) // 2
 
     def update_thickness(self, change=None):
-        index = change["owner"].index
-        self.update_slider_range(index, change["new"], change["owner"].max - 1,
-            set_value=False)
+        """
+        When the slice thickness is changed, we update the slider range and
+        update the data in the slice.
+        """
+        self.update_slider_range(change["owner"].index,
+                                 change["new"],
+                                 change["owner"].max - 1,
+                                 set_value=False)
         self.interface["update_data"](change)
 
-
     def update_thickness_slider_range(self, inds_and_dims):
-        # Update the slider max and value. Before we update the value, we need
-        # to lock the data update which is linked to the slider.
+        """
+        Update the slider max and values. Before we update the value, we need
+        to lock the data update which is linked to the slider.
+        """
         self.interface["lock_update_data"]()
         for ind, dim in inds_and_dims.items():
             slider_max = self.interface["get_dim_shape"](dim)
             self.thickness_slider[ind].max = slider_max
             self.thickness_slider[ind].value = slider_max
-
-            # sl_min = (slider_max // 2) + (slider_max % 2) - 1
-            # sl_max = 8 - (j // 2)
-
-            # if slider_max < self.slider[ind].value:
-            #     self.slider[ind].value = slider_max // 2
-            #     self.slider[ind].max = slider_max
-            # else:
-            #     self.slider[ind].max = slider_max
-            #     self.slider[ind].value = slider_max // 2
             self.update_slider_range(ind, slider_max, slider_max - 1)
-
-            # # Thickness slider
-            # self.thickness_slider[dim].max = item["thickness_slider"]
-            # self.thickness_slider[dim].value = item["thickness_slider"]
-            # # Only index slicing is allowed when ragged coords are present
-            # if multid_coord is not None:
-            #     self.thickness_slider[dim].value = 0.
-            #     self.thickness_slider[dim].layout.display = 'none'
-            # self.thickness_slider[dim].step = item["thickness_slider"] * 0.01
         self.interface["unlock_update_data"]()
 
     def toggle_all_masks(self, change):
@@ -384,15 +273,12 @@ class PlotWidgets:
         Connect the widget interface to the callbacks provided by the
         `PlotController`.
         """
-        # self.rescale_button.on_click(callbacks["rescale_to_data"])
         for index in self.slider:
-            self.profile_button[index].on_click(callbacks["toggle_profile_view"])
+            self.profile_button[index].on_click(
+                callbacks["toggle_profile_view"])
             self.slider[index].observe(callbacks["update_data"], names="value")
-            # self.thickness_slider[dim].observe(callbacks["update_data"],
-            #                                    names="value")
             self.thickness_slider[index].observe(self.update_thickness,
-                                               names="value")
-        # self.interface["update_axes"] = callbacks["update_axes"]
+                                                 names="value")
         self.interface["update_data"] = callbacks["update_data"]
         self.interface["get_dim_shape"] = callbacks["get_dim_shape"]
         self.interface["lock_update_data"] = callbacks["lock_update_data"]
@@ -405,7 +291,6 @@ class PlotWidgets:
                 self.mask_checkboxes[name][m].observe(callbacks["toggle_mask"],
                                                       names="value")
 
-    # def initialise(self, parameters, multid_coord=None):
     def initialise(self, dim_to_shape, xlims, coord_units):
         """
         Initialise widget parameters once the `PlotModel`, `PlotView` and
@@ -419,49 +304,14 @@ class PlotWidgets:
             self.thickness_slider[index].max = nmax
             self.thickness_slider[index].value = nmax
             self.update_slider_range(index, nmax, nmax - 1)
-
             lims = xlims[dim].values
-            self.update_slider_readout(
-                              index,
-                              lims[0],
-                              lims[1],
-                              [0, nmax - 1])
-
+            self.update_slider_readout(index, lims[0], lims[1], [0, nmax - 1])
             self.unit_labels[index].value = coord_units[dim]
-        # for dim, item in parameters.items():
-        #     # TODO: for now we prevent a ragged coord from being along a slider
-        #     # dimension, as it causes conceptual issues with respect to
-        #     # resampling a displayed image.
-        #     if dim == multid_coord:
-        #         if not self.slider[dim].disabled:
-        #             raise RuntimeError("A ragged coordinate cannot lie along "
-        #                                "a slider dimension, it must be one of "
-        #                                "the displayed dimensions.")
-        #         self.buttons[dim].disabled = True
-        #     # # Dimension labels
-        #     # self.dim_labels[dim].value = item["labels"]
-
-        #     # Dimension slider
-        #     size = item["slider"]
-        #     # Caution: we need to update max first because it is set to 100 by
-        #     # default in ipywidgets, thus preventing a value to be set above
-        #     # 100.
-        #     self.slider[dim].max = size - 1
-        #     self.slider[dim].value = size // 2
-
-        #     # Thickness slider
-        #     self.thickness_slider[dim].max = item["thickness_slider"]
-        #     self.thickness_slider[dim].value = item["thickness_slider"]
-        #     # Only index slicing is allowed when ragged coords are present
-        #     if multid_coord is not None:
-        #         self.thickness_slider[dim].value = 0.
-        #         self.thickness_slider[dim].layout.display = 'none'
-        #     self.thickness_slider[dim].step = item["thickness_slider"] * 0.01
-
-        #     # Slider readouts
-        #     self.update_slider_readout(*item["slider_readout"])
 
     def get_slider_bounds(self, exclude=None):
+        """
+        Get the current range covered by the thick slice (in integers).
+        """
         bounds = {}
         for index, sl in self.slider.items():
             dim = self.index_to_dim[index]
@@ -472,52 +322,6 @@ class PlotWidgets:
                 upper = pos + (delta // 2) + 1
                 bounds[dim] = [lower, upper]
         return bounds
-
-    def get_slider_value(self, key):
-        """
-        Return value of the slider corresponding to the requested dimension.
-        """
-        return self.slider[key].value
-
-    def get_thickness_slider_value(self, key):
-        """
-        Return value of the thickness slider corresponding to the requested
-        dimension.
-        """
-        return self.thickness_slider[key].value
-
-    def get_slider_dims_and_values(self):
-        """
-        Return the values of all sliders that are not disabled.
-        """
-        # slider_values = {}
-        # for index, sl in self.slider.items():
-        #     # if not sl.disabled:
-        #     slider_values[self.index_to_dim[index]] = sl.value
-        # return slider_values
-        return {self.index_to_dim[index]: [index, sl.value] for index, sl in self.slider.items()}
-
-    # def get_non_profile_slider_values(self, profile_dim):
-    #     """
-    #     Return the values of all sliders that do not correspond to the profile
-    #     dimension.
-    #     """
-    #     slider_values = {}
-    #     for dim, sl in self.slider.items():
-    #         if dim != profile_dim:
-    #             slider_values[dim] = sl.value
-    #     return slider_values
-
-    # def get_buttons_and_disabled_sliders(self):
-    #     """
-    #     Get the values and dimensions of the buttons for dimensions that have
-    #     active sliders.
-    #     """
-    #     buttons_and_dims = {}
-    #     for dim, button in self.buttons.items():
-    #         if self.slider[dim].disabled:
-    #             buttons_and_dims[dim] = button.value
-    #     return buttons_and_dims
 
     def clear_profile_buttons(self, exclude=None):
         """
@@ -541,26 +345,12 @@ class PlotWidgets:
             }
         return mask_info
 
-    # def get_slice_bounds(self, key, left, centre, right):
-    #     """
-    #     Get the bounds of the slice for a given dimension, computed from the
-    #     slider position and the thickness of the slice. Return as floats.
-    #     """
-    #     thickness = self.thickness_slider[key].value
-    #     if thickness == 0.0:
-    #         lower = left
-    #         upper = right
-    #     else:
-    #         lower = centre - 0.5 * thickness
-    #         upper = centre + 0.5 * thickness
-    #     return lower, upper
-
     def get_slice_extent(self,
-                                   lower,
-                                   upper,
-                                   indices,
-                                   is_multid=False,
-                                   precision=1):
+                         lower,
+                         upper,
+                         indices,
+                         is_multid=False,
+                         precision=1):
         """
         Get the bounds of the slice for a given dimension as a single string.
         """

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -62,7 +62,7 @@ class PlotWidgets:
             # elif string_ax:
             #     disabled = True
 
-            self.unit_labels[index] = ipw.Label(layout={"width": "40px"})
+            self.unit_labels[index] = ipw.Label(layout={"width": "60px"})
 
             # Add a slider to slice along additional dimensions of the array
             self.slider[index] = ipw.IntSlider(step=1,

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -255,14 +255,21 @@ class PlotWidgets:
         """
         self.interface["lock_update_data"]()
         for ind, dim in inds_and_dims.items():
-            slider_max = self.interface["get_dim_shape"](dim)
-            # If there is a multid coord, we only allow slices of thickness 1
-            self.thickness_slider[
-                ind].max = 1 if self.multid_coord is not None else slider_max
-            self.thickness_slider[ind].value = self.thickness_slider[ind].max
-            self.update_slider_range(ind, self.thickness_slider[ind].value,
-                                     slider_max - 1)
+            self._set_slider_defaults(ind,
+                                      self.interface["get_dim_shape"](dim))
         self.interface["unlock_update_data"]()
+
+    def _set_slider_defaults(self, index, max_value):
+        """
+        On axes change, set the thickness to 1, its max range to the shape of
+        the dim, and set the position slider to accordingly.
+        """
+        self.thickness_slider[
+            index].max = 1 if self.multid_coord is not None else max_value
+        self.thickness_slider[
+            index].value = 1  # self.thickness_slider[ind].max
+        self.update_slider_range(index, self.thickness_slider[index].value,
+                                 max_value - 1)
 
     def toggle_all_masks(self, change):
         """
@@ -307,14 +314,7 @@ class PlotWidgets:
         """
         for index in self.thickness_slider:
             dim = self.index_to_dim[index]
-            nmax = dim_to_shape[dim]
-            # If there is a multid coord, we only allow slices of thickness 1
-            self.thickness_slider[
-                index].max = 1 if self.multid_coord is not None else nmax
-            self.thickness_slider[index].value = self.thickness_slider[
-                index].max
-            self.update_slider_range(index, self.thickness_slider[index].value,
-                                     nmax - 1)
+            self._set_slider_defaults(index, dim_to_shape[dim])
             lims = xlims[dim].values
             self.update_slider_readout(
                 index, lims[0], lims[1],

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -124,12 +124,12 @@ class PlotWidgets:
 
             # setattr(self.dim_buttons[index], "index", index)
             # setattr(self.dim_buttons[index], "old_value", self.dim_buttons[index].value)
-            setattr(self.slider[index], "dim", dim)
+            # setattr(self.slider[index], "dim", dim)
             setattr(self.slider[index], "index", index)
             # setattr(self.continuous_update[index], "index", index)
-            setattr(self.thickness_slider[index], "dim", dim)
+            # setattr(self.thickness_slider[index], "dim", dim)
             setattr(self.thickness_slider[index], "index", index)
-            # setattr(self.profile_button[index], "index", index)
+            setattr(self.profile_button[index], "index", index)
 
             # # Hide buttons and labels for 1d variables
             # if ndim == 1:
@@ -263,8 +263,8 @@ class PlotWidgets:
             self.dim_buttons[new_ind][dim].button_style = ""
         owner.button_style = "info"
 
-        self.slider[new_ind].dim = new_dim
-        self.thickness_slider[new_ind].dim = new_dim
+        # self.slider[new_ind].dim = new_dim
+        # self.thickness_slider[new_ind].dim = new_dim
 
         # Update the slider max and value.
         self.update_thickness_slider_range({new_ind: new_dim})
@@ -309,6 +309,10 @@ class PlotWidgets:
         self.interface["swap_dimensions"](new_ind, old_dim, new_dim)
         # self.interface["update_axes"]()
         return
+
+    def get_index_dim(self, index):
+        return self.index_to_dim[index]
+
 
     def update_slider_range(self, index, thickness, nmax, set_value=True):
         sl_min = (thickness // 2) + (thickness % 2) - 1
@@ -457,14 +461,16 @@ class PlotWidgets:
         #     # Slider readouts
         #     self.update_slider_readout(*item["slider_readout"])
 
-    def get_slider_bounds(self):
+    def get_slider_bounds(self, exclude=None):
         bounds = {}
         for index, sl in self.slider.items():
-            pos = sl.value
-            delta = self.thickness_slider[index].value
-            lower = pos - (delta // 2) + ((delta + 1) % 2)
-            upper = pos + (delta // 2) + 1
-            bounds[self.index_to_dim[index]] = [lower, upper]
+            dim = self.index_to_dim[index]
+            if dim != exclude:
+                pos = sl.value
+                delta = self.thickness_slider[index].value
+                lower = pos - (delta // 2) + ((delta + 1) % 2)
+                upper = pos + (delta // 2) + 1
+                bounds[dim] = [lower, upper]
         return bounds
 
     def get_slider_value(self, key):
@@ -491,35 +497,35 @@ class PlotWidgets:
         # return slider_values
         return {self.index_to_dim[index]: [index, sl.value] for index, sl in self.slider.items()}
 
-    def get_non_profile_slider_values(self, profile_dim):
-        """
-        Return the values of all sliders that do not correspond to the profile
-        dimension.
-        """
-        slider_values = {}
-        for dim, sl in self.slider.items():
-            if dim != profile_dim:
-                slider_values[dim] = sl.value
-        return slider_values
+    # def get_non_profile_slider_values(self, profile_dim):
+    #     """
+    #     Return the values of all sliders that do not correspond to the profile
+    #     dimension.
+    #     """
+    #     slider_values = {}
+    #     for dim, sl in self.slider.items():
+    #         if dim != profile_dim:
+    #             slider_values[dim] = sl.value
+    #     return slider_values
 
-    def get_buttons_and_disabled_sliders(self):
-        """
-        Get the values and dimensions of the buttons for dimensions that have
-        active sliders.
-        """
-        buttons_and_dims = {}
-        for dim, button in self.buttons.items():
-            if self.slider[dim].disabled:
-                buttons_and_dims[dim] = button.value
-        return buttons_and_dims
+    # def get_buttons_and_disabled_sliders(self):
+    #     """
+    #     Get the values and dimensions of the buttons for dimensions that have
+    #     active sliders.
+    #     """
+    #     buttons_and_dims = {}
+    #     for dim, button in self.buttons.items():
+    #         if self.slider[dim].disabled:
+    #             buttons_and_dims[dim] = button.value
+    #     return buttons_and_dims
 
-    def clear_profile_buttons(self, profile_dim=None):
+    def clear_profile_buttons(self, exclude=None):
         """
         Reset all profile buttons, when for example a new dimension is
         displayed along one of the figure axes.
         """
-        for dim, but in self.profile_button.items():
-            if dim != profile_dim:
+        for index, but in self.profile_button.items():
+            if index != exclude:
                 but.button_style = ""
 
     def get_masks_info(self):
@@ -549,20 +555,20 @@ class PlotWidgets:
     #         upper = centre + 0.5 * thickness
     #     return lower, upper
 
-    def get_slice_bounds(self,
-                                   key,
+    def get_slice_extent(self,
                                    lower,
                                    upper,
                                    indices,
-                                   is_multid=False):
+                                   is_multid=False,
+                                   precision=1):
         """
         Get the bounds of the slice for a given dimension as a single string.
         """
         if is_multid:
             return "i{}:i{}".format(indices[0], indices[1])
         else:
-            return "{}:{}".format(value_to_string(lower),
-                                  value_to_string(upper))
+            return "{}:{}".format(value_to_string(lower, precision=precision),
+                                  value_to_string(upper, precision=precision))
 
     def update_slider_readout(self,
                               key,
@@ -573,5 +579,5 @@ class PlotWidgets:
         """
         Update the slider readout with new slider bounds.
         """
-        self.slider_readout[key].value = self.get_slice_bounds(
-            key, lower, upper, indices, is_multid)
+        self.slider_readout[key].value = self.get_slice_extent(
+            lower, upper, indices, is_multid)

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -312,16 +312,15 @@ class PlotWidgets:
         sl_min = (thickness // 2) + (thickness % 2) - 1
         sl_max = nmax - (thickness // 2)
         # print(sl_min, sl_mid, sl_max)
-        print(self.slider[index].min, self.slider[index].value, self.slider[index].max)
-        # if sl_max < self.slider[index].min:
-        #     if sl_max <
-        #     self.slider[index].value = sl_mid
-        #     self.slider[index].max = sl_max
-        # else:
-        #     self.slider[index].max = sl_max
-        #     self.slider[index].value = sl_mid
-        self.slider[index].min = sl_min
-        self.slider[index].max = sl_max
+        # print(self.slider[index].min, self.slider[index].value, self.slider[index].max)
+        if sl_max < self.slider[index].min:
+            self.slider[index].min = sl_min
+            self.slider[index].max = sl_max
+        else:
+            self.slider[index].max = sl_max
+            self.slider[index].min = sl_min
+        # self.slider[index].min = sl_min
+        # self.slider[index].max = sl_max
         if set_value:
             # sl_mid = (sl_min + sl_max) // 2
             self.slider[index].value = (sl_min + sl_max) // 2

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -101,9 +101,9 @@ class PlotWidgets:
             # Add one set of buttons per dimension
             self.dim_buttons[index] = {}
             for dim_ in possible_dims:
-                dstr = str(dim_)
-                self.dim_buttons[index][dstr] = ipw.Button(
-                description=dstr,
+                # dstr = str(dim_)
+                self.dim_buttons[index][dim_] = ipw.Button(
+                description=dim_,
                 # value=dim == dim_,
                 button_style='info' if dim == dim_ else '',
                 # style={"button_width": "initial"}
@@ -111,8 +111,8 @@ class PlotWidgets:
                 layout={"width":'initial'})
                 # Add observer to buttons
                 # self.dim_buttons[index][dim_].on_msg(self.update_buttons)
-                self.dim_buttons[index][dstr].on_click(self.update_buttons)
-                setattr(self.dim_buttons[index][dstr], "index", index)
+                self.dim_buttons[index][dim_].on_click(self.update_buttons)
+                setattr(self.dim_buttons[index][dim_], "index", index)
 
             self.slider_dims[index] = dim
 

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -125,6 +125,7 @@ class PlotWidgets:
             setattr(self.slider[index], "dim", dim)
             setattr(self.slider[index], "index", index)
             # setattr(self.continuous_update[index], "index", index)
+            setattr(self.thickness_slider[index], "dim", dim)
             setattr(self.thickness_slider[index], "index", index)
             # setattr(self.profile_button[index], "index", index)
 
@@ -261,6 +262,7 @@ class PlotWidgets:
         owner.button_style = "info"
 
         self.slider[new_ind].dim = new_dim
+        self.thickness_slider[new_ind].dim = new_dim
 
         # Update the slider max and value.
         self.update_thickness_slider_range({new_ind: new_dim})
@@ -300,6 +302,7 @@ class PlotWidgets:
         #             self.profile_button[dim].disabled = False
         #             self.continuous_update[dim].disabled = False
         # owner.old_value = owner.value
+        self.unit_labels[new_ind].value = self.interface["get_coord_unit"](new_dim)
 
         self.interface["swap_axes"](new_ind, old_dim, new_dim)
         self.interface["update_axes"]()
@@ -327,7 +330,7 @@ class PlotWidgets:
         index = change["owner"].index
         self.update_slider_range(index, change["new"], change["owner"].max - 1,
             set_value=False)
-        self.interface["update_data"]()
+        self.interface["update_data"](change)
 
 
     def update_thickness_slider_range(self, inds_and_dims):
@@ -390,6 +393,7 @@ class PlotWidgets:
         self.interface["lock_update_data"] = callbacks["lock_update_data"]
         self.interface["unlock_update_data"] = callbacks["unlock_update_data"]
         self.interface["swap_axes"] = callbacks["swap_axes"]
+        self.interface["get_coord_unit"] = callbacks["get_coord_unit"]
 
         for name in self.mask_checkboxes:
             for m in self.mask_checkboxes[name]:
@@ -397,7 +401,7 @@ class PlotWidgets:
                                                       names="value")
 
     # def initialise(self, parameters, multid_coord=None):
-    def initialise(self, dim_to_shape):
+    def initialise(self, dim_to_shape, xlims, coord_units):
         """
         Initialise widget parameters once the `model`, `view` and `controller`
         have been created, since, for instance, slider limits depend on the
@@ -405,10 +409,20 @@ class PlotWidgets:
         created.
         """
         for index in self.thickness_slider:
-            nmax = dim_to_shape[self.index_to_dim[index]]
+            dim = self.index_to_dim[index]
+            nmax = dim_to_shape[dim]
             self.thickness_slider[index].max = nmax
             self.thickness_slider[index].value = nmax
             self.update_slider_range(index, nmax, nmax - 1)
+
+            lims = xlims[dim].values
+            self.update_slider_readout(
+                              index,
+                              lims[0],
+                              lims[1],
+                              [0, nmax - 1])
+
+            self.unit_labels[index].value = coord_units[dim]
         # for dim, item in parameters.items():
         #     # TODO: for now we prevent a ragged coord from being along a slider
         #     # dimension, as it causes conceptual issues with respect to

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -84,7 +84,8 @@ class PlotWidgets:
                 description="Thickness",
                 continuous_update=False,
                 readout=False,
-                layout={'width': "180px"})
+                layout={'width': "180px"},
+                style={'description_width': 'initial'})
 
             self.slider_readout[index] = ipw.Label()
 
@@ -161,10 +162,10 @@ class PlotWidgets:
             #     self.profile_button[dim]
             # ]
             row = list(self.dim_buttons[index].values()) + [
+                self.continuous_update[index],
                 self.slider[index],
                 self.slider_readout[index],
                 self.unit_labels[index],
-                self.continuous_update[index],
                 self.thickness_slider[index],
                 self.profile_button[index]
             ]
@@ -305,8 +306,8 @@ class PlotWidgets:
         # owner.old_value = owner.value
         self.unit_labels[new_ind].value = self.interface["get_coord_unit"](new_dim)
 
-        self.interface["swap_axes"](new_ind, old_dim, new_dim)
-        self.interface["update_axes"]()
+        self.interface["swap_dimensions"](new_ind, old_dim, new_dim)
+        # self.interface["update_axes"]()
         return
 
     def update_slider_range(self, index, thickness, nmax, set_value=True):
@@ -387,12 +388,12 @@ class PlotWidgets:
             #                                    names="value")
             self.thickness_slider[index].observe(self.update_thickness,
                                                names="value")
-        self.interface["update_axes"] = callbacks["update_axes"]
+        # self.interface["update_axes"] = callbacks["update_axes"]
         self.interface["update_data"] = callbacks["update_data"]
         self.interface["get_dim_shape"] = callbacks["get_dim_shape"]
         self.interface["lock_update_data"] = callbacks["lock_update_data"]
         self.interface["unlock_update_data"] = callbacks["unlock_update_data"]
-        self.interface["swap_axes"] = callbacks["swap_axes"]
+        self.interface["swap_dimensions"] = callbacks["swap_dimensions"]
         self.interface["get_coord_unit"] = callbacks["get_coord_unit"]
 
         for name in self.mask_checkboxes:

--- a/python/src/scipp/plot/widgets.py
+++ b/python/src/scipp/plot/widgets.py
@@ -254,13 +254,18 @@ class PlotWidgets:
             # if self.dim_buttons[owner.index][dim].description != owner.description:
             self.dim_buttons[new_ind][dim].button_style = ""
         owner.button_style = "info"
-        slider_max = self.interface["get_dim_shape"](new_dim)
+
+        # Update the slider max and value. Before we update the value, we need
+        # to lock the data update which is linked to the slider.
+        self.interface["lock_update_data"]()
+        slider_max = self.interface["get_dim_shape"](new_dim) - 1
         if slider_max < self.slider[new_ind].value:
             self.slider[new_ind].value = slider_max // 2
-            self.slider[new_ind].max = slider_max - 1
+            self.slider[new_ind].max = slider_max
         else:
-            self.slider[new_ind].max = slider_max - 1
+            self.slider[new_ind].max = slider_max
             self.slider[new_ind].value = slider_max // 2
+        self.interface["unlock_update_data"]()
         # for dim in self.dim_buttons[owner.index]:
         #     if self.dim_buttons[owner.index][dim].description != owner.description:
         #         self.dim_buttons[owner.index][dim].button_style = ""
@@ -312,6 +317,8 @@ class PlotWidgets:
                                                names="value")
         self.interface["update_axes"] = callbacks["update_axes"]
         self.interface["get_dim_shape"] = callbacks["get_dim_shape"]
+        self.interface["lock_update_data"] = callbacks["lock_update_data"]
+        self.interface["unlock_update_data"] = callbacks["unlock_update_data"]
 
         for name in self.mask_checkboxes:
             for m in self.mask_checkboxes[name]:

--- a/python/tests/plot/test_plot_3d.py
+++ b/python/tests/plot/test_plot_3d.py
@@ -49,6 +49,29 @@ def test_plot_projection_3d_with_vectors():
     plot(d, projection="3d", positions="xyz")
 
 
+def test_plot_projection_3d_with_vectors_non_dim_coord():
+    N = 1000
+    M = 100
+    theta = np.random.random(N) * np.pi
+    phi = np.random.random(N) * 2.0 * np.pi
+    r = 10.0 + (np.random.random(N) - 0.5)
+    x = r * np.sin(theta) * np.sin(phi)
+    y = r * np.sin(theta) * np.cos(phi)
+    z = r * np.cos(theta)
+    tof = np.arange(M).astype(np.float)
+    a = np.arange(M * N).reshape([M, N]) * np.sin(y)
+    d = sc.Dataset()
+    d.coords['xyz'] = sc.Variable(['xyz'],
+                                  values=np.array([x, y, z]).T,
+                                  dtype=sc.dtype.vector_3_float64)
+    d.coords['pos'] = sc.Variable(['xyz'],
+                                  values=np.array([x, y, z]).T + 20.0,
+                                  dtype=sc.dtype.vector_3_float64)
+    d.coords['tof'] = sc.Variable(['tof'], values=tof)
+    d['a'] = sc.Variable(['tof', 'xyz'], values=a)
+    plot(d, projection="3d", positions="pos")
+
+
 def test_plot_variable_3d():
     N = 50
     v3d = sc.Variable(['tof', 'x', 'y'],

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -35,7 +35,7 @@ def test_create():
     assert sc.is_equal(d.coords['y'], y)
     assert sc.is_equal(d['xy'].data, xy)
     assert sc.is_equal(d['x'].data, x)
-    assert bool(set(d.dims) - set(['y', 'x']))
+    assert set(d.dims) == set(['y', 'x'])
 
 
 def test_create_from_data_array():


### PR DESCRIPTION
In this PR, the interactive plot interface has been tidied up and improved.

The key changes are:
- Only display slider for additional dimensions instead of for every dimension.
- The dimension that is controlled by a slider is now changed via toggle buttons on each row
- To flip the current figure axes on a 2d or 3d plot, we now have a "Swap axes" button in the toolbar.
- There are now buttons to control the log scales of the axes and the colorbar in the toolbar.
- The slice thickness controlled by the thickness slider is no longer an arbitrary float but an integer number of bins
- I've started to change the interface with core `Dim` so that when accessing Variable an DataArray dims, strings are returned instead of `Dim` objects. This made many things easier when storing dimensions in python dicts, for instance.

**Reviewer**:
When playing around with it, look for:
- if an axis is displayed as log, when we swap the axes with the Swap axes button, the log should follow the dim (meaning it should also flip, and the log buttons in the toolbar should also update)
- A profile plot should also be able to have log axes.

On the question of replacing `Dim` with strings in the python interface, I haven't changed the objects returned by the `.keys()` methods. I suggest this could be done as a follow-up. I only needed the minimum changes here (what the `.dims` method returns).

Fixes #1360
Fixes #625 
Fixes #1362 
