### PR TITLE
Fix plots in docs

### DIFF
--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -28,8 +28,8 @@ if ipy is not None:
     meta = cfg["Session"]["metadata"]
     if hasattr(meta, "to_dict"):
         meta = meta.to_dict()
-        if "scipp_docs_build" in meta:
-            is_doc_build = meta["scipp_docs_build"]
+    if "scipp_docs_build" in meta:
+        is_doc_build = meta["scipp_docs_build"]
     # If we are in an IPython kernel, try to select widget backend
     if ("IPKernelApp" in ipy.config) and (not is_doc_build) and (mpl
                                                                  is not None):


### PR DESCRIPTION
When running notebooks in Sphinx, the `cfg["Session"]["metadata"]` is already a dict and so the dict did not have a `to_dict` method and `is_docs_build` was never being set to `True`.
So interactive matplotlib plots were created in the notebooks, and they do not show up in the final html pages of the documentation.
With this change, static plots now show up again in the docs.