### PR TITLE
Extend colorbar ends

### DIFF
--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -24,10 +24,9 @@ class PlotFigure2d(PlotFigure):
                  title=None,
                  cbar=None,
                  unit=None,
-                 vmin=None,
-                 vmax=None,
                  masks=None,
-                 resolution=None):
+                 resolution=None,
+                 extend=None):
 
         super().__init__(ax=ax, cax=cax, figsize=figsize, title=title, ndim=2)
 
@@ -41,7 +40,10 @@ class PlotFigure2d(PlotFigure):
 
         self.cbar = None
         if cbar:
-            self.cbar = plt.colorbar(self.image, ax=self.ax, cax=self.cax)
+            self.cbar = plt.colorbar(self.image,
+                                     ax=self.ax,
+                                     cax=self.cax,
+                                     extend=extend)
             self.cbar.set_label(unit)
         if self.cax is None:
             self.cbar.ax.yaxis.set_label_coords(-1.1, 0.5)

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -27,14 +27,13 @@ class PlotFigure3d:
                  figsize=None,
                  unit=None,
                  log=None,
-                 vmin=None,
-                 vmax=None,
                  nan_color=None,
                  masks=None,
                  pixel_size=None,
                  tick_size=None,
                  background=None,
-                 show_outline=True):
+                 show_outline=True,
+                 extend=None):
 
         if figsize is None:
             figsize = (config.plot.width, config.plot.height)
@@ -43,12 +42,12 @@ class PlotFigure3d:
         self.toolbar = PlotToolbar(ndim=3)
 
         # Prepare colormaps
-        self.cmap = copy(cm.get_cmap(cmap))
+        self.cmap = cmap
         self.cmap.set_bad(color=nan_color)
         self.scalar_map = cm.ScalarMappable(norm=norm, cmap=self.cmap)
         self.masks_scalar_map = None
         if len(masks) > 0:
-            self.masks_cmap = copy(cm.get_cmap(masks["cmap"]))
+            self.masks_cmap = masks["cmap"]
             self.masks_cmap.set_bad(color=nan_color)
             self.masks_scalar_map = cm.ScalarMappable(norm=norm,
                                                       cmap=self.masks_cmap)
@@ -62,7 +61,7 @@ class PlotFigure3d:
 
         # Create the colorbar image
         self.cbar_image = ipw.Image()
-        self.cbar_fig, self.cbar = self._create_colorbar(figsize)
+        self.cbar_fig, self.cbar = self._create_colorbar(figsize, extend)
 
         # Create the point cloud material with pythreejs
         self.points_material = self._create_points_material()
@@ -290,24 +289,23 @@ void main() {
 
         return ticks_and_labels
 
-    def _create_colorbar(self, figsize):
+    def _create_colorbar(self, figsize, extend):
         """
         Make image from matplotlib colorbar.
         We need to make a dummy imshow so we can later update the limits with
         set_clim, as this method is not available on a ColorbarBase class.
         """
-        a = np.array([[0, 1]])
         height_inches = figsize[1] / config.plot.dpi
 
         cbar_fig, ax = plt.subplots(figsize=(height_inches * 0.2,
                                              height_inches),
                                     dpi=config.plot.dpi)
-        cbar_imshow = ax.imshow(a,
+        cbar_imshow = ax.imshow(np.array([[0, 1]]),
                                 cmap=self.scalar_map.get_cmap(),
                                 norm=self.scalar_map.norm)
         ax.set_visible(False)
         cbar_ax = cbar_fig.add_axes([0.05, 0.02, 0.25, 0.94])
-        cbar = plt.colorbar(cbar_imshow, cax=cbar_ax)
+        cbar = plt.colorbar(cbar_imshow, cax=cbar_ax, extend=extend)
         cbar.set_label(self.unit)
         cbar.ax.yaxis.set_label_coords(-0.9, 0.5)
         return cbar_fig, cbar_imshow

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -84,7 +84,8 @@ class SciPlot2d(SciPlot):
                                title=self.name,
                                cbar=self.params["values"][self.name]["cbar"],
                                unit=self.params["values"][self.name]["unit"],
-                               masks=self.masks[self.name])
+                               masks=self.masks[self.name],
+                               extend=self.extend_cmap)
 
         # Profile view which displays an additional dimension as a 1d plot
         if self.ndim > 2:

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -47,7 +47,6 @@ class SciPlot3d(SciPlot):
                  color=None,
                  aspect=None,
                  background="#f0f0f0",
-                 nan_color="#d3d3d3",
                  pixel_size=1.0,
                  tick_size=None,
                  show_outline=True):
@@ -83,16 +82,18 @@ class SciPlot3d(SciPlot):
 
         # The view which will display the 3d scene and send pick events back to
         # the controller
-        self.view = PlotView3d(cmap=self.params["values"][self.name]["cmap"],
-                               norm=self.params["values"][self.name]["norm"],
-                               unit=self.params["values"][self.name]["unit"],
-                               masks=self.masks[self.name],
-                               nan_color=nan_color,
-                               pixel_size=pixel_size,
-                               tick_size=tick_size,
-                               background=background,
-                               show_outline=show_outline,
-                               figsize=figsize)
+        self.view = PlotView3d(
+            cmap=self.params["values"][self.name]["cmap"],
+            norm=self.params["values"][self.name]["norm"],
+            unit=self.params["values"][self.name]["unit"],
+            masks=self.masks[self.name],
+            nan_color=self.params["values"][self.name]["nan_color"],
+            pixel_size=pixel_size,
+            tick_size=tick_size,
+            background=background,
+            show_outline=show_outline,
+            figsize=figsize,
+            extend=self.extend_cmap)
 
         # An additional panel view with widgets to control the cut surface
         self.panel = PlotPanel3d(pixel_size=pixel_size)

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -65,6 +65,17 @@ class SciPlot:
                                       view_ndims=view_ndims,
                                       positions=positions)
 
+        # Set cmap extend state: if we have sliders, then we need to extend.
+        # We also need to extend if vmin or vmax are set.
+        self.extend_cmap = "neither"
+        if (self.ndim > view_ndims) or ((vmin is not None) and
+                                        (vmax is not None)):
+            self.extend_cmap = "both"
+        elif (vmin is not None):
+            self.extend_cmap = "min"
+        elif (vmax is not None):
+            self.extend_cmap = "max"
+
         # Scan the input data and collect information
         self.params = {"values": {}, "masks": {}}
         globs = {

--- a/python/src/scipp/plot/tools.py
+++ b/python/src/scipp/plot/tools.py
@@ -5,7 +5,9 @@
 from .. import config
 from .._utils import name_with_unit
 from .._scipp import core as sc
+from matplotlib import cm
 import numpy as np
+from copy import copy
 
 
 def get_line_param(name=None, index=None):
@@ -81,6 +83,11 @@ def parse_params(params=None,
     if parsed["color"] is not None:
         parsed["cmap"] = LinearSegmentedColormap.from_list(
             "tmp", [parsed["color"], parsed["color"]])
+    else:
+        parsed["cmap"] = copy(cm.get_cmap(parsed["cmap"]))
+
+    parsed["cmap"].set_under(parsed["under_color"])
+    parsed["cmap"].set_over(parsed["over_color"])
 
     if variable is not None:
         parsed["unit"] = name_with_unit(var=variable, name="")

--- a/python/src/scipp/runtime_config.py
+++ b/python/src/scipp/runtime_config.py
@@ -32,6 +32,9 @@ defaults = {
             "color": None,
             "show": True,
             "cbar": True,
+            "nan_color": "#d3d3d3",
+            "under_color": "#9467bd",
+            "over_color": "#8c564b",
         },
         # The default image height (in pixels)
         "height":


### PR DESCRIPTION
Extend the colorbar limits when we have sliders or when vmin or vmax are set:
![Screenshot at 2020-11-05 21-14-49](https://user-images.githubusercontent.com/39047984/98291811-04c83e00-1fac-11eb-8b9b-6aecf91ff2eb.png)

**Reviewer:**
Right now, the colors for the lower and upper limits are set in the config (i tried to find a good compromise that would work for most matplotlib cmaps).
We could do something programatically. I tried setting them as the inverted color of the first and last color in the cmap, but this somehow did not work as well as the brown and purple colors I have here.
Thoughts?

Fixes #1328 