### PR TITLE
Add space before size display

### DIFF
--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -462,7 +462,7 @@ def dataset_repr(ds):
     obj_type = "scipp.{}".format(type(ds).__name__)
     header_components = [
         f"<div class='xr-obj-type'>{escape(obj_type)}"
-        f"({human_readable_size(sys.getsizeof(ds))})</div>"
+        f" ({human_readable_size(sys.getsizeof(ds))})</div>"
     ]
 
     sections = [dim_section(ds)]
@@ -489,7 +489,7 @@ def variable_repr(var):
 
     header_components = [
         f"<div class='xr-obj-type'>{escape(obj_type)}"
-        f"({human_readable_size(sys.getsizeof(var))})</div>"
+        f" ({human_readable_size(sys.getsizeof(var))})</div>"
     ]
 
     sections = [variable_section(var)]

--- a/python/tests/table_html/common.py
+++ b/python/tests/table_html/common.py
@@ -76,7 +76,7 @@ def assert_data_repr_icon_present(tags: List[bs4.element.Tag]):
 
 def assert_common(html, in_dtype, size_of):
     size_suffix = human_readable_size(size_of)
-    assert_obj_type(VARIABLE_OBJECT_TYPE + f'({size_suffix})',
+    assert_obj_type(VARIABLE_OBJECT_TYPE + f' ({size_suffix})',
                     html.find_all(class_=OBJ_TYPE_CSS_CLASS))
     assert_dtype(in_dtype, html.find_all(class_=DTYPE_CSS_CLASS))
     assert_data_repr_icon_present(html.find_all(class_=DATA_ICON_CSS_CLASS))


### PR DESCRIPTION
Adds a space between the variable type and its size.