### PR TITLE
Binned ops improvements

### DIFF
--- a/core/include/scipp/core/bucket.h
+++ b/core/include/scipp/core/bucket.h
@@ -8,10 +8,14 @@
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 
+namespace scipp {
+using index_pair = std::pair<scipp::index, scipp::index>;
+}
+
 namespace scipp::core {
 
 struct bucket_base {
-  using range_type = std::pair<scipp::index, scipp::index>;
+  using range_type = index_pair;
 };
 template <class T> struct bucket : bucket_base {
   using buffer_type = T;

--- a/core/include/scipp/core/element/event_operations.h
+++ b/core/include/scipp/core/element/event_operations.h
@@ -149,4 +149,38 @@ constexpr auto scale = overloaded{
       }
     }};
 
+constexpr auto get = [](const auto &x, const scipp::index i) {
+  if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+    return ValueAndVariance{x.value[i], x.variance[i]};
+  else
+    return x[i];
+};
+
+namespace scale_sorted_edges_detail {
+template <class Data, class Coord, class Edge, class Weight>
+using args = std::tuple<Data, Coord, span<const Edge>, span<const Weight>>;
+} // namespace scale_sorted_edges_detail
+
+constexpr auto scale_sorted_edges = overloaded{
+    element::arg_list<
+        scale_sorted_edges_detail::args<double, double, double, double>,
+        scale_sorted_edges_detail::args<float, double, double, double>,
+        scale_sorted_edges_detail::args<float, double, double, float>,
+        scale_sorted_edges_detail::args<double, float, float, double>>,
+    transform_flags::expect_in_variance_if_out_variance,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<2>,
+    [](units::Unit &data, const units::Unit &x, const units::Unit &edges,
+       const units::Unit &weights) {
+      expect::equals(x, edges);
+      data *= weights;
+    },
+    [](auto &data, const auto coord, const auto &edges, const auto &weights) {
+      auto it = std::upper_bound(edges.begin(), edges.end(), coord);
+      if (it == edges.end() || it == edges.begin())
+        data *= 0.0;
+      else
+        data *= get(weights, --it - edges.begin());
+    }};
+
 } // namespace scipp::core::element::event

--- a/core/include/scipp/core/element/event_operations.h
+++ b/core/include/scipp/core/element/event_operations.h
@@ -86,4 +86,67 @@ constexpr auto map_in_place = overloaded{
       }
     }};
 
+namespace scale_detail {
+template <class Data, class Coord, class Edge, class Weight>
+using args = std::tuple<span<Data>, span<const Coord>, span<const Edge>,
+                        span<const Weight>>;
+} // namespace scale_detail
+
+constexpr auto scale = overloaded{
+    element::arg_list<scale_detail::args<double, double, double, double>,
+                      scale_detail::args<float, double, double, double>,
+                      scale_detail::args<float, double, double, float>,
+                      scale_detail::args<double, float, float, double>>,
+    transform_flags::expect_in_variance_if_out_variance,
+    transform_flags::expect_no_variance_arg<1>,
+    transform_flags::expect_no_variance_arg<2>,
+    [](units::Unit &data, const units::Unit &x, const units::Unit &edges,
+       const units::Unit &weights) {
+      expect::equals(x, edges);
+      data *= weights;
+    },
+    [](const auto &data, const auto &coord, const auto &edges,
+       const auto &weights) {
+      using W = std::decay_t<decltype(weights)>;
+      constexpr bool vars = is_ValueAndVariance_v<W>;
+      constexpr auto get = [](const auto &x, const scipp::index i) {
+        if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+          return ValueAndVariance{x.value[i], x.variance[i]};
+        else
+          return x[i];
+      };
+      using w_type = decltype(get(weights, 0));
+      constexpr w_type out_of_bounds(0.0);
+      if (scipp::numeric::is_linspace(edges)) {
+        const auto [offset, nbin, factor] = linear_edge_params(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          const auto bin = (coord[i] - offset) * factor;
+          w_type w =
+              bin < 0.0 || bin >= nbin ? out_of_bounds : get(weights, bin);
+          if constexpr (vars) {
+            const auto tmp = get(data, i) * w;
+            data.value[i] = tmp.value;
+            data.variance[i] = tmp.variance;
+          } else {
+            data[i] *= w;
+          }
+        }
+      } else {
+        expect::histogram::sorted_edges(edges);
+        for (scipp::index i = 0; i < scipp::size(coord); ++i) {
+          auto it = std::upper_bound(edges.begin(), edges.end(), coord[i]);
+          w_type w = (it == edges.end() || it == edges.begin())
+                         ? out_of_bounds
+                         : get(weights, --it - edges.begin());
+          if constexpr (vars) {
+            const auto tmp = get(data, i) * w;
+            data.value[i] = tmp.value;
+            data.variance[i] = tmp.variance;
+          } else {
+            data[i] *= w;
+          }
+        }
+      }
+    }};
+
 } // namespace scipp::core::element::event

--- a/core/include/scipp/core/element/event_operations.h
+++ b/core/include/scipp/core/element/event_operations.h
@@ -57,14 +57,13 @@ constexpr auto map_linspace = overloaded{
       return (bin < 0.0 || bin >= nbin) ? 0.0 : get(weights, bin);
     }};
 
-constexpr auto map_sorted_edges =
-    overloaded{map,
-               [](const auto &coord, const auto &edges, const auto &weights) {
-                 auto it = std::upper_bound(edges.begin(), edges.end(), coord);
-                 return (it == edges.end() || it == edges.begin())
-                            ? 0.0
-                            : get(weights, --it - edges.begin());
-               }};
+constexpr auto map_sorted_edges = overloaded{
+    map, [](const auto &coord, const auto &edges, const auto &weights) {
+      auto it = std::upper_bound(edges.begin(), edges.end(), coord);
+      return (it == edges.end() || it == edges.begin())
+                 ? 0.0
+                 : get(weights, --it - edges.begin());
+    }};
 
 namespace map_and_mul_detail {
 template <class Data, class Coord, class Edge, class Weight>

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/common/span.h"
 #include "scipp/core/element/arg_list.h"
@@ -82,6 +83,12 @@ constexpr auto is_sorted_nonascending = overloaded{
     is_sorted_common, [](bool &out, const auto &left, const auto &right) {
       out = out && (left >= right);
     }};
+
+constexpr auto is_linspace =
+    overloaded{arg_list<span<const double>, span<const float>>,
+               transform_flags::expect_no_variance_arg<0>,
+               [](const units::Unit &) { return units::one; },
+               [](const auto &range) { return numeric::is_linspace(range); }};
 
 constexpr auto zip = overloaded{
     arg_list<scipp::index>, transform_flags::expect_no_variance_arg<0>,

--- a/dataset/bucket.cpp
+++ b/dataset/bucket.cpp
@@ -351,6 +351,7 @@ void scale(const DataArrayView &data, const DataArrayConstView &histogram,
     masked = histogram.data() * ~mask;
   const auto &[indices, buffer_dim, buffer] =
       data.data().constituents<bucket<DataArray>>();
+  /*
   // TODO "bug" here: subspan_view creates a new variable, so out unit not set!
   transform_in_place(subspan_view(buffer.data(), buffer_dim, indices),
                      subspan_view(VariableConstView(buffer.coords()[dim]),
@@ -360,6 +361,16 @@ void scale(const DataArrayView &data, const DataArrayConstView &histogram,
                      core::element::event::scale);
   // TODO Workaround, see comment above
   buffer.data().setUnit(buffer.unit() * histogram.unit());
+  */
+
+  // auto tmp = make_non_owning_bins(indices, buffer_dim, buffer.data());
+  // tmp += make_non_owning_bins(indices, buffer_dim, buffer.coords()[dim]);
+  transform_in_place(
+      make_non_owning_bins(indices, buffer_dim, buffer.data()),
+      make_non_owning_bins(indices, buffer_dim, buffer.coords()[dim]),
+      subspan_view(histogram.coords()[dim], dim),
+      subspan_view(mask ? masked : histogram.data(), dim),
+      core::element::event::scale_sorted_edges);
 }
 
 Variable sum(const VariableConstView &data) {

--- a/dataset/bucketby.cpp
+++ b/dataset/bucketby.cpp
@@ -105,7 +105,7 @@ template <class T> struct Bin {
 
 auto bin(const VariableConstView &var, const VariableConstView &indices,
          const VariableConstView &sizes) {
-  return core::CallDType<double, float, int64_t, int32_t, bool,
+  return core::CallDType<double, float, int64_t, int32_t, bool, Eigen::Vector3d,
                          std::string>::apply<Bin>(var.dtype(), var, indices,
                                                   sizes);
 }

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "scipp/dataset/dataset.h"
+#include "scipp/variable/arithmetic.h"
 
 namespace scipp::dataset {
 
@@ -228,5 +229,21 @@ void concatenate_out(const VariableConstView &var, const Dim dim,
   }
   out_indices.assign(zip(out_begin, out_current));
 }
+
+/// Helper class for applying irreducible masks along dim.
+class Masker {
+public:
+  Masker(const DataArrayConstView &array, const Dim dim) {
+    const auto mask = irreducible_mask(array.masks(), dim);
+    if (mask)
+      m_masked = array.data() * ~mask;
+    m_data = m_masked ? m_masked : array.data();
+  }
+  auto data() const noexcept { return m_data; }
+
+private:
+  Variable m_masked;
+  VariableConstView m_data;
+};
 
 } // namespace scipp::dataset

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -231,6 +231,10 @@ void concatenate_out(const VariableConstView &var, const Dim dim,
 }
 
 /// Helper class for applying irreducible masks along dim.
+///
+/// If a mask is applied this class keeps ownership of the masked temporary.
+/// `Masker` should thus be created in the scope where the masked data is
+/// needed. It will be deleted once the masked goes out of scope.
 class Masker {
 public:
   Masker(const DataArrayConstView &array, const Dim dim) {

--- a/dataset/include/scipp/dataset/bins_view.h
+++ b/dataset/include/scipp/dataset/bins_view.h
@@ -48,6 +48,10 @@ public:
 } // namespace bins_view_detail
 
 /// Return helper for accessing bin data and coords as non-owning views
+///
+/// Usage:
+/// auto data = bins_view<DataArray>(var).data();
+/// auto coord = bins_view<DataArray>(var).coords()[dim];
 template <class T, class View> auto bins_view(const View &var) {
   return bins_view_detail::Bins<T, View>(var);
 }

--- a/dataset/include/scipp/dataset/bins_view.h
+++ b/dataset/include/scipp/dataset/bins_view.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/dataset/dataset.h"
+
+namespace scipp::dataset {
+
+namespace bins_view_detail {
+template <class T, class View> class BinsCommon {
+public:
+  BinsCommon(const View &var) : m_var(var) {}
+  auto indices() const {
+    return std::get<0>(m_var.template constituents<bucket<T>>());
+  }
+  auto dim() const {
+    return std::get<1>(m_var.template constituents<bucket<T>>());
+  }
+  auto buffer() const {
+    return std::get<2>(m_var.template constituents<bucket<T>>());
+  }
+
+protected:
+  auto make(const View &view) const {
+    return make_non_owning_bins(this->indices(), this->dim(), view);
+  }
+
+private:
+  View m_var;
+};
+
+template <class T, class View> class BinsCoords : public BinsCommon<T, View> {
+public:
+  BinsCoords(const BinsCommon<T, View> base) : BinsCommon<T, View>(base) {}
+  auto operator[](const Dim dim) const {
+    return this->make(this->buffer().coords()[dim]);
+  }
+};
+
+template <class T, class View> class Bins : public BinsCommon<T, View> {
+public:
+  using BinsCommon<T, View>::BinsCommon;
+  auto data() const { return this->make(this->buffer().data()); }
+  auto coords() const { return BinsCoords<T, View>(*this); }
+};
+} // namespace bins_view_detail
+
+/// Return helper for accessing bin data and coords as non-owning views
+template <class T, class View> auto bins_view(const View &var) {
+  return bins_view_detail::Bins<T, View>(var);
+}
+
+} // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bins_view.h
+++ b/dataset/include/scipp/dataset/bins_view.h
@@ -12,15 +12,9 @@ namespace bins_view_detail {
 template <class T, class View> class BinsCommon {
 public:
   BinsCommon(const View &var) : m_var(var) {}
-  auto indices() const {
-    return std::get<0>(m_var.template constituents<bucket<T>>());
-  }
-  auto dim() const {
-    return std::get<1>(m_var.template constituents<bucket<T>>());
-  }
-  auto buffer() const {
-    return std::get<2>(m_var.template constituents<bucket<T>>());
-  }
+  auto indices() const { return std::get<0>(get()); }
+  auto dim() const { return std::get<1>(get()); }
+  auto buffer() const { return std::get<2>(get()); }
 
 protected:
   auto make(const View &view) const {
@@ -28,6 +22,7 @@ protected:
   }
 
 private:
+  auto get() const { return m_var.template constituents<bucket<T>>(); }
   View m_var;
 };
 
@@ -52,6 +47,9 @@ public:
 /// Usage:
 /// auto data = bins_view<DataArray>(var).data();
 /// auto coord = bins_view<DataArray>(var).coords()[dim];
+///
+/// The returned objects are variables referencing data in `var`. They do not
+/// own or share ownership of any data.
 template <class T, class View> auto bins_view(const View &var) {
   return bins_view_detail::Bins<T, View>(var);
 }

--- a/dataset/include/scipp/dataset/bins_view.h
+++ b/dataset/include/scipp/dataset/bins_view.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "scipp/dataset/dataset.h"
-#include "scipp/variable/bins.h"
+#include "scipp/variable/buckets.h"
 
 namespace scipp::dataset {
 

--- a/dataset/include/scipp/dataset/bins_view.h
+++ b/dataset/include/scipp/dataset/bins_view.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "scipp/dataset/dataset.h"
+#include "scipp/variable/bins.h"
 
 namespace scipp::dataset {
 

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -84,12 +84,22 @@ Variable from_constituents(Variable indices, const Dim dim, Variable buffer) {
       std::move(indices), dim, std::move(buffer))};
 }
 
+/// Construct non-owning binned variable of a mutable buffer.
+///
+/// This is intented for internal and short-lived variables. The returned
+/// variable stores *views* onto `indices` and `buffer` rather than copying the
+/// data. This is, it does not own any or share ownership of any data.
 Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
                               const VariableView &buffer) {
   return {std::make_unique<variable::DataModel<bucket<VariableView>>>(
       indices, dim, buffer)};
 }
 
+/// Construct non-owning binned variable of a const buffer.
+///
+/// This is intented for internal and short-lived variables. The returned
+/// variable stores *views* onto `indices` and `buffer` rather than copying the
+/// data. This is, it does not own any or share ownership of any data.
 Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
                               const VariableConstView &buffer) {
   return {std::make_unique<variable::DataModel<bucket<VariableConstView>>>(

--- a/variable/buckets.cpp
+++ b/variable/buckets.cpp
@@ -84,4 +84,16 @@ Variable from_constituents(Variable indices, const Dim dim, Variable buffer) {
       std::move(indices), dim, std::move(buffer))};
 }
 
+Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
+                              const VariableView &buffer) {
+  return {std::make_unique<variable::DataModel<bucket<VariableView>>>(
+      indices, dim, buffer)};
+}
+
+Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
+                              const VariableConstView &buffer) {
+  return {std::make_unique<variable::DataModel<bucket<VariableConstView>>>(
+      indices, dim, buffer)};
+}
+
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -179,8 +179,8 @@ void DataModel<bucket<T>>::copy(const VariableConstView &src,
   auto buffer1 = resize_default_init(buffer0, dim0, size1);
   copy_slices(buffer0, buffer1, dim0, indices0, indices1);
   if constexpr (is_view_v<T>) {
-    dst.replace_model(DataModel<bucket<typename T::value_type>>{
-        std::move(indices1), dim0, std::move(buffer1)});
+    throw std::runtime_error(
+        "Copying a non-owning binned view is not supported.");
   } else {
     dst.replace_model(
         DataModel<bucket<T>>{std::move(indices1), dim0, std::move(buffer1)});

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -141,7 +141,7 @@ private:
       const auto dims = base.dims();
       const auto dataDims = params.dataDims();
       return cast<range_type>(m_indices.underlying())
-          .values(core::element_array_view(offset, dims, dataDims, {}));
+          .values(core::ElementArrayViewParams(offset, dims, dataDims, {}));
     } else {
       return cast<range_type>(m_indices).values(base);
     }

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -14,26 +14,40 @@ std::tuple<Variable, Dim, typename T::buffer_type> Variable::to_constituents() {
   Variable tmp;
   std::swap(*this, tmp);
   auto &model = requireT<DataModel<T>>(tmp.data());
-  return {std::move(model.indices()), model.dim(), std::move(model.buffer())};
+  return {Variable(std::move(model.indices())), model.dim(),
+          std::move(model.buffer())};
 }
+
+//template <class T> using indices_t = typename DataModel<T>::indices_type::view_type;
+//template <class T>
+//using indices_const_t = typename DataModel<T>::indices_type::const_view_type;
 
 template <class T>
 std::tuple<VariableConstView, Dim, typename T::const_element_type>
 VariableConstView::constituents() const {
-  auto view = *this;
   const auto &model = requireT<const DataModel<T>>(underlying().data());
-  view.m_variable = &model.indices();
+  auto view = *this;
+  if constexpr (is_view_v<typename T::buffer_type>) {
+    view = model.indices();
+  } else {
+    view.m_variable = &model.indices();
+  }
   return {view, model.dim(), model.buffer()};
 }
 
 template <class T>
-std::tuple<VariableView, Dim, typename T::element_type>
+std::tuple<bin_indices_t<T>, Dim, typename T::element_type>
 VariableView::constituents() const {
-  auto view = *this;
   auto &model = requireT<DataModel<T>>(m_mutableVariable->data());
-  view.m_variable = &model.indices();
-  view.m_mutableVariable = &model.indices();
-  return {view, model.dim(), model.buffer()};
+  if constexpr (is_view_v<typename T::buffer_type>) {
+    // TODO take into account slicing params of *this
+    return {model.indices(), model.dim(), model.buffer()};
+  } else {
+    auto view = *this;
+    view.m_variable = &model.indices();
+    view.m_mutableVariable = &model.indices();
+    return {view, model.dim(), model.buffer()};
+  }
 }
 
 namespace {
@@ -89,7 +103,10 @@ public:
   }
   void set_elem_unit(const VariableView &var,
                      const units::Unit &u) const override {
-    return std::get<2>(var.constituents<bucket<T>>()).setUnit(u);
+    if constexpr(std::is_same_v<T, VariableConstView>)
+      throw std::runtime_error("Cannot set unit via const non-owning view");
+    else
+      return std::get<2>(var.constituents<bucket<T>>()).setUnit(u);
   }
   bool hasVariances(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<T>>()).hasVariances();
@@ -102,7 +119,8 @@ public:
   INSTANTIATE_VARIABLE_BASE(name, __VA_ARGS__)                                 \
   template std::tuple<Variable, Dim, typename __VA_ARGS__::buffer_type>        \
   Variable::to_constituents<__VA_ARGS__>();                                    \
-  template std::tuple<VariableView, Dim, typename __VA_ARGS__::element_type>   \
+  template std::tuple<bin_indices_t<__VA_ARGS__>, Dim,                         \
+                      typename __VA_ARGS__::element_type>                      \
   VariableView::constituents<__VA_ARGS__>() const;                             \
   template std::tuple<VariableConstView, Dim,                                  \
                       typename __VA_ARGS__::const_element_type>                \

--- a/variable/include/scipp/variable/buckets.h
+++ b/variable/include/scipp/variable/buckets.h
@@ -23,4 +23,12 @@ sizes_to_begin(const VariableConstView &sizes);
                                                                const Dim dim,
                                                                Variable buffer);
 
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+make_non_owning_bins(const VariableConstView &indices, const Dim dim,
+                     const VariableView &buffer);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+make_non_owning_bins(const VariableConstView &indices, const Dim dim,
+                     const VariableConstView &buffer);
+
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -9,9 +9,12 @@
 
 namespace scipp::variable {
 
-SCIPP_VARIABLE_EXPORT Variable linspace(const VariableConstView &start,
-                                        const VariableConstView &stop,
-                                        const Dim dim, const scipp::index num);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+linspace(const VariableConstView &start, const VariableConstView &stop,
+         const Dim dim, const scipp::index num);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+is_linspace(const VariableConstView &var, const Dim dim);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
@@ -20,7 +23,8 @@ variances(const VariableConstView &x);
 enum class SortOrder { Ascending, Descending };
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT bool
-is_sorted(const VariableConstView &x, const Dim dim, const SortOrder order);
+is_sorted(const VariableConstView &x, const Dim dim,
+          const SortOrder order = SortOrder::Ascending);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 zip(const VariableConstView &first, const VariableConstView &second);

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -199,6 +199,8 @@ Variable::Variable(const DType &type, Ts &&... args)
 class SCIPP_VARIABLE_EXPORT VariableConstView {
 public:
   using value_type = Variable;
+  using const_view_type = VariableConstView;
+  using view_type = VariableConstView;
 
   VariableConstView() = default;
   VariableConstView(const Variable &variable) : m_variable(&variable) {
@@ -269,12 +271,20 @@ protected:
   Dimensions m_dataDims; // not always actual, can be pretend, e.g. with reshape
 };
 
+template <class T>
+using bin_indices_t = std::conditional_t<
+    std::is_base_of_v<VariableConstView, typename T::buffer_type>,
+    VariableConstView, VariableView>;
+
 /** Mutable view into (a subset of) a Variable.
  *
  * By inheriting from VariableConstView any code that works for
  * VariableConstView will automatically work also for this mutable variant.*/
 class SCIPP_VARIABLE_EXPORT VariableView : public VariableConstView {
 public:
+  using const_view_type = VariableConstView;
+  using view_type = VariableView;
+
   VariableView() = default;
   VariableView(Variable &variable)
       : VariableConstView(variable), m_mutableVariable(&variable) {}
@@ -329,7 +339,8 @@ public:
   void expectCanSetUnit(const units::Unit &unit) const;
 
   template <class T>
-  std::tuple<VariableView, Dim, typename T::element_type> constituents() const;
+  std::tuple<bin_indices_t<T>, Dim, typename T::element_type>
+  constituents() const;
 
   template <class T> void replace_model(T model) const;
 

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -68,7 +68,8 @@ auto apply(const DType dtype, Args &&... args) {
   return core::callDType<Callable>(
       std::tuple<double, float, int64_t, int32_t, std::string, bool,
                  scipp::core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
-                 bucket<Variable>>{},
+                 bucket<Variable>, bucket<VariableConstView>,
+                 bucket<VariableView>>{},
       dtype, std::forward<Args>(args)...);
 }
 

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   transform_test.cpp
   trigonometry_test.cpp
   util_test.cpp
+  variable_bucket_non_owning_test.cpp
   variable_bucket_test.cpp
   variable_custom_type_test.cpp
   variable_keyword_args_constructor_test.cpp

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -17,8 +17,6 @@ TEST(BucketTest, member_types) {
 
 using Model = DataModel<bucket<Variable>>;
 
-using index_pair = std::pair<scipp::index, scipp::index>;
-
 class BucketModelTest : public ::testing::Test {
 protected:
   Variable indices = makeVariable<index_pair>(

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -21,15 +21,14 @@ using index_pair = std::pair<scipp::index, scipp::index>;
 
 class BucketModelTest : public ::testing::Test {
 protected:
-  Dimensions dims{Dim::Y, 2};
-  Variable indices =
-      makeVariable<index_pair>(dims, Values{std::pair{0, 2}, std::pair{2, 4}});
+  Variable indices = makeVariable<index_pair>(
+      Dims{Dim::Y}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 4}});
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
   auto make_indices(
       const std::vector<std::pair<scipp::index, scipp::index>> &is) const {
-    return makeVariable<std::pair<scipp::index, scipp::index>>(dims,
-                                                               Values(is));
+    return makeVariable<std::pair<scipp::index, scipp::index>>(
+        Dims{Dim::Y}, Shape{is.size()}, Values(is));
   }
 };
 

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -129,7 +129,7 @@ class NonOwningBucketModelTest : public BucketModelTest {};
 
 TEST_F(NonOwningBucketModelTest, buffer_is_view) {
   DataModel<bucket<VariableView>> model(indices, Dim::X, buffer);
-  core::element_array_view params(0, indices.dims(), indices.dims(), {});
+  core::ElementArrayViewParams params(0, indices.dims(), indices.dims(), {});
   (*model.values(params).begin()) += 2.0 * units::one;
   EXPECT_EQ(buffer, makeVariable<double>(buffer.dims(), Values{3, 4, 3, 4}));
 }

--- a/variable/test/variable_bucket_non_owning_test.cpp
+++ b/variable/test/variable_bucket_non_owning_test.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/variable/buckets.h"
+#include "scipp/variable/operations.h"
+#include "scipp/variable/string.h"
+
+using namespace scipp;
+
+class VariableBucketNonOwningTest : public ::testing::Test {
+protected:
+  Variable buffer =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  const Variable indices = makeVariable<index_pair>(
+      Dims{Dim::Y}, Shape{3},
+      Values{index_pair{0, 1}, index_pair{1, 3}, index_pair{3, 4}});
+  // const Variable base = from_constituents(indices, Dim::X, buffer);
+  Variable view = make_non_owning_bins(indices, Dim::X, VariableView(buffer));
+};
+
+TEST_F(VariableBucketNonOwningTest, slicing) {
+  const auto sliced_indices = indices.slice({Dim::Y, 1, 3});
+  const auto view_sliced =
+      make_non_owning_bins(sliced_indices, Dim::X, VariableView(buffer));
+  EXPECT_EQ(view_sliced, view.slice({Dim::Y, 1, 3}));
+}
+
+TEST_F(VariableBucketNonOwningTest, copy) {
+  // Still a non-owning view, no copy of data or indices is made.
+  Variable copy(view);
+  EXPECT_EQ(copy, view);
+  view.values<bucket<VariableView>>()[0] +=
+      view.values<bucket<VariableView>>()[2];
+  EXPECT_EQ(copy, view);
+}
+
+TEST_F(VariableBucketNonOwningTest, assign) {
+  Variable buffer_copy(buffer);
+  Variable copy =
+      make_non_owning_bins(indices, Dim::X, VariableView(buffer_copy));
+  view.values<bucket<VariableView>>()[0] +=
+      view.values<bucket<VariableView>>()[2];
+  EXPECT_NE(copy, view);
+  // Assignment changes referenced buffer rather than assigning values
+  copy = view;
+  EXPECT_EQ(copy, view);
+  view.values<bucket<VariableView>>()[0] +=
+      view.values<bucket<VariableView>>()[2];
+  EXPECT_EQ(copy, view);
+}
+
+TEST_F(VariableBucketNonOwningTest, copy_view) {
+  // Should still be a non-owning view, no copy of data or indices is made, but
+  // not implemented right now.
+  EXPECT_ANY_THROW(Variable(view.slice({Dim::Y, 0, 2})));
+}
+
+template <class T>
+class VariableBucketNonOwningTypedTest : public VariableBucketNonOwningTest {
+protected:
+  using ViewType = T;
+  Variable view = make_non_owning_bins(indices, Dim::X, T(buffer));
+  T get_view() { return view; }
+  T get_buffer() { return buffer; }
+};
+using VariableBucketNonOwningTypes =
+    ::testing::Types<VariableConstView, VariableView>;
+TYPED_TEST_SUITE(VariableBucketNonOwningTypedTest,
+                 VariableBucketNonOwningTypes);
+
+TYPED_TEST(VariableBucketNonOwningTypedTest, constituents) {
+  auto [idx, dim, buf] =
+      TestFixture::get_view()
+          .template constituents<bucket<typename TestFixture::ViewType>>();
+  EXPECT_EQ(idx, this->indices);
+  EXPECT_EQ(dim, Dim::X);
+  EXPECT_EQ(buf, this->buffer);
+}
+
+TYPED_TEST(VariableBucketNonOwningTypedTest, constituents_slice) {
+  auto [idx, dim, buf] =
+      TestFixture::get_view()
+          .slice({Dim::Y, 1, 3})
+          .template constituents<bucket<typename TestFixture::ViewType>>();
+  EXPECT_EQ(idx, this->indices.slice({Dim::Y, 1, 3}));
+  EXPECT_EQ(dim, Dim::X);
+  EXPECT_EQ(buf, this->buffer);
+}
+
+TYPED_TEST(VariableBucketNonOwningTypedTest, constituents_slice_of_slice) {
+  const auto sliced_indices = this->indices.slice({Dim::Y, 1, 3});
+  const auto view_sliced =
+      make_non_owning_bins(sliced_indices, Dim::X, TestFixture::get_buffer());
+  auto [idx, dim, buf] =
+      view_sliced.slice({Dim::Y, 1, 2})
+          .template constituents<bucket<typename TestFixture::ViewType>>();
+  EXPECT_EQ(idx, this->indices.slice({Dim::Y, 2, 3}));
+  EXPECT_EQ(dim, Dim::X);
+  EXPECT_EQ(buf, this->buffer);
+}

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -10,6 +10,7 @@
 #include "scipp/variable/except.h"
 #include "scipp/variable/misc_operations.h"
 #include "scipp/variable/reduction.h"
+#include "scipp/variable/subspan_view.h"
 #include "scipp/variable/transform.h"
 
 using namespace scipp::core;
@@ -41,6 +42,10 @@ Variable linspace(const VariableConstView &start, const VariableConstView &stop,
             range);
   out.slice({dim, num - 1}).assign(stop); // endpoint included
   return out;
+}
+
+Variable is_linspace(const VariableConstView &var, const Dim dim) {
+  return transform(subspan_view(var, dim), core::element::is_linspace);
 }
 
 Variable values(const VariableConstView &x) {

--- a/variable/variable_instantiate_bucket_elements.cpp
+++ b/variable/variable_instantiate_bucket_elements.cpp
@@ -9,8 +9,12 @@ namespace scipp::variable {
 
 INSTANTIATE_VARIABLE(pair_int64, std::pair<scipp::index, scipp::index>)
 INSTANTIATE_BUCKET_VARIABLE(VariableView, bucket<Variable>)
+INSTANTIATE_BUCKET_VARIABLE(VariableView_observer, bucket<VariableView>)
+INSTANTIATE_BUCKET_VARIABLE(VariableConstView_observer,
+                            bucket<VariableConstView>)
 
-class BucketVariableMakerVariable : public BucketVariableMaker<Variable> {
+template <class T>
+class BucketVariableMakerVariable : public BucketVariableMaker<T> {
 private:
   Variable make_buckets(const VariableConstView &,
                         const VariableConstView &indices, const Dim dim,
@@ -23,27 +27,38 @@ private:
         indices, dim, variableFactory().create(type, dims, unit, variances))};
   }
   VariableConstView data(const VariableConstView &var) const override {
-    return std::get<2>(var.constituents<bucket<Variable>>());
+    return std::get<2>(var.constituents<bucket<T>>());
   }
   VariableView data(const VariableView &var) const override {
-    return std::get<2>(var.constituents<bucket<Variable>>());
+    if constexpr (std::is_same_v<T, VariableConstView>)
+      throw std::runtime_error("xxx");
+    else
+      return std::get<2>(var.constituents<bucket<T>>());
   }
   core::ElementArrayViewParams
   array_params(const VariableConstView &var) const override {
-    const auto &[indices, dim, buffer] = var.constituents<bucket<Variable>>();
+    const auto &[indices, dim, buffer] = var.constituents<bucket<T>>();
     auto params = var.array_params();
     return {0, // no offset required in buffer since access via indices
             params.dims(),
             params.dataDims(),
             {dim, buffer.dims(),
-             indices.values<std::pair<scipp::index, scipp::index>>().data()}};
+             indices.template values<std::pair<scipp::index, scipp::index>>()
+                 .data()}};
   }
 };
 
 namespace {
 auto register_variable_maker_bucket_Variable(
-    (variableFactory().emplace(dtype<bucket<Variable>>,
-                               std::make_unique<BucketVariableMakerVariable>()),
+    (variableFactory().emplace(
+         dtype<bucket<Variable>>,
+         std::make_unique<BucketVariableMakerVariable<Variable>>()),
+     variableFactory().emplace(
+         dtype<bucket<VariableView>>,
+         std::make_unique<BucketVariableMakerVariable<VariableView>>()),
+     variableFactory().emplace(
+         dtype<bucket<VariableConstView>>,
+         std::make_unique<BucketVariableMakerVariable<VariableConstView>>()),
      0));
 }
 

--- a/variable/variable_instantiate_bucket_elements.cpp
+++ b/variable/variable_instantiate_bucket_elements.cpp
@@ -31,7 +31,11 @@ private:
   }
   VariableView data(const VariableView &var) const override {
     if constexpr (std::is_same_v<T, VariableConstView>)
-      throw std::runtime_error("xxx");
+      // This code is an indication of some shortcomings with the const handling
+      // of variables and views. Essentially we would require better support for
+      // variables with const elements.
+      throw std::runtime_error("Mutable access to data of non-owning binned "
+                               "view of const buffer is not possible.");
     else
       return std::get<2>(var.constituents<bucket<T>>());
   }


### PR DESCRIPTION
This is a step in cleanup and generalization of the operations (and their implementation) for binned data:

- Add `Masker`, an internal helper class for applying subset of masks in reduction.
- Add `bins_view` and unterlying machinery for accessing data and coords of data stored with dtype `bucket<DataArray>`.
- Refactor some operations to element-wise `transform` rather than requiring a more complex kernel implementation with a loop over a span (and avoiding creation of a new variable from `subspan_view`). Note that this leads to some potentialy inefficiencies because `linear_edge_params` is called for every event instead of every "event list". However, I see big negative effect of this, probably the CPU pipeline can deal with it pretty well. Furthermore, if we optimize `transform` to explicitly handle stride 0 in a branch with an explicit loop, the compiler should be able to pull this function call out of the loop. The idea here is to simplify all the client code and rather spend more time later on bringing `transform` in a state where the compiler can optimize it better.
- Do not use `map` to implement `scale`. This avoids creation of a large temporary variable and thus gives better performance.
- Support "rebinning" by `sc.bin` (for now still named `bucketby` in the C++ side). Currently in a very inefficient manner by first concatenating the "rebinned" dim.
- Fix (and test) issue with `sc.histogram` for dense data along non-dimension coord.