### PR TITLE
Fix double figures in docs

### DIFF
--- a/docs/user-guide/binned-data.ipynb
+++ b/docs/user-guide/binned-data.ipynb
@@ -121,8 +121,7 @@
     "ax.set_xlabel('x [{}]'.format(data.coords['x'].unit))\n",
     "ax.set_ylabel('y [{}]'.format(data.coords['y'].unit))\n",
     "cbar = plt.colorbar(scatter)\n",
-    "cbar.set_label(\"[{}]\".format(data.unit))\n",
-    "fig.show()"
+    "cbar.set_label(\"[{}]\".format(data.unit))"
    ]
   },
   {
@@ -193,8 +192,7 @@
     "ax.set_yticks(binned.coords['y'].values)\n",
     "ax.grid()\n",
     "cbar = fig.colorbar(scatter)\n",
-    "cbar.set_label(\"[{}]\".format(data.unit))\n",
-    "fig.show()"
+    "cbar.set_label(\"[{}]\".format(data.unit))"
    ]
   },
   {

--- a/docs/visualization/customizing-figures.ipynb
+++ b/docs/visualization/customizing-figures.ipynb
@@ -41,16 +41,10 @@
     "d.coords['tof'] = sc.Variable(['tof'],\n",
     "                              values=np.arange(N+1).astype(np.float64),\n",
     "                              unit=sc.units.us)\n",
-    "d['Sample1D'] = sc.Variable(['tof'], values=10.0*np.random.rand(N),\n",
-    "                            unit=sc.units.counts)\n",
-    "d['Noise1D'] = sc.Variable(['tof'], values=10.0*np.random.rand(N),\n",
-    "                           variances=3.0*np.random.rand(N),\n",
-    "                           unit=sc.units.counts)\n",
     "d.coords['x'] = sc.Variable(['x'], values=np.arange(M).astype(np.float64),\n",
     "                            unit=sc.units.m)\n",
-    "d['Image2D'] = sc.Variable(['x', 'tof'], values=10.0*np.random.rand(M, N),\n",
-    "                           variances=np.random.rand(M, N))\n",
-    "out = plot(d)\n",
+    "d['noise'] = sc.Variable(['x', 'tof'], values=10.0*np.random.rand(M, N))\n",
+    "out = plot(d, projection=\"1d\")\n",
     "out"
    ]
   },
@@ -58,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `out` object contains one key per figure, which is either a combination of `Dimension` and unit for 1d plots, or the name of the variable (`Image2D`) in out case:"
+    "The `out` object contains one key per figure, which is either a combination of `Dimension` and unit for 1d variables, or the name of the variable (`noise`) in our case:"
    ]
   },
   {
@@ -68,7 +62,7 @@
    "outputs": [],
    "source": [
     "print(out.keys())\n",
-    "print(out['tof.counts'])"
+    "print(out['noise'])"
    ]
   },
   {
@@ -90,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out['Image2D'].widgets"
+    "out['noise'].widgets"
    ]
   },
   {
@@ -108,9 +102,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out['tof.counts'].view.figure.data_lines['Sample1D'].set_color('cyan')\n",
-    "out['tof.counts'].view.figure.ax.set_title('This is a new title!')\n",
-    "out['tof.counts']"
+    "out['noise'].view.figure.data_lines['noise'].set_color('red')\n",
+    "out['noise'].view.figure.ax.set_title('This is a new title!')\n",
+    "out['noise']"
    ]
   },
   {
@@ -123,24 +117,7 @@
     "\n",
     "This is achieved via the `ax` keyword argument (and `cax` for colorbar axes), and is best illustrated via a short demo.\n",
     "\n",
-    "We first close the figures that were created in the section above:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for i in plt.get_fignums():\n",
-    "    plt.close(i)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we create 3 subplots:"
+    "We first create 3 subplots:"
    ]
   },
   {
@@ -310,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/docs/visualization/customizing-figures.ipynb
+++ b/docs/visualization/customizing-figures.ipynb
@@ -24,7 +24,8 @@
     "import numpy as np\n",
     "import scipp as sc\n",
     "from scipp.plot import plot\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "plt.ioff() # turn off automatic figure show"
    ]
   },
   {
@@ -126,7 +127,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "figs, axs = plt.subplots(1, 3, figsize=(8, 3))"
+    "figs, axs = plt.subplots(1, 3, figsize=(8, 3))\n",
+    "figs"
    ]
   },
   {

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -8,10 +8,15 @@ import warnings
 
 is_doc_build = False
 
+# Note: due to some strange behaviour when importing matplotlib and pyplot in
+# different order, we need to import matplotlib and pyplot before everything
+# else.
 try:
     import matplotlib as mpl
+    import matplotlib.pyplot as plt
 except ImportError:
     mpl = None
+    plt = None
 
 try:
     from IPython import get_ipython
@@ -47,20 +52,15 @@ if ipy is not None:
                 "Falling back to a static backend. Use "
                 "conda install -c conda-forge ipympl to install ipympl.")
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    plt = None
-
 if is_doc_build and plt is not None:
     plt.rcParams.update({'figure.max_open_warning': 0})
 
 
-def _is_interactive():
+def _is_inline():
     """
     Determine if we are using a static or interactive backend
     """
-    return not mpl.get_backend().lower().endswith('inline')
+    return mpl.get_backend().lower().endswith('inline')
 
 
 def plot(*args, **kwargs):
@@ -185,15 +185,20 @@ def plot(*args, **kwargs):
 
     # Switch auto figure display off for better control over when figures are
     # displayed.
-    plt.ioff()
+    interactive_on = False
+    if plt.isinteractive():
+        plt.ioff()
+        interactive_on = True
+
     output = _plot(*args, **kwargs)
-    if not _is_interactive():
+    if _is_inline():
         for key in output:
             output[key].as_static(keep_widgets=is_doc_build)
     # Turn auto figure display back on.
     # TODO: we need to consider whether users manually turned auto figure
     # display off, in which case we would not want to turn it back on here.
-    plt.ion()
+    if interactive_on:
+        plt.ion()
     return output
 
 

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -194,11 +194,11 @@ def plot(*args, **kwargs):
     if _is_inline():
         for key in output:
             output[key].as_static(keep_widgets=is_doc_build)
-    # Turn auto figure display back on.
-    # TODO: we need to consider whether users manually turned auto figure
-    # display off, in which case we would not want to turn it back on here.
+
+    # Turn auto figure display back on if needed.
     if interactive_on:
         plt.ion()
+
     return output
 
 

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -84,6 +84,9 @@ class PlotFigure:
         else:
             buf = io.BytesIO()
             self.fig.savefig(buf, format='png')
+            # Here we close the figure to prevent it from showing up again in
+            # cells further down the notebook.
+            plt.close(self.fig)
             buf.seek(0)
             return ipw.Image(value=buf.getvalue(),
                              width=config.plot.width,

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -164,7 +164,7 @@ def plot(scipp_obj,
     for name, var in sorted(inventory.items()):
         ndims = len(var.dims)
         if ndims > 0:
-            if ndims == 1 or projection == "1d" or projection == "1D":
+            if ndims == 1:
                 # Construct a key from the dimensions
                 if axes is not None:
                     key = list(axes.values())[0]
@@ -172,9 +172,10 @@ def plot(scipp_obj,
                     key = var.dims[0]
                 # Add unit to key
                 key = "{}.{}".format(key, str(var.unit))
-                line_count += 1
             else:
                 key = name
+            if ndims == 1 or projection == "1d" or projection == "1D":
+                line_count += 1
 
             mpl_line_params = {}
             for n, p in line_params.items():

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -268,13 +268,13 @@ class SciPlot:
         Convert the plot to a static plot, releasing the memory held (a full
         copy of the data is made on input).
         """
-        # Delete all members of controller
+        # Delete controller members
         self.controller.widgets = None
         self.controller.model = None
         self.controller.panel = None
         self.controller.profile = None
         self.controller.view = None
-        # Delete controller and members of sciplot
+        # Delete sciplot members
         self.controller = None
         self.model = None
         self.profile = None


### PR DESCRIPTION
Figure were showing up twice in the "Binned data" notebook.

- import `matplotlib.pyplot` before anything else, as this leads to strange behavious with auto figures being enabled or not depending on the order of the import statements
- Also close figures when they are rendered as static to prevent them showing up in cells further down in the notebook.
- Update binned data and customizing figures notebooks.