### PR TITLE
Better mpl api for plots

### DIFF
--- a/docs/visualization/customizing-figures.ipynb
+++ b/docs/visualization/customizing-figures.ipynb
@@ -94,7 +94,25 @@
    "source": [
     "and they are still connected to the figure above.\n",
     "\n",
-    "It is also possible to customize figures such as changing a line color or an axis label by accessing the members of the view attribute:"
+    "It is also possible to customize figures such as changing the figure title or the axes labels by accessing the underlying matplotlib axes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out['noise'].ax.set_title('This is a new title!')\n",
+    "out['noise'].ax.set_xlabel('My new Xaxis label')\n",
+    "out['noise']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A line color may be modified by accessing the members of the figure, which is in turn a member of the `view` attribute:"
    ]
   },
   {
@@ -104,7 +122,6 @@
    "outputs": [],
    "source": [
     "out['noise'].view.figure.data_lines['noise'].set_color('red')\n",
-    "out['noise'].view.figure.ax.set_title('This is a new title!')\n",
     "out['noise']"
    ]
   },

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -193,7 +193,8 @@ def plot(*args, **kwargs):
     output = _plot(*args, **kwargs)
     if _is_inline():
         for key in output:
-            output[key].as_static(keep_widgets=is_doc_build)
+            if output[key] is not None:
+                output[key].as_static(keep_widgets=is_doc_build)
 
     # Turn auto figure display back on if needed.
     if interactive_on:

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -20,7 +20,9 @@ class PlotFigure:
                  figsize=None,
                  title=None,
                  padding=None,
-                 ndim=1):
+                 ndim=1,
+                 xlabel=None,
+                 ylabel=None):
         self.fig = None
         self.ax = ax
         self.cax = cax
@@ -49,6 +51,9 @@ class PlotFigure:
 
         self.axformatter = {}
         self.axlocator = {}
+        self.xlabel = xlabel
+        self.ylabel = ylabel
+
 
     def is_widget(self):
         """

--- a/python/src/scipp/plot/figure.py
+++ b/python/src/scipp/plot/figure.py
@@ -54,7 +54,6 @@ class PlotFigure:
         self.xlabel = xlabel
         self.ylabel = ylabel
 
-
     def is_widget(self):
         """
         Check whether we are using the Matplotlib widget backend or not.

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -112,8 +112,8 @@ class PlotFigure1d(PlotFigure):
         for name, hist in xparams["hist"].items():
 
             label = None
-            if legend_labels:
-                label = name if len(name) > 0 else " "
+            if legend_labels and len(name) > 0:
+                label = name # if len(name) > 0 else " "
 
             self.mask_lines[name] = {}
 

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -29,9 +29,13 @@ class PlotFigure1d(PlotFigure):
                  figsize=None,
                  picker=False,
                  legend={"show": True},
-                 padding=None):
+                 padding=None,
+                 xlabel=None,
+                 ylabel=None):
 
-        super().__init__(ax=ax, figsize=figsize, title=title, padding=padding)
+        super().__init__(ax=ax, figsize=figsize, title=title, padding=padding,
+                         xlabel=xlabel,
+                         ylabel=ylabel)
 
         # Matplotlib line containers
         self.data_lines = {}
@@ -64,7 +68,9 @@ class PlotFigure1d(PlotFigure):
         xparams = axparams["x"]
 
         if self.own_axes:
+            title = self.ax.get_title()
             self.ax.clear()
+            self.ax.set_title(title)
 
         if self.mpl_line_params is None:
             self.mpl_line_params = {
@@ -85,7 +91,7 @@ class PlotFigure1d(PlotFigure):
 
         self.ax.set_xscale(xparams["scale"])
         self.ax.set_yscale("log" if self.norm == "log" else "linear")
-        self.ax.set_ylabel(self.unit)
+        self.ax.set_ylabel(self.unit if self.ylabel is None else self.ylabel)
 
         if self.grid:
             self.ax.grid()
@@ -96,7 +102,7 @@ class PlotFigure1d(PlotFigure):
             self.ax.set_xlim(
                 [xparams["lims"][0] - deltax, xparams["lims"][1] + deltax])
 
-        self.ax.set_xlabel(xparams["label"])
+        self.ax.set_xlabel(xparams["label"] if self.xlabel is None else self.xlabel)
 
         self.ax.xaxis.set_major_locator(
             self.axlocator[xparams["dim"]][xparams["scale"]])

--- a/python/src/scipp/plot/figure1d.py
+++ b/python/src/scipp/plot/figure1d.py
@@ -33,7 +33,10 @@ class PlotFigure1d(PlotFigure):
                  xlabel=None,
                  ylabel=None):
 
-        super().__init__(ax=ax, figsize=figsize, title=title, padding=padding,
+        super().__init__(ax=ax,
+                         figsize=figsize,
+                         title=title,
+                         padding=padding,
                          xlabel=xlabel,
                          ylabel=ylabel)
 
@@ -102,7 +105,8 @@ class PlotFigure1d(PlotFigure):
             self.ax.set_xlim(
                 [xparams["lims"][0] - deltax, xparams["lims"][1] + deltax])
 
-        self.ax.set_xlabel(xparams["label"] if self.xlabel is None else self.xlabel)
+        self.ax.set_xlabel(
+            xparams["label"] if self.xlabel is None else self.xlabel)
 
         self.ax.xaxis.set_major_locator(
             self.axlocator[xparams["dim"]][xparams["scale"]])
@@ -113,7 +117,7 @@ class PlotFigure1d(PlotFigure):
 
             label = None
             if legend_labels and len(name) > 0:
-                label = name # if len(name) > 0 else " "
+                label = name
 
             self.mask_lines[name] = {}
 

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -21,14 +21,23 @@ class PlotFigure2d(PlotFigure):
                  aspect=None,
                  cmap=None,
                  norm=None,
-                 title=None,
+                 name=None,
                  cbar=None,
                  unit=None,
                  masks=None,
                  resolution=None,
-                 extend=None):
+                 extend=None,
+                 title=None,
+                 xlabel=None,
+                 ylabel=None):
 
-        super().__init__(ax=ax, cax=cax, figsize=figsize, title=title, ndim=2)
+        super().__init__(ax=ax,
+                         cax=cax,
+                         figsize=figsize,
+                         title=name if title is None else title,
+                         ndim=2,
+                         xlabel=xlabel,
+                         ylabel=ylabel)
 
         if aspect is None:
             aspect = config.plot.aspect
@@ -115,8 +124,8 @@ class PlotFigure2d(PlotFigure):
         Update axes labels, scales, tick locations and labels, as well as axes
         limits.
         """
-        self.ax.set_xlabel(axparams["x"]["label"])
-        self.ax.set_ylabel(axparams["y"]["label"])
+        self.ax.set_xlabel(axparams["x"]["label"] if self.xlabel is None else self.xlabel)
+        self.ax.set_ylabel(axparams["y"]["label"] if self.ylabel is None else self.ylabel)
         self.ax.set_xscale(axparams["x"]["scale"])
         self.ax.set_yscale(axparams["y"]["scale"])
 

--- a/python/src/scipp/plot/figure2d.py
+++ b/python/src/scipp/plot/figure2d.py
@@ -124,8 +124,10 @@ class PlotFigure2d(PlotFigure):
         Update axes labels, scales, tick locations and labels, as well as axes
         limits.
         """
-        self.ax.set_xlabel(axparams["x"]["label"] if self.xlabel is None else self.xlabel)
-        self.ax.set_ylabel(axparams["y"]["label"] if self.ylabel is None else self.ylabel)
+        self.ax.set_xlabel(
+            axparams["x"]["label"] if self.xlabel is None else self.xlabel)
+        self.ax.set_ylabel(
+            axparams["y"]["label"] if self.ylabel is None else self.ylabel)
         self.ax.set_xscale(axparams["x"]["scale"])
         self.ax.set_yscale(axparams["y"]["scale"])
 

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -284,7 +284,8 @@ void main() {
                             tick, precision=1),
                                              position=tick_pos.tolist(),
                                              size=self.tick_size))
-            axis_label = axparams[x]["label"] if self.axlabels[x] is None else self.axlabels[x]
+            axis_label = axparams[x][
+                "label"] if self.axlabels[x] is None else self.axlabels[x]
             ticks_and_labels.add(
                 self._make_axis_tick(
                     string=axis_label,

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -33,7 +33,10 @@ class PlotFigure3d:
                  tick_size=None,
                  background=None,
                  show_outline=True,
-                 extend=None):
+                 extend=None,
+                 xlabel=None,
+                 ylabel=None,
+                 zlabel=None):
 
         if figsize is None:
             figsize = (config.plot.width, config.plot.height)
@@ -52,7 +55,7 @@ class PlotFigure3d:
             self.masks_scalar_map = cm.ScalarMappable(norm=norm,
                                                       cmap=self.masks_cmap)
 
-        self.axlabels = {"x": "", "y": "", "z": ""}
+        self.axlabels = {"x": xlabel, "y": ylabel, "z": zlabel}
         self.positions = None
         self.pixel_size = pixel_size
         self.tick_size = tick_size
@@ -93,8 +96,8 @@ class PlotFigure3d:
                                     width=figsize[0],
                                     height=figsize[1])
 
-        self.figure = ipw.HBox(
-            [self.toolbar._to_widget(), self.renderer, self.cbar_image])
+        # self.figure = ipw.HBox(
+        #     [self.toolbar._to_widget(), self.renderer, self.cbar_image])
 
         return
 
@@ -108,7 +111,8 @@ class PlotFigure3d:
         """
         Return the renderer and the colorbar into a widget box.
         """
-        return self.figure
+        return ipw.HBox(
+            [self.toolbar._to_widget(), self.renderer, self.cbar_image])
 
     def savefig(self, filename=None):
         """
@@ -280,12 +284,13 @@ void main() {
                             tick, precision=1),
                                              position=tick_pos.tolist(),
                                              size=self.tick_size))
+            axis_label = axparams[x]["label"] if self.axlabels[x] is None else self.axlabels[x]
             ticks_and_labels.add(
                 self._make_axis_tick(
-                    string=axparams[x]["label"],
+                    string=axis_label,
                     position=(iden[axis] * 0.5 * np.sum(axparams[x]["lims"]) +
                               offsets[x]).tolist(),
-                    size=self.tick_size * 0.3 * len(axparams[x]["label"])))
+                    size=self.tick_size * 0.3 * len(axis_label)))
 
         return ticks_and_labels
 

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -96,11 +96,6 @@ class PlotFigure3d:
                                     width=figsize[0],
                                     height=figsize[1])
 
-        # self.figure = ipw.HBox(
-        #     [self.toolbar._to_widget(), self.renderer, self.cbar_image])
-
-        return
-
     def _ipython_display_(self):
         """
         IPython display representation for Jupyter notebooks.

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -35,7 +35,8 @@ class Plot(dict):
         import ipywidgets as ipw
         contents = []
         for item in self.values():
-            contents.append(item._to_widget())
+            if item is not None:
+                contents.append(item._to_widget())
         return ipw.VBox(contents)
 
     def show(self):

--- a/python/src/scipp/plot/plot1d.py
+++ b/python/src/scipp/plot/plot1d.py
@@ -24,7 +24,8 @@ def plot1d(*args, filename=None, **kwargs):
     sp = SciPlot1d(*args, **kwargs)
     if filename is not None:
         sp.savefig(filename)
-    return sp
+    else:
+        return sp
 
 
 class SciPlot1d(SciPlot):
@@ -50,7 +51,9 @@ class SciPlot1d(SciPlot):
                  vmax=None,
                  scale=None,
                  grid=False,
-                 title=None):
+                 title=None,
+                 xlabel=None,
+                 ylabel=None):
 
         view_ndims = 1
 
@@ -89,7 +92,9 @@ class SciPlot1d(SciPlot):
                                masks=self.masks,
                                mpl_line_params=mpl_line_params,
                                picker=True,
-                               grid=grid)
+                               grid=grid,
+                               xlabel=xlabel,
+                               ylabel=ylabel)
 
         # Profile view which displays an additional dimension as a 1d plot
         if self.ndim > 1:

--- a/python/src/scipp/plot/plot2d.py
+++ b/python/src/scipp/plot/plot2d.py
@@ -20,7 +20,8 @@ def plot2d(*args, filename=None, **kwargs):
     sp = SciPlot2d(*args, **kwargs)
     if filename is not None:
         sp.savefig(filename)
-    return sp
+    else:
+        return sp
 
 
 class SciPlot2d(SciPlot):
@@ -44,7 +45,10 @@ class SciPlot2d(SciPlot):
                  scale=None,
                  vmin=None,
                  vmax=None,
-                 resolution=None):
+                 resolution=None,
+                 title=None,
+                 xlabel=None,
+                 ylabel=None):
 
         view_ndims = 2
 
@@ -81,11 +85,14 @@ class SciPlot2d(SciPlot):
                                aspect=aspect,
                                cmap=self.params["values"][self.name]["cmap"],
                                norm=self.params["values"][self.name]["norm"],
-                               title=self.name,
+                               name=self.name,
                                cbar=self.params["values"][self.name]["cbar"],
                                unit=self.params["values"][self.name]["unit"],
                                masks=self.masks[self.name],
-                               extend=self.extend_cmap)
+                               extend=self.extend_cmap,
+                               title=title,
+                               xlabel=xlabel,
+                               ylabel=ylabel)
 
         # Profile view which displays an additional dimension as a 1d plot
         if self.ndim > 2:

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -21,7 +21,8 @@ def plot3d(*args, filename=None, **kwargs):
     sp = SciPlot3d(*args, **kwargs)
     if filename is not None:
         sp.savefig(filename)
-    return sp
+    else:
+        return sp
 
 
 class SciPlot3d(SciPlot):
@@ -49,7 +50,10 @@ class SciPlot3d(SciPlot):
                  background="#f0f0f0",
                  pixel_size=1.0,
                  tick_size=None,
-                 show_outline=True):
+                 show_outline=True,
+                 xlabel=None,
+                 ylabel=None,
+                 zlabel=None):
 
         view_ndims = 3
 
@@ -93,7 +97,10 @@ class SciPlot3d(SciPlot):
             background=background,
             show_outline=show_outline,
             figsize=figsize,
-            extend=self.extend_cmap)
+            extend=self.extend_cmap,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            zlabel=zlabel)
 
         # An additional panel view with widgets to control the cut surface
         self.panel = PlotPanel3d(pixel_size=pixel_size)

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -49,6 +49,10 @@ class SciPlot:
         self.view = None
         self.widgets = None
 
+        # Shortcut access to the underlying figure for easier modification
+        self.fig = None
+        self.ax = None
+
         # Get first item in dict and process dimensions.
         # Dimensions should be the same for all dict items.
         self.axes = None
@@ -179,6 +183,10 @@ class SciPlot:
         have been created.
         """
         self.controller.render(*args, **kwargs)
+        if hasattr(self.view.figure, "fig"):
+            self.fig = self.view.figure.fig
+        if hasattr(self.view.figure, "ax"):
+            self.ax = self.view.figure.ax
 
     def _process_axes_dimensions(self,
                                  array=None,

--- a/python/tests/plot/test_plot_1d.py
+++ b/python/tests/plot/test_plot_1d.py
@@ -191,3 +191,15 @@ def test_plot_string_axis_labels_1d_short():
                               values=np.random.random(N),
                               unit=sc.units.counts)
     plot(d)
+
+
+def test_plot_customized_mpl_axes():
+    d = make_dense_dataset(ndim=1)
+    plot(d["Sample"], title="MyTitle", xlabel="MyXlabel", ylabel="MyYlabel")
+
+
+def test_plot_access_ax_and_fig():
+    d = make_dense_dataset(ndim=1)
+    out = plot(d["Sample"], title="MyTitle")
+    out['tof.counts'].ax.set_xlabel("MyXlabel")
+    out['tof.counts'].fig.set_dpi(120.)

--- a/python/tests/plot/test_plot_2d.py
+++ b/python/tests/plot/test_plot_2d.py
@@ -230,3 +230,15 @@ def test_plot_2d_binned_data_with_variances_nbin():
 
 def test_plot_2d_binned_data_with_masks():
     plot(make_binned_data_array(ndim=2, masks=True))
+
+
+def test_plot_customized_mpl_axes():
+    d = make_dense_dataset(ndim=2)
+    plot(d["Sample"], title="MyTitle", xlabel="MyXlabel", ylabel="MyYlabel")
+
+
+def test_plot_access_ax_and_fig():
+    d = make_dense_dataset(ndim=2)
+    out = plot(d["Sample"], title="MyTitle")
+    out["Sample"].ax.set_xlabel("MyXlabel")
+    out["Sample"].fig.set_dpi(120.)

--- a/python/tests/plot/test_plot_3d.py
+++ b/python/tests/plot/test_plot_3d.py
@@ -92,5 +92,9 @@ def test_plot_4d_with_masks_projection_3d():
 
 
 def test_plot_customized_axes():
-    d = make_dense_dataset(ndim=1)
-    plot(d["Sample"], xlabel="MyXlabel", ylabel="MyYlabel", zlabel="MyZlabel")
+    d = make_dense_dataset(ndim=3)
+    plot(d["Sample"],
+         projection="3d",
+         xlabel="MyXlabel",
+         ylabel="MyYlabel",
+         zlabel="MyZlabel")

--- a/python/tests/plot/test_plot_3d.py
+++ b/python/tests/plot/test_plot_3d.py
@@ -89,3 +89,8 @@ def test_plot_4d_with_masks_projection_3d():
                                           values=np.where(
                                               a > 0.5, True, False))
     plot(data, projection="3d")
+
+
+def test_plot_customized_axes():
+    d = make_dense_dataset(ndim=1)
+    plot(d["Sample"], xlabel="MyXlabel", ylabel="MyYlabel", zlabel="MyZlabel")


### PR DESCRIPTION
This gives easier access to the matplotlib axes and figure of a plot object.

Before:
```
out = plot(d['noise'])
out['noise'].view.figure.ax.set_title('This is a new title!')
```

After:
```
out = plot(d['noise'])
out['noise'].ax.set_title('This is a new title!')
```

Also add kwargs to set axes labels and title directly in the `plot` function:
```
plot(da, title="MyTitle", xlabel="New Xlabel")
```

Also hide legend entry if data name is empty (in the case of plotting a DataArray) in 1d plots.

Fixes #1393 
Fixes #1377 
