### PR TITLE
More gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ compile_commands.json
 
 build/
 install/
+cmake-build-*
 .clangd/
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 compile_commands.json
 
 build/
+install/
 .clangd/
 .idea/
 .vscode/


### PR DESCRIPTION
Add two things to .gitignore:
- `install/` The developer docs suggest, using this directory for installing scipp.
- `cmake-install-*` These directories are created by CLion when building the library and tests. Since we already support IntelliJ files by ignoring `.idea/`, we can also ignore those build directories.