### PR TITLE
CMake option to turn off multi threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,11 @@ include(pybind11)
 include(GoogleBenchmark)
 include(GenerateExportHeader)
 find_package(Boost 1.67 REQUIRED)
-find_package(TBB CONFIG)
+
+option(DISABLE_MULTI_THREADING "Disable multi threading" OFF)
+if(NOT DISABLE_MULTI_THREADING)
+  find_package(TBB CONFIG)
+endif()
 if(TBB_FOUND)
   set(ENABLE_THREAD_LIMIT
       OFF

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -94,6 +94,7 @@ Additional build options
 
 1. ``-DDYNAMIC_LIB`` forces the shared libraries building, that also decreases link time.
 2. ``-DENABLE_THREAD_LIMIT`` limits the maximum number of threads that TBB can use. This defaults to the maximum number of cores identified on your build system. You may then optionally apply an artificial limit via ``-DTHREAD_LIMIT``.
+3. ``-DDISABLE_MULTI_THREADING`` disable multi-threading. By default, multi-threading is enabled if TBB was found. If this option is set to ``ON``, it overrides that.
 
 Running the unit tests
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds `-DDISABLE_MULTI_THREADING` to CMake which overrides the automatic choice of whether to build with TBB, It is `OFF` by default because it should probably only be used in special cases.