### PR TITLE
Add check to prevent bad rebin if there are unaligned (2d) bins

### DIFF
--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -26,7 +26,9 @@ Dimensions::Dimensions(const std::vector<Dim> &labels,
   if (labels.size() != shape.size())
     throw except::DimensionError(
         "Constructing Dimensions: Number of dimensions "
-        "labels does not match shape.");
+        "labels (" +
+        std::to_string(labels.size()) + ") does not match shape size (" +
+        std::to_string(shape.size()) + ").");
   for (scipp::index i = 0; i < scipp::size(shape); ++i)
     addInner(labels[i], shape[i]);
 }

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -278,7 +278,7 @@ auto axis_actions(const DataArrayConstView &array,
             "2-D coordinate " + to_string(array.coords()[dim]) +
             " conflicting with (re)bin of outer dimension. Try specifying new "
             "aligned (1-D) edges for dimension '" +
-            to_string(dim) + "'.");
+            to_string(dim) + "' with the `edges` option of `bin`.");
       axes.emplace_back(AxisAction::Existing, dim, VariableConstView{});
     }
   }


### PR DESCRIPTION
Previous implementation allowed rebinning (e.g., merging) bins of an outer dimension, *keeping* binning of any inner dimensions. However, if those inner bins are unaligned (indicated by presence of a 2d coord) this would give wrong results.

Add checks and test.