### PR TITLE
Enable multi-threading when histogramming binned dimensions

### DIFF
--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -10,6 +10,7 @@
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
+#include "scipp/core/element/util.h"
 #include "scipp/core/histogram.h"
 #include "scipp/core/transform_common.h"
 
@@ -49,7 +50,6 @@ using args = std::tuple<span<Out>, span<const Coord>, span<const Weight>,
 }
 
 static constexpr auto histogram = overloaded{
-    transform_flags::zero_output,
     element::arg_list<histogram_detail::args<float, double, float, double>,
                       histogram_detail::args<double, double, double, double>,
                       histogram_detail::args<double, float, double, double>,
@@ -57,6 +57,7 @@ static constexpr auto histogram = overloaded{
                       histogram_detail::args<double, double, float, double>>,
     [](const auto &data, const auto &events, const auto &weights,
        const auto &edges) {
+      zero(data);
       // Special implementation for linear bins. Gives a 1x to 20x speedup
       // for few and many events per histogram, respectively.
       if (scipp::numeric::is_linspace(edges)) {

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -104,10 +104,6 @@ static constexpr auto expect_all_or_none_have_variance = []() {};
 using expect_all_or_none_have_variance_t =
     decltype(expect_all_or_none_have_variance);
 
-/// Initialize output with zeros. Used only by transform_subspan.
-static constexpr auto zero_output = []() {};
-using zero_output_t = decltype(zero_output);
-
 } // namespace transform_flags
 
 } // namespace scipp::core

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -276,6 +276,8 @@ public:
   auto &underlying() const { return *m_variable; }
   bool is_trivial() const noexcept;
 
+  void rename(const Dim from, const Dim to);
+
   core::ElementArrayViewParams array_params() const noexcept {
     return {m_offset, m_dims, m_dataDims, {}};
   }

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -807,10 +807,14 @@ TEST(VariableTest, rename) {
   VariableConstView view(var);
   view.rename(Dim::Y, Dim::Z);
   ASSERT_EQ(view, expected);
+  ASSERT_EQ(view.slice({Dim::X, 1}), expected.slice({Dim::X, 1}));
+  ASSERT_EQ(view.slice({Dim::Z, 1}), expected.slice({Dim::Z, 1}));
   ASSERT_NE(var, expected);
 
   var.rename(Dim::Y, Dim::Z);
   ASSERT_EQ(view, expected);
+  ASSERT_EQ(view.slice({Dim::X, 1}), expected.slice({Dim::X, 1}));
+  ASSERT_EQ(view.slice({Dim::Z, 1}), expected.slice({Dim::Z, 1}));
   ASSERT_EQ(var, expected);
 }
 

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -804,7 +804,13 @@ TEST(VariableTest, rename) {
                                   Variances{7, 8, 9, 10, 11, 12});
   const Variable expected(reshape(var, {{Dim::X, 2}, {Dim::Z, 3}}));
 
+  VariableConstView view(var);
+  view.rename(Dim::Y, Dim::Z);
+  ASSERT_EQ(view, expected);
+  ASSERT_NE(var, expected);
+
   var.rename(Dim::Y, Dim::Z);
+  ASSERT_EQ(view, expected);
   ASSERT_EQ(var, expected);
 }
 

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -182,6 +182,14 @@ void Variable::rename(const Dim from, const Dim to) {
     data().m_dimensions.relabel(dims().index(from), to);
 }
 
+/// Rename dims of a view. Does NOT rename dims of the underlying variable.
+void VariableConstView::rename(const Dim from, const Dim to) {
+  if (dims().contains(from)) {
+    m_dims.relabel(m_dims.index(from), to);
+    m_dataDims.relabel(m_dataDims.index(from), to);
+  }
+}
+
 void Variable::setVariances(Variable v) {
   if (v)
     core::expect::equals(unit(), v.unit());


### PR DESCRIPTION
Fixes #1435.

There is one down-side to this approach: If there are *many* bins along the histogramming dimension we may end up creating a large temporary array. We can solve that when we run into that problem in real life (on solution would be to process in chunks, enabling multi-threading but avoiding excessive allocations). For now the multi-threading we gain seems more important and relevant in more cases.