### PR TITLE
Add wrapper to sort on python side.

### DIFF
--- a/dataset/include/scipp/dataset/sort.h
+++ b/dataset/include/scipp/dataset/sort.h
@@ -7,19 +7,26 @@
 #include <vector>
 
 #include <scipp/dataset/dataset.h>
+#include <scipp/variable/util.h>
 #include <scipp/variable/variable.h>
 
-namespace scipp::dataset {
+using scipp::variable::SortOrder;
 
-SCIPP_DATASET_EXPORT Variable sort(const VariableConstView &var,
-                                   const VariableConstView &key);
-SCIPP_DATASET_EXPORT DataArray sort(const DataArrayConstView &array,
-                                    const VariableConstView &key);
-SCIPP_DATASET_EXPORT DataArray sort(const DataArrayConstView &array,
-                                    const Dim &key);
-SCIPP_DATASET_EXPORT Dataset sort(const DatasetConstView &dataset,
-                                  const VariableConstView &key);
-SCIPP_DATASET_EXPORT Dataset sort(const DatasetConstView &dataset,
-                                  const Dim &key);
+namespace scipp::dataset {
+SCIPP_DATASET_EXPORT Variable
+sort(const VariableConstView &var, const VariableConstView &key,
+     const SortOrder &order = SortOrder::Ascending);
+SCIPP_DATASET_EXPORT DataArray
+sort(const DataArrayConstView &array, const VariableConstView &key,
+     const SortOrder &order = SortOrder::Ascending);
+SCIPP_DATASET_EXPORT DataArray
+sort(const DataArrayConstView &array, const Dim &key,
+     const SortOrder &order = SortOrder::Ascending);
+SCIPP_DATASET_EXPORT Dataset
+sort(const DatasetConstView &dataset, const VariableConstView &key,
+     const SortOrder &order = SortOrder::Ascending);
+SCIPP_DATASET_EXPORT Dataset
+sort(const DatasetConstView &dataset, const Dim &key,
+     const SortOrder &order = SortOrder::Ascending);
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/sort.h
+++ b/dataset/include/scipp/dataset/sort.h
@@ -10,9 +10,9 @@
 #include <scipp/variable/util.h>
 #include <scipp/variable/variable.h>
 
+namespace scipp::dataset {
 using scipp::variable::SortOrder;
 
-namespace scipp::dataset {
 SCIPP_DATASET_EXPORT Variable
 sort(const VariableConstView &var, const VariableConstView &key,
      const SortOrder &order = SortOrder::Ascending);

--- a/dataset/sort.cpp
+++ b/dataset/sort.cpp
@@ -11,11 +11,11 @@
 #include "scipp/variable/indexed_slice_view.h"
 
 using scipp::variable::IndexedSliceView;
+using scipp::variable::SortOrder;
 
 namespace scipp::dataset {
-
 template <class T> struct MakePermutation {
-  static auto apply(const VariableConstView &key) {
+  static auto apply(const VariableConstView &key, const SortOrder &order) {
     if (key.dims().ndim() != 1)
       throw except::DimensionError("Sort key must be 1-dimensional");
 
@@ -24,44 +24,59 @@ template <class T> struct MakePermutation {
 
     std::vector<scipp::index> permutation(values.size());
     std::iota(permutation.begin(), permutation.end(), 0);
-    std::sort(
-        permutation.begin(), permutation.end(),
-        [&](scipp::index i, scipp::index j) { return values[i] < values[j]; });
+    if (order == SortOrder::Ascending) {
+      std::sort(permutation.begin(), permutation.end(),
+                [&](scipp::index i, scipp::index j) {
+                  return values[i] < values[j];
+                });
+    } else {
+      std::sort(permutation.begin(), permutation.end(),
+                [&](scipp::index i, scipp::index j) {
+                  return values[i] > values[j];
+                });
+    }
     return permutation;
   }
 };
 
-static auto makePermutation(const VariableConstView &key) {
+static auto makePermutation(const VariableConstView &key,
+                            const SortOrder &order) {
   return core::CallDType<double, float, int64_t, int32_t, bool,
-                         std::string>::apply<MakePermutation>(key.dtype(), key);
+                         std::string>::apply<MakePermutation>(key.dtype(), key,
+                                                              order);
 }
 
 /// Return a Variable sorted based on key.
-Variable sort(const VariableConstView &var, const VariableConstView &key) {
+Variable sort(const VariableConstView &var, const VariableConstView &key,
+              const SortOrder &order) {
   return concatenate(
-      IndexedSliceView{var, key.dims().inner(), makePermutation(key)});
+      IndexedSliceView{var, key.dims().inner(), makePermutation(key, order)});
 }
 
 /// Return a DataArray sorted based on key.
-DataArray sort(const DataArrayConstView &array, const VariableConstView &key) {
+DataArray sort(const DataArrayConstView &array, const VariableConstView &key,
+               const SortOrder &order) {
   return concatenate(
-      IndexedSliceView{array, key.dims().inner(), makePermutation(key)});
+      IndexedSliceView{array, key.dims().inner(), makePermutation(key, order)});
 }
 
 /// Return a DataArray sorted based on coordinate.
-DataArray sort(const DataArrayConstView &array, const Dim &key) {
-  return sort(array, array.coords()[key]);
+DataArray sort(const DataArrayConstView &array, const Dim &key,
+               const SortOrder &order) {
+  return sort(array, array.coords()[key], order);
 }
 
 /// Return a Dataset sorted based on key.
-Dataset sort(const DatasetConstView &dataset, const VariableConstView &key) {
-  return concatenate(
-      IndexedSliceView{dataset, key.dims().inner(), makePermutation(key)});
+Dataset sort(const DatasetConstView &dataset, const VariableConstView &key,
+             const SortOrder &order) {
+  return concatenate(IndexedSliceView{dataset, key.dims().inner(),
+                                      makePermutation(key, order)});
 }
 
 /// Return a Dataset sorted based on coordinate.
-Dataset sort(const DatasetConstView &dataset, const Dim &key) {
-  return sort(dataset, dataset.coords()[key]);
+Dataset sort(const DatasetConstView &dataset, const Dim &key,
+             const SortOrder &order) {
+  return sort(dataset, dataset.coords()[key], order);
 }
 
 } // namespace scipp::dataset

--- a/dataset/sort.cpp
+++ b/dataset/sort.cpp
@@ -11,7 +11,6 @@
 #include "scipp/variable/indexed_slice_view.h"
 
 using scipp::variable::IndexedSliceView;
-using scipp::variable::SortOrder;
 
 namespace scipp::dataset {
 template <class T> struct MakePermutation {

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -31,6 +31,7 @@ from ._cumulative import *
 from ._dataset import *
 from ._groupby import *
 from ._math import *
+from ._operations import *
 from ._reduction import *
 from ._shape import *
 from ._trigonometry import *

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Matthew Andrew
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+
+
+def sort(x, key, order='ascending'):
+    """Sort variable along a dimension by a sort key or dimension label
+
+    :param x: Data to be sorted.
+    :param key: Either a 1D variable sort key or a dimension label.
+    :param order: Optional Sorted order. Valid options are 'ascending' and
+      'descending'. Default is 'ascending'.
+    :type x: Dataset, DataArray, Variable
+    :type key: Variable, str
+    :type order: str
+    :raises: If the key is invalid, e.g., if it does not have
+      exactly one dimension, or if its dtype is not sortable.
+    :return: The sorted equivalent of the input.
+    """
+    return _call_cpp_func(_cpp.sort, x, key, order)

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -20,7 +20,7 @@ is_linspace(const VariableConstView &var, const Dim dim);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 variances(const VariableConstView &x);
 
-enum class SortOrder { Ascending, Descending };
+enum class SCIPP_VARIABLE_EXPORT SortOrder { Ascending, Descending };
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT bool
 is_sorted(const VariableConstView &x, const Dim dim,


### PR DESCRIPTION
Review/merge after #1434

This provides a wrapper to sort to improve the documentation and make the way the function is called more pythonic.
Two changes have been made to the functionality here:
  * The keyword `dim` has been replaced with `key` such that the same keyword is used independent of whether you pass a Variable or a dimension label as the sort key.
  * An order argument has been added to all the cases which did not have one.