### PR TITLE
Use int32 target bin index in "bin" for 10-20% speedup

### DIFF
--- a/core/include/scipp/core/element/bin.h
+++ b/core/include/scipp/core/element/bin.h
@@ -121,8 +121,8 @@ static constexpr auto update_indices_from_existing = overloaded{
 // - `offsets` Start indices of the output bins
 // - `bin_indices` Target output bin index (within input bin)
 template <class T, class Index>
-using bin_arg =
-    std::tuple<span<T>, span<const Index>, span<const T>, span<const Index>>;
+using bin_arg = std::tuple<span<T>, span<const scipp::index>, span<const T>,
+                           span<const Index>>;
 static constexpr auto bin = overloaded{
     element::arg_list<
         bin_arg<double, int64_t>, bin_arg<double, int32_t>,
@@ -155,8 +155,8 @@ static constexpr auto bin = overloaded{
 
 static constexpr auto count_indices = overloaded{
     element::arg_list<
-        std::tuple<scipp::span<int64_t>, scipp::span<const int64_t>>,
-        std::tuple<scipp::span<int32_t>, scipp::span<const int32_t>>>,
+        std::tuple<scipp::span<scipp::index>, scipp::span<const int64_t>>,
+        std::tuple<scipp::span<scipp::index>, scipp::span<const int32_t>>>,
     [](const units::Unit &counts, const units::Unit &indices) {
       expect::equals(indices, units::one);
       expect::equals(counts, units::one);

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -91,7 +91,7 @@ constexpr auto is_linspace =
                [](const auto &range) { return numeric::is_linspace(range); }};
 
 constexpr auto zip = overloaded{
-    arg_list<scipp::index>, transform_flags::expect_no_variance_arg<0>,
+    arg_list<int64_t, int32_t>, transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     [](const units::Unit &first, const units::Unit &second) {
       expect::equals(first, second);

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -13,6 +13,7 @@
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/bins.h"
 #include "scipp/variable/cumulative.h"
+#include "scipp/variable/misc_operations.h"
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/subspan_view.h"
@@ -53,16 +54,19 @@ void update_indices_by_binning(const VariableView &indices,
   }
 }
 
+template <class Index>
 Variable groups_to_map(const VariableConstView &var, const Dim dim) {
   return variable::transform(subspan_view(var, dim),
-                             core::element::groups_to_map);
+                             core::element::groups_to_map<Index>);
 }
 
 void update_indices_by_grouping(const VariableView &indices,
                                 const VariableConstView &key,
                                 const VariableConstView &groups) {
   const auto dim = groups.dims().inner();
-  const auto map = groups_to_map(groups, dim);
+  const auto map = (indices.dtype() == dtype<int64_t>)
+                       ? groups_to_map<int64_t>(groups, dim)
+                       : groups_to_map<int32_t>(groups, dim);
   variable::transform_in_place(indices, key, map,
                                core::element::update_indices_by_grouping);
 }
@@ -118,9 +122,13 @@ auto bin(const VariableConstView &data, const VariableConstView &indices,
       output_bin_sizes = sum(output_bin_sizes, dim);
     }
   offsets += cumsum_bins(output_bin_sizes, CumSumMode::Exclusive);
+  if (output_bin_sizes.dtype() != dtype<scipp::index>)
+    output_bin_sizes = astype(output_bin_sizes, dtype<scipp::index>);
   Variable filtered_input_bin_size = buckets::sum(output_bin_sizes);
   auto end = cumsum(filtered_input_bin_size);
-  const auto total_size = end.values<scipp::index>().as_span().back();
+  const auto total_size = end.dtype() == dtype<int64_t>
+                              ? end.values<int64_t>().as_span().back()
+                              : end.values<int32_t>().as_span().back();
   end = broadcast(end, data.dims()); // required for some cases of rebinning
   const auto filtered_input_bin_ranges =
       zip(end - filtered_input_bin_size, end);
@@ -353,12 +361,14 @@ auto hide_masked(const DataArrayConstView &array, const Dimensions &dims) {
 
 template <class T> class TargetBins {
 public:
-  TargetBins(const VariableConstView &var) {
+  TargetBins(const VariableConstView &var, const Dimensions &dims) {
     // In some cases all events in an input bin map to the same output, but
     // right now bin<> cannot handle this and requires target bin indices for
     // every bin element.
     const auto &[begin_end, dim, buffer] = var.constituents<core::bin<T>>();
-    m_target_bins_buffer = makeVariable<scipp::index>(buffer.dims());
+    m_target_bins_buffer = (dims.volume() > std::numeric_limits<int32_t>::max())
+                               ? makeVariable<int64_t>(buffer.dims())
+                               : makeVariable<int32_t>(buffer.dims());
     m_target_bins = make_non_owning_bins(begin_end, dim,
                                          VariableView(m_target_bins_buffer));
   }
@@ -379,7 +389,7 @@ template <class T>
 Variable concat_bins(const VariableConstView &var, const Dim dim) {
   TargetBinBuilder builder;
   builder.erase(dim);
-  TargetBins<T> target_bins(var);
+  TargetBins<T> target_bins(var, builder.dims());
   builder.build(*target_bins, std::map<Dim, Variable>{});
   auto [buffer, bin_sizes] = bin<DataArray>(var, *target_bins, builder.dims());
   squeeze(bin_sizes, {dim});
@@ -414,7 +424,7 @@ DataArray groupby_concat_bins(const DataArrayConstView &array,
       builder.join(dim, array.coords()[dim]);
 
   const auto masked = hide_masked(array, builder.dims());
-  TargetBins<DataArrayConstView> target_bins(masked);
+  TargetBins<DataArrayConstView> target_bins(masked, builder.dims());
   builder.build(*target_bins, array.coords());
   return add_metadata(
       bin<DataArrayConstView>(masked, *target_bins, builder.dims()), array,
@@ -428,7 +438,7 @@ DataArray bin(const DataArrayConstView &array,
   auto builder = axis_actions(array, edges, groups);
   if (array.dtype() == dtype<core::bin<DataArray>>) {
     const auto masked = hide_masked(array, builder.dims());
-    TargetBins<DataArrayConstView> target_bins(masked);
+    TargetBins<DataArrayConstView> target_bins(masked, builder.dims());
     builder.build(*target_bins, bins_view<DataArrayConstView>(masked).coords());
     proto = bin<DataArrayConstView>(masked, *target_bins, builder.dims());
   } else {
@@ -444,7 +454,10 @@ DataArray bin(const DataArrayConstView &array,
     end.values<scipp::index>().as_span().back() = array.dims()[dim];
     const auto indices = zip(begin, end);
     const auto tmp = make_non_owning_bins(indices, dim, array);
-    auto target_bins_buffer = makeVariable<scipp::index>(array.dims());
+    auto target_bins_buffer =
+        (array.dims().volume() > std::numeric_limits<int32_t>::max())
+            ? makeVariable<int64_t>(array.dims())
+            : makeVariable<int32_t>(array.dims());
     builder.build(target_bins_buffer, array.coords());
     const auto target_bins = make_non_owning_bins(
         indices, dim, VariableConstView(target_bins_buffer));

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -70,6 +70,9 @@ class BucketVariableMakerDataset : public variable::AbstractVariableMaker {
                   const std::vector<VariableConstView> &) const override {
     throw std::runtime_error("not implemented");
   }
+  Dim elem_dim(const VariableConstView &) const override {
+    throw std::runtime_error("undefined");
+  }
   DType elem_dtype(const VariableConstView &) const override {
     throw std::runtime_error("undefined");
   }

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -106,6 +106,9 @@ public:
                         variances);
   }
 
+  Dim elem_dim(const VariableConstView &var) const override {
+    return std::get<1>(var.constituents<bucket<T>>());
+  }
   DType elem_dtype(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<T>>()).dtype();
   }

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -23,6 +23,7 @@ public:
   create(const DType elem_dtype, const Dimensions &dims,
          const units::Unit &unit, const bool variances,
          const std::vector<VariableConstView> &parents) const = 0;
+  virtual Dim elem_dim(const VariableConstView &var) const = 0;
   virtual DType elem_dtype(const VariableConstView &var) const = 0;
   virtual units::Unit elem_unit(const VariableConstView &var) const = 0;
   virtual void set_elem_unit(const VariableView &var,
@@ -52,6 +53,9 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
     else
       return makeVariable<T>(dims, unit,
                              Values(volume, core::default_init_elements));
+  }
+  Dim elem_dim(const VariableConstView &) const override {
+    return Dim::Invalid;
   }
   DType elem_dtype(const VariableConstView &var) const override {
     return var.dtype();
@@ -100,6 +104,7 @@ public:
         ->create(elem_dtype, dims, unit, variances,
                  std::vector<VariableConstView>{parents...});
   }
+  Dim elem_dim(const VariableConstView &var) const;
   DType elem_dtype(const VariableConstView &var) const;
   units::Unit elem_unit(const VariableConstView &var) const;
   void set_elem_unit(const VariableView &var, const units::Unit &u) const;

--- a/variable/variable_factory.cpp
+++ b/variable/variable_factory.cpp
@@ -18,6 +18,10 @@ bool VariableFactory::is_buckets(const VariableConstView &var) const {
   return m_makers.at(var.dtype())->is_buckets();
 }
 
+Dim VariableFactory::elem_dim(const VariableConstView &var) const {
+  return m_makers.at(var.dtype())->elem_dim(var);
+}
+
 DType VariableFactory::elem_dtype(const VariableConstView &var) const {
   return m_makers.at(var.dtype())->elem_dtype(var);
 }

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -7,7 +7,8 @@
 
 namespace scipp::variable {
 
-INSTANTIATE_VARIABLE(pair_int64, std::pair<scipp::index, scipp::index>)
+INSTANTIATE_VARIABLE(pair_int64, std::pair<int64_t, int64_t>)
+INSTANTIATE_VARIABLE(pair_int32, std::pair<int32_t, int32_t>)
 INSTANTIATE_BUCKET_VARIABLE(VariableView, bucket<Variable>)
 INSTANTIATE_BUCKET_VARIABLE(VariableView_observer, bucket<VariableView>)
 INSTANTIATE_BUCKET_VARIABLE(VariableConstView_observer,

--- a/variable/variable_instantiate_map_elements.cpp
+++ b/variable/variable_instantiate_map_elements.cpp
@@ -11,17 +11,34 @@
 namespace scipp::variable {
 
 // Used internally in implementation of grouping and binning
-INSTANTIATE_VARIABLE(unordered_map_double_to_index,
-                     std::unordered_map<double, scipp::index>)
-INSTANTIATE_VARIABLE(unordered_map_float_to_index,
-                     std::unordered_map<float, scipp::index>)
-INSTANTIATE_VARIABLE(unordered_map_float64_to_index,
-                     std::unordered_map<int64_t, scipp::index>)
-INSTANTIATE_VARIABLE(unordered_map_float32_to_index,
-                     std::unordered_map<int32_t, scipp::index>)
-INSTANTIATE_VARIABLE(unordered_map_bool_to_index,
-                     std::unordered_map<bool, scipp::index>)
-INSTANTIATE_VARIABLE(unordered_map_string_to_index,
-                     std::unordered_map<std::string, scipp::index>)
+INSTANTIATE_VARIABLE(unordered_map_double_to_int64_t,
+                     std::unordered_map<double, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_double_to_int32_t,
+                     std::unordered_map<double, int32_t>)
+
+INSTANTIATE_VARIABLE(unordered_map_float_to_int64_t,
+                     std::unordered_map<float, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_float_to_int32_t,
+                     std::unordered_map<float, int32_t>)
+
+INSTANTIATE_VARIABLE(unordered_map_float64_to_int64_t,
+                     std::unordered_map<int64_t, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_float64_to_int32_t,
+                     std::unordered_map<int64_t, int32_t>)
+
+INSTANTIATE_VARIABLE(unordered_map_float32_to_int64_t,
+                     std::unordered_map<int32_t, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_float32_to_int32_t,
+                     std::unordered_map<int32_t, int32_t>)
+
+INSTANTIATE_VARIABLE(unordered_map_bool_to_int64_t,
+                     std::unordered_map<bool, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_bool_to_int32_t,
+                     std::unordered_map<bool, int32_t>)
+
+INSTANTIATE_VARIABLE(unordered_map_string_to_int64_t,
+                     std::unordered_map<std::string, int64_t>)
+INSTANTIATE_VARIABLE(unordered_map_string_to_int32_t,
+                     std::unordered_map<std::string, int32_t>)
 
 } // namespace scipp::variable


### PR DESCRIPTION
`sc.bin` allocates a variable containing the target bin index for every event in the input. The original implementation used `scipp::index`, i.e., `int64_t` for this. This index not only has to be allocated, but is streamed through multiple times, e.g., once for every "column" in the event table (e.g., time-of-flight, pulse-time, weights), so it contributes to the pressure on the memory system (which is critical, since binning implies semi-random writes).

Since in most cases we have less than "int32_max" target bins per input bit we can instead use `int32_t`.

Tests of binning `5e8` events `-> (1000) -> (1000, 1000)` bins (in to steps) show up to 20% speedup.