### PR TITLE
Variable constructor factories

### DIFF
--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -17,7 +17,7 @@ Classes
    GroupByDataArray
    GroupByDataset
 
-Class factories
+Creation functions
 ===============
 
 .. autosummary::

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -17,6 +17,16 @@ Classes
    GroupByDataArray
    GroupByDataset
 
+Class factories
+===============
+
+.. autosummary::
+   :toctree: ../generated
+
+   array
+   scalar
+   zeros
+
 Free functions
 ==============
 

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -34,7 +34,7 @@
     "import numpy as np\n",
     "import scipp as sc\n",
     "\n",
-    "var = sc.Variable(\n",
+    "var = sc.array(\n",
     "    dims=['z', 'y', 'x'],\n",
     "    values=np.random.rand(2, 3, 4),\n",
     "    variances=np.random.rand(2, 3, 4))\n",
@@ -117,15 +117,15 @@
    "outputs": [],
    "source": [
     "d = sc.Dataset(\n",
-    "    {'a': sc.Variable(dims=['x', 'y'], values=np.random.rand(2, 3)),\n",
-    "     'b': sc.Variable(dims=['y', 'x'], values=np.random.rand(3, 2)),\n",
-    "     'c': sc.Variable(dims=['x'], values=np.random.rand(2)),\n",
-    "     '0d-data': sc.Variable(1.0)},\n",
+    "    {'a': sc.array(dims=['x', 'y'], values=np.random.rand(2, 3)),\n",
+    "     'b': sc.array(dims=['y', 'x'], values=np.random.rand(3, 2)),\n",
+    "     'c': sc.array(dims=['x'], values=np.random.rand(2)),\n",
+    "     '0d-data': sc.scalar(1.0)},\n",
     "    coords={\n",
-    "        'x': sc.Variable(['x'], values=np.arange(2.0), unit=sc.units.m),\n",
-    "        'y': sc.Variable(['y'], values=np.arange(3.0), unit=sc.units.m),\n",
-    "        'aux_x': sc.Variable(['x'], values=np.arange(2.0), unit=sc.units.m),\n",
-    "        'aux_y': sc.Variable(['y'], values=np.arange(3.0), unit=sc.units.m)})\n",
+    "        'x': sc.array(dims=['x'], values=np.arange(2.0), unit=sc.units.m),\n",
+    "        'y': sc.array(dims=['y'], values=np.arange(3.0), unit=sc.units.m),\n",
+    "        'aux_x': sc.array(dims=['x'], values=np.arange(2.0), unit=sc.units.m),\n",
+    "        'aux_y': sc.array(dims=['y'], values=np.arange(3.0), unit=sc.units.m)})\n",
     "sc.show(d)"
    ]
   },
@@ -257,10 +257,10 @@
    "outputs": [],
    "source": [
     "da = sc.DataArray(\n",
-    "    data=sc.Variable(dims=['year','x'], values=np.random.random((3, 7))),\n",
+    "    data=sc.array(dims=['year','x'], values=np.random.random((3, 7))),\n",
     "    coords={\n",
-    "        'x': sc.Variable(['x'], values=np.linspace(0.1, 0.9, num=7), unit=sc.units.m),\n",
-    "        'year': sc.Variable(['year'], values=[2020,2023,2027])})\n",
+    "        'x': sc.array(dims=['x'], values=np.linspace(0.1, 0.9, num=7), unit=sc.units.m),\n",
+    "        'year': sc.array(dims=['year'], values=[2020,2023,2027])})\n",
     "sc.show(da)\n",
     "da"
    ]
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year = 2023 * sc.units.one\n",
+    "year = sc.scalar(2023)\n",
     "da['year', year] "
    ]
   },
@@ -328,7 +328,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = 0.23 * sc.units.m # No x coordinate value at this point\n",
+    "x = 0.23 * sc.units.m # No x coordinate value at this point. Equivalent of sc.scalar(0.23, unit=sc.units.m)\n",
     "try:\n",
     "    da['x', x]\n",
     "except IndexError as e:\n",
@@ -409,9 +409,9 @@
    "outputs": [],
    "source": [
     "da = sc.DataArray(\n",
-    "    data = sc.Variable(dims=['x'], values=np.random.random(7)),\n",
+    "    data = sc.array(dims=['x'], values=np.random.random(7)),\n",
     "    coords={\n",
-    "        'x': sc.Variable(['x'], values=np.linspace(1.0, 2.0, num=8), unit=sc.units.m)})\n",
+    "        'x': sc.array(dims=['x'], values=np.linspace(1.0, 2.0, num=8), unit=sc.units.m)})\n",
     "da"
    ]
   },

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -36,6 +36,7 @@ from ._unary import *
 from ._reduction import *
 from ._shape import *
 from ._trigonometry import *
+from ._variable import *
 
 setattr(Variable, '_repr_html_', make_html)
 setattr(VariableConstView, '_repr_html_', make_html)

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Matthew Andrew
+from ._scipp import core as _cpp
+from . import units, Unit, dtype
+from typing import Any, Sequence
+
+
+def scalar(value: Any, variance: Any = None, unit: Unit = units.one):
+    """Constructs a zero dimensional :class:`Variable` with a unit and optional
+    variance.
+
+    :param value: Initial value.
+    :param variance: Initial variance
+    :param unit: Unit.
+    :type value: Any
+    :type variance: Same type as value
+    :type unit: Unit
+    """
+    return _cpp.Variable(value=value, variance=variance, unit=unit)
+
+
+def zeros(*, dims: Sequence[str], shape: Sequence[int],
+          unit: Unit = units.one, dtype: dtype = dtype.float64,
+          variances: bool = False):
+    """Constructs a default initialised :class:`Variable` with given dimension
+    labels and shape.
+
+    :param dims: Dimension labels.
+    :param shape: Dimension sizes.
+    :param unit: Unit of contents.
+    :param dtype: Type of underlying data.
+    :param variance: Boolean flag, if True include variances.
+    :type dims: list[str]
+    :type shape: list[int]
+    :type unit: Unit
+    :type variance: bool
+    :type dtype: dtype
+    """
+    return _cpp.Variable(dims=dims, shape=shape, unit=unit,
+                         dtype=dtype, variances=variances)
+
+
+def array(*, dims: Sequence[str], values, variances=None,
+          unit: Unit = units.one, dtype: dtype = dtype.float64):
+    """Constructs a :class:`Variable` with given dimensions containing given
+    values. Dimensions and value shape must match.
+
+    :param dims: Dimensions labels.
+    :param values: Initial values.
+    :param variances: Initial variances, must be same shape and size as values.
+    :param unit: Data unit.
+    :param dtype: Type of underlying data.
+    :type dims: list[str]
+    :type values: numpy.ndarray, list
+    :type variances: numpy.ndarray, list
+    :type unit: Unit
+    :type dtype: dtype
+    """
+    return _cpp.Variable(dims=dims, values=values, variances=variances,
+                         unit=unit, dtype=dtype)

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -33,8 +33,8 @@ def scalar(value: Any,
         except TypeError:
             # Raise a more comprehensible error message in the case
             # where a dtype cannot be specified.
-            raise TypeError(f"dtype cannot be specified for value"
-                            f" type of {type(value)}")
+            raise TypeError(f"Cannot convert {value} to {dtype}. "
+                            f"Try omitting the 'dtype=' parameter.")
 
 
 def zeros(*,

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -1,18 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
-from ._scipp import core as _cpp
-from . import units, Unit, dtype
-from typing import Any, Sequence
-
-
-dtype_overload = (bool, int, float, list)
+from ._scipp.core import _Dtype
+from . import units, Unit, dtype, Variable
+from typing import Any, Sequence, Union
+import numpy
 
 
 def scalar(value: Any,
            variance: Any = None,
            unit: Unit = units.dimensionless,
-           dtype: dtype = None):
+           dtype: _Dtype = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
@@ -23,18 +21,15 @@ def scalar(value: Any,
       in which case type is inferred from value input.
       Cannot be specified for value types of
       str, Dataset or DataArray.
-    :type value: Any
-    :type variance: Same type as value
-    :type unit: Unit
     """
     if dtype is None:
-        return _cpp.Variable(value=value, variance=variance, unit=unit)
+        return Variable(value=value, variance=variance, unit=unit)
     else:
         try:
-            return _cpp.Variable(value=value,
-                                 variance=variance,
-                                 unit=unit,
-                                 dtype=dtype)
+            return Variable(value=value,
+                            variance=variance,
+                            unit=unit,
+                            dtype=dtype)
         except TypeError:
             # Raise a more comprehensible error message in the case
             # where a dtype cannot be specified.
@@ -46,8 +41,8 @@ def zeros(*,
           dims: Sequence[str],
           shape: Sequence[int],
           unit: Unit = units.dimensionless,
-          dtype: dtype = dtype.float64,
-          variances: bool = False):
+          dtype: _Dtype = dtype.float64,
+          variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with default initialised values with
     given dimension labels and shape.
     Optionally can add default initialised variances.
@@ -57,29 +52,24 @@ def zeros(*,
     :param shape: Dimension sizes.
     :param unit: Optional, unit of contents. Default=dimensionless
     :param dtype: Optional, type of underlying data. Default=float64
-    :param variance: Optional, boolean flag, if True includes variances
-      initialised to the default value for dtype. 
+    :param variances: Optional, boolean flag, if True includes variances
+      initialised to the default value for dtype.
       For example for a float type values and variances would all be
       initialised to 0.0. Default=False
-    :type dims: list[str]
-    :type shape: list[int]
-    :type unit: Unit
-    :type variance: bool
-    :type dtype: dtype
     """
-    return _cpp.Variable(dims=dims,
-                         shape=shape,
-                         unit=unit,
-                         dtype=dtype,
-                         variances=variances)
+    return Variable(dims=dims,
+                    shape=shape,
+                    unit=unit,
+                    dtype=dtype,
+                    variances=variances)
 
 
 def array(*,
           dims: Sequence[str],
-          values,
-          variances=None,
+          values: Union[numpy.ndarray, list],
+          variances: Union[numpy.ndarray, list] = None,
           unit: Unit = units.dimensionless,
-          dtype: dtype = None):
+          dtype: _Dtype = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
@@ -91,14 +81,9 @@ def array(*,
     :param unit: Optional, data unit. Default=dimensionless
     :param dtype: Optional, type of underlying data. Default=None,
       in which case type is inferred from value input.
-    :type dims: list[str]
-    :type values: numpy.ndarray, list
-    :type variances: numpy.ndarray, list
-    :type unit: Unit
-    :type dtype: dtype
     """
-    return _cpp.Variable(dims=dims,
-                         values=values,
-                         variances=variances,
-                         unit=unit,
-                         dtype=dtype)
+    return Variable(dims=dims,
+                    values=values,
+                    variances=variances,
+                    unit=unit,
+                    dtype=dtype)

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -11,8 +11,8 @@ def scalar(value: Any, variance: Any = None, unit: Unit = units.one):
     variance.
 
     :param value: Initial value.
-    :param variance: Initial variance
-    :param unit: Unit.
+    :param variance: Optional, initial variance, Default=None
+    :param unit: Optional, unit. Default=dimensionless
     :type value: Any
     :type variance: Same type as value
     :type unit: Unit
@@ -24,13 +24,14 @@ def zeros(*, dims: Sequence[str], shape: Sequence[int],
           unit: Unit = units.one, dtype: dtype = dtype.float64,
           variances: bool = False):
     """Constructs a default initialised :class:`Variable` with given dimension
-    labels and shape.
+    labels and shape. Only keyword arguments accepted.
 
     :param dims: Dimension labels.
     :param shape: Dimension sizes.
-    :param unit: Unit of contents.
-    :param dtype: Type of underlying data.
-    :param variance: Boolean flag, if True include variances.
+    :param unit: Optional, unit of contents. Default=dimensionless
+    :param dtype: Optional, type of underlying data. Default=float64
+    :param variance: Optional, boolean flag, if True include variances.
+      Default=False
     :type dims: list[str]
     :type shape: list[int]
     :type unit: Unit
@@ -43,14 +44,17 @@ def zeros(*, dims: Sequence[str], shape: Sequence[int],
 
 def array(*, dims: Sequence[str], values, variances=None,
           unit: Unit = units.one, dtype: dtype = None):
-    """Constructs a :class:`Variable` with given dimensions containing given
-    values. Dimensions and value shape must match.
+    """Constructs a :class:`Variable` with given dimensions, containing given
+    values. Dimension and value shape must match.
+    Only keyword arguments accepted.
 
-    :param dims: Dimensions labels.
+    :param dims: Dimension labels.
     :param values: Initial values.
-    :param variances: Initial variances, must be same shape and size as values.
-    :param unit: Data unit.
-    :param dtype: Type of underlying data.
+    :param variances: Optional, initial variances, must be same shape
+      and size as values. Default=None
+    :param unit: Optional, data unit. Default=dimensionless
+    :param dtype: Optional, type of underlying data. Default=None,
+      in which case type is inferred from value input.
     :type dims: list[str]
     :type values: numpy.ndarray, list
     :type variances: numpy.ndarray, list

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -6,35 +6,61 @@ from . import units, Unit, dtype
 from typing import Any, Sequence
 
 
-def scalar(value: Any, variance: Any = None, unit: Unit = units.one):
+dtype_overload = (bool, int, float, list)
+
+
+def scalar(value: Any,
+           variance: Any = None,
+           unit: Unit = units.dimensionless,
+           dtype: dtype = None):
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
     :param value: Initial value.
     :param variance: Optional, initial variance, Default=None
     :param unit: Optional, unit. Default=dimensionless
+    :param dtype: Optional, type of underlying data. Default=None,
+      in which case type is inferred from value input.
+      Cannot be specified for value types of
+      str, Dataset or DataArray.
     :type value: Any
     :type variance: Same type as value
     :type unit: Unit
     """
-    return _cpp.Variable(value=value, variance=variance, unit=unit)
+    if dtype is None:
+        return _cpp.Variable(value=value, variance=variance, unit=unit)
+    else:
+        try:
+            return _cpp.Variable(value=value,
+                                 variance=variance,
+                                 unit=unit,
+                                 dtype=dtype)
+        except TypeError:
+            # Raise a more comprehensible error message in the case
+            # where a dtype cannot be specified.
+            raise RuntimeError(f"dtype cannot be specified for value"
+                               f"type of {type(value)}")
 
 
 def zeros(*,
           dims: Sequence[str],
           shape: Sequence[int],
-          unit: Unit = units.one,
+          unit: Unit = units.dimensionless,
           dtype: dtype = dtype.float64,
           variances: bool = False):
-    """Constructs a default initialised :class:`Variable` with given dimension
-    labels and shape. Only keyword arguments accepted.
+    """Constructs a :class:`Variable` with default initialised values with
+    given dimension labels and shape.
+    Optionally can add default initialised variances.
+    Only keyword arguments accepted.
 
     :param dims: Dimension labels.
     :param shape: Dimension sizes.
     :param unit: Optional, unit of contents. Default=dimensionless
     :param dtype: Optional, type of underlying data. Default=float64
-    :param variance: Optional, boolean flag, if True include variances.
-      Default=False
+    :param variance: Optional, boolean flag, if True includes variances
+      initialised to the default value for dtype. 
+      For example for a float type values and variances would all be
+      initialised to 0.0. Default=False
     :type dims: list[str]
     :type shape: list[int]
     :type unit: Unit
@@ -52,10 +78,10 @@ def array(*,
           dims: Sequence[str],
           values,
           variances=None,
-          unit: Unit = units.one,
+          unit: Unit = units.dimensionless,
           dtype: dtype = None):
     """Constructs a :class:`Variable` with given dimensions, containing given
-    values. Dimension and value shape must match.
+    values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
 
     :param dims: Dimension labels.

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -20,8 +20,11 @@ def scalar(value: Any, variance: Any = None, unit: Unit = units.one):
     return _cpp.Variable(value=value, variance=variance, unit=unit)
 
 
-def zeros(*, dims: Sequence[str], shape: Sequence[int],
-          unit: Unit = units.one, dtype: dtype = dtype.float64,
+def zeros(*,
+          dims: Sequence[str],
+          shape: Sequence[int],
+          unit: Unit = units.one,
+          dtype: dtype = dtype.float64,
           variances: bool = False):
     """Constructs a default initialised :class:`Variable` with given dimension
     labels and shape. Only keyword arguments accepted.
@@ -38,12 +41,19 @@ def zeros(*, dims: Sequence[str], shape: Sequence[int],
     :type variance: bool
     :type dtype: dtype
     """
-    return _cpp.Variable(dims=dims, shape=shape, unit=unit,
-                         dtype=dtype, variances=variances)
+    return _cpp.Variable(dims=dims,
+                         shape=shape,
+                         unit=unit,
+                         dtype=dtype,
+                         variances=variances)
 
 
-def array(*, dims: Sequence[str], values, variances=None,
-          unit: Unit = units.one, dtype: dtype = None):
+def array(*,
+          dims: Sequence[str],
+          values,
+          variances=None,
+          unit: Unit = units.one,
+          dtype: dtype = None):
     """Constructs a :class:`Variable` with given dimensions, containing given
     values. Dimension and value shape must match.
     Only keyword arguments accepted.
@@ -61,5 +71,8 @@ def array(*, dims: Sequence[str], values, variances=None,
     :type unit: Unit
     :type dtype: dtype
     """
-    return _cpp.Variable(dims=dims, values=values, variances=variances,
-                         unit=unit, dtype=dtype)
+    return _cpp.Variable(dims=dims,
+                         values=values,
+                         variances=variances,
+                         unit=unit,
+                         dtype=dtype)

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -42,7 +42,7 @@ def zeros(*, dims: Sequence[str], shape: Sequence[int],
 
 
 def array(*, dims: Sequence[str], values, variances=None,
-          unit: Unit = units.one, dtype: dtype = dtype.float64):
+          unit: Unit = units.one, dtype: dtype = None):
     """Constructs a :class:`Variable` with given dimensions containing given
     values. Dimensions and value shape must match.
 

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
-from ._scipp.core import _Dtype
 from . import units, Unit, dtype, Variable
 from typing import Any, Sequence, Union
 import numpy
@@ -10,7 +9,7 @@ import numpy
 def scalar(value: Any,
            variance: Any = None,
            unit: Unit = units.dimensionless,
-           dtype: _Dtype = None) -> Variable:
+           dtype: type(dtype.float64) = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
@@ -21,6 +20,7 @@ def scalar(value: Any,
       in which case type is inferred from value input.
       Cannot be specified for value types of
       str, Dataset or DataArray.
+    :raises: Add this
     """
     if dtype is None:
         return Variable(value=value, variance=variance, unit=unit)
@@ -33,15 +33,15 @@ def scalar(value: Any,
         except TypeError:
             # Raise a more comprehensible error message in the case
             # where a dtype cannot be specified.
-            raise RuntimeError(f"dtype cannot be specified for value"
-                               f"type of {type(value)}")
+            raise TypeError(f"dtype cannot be specified for value"
+                            f" type of {type(value)}")
 
 
 def zeros(*,
           dims: Sequence[str],
           shape: Sequence[int],
           unit: Unit = units.dimensionless,
-          dtype: _Dtype = dtype.float64,
+          dtype: type(dtype.float64) = dtype.float64,
           variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with default initialised values with
     given dimension labels and shape.
@@ -69,7 +69,7 @@ def array(*,
           values: Union[numpy.ndarray, list],
           variances: Union[numpy.ndarray, list] = None,
           unit: Unit = units.dimensionless,
-          dtype: _Dtype = None) -> Variable:
+          dtype: type(dtype.float64) = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.

--- a/python/tests/test_variable_creation.py
+++ b/python/tests/test_variable_creation.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import pytest
+import scipp as sc
+
+
+def test_scalar_with_dtype():
+    value = 1.0
+    variance = 5.0
+    unit = sc.units.m
+    dtype = sc.dtype.float64
+    var = sc.scalar(value=value, variance=variance, unit=unit, dtype=dtype)
+    expected = sc.Variable(value=value,
+                           variance=variance,
+                           unit=unit,
+                           dtype=dtype)
+
+    comparison = var == expected
+    assert comparison.values.all()
+
+
+def test_scalar_without_dtype():
+    value = 'temp'
+    var = sc.scalar(value)
+    expected = sc.Variable(value)
+
+    # Cannot directly compare variables with string dtype
+    assert var.values == expected.values
+
+
+def test_scalar_throws_if_dtype_provided_for_str_types():
+    with pytest.raises(TypeError):
+        sc.scalar(value='temp', unit=sc.units.one, dtype=sc.dtype.float64)
+
+
+def test_zeros_creates_variable_with_correct_dims_and_shape():
+    var = sc.zeros(dims=['x', 'y', 'z'], shape=[1, 2, 3])
+    expected = sc.Variable(dims=['x', 'y', 'z'], shape=[1, 2, 3])
+
+    comparison = var == expected
+    assert comparison.values.all()
+
+
+def test_array_creates_correct_variable():
+    dims = ['x']
+    values = [1, 2, 3]
+    variances = [4, 5, 6]
+    unit = sc.units.m
+    dtype = sc.dtype.float64
+    var = sc.array(dims=dims,
+                   values=values,
+                   variances=variances,
+                   unit=unit,
+                   dtype=dtype)
+    expected = sc.Variable(dims=dims,
+                           values=values,
+                           variances=variances,
+                           unit=unit,
+                           dtype=dtype)
+
+    comparison = var == expected
+    assert comparison.values.all()


### PR DESCRIPTION
This adds three wrapper functions around the `Variable` constructor on the python side. These are:
  * `sc.scalar` for constructing 0D Variables
  * `sc.zeros` for constructing default initialized Variables of a given shape.
  * `sc.array` for constructing a Variable from a given array-like object of values.

The notebook slicing.ipynb has also been updated as a demo to show how these wrappers would work in practice. The motivation for adding these wrappers was twofold:
 1) To clean up the documentation of Variable construction.
 2) To simplify the api so that each method only has one set of viable keywords.

Still experimental at this stage.