### PR TITLE
Removed copy overload for Variable init in python

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -728,11 +728,11 @@ def test_make_variable_from_unit_scalar_mult_div():
 
 def test_construct_0d_numpy():
     v = sc.Variable(dims=['x'], values=np.array([0]), dtype=np.float32)
-    var = sc.Variable(v['x', 0])
+    var = v['x', 0].copy()
     assert sc.is_equal(var, sc.Variable(np.float32()))
 
     v = sc.Variable(dims=['x'], values=np.array([0]), dtype=np.float32)
-    var = sc.Variable(v['x', 0])
+    var = v['x', 0].copy()
     var.unit = sc.units.m
     assert sc.is_equal(var, np.float32(0.0) * sc.units.m)
     var.unit = sc.units.m**(-1)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -147,7 +147,7 @@ of variances.)");
   bind_init_0D<scipp::core::time_point>(variable);
   bind_init_0D<Eigen::Vector3d>(variable);
   bind_init_0D<Eigen::Matrix3d>(variable);
-  variable.def(py::init<const VariableView &>())
+  variable
       .def(py::init(&makeVariableDefaultInit),
            py::arg("dims") = std::vector<Dim>{},
            py::arg("shape") = std::vector<scipp::index>{},


### PR DESCRIPTION
This removes the `__init__(VariableView)` init from the python version of the Variable class. I have run the tests and built the docs and I think I have modified the locations which this breaks although obviously there may be some case not covered properly by these checks that I have missed. 

 The motivation for this is that this overload was making the interface more confusing and is not needed in python where the copy method achieves the same thing in a more pythonic way. As the copy method is able to both create a copy of a Variable as well as convert a VariableView to a Variable. The updated test shows how this can be achieved.