### PR TITLE
Support data without variances in `histogram`

### DIFF
--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -18,28 +18,10 @@ namespace scipp::core::element {
 
 namespace {
 constexpr auto value = [](const auto &v, const scipp::index idx) {
-  using V = std::decay_t<decltype(v)>;
-  if constexpr (is_ValueAndVariance_v<V>) {
-    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
-      static_cast<void>(idx);
-      return v.value;
-    } else {
-      return v.value[idx];
-    }
-  } else
-    return v.values[idx];
+  return v.value[idx];
 };
 constexpr auto variance = [](const auto &v, const scipp::index idx) {
-  using V = std::decay_t<decltype(v)>;
-  if constexpr (is_ValueAndVariance_v<V>) {
-    if constexpr (std::is_arithmetic_v<typename V::value_type>) {
-      static_cast<void>(idx);
-      return v.variance;
-    } else {
-      return v.variance[idx];
-    }
-  } else
-    return v.variances[idx];
+  return v.variance[idx];
 };
 } // namespace
 
@@ -67,10 +49,8 @@ static constexpr auto histogram = overloaded{
           const double bin = (x - offset) * scale;
           if (bin >= 0.0 && bin < nbin) {
             const auto b = static_cast<scipp::index>(bin);
-            const auto w = value(weights, i);
-            const auto e = variance(weights, i);
-            data.value[b] += w;
-            data.variance[b] += e;
+            data.value[b] += value(weights, i);
+            data.variance[b] += variance(weights, i);
           }
         }
       } else {
@@ -80,10 +60,8 @@ static constexpr auto histogram = overloaded{
           auto it = std::upper_bound(edges.begin(), edges.end(), x);
           if (it != edges.end() && it != edges.begin()) {
             const auto b = --it - edges.begin();
-            const auto w = value(weights, i);
-            const auto e = variance(weights, i);
-            data.value[b] += w;
-            data.variance[b] += e;
+            data.value[b] += value(weights, i);
+            data.variance[b] += variance(weights, i);
           }
         }
       }

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -73,9 +73,8 @@ static constexpr auto histogram = overloaded{
             "Data to histogram must have unit `counts` or `dimensionless`.");
       return weights_unit;
     },
-    transform_flags::expect_variance_arg<0>,
+    transform_flags::expect_in_variance_if_out_variance,
     transform_flags::expect_no_variance_arg<1>,
-    transform_flags::expect_variance_arg<2>,
     transform_flags::expect_no_variance_arg<3>};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -4,7 +4,6 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <cmath>
 #include <numeric>
 
 #include "scipp/common/numeric.h"
@@ -17,11 +16,15 @@
 namespace scipp::core::element {
 
 namespace {
-constexpr auto value = [](const auto &v, const scipp::index idx) {
-  return v.value[idx];
-};
-constexpr auto variance = [](const auto &v, const scipp::index idx) {
-  return v.variance[idx];
+constexpr auto iadd = [](const auto &x1, const scipp::index i1, const auto &x2,
+                         const scipp::index i2) {
+  using V = std::decay_t<decltype(x1)>;
+  if constexpr (is_ValueAndVariance_v<V>) {
+    x1.value[i1] += x2.value[i2];
+    x1.variance[i1] += x2.variance[i2];
+  } else {
+    x1[i1] += x2[i2];
+  }
 };
 } // namespace
 
@@ -47,33 +50,27 @@ static constexpr auto histogram = overloaded{
         for (scipp::index i = 0; i < scipp::size(events); ++i) {
           const auto x = events[i];
           const double bin = (x - offset) * scale;
-          if (bin >= 0.0 && bin < nbin) {
-            const auto b = static_cast<scipp::index>(bin);
-            data.value[b] += value(weights, i);
-            data.variance[b] += variance(weights, i);
-          }
+          if (bin >= 0.0 && bin < nbin)
+            iadd(data, static_cast<scipp::index>(bin), weights, i);
         }
       } else {
         core::expect::histogram::sorted_edges(edges);
         for (scipp::index i = 0; i < scipp::size(events); ++i) {
           const auto x = events[i];
           auto it = std::upper_bound(edges.begin(), edges.end(), x);
-          if (it != edges.end() && it != edges.begin()) {
-            const auto b = --it - edges.begin();
-            data.value[b] += value(weights, i);
-            data.variance[b] += variance(weights, i);
-          }
+          if (it != edges.end() && it != edges.begin())
+            iadd(data, --it - edges.begin(), weights, i);
         }
       }
     },
     [](const units::Unit &events_unit, const units::Unit &weights_unit,
        const units::Unit &edge_unit) {
       if (events_unit != edge_unit)
-        throw except::UnitError("Bin edges must have same unit as the events "
-                                "input coordinate.");
+        throw except::UnitError(
+            "Bin edges must have same unit as the input coordinate.");
       if (weights_unit != units::counts && weights_unit != units::dimensionless)
-        throw except::UnitError("Weights of event data must be "
-                                "`units::counts` or `units::dimensionless`.");
+        throw except::UnitError(
+            "Data to histogram must have unit `counts` or `dimensionless`.");
       return weights_unit;
     },
     transform_flags::expect_variance_arg<0>,

--- a/core/test/element_histogram_test.cpp
+++ b/core/test/element_histogram_test.cpp
@@ -10,11 +10,10 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(ElementHistogramTest, variance_flags) {
-  static_assert(std::is_base_of_v<transform_flags::expect_variance_arg_t<0>,
-                                  decltype(element::histogram)>);
+  static_assert(
+      std::is_base_of_v<transform_flags::expect_in_variance_if_out_variance_t,
+                        decltype(element::histogram)>);
   static_assert(std::is_base_of_v<transform_flags::expect_no_variance_arg_t<1>,
-                                  decltype(element::histogram)>);
-  static_assert(std::is_base_of_v<transform_flags::expect_variance_arg_t<2>,
                                   decltype(element::histogram)>);
   static_assert(std::is_base_of_v<transform_flags::expect_no_variance_arg_t<3>,
                                   decltype(element::histogram)>);
@@ -57,4 +56,13 @@ TEST(ElementHistogramTest, values) {
       ValueAndVariance(span(weight_vals), span(weight_vars)), edges);
   EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40 + 50}));
   EXPECT_EQ(result_vars, std::vector<double>({200 + 300, 400 + 500}));
+}
+
+TEST(ElementHistogramTest, no_variance) {
+  std::vector<double> edges{2, 4, 6};
+  std::vector<double> events{1, 2, 3, 4, 5, 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> result_vals{0, 0};
+  element::histogram(span(result_vals), events, span(weight_vals), edges);
+  EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40 + 50}));
 }

--- a/core/test/element_histogram_test.cpp
+++ b/core/test/element_histogram_test.cpp
@@ -52,9 +52,9 @@ TEST(ElementHistogramTest, values) {
   std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
   std::vector<double> result_vals{0, 0};
   std::vector<double> result_vars{0, 0};
-  element::histogram(ValueAndVariance(span(result_vals), span(result_vars)),
-                     events, ValuesAndVariances(weight_vals, weight_vars),
-                     edges);
+  element::histogram(
+      ValueAndVariance(span(result_vals), span(result_vars)), events,
+      ValueAndVariance(span(weight_vals), span(weight_vars)), edges);
   EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40 + 50}));
   EXPECT_EQ(result_vars, std::vector<double>({200 + 300, 400 + 500}));
 }

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
-#include "random.h"
+#include "dataset_test_common.h"
 
 #include "scipp/dataset/bin.h"
 #include "scipp/dataset/bins.h"
@@ -11,11 +11,11 @@
 #include "scipp/dataset/string.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
-#include "scipp/variable/misc_operations.h"
 #include "scipp/variable/reduction.h"
 
 using namespace scipp;
 using namespace scipp::dataset;
+using testdata::make_table;
 
 class DataArrayBinTest : public ::testing::Test {
 protected:
@@ -106,26 +106,6 @@ TEST(BinGroupTest, 1d) {
   EXPECT_EQ(binned.values<core::bin<DataArray>>()[0].slice({Dim::Row, 1}),
             table.slice({Dim::Row, 4}));
 }
-
-namespace {
-auto make_table(const scipp::index size) {
-  Random rand;
-  rand.seed(0);
-  const Dimensions dims(Dim::Row, size);
-  const auto data = makeVariable<double>(dims, Values(rand(dims.volume())),
-                                         Variances(rand(dims.volume())));
-  const auto x = makeVariable<double>(dims, Values(rand(dims.volume())));
-  const auto y = makeVariable<double>(dims, Values(rand(dims.volume())));
-  const auto group = astype(
-      makeVariable<double>(dims, Values(rand(dims.volume()))), dtype<int64_t>);
-  const auto group2 = astype(
-      makeVariable<double>(dims, Values(rand(dims.volume()))), dtype<int64_t>);
-  return DataArray(data, {{Dim::X, x},
-                          {Dim::Y, y},
-                          {Dim("group"), group},
-                          {Dim("group2"), group2}});
-}
-} // namespace
 
 class BinTest : public ::testing::TestWithParam<DataArray> {
 protected:

--- a/dataset/test/dataset_test_common.cpp
+++ b/dataset/test/dataset_test_common.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/misc_operations.h"
 
 #include "dataset_test_common.h"
 
@@ -143,6 +144,24 @@ Dataset make_dataset_x() {
   d.setCoord(Dim::Y, makeVariable<double>(Dims{Dim::X}, units::m, Shape{3},
                                           Values{1, 2, 3}));
   return d;
+}
+
+DataArray make_table(const scipp::index size) {
+  Random rand;
+  rand.seed(0);
+  const Dimensions dims(Dim::Row, size);
+  const auto data = makeVariable<double>(dims, Values(rand(dims.volume())),
+                                         Variances(rand(dims.volume())));
+  const auto x = makeVariable<double>(dims, Values(rand(dims.volume())));
+  const auto y = makeVariable<double>(dims, Values(rand(dims.volume())));
+  const auto group = astype(
+      makeVariable<double>(dims, Values(rand(dims.volume()))), dtype<int64_t>);
+  const auto group2 = astype(
+      makeVariable<double>(dims, Values(rand(dims.volume()))), dtype<int64_t>);
+  return DataArray(data, {{Dim::X, x},
+                          {Dim::Y, y},
+                          {Dim("group"), group},
+                          {Dim("group2"), group2}});
 }
 
 } // namespace scipp::testdata

--- a/dataset/test/dataset_test_common.h
+++ b/dataset/test/dataset_test_common.h
@@ -86,4 +86,5 @@ Dataset make_1d_masked();
 
 namespace scipp::testdata {
 Dataset make_dataset_x();
+DataArray make_table(const scipp::index size);
 } // namespace scipp::testdata

--- a/dataset/test/histogram_test.cpp
+++ b/dataset/test/histogram_test.cpp
@@ -244,7 +244,7 @@ TEST(HistogramTest, dense_vs_binned) {
   auto table_no_variance = make_table(100);
   table_no_variance.data().setVariances(Variable{});
   for (const auto &table :
-       {make_table(100), make_table(1000), table_no_variance}) {
+       {make_table(0), make_table(100), make_table(1000), table_no_variance}) {
     const auto binned_x =
         bin(table, {makeVariable<double>(Dims{Dim::X}, Shape{5},
                                          Values{-2, -1, 0, 1, 2})});

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -22,6 +22,11 @@ auto make_subspans(const ElementArrayView<T> &first,
 }
 
 template <class T>
+auto make_empty_subspans(const ElementArrayView<T> &, const Dimensions &dims) {
+  return std::vector<span<T>>(dims.volume());
+}
+
+template <class T>
 auto make_subspans(T *base, const VariableConstView &indices,
                    const scipp::index stride) {
   const auto &offset = indices.values<core::bucket_base::range_type>();
@@ -69,13 +74,17 @@ template <class T, class Var> Variable subspan_view(Var &var, const Dim dim) {
 
   auto dims = var.dims();
   dims.erase(dim);
-  const auto values_view = [dim, len](auto &v) {
-    return make_subspans(v.slice({dim, 0}).template values<E>(),
-                         v.slice({dim, len - 1}).template values<E>());
+  const auto values_view = [dim, len, dims](auto &v) {
+    return len == 0
+               ? make_empty_subspans(v.template values<E>(), dims)
+               : make_subspans(v.slice({dim, 0}).template values<E>(),
+                               v.slice({dim, len - 1}).template values<E>());
   };
-  const auto variances_view = [dim, len](auto &v) {
-    return make_subspans(v.slice({dim, 0}).template variances<E>(),
-                         v.slice({dim, len - 1}).template variances<E>());
+  const auto variances_view = [dim, len, dims](auto &v) {
+    return len == 0
+               ? make_empty_subspans(v.template variances<E>(), dims)
+               : make_subspans(v.slice({dim, 0}).template variances<E>(),
+                               v.slice({dim, len - 1}).template variances<E>());
   };
   return make_subspan_view<T>(var, dims, values_view, variances_view);
 }

--- a/variable/test/subspan_view_test.cpp
+++ b/variable/test/subspan_view_test.cpp
@@ -32,6 +32,15 @@ TEST_F(SubspanViewTest, values) {
   EXPECT_FALSE(view.hasVariances());
 }
 
+TEST_F(SubspanViewTest, values_length_0) {
+  auto view = subspan_view(var.slice({Dim::X, 0, 0}), Dim::X);
+  EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
+  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_TRUE(view.values<span<double>>()[0].empty());
+  EXPECT_TRUE(view.values<span<double>>()[1].empty());
+  EXPECT_FALSE(view.hasVariances());
+}
+
 TEST_F(SubspanViewTest, values_and_errors) {
   auto view = subspan_view(var_with_errors, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
@@ -40,6 +49,16 @@ TEST_F(SubspanViewTest, values_and_errors) {
   EXPECT_TRUE(equals(view.values<span<double>>()[1], {4, 5, 6}));
   EXPECT_TRUE(equals(view.variances<span<double>>()[0], {7, 8, 9}));
   EXPECT_TRUE(equals(view.variances<span<double>>()[1], {10, 11, 12}));
+}
+
+TEST_F(SubspanViewTest, values_and_errors_length_0) {
+  auto view = subspan_view(var_with_errors.slice({Dim::X, 0, 0}), Dim::X);
+  EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
+  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_TRUE(view.values<span<double>>()[0].empty());
+  EXPECT_TRUE(view.values<span<double>>()[1].empty());
+  EXPECT_TRUE(view.variances<span<double>>()[0].empty());
+  EXPECT_TRUE(view.variances<span<double>>()[1].empty());
 }
 
 TEST_F(SubspanViewTest, view_of_const) {


### PR DESCRIPTION
- Fixes #1390.
- Fix `subspan_view` so it works with 0 dimension extent.