### PR TITLE
Support int data in rebin, converting to double in output

### DIFF
--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -108,6 +108,8 @@ Variable rebin(const VariableConstView &var, const Dim dim,
         "The input does not have coordinates with bin-edges.");
 
   using transform_args = std::tuple<
+      args<double, double, int64_t, double>,
+      args<double, double, int32_t, double>,
       args<double, double, double, double>, args<float, float, float, float>,
       args<float, double, float, double>, args<float, float, float, double>,
       args<bool, double, bool, double>>;
@@ -118,20 +120,22 @@ Variable rebin(const VariableConstView &var, const Dim dim,
                       is_sorted(newCoord, dim, SortOrder::Descending)))
     throw except::BinEdgeError(
         "Rebin: The old or new bin edges are not sorted.");
+  const auto out_type = isInt(var.dtype()) ? dtype<double> : var.dtype();
   if (var.dims().inner() == dim) {
     if (ascending) {
       return transform_subspan<transform_args>(
-          var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
+          out_type, dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
           core::element::rebin<Less>);
     } else {
       return transform_subspan<transform_args>(
-          var.dtype(), dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
+          out_type, dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
           core::element::rebin<Greater>);
     }
   } else {
     auto dims = var.dims();
     dims.resize(dim, newCoord.dims()[dim] - 1);
-    Variable rebinned(var, dims);
+    auto rebinned =
+        Variable(astype(Variable(var, Dimensions{}), out_type), dims);
     if (newCoord.dims().ndim() > 1)
       throw std::runtime_error(
           "Not inner rebin works only for 1d coordinates for now.");
@@ -147,8 +151,8 @@ Variable rebin(const VariableConstView &var, const Dim dim,
       else
         rebin_non_inner<float, Greater>(dim, var, rebinned, oldCoord, newCoord);
     } else {
-      throw std::runtime_error(
-          "Rebinning is possible only for double and float types.");
+      throw except::TypeError("Rebinning is possible only for coords of types "
+                              "`float64` or `float32`.");
     }
     return rebinned;
   }


### PR DESCRIPTION
Required for plotting.

Note that int coords are not supported by this change.