### PR TITLE
Transform Flag Experiment

### DIFF
--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -79,29 +79,29 @@ template <typename Op> assign_unary(Op) -> assign_unary<Op>;
 /// operator.
 namespace transform_flags {
 
-template <typename T> struct Flag { void operator()() const {}; };
+/// Base and NULL flag. Do not test for this type.
+struct Flag {
+  void operator()() const {};
+};
 
+/// Helper to conditionally apply a given flag (T) under condition (B) otherwise
+/// Null Flag
+template <bool B, typename T>
+using enable_flag_if = std::conditional_t<B, T, Flag>;
+
+namespace {
+
+struct no_out_variance_t : Flag {};
 /// Add this to overloaded operator to indicate that the operation does not
 /// return data with variances, regardless of whether inputs have variances.
-// static constexpr auto no_out_variance = []() {};
-// using no_out_variance_t = decltype(no_out_variance);
-namespace {
-struct null_flag_t : public Flag<null_flag_t> {};
-
-struct no_out_variance_t : public Flag<no_out_variance_t> {};
 constexpr auto no_out_variance = no_out_variance_t{};
 
-template <int N>
-struct expect_no_variance_arg_t : public Flag<expect_no_variance_arg_t<N>> {};
+template <int N> struct expect_no_variance_arg_t : Flag {};
+/// Add this to overloaded operator to indicate that the operation does not
+/// support variances in the specified argument.
 template <int N>
 constexpr auto expect_no_variance_arg = expect_no_variance_arg_t<N>{};
 } // namespace
-
-/// Add this to overloaded operator to indicate that the operation does not
-/// support variances in the specified argument.
-// template <int N> static constexpr auto expect_no_variance_arg = []() {};
-// template <int N>
-// using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 
 /// Add this to overloaded operator to indicate that the operation requires
 /// variances in the specified argument.

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -101,23 +101,24 @@ template <int N> struct expect_no_variance_arg_t : Flag {};
 /// support variances in the specified argument.
 template <int N>
 constexpr auto expect_no_variance_arg = expect_no_variance_arg_t<N>{};
-} // namespace
 
+template <int N> struct expect_variance_arg_t : Flag {};
 /// Add this to overloaded operator to indicate that the operation requires
 /// variances in the specified argument.
-template <int N> static constexpr auto expect_variance_arg = []() {};
-template <int N> using expect_variance_arg_t = decltype(expect_variance_arg<N>);
+template <int N>
+constexpr auto expect_variance_arg = expect_variance_arg_t<N>{};
 
+struct expect_in_variance_if_out_variance_t : Flag {};
 /// Add this to overloaded operator to indicate that the in-place operation
 /// requires inputs to have a variance if the output has a variance.
-static constexpr auto expect_in_variance_if_out_variance = []() {};
-using expect_in_variance_if_out_variance_t =
-    decltype(expect_in_variance_if_out_variance);
+constexpr auto expect_in_variance_if_out_variance =
+    expect_in_variance_if_out_variance_t{};
 
-static constexpr auto expect_all_or_none_have_variance = []() {};
-using expect_all_or_none_have_variance_t =
-    decltype(expect_all_or_none_have_variance);
+struct expect_all_or_none_have_variance_t : Flag {};
+static constexpr auto expect_all_or_none_have_variance =
+    expect_all_or_none_have_variance_t{};
 
+} // namespace
 } // namespace transform_flags
 
 } // namespace scipp::core

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -78,16 +78,30 @@ template <typename Op> assign_unary(Op) -> assign_unary<Op>;
 /// actually called since flag presence is checked via the base class of the
 /// operator.
 namespace transform_flags {
+
+template <typename T> struct Flag { void operator()() const {}; };
+
 /// Add this to overloaded operator to indicate that the operation does not
 /// return data with variances, regardless of whether inputs have variances.
-static constexpr auto no_out_variance = []() {};
-using no_out_variance_t = decltype(no_out_variance);
+// static constexpr auto no_out_variance = []() {};
+// using no_out_variance_t = decltype(no_out_variance);
+namespace {
+struct null_flag_t : public Flag<null_flag_t> {};
+
+struct no_out_variance_t : public Flag<no_out_variance_t> {};
+constexpr auto no_out_variance = no_out_variance_t{};
+
+template <int N>
+struct expect_no_variance_arg_t : public Flag<expect_no_variance_arg_t<N>> {};
+template <int N>
+constexpr auto expect_no_variance_arg = expect_no_variance_arg_t<N>{};
+} // namespace
 
 /// Add this to overloaded operator to indicate that the operation does not
 /// support variances in the specified argument.
-template <int N> static constexpr auto expect_no_variance_arg = []() {};
-template <int N>
-using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
+// template <int N> static constexpr auto expect_no_variance_arg = []() {};
+// template <int N>
+// using expect_no_variance_arg_t = decltype(expect_no_variance_arg<N>);
 
 /// Add this to overloaded operator to indicate that the operation requires
 /// variances in the specified argument.

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -115,7 +115,7 @@ constexpr auto expect_in_variance_if_out_variance =
     expect_in_variance_if_out_variance_t{};
 
 struct expect_all_or_none_have_variance_t : Flag {};
-static constexpr auto expect_all_or_none_have_variance =
+constexpr auto expect_all_or_none_have_variance =
     expect_all_or_none_have_variance_t{};
 
 } // namespace

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -84,10 +84,11 @@ struct Flag {
   void operator()() const {};
 };
 
-/// Helper to conditionally apply a given flag (T) under condition (B) otherwise
+/// Helper to conditionally apply a given flag under condition (B) otherwise
 /// Null Flag
-template <bool B, typename T>
-using enable_flag_if = std::conditional_t<B, T, Flag>;
+template <bool B>
+constexpr auto conditional_flag =
+    [](auto flag) { return std::conditional_t<B, decltype(flag), Flag>{}; };
 
 namespace {
 

--- a/variable/type_conversion.cpp
+++ b/variable/type_conversion.cpp
@@ -16,8 +16,8 @@ struct MakeVariableWithType {
     static Variable apply(const VariableConstView &parent) {
       using namespace core::transform_flags;
       constexpr auto expect_input_variances =
-          enable_flag_if<!core::canHaveVariances<T>(),
-                         expect_no_variance_arg_t<0>>{};
+          conditional_flag<!core::canHaveVariances<T>()>(
+              expect_no_variance_arg<0>);
       return transform<double, float, int64_t, int32_t, bool>(
           parent,
           overloaded{

--- a/variable/type_conversion.cpp
+++ b/variable/type_conversion.cpp
@@ -14,22 +14,21 @@ namespace scipp::variable {
 struct MakeVariableWithType {
   template <class T> struct Maker {
     static Variable apply(const VariableConstView &parent) {
-      auto conversion = overloaded{
-          [](const units::Unit &x) { return x; },
-          [](const auto &x) {
-            if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
-              return ValueAndVariance<T>{static_cast<T>(x.value),
-                                         static_cast<T>(x.variance)};
-            else
-              return static_cast<T>(x);
-          }};
-      if constexpr (core::canHaveVariances<T>())
-        return transform<double, float, int64_t, int32_t, bool>(parent,
-                                                                conversion);
-      else
-        return transform<double, float, int64_t, int32_t, bool>(
-            parent, overloaded{core::transform_flags::expect_no_variance_arg<0>,
-                               conversion});
+      using namespace core::transform_flags;
+      constexpr auto expect_input_variances =
+          std::conditional_t<core::canHaveVariances<T>(), null_flag_t,
+                             expect_no_variance_arg_t<0>>{};
+      return transform<double, float, int64_t, int32_t, bool>(
+          parent,
+          overloaded{
+              expect_input_variances, [](const units::Unit &x) { return x; },
+              [](const auto &x) {
+                if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+                  return ValueAndVariance<T>{static_cast<T>(x.value),
+                                             static_cast<T>(x.variance)};
+                else
+                  return static_cast<T>(x);
+              }});
     }
   };
   static Variable make(const VariableConstView &var, DType type) {

--- a/variable/type_conversion.cpp
+++ b/variable/type_conversion.cpp
@@ -16,8 +16,8 @@ struct MakeVariableWithType {
     static Variable apply(const VariableConstView &parent) {
       using namespace core::transform_flags;
       constexpr auto expect_input_variances =
-          std::conditional_t<core::canHaveVariances<T>(), null_flag_t,
-                             expect_no_variance_arg_t<0>>{};
+          enable_flag_if<!core::canHaveVariances<T>(),
+                         expect_no_variance_arg_t<0>>{};
       return transform<double, float, int64_t, int32_t, bool>(
           parent,
           overloaded{


### PR DESCRIPTION
This experimental change - which is incomplete and for demo purposes only changes a few select `core::transform_flag` flags from lambdas to instances of of derived CRTP structs. The advantage is that it's easier to work with the flags with the standard library, such as `std::conditional` as the refactor demonstrates.