### PR TITLE
Special value int support

### DIFF
--- a/core/include/scipp/core/element/special_values.h
+++ b/core/include/scipp/core/element/special_values.h
@@ -8,37 +8,48 @@
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 #include <cmath>
+#include <limits>
 #include <numeric>
 
 namespace scipp::core::element {
 
+constexpr auto special_value_args = arg_list<int32_t, int64_t, double, float>;
+
+template <typename T>
+constexpr auto is_integer = std::numeric_limits<std::decay_t<T>>::is_integer;
+
 constexpr auto isnan =
-    overloaded{arg_list<double, float>,
+    overloaded{special_value_args,
                [](const auto x) {
                  using std::isnan;
-                 return isnan(x);
+                 if constexpr (is_integer<decltype(x)>)
+                   return false;
+                 else
+                   return isnan(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
 constexpr auto isinf =
-    overloaded{arg_list<double, float>,
+    overloaded{special_value_args,
                [](const auto x) {
                  using std::isinf;
-                 return isinf(x);
+                 if constexpr (is_integer<decltype(x)>)
+                   return false;
+                 else
+                   return isinf(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
-constexpr auto isfinite = overloaded{
-    arg_list<int64_t, int32_t, double, float>,
-    [](const auto x) {
-      using std::isfinite;
-      if constexpr (std::numeric_limits<std::decay_t<decltype(x)>>::is_integer)
-        return true;
-      else {
-        return isfinite(x);
-      };
-    },
-    [](const units::Unit &) { return units::dimensionless; }};
+constexpr auto isfinite =
+    overloaded{special_value_args,
+               [](const auto x) {
+                 using std::isfinite;
+                 if constexpr (is_integer<decltype(x)>)
+                   return true;
+                 else
+                   return isfinite(x);
+               },
+               [](const units::Unit &) { return units::dimensionless; }};
 
 namespace detail {
 template <typename T>
@@ -53,18 +64,25 @@ auto isneginf(T x) -> std::enable_if_t<std::is_floating_point_v<T>, bool> {
 } // namespace detail
 
 constexpr auto isposinf =
-    overloaded{arg_list<double, float>,
+    overloaded{special_value_args,
                [](const auto x) {
                  using detail::isposinf;
-                 return isposinf(x);
+                 if constexpr (is_integer<decltype(x)>)
+                   return false;
+                 else
+                   return isposinf(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
 constexpr auto isneginf =
-    overloaded{arg_list<double, float>,
+    overloaded{special_value_args,
                [](const auto x) {
                  using detail::isneginf;
-                 return isneginf(x);
+                 if constexpr (is_integer<decltype(x)>)
+                   return false;
+                 else {
+                   return isneginf(x);
+                 }
                },
                [](const units::Unit &) { return units::dimensionless; }};
 

--- a/core/include/scipp/core/element/special_values.h
+++ b/core/include/scipp/core/element/special_values.h
@@ -8,7 +8,6 @@
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 #include <cmath>
-#include <limits>
 #include <numeric>
 
 namespace scipp::core::element {

--- a/core/include/scipp/core/element/special_values.h
+++ b/core/include/scipp/core/element/special_values.h
@@ -8,20 +8,17 @@
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 #include <cmath>
-#include <numeric>
+#include <type_traits>
 
 namespace scipp::core::element {
 
 constexpr auto special_value_args = arg_list<int32_t, int64_t, double, float>;
 
-template <typename T>
-constexpr auto is_integer = std::numeric_limits<std::decay_t<T>>::is_integer;
-
 constexpr auto isnan =
     overloaded{special_value_args,
                [](const auto x) {
                  using std::isnan;
-                 if constexpr (is_integer<decltype(x)>)
+                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
                    return false;
                  else
                    return isnan(x);
@@ -32,7 +29,7 @@ constexpr auto isinf =
     overloaded{special_value_args,
                [](const auto x) {
                  using std::isinf;
-                 if constexpr (is_integer<decltype(x)>)
+                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
                    return false;
                  else
                    return isinf(x);
@@ -43,7 +40,7 @@ constexpr auto isfinite =
     overloaded{special_value_args,
                [](const auto x) {
                  using std::isfinite;
-                 if constexpr (is_integer<decltype(x)>)
+                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
                    return true;
                  else
                    return isfinite(x);
@@ -66,7 +63,7 @@ constexpr auto isposinf =
     overloaded{special_value_args,
                [](const auto x) {
                  using detail::isposinf;
-                 if constexpr (is_integer<decltype(x)>)
+                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
                    return false;
                  else
                    return isposinf(x);
@@ -77,7 +74,7 @@ constexpr auto isneginf =
     overloaded{special_value_args,
                [](const auto x) {
                  using detail::isneginf;
-                 if constexpr (is_integer<decltype(x)>)
+                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
                    return false;
                  else {
                    return isneginf(x);

--- a/core/test/element_special_values_test.cpp
+++ b/core/test/element_special_values_test.cpp
@@ -11,6 +11,19 @@
 using namespace scipp;
 using namespace scipp::core;
 
+namespace {
+template <typename T, typename Op> void test_int_to_false_with_op(Op op) {
+  EXPECT_FALSE(op(std::numeric_limits<T>::min()));
+  EXPECT_FALSE(op(std::numeric_limits<T>::max()));
+  EXPECT_FALSE(op(T{0}));
+}
+template <typename T, typename Op> void test_int_to_true_with_op(Op op) {
+  EXPECT_TRUE(op(std::numeric_limits<T>::min()));
+  EXPECT_TRUE(op(std::numeric_limits<T>::max()));
+  EXPECT_TRUE(op(T{0}));
+}
+} // namespace
+
 using ElementSpecialValuesTestTypes = ::testing::Types<double, float>;
 
 template <typename T> class ElementIsnanTest : public ::testing::Test {};
@@ -34,6 +47,11 @@ TYPED_TEST(ElementIsnanTest, value) {
   }
 }
 
+TYPED_TEST(ElementIsnanTest, int_values) {
+  test_int_to_false_with_op<int32_t>(element::isnan);
+  test_int_to_false_with_op<int64_t>(element::isnan);
+}
+
 template <typename T> class ElementIsinfTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIsinfTest, ElementSpecialValuesTestTypes);
 
@@ -53,6 +71,11 @@ TYPED_TEST(ElementIsinfTest, value) {
                        std::numeric_limits<TypeParam>::signaling_NaN()}) {
     EXPECT_FALSE(element::isinf(x));
   }
+}
+
+TYPED_TEST(ElementIsinfTest, int_values) {
+  test_int_to_false_with_op<int32_t>(element::isinf);
+  test_int_to_false_with_op<int64_t>(element::isinf);
 }
 
 template <typename T> class ElementIsfiniteTest : public ::testing::Test {};
@@ -77,6 +100,11 @@ TYPED_TEST(ElementIsfiniteTest, value) {
   EXPECT_TRUE(element::isfinite(1));
 }
 
+TYPED_TEST(ElementIsfiniteTest, int_values) {
+  test_int_to_true_with_op<int32_t>(element::isfinite);
+  test_int_to_true_with_op<int64_t>(element::isfinite);
+}
+
 template <typename T> class ElementIssignedinfTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIssignedinfTest, ElementSpecialValuesTestTypes);
 
@@ -85,6 +113,13 @@ TEST(ElementIssignedinfTest, unit) {
     EXPECT_EQ(element::isposinf(u), units::dimensionless);
     EXPECT_EQ(element::isneginf(u), units::dimensionless);
   }
+}
+
+TYPED_TEST(ElementIssignedinfTest, int_values) {
+  test_int_to_false_with_op<int32_t>(element::isposinf);
+  test_int_to_false_with_op<int64_t>(element::isposinf);
+  test_int_to_false_with_op<int32_t>(element::isneginf);
+  test_int_to_false_with_op<int64_t>(element::isneginf);
 }
 
 TYPED_TEST(ElementIssignedinfTest, value) {


### PR DESCRIPTION
Fix mentioned in #1451 

While `std` special value mathematical functions such as `std::isinf` do not support ints, scipps element level equivalents are made to do so. returned true/false is essentially compile-time depending by function. `isnan` on ints always false for example. Makes scipps behaviour more like numpy.