### PR TITLE
Plot method on scipp objects

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,9 +12,11 @@ Features
 * New ``profiler`` plotting functionality where one of the slider dimensions can be displayed as a profile in a subplot (1D and 2D projections only).
 * Sliders have a thickness slider associated with them and can be used to show slices of arbitrary thickness.
 * Can hide/show individual masks on plots.
+* Can toggle log scale of axes and colorbar with buttons in figure toolbar.
 * Add binned data support, replacing "event list" dtypes as well as "realign" support.
 * Value-based slicing support.
 * Support for saving scipp objects to HDF5.
+* Possibility to plot Scipp objects using ``my_data_array.plot()`` in addition to the classical ``plot()`` free function.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/visualization/plotting-overview.ipynb
+++ b/docs/visualization/plotting-overview.ipynb
@@ -9,7 +9,15 @@
     "## Getting started\n",
     "\n",
     "`scipp` offers a number of different ways to plot data from a `DataArray` or a `Dataset`.\n",
-    "It uses the `matplotlib` graphing library to do so, as well as the `ipyvolume` project for 3D visualizations."
+    "It uses the `matplotlib` graphing library to do so, as well as the `pythreejs` project for 3D visualizations.\n",
+    "\n",
+    "Plotting functionality is available in two different ways:\n",
+    "- using the `plot()` free function inside the `scipp.plot` module\n",
+    "- using the `.plot()` method on a Scipp object (variable, data array or dataset)\n",
+    "\n",
+    "The difference between the two possible plot functions is that the free function can accept more input types than just the Scipp objects.\n",
+    "It can also plot raw numpy arrays, as well as python dicts of Scipp variables or data arrays.\n",
+    "Internally, the `.plot()` method just forwards the Scipp object to the free function `plot()`."
    ]
   },
   {
@@ -19,7 +27,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import scipp as sc"
+    "import scipp as sc\n",
+    "from scipp.plot import plot"
    ]
   },
   {
@@ -51,7 +60,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plotting functionality is available in the `scipp.plot` module, with the `plot` function.\n",
     "The information in a data array or dataset is typically enough to create meaningful plots:"
    ]
   },
@@ -63,8 +71,6 @@
    },
    "outputs": [],
    "source": [
-    "from scipp.plot import plot\n",
-    "\n",
     "plot(d)"
    ]
   },
@@ -86,6 +92,22 @@
    "outputs": [],
    "source": [
     "plot(d['data'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or alternatively"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d['data'].plot()"
    ]
   },
   {
@@ -183,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -62,3 +62,10 @@ setattr(DatasetView, 'bins', property(_bins, _set_bins))
 from ._bins import _groupby_bins
 setattr(GroupByDataArray, 'bins', property(_groupby_bins))
 setattr(GroupByDataset, 'bins', property(_groupby_bins))
+
+setattr(Variable, 'plot', plot.plot)
+setattr(VariableConstView, 'plot', plot.plot)
+setattr(DataArray, 'plot', plot.plot)
+setattr(DataArrayConstView, 'plot', plot.plot)
+setattr(Dataset, 'plot', plot.plot)
+setattr(DatasetConstView, 'plot', plot.plot)

--- a/python/tests/plot/test_plot_methods.py
+++ b/python/tests/plot/test_plot_methods.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Neil Vaytet
+
+import numpy as np
+import scipp as sc
+
+
+def test_plot_variable():
+    v = sc.Variable(['x'], values=np.arange(10.0), unit=sc.units.m)
+    v.plot()
+
+
+def test_plot_data_array():
+    da = sc.DataArray(data=sc.Variable(['x'], values=np.random.random(10)),
+                      coords={
+                          'x':
+                          sc.Variable(['x'],
+                                      values=np.arange(10.0),
+                                      unit=sc.units.m)
+                      })
+    da.plot()
+
+
+def test_plot_dataset():
+    N = 100
+    ds = sc.Dataset()
+    ds.coords['x'] = sc.Variable(['x'], values=np.arange(N), unit=sc.units.m)
+    ds['a'] = sc.Variable(['x'], values=np.random.random(N), unit=sc.units.K)
+    ds['b'] = sc.Variable(['x'], values=np.random.random(N), unit=sc.units.K)
+    ds.plot()
+
+
+def test_plot_data_array_with_kwargs():
+    da = sc.DataArray(data=sc.Variable(['y', 'x'],
+                                       values=np.random.random([10, 5])),
+                      coords={
+                          'x':
+                          sc.Variable(['x'],
+                                      values=np.arange(5.0),
+                                      unit=sc.units.m),
+                          'y':
+                          sc.Variable(['y'],
+                                      values=np.arange(10.0),
+                                      unit=sc.units.m)
+                      })
+    da.plot(cmap="magma", norm="log")


### PR DESCRIPTION
This adds the possibility to do `my_data_array.plot()` instead of `sc.plot.plot(my_data_array)` to plot a Scipp object.

Note that the `.plot` method is just forwarding to the free function.