### PR TITLE
Wrap 3d renderer in widget to prevent toolbar from being hidden

### DIFF
--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -106,8 +106,10 @@ class PlotFigure3d:
         """
         Return the renderer and the colorbar into a widget box.
         """
-        return ipw.HBox(
-            [self.toolbar._to_widget(), self.renderer, self.cbar_image])
+        return ipw.HBox([
+            self.toolbar._to_widget(),
+            ipw.HBox([self.renderer]), self.cbar_image
+        ])
 
     def savefig(self, filename=None):
         """


### PR DESCRIPTION
Wrap 3d renderer in widget to prevent toolbar from being hidden behind the scene on browser zoom or narrow window, as reported in #1456 

Note that while this helps, it doesn't fix the problem perfectly, as the scene seems to overlap a little on the toolbar buttons, but I couldn't find a better fix right now (maybe playing with the layout padding in the parent box widget would work?)