### PR TITLE
Improvements around nanmean, mean and nansum

### DIFF
--- a/common/include/scipp/common/numeric.h
+++ b/common/include/scipp/common/numeric.h
@@ -31,4 +31,32 @@ template <class Range> bool is_linspace(const Range &range) {
                             }) == range.end();
 }
 
+template <typename T> bool isnan(T x) {
+  if constexpr (std::is_floating_point_v<std::decay_t<T>>)
+    return std::isnan(x);
+  else
+    return false;
+}
+
+template <typename T> bool isinf(T x) {
+  if constexpr (std::is_floating_point_v<std::decay_t<T>>)
+    return std::isinf(x);
+  else
+    return false;
+}
+
+template <typename T> bool isfinite(T x) {
+  if constexpr (std::is_floating_point_v<std::decay_t<T>>)
+    return std::isfinite(x);
+  else
+    return true;
+}
+
+template <typename T> bool signbit(T x) {
+  if constexpr (std::is_floating_point_v<std::decay_t<T>>)
+    return std::signbit(x);
+  else
+    return std::signbit(double(x));
+}
+
 } // namespace scipp::numeric

--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -29,22 +29,23 @@ template <class T> struct ValueType<ValueAndVariance<T>> {
 
 constexpr auto plus_equals =
     overloaded{add_inplace_types, [](auto &&a, const auto &b) { a += b; }};
+
+namespace detail {
+constexpr auto zero_if_nan = [](auto &x) {
+  using ArgT = std::decay_t<decltype(x)>;
+  using std::isnan;
+  if constexpr (std::is_floating_point_v<
+                    typename ValueType<ArgT>::value_type>) {
+    if (isnan(x))
+      x = ArgT{0}; // Force zero
+  }
+};
+}
+
 constexpr auto nan_plus_equals =
     overloaded{add_inplace_types, [](auto &&a, auto b) {
-                 using std::isnan;
-                 using ArgTA = std::decay_t<decltype(a)>;
-                 using ArgTB = std::decay_t<decltype(b)>;
-                 if constexpr (std::is_floating_point_v<
-                                   typename ValueType<ArgTA>::value_type>) {
-                   if (isnan(a))
-                     a = ArgTA{0}; // Force zero
-                 }
-
-                 if constexpr (std::is_floating_point_v<
-                                   typename ValueType<ArgTB>::value_type>) {
-                   if (isnan(b))
-                     b = ArgTA{0}; // Force zero
-                 }
+                 detail::zero_if_nan(a);
+                 detail::zero_if_nan(b);
                  a += b;
                }};
 constexpr auto minus_equals =

--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -30,18 +30,22 @@ template <class T> struct ValueType<ValueAndVariance<T>> {
 constexpr auto plus_equals =
     overloaded{add_inplace_types, [](auto &&a, const auto &b) { a += b; }};
 constexpr auto nan_plus_equals =
-    overloaded{add_inplace_types, [](auto &&a, const auto &b) {
-                 using ArgT = std::decay_t<decltype(a)>;
+    overloaded{add_inplace_types, [](auto &&a, auto b) {
+                 using std::isnan;
+                 using ArgTA = std::decay_t<decltype(a)>;
+                 using ArgTB = std::decay_t<decltype(b)>;
                  if constexpr (std::is_floating_point_v<
-                                   typename ValueType<ArgT>::value_type>) {
-                   using std::isnan;
+                                   typename ValueType<ArgTA>::value_type>) {
                    if (isnan(a))
-                     a = ArgT{0}; // Force zero
-                   if (!isnan(b))
-                     a += b;
-                 } else {
-                   a += b;
+                     a = ArgTA{0}; // Force zero
                  }
+
+                 if constexpr (std::is_floating_point_v<
+                                   typename ValueType<ArgTB>::value_type>) {
+                   if (isnan(b))
+                     b = ArgTA{0}; // Force zero
+                 }
+                 a += b;
                }};
 constexpr auto minus_equals =
     overloaded{add_inplace_types, [](auto &&a, const auto &b) { a -= b; }};

--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -23,11 +23,6 @@ constexpr auto add_inplace_types =
              std::tuple<float, int64_t>, std::tuple<float, int32_t>,
              std::tuple<int64_t, bool>>;
 
-template <class T> struct ValueType { using value_type = T; };
-template <class T> struct ValueType<ValueAndVariance<T>> {
-  using value_type = T;
-};
-
 constexpr auto plus_equals =
     overloaded{add_inplace_types, [](auto &&a, const auto &b) { a += b; }};
 

--- a/core/include/scipp/core/element/special_values.h
+++ b/core/include/scipp/core/element/special_values.h
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
@@ -17,45 +18,34 @@ constexpr auto special_value_args = arg_list<int32_t, int64_t, double, float>;
 constexpr auto isnan =
     overloaded{special_value_args,
                [](const auto x) {
-                 using std::isnan;
-                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
-                   return false;
-                 else
-                   return isnan(x);
+                 using numeric::isnan;
+                 return isnan(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
 constexpr auto isinf =
     overloaded{special_value_args,
                [](const auto x) {
-                 using std::isinf;
-                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
-                   return false;
-                 else
-                   return isinf(x);
+                 using numeric::isinf;
+                 return isinf(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
 constexpr auto isfinite =
     overloaded{special_value_args,
                [](const auto x) {
-                 using std::isfinite;
-                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
-                   return true;
-                 else
-                   return isfinite(x);
+                 using numeric::isfinite;
+                 return isfinite(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
 namespace detail {
-template <typename T>
-auto isposinf(T x) -> std::enable_if_t<std::is_floating_point_v<T>, bool> {
-  return std::isinf(x) && !std::signbit(x);
+template <typename T> auto isposinf(T x) {
+  return numeric::isinf(x) && !numeric::signbit(x);
 }
 
-template <typename T>
-auto isneginf(T x) -> std::enable_if_t<std::is_floating_point_v<T>, bool> {
-  return std::isinf(x) && std::signbit(x);
+template <typename T> auto isneginf(T x) {
+  return numeric::isinf(x) && numeric::signbit(x);
 }
 } // namespace detail
 
@@ -63,10 +53,7 @@ constexpr auto isposinf =
     overloaded{special_value_args,
                [](const auto x) {
                  using detail::isposinf;
-                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
-                   return false;
-                 else
-                   return isposinf(x);
+                 return isposinf(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
@@ -74,11 +61,7 @@ constexpr auto isneginf =
     overloaded{special_value_args,
                [](const auto x) {
                  using detail::isneginf;
-                 if constexpr (std::is_integral_v<std::decay_t<decltype(x)>>)
-                   return false;
-                 else {
-                   return isneginf(x);
-                 }
+                 return isneginf(x);
                },
                [](const units::Unit &) { return units::dimensionless; }};
 
@@ -104,7 +87,7 @@ constexpr auto nan_to_num =
 
 constexpr auto nan_to_num_out_arg = overloaded{
     replace_special_out_arg, [](auto &x, const auto y, const auto &repl) {
-      using std::isnan;
+      using numeric::isnan;
       x = isnan(y) ? repl : y;
     }};
 
@@ -113,7 +96,7 @@ constexpr auto positive_inf_to_num =
                  if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
                    return isinf(x) && x.value > 0 ? repl : x;
                  else
-                   return std::isinf(x) && x > 0 ? repl : x;
+                   return numeric::isinf(x) && x > 0 ? repl : x;
                }};
 
 constexpr auto positive_inf_to_num_out_arg = overloaded{
@@ -121,7 +104,7 @@ constexpr auto positive_inf_to_num_out_arg = overloaded{
       if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(y)>>)
         x = isinf(y) && y.value > 0 ? repl : y;
       else
-        x = std::isinf(y) && y > 0 ? repl : y;
+        x = numeric::isinf(y) && y > 0 ? repl : y;
     }};
 
 constexpr auto negative_inf_to_num =
@@ -129,7 +112,7 @@ constexpr auto negative_inf_to_num =
                  if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
                    return isinf(x) && x.value < 0 ? repl : x;
                  else
-                   return std::isinf(x) && x < 0 ? repl : x;
+                   return numeric::isinf(x) && x < 0 ? repl : x;
                }};
 
 constexpr auto negative_inf_to_num_out_arg = overloaded{
@@ -137,7 +120,7 @@ constexpr auto negative_inf_to_num_out_arg = overloaded{
       if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(y)>>)
         x = isinf(y) && y.value < 0 ? repl : y;
       else
-        x = std::isinf(y) && y < 0 ? repl : y;
+        x = numeric::isinf(y) && y < 0 ? repl : y;
     }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -114,13 +114,13 @@ constexpr auto isfinite(const ValueAndVariance<T> a) noexcept {
 
 template <class T>
 constexpr auto isposinf(const ValueAndVariance<T> a) noexcept {
-  using numeric::isinf, std::signbit;
+  using numeric::isinf, numeric::signbit;
   return isinf(a.value) && !signbit(a.value);
 }
 
 template <class T>
 constexpr auto isneginf(const ValueAndVariance<T> a) noexcept {
-  using numeric::isinf, std::signbit;
+  using numeric::isinf, numeric::signbit;
   return isinf(a.value) && signbit(a.value);
 }
 

--- a/core/include/scipp/core/value_and_variance.h
+++ b/core/include/scipp/core/value_and_variance.h
@@ -5,8 +5,8 @@
 
 #include <cmath>
 
+#include "scipp/common/numeric.h"
 #include "scipp/common/span.h"
-
 #include "scipp/core/dtype.h"
 
 namespace scipp::core {
@@ -97,30 +97,30 @@ constexpr auto log10(const ValueAndVariance<T> a) noexcept {
 }
 
 template <class T> constexpr auto isnan(const ValueAndVariance<T> a) noexcept {
-  using std::isnan;
+  using numeric::isnan;
   return isnan(a.value);
 }
 
 template <class T> constexpr auto isinf(const ValueAndVariance<T> a) noexcept {
-  using std::isinf;
+  using numeric::isinf;
   return isinf(a.value);
 }
 
 template <class T>
 constexpr auto isfinite(const ValueAndVariance<T> a) noexcept {
-  using std::isfinite;
+  using numeric::isfinite;
   return isfinite(a.value);
 }
 
 template <class T>
 constexpr auto isposinf(const ValueAndVariance<T> a) noexcept {
-  using std::isinf, std::signbit;
+  using numeric::isinf, std::signbit;
   return isinf(a.value) && !signbit(a.value);
 }
 
 template <class T>
 constexpr auto isneginf(const ValueAndVariance<T> a) noexcept {
-  using std::isinf, std::signbit;
+  using numeric::isinf, std::signbit;
   return isinf(a.value) && signbit(a.value);
 }
 

--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -112,3 +112,18 @@ TEST_F(ElementNanArithmeticTest, plus_equals_with_rhs_nan_ValueAndVariance) {
   nan_plus_equals(z, asNaN);
   EXPECT_EQ(expected, z);
 }
+TEST_F(ElementNanArithmeticTest, plus_equals_with_lhs_nan_rhs_int) {
+  auto lhs = dNaN;
+  nan_plus_equals(lhs, 1);
+  EXPECT_EQ(1.0, lhs);
+}
+TEST_F(ElementNanArithmeticTest, plus_equals_with_rhs_int_lhs_nan) {
+  auto lhs = 1;
+  nan_plus_equals(lhs, dNaN);
+  EXPECT_EQ(1, lhs);
+}
+TEST_F(ElementNanArithmeticTest, plus_equals_with_rhs_int_lhs_int) {
+  auto lhs = 1;
+  nan_plus_equals(lhs, 2);
+  EXPECT_EQ(3, lhs);
+}

--- a/dataset/reduction.cpp
+++ b/dataset/reduction.cpp
@@ -83,9 +83,10 @@ DataArray nanmean(const DataArrayConstView &a, const Dim dim) {
 }
 
 DataArray nanmean(const DataArrayConstView &a) {
-  if (isInt(a.data().dtype()))
-    return mean(a);
-  return nansum(a) * reciprocal(astype(sum(isfinite(a)), a.dtype()));
+  if (isInt(a.dtype()))
+    return nansum(a) * reciprocal(astype(sum(isfinite(a)), dtype<double>));
+  else
+    return nansum(a) * reciprocal(astype(sum(isfinite(a)), a.dtype()));
 }
 
 Dataset nanmean(const DatasetConstView &d, const Dim dim) {

--- a/dataset/reduction.cpp
+++ b/dataset/reduction.cpp
@@ -84,7 +84,7 @@ DataArray nanmean(const DataArrayConstView &a, const Dim dim) {
 
 DataArray nanmean(const DataArrayConstView &a) {
   if (isInt(a.dtype()))
-    return nansum(a) * reciprocal(astype(sum(isfinite(a)), dtype<double>));
+    return mean(a);
   else
     return nansum(a) * reciprocal(astype(sum(isfinite(a)), a.dtype()));
 }

--- a/dataset/test/mean_test.cpp
+++ b/dataset/test/mean_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 #include "fix_typed_test_suite_warnings.h"
 #include "scipp/dataset/reduction.h"
+#include "test_nans.h"
 #include <gtest/gtest.h>
 #include <scipp/common/overloaded.h>
 
@@ -10,18 +11,6 @@ using namespace scipp;
 using namespace scipp::dataset;
 
 using MeanTestTypes = testing::Types<int32_t, int64_t, float, double>;
-template <typename T> struct MeanTest : public ::testing::Test {
-  /**
-   * mean and nanmean will preserve input type for floating point types.
-   * For any integer input type we expect the return type to be double
-   */
-  using RetType =
-      std::conditional_t<std::numeric_limits<T>::is_integer, double, T>;
-  /// Held type supports nan testing. All FP types -> true
-  constexpr static bool TestNans = !std::numeric_limits<T>::is_integer;
-  /// Held type supports variances testing. All FP types -> true
-  constexpr static bool TestVariances = !std::numeric_limits<T>::is_integer;
-};
 TYPED_TEST_SUITE(MeanTest, MeanTestTypes);
 
 template <class T, class T2>

--- a/dataset/test/mean_test.cpp
+++ b/dataset/test/mean_test.cpp
@@ -188,9 +188,9 @@ TYPED_TEST(MeanTest, nanmean_over_dim) {
               makeVariable<TypeParam>(Values{1.5}, Variances{6.75}));
     // Set and test with NANS
     ds["a"].template values<TypeParam>()[2] = TypeParam(NAN);
-    EXPECT_EQ(nanmean(ds)["a"].data(),
+    EXPECT_EQ(nanmean(ds, Dim::X)["a"].data(),
               makeVariable<TypeParam>(Values{1.5}, Variances{6.75}));
-    EXPECT_EQ(nanmean(ds["a"]).data(),
+    EXPECT_EQ(nanmean(ds["a"], Dim::X).data(),
               makeVariable<TypeParam>(Values{1.5}, Variances{6.75}));
   } else {
     auto ds = make_one_item_dataset<TypeParam>("a", {Dim::X, 3},

--- a/dataset/test/mean_test.cpp
+++ b/dataset/test/mean_test.cpp
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include "fix_typed_test_suite_warnings.h"
 #include "scipp/dataset/reduction.h"
 #include <gtest/gtest.h>
 #include <scipp/common/overloaded.h>
-// clang-format off
-#include "fix_typed_test_suite_warnings.h"
-// clang-format on
 
 namespace {
 using namespace scipp;

--- a/dataset/variable_reduction.cpp
+++ b/dataset/variable_reduction.cpp
@@ -65,8 +65,6 @@ Variable mean(const VariableConstView &var, const Dim dim,
 Variable nanmean(const VariableConstView &var, const Dim dim,
                  const MasksConstView &masks) {
   using variable::isfinite;
-  if (isInt(var.dtype()))
-    return mean(var, dim, masks);
   if (const auto mask_union = irreducible_mask(masks, dim)) {
     const auto count = sum(applyMask(isfinite(var), mask_union), dim);
     return nanmean_impl(applyMask(var, mask_union), dim, count);

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -34,7 +34,6 @@ def nanmean(x, dim=None, out=None):
     """Element-wise mean over the specified dimension, if variances are
     present, the new variance is computed as standard-deviation of the mean.
     NaNs are ignored.
-    This function only supports variables of floating point types as input.
 
     If the input has variances, the variances stored in the ouput are based on
     the "standard deviation of the mean", i.e.,

--- a/test/fix_typed_test_suite_warnings.h
+++ b/test/fix_typed_test_suite_warnings.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 
 #pragma once
+#include <gtest/gtest-typed-test.h>
 
 // Originally definition of this macro in gtest contains ellipsis
 // TYPED_TEST_SUITE(CaseName, Types, ...)

--- a/test/test_nans.h
+++ b/test/test_nans.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <gtest/gtest.h>
+#include <numeric>
+#include <type_traits>
+
+namespace {
+template <typename T> struct MeanTest : public ::testing::Test {
+  /**
+   * mean and nanmean will preserve input type for floating point types.
+   * For any integer input type we expect the return type to be double
+   */
+  using RetType =
+      std::conditional_t<std::numeric_limits<T>::is_integer, double, T>;
+  /// Held type supports nan testing. All FP types -> true
+  constexpr static bool TestNans = !std::numeric_limits<T>::is_integer;
+  /// Held type supports variances testing. All FP types -> true
+  constexpr static bool TestVariances = !std::numeric_limits<T>::is_integer;
+};
+} // namespace

--- a/test/test_nans.h
+++ b/test/test_nans.h
@@ -5,6 +5,7 @@
 
 namespace {
 template <typename T> struct MeanTest : public ::testing::Test {
+  using TestType = T;
   /**
    * mean and nanmean will preserve input type for floating point types.
    * For any integer input type we expect the return type to be double

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -85,17 +85,6 @@ VariableView nansum(const VariableConstView &var, const Dim dim,
   return sum_with_dim_inplace_impl(nansum_impl, var, dim, out);
 }
 
-Variable nanmean_impl(const VariableConstView &var, const Dim dim,
-                      const VariableConstView &count) {
-  auto summed = nansum(var, dim);
-  auto scale = reciprocal(astype(count, core::dtype<double>));
-  if (isInt(var.dtype()))
-    summed = summed * scale;
-  else
-    summed *= scale;
-  return summed;
-}
-
 VariableView nanmean_impl(const VariableConstView &var, const Dim dim,
                           const VariableConstView &count,
                           const VariableView &out) {
@@ -117,6 +106,15 @@ Variable mean_impl(const VariableConstView &var, const Dim dim,
     summed = summed * scale;
   else
     summed *= scale;
+  return summed;
+}
+
+Variable nanmean_impl(const VariableConstView &var, const Dim dim,
+                      const VariableConstView &count) {
+  if (isInt(var.dtype()))
+    return mean_impl(var, dim, count);
+  auto summed = nansum(var, dim);
+  summed *= reciprocal(astype(count, core::dtype<double>));
   return summed;
 }
 

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -89,7 +89,10 @@ Variable nanmean_impl(const VariableConstView &var, const Dim dim,
                       const VariableConstView &count) {
   auto summed = nansum(var, dim);
   auto scale = reciprocal(astype(count, core::dtype<double>));
-  summed *= scale;
+  if (isInt(var.dtype()))
+    summed = summed * scale;
+  else
+    summed *= scale;
   return summed;
 }
 
@@ -152,16 +155,12 @@ Variable nanmean(const VariableConstView &var) {
 
 Variable nanmean(const VariableConstView &var, const Dim dim) {
   using variable::isfinite;
-  if (isInt(var.dtype()))
-    return mean(var, dim);
   return nanmean_impl(var, dim, sum(isfinite(var), dim));
 }
 
 VariableView nanmean(const VariableConstView &var, const Dim dim,
                      const VariableView &out) {
   using variable::isfinite;
-  if (isInt(var.dtype()))
-    return mean(var, dim, out);
   return nanmean_impl(var, dim, sum(isfinite(var), dim), out);
 }
 

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -69,14 +69,14 @@ TEST(ComparisonTest, variances_test) {
 TEST(ComparisonTest, less_dtypes_test) {
   const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   const auto b = makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{0, 1});
-  EXPECT_THROW(less(a, b), std::runtime_error);
+  EXPECT_THROW([[maybe_unused]] auto out = less(a, b), std::runtime_error);
 }
 
 TEST(ComparisonTest, less_units_test) {
   const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.0, 3.0});
   b.setUnit(units::m);
-  EXPECT_THROW(less(a, b), std::runtime_error);
+  EXPECT_THROW([[maybe_unused]] auto out = less(a, b), std::runtime_error);
 }
 
 namespace {

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
-// clang-format off
-#include <gtest/gtest.h>
-#include "test_macros.h"
-// clang-format on
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
+#include "test_macros.h"
+#include <gtest/gtest.h>
 
 using namespace scipp;
 using namespace scipp::variable;

--- a/variable/test/mean_test.cpp
+++ b/variable/test/mean_test.cpp
@@ -191,6 +191,6 @@ TYPED_TEST(MeanTest, nanmean_basic_inplace) {
     EXPECT_EQ(viewY, meanY);
     EXPECT_EQ(viewY.underlying(), meanY);
   } else {
-    GTEST_SKIP_("Test type does not support variance testing");
+    GTEST_SKIP_("Test type does not support nan testing");
   }
 }

--- a/variable/test/mean_test.cpp
+++ b/variable/test/mean_test.cpp
@@ -146,16 +146,25 @@ TYPED_TEST(MeanTest, variances_as_standard_deviation_of_the_mean) {
   variances_as_standard_deviation_of_the_mean<TestFixture>(nanmean_func);
 }
 
-TEST(MeanTest, nanmean_basic) {
-  const auto var =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m,
-                           Values{1.0, 2.0, 3.0, double(NAN)});
+TYPED_TEST(MeanTest, nanmean_basic) {
+  auto var = makeVariable<TypeParam>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
+                                     units::m, Values{1, 2, 3, 4});
+  using RetType = typename TestFixture::RetType;
   const auto meanX =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{1.5, 3.0});
+      makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m, Values{1.5, 3.5});
   const auto meanY =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 2.0});
+      makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
   EXPECT_EQ(nanmean(var, Dim::X), meanX);
   EXPECT_EQ(nanmean(var, Dim::Y), meanY);
+  if constexpr (TestFixture::TestNans) {
+    var.template values<TypeParam>().data()[3] = TypeParam{NAN};
+    EXPECT_EQ(nanmean(var, Dim::X),
+              makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m,
+                                    Values{1.5, 3.0}));
+    EXPECT_EQ(nanmean(var, Dim::Y),
+              makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m,
+                                    Values{2.0, 2.0}));
+  }
 }
 
 TEST(MeanTest, nanmean_basic_inplace) {

--- a/variable/test/reduce_various_test.cpp
+++ b/variable/test/reduce_various_test.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
-#include <gtest/gtest.h>
-
+#include "fix_typed_test_suite_warnings.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/variable.h"
+#include <gtest/gtest.h>
 
 using namespace scipp;
 
@@ -65,27 +65,52 @@ TEST(ReduceTest, all_any_all_dims) {
   EXPECT_EQ(any(any(var)), any(var));
 }
 
-TEST(ReduceTest, nansum_all_dims) {
-  const auto x = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                      Values{1.0, 1.0, double(NAN), 1.0});
-  const auto expected = makeVariable<double>(Values{3});
-  EXPECT_EQ(nansum(x), expected);
+using NansumTypes = ::testing::Types<int32_t, int64_t, float, double>;
+template <typename T> struct NansumTest : public ::testing::Test {};
+TYPED_TEST_SUITE(NansumTest, NansumTypes);
+
+TYPED_TEST(NansumTest, nansum_all_dims) {
+  auto x = makeVariable<TypeParam>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                   Values{1, 1, 2, 1});
+  if constexpr (std::is_floating_point_v<TypeParam>) {
+    x.template values<TypeParam>()[2] = TypeParam(NAN);
+    const auto expected = makeVariable<TypeParam>(Values{3});
+    EXPECT_EQ(nansum(x), expected);
+  } else {
+    const auto expected = makeVariable<TypeParam>(Values{5});
+    EXPECT_EQ(nansum(x), expected);
+  }
+}
+TYPED_TEST(NansumTest, nansum_with_dim) {
+  auto x = makeVariable<TypeParam>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                   Values{1.0, 2.0, 3.0, 4.0});
+  if constexpr (std::is_floating_point_v<TypeParam>) {
+    x.template values<TypeParam>()[2] = TypeParam(NAN);
+    const auto expected =
+        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
+    EXPECT_EQ(nansum(x, Dim::X), expected);
+  } else {
+    const auto expected =
+        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{4, 6});
+    EXPECT_EQ(nansum(x, Dim::X), expected);
+  }
 }
 
-TEST(ReduceTest, nansum_with_dim) {
-  const auto x = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                      Values{1.0, 2.0, double(NAN), 4.0});
-  const auto expected =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
-  EXPECT_EQ(nansum(x, Dim::X), expected);
-}
-
-TEST(ReduceTest, nansum_with_dim_out) {
-  auto x = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                Values{1.0, 2.0, double(NAN), 4.0});
-  auto out = makeVariable<double>(Dims{Dim::Y}, Shape{2});
-  const auto expected =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
-  nansum(x, Dim::X, out);
-  EXPECT_EQ(out, expected);
+TYPED_TEST(NansumTest, nansum_with_dim_out) {
+  auto x = makeVariable<TypeParam>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                   Values{1.0, 2.0, 3.0, 4.0});
+  if constexpr (std::is_floating_point_v<TypeParam>) {
+    x.template values<TypeParam>()[2] = TypeParam(NAN);
+    auto out = makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2});
+    const auto expected =
+        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
+    nansum(x, Dim::X, out);
+    EXPECT_EQ(out, expected);
+  } else {
+    auto out = makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2});
+    const auto expected =
+        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{4, 6});
+    nansum(x, Dim::X, out);
+    EXPECT_EQ(out, expected);
+  }
 }


### PR DESCRIPTION
Remaining two items marked on#1451

* On Testing
  * Wider use of TYPED_TEST for existing test cases.
  * Common TestSuite for Variable and Dataset testing
  * A fix for TYPED_TEST macro related warnings
* Nansum will work on ints directly, this allows us to remove some of our bespoke considerations with the `nanmean` implementation.

Note that I'm using GTEST_SKIP here, which will show up in the test overview (much like we have anyway for our python tests). We could avoid the explicit skip marking if that style was preferred.