### PR TITLE
Small plotting cleanup

### DIFF
--- a/docs/visualization/customizing-figures.ipynb
+++ b/docs/visualization/customizing-figures.ipynb
@@ -12,7 +12,8 @@
     "\n",
     "There are two ways of customizing `scipp` figures. The first one is to first create a default figure using the `plot` function, and then modifying its contents.\n",
     "\n",
-    "The `plot` commands actually returns a `Plot` object which is basically a Python `dict` that contains all the different plot elements (`SciPlot` objects, that include their individual control widgets) grouped into a convenient fashion, and whose notebook representation (`_ipython_display_`) is a box containing the plots."
+    "The `plot` commands returns an object which is represented in a notebook as a figure (or multiple figures) using the `_ipython_display_` property.\n",
+    "This object can subsequently be modified post-creation."
    ]
   },
   {
@@ -53,24 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `out` object contains one key per figure, which is either a combination of `Dimension` and unit for 1d variables, or the name of the variable (`noise`) in our case:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(out.keys())\n",
-    "print(out['noise'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Each entry in the `out` container is a `SciPlot` object which is made up of several pieces:\n",
+    "The `out` object is a `SciPlot` object which is made up of several pieces:\n",
     "- some `widgets` that are used to interact with the displayed figure via buttons and sliders to control slicing of higher dimensions or flipping the axes of the plot\n",
     "- a `view` which contains a `figure` and is the visual interface between the user and the data\n",
     "- in the case of 1D and 3D plots, the `SciPlot` object also contains a `panel` which provides additional control widgets\n",
@@ -85,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out['noise'].widgets"
+    "out.widgets"
    ]
   },
   {
@@ -103,9 +87,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out['noise'].ax.set_title('This is a new title!')\n",
-    "out['noise'].ax.set_xlabel('My new Xaxis label')\n",
-    "out['noise']"
+    "out.ax.set_title('This is a new title!')\n",
+    "out.ax.set_xlabel('My new Xaxis label')\n",
+    "out"
    ]
   },
   {
@@ -121,8 +105,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out['noise'].view.figure.data_lines['noise'].set_color('red')\n",
-    "out['noise']"
+    "out.view.figure.data_lines['noise'].set_color('red')\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note**\n",
+    "\n",
+    "If the plot produces more than one figure (in the case of plotting a dataset that contains both 1d and 2d data), the `out` object is a `dict` that contains one key per figure.\n",
+    "The keys are either a combination of dimension and unit for 1d figures, or the name of the variable (`noise`) in our case.\n",
+    "\n",
+    "\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -189,15 +189,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = plot(d1, ax=axs[0], cax=axs[2])\n",
-    "out.keys()"
+    "out = plot(d1, ax=axs[0], cax=axs[2])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This has just returned a `dict` of `SciPlot` objects, but then we can check that our original figure has been updated:"
+    "This has just returned a `SciPlot` object, but then we can check that our original figure has been updated:"
    ]
   },
   {
@@ -285,7 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out2['tof.counts'].view.figure.data_lines['Sample'].set_color('purple')\n",
+    "out2.view.figure.data_lines['Sample'].set_color('purple')\n",
     "figs"
    ]
   }

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -194,10 +194,6 @@ def plot(*args, **kwargs):
         interactive_on = True
 
     output = _plot(*args, **kwargs)
-    # if _is_inline():
-    #     for key in output:
-    #         if output[key] is not None:
-    #             output[key].as_static(keep_widgets=is_doc_build)
 
     # Turn auto figure display back on if needed.
     if interactive_on:

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -194,10 +194,10 @@ def plot(*args, **kwargs):
         interactive_on = True
 
     output = _plot(*args, **kwargs)
-    if _is_inline():
-        for key in output:
-            if output[key] is not None:
-                output[key].as_static(keep_widgets=is_doc_build)
+    # if _is_inline():
+    #     for key in output:
+    #         if output[key] is not None:
+    #             output[key].as_static(keep_widgets=is_doc_build)
 
     # Turn auto figure display back on if needed.
     if interactive_on:

--- a/python/src/scipp/plot/helpers.py
+++ b/python/src/scipp/plot/helpers.py
@@ -36,14 +36,6 @@ class Plot(dict):
         for item in self.values():
             item.show()
 
-    # def as_static(self, *args, **kwargs):
-    #     """
-    #     Convert all the contents of the dict to static plots, releasing the
-    #     memory held by the plot (which makes a full copy of the input data).
-    #     """
-    #     for key, item in self.items():
-    #         self[key] = item.as_static(*args, **kwargs)
-
 
 class PlotArrayView:
     """

--- a/python/src/scipp/plot/helpers.py
+++ b/python/src/scipp/plot/helpers.py
@@ -36,13 +36,13 @@ class Plot(dict):
         for item in self.values():
             item.show()
 
-    def as_static(self, *args, **kwargs):
-        """
-        Convert all the contents of the dict to static plots, releasing the
-        memory held by the plot (which makes a full copy of the input data).
-        """
-        for key, item in self.items():
-            self[key] = item.as_static(*args, **kwargs)
+    # def as_static(self, *args, **kwargs):
+    #     """
+    #     Convert all the contents of the dict to static plots, releasing the
+    #     memory held by the plot (which makes a full copy of the input data).
+    #     """
+    #     for key, item in self.items():
+    #         self[key] = item.as_static(*args, **kwargs)
 
 
 class PlotArrayView:

--- a/python/src/scipp/plot/plot.py
+++ b/python/src/scipp/plot/plot.py
@@ -176,4 +176,8 @@ def plot(scipp_obj,
                                mpl_line_params=val["mpl_line_params"],
                                bins=bins,
                                **kwargs)
-    return output
+
+    if len(output) > 1:
+        return output
+    else:
+        return output[list(output.keys())[0]]

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -271,25 +271,3 @@ class SciPlot:
         directory where the script or notebook is running.
         """
         self.view.savefig(filename=filename)
-
-    # def as_static(self, keep_widgets=False):
-    #     """
-    #     Convert the plot to a static plot, releasing the memory held (a full
-    #     copy of the data is made on input).
-    #     """
-    #     # Delete controller members
-    #     self.controller.widgets = None
-    #     self.controller.model = None
-    #     self.controller.panel = None
-    #     self.controller.profile = None
-    #     self.controller.view = None
-    #     # Delete sciplot members
-    #     self.controller = None
-    #     self.model = None
-    #     self.profile = None
-    #     if not keep_widgets:
-    #         self.panel = None
-    #         self.widgets = None
-    #         return self.view.figure
-    #     else:
-    #         return self

--- a/python/src/scipp/plot/sciplot.py
+++ b/python/src/scipp/plot/sciplot.py
@@ -272,24 +272,24 @@ class SciPlot:
         """
         self.view.savefig(filename=filename)
 
-    def as_static(self, keep_widgets=False):
-        """
-        Convert the plot to a static plot, releasing the memory held (a full
-        copy of the data is made on input).
-        """
-        # Delete controller members
-        self.controller.widgets = None
-        self.controller.model = None
-        self.controller.panel = None
-        self.controller.profile = None
-        self.controller.view = None
-        # Delete sciplot members
-        self.controller = None
-        self.model = None
-        self.profile = None
-        if not keep_widgets:
-            self.panel = None
-            self.widgets = None
-            return self.view.figure
-        else:
-            return self
+    # def as_static(self, keep_widgets=False):
+    #     """
+    #     Convert the plot to a static plot, releasing the memory held (a full
+    #     copy of the data is made on input).
+    #     """
+    #     # Delete controller members
+    #     self.controller.widgets = None
+    #     self.controller.model = None
+    #     self.controller.panel = None
+    #     self.controller.profile = None
+    #     self.controller.view = None
+    #     # Delete sciplot members
+    #     self.controller = None
+    #     self.model = None
+    #     self.profile = None
+    #     if not keep_widgets:
+    #         self.panel = None
+    #         self.widgets = None
+    #         return self.view.figure
+    #     else:
+    #         return self

--- a/python/tests/plot/test_plot_1d.py
+++ b/python/tests/plot/test_plot_1d.py
@@ -201,5 +201,15 @@ def test_plot_customized_mpl_axes():
 def test_plot_access_ax_and_fig():
     d = make_dense_dataset(ndim=1)
     out = plot(d["Sample"], title="MyTitle")
+    out.ax.set_xlabel("MyXlabel")
+    out.fig.set_dpi(120.)
+
+
+def test_plot_access_ax_and_fig_two_entries():
+    d = make_dense_dataset(ndim=1)
+    d["Background"] = sc.Variable(['tof'],
+                                  values=2.0 * np.random.random(50),
+                                  unit=sc.units.kg)
+    out = plot(d)
     out['tof.counts'].ax.set_xlabel("MyXlabel")
     out['tof.counts'].fig.set_dpi(120.)

--- a/python/tests/plot/test_plot_2d.py
+++ b/python/tests/plot/test_plot_2d.py
@@ -244,8 +244,8 @@ def test_plot_customized_mpl_axes():
 def test_plot_access_ax_and_fig():
     d = make_dense_dataset(ndim=2)
     out = plot(d["Sample"], title="MyTitle")
-    out["Sample"].ax.set_xlabel("MyXlabel")
-    out["Sample"].fig.set_dpi(120.)
+    out.ax.set_xlabel("MyXlabel")
+    out.fig.set_dpi(120.)
 
 
 def test_plot_2d_image_int32():


### PR DESCRIPTION
- Remove methods to make plots static.
- Return directly the `SciPlot` object in case the `Plot` dict contains only one entry