### PR TITLE
Disallow binning in inner dimensions (temporary)

### DIFF
--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -126,6 +126,16 @@ private:
             return x.second >= 0 && x.first > x.second;
           }) != vals.end())
         throw except::SliceError("Overlapping bucket indices are not allowed.");
+      if (buffer.dims().ndim() > 1 && buffer.dims().index(dim) != 0) {
+        if (std::find_if(vals.begin(), vals.end(), [](const auto x) {
+              return x.first == x.second;
+            }) != vals.end()) {
+          throw except::BucketError(
+              "The bin dimension must be the outermost (first) dimension of "
+              "the buffer. This is a temporary workaround for issue #1479 and "
+              "will be fixed in the future.");
+        }
+      }
       // Copy to avoid a second memory allocation
       const auto &i = indices.values<range_type>();
       std::copy(i.begin(), i.end(), vals.begin());

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -127,14 +127,10 @@ private:
           }) != vals.end())
         throw except::SliceError("Overlapping bucket indices are not allowed.");
       if (buffer.dims().ndim() > 1 && buffer.dims().index(dim) != 0) {
-        if (std::find_if(vals.begin(), vals.end(), [](const auto x) {
-              return x.first == x.second;
-            }) != vals.end()) {
-          throw except::BucketError(
-              "The bin dimension must be the outermost (first) dimension of "
-              "the buffer. This is a temporary workaround for issue #1479 and "
-              "will be fixed in the future.");
-        }
+        throw except::BucketError(
+            "The bin dimension must be the outermost (first) dimension of "
+            "the buffer. This is a temporary workaround for issue #1479 and "
+            "will be fixed in the future.");
       }
       // Copy to avoid a second memory allocation
       const auto &i = indices.values<range_type>();

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -264,6 +264,17 @@ TEST_F(TransformBinaryTest, dense_events) {
   EXPECT_EQ(ba, events);
 }
 
+TEST_F(TransformBinaryTest, events_inner_dim) {
+  auto table = makeVariable<double>(Dims{Dim::Y, Dim::Event}, Shape{2, 4},
+                                    Values{0, 1, 2, 3, 0, 1, 2, 3});
+  auto begin =
+      makeVariable<scipp::index>(Dims{Dim::X}, Shape{3}, Values{0, 1, 1});
+  auto end =
+      makeVariable<scipp::index>(Dims{Dim::X}, Shape{3}, Values{1, 1, 4});
+  ASSERT_THROW(static_cast<void>(make_bins(zip(begin, end), Dim::Event, table)),
+               except::BucketError);
+}
+
 TEST_F(TransformBinaryTest, events_size_fail) {
   const auto indicesA = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{3, 4}});


### PR DESCRIPTION
This is a temporary workaround for #1479 so that users don't get infinite loops but a somewhat informative error message.