### PR TITLE
Concatenate for bin variables

### DIFF
--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -14,6 +14,7 @@
 
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
+#include "scipp/core/bucket.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/dtype.h"
 #include "scipp/core/slice.h"
@@ -33,6 +34,7 @@ SCIPP_CORE_EXPORT std::string to_string(const bool b);
 SCIPP_CORE_EXPORT std::string to_string(const DType dtype);
 SCIPP_CORE_EXPORT std::string to_string(const Dimensions &dims);
 SCIPP_CORE_EXPORT std::string to_string(const Slice &slice);
+SCIPP_CORE_EXPORT std::string to_string(const scipp::index_pair &index);
 
 template <class Id, class Key, class Value>
 std::string to_string(const ConstView<Id, Key, Value> &view) {
@@ -66,6 +68,7 @@ template <class T>
 std::string
 element_to_string(const T &item,
                   const std::optional<units::Unit> &unit = std::nullopt) {
+  using core::to_string;
   using std::to_string;
   if constexpr (std::is_same_v<T, std::string>)
     return {'"' + item + "\", "};

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -47,6 +47,10 @@ std::string to_string(const Slice &slice) {
          std::to_string(slice.begin()) + end + ")\n";
 }
 
+std::string to_string(const scipp::index_pair &index) {
+  return '(' + index.first + ", " + index.second + ')';
+}
+
 std::map<DType, std::string> &dtypeNameRegistry() {
   static std::map<DType, std::string> registry;
   return registry;

--- a/core/string.cpp
+++ b/core/string.cpp
@@ -48,7 +48,8 @@ std::string to_string(const Slice &slice) {
 }
 
 std::string to_string(const scipp::index_pair &index) {
-  return '(' + index.first + ", " + index.second + ')';
+  return '(' + std::to_string(index.first) + ", " +
+         std::to_string(index.second) + ')';
 }
 
 std::map<DType, std::string> &dtypeNameRegistry() {

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -353,6 +353,7 @@ auto axis_actions(const VariableConstView &data, const Coords &coords,
 
 class HideMasked {
 public:
+  template <class Masks>
   HideMasked(const VariableConstView &data, const Masks &masks,
              const Dimensions &dims) {
     const auto &[begin_end, buffer_dim, buffer] =

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -132,7 +132,7 @@ auto bin(const VariableConstView &data, const VariableConstView &indices,
 
   // Perform actual binning step for data, all coords, all masks, ...
   auto out_buffer = dataset::transform(bins_view<T>(data), [&](auto &&var) {
-    if (!is_buckets(var))
+    if (!is_bins(var))
       return std::move(var);
     const auto &[input_indices, buffer_dim, in_buffer] =
         var.template constituents<core::bin<VariableConstView>>();

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -185,13 +185,11 @@ Dataset bucket_sizes(const DatasetConstView &dataset) {
   return apply_to_items(dataset, [](auto &&_) { return bucket_sizes(_); });
 }
 
-bool is_buckets(const DataArrayConstView &array) {
-  return is_buckets(array.data());
-}
+bool is_bins(const DataArrayConstView &array) { return is_bins(array.data()); }
 
-bool is_buckets(const DatasetConstView &dataset) {
+bool is_bins(const DatasetConstView &dataset) {
   return std::any_of(dataset.begin(), dataset.end(),
-                     [](const auto &item) { return is_buckets(item); });
+                     [](const auto &item) { return is_bins(item); });
 }
 
 } // namespace scipp::dataset

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -45,14 +45,33 @@ constexpr auto copy_or_match = [](const auto &a, const auto &b, const Dim dim,
   else
     core::expect::equals(a, b);
 };
+
+constexpr auto expect_matching_keys = [](const auto &a, const auto &b) {
+  bool ok = true;
+  constexpr auto key = [](const auto &x) {
+    if constexpr (std::is_base_of_v<DataArrayConstView,
+                                    std::decay_t<decltype(x)>>)
+      return x.name();
+    else
+      return x.first;
+  };
+  for (const auto &x : a)
+    ok &= b.contains(key(x));
+  for (const auto &x : b)
+    ok &= a.contains(key(x));
+  if (!ok)
+    throw std::runtime_error("Mismatching keys in\n" + to_string(a) + " and\n" +
+                             to_string(b));
+};
+
 } // namespace
 
 void copy_slices(const DataArrayConstView &src, const DataArrayView &dst,
                  const Dim dim, const VariableConstView &srcIndices,
                  const VariableConstView &dstIndices) {
   copy_slices(src.data(), dst.data(), dim, srcIndices, dstIndices);
-  core::expect::sizeMatches(src.meta(), dst.meta());
-  core::expect::sizeMatches(src.masks(), dst.masks());
+  expect_matching_keys(src.meta(), dst.meta());
+  expect_matching_keys(src.masks(), dst.masks());
   for (const auto &[name, coord] : src.meta())
     copy_or_match(coord, dst.meta()[name], dim, srcIndices, dstIndices);
   for (const auto &[name, mask] : src.masks())
@@ -64,12 +83,12 @@ void copy_slices(const DatasetConstView &src, const DatasetView &dst,
                  const VariableConstView &dstIndices) {
   for (const auto &[name, var] : src.coords())
     copy_or_match(var, dst.coords()[name], dim, srcIndices, dstIndices);
-  core::expect::sizeMatches(src.coords(), dst.coords());
-  core::expect::sizeMatches(src, dst);
+  expect_matching_keys(src.coords(), dst.coords());
+  expect_matching_keys(src, dst);
   for (const auto &item : src) {
     const auto &dst_ = dst[item.name()];
-    core::expect::sizeMatches(item.attrs(), dst_.attrs());
-    core::expect::sizeMatches(item.masks(), dst_.masks());
+    expect_matching_keys(item.attrs(), dst_.attrs());
+    expect_matching_keys(item.masks(), dst_.masks());
     copy_or_match(item.data(), dst_.data(), dim, srcIndices, dstIndices);
     for (const auto &[name, var] : item.masks())
       copy_or_match(var, dst_.masks()[name], dim, srcIndices, dstIndices);

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -59,7 +59,7 @@ T GroupBy<T>::copy(const scipp::index group,
 template <class T>
 T GroupBy<T>::makeReductionOutput(const Dim reductionDim) const {
   T out;
-  if (is_buckets(m_data)) {
+  if (is_bins(m_data)) {
     const auto out_sizes =
         GroupBy(bucket_sizes(m_data), {key(), groups()}).sum(reductionDim);
     out = resize(m_data, reductionDim, out_sizes);

--- a/dataset/include/scipp/dataset/bins.h
+++ b/dataset/include/scipp/dataset/bins.h
@@ -44,9 +44,9 @@ bucket_sizes(const DataArrayConstView &array);
 bucket_sizes(const DatasetConstView &dataset);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT bool
-is_buckets(const DataArrayConstView &array);
+is_bins(const DataArrayConstView &array);
 [[nodiscard]] SCIPP_DATASET_EXPORT bool
-is_buckets(const DatasetConstView &dataset);
+is_bins(const DatasetConstView &dataset);
 
 } // namespace scipp::dataset
 

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -800,6 +800,8 @@ using dataset::DataArrayView;
 using dataset::Dataset;
 using dataset::DatasetConstView;
 using dataset::DatasetView;
+template <> struct is_view<DataArrayConstView> : std::true_type {};
 template <> struct is_view<DataArrayView> : std::true_type {};
+template <> struct is_view<DatasetConstView> : std::true_type {};
 template <> struct is_view<DatasetView> : std::true_type {};
 } // namespace scipp

--- a/dataset/include/scipp/dataset/string.h
+++ b/dataset/include/scipp/dataset/string.h
@@ -43,8 +43,9 @@ SCIPP_DATASET_EXPORT std::string to_string(const DatasetConstView &dataset);
 template <class Id, class Key, class Value>
 std::string to_string(const ConstView<Id, Key, Value> &view) {
   std::stringstream ss;
+  ss << "<scipp.ConstView>\n";
   for (const auto &[key, item] : view) {
-    ss << "<scipp.ConstView> (" << key << "):\n" << to_string(item);
+    ss << "  " << key << ":" << to_string(item);
   }
   return ss.str();
 }
@@ -52,8 +53,9 @@ std::string to_string(const ConstView<Id, Key, Value> &view) {
 template <class T, class U>
 std::string to_string(const MutableView<T, U> &mutableView) {
   std::stringstream ss;
+  ss << "<scipp.MutableView>\n";
   for (const auto &[key, item] : mutableView) {
-    ss << "<scipp.MutableView> (" << key << "):\n" << to_string(item);
+    ss << "  " << key << ":" << to_string(item);
   }
   return ss.str();
 }

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
   attributes_test.cpp
   binned_arithmetic_test.cpp
+  binned_creation_test.cpp
   bins_test.cpp
   bin_test.cpp
   choose_test.cpp

--- a/dataset/test/binned_creation_test.cpp
+++ b/dataset/test/binned_creation_test.cpp
@@ -36,7 +36,7 @@ TEST_F(BinnedCreationTest, empty_like_slice_default_shape) {
 TEST_F(BinnedCreationTest, empty_like) {
   Variable shape = makeVariable<scipp::index>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                               Values{1, 2, 5, 6, 3, 4});
-  const auto empty = empty_like(m_var, shape);
+  const auto empty = empty_like(m_var, {}, shape);
   EXPECT_EQ(empty.dims(), shape.dims());
   const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
   EXPECT_EQ(buf.dims(), Dimensions(Dim::Event, 21));

--- a/dataset/test/binned_creation_test.cpp
+++ b/dataset/test/binned_creation_test.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/dataset/bins.h"
+#include "scipp/variable/creation.h"
+
+using namespace scipp;
+
+class BinnedCreationTest : public ::testing::Test {
+protected:
+  Variable indices = makeVariable<scipp::index_pair>(
+      Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
+  Variable data =
+      makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{1, 2, 3, 4, 5});
+  DataArray buffer = DataArray(data, {{Dim::X, data}});
+  Variable var = make_bins(indices, Dim::Event, buffer);
+};
+
+TEST_F(BinnedCreationTest, empty_like_default_shape) {
+  const auto empty = empty_like(var);
+  EXPECT_EQ(empty.dims(), var.dims());
+}
+
+TEST_F(BinnedCreationTest, empty_like) {
+  Variable shape = makeVariable<scipp::index>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                                              Values{1, 2, 5, 6, 3, 4});
+  const auto empty = empty_like(var, shape);
+  EXPECT_EQ(empty.dims(), shape.dims());
+  const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
+  EXPECT_EQ(buf.dims(), Dimensions(Dim::Event, 21));
+  scipp::index i = 0;
+  for (const auto n : {1, 2, 5, 6, 3, 4}) {
+    EXPECT_EQ(empty.values<core::bin<DataArray>>()[i++].dims()[Dim::Event], n);
+  }
+}

--- a/dataset/test/binned_creation_test.cpp
+++ b/dataset/test/binned_creation_test.cpp
@@ -22,6 +22,15 @@ protected:
 TEST_F(BinnedCreationTest, empty_like_default_shape) {
   const auto empty = empty_like(m_var);
   EXPECT_EQ(empty.dims(), m_var.dims());
+  const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
+  EXPECT_EQ(indices, m_indices);
+}
+
+TEST_F(BinnedCreationTest, empty_like_slice_default_shape) {
+  const auto empty = empty_like(m_var.slice({Dim::X, 1}));
+  EXPECT_EQ(empty.dims(), m_var.slice({Dim::X, 1}).dims());
+  const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
+  EXPECT_EQ(indices, makeVariable<scipp::index_pair>(Values{std::pair{0, 3}}));
 }
 
 TEST_F(BinnedCreationTest, empty_like) {

--- a/dataset/test/binned_creation_test.cpp
+++ b/dataset/test/binned_creation_test.cpp
@@ -12,16 +12,25 @@ class BinnedCreationTest : public ::testing::Test {
 protected:
   Variable m_indices = makeVariable<scipp::index_pair>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
-  Variable m_data =
-      makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{1, 2, 3, 4, 5});
+  Variable m_data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
+                                         Values{1, 2, 3, 4, 5});
   DataArray m_buffer = DataArray(m_data, {{Dim::X, m_data}}, {{"mask", m_data}},
                                  {{Dim("attr"), 1.2 * units::m}});
   Variable m_var = make_bins(m_indices, Dim::Event, m_buffer);
+
+  void check(const VariableConstView &var) const {
+    const auto [indices, dim, buf] = var.constituents<core::bin<DataArray>>();
+    EXPECT_EQ(buf.unit(), units::m);
+    EXPECT_EQ(buf.attrs(), m_buffer.attrs()); // scalar, so copied, not resized
+    EXPECT_TRUE(buf.masks().contains("mask"));
+    EXPECT_TRUE(buf.coords().contains(Dim::X));
+  }
 };
 
 TEST_F(BinnedCreationTest, empty_like_default_shape) {
   const auto empty = empty_like(m_var);
   EXPECT_EQ(empty.dims(), m_var.dims());
+  check(empty);
   const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
   EXPECT_EQ(indices, m_indices);
 }
@@ -29,6 +38,7 @@ TEST_F(BinnedCreationTest, empty_like_default_shape) {
 TEST_F(BinnedCreationTest, empty_like_slice_default_shape) {
   const auto empty = empty_like(m_var.slice({Dim::X, 1}));
   EXPECT_EQ(empty.dims(), m_var.slice({Dim::X, 1}).dims());
+  check(empty);
   const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
   EXPECT_EQ(indices, makeVariable<scipp::index_pair>(Values{std::pair{0, 3}}));
 }
@@ -40,9 +50,7 @@ TEST_F(BinnedCreationTest, empty_like) {
   EXPECT_EQ(empty.dims(), shape.dims());
   const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
   EXPECT_EQ(buf.dims(), Dimensions(Dim::Event, 21));
-  EXPECT_EQ(buf.attrs(), m_buffer.attrs()); // scalar, so copied, not resized
-  EXPECT_TRUE(buf.masks().contains("mask"));
-  EXPECT_TRUE(buf.coords().contains(Dim::X));
+  check(empty);
   scipp::index i = 0;
   for (const auto n : {1, 2, 5, 6, 3, 4}) {
     EXPECT_EQ(empty.values<core::bin<DataArray>>()[i++].dims()[Dim::Event], n);

--- a/dataset/test/binned_creation_test.cpp
+++ b/dataset/test/binned_creation_test.cpp
@@ -3,32 +3,37 @@
 #include <gtest/gtest.h>
 
 #include "scipp/dataset/bins.h"
+#include "scipp/variable/arithmetic.h"
 #include "scipp/variable/creation.h"
 
 using namespace scipp;
 
 class BinnedCreationTest : public ::testing::Test {
 protected:
-  Variable indices = makeVariable<scipp::index_pair>(
+  Variable m_indices = makeVariable<scipp::index_pair>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
-  Variable data =
+  Variable m_data =
       makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{1, 2, 3, 4, 5});
-  DataArray buffer = DataArray(data, {{Dim::X, data}});
-  Variable var = make_bins(indices, Dim::Event, buffer);
+  DataArray m_buffer = DataArray(m_data, {{Dim::X, m_data}}, {{"mask", m_data}},
+                                 {{Dim("attr"), 1.2 * units::m}});
+  Variable m_var = make_bins(m_indices, Dim::Event, m_buffer);
 };
 
 TEST_F(BinnedCreationTest, empty_like_default_shape) {
-  const auto empty = empty_like(var);
-  EXPECT_EQ(empty.dims(), var.dims());
+  const auto empty = empty_like(m_var);
+  EXPECT_EQ(empty.dims(), m_var.dims());
 }
 
 TEST_F(BinnedCreationTest, empty_like) {
   Variable shape = makeVariable<scipp::index>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                               Values{1, 2, 5, 6, 3, 4});
-  const auto empty = empty_like(var, shape);
+  const auto empty = empty_like(m_var, shape);
   EXPECT_EQ(empty.dims(), shape.dims());
   const auto [indices, dim, buf] = empty.constituents<core::bin<DataArray>>();
   EXPECT_EQ(buf.dims(), Dimensions(Dim::Event, 21));
+  EXPECT_EQ(buf.attrs(), m_buffer.attrs()); // scalar, so copied, not resized
+  EXPECT_TRUE(buf.masks().contains("mask"));
+  EXPECT_TRUE(buf.coords().contains(Dim::X));
   scipp::index i = 0;
   for (const auto n : {1, 2, 5, 6, 3, 4}) {
     EXPECT_EQ(empty.values<core::bin<DataArray>>()[i++].dims()[Dim::Event], n);

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/dataset/bins.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/shape.h"
@@ -298,4 +299,19 @@ TEST(ConcatenateTest, broadcast_coord) {
       DataArray(makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{2, 3, 1}),
                 {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3},
                                                Values{2, 2, 1})}}));
+}
+
+class ConcatenateBinnedTest : public ::testing::Test {
+protected:
+  Variable indices = makeVariable<scipp::index_pair>(
+      Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
+  Variable data =
+      makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{1, 2, 3, 4, 5});
+  DataArray buffer = DataArray(data, {{Dim::X, data + data}});
+  Variable var = make_bins(indices, Dim::Event, buffer);
+};
+
+TEST_F(ConcatenateBinnedTest, concat_variables) {
+  EXPECT_NO_THROW(concatenate(var, var, Dim::X));
+  EXPECT_NO_THROW(concatenate(var, var, Dim::Y));
 }

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -311,6 +311,23 @@ protected:
   Variable var = make_bins(indices, Dim::Event, buffer);
 };
 
+TEST_F(ConcatenateBinnedTest, mismatching_buffer) {
+  for (const auto buffer2 :
+       {buffer * (1.0 * units::m),
+        DataArray(data, {{Dim::X, data + data}}, {{"mask", 1.0 * units::one}},
+                  {}),
+        DataArray(data, {{Dim::X, data + data}}, {},
+                  {{Dim("attr"), 1.0 * units::one}}),
+        DataArray(data, {{Dim::Y, data + data}, {Dim::X, data + data}}),
+        DataArray(data, {})}) {
+    auto var2 = make_bins(indices, Dim::Event, buffer2);
+    EXPECT_THROW(concatenate(var, var2, Dim::X), std::runtime_error) << buffer2;
+    EXPECT_THROW(concatenate(var, var2, Dim::Y), std::runtime_error) << buffer2;
+    EXPECT_THROW(concatenate(var2, var, Dim::X), std::runtime_error) << buffer2;
+    EXPECT_THROW(concatenate(var2, var, Dim::Y), std::runtime_error) << buffer2;
+  }
+}
+
 TEST_F(ConcatenateBinnedTest, existing_dim) {
   auto out = concatenate(var, var, Dim::X);
   EXPECT_EQ(out.slice({Dim::X, 0, 2}), var);

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -321,10 +321,10 @@ TEST_F(ConcatenateBinnedTest, mismatching_buffer) {
         DataArray(data, {{Dim::Y, data + data}, {Dim::X, data + data}}),
         DataArray(data, {})}) {
     auto var2 = make_bins(indices, Dim::Event, buffer2);
-    EXPECT_THROW(concatenate(var, var2, Dim::X), std::runtime_error) << buffer2;
-    EXPECT_THROW(concatenate(var, var2, Dim::Y), std::runtime_error) << buffer2;
-    EXPECT_THROW(concatenate(var2, var, Dim::X), std::runtime_error) << buffer2;
-    EXPECT_THROW(concatenate(var2, var, Dim::Y), std::runtime_error) << buffer2;
+    EXPECT_THROW(concatenate(var, var2, Dim::X), std::runtime_error);
+    EXPECT_THROW(concatenate(var, var2, Dim::Y), std::runtime_error);
+    EXPECT_THROW(concatenate(var2, var, Dim::X), std::runtime_error);
+    EXPECT_THROW(concatenate(var2, var, Dim::Y), std::runtime_error);
   }
 }
 

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -311,7 +311,22 @@ protected:
   Variable var = make_bins(indices, Dim::Event, buffer);
 };
 
-TEST_F(ConcatenateBinnedTest, concat_variables) {
-  EXPECT_NO_THROW(concatenate(var, var, Dim::X));
-  EXPECT_NO_THROW(concatenate(var, var, Dim::Y));
+TEST_F(ConcatenateBinnedTest, existing_dim) {
+  auto out = concatenate(var, var, Dim::X);
+  EXPECT_EQ(out.slice({Dim::X, 0, 2}), var);
+  EXPECT_EQ(out.slice({Dim::X, 2, 4}), var);
+  out = concatenate(var + 1.2 * units::one, out, Dim::X);
+  EXPECT_EQ(out.slice({Dim::X, 0, 2}), var + 1.2 * units::one);
+  EXPECT_EQ(out.slice({Dim::X, 2, 4}), var);
+  EXPECT_EQ(out.slice({Dim::X, 4, 6}), var);
+}
+
+TEST_F(ConcatenateBinnedTest, new_dim) {
+  auto out = concatenate(var, var, Dim::Y);
+  EXPECT_EQ(out.slice({Dim::Y, 0}), var);
+  EXPECT_EQ(out.slice({Dim::Y, 1}), var);
+  out = concatenate(var + 1.2 * units::one, out, Dim::Y);
+  EXPECT_EQ(out.slice({Dim::Y, 0}), var + 1.2 * units::one);
+  EXPECT_EQ(out.slice({Dim::Y, 1}), var);
+  EXPECT_EQ(out.slice({Dim::Y, 2}), var);
 }

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -22,8 +22,7 @@ INSTANTIATE_BUCKET_VARIABLE(DataArrayConstView_observer,
 
 namespace scipp::dataset {
 
-class BucketVariableMakerDataArray
-    : public variable::BucketVariableMaker<DataArray> {
+class BinVariableMakerDataArray : public variable::BinVariableMaker<DataArray> {
 private:
   Variable make_buckets(const VariableConstView &parent,
                         const VariableConstView &indices, const Dim dim,
@@ -62,8 +61,8 @@ private:
 };
 
 /// This is currently a dummy implemented just to make `is_bins` work.
-class BucketVariableMakerDataset : public variable::AbstractVariableMaker {
-  bool is_bins() const override { return true; }
+class BinVariableMakerDataset
+    : public variable::BinVariableMakerCommon<Dataset> {
   Variable create(const DType, const Dimensions &, const units::Unit &,
                   const bool,
                   const std::vector<VariableConstView> &) const override {
@@ -105,12 +104,12 @@ auto register_dataset_types(
          dtype<bucket<DataArrayConstView>>,
          std::make_unique<variable::Formatter<bucket<DataArrayConstView>>>()),
      0));
-auto register_variable_maker_bucket_DataArray((
-    variable::variableFactory().emplace(
-        dtype<bucket<DataArray>>,
-        std::make_unique<BucketVariableMakerDataArray>()),
-    variable::variableFactory().emplace(
-        dtype<bucket<Dataset>>, std::make_unique<BucketVariableMakerDataset>()),
-    0));
+auto register_variable_maker_bucket_DataArray(
+    (variable::variableFactory().emplace(
+         dtype<bucket<DataArray>>,
+         std::make_unique<BinVariableMakerDataArray>()),
+     variable::variableFactory().emplace(
+         dtype<bucket<Dataset>>, std::make_unique<BinVariableMakerDataset>()),
+     0));
 } // namespace
 } // namespace scipp::dataset

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -62,9 +62,9 @@ private:
   }
 };
 
-/// This is currently a dummy implemented just to make `is_buckets` work.
+/// This is currently a dummy implemented just to make `is_bins` work.
 class BucketVariableMakerDataset : public variable::AbstractVariableMaker {
-  bool is_buckets() const override { return true; }
+  bool is_bins() const override { return true; }
   Variable create(const DType, const Dimensions &, const units::Unit &,
                   const bool,
                   const std::vector<VariableConstView> &) const override {

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -41,8 +41,7 @@ private:
     auto buffer = DataArray(
         variable::variableFactory().create(type, dims, unit, variances),
         source.coords(), source.masks(), source.attrs());
-    return Variable{std::make_unique<variable::DataModel<bucket<DataArray>>>(
-        indices, dim, std::move(buffer))};
+    return make_bins(Variable(indices), dim, std::move(buffer));
   }
   VariableConstView data(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<DataArray>>()).data();

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -24,11 +24,11 @@ namespace scipp::dataset {
 
 class BinVariableMakerDataArray : public variable::BinVariableMaker<DataArray> {
 private:
-  Variable make_buckets(const VariableConstView &parent,
-                        const VariableConstView &indices, const Dim dim,
-                        const DType type, const Dimensions &dims,
-                        const units::Unit &unit,
-                        const bool variances) const override {
+  Variable call_make_bins(const VariableConstView &parent,
+                          const VariableConstView &indices, const Dim dim,
+                          const DType type, const Dimensions &dims,
+                          const units::Unit &unit,
+                          const bool variances) const override {
     const auto &source = std::get<2>(parent.constituents<bucket<DataArray>>());
     if (parent.dims() !=
         indices

--- a/dataset/variable_instantiate_bucket_elements.cpp
+++ b/dataset/variable_instantiate_bucket_elements.cpp
@@ -55,8 +55,7 @@ private:
     return {0, // no offset required in buffer since access via indices
             params.dims(),
             params.dataDims(),
-            {dim, buffer.dims(),
-             indices.values<std::pair<scipp::index, scipp::index>>().data()}};
+            {dim, buffer.dims(), indices.values<scipp::index_pair>().data()}};
   }
 };
 

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -97,12 +97,12 @@ void init_buckets(py::module &m) {
   bind_bin_size<DataArray>(m);
   bind_bin_size<Dataset>(m);
 
-  m.def("is_bins", variable::is_buckets);
+  m.def("is_bins", variable::is_bins);
   m.def("is_bins", [](const DataArrayConstView &array) {
-    return dataset::is_buckets(array);
+    return dataset::is_bins(array);
   });
   m.def("is_bins", [](const DatasetConstView &dataset) {
-    return dataset::is_buckets(dataset);
+    return dataset::is_bins(dataset);
   });
 
   m.def("bins_begin_end", [](const VariableConstView &var) -> py::object {

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SRC_FILES
     arithmetic.cpp
     bins.cpp
     comparison.cpp
+    creation.cpp
     cumulative.cpp
     except.cpp
     inplace_arithmetic.cpp

--- a/variable/bins.cpp
+++ b/variable/bins.cpp
@@ -43,6 +43,7 @@ void copy_slices(const VariableConstView &src, const VariableView &dst,
   const auto [begin1, end1] = unzip(dstIndices);
   const auto sizes0 = end0 - begin0;
   const auto sizes1 = end1 - begin1;
+  core::expect::equals(src.unit(), dst.unit());
   // May broadcast `src` but not `dst` since that would result in
   // multiple/conflicting writes to same bucket.
   expect::contains(sizes1.dims(), sizes0.dims());

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -9,9 +9,9 @@ namespace scipp::variable {
 
 /// Create empty (uninitialized) variable with same parameters as prototype.
 ///
-/// If specified, `shape` defines the shape and dims of the output. If
-/// `prototype` contains binned data the values of `shape` are interpreted as
-/// bin sizes.
+/// If specified, `shape` defines the shape of the output. If `prototype`
+/// contains binned data `shape` may not be specified, instead `sizes` defines
+/// the sizes of the desired bins.
 Variable empty_like(const VariableConstView &prototype,
                     const std::optional<Dimensions> &shape,
                     const VariableConstView &sizes) {

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -13,8 +13,9 @@ namespace scipp::variable {
 /// `prototype` contains binned data the values of `shape` are interpreted as
 /// bin sizes.
 Variable empty_like(const VariableConstView &prototype,
-                    const VariableConstView &shape) {
-  return variableFactory().empty_like(prototype, shape);
+                    const std::optional<Dimensions> &shape,
+                    const VariableConstView &sizes) {
+  return variableFactory().empty_like(prototype, shape, sizes);
 }
 
 } // namespace scipp::variable

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/variable/creation.h"
+#include "scipp/variable/variable_factory.h"
+
+namespace scipp::variable {
+
+/// Create empty (uninitialized) variable with same parameters as prototype.
+///
+/// If specified, `shape` defines the shape and dims of the output. If
+/// `prototype` contains binned data the values of `shape` are interpreted as
+/// bin sizes.
+Variable empty_like(const VariableConstView &prototype,
+                    const VariableConstView &shape) {
+  return variableFactory().empty_like(prototype, shape);
+}
+
+} // namespace scipp::variable

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -17,12 +17,35 @@
 
 namespace scipp::variable {
 
+template <class Indices> class BinModelBase : public VariableConcept {
+public:
+  BinModelBase(const VariableConstView &indices, const Dim dim)
+      : VariableConcept(indices.dims()), m_indices(indices), m_dim(dim) {}
+
+  bool hasVariances() const noexcept override { return false; }
+  void setVariances(Variable &&) override {
+    throw except::VariancesError("This data type cannot have variances.");
+  }
+  VariableConstView bin_indices() const override { return indices(); }
+
+  const auto &indices() const { return m_indices; }
+  auto &indices() { return m_indices; }
+  Dim dim() const noexcept { return m_dim; }
+
+private:
+  Indices m_indices;
+  Dim m_dim;
+};
+
 /// Specialization of DataModel for "bucketed" data. T could be Variable,
 /// DataArray, or Dataset.
 ///
 /// A bucket in this context is defined as an element of a variable mapping to a
 /// range of data, such as a slice of a DataArray.
-template <class T> class DataModel<bucket<T>> : public VariableConcept {
+template <class T>
+class DataModel<bucket<T>>
+    : public BinModelBase<
+          std::conditional_t<is_view_v<T>, VariableConstView, Variable>> {
   using Indices = std::conditional_t<is_view_v<T>, VariableConstView, Variable>;
 
 public:
@@ -30,8 +53,7 @@ public:
   using range_type = typename bucket<T>::range_type;
 
   DataModel(const VariableConstView &indices, const Dim dim, T buffer)
-      : VariableConcept(indices.dims()),
-        m_indices(validated_indices(indices, dim, buffer)), m_dim(dim),
+      : BinModelBase<Indices>(validated_indices(indices, dim, buffer), dim),
         m_buffer(std::move(buffer)) {}
 
   VariableConceptHandle clone() const override {
@@ -39,8 +61,8 @@ public:
   }
 
   bool operator==(const DataModel &other) const noexcept {
-    return dims() == other.dims() && m_indices == other.m_indices &&
-           m_dim == other.m_dim && m_buffer == other.m_buffer;
+    return this->dims() == other.dims() && this->indices() == other.indices() &&
+           this->dim() == other.dim() && m_buffer == other.m_buffer;
   }
   bool operator!=(const DataModel &other) const noexcept {
     return !(*this == other);
@@ -48,8 +70,9 @@ public:
 
   VariableConceptHandle
   makeDefaultFromParent(const Dimensions &dims) const override {
-    return std::make_unique<DataModel>(makeVariable<range_type>(dims), m_dim,
-                                       T{m_buffer.slice({m_dim, 0, 0})});
+    return std::make_unique<DataModel>(makeVariable<range_type>(dims),
+                                       this->dim(),
+                                       T{m_buffer.slice({this->dim(), 0, 0})});
   }
 
   VariableConceptHandle
@@ -60,21 +83,17 @@ public:
     if constexpr (is_view_v<T>) {
       // converting, e.g., bucket<VariableView> to bucket<Variable>
       return std::make_unique<DataModel<bucket<typename T::value_type>>>(
-          zip(begin, begin), m_dim, resize_default_init(m_buffer, m_dim, size));
+          zip(begin, begin), this->dim(),
+          resize_default_init(m_buffer, this->dim(), size));
     } else {
       return std::make_unique<DataModel>(
-          zip(begin, begin), m_dim, resize_default_init(m_buffer, m_dim, size));
+          zip(begin, begin), this->dim(),
+          resize_default_init(m_buffer, this->dim(), size));
     }
   }
 
   static DType static_dtype() noexcept { return scipp::dtype<bucket<T>>; }
   DType dtype() const noexcept override { return scipp::dtype<bucket<T>>; }
-
-  bool hasVariances() const noexcept override { return false; }
-  void setVariances(Variable &&) override {
-    if (!core::canHaveVariances<T>())
-      throw except::VariancesError("This data type cannot have variances.");
-  }
 
   bool equals(const VariableConstView &a,
               const VariableConstView &b) const override;
@@ -82,20 +101,17 @@ public:
             const VariableView &dest) const override;
   void assign(const VariableConcept &other) override;
 
-  Dim dim() const noexcept { return m_dim; }
   // TODO Should the mutable version return a view to prevent risk of clients
   // breaking invariants of variable?
   const T &buffer() const noexcept { return m_buffer; }
   T &buffer() noexcept { return m_buffer; }
-  const auto &indices() const { return m_indices; }
-  auto &indices() { return m_indices; }
 
   ElementArrayView<bucket<T>> values(const core::ElementArrayViewParams &base) {
-    return {index_values(base), m_dim, m_buffer};
+    return {index_values(base), this->dim(), m_buffer};
   }
   ElementArrayView<const bucket<T>>
   values(const core::ElementArrayViewParams &base) const {
-    return {index_values(base), m_dim, m_buffer};
+    return {index_values(base), this->dim(), m_buffer};
   }
 
   scipp::index dtype_size() const override { return sizeof(range_type); }
@@ -135,21 +151,19 @@ private:
   auto index_values(const core::ElementArrayViewParams &base) const {
     if constexpr (is_view_v<T>) {
       // m_indices is a VariableConstView and may thus contain slicing
-      const auto params = m_indices.array_params();
+      const auto params = this->indices().array_params();
       const auto offset = params.offset() + base.offset();
       // `base` comes from the variable (view) holding this model, so it
       // contains slicing applied after the one that may be part of m_indices.
       // Dimensions are thus given by `base`:
       const auto dims = base.dims();
       const auto dataDims = params.dataDims();
-      return cast<range_type>(m_indices.underlying())
+      return cast<range_type>(this->indices().underlying())
           .values(core::ElementArrayViewParams(offset, dims, dataDims, {}));
     } else {
-      return cast<range_type>(m_indices).values(base);
+      return cast<range_type>(this->indices()).values(base);
     }
   }
-  Indices m_indices;
-  Dim m_dim;
   T m_buffer;
 };
 

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -30,7 +30,7 @@ public:
 
   const auto &indices() const { return m_indices; }
   auto &indices() { return m_indices; }
-  Dim dim() const noexcept { return m_dim; }
+  Dim bin_dim() const noexcept { return m_dim; }
 
 private:
   Indices m_indices;
@@ -62,7 +62,7 @@ public:
 
   bool operator==(const DataModel &other) const noexcept {
     return this->dims() == other.dims() && this->indices() == other.indices() &&
-           this->dim() == other.dim() && m_buffer == other.m_buffer;
+           this->bin_dim() == other.bin_dim() && m_buffer == other.m_buffer;
   }
   bool operator!=(const DataModel &other) const noexcept {
     return !(*this == other);
@@ -70,9 +70,9 @@ public:
 
   VariableConceptHandle
   makeDefaultFromParent(const Dimensions &dims) const override {
-    return std::make_unique<DataModel>(makeVariable<range_type>(dims),
-                                       this->dim(),
-                                       T{m_buffer.slice({this->dim(), 0, 0})});
+    return std::make_unique<DataModel>(
+        makeVariable<range_type>(dims), this->bin_dim(),
+        T{m_buffer.slice({this->bin_dim(), 0, 0})});
   }
 
   VariableConceptHandle
@@ -83,12 +83,12 @@ public:
     if constexpr (is_view_v<T>) {
       // converting, e.g., bucket<VariableView> to bucket<Variable>
       return std::make_unique<DataModel<bucket<typename T::value_type>>>(
-          zip(begin, begin), this->dim(),
-          resize_default_init(m_buffer, this->dim(), size));
+          zip(begin, begin), this->bin_dim(),
+          resize_default_init(m_buffer, this->bin_dim(), size));
     } else {
       return std::make_unique<DataModel>(
-          zip(begin, begin), this->dim(),
-          resize_default_init(m_buffer, this->dim(), size));
+          zip(begin, begin), this->bin_dim(),
+          resize_default_init(m_buffer, this->bin_dim(), size));
     }
   }
 
@@ -107,11 +107,11 @@ public:
   T &buffer() noexcept { return m_buffer; }
 
   ElementArrayView<bucket<T>> values(const core::ElementArrayViewParams &base) {
-    return {index_values(base), this->dim(), m_buffer};
+    return {index_values(base), this->bin_dim(), m_buffer};
   }
   ElementArrayView<const bucket<T>>
   values(const core::ElementArrayViewParams &base) const {
-    return {index_values(base), this->dim(), m_buffer};
+    return {index_values(base), this->bin_dim(), m_buffer};
   }
 
   scipp::index dtype_size() const override { return sizeof(range_type); }

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -174,19 +174,13 @@ template <class T>
 void DataModel<bucket<T>>::copy(const VariableConstView &src,
                                 const VariableView &dst) const {
   const auto &[indices0, dim0, buffer0] = src.constituents<bucket<T>>();
-  const auto [begin0, end0] = unzip(indices0);
-  const auto sizes1 = end0 - begin0;
-  const auto end1 = cumsum(sizes1);
-  const auto size1 = end1.template values<scipp::index>().as_span().back();
-  auto indices1 = zip(end1 - sizes1, end1);
-  auto buffer1 = resize_default_init(buffer0, dim0, size1);
-  copy_slices(buffer0, buffer1, dim0, indices0, indices1);
+  const auto &[indices1, dim1, buffer1] = dst.constituents<bucket<T>>();
   if constexpr (is_view_v<T>) {
+    // This is overly restrictive, could allow copy to non-const non-owning
     throw std::runtime_error(
-        "Copying a non-owning binned view is not supported.");
+        "Copying to non-owning binned view is not implemented.");
   } else {
-    dst.replace_model(
-        DataModel<bucket<T>>{std::move(indices1), dim0, std::move(buffer1)});
+    copy_slices(buffer0, buffer1, dim0, indices0, indices1);
   }
 }
 

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -86,8 +86,8 @@ public:
                       const VariableConstView &sizes) const override {
     if (shape)
       throw except::TypeError(
-          "Cannot specify shape in `empty_like` for non-bin prototype, shape "
-          "is given by shape of `sizes`.");
+          "Cannot specify shape in `empty_like` for prototype with bins, shape "
+          "must be given by shape of `sizes`.");
     const auto [indices, dim, buf] = prototype.constituents<bucket<T>>();
     Variable sizes_owner;
     auto sizes_ = sizes;

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -98,7 +98,7 @@ public:
     }
     const auto end = cumsum(sizes_);
     const auto begin = end - sizes_;
-    const auto size = sum(sizes_).template value<scipp::index>();
+    const auto size = end.template values<scipp::index>().as_span().back();
     return make_bins(zip(begin, end), dim, resize_default_init(buf, dim, size));
   }
 };

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -11,16 +11,6 @@
 
 namespace scipp::variable {
 
-VariableConstView Variable::bin_indices() const {
-  return data().bin_indices();
-}
-
-VariableConstView VariableConstView::bin_indices() const {
-  auto view = *this;
-  view.m_variable = &underlying().bin_indices().underlying();
-  return view;
-}
-
 template <class T>
 std::tuple<Variable, Dim, typename T::buffer_type> Variable::to_constituents() {
   Variable tmp;

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -16,7 +16,7 @@ std::tuple<Variable, Dim, typename T::buffer_type> Variable::to_constituents() {
   Variable tmp;
   std::swap(*this, tmp);
   auto &model = requireT<DataModel<T>>(tmp.data());
-  return {Variable(std::move(model.indices())), model.dim(),
+  return {Variable(std::move(model.indices())), model.bin_dim(),
           std::move(model.buffer())};
 }
 
@@ -45,7 +45,7 @@ VariableConstView::constituents() const {
   } else {
     view.m_variable = &model.indices();
   }
-  return {view, model.dim(), model.buffer()};
+  return {view, model.bin_dim(), model.buffer()};
 }
 
 template <class T>
@@ -54,12 +54,12 @@ VariableView::constituents() const {
   auto &model = requireT<DataModel<T>>(m_mutableVariable->data());
   if constexpr (is_view_v<typename T::buffer_type>) {
     auto view = std::get<0>(VariableConstView::constituents<T>());
-    return {view, model.dim(), model.buffer()};
+    return {view, model.bin_dim(), model.buffer()};
   } else {
     auto view = *this;
     view.m_variable = &model.indices();
     view.m_mutableVariable = &model.indices();
-    return {view, model.dim(), model.buffer()};
+    return {view, model.bin_dim(), model.buffer()};
   }
 }
 

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -91,7 +91,7 @@ private:
                                 const bool variances) const = 0;
 
 public:
-  bool is_buckets() const override { return true; }
+  bool is_bins() const override { return true; }
 
   Variable
   create(const DType elem_dtype, const Dimensions &dims,

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -89,12 +89,12 @@ public:
           "Cannot specify shape in `empty_like` for prototype with bins, shape "
           "must be given by shape of `sizes`.");
     const auto [indices, dim, buf] = prototype.constituents<bucket<T>>();
-    Variable sizes_owner;
+    Variable keep_alive_sizes;
     auto sizes_ = sizes;
     if (!sizes) {
       const auto &[begin, end] = unzip(indices);
-      sizes_owner = end - begin;
-      sizes_ = sizes_owner;
+      keep_alive_sizes = end - begin;
+      sizes_ = keep_alive_sizes;
     }
     const auto end = cumsum(sizes_);
     const auto begin = end - sizes_;

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -111,11 +111,11 @@ private:
                ? parents.front()
                : bucket_parent(parents.subspan(1));
   }
-  virtual Variable make_buckets(const VariableConstView &parent,
-                                const VariableConstView &indices, const Dim dim,
-                                const DType type, const Dimensions &dims,
-                                const units::Unit &unit,
-                                const bool variances) const = 0;
+  virtual Variable call_make_bins(const VariableConstView &parent,
+                             const VariableConstView &indices, const Dim dim,
+                             const DType type, const Dimensions &dims,
+                             const units::Unit &unit,
+                             const bool variances) const = 0;
 
 public:
   Variable
@@ -127,8 +127,8 @@ public:
     auto [indices, size] = contiguous_indices(parentIndices, dims);
     auto bufferDims = buffer.dims();
     bufferDims.resize(dim, size);
-    return make_buckets(parent, indices, dim, elem_dtype, bufferDims, unit,
-                        variances);
+    return call_make_bins(parent, indices, dim, elem_dtype, bufferDims, unit,
+                     variances);
   }
 
   Dim elem_dim(const VariableConstView &var) const override {

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -3,13 +3,16 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
+#include <optional>
 
 #include "scipp-variable_export.h"
 #include "scipp/variable/variable.h"
 
 namespace scipp::variable {
 
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable empty_like(
-    const VariableConstView &prototype, const VariableConstView &shape = {});
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+empty_like(const VariableConstView &prototype,
+           const std::optional<Dimensions> &shape = std::nullopt,
+           const VariableConstView &sizes = {});
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp-variable_export.h"
+#include "scipp/variable/variable.h"
+
+namespace scipp::variable {
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable empty_like(
+    const VariableConstView &prototype, const VariableConstView &shape = {});
+
+} // namespace scipp::variable

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -117,6 +117,9 @@ public:
   }
 
   scipp::index dtype_size() const override { return sizeof(T); }
+  VariableConstView bin_indices() const override {
+    throw except::TypeError("This data type does not have bin indices.");
+  }
 
 private:
   void expectHasVariances() const {

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -153,6 +153,8 @@ public:
     return {0, dims(), dims(), {}};
   }
 
+  VariableConstView bin_indices() const;
+
   template <class T>
   std::tuple<VariableConstView, Dim, typename T::const_element_type>
   constituents() const;
@@ -281,6 +283,8 @@ public:
   core::ElementArrayViewParams array_params() const noexcept {
     return {m_offset, m_dims, m_dataDims, {}};
   }
+
+  VariableConstView bin_indices() const;
 
   template <class T>
   std::tuple<VariableConstView, Dim, typename T::const_element_type>

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -60,6 +60,8 @@ public:
   virtual void assign(const VariableConcept &other) = 0;
   virtual scipp::index dtype_size() const = 0;
 
+  virtual VariableConstView bin_indices() const = 0;
+
   friend class Variable;
 
 private:

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -40,7 +40,8 @@ public:
     throw unreachable();
   }
   virtual Variable empty_like(const VariableConstView &prototype,
-                              const VariableConstView &shape) const = 0;
+                              const std::optional<Dimensions> &shape,
+                              const VariableConstView &sizes) const = 0;
 };
 
 template <class T> class VariableMaker : public AbstractVariableMaker {
@@ -79,8 +80,12 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
     return var.hasVariances();
   }
   Variable empty_like(const VariableConstView &prototype,
-                      const VariableConstView &shape) const override {
-    return create(prototype.dtype(), shape ? shape.dims() : prototype.dims(),
+                      const std::optional<Dimensions> &shape,
+                      const VariableConstView &sizes) const override {
+    if (sizes)
+      throw except::TypeError(
+          "Cannot specify sizes in `empty_like` for non-bin prototype.");
+    return create(prototype.dtype(), shape ? *shape : prototype.dims(),
                   prototype.unit(), prototype.hasVariances(), {});
   }
 };
@@ -141,7 +146,8 @@ public:
                             data.template variances<T>().data());
   }
   Variable empty_like(const VariableConstView &prototype,
-                      const VariableConstView &shape = {});
+                      const std::optional<Dimensions> &shape,
+                      const VariableConstView &sizes = {});
 
 private:
   VariableConstView view(const VariableConstView &var) const { return var; }

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -80,11 +80,8 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   }
   Variable empty_like(const VariableConstView &prototype,
                       const VariableConstView &shape) const override {
-    if (shape)
-      throw except::TypeError("Bin sizes provided to `empty_like`, but "
-                              "prototype does not contains bins.");
-    return create(prototype.dtype(), prototype.dims(), prototype.unit(),
-                  prototype.hasVariances(), {});
+    return create(prototype.dtype(), shape ? shape.dims() : prototype.dims(),
+                  prototype.unit(), prototype.hasVariances(), {});
   }
 };
 

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -39,6 +39,8 @@ public:
   array_params(const VariableConstView &) const {
     throw unreachable();
   }
+  virtual Variable empty_like(const VariableConstView &prototype,
+                              const VariableConstView &shape) const = 0;
 };
 
 template <class T> class VariableMaker : public AbstractVariableMaker {
@@ -75,6 +77,14 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   }
   bool hasVariances(const VariableConstView &var) const override {
     return var.hasVariances();
+  }
+  Variable empty_like(const VariableConstView &prototype,
+                      const VariableConstView &shape) const override {
+    if (shape)
+      throw except::TypeError("Bin sizes provided to `empty_like`, but "
+                              "prototype does not contains bins.");
+    return create(prototype.dtype(), prototype.dims(), prototype.unit(),
+                  prototype.hasVariances(), {});
   }
 };
 
@@ -133,6 +143,8 @@ public:
     return ElementArrayView(maker.array_params(var),
                             data.template variances<T>().data());
   }
+  Variable empty_like(const VariableConstView &prototype,
+                      const VariableConstView &shape = {});
 
 private:
   VariableConstView view(const VariableConstView &var) const { return var; }

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -69,7 +69,7 @@ auto apply(const DType dtype, Args &&... args) {
       std::tuple<double, float, int64_t, int32_t, std::string, bool,
                  scipp::core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
                  bucket<Variable>, bucket<VariableConstView>,
-                 bucket<VariableView>>{},
+                 bucket<VariableView>, scipp::index_pair>{},
       dtype, std::forward<Args>(args)...);
 }
 

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
   bucket_model_test.cpp
   comparison_test.cpp
+  creation_test.cpp
   cumulative_test.cpp
   indexed_slice_view_test.cpp
   mean_test.cpp
@@ -16,6 +17,7 @@ add_executable(
   shape_test.cpp
   sort_test.cpp
   subspan_view_test.cpp
+  test_variables.cpp
   transform_test.cpp
   trigonometry_test.cpp
   util_test.cpp

--- a/variable/test/creation_test.cpp
+++ b/variable/test/creation_test.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/variable/creation.h"
+#include "test_variables.h"
+
+using namespace scipp;
+
+TEST_P(DenseVariablesTest, empty_like_fail_if_sizes) {
+  const auto var = GetParam();
+  EXPECT_THROW(empty_like(var, {}, makeVariable<scipp::index>(Values{12})),
+               except::TypeError);
+}
+
+TEST_P(DenseVariablesTest, empty_like_default_shape) {
+  const auto var = GetParam();
+  const auto empty = empty_like(var);
+  EXPECT_EQ(empty.dtype(), var.dtype());
+  EXPECT_EQ(empty.dims(), var.dims());
+  EXPECT_EQ(empty.unit(), var.unit());
+  EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+}
+
+TEST_P(DenseVariablesTest, empty_like_slice_default_shape) {
+  const auto var = GetParam();
+  if (var.dims().contains(Dim::X)) {
+    const auto empty = empty_like(var.slice({Dim::X, 0}));
+    EXPECT_EQ(empty.dtype(), var.dtype());
+    EXPECT_EQ(empty.dims(), var.slice({Dim::X, 0}).dims());
+    EXPECT_EQ(empty.unit(), var.unit());
+    EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+  }
+}
+
+TEST_P(DenseVariablesTest, empty_like) {
+  const auto var = GetParam();
+  const Dimensions dims(Dim::X, 4);
+  const auto empty = empty_like(var, dims);
+  EXPECT_EQ(empty.dtype(), var.dtype());
+  EXPECT_EQ(empty.dims(), dims);
+  EXPECT_EQ(empty.unit(), var.unit());
+  EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+}

--- a/variable/test/test_variables.cpp
+++ b/variable/test/test_variables.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <gtest/gtest.h>
+
+#include "test_variables.h"
+
+using namespace scipp;
+
+INSTANTIATE_TEST_SUITE_P(
+    Scalar, DenseVariablesTest,
+    testing::Values(makeVariable<double>(Values{1.2}),
+                    makeVariable<double>(Values{1.2}, Variances{1.3}),
+                    makeVariable<float>(Values{1.2}, units::m),
+                    makeVariable<int64_t>(Values{12}),
+                    makeVariable<int32_t>(Values{4}, units::s),
+                    makeVariable<std::string>(Values{"abc"})));
+
+INSTANTIATE_TEST_SUITE_P(
+    1D, DenseVariablesTest,
+    testing::Values(makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+                                         Values{1, 2}, Variances{3, 4}),
+                    makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+                                         Values{1, 2}),
+                    makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::s,
+                                         Values{1, 2, 3}, Variances{3, 4, 5}),
+                    makeVariable<std::string>(Dims{Dim::Row}, Shape{3},
+                                              Values{"abc", "de", "f"})));
+
+INSTANTIATE_TEST_SUITE_P(
+    2D, DenseVariablesTest,
+    testing::Values(makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                                         units::m, Values{1, 2, 3, 4, 5, 6},
+                                         Variances{1, 1, 2, 2, 3, 3})));

--- a/variable/test/test_variables.h
+++ b/variable/test/test_variables.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <gtest/gtest.h>
+
+#include "scipp/variable/variable.h"
+
+class DenseVariablesTest : public ::testing::TestWithParam<scipp::Variable> {};

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -38,11 +38,6 @@ TEST_F(VariableBucketTest, copy_view) {
   EXPECT_EQ(Variable(var.slice({Dim::Y, 1, 2})), var.slice({Dim::Y, 1, 2}));
 }
 
-TEST_F(VariableBucketTest, shape_operations) {
-  // Not supported yet, not to ensure this fails instead of returning garbage.
-  EXPECT_ANY_THROW(concatenate(var, var, Dim::Y));
-}
-
 TEST_F(VariableBucketTest, basics) {
   // TODO Probably it would be a good idea to prevent having any other unit.
   // Does this imply unit should move from Variable into VariableConcept?

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -215,4 +215,12 @@ void expect0D(const Dimensions &dims) {
 
 } // namespace detail
 
+VariableConstView Variable::bin_indices() const { return data().bin_indices(); }
+
+VariableConstView VariableConstView::bin_indices() const {
+  auto view = *this;
+  view.m_variable = &underlying().bin_indices().underlying();
+  return view;
+}
+
 } // namespace scipp::variable

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -7,7 +7,6 @@
 #include "scipp/core/dtype.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/creation.h"
-#include "scipp/variable/string.h"
 #include "scipp/variable/variable_concept.h"
 
 namespace scipp::variable {

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -6,18 +6,15 @@
 
 #include "scipp/core/dtype.h"
 #include "scipp/core/except.h"
+#include "scipp/variable/creation.h"
+#include "scipp/variable/string.h"
 #include "scipp/variable/variable_concept.h"
 
 namespace scipp::variable {
 
 Variable::Variable(const VariableConstView &slice)
-    : Variable(slice ? slice.is_trivial() ? Variable(slice.underlying())
-                                          : Variable(slice, slice.dims())
-                     : Variable()) {
-  // There is a bug in the implementation of MultiIndex used in ElementArrayView
-  // in case one of the dimensions has extent 0.
-  if (slice && !slice.is_trivial() && dims().volume() != 0)
-    data().copy(slice, *this);
+    : Variable(empty_like(slice)) {
+  data().copy(slice, *this);
 }
 
 /// Construct from parent with same dtype, unit, and hasVariances but new dims.

--- a/variable/variable_factory.cpp
+++ b/variable/variable_factory.cpp
@@ -45,8 +45,9 @@ bool VariableFactory::hasVariances(const VariableConstView &var) const {
 }
 
 Variable VariableFactory::empty_like(const VariableConstView &prototype,
-                                     const VariableConstView &shape) {
-  return m_makers.at(prototype.dtype())->empty_like(prototype, shape);
+                                     const std::optional<Dimensions> &shape,
+                                     const VariableConstView &sizes) {
+  return m_makers.at(prototype.dtype())->empty_like(prototype, shape, sizes);
 }
 
 VariableFactory &variableFactory() {

--- a/variable/variable_factory.cpp
+++ b/variable/variable_factory.cpp
@@ -44,6 +44,11 @@ bool VariableFactory::hasVariances(const VariableConstView &var) const {
   return m_makers.at(var.dtype())->hasVariances(var);
 }
 
+Variable VariableFactory::empty_like(const VariableConstView &prototype,
+                                     const VariableConstView &shape) {
+  return m_makers.at(prototype.dtype())->empty_like(prototype, shape);
+}
+
 VariableFactory &variableFactory() {
   static VariableFactory factory;
   return factory;

--- a/variable/variable_factory.cpp
+++ b/variable/variable_factory.cpp
@@ -14,8 +14,8 @@ void VariableFactory::emplace(const DType key,
 bool VariableFactory::contains(const DType key) const noexcept {
   return m_makers.find(key) != m_makers.end();
 }
-bool VariableFactory::is_buckets(const VariableConstView &var) const {
-  return m_makers.at(var.dtype())->is_buckets();
+bool VariableFactory::is_bins(const VariableConstView &var) const {
+  return m_makers.at(var.dtype())->is_bins();
 }
 
 Dim VariableFactory::elem_dim(const VariableConstView &var) const {
@@ -49,8 +49,8 @@ VariableFactory &variableFactory() {
   return factory;
 }
 
-bool is_buckets(const VariableConstView &var) {
-  return variableFactory().is_buckets(var);
+bool is_bins(const VariableConstView &var) {
+  return variableFactory().is_bins(var);
 }
 
 } // namespace scipp::variable

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -16,11 +16,11 @@ INSTANTIATE_BUCKET_VARIABLE(VariableConstView_observer,
 
 template <class T> class BinVariableMakerVariable : public BinVariableMaker<T> {
 private:
-  Variable make_buckets(const VariableConstView &,
-                        const VariableConstView &indices, const Dim dim,
-                        const DType type, const Dimensions &dims,
-                        const units::Unit &unit,
-                        const bool variances) const override {
+  Variable call_make_bins(const VariableConstView &,
+                          const VariableConstView &indices, const Dim dim,
+                          const DType type, const Dimensions &dims,
+                          const units::Unit &unit,
+                          const bool variances) const override {
     // Buffer contains only variable, which is created with new dtype, no
     // information to copy from parent.
     return make_bins(Variable(indices), dim,

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -14,8 +14,7 @@ INSTANTIATE_BUCKET_VARIABLE(VariableView_observer, bucket<VariableView>)
 INSTANTIATE_BUCKET_VARIABLE(VariableConstView_observer,
                             bucket<VariableConstView>)
 
-template <class T>
-class BucketVariableMakerVariable : public BucketVariableMaker<T> {
+template <class T> class BinVariableMakerVariable : public BinVariableMaker<T> {
 private:
   Variable make_buckets(const VariableConstView &,
                         const VariableConstView &indices, const Dim dim,
@@ -57,13 +56,13 @@ namespace {
 auto register_variable_maker_bucket_Variable(
     (variableFactory().emplace(
          dtype<bucket<Variable>>,
-         std::make_unique<BucketVariableMakerVariable<Variable>>()),
+         std::make_unique<BinVariableMakerVariable<Variable>>()),
      variableFactory().emplace(
          dtype<bucket<VariableView>>,
-         std::make_unique<BucketVariableMakerVariable<VariableView>>()),
+         std::make_unique<BinVariableMakerVariable<VariableView>>()),
      variableFactory().emplace(
          dtype<bucket<VariableConstView>>,
-         std::make_unique<BucketVariableMakerVariable<VariableConstView>>()),
+         std::make_unique<BinVariableMakerVariable<VariableConstView>>()),
      0));
 }
 

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -47,8 +47,7 @@ private:
             params.dims(),
             params.dataDims(),
             {dim, buffer.dims(),
-             indices.template values<std::pair<scipp::index, scipp::index>>()
-                 .data()}};
+             indices.template values<scipp::index_pair>().data()}};
   }
 };
 

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -24,8 +24,8 @@ private:
                         const bool variances) const override {
     // Buffer contains only variable, which is created with new dtype, no
     // information to copy from parent.
-    return Variable{std::make_unique<DataModel<bucket<Variable>>>(
-        indices, dim, variableFactory().create(type, dims, unit, variances))};
+    return make_bins(Variable(indices), dim,
+                     variableFactory().create(type, dims, unit, variances));
   }
   VariableConstView data(const VariableConstView &var) const override {
     return std::get<2>(var.constituents<bucket<T>>());


### PR DESCRIPTION
Fixes #1432. This was not just broken for loaded neutron data, but not implemented for *any* any binned data.

A couple additions and improvements were required for this:
- The specialization of `DataModel::copy` for binned data now does not create a new buffer. It can thus be used to copy sections of data, i.e., also works with slices instead of just variables, just like the non-specialized one.
- As a consequence of the above I had to add a way of creating bin variables with given bin sizes, without requiring knowledge of the buffer type. See new addition of `empty_like`.
- Constructing variable from slice could be simplified.

Unfortunately this changeset also highlights the shortcomings of working with some of the internals of binned data. It requires touching several places, since everything has to be handled either via `VariableFactory` or new (virtual) methods of `VariableConcept`. For the latter we then need to wrap this in `Variable` and `VariableConstView`, since the concept is not aware of slicing. I think there must be a way to do this in a cleaner and more consistent way. Maybe it will not be much of a problem any more once all the required things are exposed?

@reviewers:
I also tried out a "new" approach that we may consider for more complete testing of free functions, in this case variables:
- `test_variables.h` defines test fixtures, which get instantiated as parametrized test suites.
- Tests for free function (in this case `empty_like`) can be added as definitions of new tests (include `test_variables.h` and use `TEST_P`).
This is far from perfect, and probably does not work in many cases, see, e.g., the example were a test has to be skipped of the param does not depend on `Dim::X`. Nevertheless I hope this may allow for a better coverage of the "parameter space" of possible variables.

Note that I have not instantiated the suite for an even remotely "complete" set of variables. We can add this if we think the approach is useful at all.