### PR TITLE
Bin arg validation

### DIFF
--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -462,7 +462,7 @@ void expect_edges_or_groups(const std::vector<VariableConstView> &edges,
         "must be set.");
   }
 }
-}
+} // namespace
 
 DataArray bin(const DataArrayConstView &array,
               const std::vector<VariableConstView> &edges,

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -453,9 +453,21 @@ DataArray groupby_concat_bins(const DataArrayConstView &array,
       builder.groups(), {reductionDim});
 }
 
+namespace {
+void expect_edges_or_groups(const std::vector<VariableConstView> &edges,
+                            const std::vector<VariableConstView> &groups) {
+  if (edges.empty() && groups.empty()) {
+    throw scipp::except::BucketError(
+        "Arguments 'edges' and 'groups' of 'bin' are both empty. At least one "
+        "must be set.");
+  }
+}
+}
+
 DataArray bin(const DataArrayConstView &array,
               const std::vector<VariableConstView> &edges,
               const std::vector<VariableConstView> &groups) {
+  expect_edges_or_groups(edges, groups);
   const auto &data = array.data();
   const auto &coords = array.coords();
   const auto &masks = array.masks();

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -144,6 +144,11 @@ TEST_P(BinTest, group) {
   EXPECT_EQ(binned.dims(), groups.dims());
 }
 
+TEST_P(BinTest, no_edges_or_groups) {
+  const auto table = GetParam();
+  EXPECT_THROW(bin(table, {}), except::BucketError);
+}
+
 TEST_P(BinTest, rebin_coarse_to_fine_1d) {
   const auto table = GetParam();
   EXPECT_EQ(bin(table, {edges_x}),

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -149,6 +149,12 @@ TEST_P(BinTest, no_edges_or_groups) {
   EXPECT_THROW(bin(table, {}), except::BucketError);
 }
 
+TEST_P(BinTest, edges_too_short) {
+  const auto table = GetParam();
+  const auto edges = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1});
+  EXPECT_THROW(bin(table, {edges}), except::BucketError);
+}
+
 TEST_P(BinTest, rebin_coarse_to_fine_1d) {
   const auto table = GetParam();
   EXPECT_EQ(bin(table, {edges_x}),


### PR DESCRIPTION
This fixes two segfaults caused by calling `sc.bin` with 
- empty 'edges' and 'groups' arguments;
- 'edges' with few than 2 elements.