### PR TITLE
Mark bin-edges of attributes in HTML repr

### DIFF
--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -90,7 +90,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
 
   if constexpr (std::is_same_v<D, DataArray> ||
                 std::is_same_v<D, DataArrayConstView>) {
-    s << shift << "Data:\n" << format_data_view(dataset.name(), dataset);
+    s << shift << "Data:\n" << format_data_view(dataset.name(), dataset, dims);
   } else {
     if (!dataset.empty())
       s << shift << "Data:\n";

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -52,7 +52,7 @@ template <class T> auto sorted(const T &map) {
 
 template <class Key>
 auto format_data_view(const Key &name, const DataArrayConstView &data,
-                      const Dimensions &datasetDims = Dimensions()) {
+                      const Dimensions &datasetDims) {
   std::stringstream s;
   s << format_variable(name, data.data(), datasetDims);
   if (!data.masks().empty()) {

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -172,13 +172,10 @@ def summarize_attrs_simple(attrs):
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 
 
-def summarize_attrs(attrs, ds=None):
+def summarize_attrs(attrs, embedded_in=None):
     attrs_li = "".join("<li class='xr-var-item'>{}</li>".format(
         summarize_variable(
-            name,
-            values,
-            has_attrs=False,
-            bin_edges=find_bin_edges(values, ds) if ds is not None else None))
+            name, values, has_attrs=False, embedded_in=embedded_in))
                        for name, values in _ordered_dict(attrs).items())
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
 
@@ -193,8 +190,7 @@ def _icon(icon_name):
 
 def summarize_coord(dim, var, ds=None):
     is_index = dim in var.dims
-    bin_edges = find_bin_edges(var, ds) if ds is not None else None
-    return summarize_variable(str(dim), var, is_index, bin_edges=bin_edges)
+    return summarize_variable(str(dim), var, is_index, embedded_in=ds)
 
 
 def find_bin_edges(var, ds):
@@ -202,7 +198,6 @@ def find_bin_edges(var, ds):
     Checks if the coordinate contains bin-edges.
     """
     bin_edges = []
-
     for idx, dim in enumerate(var.dims):
         len = var.shape[idx]
         if dim in ds.dims and ds.shape[ds.dims.index(dim)] + 1 == len:
@@ -218,7 +213,7 @@ def summarize_coords(coords, ds=None):
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
-def _make_inline_attributes(var, has_attrs):
+def _make_inline_attributes(var, has_attrs, embedded_in):
     disabled = "disabled"
     attrs_ul = ""
     attrs_sections = []
@@ -243,7 +238,7 @@ def _make_inline_attributes(var, has_attrs):
 
     if has_attrs and hasattr(var, "attrs"):
         if len(var.attrs) > 0:
-            attrs_sections.append(attr_section(var.attrs))
+            attrs_sections.append(attr_section(var.attrs, embedded_in))
             disabled = ""
 
     if len(attrs_sections) > 0:
@@ -291,17 +286,21 @@ def summarize_variable(name,
                        var,
                        is_index=False,
                        has_attrs=False,
-                       bin_edges=None,
+                       embedded_in=None,
                        add_dim_size=False):
     """
     Formats the variable data into the format expected when displaying
     as a standalone variable (when a single variable or data array is
     displayed) or as part of a dataset.
     """
-    dims_str = escape(f"({_make_dim_str(var, bin_edges, add_dim_size)})")
+    dims_str = escape("({})".format(
+        _make_dim_str(
+            var,
+            find_bin_edges(var, embedded_in)
+            if embedded_in is not None else None, add_dim_size)))
     unit = '' if var.unit == sc.units.dimensionless else repr(var.unit)
 
-    disabled, attrs_ul = _make_inline_attributes(var, has_attrs)
+    disabled, attrs_ul = _make_inline_attributes(var, has_attrs, embedded_in)
 
     preview = inline_variable_repr(var)
     data_repr = f"Values:<br>{short_data_repr_html(var)}"
@@ -349,11 +348,10 @@ def summarize_variable(name,
 def summarize_data(dataset):
     has_attrs = is_dataset(dataset)
     vars_li = "".join("<li class='xr-var-item'>{}</li>".format(
-        summarize_variable(
-            name,
-            var,
-            has_attrs=has_attrs,
-            bin_edges=find_bin_edges(var, dataset) if has_attrs else None))
+        summarize_variable(name,
+                           var,
+                           has_attrs=has_attrs,
+                           embedded_in=dataset if has_attrs else None))
                       for name, var in _ordered_dict(dataset).items())
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 

--- a/python/src/scipp/table_html/formatting_html.py
+++ b/python/src/scipp/table_html/formatting_html.py
@@ -172,9 +172,13 @@ def summarize_attrs_simple(attrs):
     return f"<dl class='xr-attrs'>{attrs_dl}</dl>"
 
 
-def summarize_attrs(attrs):
-    attrs_li = "".join(f"<li class='xr-var-item'>\
-            {summarize_variable(name, values, has_attrs=False)}</li>"
+def summarize_attrs(attrs, ds=None):
+    attrs_li = "".join("<li class='xr-var-item'>{}</li>".format(
+        summarize_variable(
+            name,
+            values,
+            has_attrs=False,
+            bin_edges=find_bin_edges(values, ds) if ds is not None else None))
                        for name, values in _ordered_dict(attrs).items())
     return f"<ul class='xr-var-list'>{attrs_li}</ul>"
 
@@ -476,7 +480,7 @@ def dataset_repr(ds):
         if len(ds.masks) > 0:
             sections.append(mask_section(ds.masks, ds))
         if len(ds.attrs) > 0:
-            sections.append(attr_section(ds.attrs))
+            sections.append(attr_section(ds.attrs, ds))
 
     return _obj_repr(header_components, sections)
 

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -36,7 +36,7 @@ std::string make_dims_labels(const VariableConstView &variable,
   for (const auto dim : dims.labels()) {
     diminfo += to_string(dim);
     if (datasetDims.contains(dim) && (datasetDims[dim] + 1 == dims[dim]))
-      diminfo += " [bin-edges]";
+      diminfo += " [bin-edge]";
     diminfo += ", ";
   }
   diminfo.resize(diminfo.size() - 2);


### PR DESCRIPTION
Fixed #1454 

Bin-edge coordinates in attributes are correctly marked in the HTML representations of DataArrays and Datasets:
![HTML-repr](https://user-images.githubusercontent.com/11393224/103796355-627a1480-5047-11eb-968c-e50b56972177.png)

This also fixes the string output to include the bin-edge markers:
```.py
print(da)
```
```
<scipp.DataArray>
Dimensions: {{x, 10}}
Coordinates:
    lab                       int64      [m]              (x [bin-edge])  [0, 1, ..., 9, 10]
    x                         int64      [m]              (x)  [0, 1, ..., 8, 9]
Data:
                              float64    [counts]         (x)  [0.020912, 0.255954, ..., 0.065172, 0.577774]
    Masks:
            m1                        bool       [dimensionless]  (x)  [True, False, ..., True, False]
    Coordinates (unaligned):
            a1                        float64    [m]              (x [bin-edge])  [0.000000, 1.100000, ..., 9.900000, 11.000000]
            a2                        float64    [m]              (x)  [0.000000, 1.200000, ..., 9.600000, 10.800000]
```
and
```.py
print(ds)
```
```
<scipp.Dataset>
Dimensions: {{x, 10}}
Coordinates:
    lab                       int64      [m]              (x [bin-edge])  [0, 1, ..., 9, 10]
    x                         int64      [m]              (x)  [0, 1, ..., 8, 9]
Data:
    Signal                    float64    [m]              (x)  [0.487403, 0.439712, ..., 0.662521, 0.730063]
    Masks:
            m1                        bool       [dimensionless]  (x)  [True, False, ..., True, False]
    Coordinates (unaligned):
            a1                        float64    [s]              (x [bin-edge])  [0.000000, 1.100000, ..., 9.900000, 11.000000]
            a2                        float64    [s]              (x)  [0.000000, 1.200000, ..., 9.600000, 10.800000]
```