### PR TITLE
Update string representations

### DIFF
--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -52,9 +52,8 @@ template <class T> auto sorted(const T &map) {
 
 template <class Key>
 auto format_data_view(const Key &name, const DataArrayConstView &data,
-                      const Dimensions &datasetDims,
-                      const std::string &shift, const bool inline_meta) {
-
+                      const Dimensions &datasetDims, const std::string &shift,
+                      const bool inline_meta) {
   std::stringstream s;
   s << shift << format_variable(name, data.data(), datasetDims);
 
@@ -95,8 +94,8 @@ std::string do_to_string(const D &dataset, const std::string &id,
 
   if constexpr (std::is_same_v<D, DataArray> ||
                 std::is_same_v<D, DataArrayConstView>) {
-    s << shift << "Data:\n" << format_data_view(dataset.name(), dataset,
-                          dims, shift, true);
+    s << shift << "Data:\n"
+      << format_data_view(dataset.name(), dataset, dims, shift, true);
   } else {
     if (!dataset.empty())
       s << shift << "Data:\n";

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -34,7 +34,7 @@ std::ostream &operator<<(std::ostream &os, const Dataset &dataset) {
   return os << DatasetConstView(dataset);
 }
 
-constexpr const char *tab = "    ";
+constexpr const char *tab = "  ";
 
 template <class D>
 std::string do_to_string(const D &dataset, const std::string &id,

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -57,7 +57,7 @@ auto format_data_view(const Key &name, const DataArrayConstView &data,
   std::stringstream s;
   s << shift << format_variable(name, data.data(), datasetDims);
 
-  const std::string header_shift = inline_meta ? shift : (shift + tab);
+  const std::string header_shift = inline_meta ? shift : (shift + tab + tab);
   const std::string data_shift = inline_meta ? shift : (header_shift + tab);
   if (!data.masks().empty()) {
     s << header_shift << "Masks:\n";

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -61,7 +61,7 @@ auto format_data_view(const Key &name, const DataArrayConstView &data,
       s << tab << tab << format_variable(key, var, datasetDims);
   }
   if (!data.attrs().empty()) {
-    s << tab << "Coordinates (unaligned):\n";
+    s << tab << "Attributes:\n";
     for (const auto &[key, var] : sorted(data.attrs()))
       s << tab << tab << format_variable(key, var, datasetDims);
   }

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -25,7 +25,7 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable) {
   return os << VariableConstView(variable);
 }
 
-constexpr const char *tab = "    ";
+constexpr const char *tab = "  ";
 
 std::string make_dims_labels(const VariableConstView &variable,
                              const Dimensions &datasetDims) {


### PR DESCRIPTION
- Changes 'Coordinates (Unaligned)' to 'Attributes' in string output of DataArray and Dataset.
- Changes indentation of attributes and masks to match that of HTML tables.

Masks and attributes not indented:
```.py
da = sc.DataArray(
    coords={'x': sc.Variable(['x'], values=np.arange(10), unit=sc.units.m),
            'lab': sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)},
    attrs={'a1': sc.Variable(['x'], values=1.1*np.arange(11), unit=sc.units.m),
           'a2': sc.Variable(['x'], values=1.2*np.arange(10), unit=sc.units.m)},
    masks={'m1': sc.Variable(['x'], values=np.arange(10)%2==0)},
    data=sc.Variable(['x'], values=np.random.random(10), unit=sc.units.counts))
print(da)
```
```
<scipp.DataArray>
Dimensions: {{x, 10}}
Coordinates:
    lab                       int64      [m]              (x [bin-edges])  [0, 1, ..., 9, 10]
    x                         int64      [m]              (x)  [0, 1, ..., 8, 9]
Data:
                              float64    [counts]         (x)  [0.310651, 0.220707, ..., 0.205225, 0.407591]
Masks:
    m1                        bool       [dimensionless]  (x)  [True, False, ..., True, False]
Attributes:
    a1                        float64    [m]              (x [bin-edges])  [0.000000, 1.100000, ..., 9.900000, 11.000000]
    a2                        float64    [m]              (x)  [0.000000, 1.200000, ..., 9.600000, 10.800000]
```

Masks and attributes indented:
```.py
ds = sc.Dataset()
ds.coords['x'] = sc.Variable(['x'], values=np.arange(10), unit=sc.units.m)
ds.coords['lab'] = sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)
ds['Signal'] = sc.Variable(['x'], values=np.random.random(10), unit=sc.units.m)
ds['Signal'].attrs['a1'] = sc.Variable(['x'], values=1.1*np.arange(11), unit=sc.units.s)
ds['Signal'].attrs['a2'] = sc.Variable(['x'], values=1.2*np.arange(10), unit=sc.units.s)
ds['Signal'].masks['m1'] = sc.Variable(['x'], values=np.arange(10)%2==0)
print(ds)
```
```
<scipp.Dataset>
Dimensions: {{x, 10}}
Coordinates:
    lab                       int64      [m]              (x [bin-edges])  [0, 1, ..., 9, 10]
    x                         int64      [m]              (x)  [0, 1, ..., 8, 9]
Data:
    Signal                    float64    [m]              (x)  [0.447900, 0.001226, ..., 0.769538, 0.259266]
    Masks:
            m1                        bool       [dimensionless]  (x)  [True, False, ..., True, False]
    Attributes:
            a1                        float64    [s]              (x [bin-edges])  [0.000000, 1.100000, ..., 9.900000, 11.000000]
            a2                        float64    [s]              (x)  [0.000000, 1.200000, ..., 9.600000, 10.800000]
```