### PR TITLE
Remove pseudo copy constructor and update python side docs for DataArray

### DIFF
--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -240,7 +240,6 @@ void init_dataset(py::module &m) {
 
   py::class_<DataArray> dataArray(m, "DataArray", R"(
     Named variable with associated coords, masks, and attributes.)");
-  dataArray.def(py::init<const DataArrayConstView &>());
   dataArray
       .def(py::init([](VariableConstView data,
                        std::map<Dim, VariableConstView> coords,

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -240,24 +240,42 @@ void init_dataset(py::module &m) {
 
   py::class_<DataArray> dataArray(m, "DataArray", R"(
     Named variable with associated coords, masks, and attributes.)");
+  py::options options;
+  options.disable_function_signatures();
   dataArray
-      .def(py::init([](VariableConstView data,
-                       std::map<Dim, VariableConstView> coords,
-                       std::map<std::string, VariableConstView> masks,
-                       std::map<Dim, VariableConstView> unaligned_coords,
-                       const std::string &name) {
-             return DataArray{Variable{data}, coords, masks, unaligned_coords,
-                              name};
-           }),
-           py::arg("data") = Variable{},
-           py::arg("coords") = std::map<Dim, VariableConstView>{},
-           py::arg("masks") = std::map<std::string, VariableConstView>{},
-           py::arg("attrs") = std::map<Dim, VariableConstView>{},
-           py::arg("name") = std::string{})
+      .def(
+          py::init([](VariableConstView data,
+                      std::map<Dim, VariableConstView> coords,
+                      std::map<std::string, VariableConstView> masks,
+                      std::map<Dim, VariableConstView> unaligned_coords,
+                      const std::string &name) {
+            return DataArray{Variable{data}, coords, masks, unaligned_coords,
+                             name};
+          }),
+          py::arg("data") = Variable{},
+          py::arg("coords") = std::map<Dim, VariableConstView>{},
+          py::arg("masks") = std::map<std::string, VariableConstView>{},
+          py::arg("attrs") = std::map<Dim, VariableConstView>{},
+          py::arg("name") = std::string{},
+          R"(__init__(self, data: Variable, coords: Dict[str, Variable] = {}, masks: Dict[str, Variable] = {}, attrs: Dict[str, Variable] = {}, name: str = '') -> None
+          
+          DataArray initialiser.
+
+          :param data: Data and optionally variances.
+          :param coords: Coordinates referenced by dimension.
+          :param masks: Masks referenced by name.
+          :param attrs: Attributes referenced by dimension.
+          :param name: Name of DataArray.
+          :type data: Variable
+          :type coords: Dict[str, Variable]
+          :type masks: Dict[str, Variable]
+          :type attrs: Dict[str, Variable]
+          :type name: str
+          )")
       .def("__sizeof__", [](const DataArrayConstView &array) {
         return size_of(array, true);
       });
-
+  options.enable_function_signatures();
   py::class_<DataArrayConstView>(m, "DataArrayConstView")
       .def(py::init<const DataArray &>())
       .def("__sizeof__", [](const DataArrayConstView &array) {
@@ -268,7 +286,17 @@ void init_dataset(py::module &m) {
       m, "DataArrayView", R"(
         View for DataArray, representing a sliced view onto a DataArray, or an item of a Dataset;
         Mostly equivalent to DataArray, see there for details.)");
-  dataArrayView.def(py::init<DataArray &>());
+
+  options.disable_function_signatures();
+  dataArrayView.def(py::init<DataArray &>(), py::arg("dataArray"),
+                    R"(__init__(self, dataArray: DataArray) -> None
+                    
+                    DataArrayView initialiser.
+
+                    :param dataArray: Viewed DataArray.
+                    :type dataArray: DataArray
+                    )");
+  options.enable_function_signatures();
 
   bind_data_array_properties(dataArray);
   bind_data_array_properties(dataArrayView);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -266,7 +266,7 @@ void init_dataset(py::module &m) {
           :param masks: Masks referenced by name.
           :param attrs: Attributes referenced by dimension.
           :param name: Name of DataArray.
-          :type data: Variable
+          :type data: VariableConstView
           :type coords: Dict[str, VariableConstView]
           :type masks: Dict[str, VariableConstView]
           :type attrs: Dict[str, VariableConstView]

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -257,7 +257,7 @@ void init_dataset(py::module &m) {
           py::arg("masks") = std::map<std::string, VariableConstView>{},
           py::arg("attrs") = std::map<Dim, VariableConstView>{},
           py::arg("name") = std::string{},
-          R"(__init__(self, data: Variable, coords: Dict[str, Variable] = {}, masks: Dict[str, Variable] = {}, attrs: Dict[str, Variable] = {}, name: str = '') -> None
+          R"(__init__(self, data: VariableConstView, coords: Dict[str, VariableConstView] = {}, masks: Dict[str, VariableConstView] = {}, attrs: Dict[str, VariableConstView] = {}, name: str = '') -> None
           
           DataArray initialiser.
 
@@ -267,9 +267,9 @@ void init_dataset(py::module &m) {
           :param attrs: Attributes referenced by dimension.
           :param name: Name of DataArray.
           :type data: Variable
-          :type coords: Dict[str, Variable]
-          :type masks: Dict[str, Variable]
-          :type attrs: Dict[str, Variable]
+          :type coords: Dict[str, VariableConstView]
+          :type masks: Dict[str, VariableConstView]
+          :type attrs: Dict[str, VariableConstView]
           :type name: str
           )")
       .def("__sizeof__", [](const DataArrayConstView &array) {

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -257,7 +257,7 @@ void init_dataset(py::module &m) {
           py::arg("masks") = std::map<std::string, VariableConstView>{},
           py::arg("attrs") = std::map<Dim, VariableConstView>{},
           py::arg("name") = std::string{},
-          R"(__init__(self, data: VariableConstView, coords: Dict[str, VariableConstView] = {}, masks: Dict[str, VariableConstView] = {}, attrs: Dict[str, VariableConstView] = {}, name: str = '') -> None
+          R"(__init__(self, data: Variable, coords: Dict[str, Variable] = {}, masks: Dict[str, Variable] = {}, attrs: Dict[str, Variable] = {}, name: str = '') -> None
           
           DataArray initialiser.
 
@@ -266,10 +266,10 @@ void init_dataset(py::module &m) {
           :param masks: Masks referenced by name.
           :param attrs: Attributes referenced by dimension.
           :param name: Name of DataArray.
-          :type data: VariableConstView
-          :type coords: Dict[str, VariableConstView]
-          :type masks: Dict[str, VariableConstView]
-          :type attrs: Dict[str, VariableConstView]
+          :type data: Variable
+          :type coords: Dict[str, Variable]
+          :type masks: Dict[str, Variable]
+          :type attrs: Dict[str, Variable]
           :type name: str
           )")
       .def("__sizeof__", [](const DataArrayConstView &array) {

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -128,6 +128,10 @@ class GroupbyBins:
 
 
 def _bins(obj):
+    """
+    Returns binning object allowing bin-wise operations
+    to be performed.
+    """
     if _cpp.is_bins(obj):
         return _Bins(obj)
     else:

--- a/python/src/scipp/io/hdf5.py
+++ b/python/src/scipp/io/hdf5.py
@@ -273,6 +273,9 @@ class HDF5IO:
 
 
 def to_hdf5(obj, filename):
+    """
+    Writes object out to file in hdf5 format.
+    """
     import h5py
     with h5py.File(filename, 'w') as f:
         HDF5IO.write(f, obj)

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -24,9 +24,9 @@ def test_slice_init():
     orig = sc.DataArray(
         data=sc.Variable(['x'], values=np.arange(2.0)),
         coords={'x': sc.Variable(['x'], values=np.arange(3.0))})
-    a = sc.DataArray(orig['x', :])
+    a = orig['x', :].copy()
     assert sc.is_equal(a, orig)
-    b = sc.DataArray(orig['x', 1:])
+    b = orig['x', 1:].copy()
     assert b.data.values[0] == orig.data.values[1:]
 
 


### PR DESCRIPTION
This updates the available overloads and documentation of DataArray for clarity. 

The only API change is that the `DataArray(DataArrayView)` overload has been removed from the python side as this copying/conversion of a view into a full copy can already be achieved in a more pythonic way using the `.copy()` method.

The Documentation string has been added manually so it appears correctly and clearly on the documentation page. Build the docs yourself to check it works but for me the DataArray documentation now looks like 

![image](https://user-images.githubusercontent.com/32058966/104017391-f5ce5980-51af-11eb-839c-5a2cf9a6aedf.png)
