### PR TITLE
Update dataset api and docs

### DIFF
--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -320,7 +320,7 @@ void init_dataset(py::module &m) {
              :param data: Dictionary of name and data pairs.
              :param coords: Dictionary of name and coord pairs.
              :type data: Dict[str, Union[Variable, DataArray]]
-             :type coord: Dict[str, Variable]
+             :type coords: Dict[str, Variable]
              )");
   options.enable_function_signatures();
 

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -292,21 +292,24 @@ void init_dataset(py::module &m) {
   Dict of data arrays with aligned dimensions.)");
 
   dataset
-      .def(
-          py::init([](const std::map<std::string, VariableConstView> &data,
-                      const std::map<Dim, VariableConstView> &coords) {
-            return Dataset(data, coords);
-          }),
-          py::arg("data") = std::map<std::string, VariableConstView>{},
-          py::arg("coords") = std::map<Dim, VariableConstView>{},
-          R"(__init__(self, data: Dict[str, VariableConstView] = {}, coords: Dict[str, VariableConstView] = {})
+      .def(py::init([](const std::map<std::string, VariableConstView> &data,
+                       const std::map<Dim, VariableConstView> &coords) {
+             return Dataset(data, coords);
+           }),
+           py::arg("data") = std::map<std::string, VariableConstView>{},
+           py::arg("coords") = std::map<Dim, VariableConstView>{},
+           R"(Overloaded Function
+             
+             __init__(self, data: Dict[str, VariableConstView] = {}, coords: Dict[str, VariableConstView] = {})
           
              Initialise from a dictionary of Variables and optionally coordinates.
              Each Variable is converted into a DataArray within the Dataset.
              )")
       .def(py::init<const std::map<std::string, DataArrayConstView> &>(),
            py::arg("data"),
-           R"(__init__(self, data: Dict[str, DataArrayConstView])
+           R"(Overloaded Function
+           
+              __init__(self, data: Dict[str, DataArrayConstView])
               
               Initialise from a dictionary of DataArrays.
               )");

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -302,7 +302,7 @@ void init_dataset(py::module &m) {
               d.setCoord(dim, std::move(coord));
 
             for (auto &&[name, item] : data) {
-              auto visitor = [&d, &name](auto &object) {
+              auto visitor = [&d, name = name](auto &object) {
                 d.setData(std::string(name), std::move(object));
               };
               std::visit(visitor, item);

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -299,14 +299,14 @@ void init_dataset(py::module &m) {
           }),
           py::arg("data") = std::map<std::string, VariableConstView>{},
           py::arg("coords") = std::map<Dim, VariableConstView>{},
-          R"(__init__(data: Dict[str, Variable] = {}, coords: Dict[str, Variable] = {})
+          R"(__init__(self, data: Dict[str, VariableConstView] = {}, coords: Dict[str, VariableConstView] = {})
           
              Initialise from a dictionary of Variables and optionally coordinates.
              Each Variable is converted into a DataArray within the Dataset.
              )")
       .def(py::init<const std::map<std::string, DataArrayConstView> &>(),
            py::arg("data"),
-           R"(__init__(data: Dict[str, DataArray])
+           R"(__init__(self, data: Dict[str, DataArrayConstView])
               
               Initialise from a dictionary of DataArrays.
               )");

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -123,7 +123,7 @@ class TestMantidConversion(unittest.TestCase):
         da = mantidcompat.convert_EventWorkspace_to_data_array(
             eventWS, load_pulse_times=False)
         da = sc.histogram(da.bins, target_tof)
-        d = sc.Dataset(da)
+        d = sc.Dataset({da.name: da})
         converted = sc.neutron.convert(d, 'tof', 'wavelength')
 
         self.assertTrue(

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -41,7 +41,7 @@ def test_create():
 def test_create_from_data_array():
     var = sc.Variable(dims=['x'], values=np.arange(4))
     da = sc.DataArray(var, coords={'x': var, 'aux': var})
-    d = sc.Dataset(da)
+    d = sc.Dataset({da.name: da})
     assert sc.is_equal(d[''], da)
 
 
@@ -463,7 +463,7 @@ def test_binary__with_dataarray():
     da = sc.DataArray(
         data=sc.Variable(dims=['x'], values=np.arange(1.0, 10.0)),
         coords={'x': sc.Variable(dims=['x'], values=np.arange(1.0, 10.0))})
-    ds = sc.Dataset(da)
+    ds = sc.Dataset({da.name: da})
     orig = ds.copy()
     ds += da
     ds -= da

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -65,6 +65,27 @@ def test_create_from_data_arrays():
                    }))
 
 
+def test_create_from_data_array_and_variable_mix():
+    var_1 = sc.Variable(dims=['x'], values=np.arange(4))
+    var_2 = sc.Variable(dims=['x'], values=np.arange(4))
+    da = sc.DataArray(data=var_1, coords={'x': var_1, 'aux': var_1})
+    d = sc.Dataset({'array': da, 'variable': var_2})
+    assert sc.is_equal(d['array'], da)
+    assert sc.is_equal(d['variable'].data, var_2)
+
+
+def test_create_with_data_array_and_additional_coords():
+    var = sc.Variable(dims=['x'], values=np.arange(4))
+    coord = sc.Variable(dims=['x'], values=np.arange(4))
+    da = sc.DataArray(data=var, coords={'x': var, 'aux': var})
+    d = sc.Dataset(data={'array': da}, coords={'y': coord})
+    da.coords['y'] = coord
+    assert sc.is_equal(d['array'], da)
+    assert sc.is_equal(d.coords['y'], coord)
+    assert sc.is_equal(d.coords['x'], var)
+    assert sc.is_equal(d.coords['aux'], var)
+
+
 def test_clear():
     d = sc.Dataset()
     d['a'] = sc.Variable(dims=['x'], values=np.arange(3))


### PR DESCRIPTION
Currently the Dataset python API has four initializers exposed. These are:

1. Dataset(arg0: Dict[str, DataArray])
2. Dataset(arg0: DataArray)
3. Dataset(data: Dict[str, Variable]={}, coords: Dict[str, Variable]={})
4. Dataset(arg0: Dataset)

This PR removes 2 and 4 from this list to simplify the API. The reasoning for this is.
* For 4 this is used to convert a view into a full Dataset or copy an existing dataset. This can already be achived by the .copy() methods on dataset.
* For 2 this can be easily achieved using 1 and is I think a rare case which obfuscates the fact that Dataset is a Dict of DataArrays slightly. This is a more marginal removal I have done so for now so people can see how it works in practice.

The Docstrings have for the init method have also been updated. I decided to manually specify the available overloads in the docstring as the auto-generated ones were unclear and hard to read. I've added a screenshot of the new docs page below. This still has the overloaded function message but whilst we have two incompatible overloads this feels unavoidable.

![image](https://user-images.githubusercontent.com/32058966/104016518-66747680-51ae-11eb-9e6a-4938c78bca85.png)
