### PR TITLE
DOC: Mention of the scipp.array function

### DIFF
--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -129,6 +129,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "A scipp.Variable object can also be created with the [scipp.array](../generated/scipp.array.html#scipp-array) creation function. \n",
+    "This function mirrors the [numpy.array](https://numpy.org/doc/stable/reference/generated/numpy.array.html) function, always producing an object with at least 1-dimension (and as a result a `dims` argument must always be given). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_2d = sc.array(values=np.random.rand(2, 4),\n",
+    "                  variances=np.random.rand(2, 4),\n",
+    "                  dims=['x', 'y'],\n",
+    "                  unit=sc.units.m/sc.units.s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.show(arr_2d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_2d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_1d = sc.array(dims=['x'], values=np.random.rand(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr_1d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 0-D variables (scalars)\n",
     "\n",
     "A 0-dimensional variable contains a single value (and an optional variance).\n",
@@ -464,7 +520,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarely, when accessing a 0-dimensional data item, it will have no coordinates or labels:"
+    "Similarly, when accessing a 0-dimensional data item, it will have no coordinates or labels:"
    ]
   },
   {
@@ -549,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Included a mention of the `scipp.array` creation function in the documentation, as a part of the `scipp.Variable` section. Also sorted a typo later in this Data Structures section. 