### PR TITLE
Fix mandatory tbb dependency

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -55,7 +55,7 @@ generate_export_header(${TARGET_NAME})
 target_link_libraries(
   ${TARGET_NAME} PUBLIC scipp-common scipp-units Boost::boost
 )
-if(TBB_FOUND)
+if(TBB_FOUND AND NOT DISABLE_MULTI_THREADING)
   target_link_libraries(${TARGET_NAME} PUBLIC TBB::tbb)
 endif()
 

--- a/dataset/CMakeLists.txt
+++ b/dataset/CMakeLists.txt
@@ -61,7 +61,7 @@ endif(DYNAMIC_LIB)
 add_library(${TARGET_NAME} ${LINK_TYPE} ${INC_FILES} ${SRC_FILES})
 generate_export_header(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} PUBLIC scipp-variable Boost::boost)
-if(TBB_FOUND)
+if(TBB_FOUND AND NOT DISABLE_MULTI_THREADING)
   target_link_libraries(${TARGET_NAME} PUBLIC TBB::tbb)
 endif()
 

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -73,7 +73,7 @@ endif(DYNAMIC_LIB)
 add_library(${TARGET_NAME} ${LINK_TYPE} ${INC_FILES} ${SRC_FILES})
 generate_export_header(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} PUBLIC scipp-core Boost::boost)
-if(TBB_FOUND)
+if(TBB_FOUND AND NOT DISABLE_MULTI_THREADING)
   target_link_libraries(${TARGET_NAME} PUBLIC TBB::tbb)
 endif()
 


### PR DESCRIPTION
```otool -L scipp/_scipp.cpython-37m-darwin.so``` lists `tbb` as a link library even when `DISABLE_MULTI_THREADING` set at cmake time