### PR TITLE
Optimise non-in-place transforms using special cases for strides

### DIFF
--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -483,7 +483,7 @@ template <bool dry_run> struct in_place {
       // be done differently. Explicit and precise control of chunking is
       // required to avoid multiple threads writing to the same output. Not
       // implemented for now.
-      auto indices = begin;  // copy so that run doesn't modify begin
+      auto indices = begin; // copy so that run doesn't modify begin
       auto end = begin;
       end.set_index(arg.size());
       run(indices, end);

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -105,12 +105,12 @@ inline constexpr auto stride_special_cases =
 
 template <>
 inline constexpr auto stride_special_cases<1, true> =
-    std::array<std::array<scipp::index, 1>, 2>{{{1}, {0}}};
+    std::array<std::array<scipp::index, 1>, 2>{{{1}}};
 
 template <>
 inline constexpr auto stride_special_cases<2, true> =
     std::array<std::array<scipp::index, 2>, 4>{
-        {{1, 1}, {0, 1}, {1, 0}, {0, 0}}};
+        {{1, 1}, {0, 1}, {1, 0}}};
 
 template <>
 inline constexpr auto stride_special_cases<3, true> =

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -192,7 +192,7 @@ static constexpr void call_in_place(Op &&op, const Indices &indices, Arg &&arg,
   }
 }
 /// Run transform with strides known at compile time.
-template <class Op, class... Operands, scipp::index... Strides>
+template <bool in_place, class Op, class... Operands, scipp::index... Strides>
 static void inner_loop(Op &&op,
                        std::array<scipp::index, sizeof...(Operands)> indices,
                        std::integer_sequence<scipp::index, Strides...>,
@@ -200,40 +200,48 @@ static void inner_loop(Op &&op,
   static_assert(sizeof...(Operands) == sizeof...(Strides));
 
   for (scipp::index i = 0; i < n; ++i) {
-    detail::call(op, indices, std::forward<Operands>(operands)...);
+    if constexpr (in_place) {
+      detail::call_in_place(op, indices, std::forward<Operands>(operands)...);
+    } else {
+      detail::call(op, indices, std::forward<Operands>(operands)...);
+    }
     detail::increment<Strides...>(indices);
   }
 }
 
 /// Run transform with strides known at run time but bypassing MultiIndex.
-template <class Op, class... Operands>
+template <bool in_place, class Op, class... Operands>
 static void
 inner_loop(Op &&op, std::array<scipp::index, sizeof...(Operands)> indices,
            const std::array<scipp::index, sizeof...(Operands)> &strides,
            const scipp::index n, Operands &&... operands) {
   for (scipp::index i = 0; i < n; ++i) {
-    detail::call(op, indices, std::forward<Operands>(operands)...);
+    if constexpr (in_place) {
+      detail::call_in_place(op, indices, std::forward<Operands>(operands)...);
+    } else {
+      detail::call(op, indices, std::forward<Operands>(operands)...);
+    }
     detail::increment(indices, strides);
   }
 }
 
-template <size_t I = 0, class Op, class... Operands>
-static void dispatch_inner_loop_oop(
+template <bool in_place, size_t I = 0, class Op, class... Operands>
+static void dispatch_inner_loop(
     Op &&op, const std::array<scipp::index, sizeof...(Operands)> &indices,
     const std::array<scipp::index, sizeof...(Operands)> &inner_strides,
     const scipp::index n, Operands &&... operands) {
   constexpr auto N_Operands = sizeof...(Operands);
   if constexpr (I == detail::stride_special_cases<N_Operands>.size()) {
-    inner_loop(std::forward<Op>(op), indices, inner_strides, n,
-               std::forward<Operands>(operands)...);
+    inner_loop<in_place>(std::forward<Op>(op), indices, inner_strides, n,
+                         std::forward<Operands>(operands)...);
   } else {
     if (inner_strides == detail::stride_special_cases<N_Operands>[I]) {
-      inner_loop(std::forward<Op>(op), indices,
-                 detail::make_stride_sequence<I, N_Operands>{}, n,
-                 std::forward<Operands>(operands)...);
+      inner_loop<in_place>(std::forward<Op>(op), indices,
+                           detail::make_stride_sequence<I, N_Operands>{}, n,
+                           std::forward<Operands>(operands)...);
     } else {
-      dispatch_inner_loop_oop<I + 1>(op, indices, inner_strides, n,
-                                     std::forward<Operands>(operands)...);
+      dispatch_inner_loop<in_place, I + 1>(op, indices, inner_strides, n,
+                                           std::forward<Operands>(operands)...);
     }
   }
 }
@@ -250,9 +258,9 @@ static void transform_elements(Op op, Out &&out, Ts &&... other) {
       const auto inner_size = indices.in_same_chunk(end, 1)
                                   ? indices.inner_distance_to(end)
                                   : indices.inner_distance_to_end();
-      dispatch_inner_loop_oop(op, indices.get(), inner_strides, inner_size,
-                              std::forward<Out>(out),
-                              std::forward<Ts>(other)...);
+      dispatch_inner_loop<false>(op, indices.get(), inner_strides, inner_size,
+                                 std::forward<Out>(out),
+                                 std::forward<Ts>(other)...);
       indices.increment_inner_by(inner_size);
       indices.increment_outer();
     }
@@ -434,53 +442,6 @@ constexpr auto overlaps = [](const auto &a, const auto &b) {
 /// of data. This is used to implement operations on datasets with a strong
 /// exception guarantee.
 template <bool dry_run> struct in_place {
-  /// Run transform with strides known at compile time.
-  template <class Op, class... Operands, scipp::index... Strides>
-  static void run(Op &&op,
-                  std::array<scipp::index, sizeof...(Operands)> indices,
-                  std::integer_sequence<scipp::index, Strides...>,
-                  const scipp::index n, Operands &&... operands) {
-    static_assert(sizeof...(Operands) == sizeof...(Strides));
-
-    for (scipp::index i = 0; i < n; ++i) {
-      detail::call_in_place(op, indices, std::forward<Operands>(operands)...);
-      detail::increment<Strides...>(indices);
-    }
-  }
-
-  /// Run transform with strides known at run time but bypassing MultiIndex.
-  template <class Op, class... Operands>
-  static void run(Op &&op,
-                  std::array<scipp::index, sizeof...(Operands)> indices,
-                  const std::array<scipp::index, sizeof...(Operands)> &strides,
-                  const scipp::index n, Operands &&... operands) {
-    for (scipp::index i = 0; i < n; ++i) {
-      detail::call_in_place(op, indices, std::forward<Operands>(operands)...);
-      detail::increment(indices, strides);
-    }
-  }
-
-  template <size_t I = 0, class Op, class... Operands>
-  static void dispatch_inner_loop(
-      Op &&op, const std::array<scipp::index, sizeof...(Operands)> &indices,
-      const std::array<scipp::index, sizeof...(Operands)> &inner_strides,
-      const scipp::index n, Operands &&... operands) {
-    constexpr auto N_Operands = sizeof...(Operands);
-    if constexpr (I == detail::stride_special_cases<N_Operands>.size()) {
-      run(std::forward<Op>(op), indices, inner_strides, n,
-          std::forward<Operands>(operands)...);
-    } else {
-      if (inner_strides == detail::stride_special_cases<N_Operands>[I]) {
-        run(std::forward<Op>(op), indices,
-            detail::make_stride_sequence<I, N_Operands>{}, n,
-            std::forward<Operands>(operands)...);
-      } else {
-        dispatch_inner_loop<I + 1>(op, indices, inner_strides, n,
-                                   std::forward<Operands>(operands)...);
-      }
-    }
-  }
-
   template <class Op, class T, class... Ts>
   static void transform_in_place_impl(Op op, T &&arg, Ts &&... other) {
     using namespace detail;
@@ -502,8 +463,9 @@ template <bool dry_run> struct in_place {
           const auto inner_size = indices.in_same_chunk(end, 1)
                                       ? indices.inner_distance_to(end)
                                       : indices.inner_distance_to_end();
-          dispatch_inner_loop(op, indices.get(), inner_strides, inner_size,
-                              std::forward<T>(arg), std::forward<Ts>(other)...);
+          detail::dispatch_inner_loop<true>(op, indices.get(), inner_strides,
+                                            inner_size, std::forward<T>(arg),
+                                            std::forward<Ts>(other)...);
           indices.increment_inner_by(inner_size);
           indices.increment_outer();
         }

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -112,11 +112,6 @@ inline constexpr auto stride_special_cases<2, true> =
     std::array<std::array<scipp::index, 2>, 4>{{{1, 1}, {0, 1}, {1, 0}}};
 
 template <>
-inline constexpr auto stride_special_cases<3, true> =
-    std::array<std::array<scipp::index, 3>, 3>{
-        {{1, 1, 1}, {1, 0, 1}, {1, 1, 0}}};
-
-template <>
 inline constexpr auto stride_special_cases<2, false> =
     std::array<std::array<scipp::index, 2>, 1>{{{1, 1}}};
 

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -112,6 +112,10 @@ inline constexpr auto stride_special_cases<2> =
     std::array<std::array<scipp::index, 2>, 4>{
         {{1, 1}, {0, 1}, {1, 0}, {0, 0}}};
 
+inline constexpr auto stride_special_cases<3> =
+    std::array<std::array<scipp::index, 3>, 3>{
+        {{1, 1, 1}, {1, 0, 1}, {1, 1, 0}}};
+
 template <size_t I, size_t N_Operands, size_t... Is>
 auto stride_sequence_impl(std::index_sequence<Is...>)
     -> std::integer_sequence<scipp::index,

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -249,13 +249,6 @@ static void dispatch_inner_loop(
   if constexpr (I == detail::stride_special_cases<N_Operands, in_place>.size()) {
     inner_loop<in_place>(std::forward<Op>(op), indices, inner_strides, n,
                          std::forward<Operands>(operands)...);
-  } else if constexpr (!in_place &&
-                       detail::stride_special_cases<N_Operands, in_place>[I][0] > 1) {
-    // The output Variable in non-in-place transforms always has stride 0 or 1.
-    // Skip the runtime check and code generation below when possible.
-    assert(inner_strides[0] < 2);
-    dispatch_inner_loop<in_place, I + 1>(op, indices, inner_strides, n,
-                                         std::forward<Operands>(operands)...);
   } else {
     if (inner_strides == detail::stride_special_cases<N_Operands, in_place>[I]) {
       inner_loop<in_place>(std::forward<Op>(op), indices,

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -109,8 +109,7 @@ inline constexpr auto stride_special_cases<1, true> =
 
 template <>
 inline constexpr auto stride_special_cases<2, true> =
-    std::array<std::array<scipp::index, 2>, 4>{
-        {{1, 1}, {0, 1}, {1, 0}}};
+    std::array<std::array<scipp::index, 2>, 4>{{{1, 1}, {0, 1}, {1, 0}}};
 
 template <>
 inline constexpr auto stride_special_cases<3, true> =
@@ -127,9 +126,8 @@ inline constexpr auto stride_special_cases<3, false> =
         {{1, 1, 1}, {1, 0, 1}, {1, 1, 0}}};
 
 template <size_t I, size_t N_Operands, bool in_place, size_t... Is>
-auto stride_sequence_impl(std::index_sequence<Is...>)
-    -> std::integer_sequence<scipp::index,
-                             stride_special_cases<N_Operands, in_place>.at(I)[Is]...>;
+auto stride_sequence_impl(std::index_sequence<Is...>) -> std::integer_sequence<
+    scipp::index, stride_special_cases<N_Operands, in_place>.at(I)[Is]...>;
 // THe above uses std::array::at instead of operator[] in order to circumvent
 // a false positive error in MSVC 19.
 
@@ -139,7 +137,8 @@ template <size_t I, size_t N_Operands, bool in_place> struct stride_sequence {
 };
 
 template <size_t I, size_t N_Operands, bool in_place>
-using make_stride_sequence = typename stride_sequence<I, N_Operands, in_place>::type;
+using make_stride_sequence =
+    typename stride_sequence<I, N_Operands, in_place>::type;
 
 template <scipp::index... Strides, size_t... Is>
 void increment_impl(std::array<scipp::index, sizeof...(Strides)> &indices,
@@ -246,14 +245,17 @@ static void dispatch_inner_loop(
     const std::array<scipp::index, sizeof...(Operands)> &inner_strides,
     const scipp::index n, Operands &&... operands) {
   constexpr auto N_Operands = sizeof...(Operands);
-  if constexpr (I == detail::stride_special_cases<N_Operands, in_place>.size()) {
+  if constexpr (I ==
+                detail::stride_special_cases<N_Operands, in_place>.size()) {
     inner_loop<in_place>(std::forward<Op>(op), indices, inner_strides, n,
                          std::forward<Operands>(operands)...);
   } else {
-    if (inner_strides == detail::stride_special_cases<N_Operands, in_place>[I]) {
-      inner_loop<in_place>(std::forward<Op>(op), indices,
-                           detail::make_stride_sequence<I, N_Operands, in_place>{}, n,
-                           std::forward<Operands>(operands)...);
+    if (inner_strides ==
+        detail::stride_special_cases<N_Operands, in_place>[I]) {
+      inner_loop<in_place>(
+          std::forward<Op>(op), indices,
+          detail::make_stride_sequence<I, N_Operands, in_place>{}, n,
+          std::forward<Operands>(operands)...);
     } else {
       dispatch_inner_loop<in_place, I + 1>(op, indices, inner_strides, n,
                                            std::forward<Operands>(operands)...);

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -227,6 +227,10 @@ static void do_transform(Op op, Out &&out, Tuple &&processed, const Arg &arg,
           std::tuple_cat(processed, std::tuple(ValuesAndVariances{vals, vars})),
           args...);
     }
+    // else {}  // Cannot happen because args.hasVariances()
+    //             implies canHaveVariances<value_type>.
+    //             The 2nd test is needed to avoid compilation errors
+    //             (hasVariances is a runtime check).
   } else {
     if constexpr (std::is_base_of_v<
                       core::transform_flags::expect_variance_arg_t<

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -112,6 +112,7 @@ inline constexpr auto stride_special_cases<2> =
     std::array<std::array<scipp::index, 2>, 4>{
         {{1, 1}, {0, 1}, {1, 0}, {0, 0}}};
 
+template <>
 inline constexpr auto stride_special_cases<3> =
     std::array<std::array<scipp::index, 3>, 3>{
         {{1, 1, 1}, {1, 0, 1}, {1, 1, 0}}};

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -279,8 +279,7 @@ static void transform_elements(Op op, Out &&out, Ts &&... other) {
     indices.set_index(range.begin());
     auto end = begin;
     end.set_index(range.end());
-    for (; indices != end; indices.increment())
-      run(indices, end);
+    run(indices, end);
   };
   core::parallel::parallel_for(core::parallel::blocked_range(0, out.size()),
                                run_parallel);


### PR DESCRIPTION
The same approach as PR #1486 but applied to transform with return value.

It even beats v0.4 (the new one is green):
![bench](https://user-images.githubusercontent.com/11393224/104459602-40374800-55ad-11eb-8806-8e1caa886685.png)