### PR TITLE
Simplify handling of binned data in unit conversion

### DIFF
--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -44,11 +44,10 @@ T convert_generic(T &&d, const Dim from, const Dim to, Op op,
         item.data().template constituents<bucket<DataArray>>();
     if (!buffer.coords().contains(from))
       continue;
-    auto coord =
-        make_bins(Variable(indices), dim, buffer.coords().extract(from));
+    auto buffer_coord = buffer.coords().extract(from);
+    auto coord = make_non_owning_bins(indices, dim, VariableView(buffer_coord));
     transform_in_place(coord, arg, op_);
-    buffer.coords().set(
-        to, std::get<2>(coord.template to_constituents<bucket<Variable>>()));
+    buffer.coords().set(to, std::move(buffer_coord));
   }
 
   // 3. Rename dims


### PR DESCRIPTION
Speedup should be minor, provided that `indices` are much smaller than the numer of events. If `indices` were huge we might see a speedup (unlikely in practice).