### PR TITLE
Add more units in Mantid converter to reduce number of warnings

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -55,12 +55,15 @@ def make_run(ws):
 additional_unit_mapping = {
     "Kelvin": sc.units.K,
     "microsecond": sc.units.us,
+    "us": sc.units.us,
     "nanosecond": sc.units.ns,
     "second": sc.units.s,
     "Angstrom": sc.units.angstrom,
     "Hz": sc.units.one / sc.units.s,
     "degree": sc.units.deg,
     "millimetre": sc.units.mm,
+    " ": sc.units.one,
+    "none": sc.units.one,
 }
 
 


### PR DESCRIPTION
Avoid too many warnings when loading nxs files. See, e.g., https://scipp.github.io/ess-notebooks/sans-reduction.html for a particularly bad case.