### PR TITLE
Fixes a crash when making empty Variables

### DIFF
--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -69,7 +69,7 @@ public:
 private:
   // NOTE:
   // We investigated different containers for the m_delta, m_coord & m_extent
-  // arrays, and their impact on peformance when iterating over a variable
+  // arrays, and their impact on performance when iterating over a variable
   // view.
   // Using std::array or C-style arrays give good performance (7.5 Gb/s) as long
   // as a range based loop is used:

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -50,8 +50,10 @@ public:
       m_index += m_factors[j] * m_coord[m_offsets[j]];
   }
 
-  constexpr scipp::index get() const noexcept { return m_index; }
-  constexpr scipp::index index() const noexcept { return m_fullIndex; }
+  [[nodiscard]] constexpr scipp::index get() const noexcept { return m_index; }
+  [[nodiscard]] constexpr scipp::index index() const noexcept {
+    return m_fullIndex;
+  }
 
   constexpr bool operator==(const ViewIndex &other) const noexcept {
     return m_fullIndex == other.m_fullIndex;
@@ -60,7 +62,9 @@ public:
     return m_fullIndex != other.m_fullIndex;
   }
 
-  constexpr bool has_stride_zero() const noexcept { return m_dims > m_subdims; }
+  [[nodiscard]] constexpr bool has_stride_zero() const noexcept {
+    return m_dims > m_subdims;
+  }
 
 private:
   // NOTE:

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -62,10 +62,6 @@ public:
     return m_fullIndex != other.m_fullIndex;
   }
 
-  [[nodiscard]] constexpr bool has_stride_zero() const noexcept {
-    return m_dims > m_subdims;
-  }
-
 private:
   // NOTE:
   // We investigated different containers for the m_delta, m_coord & m_extent

--- a/core/include/scipp/core/view_index.h
+++ b/core/include/scipp/core/view_index.h
@@ -37,8 +37,12 @@ public:
       return;
     auto remainder{index};
     for (int32_t d = 0; d < m_dims - 1; ++d) {
-      m_coord[d] = remainder % m_extent[d];
-      remainder /= m_extent[d];
+      if (m_extent[d] != 0) {
+        m_coord[d] = remainder % m_extent[d];
+        remainder /= m_extent[d];
+      } else {
+        m_coord[d] = 0;
+      }
     }
     m_coord[m_dims - 1] = remainder;
     m_index = 0;

--- a/core/test/view_index_test.cpp
+++ b/core/test/view_index_test.cpp
@@ -182,3 +182,20 @@ TEST_F(ViewIndex2DTest, edges) {
   i.increment();
   EXPECT_EQ(i.get(), 18);
 }
+
+TEST(ViewIndexTest, empty1D) {
+  Dimensions dims;
+  dims.add(Dim::X, 0);
+  const ViewIndex idx{dims, dims};
+  EXPECT_EQ(idx.get(), 0);
+  EXPECT_EQ(idx.index(), 0);
+}
+
+TEST(ViewIndexTest, empty2D) {
+  Dimensions dims;
+  dims.add(Dim::X, 0);
+  dims.add(Dim::Y, 0);
+  const ViewIndex idx{dims, dims};
+  EXPECT_EQ(idx.get(), 0);
+  EXPECT_EQ(idx.index(), 0);
+}

--- a/core/view_index.cpp
+++ b/core/view_index.cpp
@@ -4,6 +4,8 @@
 /// @author Neil Vaytet
 #include "scipp/core/view_index.h"
 
+#include <algorithm>
+
 namespace scipp::core {
 ViewIndex::ViewIndex(const Dimensions &targetDimensions,
                      const Dimensions &dataDimensions) {
@@ -33,7 +35,7 @@ ViewIndex::ViewIndex(const Dimensions &targetDimensions,
       for (scipp::index d2 = 0; d2 < d; ++d2)
         m_delta[d] -= m_delta[d2];
     }
-    offset *= m_extent[d];
+    offset *= m_extent[d] == 0 ? 1 : m_extent[d];
   }
   setIndex(0);
 }

--- a/python/make_variable.h
+++ b/python/make_variable.h
@@ -7,8 +7,6 @@
 #include "scipp/core/dtype.h"
 #include "scipp/units/unit.h"
 
-#include "make_variable.h"
-
 using namespace scipp;
 using namespace scipp::variable;
 

--- a/python/numpy.h
+++ b/python/numpy.h
@@ -85,8 +85,8 @@ bool memory_overlaps(const py::array_t<T> &data, const View &view) {
   if (begin == end) {
     return false;
   }
-  const auto view_begin = &*view.begin();
-  const auto view_end = &*view.end();
+  const auto view_begin = &*begin;
+  const auto view_end = &*end;
   // Note the use of std::less, pointer comparison with operator< may be
   // undefined behavior with pointers from different arrays.
   return std::less<const T *>()(data_begin, view_end) &&

--- a/python/numpy.h
+++ b/python/numpy.h
@@ -80,6 +80,11 @@ template <class T, class View>
 bool memory_overlaps(const py::array_t<T> &data, const View &view) {
   const auto &buffer_info = data.request();
   const auto [data_begin, data_end] = memory_begin_end<T>(buffer_info);
+  const auto begin = view.begin();
+  const auto end = view.end();
+  if (begin == end) {
+    return false;
+  }
   const auto view_begin = &*view.begin();
   const auto view_end = &*view.end();
   // Note the use of std::less, pointer comparison with operator< may be


### PR DESCRIPTION
Creating multi-dimensional empty Variables crashes Python. E.g.
```.py
sc.Variable(dims=['x', 'y'], values=np.array([]).reshape(0,0))
```
or
```.py
sc.Variable(dims=['x', 'y'], values=np.array([[]]))
```
This was caused by `ViewIndex::m_extent[d] == 0` for some (or all) `d`.

There were two bugs in this: division by zero and deref of invalid pointers.