### PR TITLE
Avoid division by zero in `__sizeof__`

### DIFF
--- a/dataset/test/size_of_test.cpp
+++ b/dataset/test/size_of_test.cpp
@@ -17,7 +17,7 @@ class BucketVariableSizeOfTest : public ::testing::Test {
 protected:
   Dimensions dims{Dim::Y, 3};
   Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
-      dims, Values{std::pair{0, 2}, std::pair{2, 3}, std::pair{3, 4}});
+      dims, Values{std::pair{0, 2}, std::pair{2, 2}, std::pair{2, 4}});
   Variable buffer = makeVariable<double>(Dims{Dim::X}, Shape{4});
   Variable var = make_bins(indices, Dim::X, buffer);
 };
@@ -78,6 +78,14 @@ TEST_F(BucketVariableSizeOfTest, size_in_memory_of_sliced_bucketed_variable) {
       slice.constituents<bucket<Variable>>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(slice), size_of(buffer_) * 0.5 + size_of(indices_));
+}
+
+TEST_F(BucketVariableSizeOfTest, empty_buffer) {
+  Variable empty(var.slice(Slice(Dim::Y, 1)));
+  const auto &[indices_, dim_, buffer_] =
+      empty.constituents<bucket<Variable>>();
+  EXPECT_EQ(dim_, Dim::X);
+  EXPECT_EQ(size_of(empty), size_of(indices_));
 }
 
 TEST_F(BucketDataArraySizeOfTest, size_in_memory_of_bucketed_variable) {

--- a/dataset/util.cpp
+++ b/dataset/util.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Matthew Andrew
+#include <algorithm>
+
 #include "scipp/dataset/util.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/reduction.h"
@@ -14,8 +16,10 @@ template <class T>
 scipp::index size_of_bucket_impl(const VariableConstView &view) {
   const auto &[indices, dim, buffer] = view.constituents<T>();
   const auto &[begin, end] = unzip(indices);
+  // Using max to avoid division by zero. Other factors should be zero in this
+  // case, so this should not influence the result.
   const auto scale = sum(end - begin).template value<scipp::index>() /
-                     static_cast<double>(buffer.dims()[dim]);
+                     std::max(1.0, static_cast<double>(buffer.dims()[dim]));
   return size_of(indices) + size_of(buffer) * scale;
 }
 

--- a/dataset/util.cpp
+++ b/dataset/util.cpp
@@ -2,8 +2,6 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Matthew Andrew
-#include <algorithm>
-
 #include "scipp/dataset/util.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/reduction.h"
@@ -16,10 +14,9 @@ template <class T>
 scipp::index size_of_bucket_impl(const VariableConstView &view) {
   const auto &[indices, dim, buffer] = view.constituents<T>();
   const auto &[begin, end] = unzip(indices);
-  // Using max to avoid division by zero. Other factors should be zero in this
-  // case, so this should not influence the result.
-  const auto scale = sum(end - begin).template value<scipp::index>() /
-                     std::max(1.0, static_cast<double>(buffer.dims()[dim]));
+  const auto sizes = sum(end - begin).template value<scipp::index>();
+  const auto scale = // avoid division by zero
+      sizes == 0 ? 0.0 : sizes / static_cast<double>(buffer.dims()[dim]);
   return size_of(indices) + size_of(buffer) * scale;
 }
 


### PR DESCRIPTION
Fixes #1555.