### PR TITLE
Fix python nested variable constructor dtype

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -134,6 +134,8 @@ template <class... Ts> class as_ElementArrayViewImpl {
         return {Getter::template get<std::string>(view)};
       if (type == dtype<scipp::core::time_point>)
         return {Getter::template get<scipp::core::time_point>(view)};
+      if (type == dtype<Variable>)
+        return {Getter::template get<Variable>(view)};
       if (type == dtype<DataArray>)
         return {Getter::template get<DataArray>(view)};
       if (type == dtype<Dataset>)
@@ -353,8 +355,8 @@ public:
 
 using as_ElementArrayView = as_ElementArrayViewImpl<
     double, float, int64_t, int32_t, bool, std::string, scipp::core::time_point,
-    DataArray, Dataset, bucket<Variable>, bucket<DataArray>, bucket<Dataset>,
-    Eigen::Vector3d, Eigen::Matrix3d, scipp::python::PyObject>;
+    Variable, DataArray, Dataset, bucket<Variable>, bucket<DataArray>,
+    bucket<Dataset>, Eigen::Vector3d, Eigen::Matrix3d, scipp::python::PyObject>;
 
 template <class T, class... Ignored>
 void bind_data_properties(pybind11::class_<T, Ignored...> &c) {

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -72,6 +72,7 @@ void init_element_array_view(py::module &m) {
   declare_span<const std::string>(m, "string_const");
   declare_span<std::string>(m, "string");
   declare_span<const Dim>(m, "Dim_const");
+  declare_span<Variable>(m, "Variable");
   declare_span<DataArray>(m, "DataArray");
   declare_span<Dataset>(m, "Dataset");
   declare_span<Eigen::Vector3d>(m, "Eigen_Vector3d");
@@ -83,6 +84,7 @@ void init_element_array_view(py::module &m) {
   declare_ElementArrayView<int32_t>(m, "int32");
   declare_ElementArrayView<std::string>(m, "string");
   declare_ElementArrayView<bool>(m, "bool");
+  declare_ElementArrayView<Variable>(m, "Variable");
   declare_ElementArrayView<DataArray>(m, "DataArray");
   declare_ElementArrayView<Dataset>(m, "Dataset");
   declare_ElementArrayView<Eigen::Vector3d>(m, "Eigen_Vector3d");

--- a/python/make_variable.h
+++ b/python/make_variable.h
@@ -146,7 +146,7 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
                                  const bool variances) {
   return core::CallDType<
       double, float, int64_t, int32_t, bool, scipp::core::time_point,
-      std::string, DataArray, Dataset, Eigen::Vector3d,
+      std::string, Variable, DataArray, Dataset, Eigen::Vector3d,
       Eigen::Matrix3d>::apply<MakeVariableDefaultInit>(scipp_dtype(dtype),
                                                        labels, shape, unit,
                                                        variances);

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -87,30 +87,36 @@ def test_create_scalar():
 
 
 def test_create_scalar_Variable():
-    elem = 1.2 * sc.units.m
+    elem = sc.Variable(dims=['x'], values=np.arange(4.0))
     var = sc.Variable(elem)
     assert sc.is_equal(var.value, elem)
     assert var.dims == []
     assert var.dtype == sc.dtype.Variable
     assert var.unit == sc.units.dimensionless
+    var = sc.Variable(elem['x', 1:3])
+    assert var.dtype == sc.dtype.Variable
 
 
 def test_create_scalar_DataArray():
-    data = sc.DataArray({'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
-    var = sc.Variable(data)
-    assert sc.is_equal(var.value, data)
+    elem = sc.DataArray(data=sc.Variable(dims=['x'], values=np.arange(4.0)))
+    var = sc.Variable(elem)
+    assert sc.is_equal(var.value, elem)
     assert var.dims == []
     assert var.dtype == sc.dtype.DataArray
     assert var.unit == sc.units.dimensionless
+    var = sc.Variable(elem['x', 1:3])
+    assert var.dtype == sc.dtype.DataArray
 
 
 def test_create_scalar_Dataset():
-    dataset = sc.Dataset({'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
-    var = sc.Variable(dataset)
-    assert sc.is_equal(var.value, dataset)
+    elem = sc.Dataset({'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
+    var = sc.Variable(elem)
+    assert sc.is_equal(var.value, elem)
     assert var.dims == []
     assert var.dtype == sc.dtype.Dataset
     assert var.unit == sc.units.dimensionless
+    var = sc.Variable(elem['x', 1:3])
+    assert var.dtype == sc.dtype.Dataset
 
 
 def test_create_scalar_quantity():

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -86,6 +86,24 @@ def test_create_scalar():
     assert var.unit == sc.units.dimensionless
 
 
+def test_create_scalar_Variable():
+    elem = 1.2 * sc.units.m
+    var = sc.Variable(elem)
+    assert sc.is_equal(var.value, elem)
+    assert var.dims == []
+    assert var.dtype == sc.dtype.Variable
+    assert var.unit == sc.units.dimensionless
+
+
+def test_create_scalar_DataArray():
+    data = sc.DataArray({'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
+    var = sc.Variable(data)
+    assert sc.is_equal(var.value, data)
+    assert var.dims == []
+    assert var.dtype == sc.dtype.DataArray
+    assert var.unit == sc.units.dimensionless
+
+
 def test_create_scalar_Dataset():
     dataset = sc.Dataset({'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
     var = sc.Variable(dataset)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -142,6 +142,7 @@ void init_variable(py::module &m) {
                                 R"(
 Array of values with dimension labels and a unit, optionally including an array
 of variances.)");
+  bind_init_0D<Variable>(variable);
   bind_init_0D<DataArray>(variable);
   bind_init_0D<Dataset>(variable);
   bind_init_0D<std::string>(variable);

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -45,6 +45,16 @@ template <class T> void bind_init_0D(py::class_<Variable> &c) {
         }),
         py::arg("value"), py::arg("variance") = std::nullopt,
         py::arg("unit") = units::one);
+  if constexpr (std::is_same_v<T, Variable> || std::is_same_v<T, DataArray> ||
+                std::is_same_v<T, Dataset>) {
+    c.def(
+        py::init([](const typename T::const_view_type &value,
+                    const std::optional<T> &variance, const units::Unit &unit) {
+          return do_init_0D(copy(value), variance, unit);
+        }),
+        py::arg("value"), py::arg("variance") = std::nullopt,
+        py::arg("unit") = units::one);
+  }
 }
 
 // This function is used only to bind native python types: pyInt -> int64_t;

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -68,7 +68,7 @@ auto apply(const DType dtype, Args &&... args) {
   return core::callDType<Callable>(
       std::tuple<double, float, int64_t, int32_t, std::string, bool,
                  scipp::core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
-                 bucket<Variable>, bucket<VariableConstView>,
+                 Variable, bucket<Variable>, bucket<VariableConstView>,
                  bucket<VariableView>, scipp::index_pair>{},
       dtype, std::forward<Args>(args)...);
 }

--- a/variable/variable_instantiate_basic.cpp
+++ b/variable/variable_instantiate_basic.cpp
@@ -18,5 +18,6 @@ INSTANTIATE_VARIABLE(bool, bool)
 INSTANTIATE_VARIABLE(datetime64, scipp::core::time_point)
 INSTANTIATE_VARIABLE(vector_3_float64, Eigen::Vector3d)
 INSTANTIATE_VARIABLE(matrix_3_float64, Eigen::Matrix3d)
+INSTANTIATE_VARIABLE(Variable, Variable)
 
 } // namespace scipp::variable


### PR DESCRIPTION
Fixes #1566.

This was exposed by #1560, which broke `sc.concatenate` for certain loaded Nexus files.

Also fixing/changing behavior when `value` is a scipp view. Previously this also led to `dtype=PyObject`.