### PR TITLE
Support int-float combinations in comparison operations

### DIFF
--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -62,12 +62,12 @@ constexpr auto times_equals =
 constexpr auto divide_equals =
     overloaded{div_inplace_types, [](auto &&a, const auto &b) { a /= b; }};
 
-template <class... Ts> struct add_types_t {
+struct add_types_t {
   constexpr void operator()() const noexcept;
   using types = arithmetic_and_matrix_type_pairs;
 };
 
-template <class... Ts> struct times_types_t {
+struct times_types_t {
   constexpr void operator()() const noexcept;
   using types = decltype(std::tuple_cat(
       std::declval<arithmetic_type_pairs_with_bool>(),
@@ -75,7 +75,7 @@ template <class... Ts> struct times_types_t {
       std::tuple<std::tuple<Eigen::Matrix3d, Eigen::Vector3d>>()));
 };
 
-template <class... Ts> struct divide_types_t {
+struct divide_types_t {
   constexpr void operator()() const noexcept;
   using types = arithmetic_type_pairs;
 };

--- a/core/include/scipp/core/element/comparison.h
+++ b/core/include/scipp/core/element/comparison.h
@@ -15,19 +15,6 @@
 /// operations for Variable.
 namespace scipp::core::element {
 
-constexpr auto comparison = overloaded{
-    transform_flags::no_out_variance,
-    arg_list<double, float, int64_t, int32_t, bool,
-             std::tuple<int64_t, int32_t>, std::tuple<int32_t, int64_t>>,
-    [](const units::Unit &x, const units::Unit &y) {
-      expect::equals(x, y);
-      return units::dimensionless;
-    }};
-
-constexpr auto less = overloaded{
-    comparison,
-    [](const auto &x, const auto &y) { return x < y; },
-};
 constexpr auto is_approx = overloaded{
     transform_flags::no_out_variance,
     arg_list<double, float, int64_t, int32_t, std::tuple<double, double, float>,
@@ -45,6 +32,24 @@ constexpr auto is_approx = overloaded{
       using std::abs;
       return abs(x - y) <= t;
     }};
+
+struct comparison_types_t {
+  constexpr void operator()() const noexcept;
+  using types = decltype(std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                                        std::tuple<bool>{}));
+};
+
+constexpr auto comparison =
+    overloaded{comparison_types_t{}, transform_flags::no_out_variance,
+               [](const units::Unit &x, const units::Unit &y) {
+                 expect::equals(x, y);
+                 return units::dimensionless;
+               }};
+
+constexpr auto less = overloaded{
+    comparison,
+    [](const auto &x, const auto &y) { return x < y; },
+};
 
 constexpr auto greater = overloaded{
     comparison,

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -66,12 +66,6 @@ TEST(ComparisonTest, variances_test) {
   EXPECT_EQ(not_equal(a, b), true * units::one);
 }
 
-TEST(ComparisonTest, less_dtypes_test) {
-  const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
-  const auto b = makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{0, 1});
-  EXPECT_THROW([[maybe_unused]] auto out = less(a, b), std::runtime_error);
-}
-
 TEST(ComparisonTest, less_units_test) {
   const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.0, 3.0});


### PR DESCRIPTION
This also allows for using integers in value-based indexing with float coords, for user convenience.

Not supporting int-bool or float-bool for now.