### PR TITLE
Get pixel ratio of device from running javascript command in ipykernel

### DIFF
--- a/docs/scipp-neutron/instrument-view.ipynb
+++ b/docs/scipp-neutron/instrument-view.ipynb
@@ -7,7 +7,10 @@
     "# Instrument view\n",
     "\n",
     "A simple version of the Mantid [instrument view](https://www.mantidproject.org/MantidPlot:_Instrument_View) is available in `scipp`.\n",
-    "It currently does not support detector 'picking' and manual drawing of masks, nor does it render the actual shape of the detectors (currently it represents them as 2d squares), but basic functionalities such as spatial slicing, as well as navigation through the time-of-flight dimension via a slider, are provided."
+    "It currently does not support detector 'picking' and manual drawing of masks,\n",
+    "nor does it render the actual shape of the detectors (currently it represents them as 2d squares),\n",
+    "but basic functionalities such as spatial slicing,\n",
+    "as well as navigation through the time-of-flight dimension via a slider, are provided."
    ]
   },
   {
@@ -31,7 +34,10 @@
     "\n",
     "**Warning**\n",
     "    \n",
-    "While you can interact with the 3D view of the instrument, the buttons and sliders will have no effect in the documentation pages, as there is no kernel to perform the operations. These will only work inside a Jupyter notebook.\n",
+    "While you can interact with the 3D view of the instrument,\n",
+    "the buttons and sliders will have no effect in the documentation pages,\n",
+    "as there is no kernel to perform the operations.\n",
+    "These will only work inside a Jupyter notebook.\n",
     "\n",
     "</div>"
    ]
@@ -81,7 +87,7 @@
    "source": [
     "You can adjust opacities and create a cut surface to slice your data in 3D using the control buttons below the scene.\n",
     "\n",
-    "It is possible to customize the figure using the usual arguments, e.g."
+    "It is possible to customize the figure using the usual arguments, as well as adjusting the pixel size, e.g."
    ]
   },
   {
@@ -92,7 +98,7 @@
    },
    "outputs": [],
    "source": [
-    "sn.instrument_view(sample, cmap=\"magma\", vmax=2000.0, norm=\"log\")"
+    "sn.instrument_view(sample, cmap=\"magma\", vmax=2000.0, norm=\"log\", pixel_size=0.03)"
    ]
   },
   {
@@ -161,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/docs/scipp-neutron/instrument-view.ipynb
+++ b/docs/scipp-neutron/instrument-view.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "You can adjust opacities and create a cut surface to slice your data in 3D using the control buttons below the scene.\n",
     "\n",
-    "It is possible to customize the figure using the usual arguments, as well as adjusting the pixel size, e.g."
+    "It is possible to customize the figure using the usual arguments, e.g."
    ]
   },
   {
@@ -92,7 +92,7 @@
    },
    "outputs": [],
    "source": [
-    "sn.instrument_view(sample, cmap=\"magma\", vmax=2000.0, norm=\"log\", pixel_size=0.03)"
+    "sn.instrument_view(sample, cmap=\"magma\", vmax=2000.0, norm=\"log\")"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sn.instrument_view(sn.load(filename='GEM40979.raw'))"
+    "sn.instrument_view(sn.load(filename='GEM40979.raw'), pixel_size=0.05)"
    ]
   },
   {

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -3,7 +3,6 @@
 # @file
 # @author Neil Vaytet
 
-from .. import config
 from .plot import plot as _plot
 import warnings
 
@@ -48,6 +47,9 @@ if ipy is not None:
 
         # Run some javascript to find the current device pixel ratio, which is
         # needed to properly scale the pixels in the three.js renderer.
+        # Note that the javascript has to be run here so that the pixel_ratio
+        # value is set after the initial import. Dealying this to inside the
+        # call to plot() would lead to devicePixelRatio being None.
         ipy.run_cell_magic(
             "js", "", "var kernel = IPython.notebook.kernel; "
             "var value = window.devicePixelRatio; "
@@ -191,12 +193,6 @@ def plot(*args, **kwargs):
     if plt is None:
         raise RuntimeError("Matplotlib not found. Matplotlib is required to "
                            "use plotting in Scipp.")
-
-    # If the pixel_ratio is not set in the user config, get the value from the
-    # kernel.
-    if ("pixel_ratio" not in config.plot) and (ipy is not None):
-        pixel_ratio = ipy.kernel.shell.user_ns.get("devicePixelRatio")
-        config.update({'plot.pixel_ratio': pixel_ratio})
 
     # Switch auto figure display off for better control over when figures are
     # displayed.

--- a/python/src/scipp/plot/__init__.py
+++ b/python/src/scipp/plot/__init__.py
@@ -49,12 +49,10 @@ if ipy is not None:
         # Run some javascript to find the current device pixel ratio, which is
         # needed to properly scale the pixels in the three.js renderer.
         ipy.run_cell_magic(
-            "js", "",
-            "var kernel = IPython.notebook.kernel; "
+            "js", "", "var kernel = IPython.notebook.kernel; "
             "var value = window.devicePixelRatio; "
             "var command = 'devicePixelRatio = ' + value; "
-            "kernel.execute(command);"
-        )
+            "kernel.execute(command);")
 
 # Note: due to some strange behaviour when importing matplotlib and pyplot in
 # different order, we need to import pyplot after switching to the ipympl

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -236,7 +236,7 @@ void main(){
     delta = pow(xDelta + yDelta + zDelta, 0.5);
     gl_PointSize = %f / delta;
 }
-''' % (580.0 * axparams["pixel_size"], ),
+''' % (580.0 * axparams["pixel_size"] * config.plot.pixel_ratio, ),
                                                  fragmentShader='''
 precision highp float;
 varying vec4 vColor;

--- a/python/src/scipp/plot/figure3d.py
+++ b/python/src/scipp/plot/figure3d.py
@@ -219,6 +219,10 @@ class PlotFigure3d:
         Define custom raw shader for point cloud to allow to RGBA color format.
         Note that the value of 580 was obtained from trial and error.
         """
+        if "pixel_ratio" in config.plot:
+            pixel_ratio = config.plot.pixel_ratio
+        else:
+            pixel_ratio = 1.0
         self.points_material = p3.ShaderMaterial(vertexShader='''
 precision highp float;
 attribute vec4 rgba_color;
@@ -236,7 +240,7 @@ void main(){
     delta = pow(xDelta + yDelta + zDelta, 0.5);
     gl_PointSize = %f / delta;
 }
-''' % (580.0 * axparams["pixel_size"] * config.plot.pixel_ratio, ),
+''' % (580.0 * axparams["pixel_size"] * pixel_ratio, ),
                                                  fragmentShader='''
 precision highp float;
 varying vec4 vColor;

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Neil Vaytet
 
+from .. import config
 from .controller3d import PlotController3d
 from .model3d import PlotModel3d
 from .panel3d import PlotPanel3d
@@ -18,6 +19,26 @@ def plot3d(*args, filename=None, **kwargs):
     It is possible to add cut surfaces as cartesian, cylindrical or spherical
     planes.
     """
+
+    # In 3d scenes, the size of the pixels depends on the display's pixel
+    # scaling ratio, so we retrieve this from a javascript variable run when
+    # we imported the plot module.
+    if "pixel_ratio" not in config.plot:
+        try:
+            from IPython import get_ipython
+            ipy = get_ipython()
+            pixel_ratio = ipy.kernel.shell.user_ns.get("devicePixelRatio")
+            # Note that pixel_ratio appears to be None when building the
+            # documentation, possibly because the page is rendered in one go,
+            # before the asynchronous javascript has been run.
+            # See https://stackoverflow.com/questions/30902898
+            # So we do not update the config if it is None, and it will default
+            # to 1.0 in figure3d.py.
+            if pixel_ratio is not None:
+                config.update({'plot.pixel_ratio': pixel_ratio})
+        except ImportError:
+            pass
+
     sp = SciPlot3d(*args, **kwargs)
     if filename is not None:
         sp.savefig(filename)

--- a/python/src/scipp/plot/plot3d.py
+++ b/python/src/scipp/plot/plot3d.py
@@ -27,15 +27,16 @@ def plot3d(*args, filename=None, **kwargs):
         try:
             from IPython import get_ipython
             ipy = get_ipython()
-            pixel_ratio = ipy.kernel.shell.user_ns.get("devicePixelRatio")
-            # Note that pixel_ratio appears to be None when building the
-            # documentation, possibly because the page is rendered in one go,
-            # before the asynchronous javascript has been run.
-            # See https://stackoverflow.com/questions/30902898
-            # So we do not update the config if it is None, and it will default
-            # to 1.0 in figure3d.py.
-            if pixel_ratio is not None:
-                config.update({'plot.pixel_ratio': pixel_ratio})
+            if ipy is not None:
+                pixel_ratio = ipy.kernel.shell.user_ns.get("devicePixelRatio")
+                # Note that pixel_ratio appears to be None when building the
+                # documentation, possibly because the page is rendered in one
+                # go, before the asynchronous javascript has been run.
+                # See https://stackoverflow.com/questions/30902898
+                # So we do not update the config if it is None, and it will
+                # default to 1.0 in figure3d.py.
+                if pixel_ratio is not None:
+                    config.update({'plot.pixel_ratio': pixel_ratio})
         except ImportError:
             pass
 

--- a/python/src/scipp/plot/toolbar.py
+++ b/python/src/scipp/plot/toolbar.py
@@ -212,12 +212,12 @@ class PlotToolbar3d(PlotToolbar):
         self.add_button(name="camera_y_normal",
                         icon="camera",
                         description="Y",
-                        tooltip="Camera to Y normal "
+                        tooltip="Camera to Y normal. "
                         "Click twice to flip the view direction.")
         self.add_button(name="camera_z_normal",
                         icon="camera",
                         description="Z",
-                        tooltip="Camera to Z normal "
+                        tooltip="Camera to Z normal. "
                         "Click twice to flip the view direction.")
         self.add_button(name="rescale_to_data",
                         icon="arrows-v",


### PR DESCRIPTION
The `pixel_ratio` can be hard-set in the user's config.
If it is not found in the config, we run some javascript in the kernel to get it from the browser.