### PR TITLE
Improve event data error message and add operation table to docs

### DIFF
--- a/core/multi_index.cpp
+++ b/core/multi_index.cpp
@@ -33,7 +33,11 @@ void validate_bucket_indices_impl(const ElementArrayViewParams &param0,
   for (scipp::index i = 0; i < iterDims.volume(); ++i) {
     const auto [i0, i1] = index.get();
     if (size(indices0[i0]) != size(indices1[i1]))
-      throw except::BucketError("Bucket size mismatch");
+      throw except::BucketError(
+          "Bin size mismatch in operation with binned data. Refer to "
+          "https://scipp.github.io/user-guide/binned-data/"
+          "computation.html#Overview-and-Quick-Reference for equivalent "
+          "operations for binned data (event data).");
     index.increment();
   }
 }

--- a/docs/user-guide/binned-data/computation.ipynb
+++ b/docs/user-guide/binned-data/computation.ipynb
@@ -13,8 +13,40 @@
     "\n",
     "1. [Bin-centric arithmetic](#Bin-centric-arithmetic) treats every bin as an element to, e.g., apply a different scale factor to every bin.\n",
     "2. [Event-centric arithmetic](#Event-centric-arithmetic) considers the individual events within bins.\n",
-    "   This allows for operation without the precision loss that would ensue from simply histogramming data.\n",
+    "   This allows for operation without the precision loss that would ensue from simply histogramming data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview and Quick Reference\n",
     "\n",
+    "Before going into a detailed explanation below we provide a quick reference:\n",
+    "\n",
+    "- Unary operations such as `sin`, `cos`, or `sqrt` work as normal.\n",
+    "- Comparison operations such as `less` (`<`) are not supported.\n",
+    "- Binary operations such as `+` work in principle, but usually not if both operands represent event data.\n",
+    "  In that case, see table below.\n",
+    "\n",
+    "Given two data arrays `a` and `b`, equivalent operations are:\n",
+    "\n",
+    "Dense data operation | Binned data equivalent | Comment\n",
+    ":--- |:--- |:---\n",
+    "`a + b` | `a.bins.concatenate(b)` | if both `a` and `b` are event data\n",
+    "`a - b` | `a.bins.concatenate(-b)` | if both `a` and `b` are event data\n",
+    "`a += b` | `a.bins.concatenate(b, out=a)` | if both `a` and `b` are event data\n",
+    "`a -= b` | `a.bins.concatenate(-b, out=a)` | if both `a` and `b` are event data\n",
+    "`sc.sum(a, 'dim')` | `a.bins.concatenate('dim')` | \n",
+    "`sc.mean(a, 'dim')` | not available | `min`, `max`, and other similar reductions are also not available\n",
+    "`sc.rebin(a, dim, 'edges')` | `sc.bin(a, edges=[edges])` | \n",
+    "`groupby(...).sum('dim')` | `groupby(...).bins.concatenate('dim')` | `mean`, `max`, and other similar reductions are also available"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Concepts\n",
     "\n",
     "Before assigning events to bins, we can initialize them as a single long list or table.\n",


### PR DESCRIPTION
The old "Bucket size mismatch" was not very helpful for users.

When fixing the message, I also noticed that we did not have a collection of equivalent operations, previously users had to look through all the related doc pages to find what they need.