### PR TITLE
Correct issue when creating 2D plot of 3D binned data

### DIFF
--- a/python/src/scipp/plot/resampling_model.py
+++ b/python/src/scipp/plot/resampling_model.py
@@ -125,6 +125,10 @@ class ResamplingBinnedModel(ResamplingModel):
         super().__init__(*args, **kwargs)
         # TODO See #1469. This is a temporary hack to work around the
         # conversion of coords to edges in model.py.
+        new_meta = {name: var.copy() for name, var in self._array.meta.items()}
+        self._array = PlotArray(data=self._array.data,
+                                masks=self._array.masks,
+                                meta=new_meta)
         for name, var in self._array.meta.items():
             if len(var.dims) == 0:
                 continue


### PR DESCRIPTION
See #1557 for how to replicate the issue. 

This issue is caused by the ResamplingBinnedModel requiring centered coords but the wider PlotModel assuming it has bin edge coords in various places. I have got around this by copy the coords before they are modified in ResamplingBinnedModel. As PlotArray holds views to the data I don't think this should have a large memory imprint but correct me if I am wrong here.