### PR TITLE
Fix table view

### DIFF
--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -186,11 +186,8 @@ def _is_bin_centers(container, var, dim):
     :param dim: dimension to consider
     :return:
     """
-    consider = []
-    for _, c in container.meta.items():
-        if (dim in c.dims):
-            consider.append(c.shape[0])
-    return max(consider) == var.shape[0] + 1 if len(consider) > 0 else False
+    largest = [c.shape[0] for _, c in container.meta.items() if dim in c.dims]
+    return max(largest) == var.shape[0] + 1 if len(largest) > 0 else False
 
 
 def table(scipp_obj):

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -176,6 +176,23 @@ def _table_from_dict_of_variables(dict_of_variables,
     return html
 
 
+def _is_bin_centers(container, var, dim):
+    """
+    Is var considered to be bin_centers in dimension dim
+    Considers all meta including non-dimensional meta
+
+    :param container: scipp object defining all meta
+    :param var: variable to determine if bin centers
+    :param dim: dimension to consider
+    :return:
+    """
+    consider = []
+    for _, c in container.meta.items():
+        if (dim in c.dims):
+            consider.append(c.shape[0])
+    return max(consider) == var.shape[0] + 1 if len(consider) > 0 else False
+
+
 def table(scipp_obj):
     """
     Create a html table from the contents of a Dataset (0D and 1D Variables
@@ -231,14 +248,12 @@ class TableViewer:
                             self.is_bin_centers[group][key] = self.make_dict()
                             self.sizes[group][key] = []
                         self.is_bin_centers[group][key][tag][name_str] = False
-                        if dim in scipp_obj.coords:
-                            if scipp_obj.coords[dim].shape[
-                                    0] == var.shape[0] + 1:
-                                self.is_bin_centers[group][key][tag][
-                                    name_str] = True
+                        self.is_bin_centers[group][key][tag][
+                            name_str] = _is_bin_centers(scipp_obj, var, dim)
                         self.tabledict[group][key][tag][name_str] = var
                         self.sizes[group][key].append(
                             var.shape[0] if ndims > 0 else None)
+
         else:
             ndims = len(scipp_obj.shape)
             if ndims < 2:

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -184,7 +184,7 @@ def _is_bin_centers(container, var, dim):
     :param container: scipp object defining all meta
     :param var: variable to determine if bin centers
     :param dim: dimension to consider
-    :return:
+    :return: True only if var is bin centers
     """
     largest = [c.shape[0] for _, c in container.meta.items() if dim in c.dims]
     return max(largest) == var.shape[0] + 1 if len(largest) > 0 else False

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -147,3 +147,38 @@ def test_dataset_histogram_with_masks():
                                             values=np.zeros(N, dtype=np.bool))
 
     sc.table(d)
+
+
+def test_display_when_only_non_dim_coords_is_bin_edges():
+    da = sc.DataArray(coords={
+        'lab':
+        sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)
+    },
+                      data=sc.Variable(['x'],
+                                       values=np.random.random(10),
+                                       unit=sc.units.counts))
+    sc.table(da)
+
+
+def test_display_when_only_attr_is_bin_edges():
+    da = sc.DataArray(attrs={
+        'attr0':
+        sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)
+    },
+                      data=sc.Variable(['x'],
+                                       values=np.random.random(10),
+                                       unit=sc.units.counts))
+    sc.table(da)
+
+
+def test_display_when_largest_coord_non_dimensional():
+    da = sc.DataArray(coords={
+        'x':
+        sc.Variable(['x'], values=np.arange(10), unit=sc.units.m),
+        'lab':
+        sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)
+    },
+                      data=sc.Variable(['x'],
+                                       values=np.random.random(10),
+                                       unit=sc.units.counts))
+    sc.table(da)


### PR DESCRIPTION
Fixes #1508

In addition, also makes it possible to display containers where we have bin-edge attributes:

```python
import scipp as sc
import numpy as np
da = sc.DataArray(
    attrs={'att0': sc.Variable(['x'], values=np.arange(11), unit=sc.units.m)},
    coords={'x': sc.Variable(['x'], values=np.arange(10), unit=sc.units.m),
            'lab': sc.Variable(['x'], values=np.arange(10), unit=sc.units.m)},
    data=sc.Variable(['x'], values=np.random.random(10), unit=sc.units.counts))

sc.table(da)
```