### PR TITLE
Reduction zero dimension extent fixes

### DIFF
--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -41,10 +41,10 @@ constexpr auto numeric_limits_max_like =
                      underlying_t<std::decay_t<decltype(x)>>>::max();
                }};
 
-constexpr auto numeric_limits_min_like =
+constexpr auto numeric_limits_lowest_like =
     overloaded{special_like, [](const auto &x) {
                  return std::numeric_limits<
-                     underlying_t<std::decay_t<decltype(x)>>>::min();
+                     underlying_t<std::decay_t<decltype(x)>>>::lowest();
                }};
 
 } // namespace scipp::core::element

--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <limits>
+
+#include "scipp/common/overloaded.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/transform_common.h"
+#include "scipp/units/unit.h"
+
+
+namespace scipp::core::element {
+
+constexpr auto full_like =
+    overloaded{arg_list<double, float, int64_t, int32_t, bool>,
+               [](const units::Unit &u) { return u; }};
+
+constexpr auto zero_like = overloaded{
+    full_like, [](const auto &x) { return std::decay_t<decltype(x)>{0}; }};
+
+template <class T, T Value>
+constexpr auto value_like =
+    overloaded{full_like, [](const auto &) { return Value; }};
+
+template <class T> struct underlying { using type = T; };
+template <class T> struct underlying<ValueAndVariance<T>> { using type = T; };
+template <class T> using underlying_t = typename underlying<T>::type;
+
+constexpr auto numeric_limits_max_like =
+    overloaded{full_like, [](const auto &x) {
+                 return std::numeric_limits<
+                     underlying_t<std::decay_t<decltype(x)>>>::max();
+               }};
+
+constexpr auto numeric_limits_min_like =
+    overloaded{full_like, [](const auto &x) {
+                 return std::numeric_limits<
+                     underlying_t<std::decay_t<decltype(x)>>>::min();
+               }};
+
+} // namespace scipp::core::element

--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -14,29 +14,35 @@
 
 namespace scipp::core::element {
 
-constexpr auto full_like =
+constexpr auto special_like =
     overloaded{arg_list<double, float, int64_t, int32_t, bool>,
                [](const units::Unit &u) { return u; }};
 
-constexpr auto zero_like = overloaded{
-    full_like, [](const auto &x) { return std::decay_t<decltype(x)>{0}; }};
+constexpr auto zeros_not_bool_like =
+    overloaded{special_like, [](const auto &x) {
+                 using T = std::decay_t<decltype(x)>;
+                 if constexpr (std::is_same_v<T, bool>)
+                   return int64_t{0};
+                 else
+                   return T{0};
+               }};
 
 template <class T, T Value>
-constexpr auto value_like =
-    overloaded{full_like, [](const auto &) { return Value; }};
+constexpr auto values_like =
+    overloaded{special_like, [](const auto &) { return Value; }};
 
 template <class T> struct underlying { using type = T; };
 template <class T> struct underlying<ValueAndVariance<T>> { using type = T; };
 template <class T> using underlying_t = typename underlying<T>::type;
 
 constexpr auto numeric_limits_max_like =
-    overloaded{full_like, [](const auto &x) {
+    overloaded{special_like, [](const auto &x) {
                  return std::numeric_limits<
                      underlying_t<std::decay_t<decltype(x)>>>::max();
                }};
 
 constexpr auto numeric_limits_min_like =
-    overloaded{full_like, [](const auto &x) {
+    overloaded{special_like, [](const auto &x) {
                  return std::numeric_limits<
                      underlying_t<std::decay_t<decltype(x)>>>::min();
                }};

--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -11,7 +11,6 @@
 #include "scipp/core/transform_common.h"
 #include "scipp/units/unit.h"
 
-
 namespace scipp::core::element {
 
 constexpr auto special_like =

--- a/core/include/scipp/core/element_array_view.h
+++ b/core/include/scipp/core/element_array_view.h
@@ -153,7 +153,7 @@ public:
   }
 
   template <class T2> bool overlaps(const ElementArrayView<T2> &other) const {
-    if (buffer() == other.buffer())
+    if (buffer() && buffer() == other.buffer())
       return ElementArrayViewParams::overlaps(other);
     return false;
   }

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -30,8 +30,8 @@ Variable special_like(const VariableConstView &prototype,
     return transform(prototype, core::element::values_like<bool, false>);
   if (fill == FillValue::Max)
     return transform(prototype, core::element::numeric_limits_max_like);
-  if (fill == FillValue::Min)
-    return transform(prototype, core::element::numeric_limits_min_like);
+  if (fill == FillValue::Lowest)
+    return transform(prototype, core::element::numeric_limits_lowest_like);
   throw std::runtime_error("Unsupported fill value.");
 }
 

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -20,13 +20,14 @@ Variable empty_like(const VariableConstView &prototype,
   return variableFactory().empty_like(prototype, shape, sizes);
 }
 
-Variable full_like(const VariableConstView &prototype, const FillValue &fill) {
-  if (fill == FillValue::Zero)
-    return transform(prototype, core::element::zero_like);
+Variable special_like(const VariableConstView &prototype,
+                      const FillValue &fill) {
+  if (fill == FillValue::ZeroNotBool)
+    return transform(prototype, core::element::zeros_not_bool_like);
   if (fill == FillValue::True)
-    return transform(prototype, core::element::value_like<bool, true>);
+    return transform(prototype, core::element::values_like<bool, true>);
   if (fill == FillValue::False)
-    return transform(prototype, core::element::value_like<bool, false>);
+    return transform(prototype, core::element::values_like<bool, false>);
   if (fill == FillValue::Max)
     return transform(prototype, core::element::numeric_limits_max_like);
   if (fill == FillValue::Min)

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -2,7 +2,9 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/element/creation.h"
 #include "scipp/variable/creation.h"
+#include "scipp/variable/transform.h"
 #include "scipp/variable/variable_factory.h"
 
 namespace scipp::variable {
@@ -16,6 +18,20 @@ Variable empty_like(const VariableConstView &prototype,
                     const std::optional<Dimensions> &shape,
                     const VariableConstView &sizes) {
   return variableFactory().empty_like(prototype, shape, sizes);
+}
+
+Variable full_like(const VariableConstView &prototype, const FillValue &fill) {
+  if (fill == FillValue::Zero)
+    return transform(prototype, core::element::zero_like);
+  if (fill == FillValue::True)
+    return transform(prototype, core::element::value_like<bool, true>);
+  if (fill == FillValue::False)
+    return transform(prototype, core::element::value_like<bool, false>);
+  if (fill == FillValue::Max)
+    return transform(prototype, core::element::numeric_limits_max_like);
+  if (fill == FillValue::Min)
+    return transform(prototype, core::element::numeric_limits_min_like);
+  throw std::runtime_error("Unsupported fill value.");
 }
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -15,9 +15,15 @@ empty_like(const VariableConstView &prototype,
            const std::optional<Dimensions> &shape = std::nullopt,
            const VariableConstView &sizes = {});
 
-enum class SCIPP_VARIABLE_EXPORT FillValue { Zero, True, False, Max, Min };
+enum class SCIPP_VARIABLE_EXPORT FillValue {
+  ZeroNotBool,
+  True,
+  False,
+  Max,
+  Min
+};
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-full_like(const VariableConstView &prototype, const FillValue &fill);
+special_like(const VariableConstView &prototype, const FillValue &fill);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -20,7 +20,7 @@ enum class SCIPP_VARIABLE_EXPORT FillValue {
   True,
   False,
   Max,
-  Min
+  Lowest
 };
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -15,4 +15,9 @@ empty_like(const VariableConstView &prototype,
            const std::optional<Dimensions> &shape = std::nullopt,
            const VariableConstView &sizes = {});
 
+enum class SCIPP_VARIABLE_EXPORT FillValue { Zero, True, False, Max, Min };
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+full_like(const VariableConstView &prototype, const FillValue &fill);
+
 } // namespace scipp::variable

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -9,6 +9,7 @@
 #include "scipp/core/element/comparison.h"
 #include "scipp/core/element/logical.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/creation.h"
 #include "scipp/variable/math.h"
 #include "scipp/variable/misc_operations.h"
 #include "scipp/variable/special_values.h"
@@ -19,6 +20,8 @@ using namespace scipp::core;
 using scipp::common::reduce_all_dims;
 
 namespace scipp::variable {
+
+namespace {
 
 // Workaround VS C7526 (undefined inline variable) with dtype<> in template.
 bool is_dtype_bool(const VariableConstView &var) {
@@ -36,15 +39,23 @@ void nansum_impl(const VariableView &summed, const VariableConstView &var) {
   accumulate_in_place(summed, var, element::nan_plus_equals);
 }
 
-template <typename Op>
-Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {
+auto make_accumulant(const VariableConstView &var, const Dim dim,
+                     const FillValue &init) {
   auto dims = var.dims();
   dims.erase(dim);
+  return full_like(
+      var.dims()[dim] == 0 ? Variable(var, dims) : var.slice({dim, 0}), init);
+}
+
+} // namespace
+
+template <typename Op>
+Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {
   // Bool DType is a bit special in that it cannot contain it's sum.
   // Instead the sum is stored in a int64_t Variable
-  Variable summed{is_dtype_bool(var) ? makeVariable<int64_t>(Dimensions(dims))
-                                     : copy(var.slice({dim, 0}))};
-  fill_zeros(summed);
+  auto summed = make_accumulant(var, dim, FillValue::Zero);
+  if (is_dtype_bool(var))
+    summed = astype(summed, dtype<int64_t>);
   op(summed, var);
   return summed;
 }
@@ -174,8 +185,9 @@ void reduce_impl(const VariableView &out, const VariableConstView &var, Op op) {
 /// `max`. Note that masking is not supported here since it would make creation
 /// of a sensible starting value difficult.
 template <class Op>
-Variable reduce_idempotent(const VariableConstView &var, const Dim dim, Op op) {
-  Variable out(var.slice({dim, 0}));
+Variable reduce_idempotent(const VariableConstView &var, const Dim dim, Op op,
+                           const FillValue &init) {
+  auto out = make_accumulant(var, dim, init);
   reduce_impl(out, var, op);
   return out;
 }
@@ -185,7 +197,8 @@ void any_impl(const VariableView &out, const VariableConstView &var) {
 }
 
 Variable any(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::logical_or_equals);
+  return reduce_idempotent(var, dim, core::element::logical_or_equals,
+                           FillValue::False);
 }
 
 void all_impl(const VariableView &out, const VariableConstView &var) {
@@ -193,7 +206,8 @@ void all_impl(const VariableView &out, const VariableConstView &var) {
 }
 
 Variable all(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::logical_and_equals);
+  return reduce_idempotent(var, dim, core::element::logical_and_equals,
+                           FillValue::True);
 }
 
 void max_impl(const VariableView &out, const VariableConstView &var) {
@@ -205,7 +219,7 @@ void max_impl(const VariableView &out, const VariableConstView &var) {
 /// Variances are not considered when determining the maximum. If present, the
 /// variance of the maximum element is returned.
 Variable max(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::max_equals);
+  return reduce_idempotent(var, dim, core::element::max_equals, FillValue::Min);
 }
 
 /// Return the maximum along given dimension ignoring NaN values.
@@ -213,7 +227,8 @@ Variable max(const VariableConstView &var, const Dim dim) {
 /// Variances are not considered when determining the maximum. If present, the
 /// variance of the maximum element is returned.
 Variable nanmax(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::nanmax_equals);
+  return reduce_idempotent(var, dim, core::element::nanmax_equals,
+                           FillValue::Min);
 }
 
 void min_impl(const VariableView &out, const VariableConstView &var) {
@@ -225,7 +240,7 @@ void min_impl(const VariableView &out, const VariableConstView &var) {
 /// Variances are not considered when determining the minimum. If present, the
 /// variance of the minimum element is returned.
 Variable min(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::min_equals);
+  return reduce_idempotent(var, dim, core::element::min_equals, FillValue::Max);
 }
 
 /// Return the minimum along given dimension ignorning NaN values.
@@ -233,7 +248,8 @@ Variable min(const VariableConstView &var, const Dim dim) {
 /// Variances are not considered when determining the minimum. If present, the
 /// variance of the minimum element is returned.
 Variable nanmin(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::nanmin_equals);
+  return reduce_idempotent(var, dim, core::element::nanmin_equals,
+                           FillValue::Max);
 }
 
 /// Return the sum along all dimensions.

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -217,7 +217,8 @@ void max_impl(const VariableView &out, const VariableConstView &var) {
 /// Variances are not considered when determining the maximum. If present, the
 /// variance of the maximum element is returned.
 Variable max(const VariableConstView &var, const Dim dim) {
-  return reduce_idempotent(var, dim, core::element::max_equals, FillValue::Min);
+  return reduce_idempotent(var, dim, core::element::max_equals,
+                           FillValue::Lowest);
 }
 
 /// Return the maximum along given dimension ignoring NaN values.
@@ -226,7 +227,7 @@ Variable max(const VariableConstView &var, const Dim dim) {
 /// variance of the maximum element is returned.
 Variable nanmax(const VariableConstView &var, const Dim dim) {
   return reduce_idempotent(var, dim, core::element::nanmax_equals,
-                           FillValue::Min);
+                           FillValue::Lowest);
 }
 
 void min_impl(const VariableView &out, const VariableConstView &var) {

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -72,6 +72,7 @@ VariableView sum_with_dim_inplace_impl(Op op, const VariableConstView &var,
         "Output argument dimensions must be equal to input dimensions without "
         "the summing dimension.");
 
+  out.setUnit(var.unit());
   op(out, var);
   return out;
 }

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -62,8 +62,8 @@ template <typename Op>
 VariableView sum_with_dim_inplace_impl(Op op, const VariableConstView &var,
                                        const Dim dim, const VariableView &out) {
   if (is_dtype_bool(var) && !is_dtype_int64(out))
-    throw except::UnitError("In-place sum of Bool dtype must be stored in an "
-                            "output variable of Int64 dtype.");
+    throw except::TypeError("In-place sum of dtype=bool must be stored in an "
+                            "output variable with dtype=int64.");
 
   auto dims = var.dims();
   dims.erase(dim);
@@ -99,7 +99,7 @@ VariableView nanmean_impl(const VariableConstView &var, const Dim dim,
                           const VariableConstView &count,
                           const VariableView &out) {
   if (isInt(out.dtype()))
-    throw except::UnitError(
+    throw except::TypeError(
         "Cannot calculate nanmean in-place when output dtype is integer");
 
   nansum(var, dim, out);
@@ -132,7 +132,7 @@ VariableView mean_impl(const VariableConstView &var, const Dim dim,
                        const VariableConstView &count,
                        const VariableView &out) {
   if (isInt(out.dtype()))
-    throw except::UnitError(
+    throw except::TypeError(
         "Cannot calculate mean in-place when output dtype is integer");
 
   sum(var, dim, out);

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -51,7 +51,7 @@ void nansum_impl(const VariableView &summed, const VariableConstView &var) {
 
 template <typename Op>
 Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {
-  // Bool DType is a bit special in that it cannot contain it's sum.
+  // Bool DType is a bit special in that it cannot contain its sum.
   // Instead the sum is stored in a int64_t Variable
   auto summed = make_accumulant(var, dim, FillValue::ZeroNotBool);
   op(summed, var);

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -43,7 +43,7 @@ auto make_accumulant(const VariableConstView &var, const Dim dim,
                      const FillValue &init) {
   auto dims = var.dims();
   dims.erase(dim);
-  return full_like(
+  return special_like(
       var.dims()[dim] == 0 ? Variable(var, dims) : var.slice({dim, 0}), init);
 }
 
@@ -53,9 +53,7 @@ template <typename Op>
 Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {
   // Bool DType is a bit special in that it cannot contain it's sum.
   // Instead the sum is stored in a int64_t Variable
-  auto summed = make_accumulant(var, dim, FillValue::Zero);
-  if (is_dtype_bool(var))
-    summed = astype(summed, dtype<int64_t>);
+  auto summed = make_accumulant(var, dim, FillValue::ZeroNotBool);
   op(summed, var);
   return summed;
 }

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -31,14 +31,6 @@ bool is_dtype_int64(const VariableConstView &var) {
   return var.dtype() == dtype<int64_t>;
 }
 
-void sum_impl(const VariableView &summed, const VariableConstView &var) {
-  accumulate_in_place(summed, var, element::plus_equals);
-}
-
-void nansum_impl(const VariableView &summed, const VariableConstView &var) {
-  accumulate_in_place(summed, var, element::nan_plus_equals);
-}
-
 auto make_accumulant(const VariableConstView &var, const Dim dim,
                      const FillValue &init) {
   auto dims = var.dims();
@@ -48,6 +40,14 @@ auto make_accumulant(const VariableConstView &var, const Dim dim,
 }
 
 } // namespace
+
+void sum_impl(const VariableView &summed, const VariableConstView &var) {
+  accumulate_in_place(summed, var, element::plus_equals);
+}
+
+void nansum_impl(const VariableView &summed, const VariableConstView &var) {
+  accumulate_in_place(summed, var, element::nan_plus_equals);
+}
 
 template <typename Op>
 Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   shape_test.cpp
   sort_test.cpp
   subspan_view_test.cpp
+  sum_test.cpp
   test_variables.cpp
   transform_test.cpp
   trigonometry_test.cpp

--- a/variable/test/creation_test.cpp
+++ b/variable/test/creation_test.cpp
@@ -60,10 +60,10 @@ TEST(CreationTest, special_like_double) {
                                  Values{std::numeric_limits<double>::max(),
                                         std::numeric_limits<double>::max()},
                                  Variances{0, 0}));
-  EXPECT_EQ(special_like(var, variable::FillValue::Min),
+  EXPECT_EQ(special_like(var, variable::FillValue::Lowest),
             makeVariable<double>(var.dims(), var.unit(),
-                                 Values{std::numeric_limits<double>::min(),
-                                        std::numeric_limits<double>::min()},
+                                 Values{std::numeric_limits<double>::lowest(),
+                                        std::numeric_limits<double>::lowest()},
                                  Variances{0, 0}));
 }
 
@@ -80,10 +80,11 @@ TEST(CreationTest, special_like_int) {
             makeVariable<int64_t>(var.dims(), var.unit(),
                                   Values{std::numeric_limits<int64_t>::max(),
                                          std::numeric_limits<int64_t>::max()}));
-  EXPECT_EQ(special_like(var, variable::FillValue::Min),
-            makeVariable<int64_t>(var.dims(), var.unit(),
-                                  Values{std::numeric_limits<int64_t>::min(),
-                                         std::numeric_limits<int64_t>::min()}));
+  EXPECT_EQ(
+      special_like(var, variable::FillValue::Lowest),
+      makeVariable<int64_t>(var.dims(), var.unit(),
+                            Values{std::numeric_limits<int64_t>::lowest(),
+                                   std::numeric_limits<int64_t>::lowest()}));
 }
 
 TEST(CreationTest, special_like_bool) {
@@ -95,8 +96,8 @@ TEST(CreationTest, special_like_bool) {
             makeVariable<bool>(var.dims(), var.unit(),
                                Values{std::numeric_limits<bool>::max(),
                                       std::numeric_limits<bool>::max()}));
-  EXPECT_EQ(special_like(var, variable::FillValue::Min),
+  EXPECT_EQ(special_like(var, variable::FillValue::Lowest),
             makeVariable<bool>(var.dims(), var.unit(),
-                               Values{std::numeric_limits<bool>::min(),
-                                      std::numeric_limits<bool>::min()}));
+                               Values{std::numeric_limits<bool>::lowest(),
+                                      std::numeric_limits<bool>::lowest()}));
 }

--- a/variable/test/creation_test.cpp
+++ b/variable/test/creation_test.cpp
@@ -44,3 +44,44 @@ TEST_P(DenseVariablesTest, empty_like) {
   EXPECT_EQ(empty.unit(), var.unit());
   EXPECT_EQ(empty.hasVariances(), var.hasVariances());
 }
+
+TEST(CreationTest, full_like_double) {
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+                                        Values{1, 2}, Variances{3, 4});
+  EXPECT_EQ(full_like(var, variable::FillValue::Zero),
+            makeVariable<double>(var.dims(), var.unit(), Values{0, 0},
+                                 Variances{0, 0}));
+  EXPECT_EQ(full_like(var, variable::FillValue::True),
+            makeVariable<bool>(var.dims(), var.unit(), Values{true, true}));
+  EXPECT_EQ(full_like(var, variable::FillValue::False),
+            makeVariable<bool>(var.dims(), var.unit(), Values{false, false}));
+  EXPECT_EQ(full_like(var, variable::FillValue::Max),
+            makeVariable<double>(var.dims(), var.unit(),
+                                 Values{std::numeric_limits<double>::max(),
+                                        std::numeric_limits<double>::max()},
+                                 Variances{0, 0}));
+  EXPECT_EQ(full_like(var, variable::FillValue::Min),
+            makeVariable<double>(var.dims(), var.unit(),
+                                 Values{std::numeric_limits<double>::min(),
+                                        std::numeric_limits<double>::min()},
+                                 Variances{0, 0}));
+}
+
+TEST(CreationTest, full_like_int) {
+  const auto var =
+      makeVariable<int64_t>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
+  EXPECT_EQ(full_like(var, variable::FillValue::Zero),
+            makeVariable<int64_t>(var.dims(), var.unit(), Values{0, 0}));
+  EXPECT_EQ(full_like(var, variable::FillValue::True),
+            makeVariable<bool>(var.dims(), var.unit(), Values{true, true}));
+  EXPECT_EQ(full_like(var, variable::FillValue::False),
+            makeVariable<bool>(var.dims(), var.unit(), Values{false, false}));
+  EXPECT_EQ(full_like(var, variable::FillValue::Max),
+            makeVariable<int64_t>(var.dims(), var.unit(),
+                                  Values{std::numeric_limits<int64_t>::max(),
+                                         std::numeric_limits<int64_t>::max()}));
+  EXPECT_EQ(full_like(var, variable::FillValue::Min),
+            makeVariable<int64_t>(var.dims(), var.unit(),
+                                  Values{std::numeric_limits<int64_t>::min(),
+                                         std::numeric_limits<int64_t>::min()}));
+}

--- a/variable/test/creation_test.cpp
+++ b/variable/test/creation_test.cpp
@@ -45,43 +45,58 @@ TEST_P(DenseVariablesTest, empty_like) {
   EXPECT_EQ(empty.hasVariances(), var.hasVariances());
 }
 
-TEST(CreationTest, full_like_double) {
+TEST(CreationTest, special_like_double) {
   const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
                                         Values{1, 2}, Variances{3, 4});
-  EXPECT_EQ(full_like(var, variable::FillValue::Zero),
+  EXPECT_EQ(special_like(var, variable::FillValue::ZeroNotBool),
             makeVariable<double>(var.dims(), var.unit(), Values{0, 0},
                                  Variances{0, 0}));
-  EXPECT_EQ(full_like(var, variable::FillValue::True),
+  EXPECT_EQ(special_like(var, variable::FillValue::True),
             makeVariable<bool>(var.dims(), var.unit(), Values{true, true}));
-  EXPECT_EQ(full_like(var, variable::FillValue::False),
+  EXPECT_EQ(special_like(var, variable::FillValue::False),
             makeVariable<bool>(var.dims(), var.unit(), Values{false, false}));
-  EXPECT_EQ(full_like(var, variable::FillValue::Max),
+  EXPECT_EQ(special_like(var, variable::FillValue::Max),
             makeVariable<double>(var.dims(), var.unit(),
                                  Values{std::numeric_limits<double>::max(),
                                         std::numeric_limits<double>::max()},
                                  Variances{0, 0}));
-  EXPECT_EQ(full_like(var, variable::FillValue::Min),
+  EXPECT_EQ(special_like(var, variable::FillValue::Min),
             makeVariable<double>(var.dims(), var.unit(),
                                  Values{std::numeric_limits<double>::min(),
                                         std::numeric_limits<double>::min()},
                                  Variances{0, 0}));
 }
 
-TEST(CreationTest, full_like_int) {
+TEST(CreationTest, special_like_int) {
   const auto var =
       makeVariable<int64_t>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
-  EXPECT_EQ(full_like(var, variable::FillValue::Zero),
+  EXPECT_EQ(special_like(var, variable::FillValue::ZeroNotBool),
             makeVariable<int64_t>(var.dims(), var.unit(), Values{0, 0}));
-  EXPECT_EQ(full_like(var, variable::FillValue::True),
+  EXPECT_EQ(special_like(var, variable::FillValue::True),
             makeVariable<bool>(var.dims(), var.unit(), Values{true, true}));
-  EXPECT_EQ(full_like(var, variable::FillValue::False),
+  EXPECT_EQ(special_like(var, variable::FillValue::False),
             makeVariable<bool>(var.dims(), var.unit(), Values{false, false}));
-  EXPECT_EQ(full_like(var, variable::FillValue::Max),
+  EXPECT_EQ(special_like(var, variable::FillValue::Max),
             makeVariable<int64_t>(var.dims(), var.unit(),
                                   Values{std::numeric_limits<int64_t>::max(),
                                          std::numeric_limits<int64_t>::max()}));
-  EXPECT_EQ(full_like(var, variable::FillValue::Min),
+  EXPECT_EQ(special_like(var, variable::FillValue::Min),
             makeVariable<int64_t>(var.dims(), var.unit(),
                                   Values{std::numeric_limits<int64_t>::min(),
                                          std::numeric_limits<int64_t>::min()}));
+}
+
+TEST(CreationTest, special_like_bool) {
+  const auto var =
+      makeVariable<bool>(Dims{Dim::X}, Shape{2}, units::m, Values{true, false});
+  EXPECT_EQ(special_like(var, variable::FillValue::ZeroNotBool),
+            makeVariable<int64_t>(var.dims(), var.unit(), Values{0, 0}));
+  EXPECT_EQ(special_like(var, variable::FillValue::Max),
+            makeVariable<bool>(var.dims(), var.unit(),
+                               Values{std::numeric_limits<bool>::max(),
+                                      std::numeric_limits<bool>::max()}));
+  EXPECT_EQ(special_like(var, variable::FillValue::Min),
+            makeVariable<bool>(var.dims(), var.unit(),
+                               Values{std::numeric_limits<bool>::min(),
+                                      std::numeric_limits<bool>::min()}));
 }

--- a/variable/test/mean_test.cpp
+++ b/variable/test/mean_test.cpp
@@ -66,7 +66,7 @@ template <typename Op> void in_place_fail_output_dtype(Op op) {
                                         units::m, Values{1.0, 2.0, 3.0, 4.0});
   auto out = makeVariable<int>(Dims{Dim::Y}, Shape{2}, units::m);
   EXPECT_THROW([[maybe_unused]] const auto view = op(var, Dim::X, out),
-               except::UnitError);
+               except::TypeError);
 }
 
 template <typename TestFixture, typename Op> void dtype_preservation(Op op) {

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -407,62 +407,6 @@ TEST(Variable, concatenate_from_slices_with_broadcast) {
                                       Values(expected), Variances(expected)));
 }
 
-TEST(Variable, sum) {
-  const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
-  const auto expectedX =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
-  const auto expectedY =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{4.0, 6.0});
-  EXPECT_EQ(sum(var, Dim::X), expectedX);
-  EXPECT_EQ(sum(var, Dim::Y), expectedY);
-}
-
-TEST(Variable, sum_in_place) {
-  const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
-
-  auto out =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::Unit{units::m});
-  auto view = sum(var, Dim::X, out);
-
-  const auto expected =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
-
-  EXPECT_EQ(out, expected);
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
-}
-
-TEST(Variable, sum_in_place_bool) {
-  const auto var = makeVariable<bool>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                      Values{true, false, true, true});
-
-  auto out = makeVariable<int64_t>(Dims{Dim::Y}, Shape{2});
-  auto view = sum(var, Dim::X, out);
-
-  const auto expected =
-      makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, Values{1, 2});
-
-  EXPECT_EQ(out, expected);
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
-}
-
-TEST(Variable, sum_in_place_bool_incorrect_out_type) {
-  const auto var = makeVariable<bool>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                      Values{true, false, true, true});
-  auto out = makeVariable<float>(Dims{Dim::Y}, Shape{2});
-  EXPECT_THROW(sum(var, Dim::X, out), except::UnitError);
-}
-
-TEST(VariableConstView, sum) {
-  const auto var =
-      makeVariable<float>(Dims{Dim::X}, Shape{4}, Values{1.0, 2.0, 3.0, 4.0});
-  EXPECT_EQ(sum(var.slice({Dim::X, 0, 2}), Dim::X),
-            makeVariable<float>(Values{3}));
-}
-
 TEST(VariableView, minus_equals_failures) {
   auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});

--- a/variable/test/reduce_logical_test.cpp
+++ b/variable/test/reduce_logical_test.cpp
@@ -23,6 +23,8 @@ TEST(ReduceLogicalTest, all) {
             makeVariable<bool>(Dims{Dim::Y}, Shape{2}, Values{false, true}));
   EXPECT_EQ(all(var, Dim::Y),
             makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{true, false}));
+  EXPECT_EQ(all(var.slice({Dim::X, 0, 0}), Dim::X),
+            makeVariable<bool>(Dims{Dim::Y}, Shape{2}, Values{true, true}));
 }
 
 TEST(ReduceLogicalTest, any) {
@@ -32,4 +34,6 @@ TEST(ReduceLogicalTest, any) {
             makeVariable<bool>(Dims{Dim::Y}, Shape{2}, Values{true, false}));
   EXPECT_EQ(any(var, Dim::Y),
             makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{false, true}));
+  EXPECT_EQ(any(var.slice({Dim::X, 0, 0}), Dim::X),
+            makeVariable<bool>(Dims{Dim::Y}, Shape{2}, Values{false, false}));
 }

--- a/variable/test/reduce_various_test.cpp
+++ b/variable/test/reduce_various_test.cpp
@@ -47,6 +47,22 @@ TEST(ReduceTest, min_max_with_variances) {
                                  Variances{5, 7}));
 }
 
+TEST(ReduceTest, min_max_empty_dim) {
+  const auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 0},
+                                        Values{}, Variances{});
+  EXPECT_EQ(max(var, Dim::X), makeVariable<double>(Dims{Dim::Y}, Shape{0},
+                                                   Values{}, Variances{}));
+  const auto highest = std::numeric_limits<double>::max();
+  EXPECT_EQ(max(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                 Values{-highest, -highest}, Variances{0, 0}));
+  EXPECT_EQ(min(var, Dim::X), makeVariable<double>(Dims{Dim::Y}, Shape{0},
+                                                   Values{}, Variances{}));
+  EXPECT_EQ(min(var, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                 Values{highest, highest}, Variances{0, 0}));
+}
+
 TEST(ReduceTest, min_max_all_dims) {
   const auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
                                         Values{1, 2, 3, 4});

--- a/variable/test/sum_test.cpp
+++ b/variable/test/sum_test.cpp
@@ -24,6 +24,7 @@ TEST_F(SumTest, sum) {
   const auto expectedY =
       makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{4.0, 6.0});
   EXPECT_EQ(sum(var, Dim::X), expectedX);
+  EXPECT_EQ(sum(var, Dim::Y), expectedY);
 }
 
 TEST_F(SumTest, sum_with_empty_dim) {
@@ -38,11 +39,8 @@ TEST_F(SumTest, sum_with_empty_dim) {
 TEST_F(SumTest, sum_in_place) {
   auto out = makeVariable<double>(Dims{Dim::Y}, Shape{2});
   auto view = sum(var, Dim::X, out);
-
-  const auto expected =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
-
-  EXPECT_EQ(out, expected);
+  EXPECT_EQ(out, makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
+                                      Values{3.0, 7.0}));
   EXPECT_EQ(view, out);
   EXPECT_EQ(view.underlying(), out);
 }
@@ -50,17 +48,13 @@ TEST_F(SumTest, sum_in_place) {
 TEST_F(SumTest, sum_in_place_bool) {
   auto out = makeVariable<int64_t>(Dims{Dim::Y}, Shape{2});
   auto view = sum(var_bool, Dim::X, out);
-
-  const auto expected =
-      makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, units::m, Values{1, 2});
-
-  EXPECT_EQ(out, expected) << out << expected;
+  EXPECT_EQ(out, makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, units::m,
+                                       Values{1, 2}));
   EXPECT_EQ(view, out);
   EXPECT_EQ(view.underlying(), out);
 }
 
 TEST_F(SumTest, sum_in_place_bool_incorrect_out_type) {
   auto out = makeVariable<float>(Dims{Dim::Y}, Shape{2});
-  // why this error? TypeError?
-  EXPECT_THROW(sum(var_bool, Dim::X, out), except::UnitError);
+  EXPECT_THROW(sum(var_bool, Dim::X, out), except::TypeError);
 }

--- a/variable/test/sum_test.cpp
+++ b/variable/test/sum_test.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/variable/reduction.h"
+#include "scipp/variable/string.h"
+#include "scipp/variable/variable.h"
+
+using namespace scipp;
+using namespace scipp::variable;
+
+class SumTest : public ::testing::Test {
+protected:
+  Variable var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
+                                      units::m, Values{1.0, 2.0, 3.0, 4.0});
+  Variable var_bool =
+      makeVariable<bool>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m,
+                         Values{true, false, true, true});
+};
+
+TEST_F(SumTest, sum) {
+  const auto expectedX =
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
+  const auto expectedY =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{4.0, 6.0});
+  EXPECT_EQ(sum(var, Dim::X), expectedX);
+}
+
+TEST_F(SumTest, sum_with_empty_dim) {
+  const auto empty_slice = var.slice({Dim::X, 0, 0});
+  EXPECT_EQ(
+      sum(empty_slice, Dim::X),
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{0, 0}));
+  EXPECT_EQ(sum(empty_slice, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{0}, units::m, Values{}));
+}
+
+TEST_F(SumTest, sum_in_place) {
+  auto out = makeVariable<double>(Dims{Dim::Y}, Shape{2});
+  auto view = sum(var, Dim::X, out);
+
+  const auto expected =
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
+
+  EXPECT_EQ(out, expected);
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
+}
+
+TEST_F(SumTest, sum_in_place_bool) {
+  auto out = makeVariable<int64_t>(Dims{Dim::Y}, Shape{2});
+  auto view = sum(var_bool, Dim::X, out);
+
+  const auto expected =
+      makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, units::m, Values{1, 2});
+
+  EXPECT_EQ(out, expected) << out << expected;
+  EXPECT_EQ(view, out);
+  EXPECT_EQ(view.underlying(), out);
+}
+
+TEST_F(SumTest, sum_in_place_bool_incorrect_out_type) {
+  auto out = makeVariable<float>(Dims{Dim::Y}, Shape{2});
+  // why this error? TypeError?
+  EXPECT_THROW(sum(var_bool, Dim::X, out), except::UnitError);
+}

--- a/variable/test/test_variables.cpp
+++ b/variable/test/test_variables.cpp
@@ -19,7 +19,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     1D, DenseVariablesTest,
-    testing::Values(makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+    testing::Values(makeVariable<double>(Dims{Dim::X}, Shape{0}, units::m),
+                    makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
                                          Values{1, 2}, Variances{3, 4}),
                     makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
                                          Values{1, 2}),
@@ -30,6 +31,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     2D, DenseVariablesTest,
-    testing::Values(makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
-                                         units::m, Values{1, 2, 3, 4, 5, 6},
-                                         Variances{1, 1, 2, 2, 3, 3})));
+    testing::Values(
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 0}, units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 2}, units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 0}, units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3}, units::m,
+                             Values{1, 2, 3, 4, 5, 6},
+                             Variances{1, 1, 2, 2, 3, 3})));


### PR DESCRIPTION
- Fix reduction operations for cases where reduction dim or other dim have extent 0.
- Fix missing unit in `sum` with `out` arg.
- Unrelated: Use correct exception type.