### PR TITLE
Binned plot fixed for inner dimension without event coord

### DIFF
--- a/python/tests/plot/test_plot_2d.py
+++ b/python/tests/plot/test_plot_2d.py
@@ -241,11 +241,17 @@ def test_plot_2d_binned_data():
     plot(make_binned_data_array(ndim=2))
 
 
-def test_plot_3d_binned_data_where_outer_dimension_not_in_buffer():
+def test_plot_3d_binned_data_where_outer_dimension_has_no_event_coord():
     data = make_binned_data_array(ndim=2)
     data = sc.concatenate(data, data + data, 'run')
     plot_obj = sc.plot.plot(data)
     plot_obj.widgets.slider[0].value = 1
+
+
+def test_plot_3d_binned_data_where_inner_dimension_nas_no_event_coord():
+    data = make_binned_data_array(ndim=2)
+    data = sc.concatenate(data, data + data, 'run')
+    sc.plot.plot(data, axes={'x': 'run', 'y': 'tof'})
 
 
 def test_plot_2d_binned_data_with_variances():


### PR DESCRIPTION
Fixes #1577.

Note that before #1552 this will consume a lot of memory and will throw a `bad_alloc` in some cases.