### PR TITLE
Fix segault from bad GIL release

### DIFF
--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -228,8 +228,8 @@ void init_buckets(py::module &m) {
         for (const auto &[name, coord] : coords)
           c.emplace(Dim(py::cast<std::string>(name)),
                     py::cast<VariableConstView>(coord));
+        py::gil_scoped_release release; // release only *after* using py::cast
         return dataset::bin(data, c, std::map<std::string, VariableConstView>{},
                             std::map<Dim, VariableConstView>{}, edges, groups);
-      },
-      py::call_guard<py::gil_scoped_release>());
+      });
 }

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -219,17 +219,16 @@ void init_buckets(py::module &m) {
         return dataset::bin(array, edges, groups);
       },
       py::call_guard<py::gil_scoped_release>());
-  m.def(
-      "bin_with_coords",
-      [](const VariableConstView &data, const py::dict &coords,
-         const std::vector<VariableConstView> &edges,
-         const std::vector<VariableConstView> &groups) {
-        std::map<Dim, VariableConstView> c;
-        for (const auto &[name, coord] : coords)
-          c.emplace(Dim(py::cast<std::string>(name)),
-                    py::cast<VariableConstView>(coord));
-        py::gil_scoped_release release; // release only *after* using py::cast
-        return dataset::bin(data, c, std::map<std::string, VariableConstView>{},
-                            std::map<Dim, VariableConstView>{}, edges, groups);
-      });
+  m.def("bin_with_coords", [](const VariableConstView &data,
+                              const py::dict &coords,
+                              const std::vector<VariableConstView> &edges,
+                              const std::vector<VariableConstView> &groups) {
+    std::map<Dim, VariableConstView> c;
+    for (const auto &[name, coord] : coords)
+      c.emplace(Dim(py::cast<std::string>(name)),
+                py::cast<VariableConstView>(coord));
+    py::gil_scoped_release release; // release only *after* using py::cast
+    return dataset::bin(data, c, std::map<std::string, VariableConstView>{},
+                        std::map<Dim, VariableConstView>{}, edges, groups);
+  });
 }


### PR DESCRIPTION
`py::cast` may not be used while GIL is released. This lead to a crash when turning on the profile view when plotting event data.