### PR TITLE
Fix infinite loop when zooming on empty bins

### DIFF
--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -83,7 +83,7 @@ public:
     scipp::index dim = iterDims.ndim() - 1 + nestedDims.ndim();
     m_end_sentinel = iterDims.volume();
     if (m_end_sentinel == 0) {
-      return;  // operands are empty, leave everything below default initialised
+      return; // operands are empty, leave everything below default initialised
     }
     for (const auto size : iterDims.shape()) {
       m_shape[dim--] = size;

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -81,6 +81,10 @@ public:
     m_nested_stride = nestedDims.offset(sliceDim);
     m_nested_dim_index = m_ndim_nested - nestedDims.index(sliceDim) - 1;
     scipp::index dim = iterDims.ndim() - 1 + nestedDims.ndim();
+    m_end_sentinel = iterDims.volume();
+    if (m_end_sentinel == 0) {
+      return;  // operands are empty, leave everything below default initialised
+    }
     for (const auto size : iterDims.shape()) {
       m_shape[dim--] = size;
     }
@@ -97,7 +101,6 @@ public:
         m_stride[data][m_ndim_nested + d] = bucketStrides[data][d];
       load_bucket_params(data);
     }
-    m_end_sentinel = iterDims.volume();
     if (m_shape[m_nested_dim_index] == 0)
       seek_bucket();
   }

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -287,3 +287,10 @@ TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets_bucket_size_mismatch) {
                                   {0, 1, 2, 3, 4, 5, 6}, {0, 1, 2, 3, 4, 5, 6}),
                except::BucketError);
 }
+
+TEST_F(MultiIndexTest, 2d_empty_dims_array_of_1d_buckets) {
+  const Dim dim = Dim::Row;
+  Dimensions buf{dim, 0}; // 1d cut into dims=0x0 sections
+  Dimensions dims{{Dim::X, 0}};
+  check_with_buckets(buf, dim, {}, dims, dims, {});
+}

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -290,7 +290,7 @@ TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets_bucket_size_mismatch) {
 
 TEST_F(MultiIndexTest, 2d_empty_dims_array_of_1d_buckets) {
   const Dim dim = Dim::Row;
-  Dimensions buf{dim, 0}; // 1d cut into dims=0x0 sections
+  Dimensions buf{dim, 0}; // 1d cut into dims=0 sections
   Dimensions dims{{Dim::X, 0}};
   check_with_buckets(buf, dim, {}, dims, dims, {});
 }

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -133,7 +133,7 @@ auto bin(const VariableConstView &data, const VariableConstView &indices,
   // Perform actual binning step for data, all coords, all masks, ...
   auto out_buffer = dataset::transform(bins_view<T>(data), [&](auto &&var) {
     if (!is_bins(var))
-      return std::move(var);
+        return std::forward<decltype(var)>(var);
     const auto &[input_indices, buffer_dim, in_buffer] =
         var.template constituents<core::bin<VariableConstView>>();
     static_cast<void>(input_indices);

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -133,7 +133,7 @@ auto bin(const VariableConstView &data, const VariableConstView &indices,
   // Perform actual binning step for data, all coords, all masks, ...
   auto out_buffer = dataset::transform(bins_view<T>(data), [&](auto &&var) {
     if (!is_bins(var))
-        return std::forward<decltype(var)>(var);
+      return std::forward<decltype(var)>(var);
     const auto &[input_indices, buffer_dim, in_buffer] =
         var.template constituents<core::bin<VariableConstView>>();
     static_cast<void>(input_indices);

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -8,7 +8,6 @@
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/bins_view.h"
 #include "scipp/dataset/histogram.h"
-#include "scipp/dataset/string.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
 #include "scipp/variable/reduction.h"

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -11,6 +11,7 @@
 #include "scipp/dataset/string.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
+#include "scipp/variable/math.h"
 #include "scipp/variable/reduction.h"
 
 using namespace scipp;
@@ -87,6 +88,16 @@ TEST_F(DataArrayBinTest, 2d) {
             sorted_table.slice({Dim::Event, 1, 3}));
 
   EXPECT_EQ(bin(bin(table, {edges_x}), {edges_y}), bucketed);
+}
+
+TEST_F(DataArrayBinTest, operations_on_empty) {
+  const Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
+      Dimensions{{Dim::Event, 0}, {Dim::Y, 0}}, Values{});
+  const Variable binned = make_bins(indices, Dim::Event, data);
+
+  EXPECT_EQ(abs(binned), binned);
+  EXPECT_EQ(binned, binned * binned);
+  EXPECT_EQ(binned, binned * (2 * units::one));
 }
 
 TEST(BinGroupTest, 1d) {

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -11,7 +11,6 @@
 #include "scipp/dataset/string.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/comparison.h"
-#include "scipp/variable/math.h"
 #include "scipp/variable/reduction.h"
 
 using namespace scipp;
@@ -88,16 +87,6 @@ TEST_F(DataArrayBinTest, 2d) {
             sorted_table.slice({Dim::Event, 1, 3}));
 
   EXPECT_EQ(bin(bin(table, {edges_x}), {edges_y}), bucketed);
-}
-
-TEST_F(DataArrayBinTest, operations_on_empty) {
-  const Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
-      Dimensions{{Dim::Event, 0}, {Dim::Y, 0}}, Values{});
-  const Variable binned = make_bins(indices, Dim::Event, data);
-
-  EXPECT_EQ(abs(binned), binned);
-  EXPECT_EQ(binned, binned * binned);
-  EXPECT_EQ(binned, binned * (2 * units::one));
 }
 
 TEST(BinGroupTest, 1d) {

--- a/dataset/test/bins_test.cpp
+++ b/dataset/test/bins_test.cpp
@@ -7,6 +7,7 @@
 #include "scipp/dataset/histogram.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/bins.h"
+#include "scipp/variable/math.h"
 #include "scipp/variable/operations.h"
 #include "scipp/variable/variable_factory.h"
 
@@ -171,6 +172,17 @@ TEST_F(DataArrayBinsTest, histogram_existing_dim) {
 TEST_F(DataArrayBinsTest, sum) {
   EXPECT_EQ(buckets::sum(var),
             makeVariable<double>(indices.dims(), Values{3, 7}));
+}
+
+TEST_F(DataArrayBinsTest, operations_on_empty) {
+  const Variable empty_indices =
+      makeVariable<std::pair<scipp::index, scipp::index>>(
+          Dimensions{{Dim::Y, 0}, {Dim::Z, 0}}, Values{});
+  const Variable binned = make_bins(empty_indices, Dim::X, data);
+
+  EXPECT_EQ(abs(binned), binned);
+  EXPECT_EQ(binned, binned * binned);
+  EXPECT_EQ(binned, binned * (2 * units::one));
 }
 
 class DataArrayBinsMapTest : public ::testing::Test {

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -80,10 +80,11 @@ auto contiguous_indices(const VariableConstView &parent,
 
 template <class T> class BinVariableMakerCommon : public AbstractVariableMaker {
 public:
-  bool is_bins() const override { return true; }
-  Variable empty_like(const VariableConstView &prototype,
-                      const std::optional<Dimensions> &shape,
-                      const VariableConstView &sizes) const override {
+  [[nodiscard]] bool is_bins() const override { return true; }
+  [[nodiscard]] Variable
+  empty_like(const VariableConstView &prototype,
+             const std::optional<Dimensions> &shape,
+             const VariableConstView &sizes) const override {
     if (shape)
       throw except::TypeError(
           "Cannot specify shape in `empty_like` for prototype with bins, shape "

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -98,7 +98,7 @@ public:
     }
     const auto end = cumsum(sizes_);
     const auto begin = end - sizes_;
-    const auto size = end.template values<scipp::index>().as_span().back();
+    const auto size = sum(end - begin).template value<scipp::index>();
     return make_bins(zip(begin, end), dim, resize_default_init(buf, dim, size));
   }
 };


### PR DESCRIPTION
Fixed #1527 

The problem is more general, it appears with all operations on binned variables with more than one outer dimension where in all operands at least one outer dimension has extent 0.