### PR TITLE
Support binning pulse-time in histogram

### DIFF
--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -36,6 +36,7 @@ using args = std::tuple<span<Out>, span<const Coord>, span<const Weight>,
 
 static constexpr auto histogram = overloaded{
     element::arg_list<histogram_detail::args<float, double, float, double>,
+                      histogram_detail::args<float, int64_t, float, double>,
                       histogram_detail::args<double, double, double, double>,
                       histogram_detail::args<double, float, double, double>,
                       histogram_detail::args<double, float, double, float>,


### PR DESCRIPTION
We are (currently) storing pulse-time as `int64_t` (will be changed to `datetime` in the future), but binning this in `histogram` was not supported.