### PR TITLE
Forbid non range bins

### DIFF
--- a/python/tests/test_bins.py
+++ b/python/tests/test_bins.py
@@ -14,7 +14,7 @@ def test_bins_default_begin_end():
     assert var.dims == data.dims
     assert var.shape == data.shape
     for i in range(4):
-        assert sc.is_equal(var['x', i].value, data['x', i])
+        assert sc.is_equal(var['x', i].value, data['x', i:i + 1])
 
 
 def test_bins_default_end():
@@ -23,8 +23,8 @@ def test_bins_default_end():
     var = sc.bins(begin=begin, dim='x', data=data)
     assert var.dims == begin.dims
     assert var.shape == begin.shape
-    assert sc.is_equal(var['y', 0].value, data['x', 1])
-    assert sc.is_equal(var['y', 1].value, data['x', 3])
+    assert sc.is_equal(var['y', 0].value, data['x', 1:3])
+    assert sc.is_equal(var['y', 1].value, data['x', 3:4])
 
 
 def test_bins_fail_only_end():

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -142,7 +142,7 @@ private:
                              [](const auto a, const auto b) {
                                return a.second > b.first;
                              }) != vals.end())
-        throw except::SliceError("Overlapping bucket indices are not allowed.");
+        throw except::SliceError("Overlapping bin indices are not allowed.");
       if (std::find_if(vals.begin(), vals.end(), [](const auto x) {
             return x.first > x.second;
           }) != vals.end())

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -137,17 +137,17 @@ private:
       std::sort(vals.begin(), vals.end());
       if ((!vals.empty() && (vals.begin()->first < 0)) ||
           (!vals.empty() && ((vals.end() - 1)->second > buffer.dims()[dim])))
-        throw except::SliceError("Bucket indices out of range");
+        throw except::SliceError("Bin indices out of range");
       if (std::adjacent_find(vals.begin(), vals.end(),
                              [](const auto a, const auto b) {
                                return a.second > b.first;
                              }) != vals.end())
-        throw except::SliceError(
-            "Bucket begin index must be less or equal to its end index.");
-      if (std::find_if(vals.begin(), vals.end(), [](const auto x) {
-            return x.second >= 0 && x.first > x.second;
-          }) != vals.end())
         throw except::SliceError("Overlapping bucket indices are not allowed.");
+      if (std::find_if(vals.begin(), vals.end(), [](const auto x) {
+            return x.first > x.second;
+          }) != vals.end())
+        throw except::SliceError(
+            "Bin begin index must be less or equal to its end index.");
       // Copy to avoid a second memory allocation
       const auto &i = indices.values<range_type>();
       std::copy(i.begin(), i.end(), vals.begin());

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -111,10 +111,9 @@ TEST_F(BucketModelTest, values_const) {
 
 TEST_F(BucketModelTest, values_non_range) {
   auto i = make_indices({{2, 4}, {0, -1}});
-  Model model(i, Dim::X, buffer);
-  core::ElementArrayViewParams params(0, i.dims(), i.dims(), {});
-  EXPECT_EQ(*(model.values(params).begin() + 0), buffer.slice({Dim::X, 2, 4}));
-  EXPECT_EQ(*(model.values(params).begin() + 1), buffer.slice({Dim::X, 0}));
+  // The model would actually support this, but operations with such data do not
+  // handle this case, so it is disabled.
+  EXPECT_THROW(Model(i, Dim::X, buffer), except::SliceError);
 }
 
 TEST_F(BucketModelTest, out_of_order_indices) {


### PR DESCRIPTION
Fixes #1595.

- Forbid non-range slices being used for bins.
- Make bins contiguous (instead of length 1) if `end` is not given to `sc.bins`.