### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -15,8 +15,6 @@ stages:
         timeoutInMinutes: 80
         strategy:
           matrix:
-            Python36:
-              PYTHON_VERSION: '3.6'
             Python37:
               PYTHON_VERSION: '3.7'
         pool:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -17,8 +17,6 @@ stages:
         timeoutInMinutes: 60
         strategy:
           matrix:
-            Python36:
-              PYTHON_VERSION: '3.6'
             Python37:
               PYTHON_VERSION: '3.7'
         pool:

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -7,6 +7,8 @@ Installation
 Once multiple options are available (or required) we will look into either shipping multiple binaries, or allow for configuration at run time.
 If you want to use scipp and require different units/dimensions, please see* :ref:`customizing`, *or better, get in touch with us.*
 
+Scipp requires Python 3.7 or above.
+
 Conda
 -----
 


### PR DESCRIPTION
Closes #1608 

Removed Python 3.6 CI jobs and documented requirement of 3.7 or above on the installation page of the docs.