### PR TITLE
Doc build updates

### DIFF
--- a/CMake/docs_build.bat.in
+++ b/CMake/docs_build.bat.in
@@ -1,0 +1,6 @@
+@ECHO OFF
+setlocal
+if not exist docs mkdir docs
+set PYTHONPATH=@CMAKE_INSTALL_PREFIX@
+sphinx-build @CMAKE_SOURCE_DIR@/docs docs
+endlocal

--- a/CMake/docs_build.bat.in
+++ b/CMake/docs_build.bat.in
@@ -1,6 +1,3 @@
-@ECHO OFF
-setlocal
-if not exist docs mkdir docs
-set PYTHONPATH=@CMAKE_INSTALL_PREFIX@
-sphinx-build @CMAKE_SOURCE_DIR@/docs docs
-endlocal
+@ECHO OFF setlocal if not exist docs mkdir docs set PYTHONPATH =
+    @CMAKE_INSTALL_PREFIX @sphinx -
+    build @CMAKE_SOURCE_DIR @ / docs docs endlocal

--- a/CMake/docs_build.bat.in
+++ b/CMake/docs_build.bat.in
@@ -1,3 +1,7 @@
-@ECHO OFF setlocal if not exist docs mkdir docs set PYTHONPATH =
-    @CMAKE_INSTALL_PREFIX @sphinx -
-    build @CMAKE_SOURCE_DIR @ / docs docs endlocal
+@ECHO OFF
+setlocal
+cmake --build @CMAKE_BINARY_DIR@ --target install
+if not exist docs mkdir docs
+set PYTHONPATH=@CMAKE_INSTALL_PREFIX@
+sphinx-build @CMAKE_SOURCE_DIR@/docs docs
+endlocal

--- a/CMake/docs_build.sh.in
+++ b/CMake/docs_build.sh.in
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+cmake --build @CMAKE_BINARY_DIR@ --target install
 mkdir -p docs 
 @PYTHON_EXECUTABLE@ @CMAKE_SOURCE_DIR@/docs/data/fetch_neutron_data.py --destination=@CMAKE_SOURCE_DIR@/docs/data/ 
 PYTHONPATH=$PYTHONPATH:@CMAKE_INSTALL_PREFIX@ sphinx-build @CMAKE_SOURCE_DIR@/docs docs

--- a/CMake/docs_build.sh.in
+++ b/CMake/docs_build.sh.in
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir -p docs 
 @PYTHON_EXECUTABLE@ @CMAKE_SOURCE_DIR@/docs/data/fetch_neutron_data.py --destination=@CMAKE_SOURCE_DIR@/docs/data/ 
 PYTHONPATH=$PYTHONPATH:@CMAKE_INSTALL_PREFIX@ sphinx-build @CMAKE_SOURCE_DIR@/docs docs

--- a/CMake/docs_build.sh.in
+++ b/CMake/docs_build.sh.in
@@ -1,0 +1,3 @@
+mkdir -p docs 
+@PYTHON_EXECUTABLE@ @CMAKE_SOURCE_DIR@/docs/data/fetch_neutron_data.py --destination=@CMAKE_SOURCE_DIR@/docs/data/ 
+PYTHONPATH=$PYTHONPATH:@CMAKE_INSTALL_PREFIX@ sphinx-build @CMAKE_SOURCE_DIR@/docs docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,9 @@ enable_testing()
 
 # Custom target for building tests. all excludes tests by default
 add_custom_target(all-tests)
+add_custom_target(docs
+COMMAND mkdir -p docs && PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
+DEPENDS install)
 
 # Generate files for free scipp API functions
 include(scipp-functions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,12 +161,12 @@ if(NOT WIN32)
   add_custom_target(
     docs
     COMMAND ./docs_build.sh
-    DEPENDS install)
+    DEPENDS _scipp)
 else()
   add_custom_target(
     docs
     COMMAND docs_build.bat
-    DEPENDS install)
+    DEPENDS _scipp)
 endif()
 
 configure_file(CMake/docs_build.bat.in docs_build.bat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,12 +159,16 @@ add_custom_target(all-tests)
 # Custom target for building documentation
 if(NOT WIN32)
 add_custom_target(docs
-COMMAND rm -r docs/
-&& mkdir -p docs 
-&& ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/data/fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}/docs/data/ 
-&& PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
+COMMAND docs_build.sh
+DEPENDS install)
+else()
+add_custom_target(docs
+COMMAND docs_build.bat
 DEPENDS install)
 endif(NOT WIN32)
+
+configure_file(CMake/docs_build.bat.in docs_build.bat)
+configure_file(CMake/docs_build.sh.in docs_build.sh)
 
 # Generate files for free scipp API functions
 include(scipp-functions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,15 +159,10 @@ add_custom_target(all-tests)
 # Custom target for building documentation
 if(NOT WIN32)
 add_custom_target(docs
-COMMAND mkdir -p docs 
+COMMAND rm -r docs/
+&& mkdir -p docs 
 && ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/data/fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}/docs/data/ 
 && PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
-DEPENDS install)
-else()
-add_custom_target(docs
-COMMAND IF NOT EXIST docs MKDIR docs
-&& ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}\docs\data\fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}\docs\data\ 
-&& PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}\docs docs
 DEPENDS install)
 endif(NOT WIN32)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,12 +161,14 @@ if(NOT WIN32)
   add_custom_target(
     docs
     COMMAND ./docs_build.sh
-    DEPENDS _scipp)
+    DEPENDS _scipp
+  )
 else()
   add_custom_target(
     docs
     COMMAND docs_build.bat
-    DEPENDS _scipp)
+    DEPENDS _scipp
+  )
 endif()
 
 configure_file(CMake/docs_build.bat.in docs_build.bat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,14 +158,16 @@ add_custom_target(all-tests)
 
 # Custom target for building documentation
 if(NOT WIN32)
-add_custom_target(docs
-COMMAND ./docs_build.sh
-DEPENDS install)
+  add_custom_target(
+    docs
+    COMMAND ./docs_build.sh
+    DEPENDS install)
 else()
-add_custom_target(docs
-COMMAND docs_build.bat
-DEPENDS install)
-endif(NOT WIN32)
+  add_custom_target(
+    docs
+    COMMAND docs_build.bat
+    DEPENDS install)
+endif()
 
 configure_file(CMake/docs_build.bat.in docs_build.bat)
 configure_file(CMake/docs_build.sh.in docs_build.sh)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,12 @@ enable_testing()
 
 # Custom target for building tests. all excludes tests by default
 add_custom_target(all-tests)
+
+# Custom target for building documentation
 add_custom_target(docs
-COMMAND mkdir -p docs && PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
+COMMAND mkdir -p docs 
+&& ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/data/fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}/docs/data/ 
+&& PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
 DEPENDS install)
 
 # Generate files for free scipp API functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,11 +157,19 @@ enable_testing()
 add_custom_target(all-tests)
 
 # Custom target for building documentation
+if(NOT WIN32)
 add_custom_target(docs
 COMMAND mkdir -p docs 
 && ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/data/fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}/docs/data/ 
 && PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}/docs docs
 DEPENDS install)
+else()
+add_custom_target(docs
+COMMAND IF NOT EXIST docs MKDIR docs
+&& ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}\docs\data\fetch_neutron_data.py --destination=${CMAKE_SOURCE_DIR}\docs\data\ 
+&& PYTHONPATH=$PYTHONPATH:${CMAKE_INSTALL_PREFIX} sphinx-build ${CMAKE_SOURCE_DIR}\docs docs
+DEPENDS install)
+endif(NOT WIN32)
 
 # Generate files for free scipp API functions
 include(scipp-functions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ add_custom_target(all-tests)
 # Custom target for building documentation
 if(NOT WIN32)
 add_custom_target(docs
-COMMAND docs_build.sh
+COMMAND ./docs_build.sh
 DEPENDS install)
 else()
 add_custom_target(docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,17 +158,9 @@ add_custom_target(all-tests)
 
 # Custom target for building documentation
 if(NOT WIN32)
-  add_custom_target(
-    docs
-    COMMAND ./docs_build.sh
-    DEPENDS _scipp
-  )
+  add_custom_target(docs COMMAND ./docs_build.sh)
 else()
-  add_custom_target(
-    docs
-    COMMAND docs_build.bat
-    DEPENDS _scipp
-  )
+  add_custom_target(docs COMMAND docs_build.bat)
 endif()
 
 configure_file(CMake/docs_build.bat.in docs_build.bat)

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 # Doxygen build directory
 doxygen/
+generated/

--- a/docs/data/fetch_neutron_data.py
+++ b/docs/data/fetch_neutron_data.py
@@ -4,6 +4,12 @@
 
 import os
 import subprocess as sp
+import argparse
+
+parser = argparse.ArgumentParser(description='Download test data')
+parser.add_argument('--destination', default='data/')
+
+args = parser.parse_args()
 
 
 def download_file(source, destination):
@@ -15,9 +21,8 @@ def download_file(source, destination):
 
 
 if __name__ == '__main__':
-
     remote_url = "http://198.74.56.37/ftp/external-data/MD5/"
-    target_dir = "data/"
+    target_dir = args.destination
 
     data_files = {
         "PG3_4871_event.nxs": "a3d0edcb36ab8e9e3342cd8a4440b779",
@@ -27,4 +32,6 @@ if __name__ == '__main__':
     }
 
     for f, h in data_files.items():
-        download_file(os.path.join(remote_url, h), os.path.join(target_dir, f))
+        destination = os.path.join(target_dir, f)
+        if not os.path.isfile(destination):
+            download_file(os.path.join(remote_url, h), destination)

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -111,9 +111,9 @@ To run the Python tests, run (in the ``python/`` directory):
 
 Building Documentation
 ----------------------
-- If Mantid is unavailable (e.g. on Windows) edit docs/conf.py and include nbsphinx_allow_errors = True. Take care to not commit this change though.
-- run `cmake --build . --target docs` from your build directory.
-- This will build the documentation and put it on <build dir>/docs.
+- If Mantid is unavailable (e.g. on Windows) edit ``docs/conf.py`` and include ``nbsphinx_allow_errors = True``. Take care to not commit this change though.
+- run ``cmake --build . --target docs`` from your build directory.
+- This will build the documentation and put it on ``<build dir>/docs``.
 - If rebuuilding the documentation is slow it can be quicker to remove the docs build directory and start a fresh build.
 
 Precommit Hooks

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -111,12 +111,10 @@ To run the Python tests, run (in the ``python/`` directory):
 
 Building Documentation
 ----------------------
-- You first need to build a local installation of scipp.
-- Run ``python docs/data/fetch_neutron_data.py``. This downloads the data files required for some of the doc examples, storing them in docs/data.
-- Create the directory where the docs should be built (e.g. ``mkdir -p build/docs``)
-- Activate a conda environment with Mantid or ensure Mantid is in your ``PYTHONPATH``
-- If Mantid is unavailable (e.g. on Windows) edit ``docs/conf.py`` and include ``nbsphinx_allow_errors = True``. Take care to not commit this change though.
-- Run ``PYTHONPATH=$PYTHONPATH:install sphinx-build docs build/docs``. The form of this command is ``spinx-build <path to conf.py> <path to destination folder>``. The PYTHONPATH command is to ensure that scipp is on the python path.
+- If Mantid is unavailable (e.g. on Windows) edit docs/conf.py and include nbsphinx_allow_errors = True. Take care to not commit this change though.
+- run `cmake --build . --target docs` from your build directory.
+- This will build the documentation and put it on <build dir>/docs.
+- If rebuuilding the documentation is slow it can be quicker to remove the docs build directory and start a fresh build.
 
 Precommit Hooks
 ---------------

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -111,12 +111,12 @@ To run the Python tests, run (in the ``python/`` directory):
 
 Building Documentation
 ----------------------
-
-- Run ``python docs/data/fetch_neutron_data.py``
-- cd to a directory where the docs should be built (e.g. ``mkdir -p build/docs && cd build/docs``)
+- You first need to build a local installation of scipp.
+- Run ``python docs/data/fetch_neutron_data.py``. This downloads the data files required for some of the doc examples, storing them in docs/data.
+- Create the directory where the docs should be built (e.g. ``mkdir -p build/docs``)
 - Activate a conda environment with Mantid or ensure Mantid is in your ``PYTHONPATH``
 - If Mantid is unavailable (e.g. on Windows) edit ``docs/conf.py`` and include ``nbsphinx_allow_errors = True``. Take care to not commit this change though.
-- Run ``sphinx-build ../../docs .``
+- Run ``PYTHONPATH=$PYTHONPATH:install sphinx-build docs build/docs``. The form of this command is ``spinx-build <path to conf.py> <path to destination folder>``. The PYTHONPATH command is to ensure that scipp is on the python path.
 
 Precommit Hooks
 ---------------


### PR DESCRIPTION
This adds a cmake target to build the documentation and updates the getting started instructions to reflect this. 
It also adds a gitignore for the generated docs in `scipp/docs`.

With this PR running `cmake --build . --target docs` in your build directory should build the documentation and put it in build/docs.

If possible it would be good to get someone to test this on OSX. I've tried on Ubuntu and windows myself.