### PR TITLE
Show plot correctly in tutorial

### DIFF
--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -279,8 +279,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot(d['z', 0])\n",
-    "d"
+    "sc.to_html(d)\n",
+    "plot(d['z', 0])"
    ]
   },
   {
@@ -442,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.9"
   },
   "nbsphinx": {
    "allow_errors": true


### PR DESCRIPTION
In https://scipp.github.io/tutorials/multi-d-datasets.html in the cell after
> Before `rebin` we have the following:

The plot is now shown together with the HTML repr.