### PR TITLE
__setitem__ broadcast support

### DIFF
--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -143,7 +143,7 @@ class TestSliceByValue:
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless] = sc.Variable(
                              dims=['x'], values=[6.0, 6.0], unit=sc.units.m)
-        assert str(e_info.value) == '{{x, 3}} expected to be equal to {{x, 2}}'
+        assert str(e_info.value) == 'Expected {{x, 3}} to contain {{x, 2}}.'
 
     def test_assign_incompatible_dataarray(self):
         with pytest.raises(RuntimeError):

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -327,12 +327,18 @@ def test_create_dtype():
     assert var.dtype == sc.dtype.int32
 
 
-def test_get_slice():
+def test_getitem():
     var = sc.Variable(dims=['x', 'y'], values=np.arange(0, 8).reshape(2, 4))
     var_slice = var['x', 1:2]
     assert sc.is_equal(
         var_slice,
         sc.Variable(dims=['x', 'y'], values=np.arange(4, 8).reshape(1, 4)))
+
+
+def test_setitem_broadcast():
+    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    var['x', 1:3] = sc.Variable(value=5)
+    assert sc.is_equal(var, sc.Variable(dims=['x'], values=[1, 5, 5, 4]))
 
 
 def test_slicing():

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -336,9 +336,11 @@ def test_getitem():
 
 
 def test_setitem_broadcast():
-    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    var['x', 1:3] = sc.Variable(value=5)
-    assert sc.is_equal(var, sc.Variable(dims=['x'], values=[1, 5, 5, 4]))
+    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4], dtype=sc.dtype.int64)
+    var['x', 1:3] = sc.Variable(value=5, dtype=sc.dtype.int64)
+    assert sc.is_equal(var,
+                       sc.Variable(dims=['x'], values=[1, 5, 5, 4]),
+                       dtype=sc.dtype.int64)
 
 
 def test_slicing():

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -338,9 +338,9 @@ def test_getitem():
 def test_setitem_broadcast():
     var = sc.Variable(dims=['x'], values=[1, 2, 3, 4], dtype=sc.dtype.int64)
     var['x', 1:3] = sc.Variable(value=5, dtype=sc.dtype.int64)
-    assert sc.is_equal(var,
-                       sc.Variable(dims=['x'], values=[1, 5, 5, 4]),
-                       dtype=sc.dtype.int64)
+    assert sc.is_equal(
+        var, sc.Variable(dims=['x'], values=[1, 5, 5, 4],
+                         dtype=sc.dtype.int64))
 
 
 def test_slicing():

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -634,6 +634,13 @@ TEST(VariableView, variable_assign_from_slice_clears_variances) {
                                          Values{11, 12, 21, 22}));
 }
 
+TEST(VariableView, slice_assign_from_variable_broadcast) {
+  const auto source = makeVariable<double>(Values{2});
+  auto target = makeVariable<double>(Dims{Dim::X}, Shape{3});
+  target.slice({Dim::X, 1, 3}).assign(source);
+  EXPECT_EQ(target, makeVariable<double>(target.dims(), Values{0, 2, 2}));
+}
+
 TEST(VariableView, variable_self_assign_via_slice) {
   auto target =
       makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3},
@@ -654,6 +661,13 @@ TEST(VariableView, slice_assign_from_variable_unit_fail) {
   EXPECT_THROW(target.slice({Dim::X, 1, 2}).assign(source), except::UnitError);
   target = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
   EXPECT_NO_THROW(target.slice({Dim::X, 1, 2}).assign(source));
+}
+
+TEST(VariableView, slice_assign_from_variable_dimension_fail) {
+  const auto source = makeVariable<double>(Dims{Dim::Y}, Shape{1});
+  auto target = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  EXPECT_THROW(target.slice({Dim::X, 1, 2}).assign(source),
+               except::NotFoundError);
 }
 
 TEST(VariableView, slice_assign_from_variable_full_slice_can_change_unit) {

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -86,7 +86,6 @@ template <class T> VariableView VariableView::assign(const T &other) const {
   if (*this == VariableConstView(other))
     return *this; // Self-assignment, return early.
   setUnit(other.unit());
-  core::expect::equals(dims(), other.dims());
   underlying().data().copy(other, *this);
   return *this;
 }

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -85,7 +85,6 @@ bool Variable::operator!=(const VariableConstView &other) const {
 template <class T> VariableView VariableView::assign(const T &other) const {
   if (*this == VariableConstView(other))
     return *this; // Self-assignment, return early.
-  setUnit(other.unit());
   underlying().data().copy(other, *this);
   return *this;
 }


### PR DESCRIPTION
See updated unit tests. Fixes #1606.

Why was this not implemented initially? I think the reason was that originally `transform` was limited to POD types, so `assign` was using a hand-written `copy`, which was kept simple instead of supporting broadcasting. Some time last year I generalized `transform`, giving as a flexible `copy` method of `VariableConcept`, so this is now trivial to implement.

Note that right now this does not support type conversion, since that would require listing type combos in `DataModel::copy`. Could probably be done using a mechanism that lets us list types convertible to `T` using a specialization.