### PR TITLE
Allow end < begin in slices in Python

### DIFF
--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -40,7 +40,7 @@ auto from_py_slice(const T &source,
   if (step != 1)
     throw std::runtime_error("Step must be 1");
   if (slicelength == 0) {
-    stop = start;  // Propagate vanishing slice length downstream.
+    stop = start; // Propagate vanishing slice length downstream.
   }
   return Slice(dim, start, stop);
 }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -39,6 +39,9 @@ auto from_py_slice(const T &source,
     throw py::error_already_set();
   if (step != 1)
     throw std::runtime_error("Step must be 1");
+  if (slicelength == 0) {
+    stop = start;  // Propagate vanishing slice length downstream.
+  }
   return Slice(dim, start, stop);
 }
 

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -345,8 +345,7 @@ def test_setitem_broadcast():
 
 def test_slicing():
     var = sc.Variable(dims=['x'], values=np.arange(0, 3))
-    for slice_, expected in ((slice(0, 2), [0, 1]),
-                             (slice(-3, -1), [0, 1]),
+    for slice_, expected in ((slice(0, 2), [0, 1]), (slice(-3, -1), [0, 1]),
                              (slice(2, 1), [])):
         var_slice = var[('x', slice_)]
         assert isinstance(var_slice, sc.VariableView)

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -345,10 +345,13 @@ def test_setitem_broadcast():
 
 def test_slicing():
     var = sc.Variable(dims=['x'], values=np.arange(0, 3))
-    var_slice = var[('x', slice(0, 2))]
-    assert isinstance(var_slice, sc.VariableView)
-    assert len(var_slice.values) == 2
-    assert np.array_equal(var_slice.values, np.array([0, 1]))
+    for slice_, expected in ((slice(0, 2), [0, 1]),
+                             (slice(-3, -1), [0, 1]),
+                             (slice(2, 1), [])):
+        var_slice = var[('x', slice_)]
+        assert isinstance(var_slice, sc.VariableView)
+        assert len(var_slice.values) == len(expected)
+        assert np.array_equal(var_slice.values, np.array(expected))
 
 
 def test_iadd():


### PR DESCRIPTION
Rework of #1610 which modifies only the Python bindings.

Fixes #1602