### PR TITLE
Wrappers not returning

### DIFF
--- a/python/src/scipp/_unary.py
+++ b/python/src/scipp/_unary.py
@@ -9,32 +9,32 @@ def isnan(x: _cpp.Variable) -> bool:
     """
     Returns true if any element of the variable is nan.
     """
-    _call_cpp_func(_cpp.isnan, x)
+    return _call_cpp_func(_cpp.isnan, x)
 
 
 def isinf(x: _cpp.Variable) -> bool:
     """
     Returns true if any element of the variable is inf.
     """
-    _call_cpp_func(_cpp.isinf, x)
+    return _call_cpp_func(_cpp.isinf, x)
 
 
 def isfinite(x: _cpp.Variable) -> bool:
     """
     Returns true if all elements are finite.
     """
-    _call_cpp_func(_cpp.isfinite, x)
+    return _call_cpp_func(_cpp.isfinite, x)
 
 
 def isposinf(x: _cpp.Variable) -> bool:
     """
     Returns true if any element is a positive infinity.
     """
-    _call_cpp_func(_cpp.isposinf, x)
+    return _call_cpp_func(_cpp.isposinf, x)
 
 
 def isneginf(x: _cpp.Variable) -> bool:
     """
     Returns true if any element is a negative infinity.
     """
-    _call_cpp_func(_cpp.isneginf, x)
+    return _call_cpp_func(_cpp.isneginf, x)


### PR DESCRIPTION
All of these should now be fixed.

```python
import scipp as sc
import numpy as np
sc.isnan(sc.Variable(['x'], values=np.array([1, 1, np.nan])))
sc.isfinite(sc.Variable(['x'], values=np.array([1, 1, np.nan])))
sc.isposinf(sc.Variable(['x'], values=np.array([1, 1, np.inf, -np.inf])))
sc.isneginf(sc.Variable(['x'], values=np.array([1, np.inf, -np.inf])))
sc.isfinite(sc.Variable(['x'], values=np.array([1, np.inf, -np.inf])))
```

Will follow up with unit test improvements later