### PR TITLE
Fix tests to properly check exports for _unary.py

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -896,23 +896,34 @@ def test_variable_data_array_binary_ops():
 
 
 def test_isnan():
-    assert_export(sc.isnan, sc.Variable())
+    assert sc.is_equal(
+        sc.isnan(sc.Variable(['x'], values=np.array([1, 1, np.nan]))),
+        sc.Variable(['x'], values=[False, False, True]))
 
 
 def test_isinf():
-    assert_export(sc.isinf, sc.Variable())
+    assert sc.is_equal(
+        sc.isinf(sc.Variable(['x'], values=np.array([1, -np.inf, np.inf]))),
+        sc.Variable(['x'], values=[False, True, True]))
 
 
 def test_isfinite():
-    assert_export(sc.isfinite, sc.Variable())
+    assert sc.is_equal(
+        sc.isfinite(
+            sc.Variable(['x'], values=np.array([1, -np.inf, np.inf, np.nan]))),
+        sc.Variable(['x'], values=[True, False, False, False]))
 
 
 def test_isposinf():
-    assert_export(sc.isposinf, sc.Variable())
+    assert sc.is_equal(
+        sc.isposinf(sc.Variable(['x'], values=np.array([1, -np.inf, np.inf]))),
+        sc.Variable(['x'], values=[False, False, True]))
 
 
 def test_isneginf():
-    assert_export(sc.isneginf, sc.Variable())
+    assert sc.is_equal(
+        sc.isneginf(sc.Variable(['x'], values=np.array([1, -np.inf, np.inf]))),
+        sc.Variable(['x'], values=[False, True, False]))
 
 
 def test_nan_to_num():


### PR DESCRIPTION
Should have been part of #1628, but really tried to put former fix through as quickly as possible.

Few more lines of python gives us proper testing for these bindings. Previously tests only checked that exports were present and did not find missing return.