### PR TITLE
Add instant redirect to v0.5 and change 0.5 to selected

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,10 @@
 {% extends "!layout.html" %}
 
+  {% block htmltitle %}
+    {{ super() }}
+    <meta http-equiv="refresh" content="0; URL=https://scipp.github.io/release/0.5.0/" />
+  {% endblock %}
+
   {% block menu %}
     {{ super() }}
     <div style="height: 32px; position: fixed; bottom: 0; left: 15px;">
@@ -7,8 +12,8 @@
       <select onchange="location = this.value;"
               style="height: 30px; color: #27a54b; background-color: #403d3d;
                     border: 0px; box-shadow: none;">
-        <option value="https://scipp.github.io" selected>latest (unstable)</option>
-        <option value="https://scipp.github.io/release/0.5.0">v0.5</option>
+        <option value="https://scipp.github.io">latest (unstable)</option>
+        <option value="https://scipp.github.io/release/0.5.0" selected>v0.5</option>
         <option value="https://scipp.github.io/release/0.4.0">v0.4</option>
         <option value="https://scipp.github.io/release/0.3.0">v0.3</option>
       </select>


### PR DESCRIPTION
This redirects visitors to the 0.5 pages and makes the default selected version 0.5 in the menu.
Once a new version of the 0.5 release is done and new doc pages have been published, we should revert the changes to the select option to mark the "latest" as being "selected".

Does this logic make sense?