### PR TITLE
Support binning data with column dtype Eigen::Vector3d

### DIFF
--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -119,8 +119,8 @@ auto invoke_subspan_view(const DType dtype, Args &&... args) {
 
 template <class Var, class... Args>
 Variable subspan_view_impl(Var &var, Args &&... args) {
-  return invoke_subspan_view<double, float, int64_t, int32_t, bool,
-                             std::string>(var.dtype(), var, args...);
+  return invoke_subspan_view<double, float, int64_t, int32_t, bool, std::string,
+                             Eigen::Vector3d>(var.dtype(), var, args...);
 }
 
 } // namespace


### PR DESCRIPTION
This is not for binning *by* a position vector, rather it avoids failing if there is an extra coord column with such a dtype.