### PR TITLE
Return str dims from iterators

### DIFF
--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -6,7 +6,6 @@ Classes
 .. autosummary::
    :toctree: ../generated
 
-   Dim
    Unit
    Variable
    VariableView

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -106,7 +106,12 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name) {
   py::class_<T, ConstT> view(m, (name + "View").c_str());
   bind_common_mutable_view_operators<T>(view);
   view.def(
-          "__iter__", [](T &self) { return str_keys_view(self); },
+          "__iter__",
+          [](T &self) {
+            auto keys_view = str_keys_view(self);
+            return py::make_iterator(keys_view.begin(), keys_view.end(),
+                                     py::return_value_policy::move);
+          },
           py::keep_alive<0, 1>())
       .def(
           "keys", [](T &self) { return str_keys_view(self); },

--- a/python/tests/test_iteration.py
+++ b/python/tests/test_iteration.py
@@ -5,7 +5,6 @@
 import pytest
 
 import scipp as sc
-from scipp import Dim
 
 
 @pytest.fixture(params=['Dataset', 'DatasetView'])
@@ -66,7 +65,7 @@ def test_dataset_coords_iter():
 
 def test_dataset_coords_keys():
     d = make_coords_xyz()
-    assert set(d.coords.keys()) == set([Dim('x'), Dim('y'), Dim('z')])
+    assert set(d.coords.keys()) == set(['x', 'y', 'z'])
 
 
 def test_dataset_coords_values():

--- a/python/view.h
+++ b/python/view.h
@@ -54,3 +54,46 @@ private:
   T *m_obj;
 };
 template <class T> keys_view(T &) -> keys_view<T>;
+
+static constexpr auto dim_to_str = [](auto &&dim) -> decltype(auto) {
+  return dim.name();
+};
+
+/// Helper to provide equivalent of the `keys()` method of a Python dict.
+template <class T> class str_keys_view {
+public:
+  str_keys_view(T &obj) : m_obj(&obj) {}
+  auto size() const noexcept { return m_obj->size(); }
+  auto begin() const {
+    return boost::make_transform_iterator(m_obj->keys_begin(), dim_to_str);
+  }
+  auto end() const {
+    return boost::make_transform_iterator(m_obj->keys_end(), dim_to_str);
+  }
+
+private:
+  T *m_obj;
+};
+template <class T> str_keys_view(T &) -> str_keys_view<T>;
+
+static constexpr auto item_to_str = [](auto &&item) -> decltype(auto) {
+  return std::make_pair<std::string, decltype((item.second))>(item.first.name(),
+                                                              item.second);
+};
+
+/// Helper to provide equivalent of the `keys()` method of a Python dict.
+template <class T> class str_items_view {
+public:
+  str_items_view(T &obj) : m_obj(&obj) {}
+  auto size() const noexcept { return m_obj->size(); }
+  auto begin() const {
+    return boost::make_transform_iterator(m_obj->items_begin(), item_to_str);
+  }
+  auto end() const {
+    return boost::make_transform_iterator(m_obj->items_end(), item_to_str);
+  }
+
+private:
+  T *m_obj;
+};
+template <class T> str_items_view(T &) -> str_items_view<T>;

--- a/python/view.h
+++ b/python/view.h
@@ -77,8 +77,8 @@ private:
 template <class T> str_keys_view(T &) -> str_keys_view<T>;
 
 static constexpr auto item_to_str = [](auto &&item) -> decltype(auto) {
-  return std::make_pair<std::string, decltype((item.second))>(item.first.name(),
-                                                              item.second);
+  return std::make_pair<std::string, decltype(item.second)>(
+      item.first.name(), std::move(item.second));
 };
 
 /// Helper to provide equivalent of the `items()` method of a Python dict.

--- a/python/view.h
+++ b/python/view.h
@@ -81,7 +81,7 @@ static constexpr auto item_to_str = [](auto &&item) -> decltype(auto) {
                                                               item.second);
 };
 
-/// Helper to provide equivalent of the `keys()` method of a Python dict.
+/// Helper to provide equivalent of the `items()` method of a Python dict.
 template <class T> class str_items_view {
 public:
   str_items_view(T &obj) : m_obj(&obj) {}


### PR DESCRIPTION
Fixes #1365 

This updates the `items` and `keys` methods of DataArrays and Datasets so that they return python strings rather than Dim objects. Is this implemented in the right place.

For now I have left the Dim object exposed to python. This is  allows us to tell pybind11 that Dim and str can be explicitly converted between which makes all the Variable, Dataset and DataArrays constructors work. Do we want to go a step further and remove the Dim object and wrap the constructors as well?