### PR TITLE
Add m * angstrom

### DIFF
--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -64,14 +64,14 @@ struct supported_units {
   using type = decltype(detail::make_unit(
       std::make_tuple(m, dimensionless / m, us, dimensionless / us, angstrom,
                       dimensionless / angstrom),
-      std::make_tuple(dimensionless, rad, deg, rad / deg, deg / rad, counts,
-                      dimensionless / counts, s, kg, meV, dimensionless / s,
-                      counts / us, counts / angstrom, counts / meV, m *m *m,
-                      meV *us *us / (m * m), meV *us *us *dimensionless,
-                      kg *m / s, m / s, c, c *m, meV / c, dimensionless / c, K,
-                      us / angstrom, us / (angstrom * angstrom),
-                      us / (m * angstrom), angstrom / us, (m * angstrom) / us,
-                      ns, mm, dimensionless / meV, rad / s, (m * m) / s)));
+      std::make_tuple(
+          dimensionless, rad, deg, rad / deg, deg / rad, counts,
+          dimensionless / counts, s, kg, meV, dimensionless / s, counts / us,
+          counts / angstrom, counts / meV, m *m *m, meV *us *us / (m * m),
+          meV *us *us *dimensionless, kg *m / s, m / s, c, c *m, meV / c,
+          dimensionless / c, K, us / angstrom, us / (angstrom * angstrom),
+          us / (m * angstrom), angstrom / us, m *angstrom, (m * angstrom) / us,
+          ns, mm, dimensionless / meV, rad / s, (m * m) / s)));
 };
 struct counts_unit {
   using type = decltype(boost_units::counts);


### PR DESCRIPTION
We had `m * AA / us` but not `m * AA`, which can easily show up as intermediate result.