### PR TITLE
Load workspace groups into scipp

### DIFF
--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -771,6 +771,15 @@ def convert_TableWorkspace_to_dataset(ws, error_connection=None, **ignored):
     return dataset
 
 
+def convert_WorkspaceGroup_to_dataarray_dict(group_workspace, **kwargs):
+    workspace_dict = {}
+    for i in range(group_workspace.getNumberOfEntries()):
+        workspace = group_workspace.getItem(i)
+        workspace_dict[workspace.name()] = from_mantid(workspace, **kwargs)
+
+    return workspace_dict
+
+
 def from_mantid(workspace, **kwargs):
     """Convert Mantid workspace to a scipp data array or dataset.
     :param workspace: Mantid workspace to convert.
@@ -799,6 +808,8 @@ def from_mantid(workspace, **kwargs):
         scipp_obj = convert_TableWorkspace_to_dataset(workspace, **kwargs)
     elif w_id == 'MDHistoWorkspace':
         scipp_obj = convert_MDHistoWorkspace_to_data_array(workspace, **kwargs)
+    elif w_id == 'WorkspaceGroup':
+        scipp_obj = convert_WorkspaceGroup_to_dataarray_dict(workspace, **kwargs)
 
     if scipp_obj is None:
         raise RuntimeError('Unsupported workspace type {}'.format(w_id))

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -775,7 +775,8 @@ def convert_WorkspaceGroup_to_dataarray_dict(group_workspace, **kwargs):
     workspace_dict = {}
     for i in range(group_workspace.getNumberOfEntries()):
         workspace = group_workspace.getItem(i)
-        workspace_dict[workspace.name()] = from_mantid(workspace, **kwargs)
+        workspace_name = workspace.name().replace(group_workspace.name(), '')
+        workspace_dict[workspace_name] = from_mantid(workspace, **kwargs)
 
     return workspace_dict
 
@@ -910,7 +911,7 @@ def load(filename="",
             mantid.LoadInstrument(data_ws,
                                   FileName=instrument_filename,
                                   RewriteSpectraMap=True)
-
+        print(data_ws.name())
         return from_mantid(data_ws,
                            load_pulse_times=load_pulse_times,
                            error_connection=error_connection,

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -810,7 +810,8 @@ def from_mantid(workspace, **kwargs):
     elif w_id == 'MDHistoWorkspace':
         scipp_obj = convert_MDHistoWorkspace_to_data_array(workspace, **kwargs)
     elif w_id == 'WorkspaceGroup':
-        scipp_obj = convert_WorkspaceGroup_to_dataarray_dict(workspace, **kwargs)
+        scipp_obj = convert_WorkspaceGroup_to_dataarray_dict(
+            workspace, **kwargs)
 
     if scipp_obj is None:
         raise RuntimeError('Unsupported workspace type {}'.format(w_id))

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -911,7 +911,6 @@ def load(filename="",
             mantid.LoadInstrument(data_ws,
                                   FileName=instrument_filename,
                                   RewriteSpectraMap=True)
-        print(data_ws.name())
         return from_mantid(data_ws,
                            load_pulse_times=load_pulse_times,
                            error_connection=error_connection,

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -591,6 +591,21 @@ class TestMantidConversion(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 mantidcompat.validate_dim_and_get_mantid_string(i)
 
+    def test_WorkspaceGroup_parsed_correctly(self):
+        from mantid.simpleapi import mtd, CreateSampleWorkspace, GroupWorkspaces
+        CreateSampleWorkspace(OutputWorkspace="ws1")
+        CreateSampleWorkspace(OutputWorkspace="ws2")
+        CreateSampleWorkspace(OutputWorkspace="ws3")
+        GroupWorkspaces(InputWorkspaces="ws1,ws2,ws3", OutputWorkspace="NewGroup")
+
+        converted_group = mantidcompat.from_mantid(mtd["NewGroup"])
+        converted_single = mantidcompat.from_mantid(mtd["ws1"])
+
+        assert len(ds) == 3
+        assert sc.is_equal(converted_group['ws1'], converted_single)
+
+        mtd.clear()
+
 
 def test_to_rot_from_vectors():
     a = sc.Variable(value=[1, 0, 0], dtype=sc.dtype.vector_3_float64)

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -592,16 +592,18 @@ class TestMantidConversion(unittest.TestCase):
                 mantidcompat.validate_dim_and_get_mantid_string(i)
 
     def test_WorkspaceGroup_parsed_correctly(self):
-        from mantid.simpleapi import mtd, CreateSampleWorkspace, GroupWorkspaces
+        from mantid.simpleapi import (mtd, CreateSampleWorkspace,
+                                      GroupWorkspaces)
         CreateSampleWorkspace(OutputWorkspace="ws1")
         CreateSampleWorkspace(OutputWorkspace="ws2")
         CreateSampleWorkspace(OutputWorkspace="ws3")
-        GroupWorkspaces(InputWorkspaces="ws1,ws2,ws3", OutputWorkspace="NewGroup")
+        GroupWorkspaces(InputWorkspaces="ws1,ws2,ws3",
+                        OutputWorkspace="NewGroup")
 
         converted_group = mantidcompat.from_mantid(mtd["NewGroup"])
         converted_single = mantidcompat.from_mantid(mtd["ws1"])
 
-        assert len(ds) == 3
+        assert len(converted_group) == 3
         assert sc.is_equal(converted_group['ws1'], converted_single)
 
         mtd.clear()


### PR DESCRIPTION
Fixes #1646 

Adds the ability for mantidcompat to convert Workspace groups into scipp objects. It returns a dict object of containing the results of running the converter on each sub workspace individually. This is normally a dict of DataArrays but in the case of TableWorkspaces would produce a dict of Datasets.