### PR TITLE
Precompiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,10 @@ endif(NOT WIN32)
 # This is currently causing to many warnings, reenable when appropriate.
 # add_compile_options ( -Wconversion )
 
-# permissive- : Std compilant parsing, warnings (W3) set by CMake defaults
+# permissive- : Std compliant parsing, warnings (W3) set by CMake defaults
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:-permissive->)
+
+option(PRECOMPILED_HEADERS "Set whether to build with precompiled headers" ON)
 
 enable_testing()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,6 +81,15 @@ target_include_directories(
 )
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+if (PRECOMPILED_HEADERS)
+  target_precompile_headers(${TARGET_NAME} PUBLIC
+                            include/scipp/core/element_array.h
+                            include/scipp/core/element_array_view.h
+                            include/scipp/core/multi_index.h
+                            ${CMAKE_CURRENT_BINARY_DIR}/include/scipp/core/parallel.h)
+endif()
+
 add_subdirectory(test)
 
 if(DYNAMIC_LIB)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,12 +82,12 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-if (PRECOMPILED_HEADERS)
-  target_precompile_headers(${TARGET_NAME} PUBLIC
-                            include/scipp/core/element_array.h
-                            include/scipp/core/element_array_view.h
-                            include/scipp/core/multi_index.h
-                            ${CMAKE_CURRENT_BINARY_DIR}/include/scipp/core/parallel.h)
+if(PRECOMPILED_HEADERS)
+  target_precompile_headers(
+    ${TARGET_NAME} PUBLIC include/scipp/core/element_array.h
+    include/scipp/core/element_array_view.h include/scipp/core/multi_index.h
+    ${CMAKE_CURRENT_BINARY_DIR}/include/scipp/core/parallel.h
+  )
 endif()
 
 add_subdirectory(test)

--- a/docs/developer/getting-started.rst
+++ b/docs/developer/getting-started.rst
@@ -95,6 +95,7 @@ Additional build options
 1. ``-DDYNAMIC_LIB`` forces the shared libraries building, that also decreases link time.
 2. ``-DENABLE_THREAD_LIMIT`` limits the maximum number of threads that TBB can use. This defaults to the maximum number of cores identified on your build system. You may then optionally apply an artificial limit via ``-DTHREAD_LIMIT``.
 3. ``-DDISABLE_MULTI_THREADING`` disable multi-threading. By default, multi-threading is enabled if TBB was found. If this option is set to ``ON``, it overrides that.
+4. ``-DPRECOMPILED_HEADERS`` toggle usage of precompiled headers. ``ON`` by default.
 
 Running the unit tests
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -43,6 +43,10 @@ target_link_libraries(_scipp LINK_PRIVATE scipp-dataset scipp-neutron)
 set_target_properties(_scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(_scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 
+if (PRECOMPILED_HEADERS)
+  target_precompile_headers(_scipp PRIVATE pybind11.h)
+endif()
+
 add_sanitizers(_scipp)
 
 set(PY_FILES

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(_scipp LINK_PRIVATE scipp-dataset scipp-neutron)
 set_target_properties(_scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(_scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 
-if (PRECOMPILED_HEADERS)
+if(PRECOMPILED_HEADERS)
   target_precompile_headers(_scipp PRIVATE pybind11.h)
 endif()
 

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -30,6 +30,10 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
+if (PRECOMPILED_HEADERS)
+  target_precompile_headers(${TARGET_NAME} PUBLIC ${INC_FILES})
+endif()
+
 add_subdirectory(test)
 
 if(DYNAMIC_LIB)

--- a/units/CMakeLists.txt
+++ b/units/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-if (PRECOMPILED_HEADERS)
+if(PRECOMPILED_HEADERS)
   target_precompile_headers(${TARGET_NAME} PUBLIC ${INC_FILES})
 endif()
 

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -91,6 +91,13 @@ target_include_directories(
 )
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+if (PRECOMPILED_HEADERS)
+  target_precompile_headers(${TARGET_NAME} PUBLIC
+                            include/scipp/variable/transform.h
+                            include/scipp/variable/variable.h)
+endif()
+
 add_subdirectory(test)
 
 if(DYNAMIC_LIB)

--- a/variable/CMakeLists.txt
+++ b/variable/CMakeLists.txt
@@ -92,10 +92,11 @@ target_include_directories(
 
 set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
-if (PRECOMPILED_HEADERS)
-  target_precompile_headers(${TARGET_NAME} PUBLIC
-                            include/scipp/variable/transform.h
-                            include/scipp/variable/variable.h)
+if(PRECOMPILED_HEADERS)
+  target_precompile_headers(
+    ${TARGET_NAME} PUBLIC include/scipp/variable/transform.h
+    include/scipp/variable/variable.h
+  )
 endif()
 
 add_subdirectory(test)


### PR DESCRIPTION
Uses CMake's feature to precompile some big and commonly used headers. Fixes #1640 

Here is a benchmark of building with `-DCMAKE_BUILD_TYPE=Debug -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
-DDYNAMIC_LIB=ON` for a clean build or when re-building after touching the listed files. Times are as reported by `time` on Linux with R=real U=user. This was built with 12 threads and gcc 10.2. Different columns show different combinations of precompiled headers in the various sub libraries. `corunitvar` is essentially what is proposed in this PR but is lacking the PCH's in the Python bindings.
```
                      base                  core                  corunit               corunitvar            unit                

clean                 R 2m29s U17m20s       R 2m24s U15m20s       R 2m15s U12m05s       R 2m16s U12m06s       R 2m18s U13m18s     

p/core/multi_index.h  R 1m26s U 6m53s       R 1m20s U 6m07s       R 1m12s U 5m03s       R 1m12s U 5m05s       R 1m15s U 5m26s     

variable/transform.h  R 1m26s U 7m02s       R 1m20s U 6m19s       R 1m13s U 5m14s       R 1m12s U 5m15s       R 1m14s U 5m37s
```

It looks like we can get a significant speedup in a sequential build. But in parallel, the load balance seems to be bad enough to almost remove the effect in some cases.