### PR TITLE
Improve dim label generation from mantid

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,6 +15,7 @@ Features
 
   * Support unit conversion to energy transfer, for inelastic TOF experiments [#1635](https://github.com/scipp/scipp/pull/1635).
   * Support loading/converting Mantid ``WorkspaceGroup``, this will produce a ``dict`` of data arrays [#1654](https://github.com/scipp/scipp/pull/1654).
+  * Fixes to support loading/converting ``McStasNexus`` files [#1659](https://github.com/scipp/scipp/pull/1659).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -675,8 +675,8 @@ def convert_EventWorkspace_to_data_array(ws,
     # of `bins`?
     edges = coords_labs_data['coords'][dim]
     # Using range slice of thickness 1 to avoid transposing 2-D coords
-    coords_labs_data['coords'][dim] = sc.concatenate(edges[dim, 0:1],
-                                                     edges[dim, -2:-1], dim)
+    coords_labs_data['coords'][dim] = sc.concatenate(edges[dim, :1],
+                                                     edges[dim, -1:], dim)
 
     coords_labs_data["data"] = sc.bins(begin=begins,
                                        end=ends,

--- a/python/src/scipp/compat/mantid.py
+++ b/python/src/scipp/compat/mantid.py
@@ -775,8 +775,8 @@ def convert_WorkspaceGroup_to_dataarray_dict(group_workspace, **kwargs):
     workspace_dict = {}
     for i in range(group_workspace.getNumberOfEntries()):
         workspace = group_workspace.getItem(i)
-        workspace_name = workspace.name().replace(f'_{group_workspace.name()}',
-                                                  '')
+        workspace_name = workspace.name().replace(f'{group_workspace.name()}',
+                                                  '').strip('_')
         workspace_dict[workspace_name] = from_mantid(workspace, **kwargs)
 
     return workspace_dict

--- a/python/tests/compat/test_mantid.py
+++ b/python/tests/compat/test_mantid.py
@@ -645,7 +645,8 @@ def test_to_rot_from_vectors():
                     reason='Mantid framework is unavailable')
 @pytest.mark.parametrize(
     "param_dim",
-    ('tof', 'wavelength', 'E', 'd-spacing', 'Q', 'Q^2', 'Delta-E'))
+    ('tof', 'wavelength', 'energy', 'd-spacing', 'Q', 'Q^2', 'energy-transfer')
+)
 def test_to_workspace_2d(param_dim):
     from mantid.simpleapi import mtd
     mtd.clear()


### PR DESCRIPTION
This ensures that McStas Nexus files can be loaded via our converters.

- For `Label` dimensions, use unit name to determine dim label.
- Fix and issue that was using the second-to-last TOF bin instead of last.