### PR TITLE
Expose methods from is_type

### DIFF
--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -21,7 +21,8 @@ from .extend_units import *
 from .table_html import to_html, make_html
 from .object_list import _repr_html_
 from ._utils import collapse, slices
-from ._utils.is_type import *
+from ._utils.is_type import is_variable, is_dataset, is_data_array, \
+                            is_dataset_or_array
 from .compat.dict import to_dict, from_dict
 from .sizes import _make_sizes
 

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -21,6 +21,7 @@ from .extend_units import *
 from .table_html import to_html, make_html
 from .object_list import _repr_html_
 from ._utils import collapse, slices
+from ._utils.is_type import *
 from .compat.dict import to_dict, from_dict
 from .sizes import _make_sizes
 


### PR DESCRIPTION
Exposes `is_variable()`, `is_dataset()` functions in the main scipp module.
This is useful in code that is not part of the scipp repo, such as in the `ess` repo.

`sc.is_dataset(obj)` returns `True` if `obj` is either a Dataset or a DatasetView.