### PR TITLE
Update units wrapper

### DIFF
--- a/python/tests/test_units.py
+++ b/python/tests/test_units.py
@@ -18,6 +18,8 @@ class TestUnits():
         assert repr(var1.unit) == "\u212B" or repr(var1.unit) == "\u00C5"
         var1.unit = sc.units.m * sc.units.m
         assert repr(var1.unit) == "m^2"
+        var1.unit = sc.units.counts
+        assert repr(var1.unit) == "counts"
         var1.unit = sc.units.counts / sc.units.m
         assert repr(var1.unit) == "counts/m"
         var1.unit = sc.units.m / sc.units.m * sc.units.counts

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -177,6 +177,11 @@ TEST(UnitFunctionsTest, atan2) {
   EXPECT_THROW(atan2(units::m, units::s), except::UnitError);
 }
 
+TEST(UnitParseTest, singular_plural) {
+  EXPECT_EQ(units::Unit("counts"), units::counts);
+  EXPECT_EQ(units::Unit("count"), units::counts);
+}
+
 TEST(UnitFormatTest, roundtrip_string) {
   for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts",
                         "counts/meV", "1/counts", "counts/m"}) {

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -178,7 +178,8 @@ TEST(UnitFunctionsTest, atan2) {
 }
 
 TEST(UnitFormatTest, roundtrip_string) {
-  for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts"}) {
+  for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts",
+                        "counts/meV", "1/counts", "counts/m"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(to_string(unit), s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);
@@ -188,8 +189,7 @@ TEST(UnitFormatTest, roundtrip_string) {
 TEST(UnitFormatTest, roundtrip_unit) {
   // Some formattings use special characters, e.g., for micro and Angstrom, but
   // some are actually formatted badly right now, but at least roundtrip works.
-  for (const auto &s :
-       {"us", "angstrom", "counts/us", "1/counts", "counts/meV"}) {
+  for (const auto &s : {"us", "angstrom", "counts/us"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);
   }

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -23,8 +23,8 @@ Unit::Unit(const std::string &unit)
 std::string Unit::name() const {
   auto repr = to_string(m_unit);
   repr = std::regex_replace(repr, std::regex("^u"), "µ");
-  repr = std::regex_replace(repr, std::regex("count"), "counts");
-  repr = std::regex_replace(repr, std::regex("item"), "counts");
+  repr = std::regex_replace(repr, std::regex("item"), "count");
+  repr = std::regex_replace(repr, std::regex("count(?!s)"), "counts");
   return repr == "" ? "dimensionless" : repr;
 }
 

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -23,6 +23,7 @@ Unit::Unit(const std::string &unit)
 std::string Unit::name() const {
   auto repr = to_string(m_unit);
   repr = std::regex_replace(repr, std::regex("^u"), "µ");
+  repr = std::regex_replace(repr, std::regex("count"), "counts");
   repr = std::regex_replace(repr, std::regex("item"), "counts");
   return repr == "" ? "dimensionless" : repr;
 }


### PR DESCRIPTION
Avoid inconsistently updated formatting of `counts` in upstream.