### PR TITLE
zero_init specialisation

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(TARGET_NAME "scipp-common")
 set(INC_FILES include/scipp/common/index.h include/scipp/common/overloaded.h
               include/scipp/common/reduction.h include/scipp/common/span.h
+              include/scipp/common/initialization.h
 )
 
 add_library(${TARGET_NAME} INTERFACE)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -3,9 +3,10 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # ~~~
 set(TARGET_NAME "scipp-common")
-set(INC_FILES include/scipp/common/index.h include/scipp/common/overloaded.h
-              include/scipp/common/reduction.h include/scipp/common/span.h
-              include/scipp/common/initialization.h
+set(INC_FILES
+    include/scipp/common/index.h include/scipp/common/overloaded.h
+    include/scipp/common/reduction.h include/scipp/common/span.h
+    include/scipp/common/initialization.h
 )
 
 add_library(${TARGET_NAME} INTERFACE)

--- a/common/include/scipp/common/initialization.h
+++ b/common/include/scipp/common/initialization.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Owen Arnold
+#pragma once
+#include <Eigen/Core>
+namespace scipp {
+template <class T> struct default_init {
+  static T value() { return T{}; }
+};
+// Eigen does not zero-initialize matrices (vectors), which is a recurrent
+// source of bugs. Variable does zero-init instead.
+template <class T, int Rows, int Cols>
+struct default_init<Eigen::Matrix<T, Rows, Cols>> {
+  static Eigen::Matrix<T, Rows, Cols> value() {
+    return Eigen::Matrix<T, Rows, Cols>::Zero();
+  }
+};
+
+template <class T> struct zero_init {
+  static T value() { return T{0}; }
+};
+
+template <class T, int Rows, int Cols>
+struct zero_init<Eigen::Matrix<T, Rows, Cols>>
+    : default_init<Eigen::Matrix<T, Rows, Cols>> {};
+} // namespace scipp

--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -6,6 +6,7 @@
 
 #include <limits>
 
+#include "scipp/common/initialization.h"
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/subbin_sizes.h"
@@ -24,10 +25,8 @@ constexpr auto zeros_not_bool_like =
                  using T = std::decay_t<decltype(x)>;
                  if constexpr (std::is_same_v<T, bool>)
                    return int64_t{0};
-                 else if constexpr (std::is_same_v<Eigen::Vector3d, T>)
-                   return T::Zero();
                  else
-                   return T{0};
+                   return zero_init<T>::value();
                }};
 
 template <class T, T Value>

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
+#include "scipp/common/initialization.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/element_array_view.h"
 #include "scipp/core/except.h"
@@ -36,20 +37,6 @@ bool equals_impl(const T1 &view1, const T2 &view2) {
   else
     return std::equal(view1.begin(), view1.end(), view2.begin(), view2.end());
 }
-
-namespace {
-template <class T> struct default_init {
-  static T value() { return T(); }
-};
-// Eigen does not zero-initialize matrices (vectors), which is a recurrent
-// source of bugs. Variable does zero-init instead.
-template <class T, int Rows, int Cols>
-struct default_init<Eigen::Matrix<T, Rows, Cols>> {
-  static Eigen::Matrix<T, Rows, Cols> value() {
-    return Eigen::Matrix<T, Rows, Cols>::Zero();
-  }
-};
-} // namespace
 
 /// Implementation of VariableConcept that holds and array with element type T.
 template <class T> class DataModel : public VariableConcept {


### PR DESCRIPTION
Clean-up from #1670, bug found whereby eigen vector3d not zero initialised. Fix provided in that pr did not future proof against other eigen vector type usage. Furthermore common solution available via template specialisation already in data_model. Refactored to use shared implementation.