### PR TITLE
Register exceptions to pybind

### DIFF
--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -67,7 +67,7 @@ struct SCIPP_CORE_EXPORT EventsDimensionError : public DimensionError {
       : DimensionError("Unsupported operation for events dimensions.") {}
 };
 
-struct SCIPP_CORE_EXPORT BucketError : public std::runtime_error {
+struct SCIPP_CORE_EXPORT BinnedDataError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
@@ -88,18 +88,6 @@ struct SCIPP_CORE_EXPORT BinEdgeError : public std::runtime_error {
 };
 
 struct SCIPP_CORE_EXPORT NotFoundError : public std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
-struct SCIPP_CORE_EXPORT UnalignedError : public std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
-struct SCIPP_CORE_EXPORT RealignedDataError : public std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
-struct SCIPP_CORE_EXPORT EventDataError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 

--- a/core/multi_index.cpp
+++ b/core/multi_index.cpp
@@ -33,7 +33,7 @@ void validate_bucket_indices_impl(const ElementArrayViewParams &param0,
   for (scipp::index i = 0; i < iterDims.volume(); ++i) {
     const auto [i0, i1] = index.get();
     if (size(indices0[i0]) != size(indices1[i1]))
-      throw except::BucketError(
+      throw except::BinnedDataError(
           "Bin size mismatch in operation with binned data. Refer to "
           "https://scipp.github.io/user-guide/binned-data/"
           "computation.html#Overview-and-Quick-Reference for equivalent "

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -281,11 +281,11 @@ TEST_F(MultiIndexTest, two_1d_arrays_of_1d_buckets_bucket_size_mismatch) {
   EXPECT_THROW(check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, buf, dim,
                                   {{0, 4}, {3, 7}}, x, x, x,
                                   {0, 1, 2, 3, 4, 5, 6}, {0, 1, 2, 3, 4, 5, 6}),
-               except::BucketError);
+               except::BinnedDataError);
   EXPECT_THROW(check_with_buckets(buf, dim, {{0, 3}, {3, 7}}, buf, dim,
                                   {{0, 3}, {4, 7}}, x, x, x,
                                   {0, 1, 2, 3, 4, 5, 6}, {0, 1, 2, 3, 4, 5, 6}),
-               except::BucketError);
+               except::BinnedDataError);
 }
 
 TEST_F(MultiIndexTest, 2d_empty_dims_array_of_1d_buckets) {

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -520,8 +520,9 @@ namespace {
 void validate_bin_args(const std::vector<VariableConstView> &edges,
                        const std::vector<VariableConstView> &groups) {
   if (edges.empty() && groups.empty())
-    throw except::BucketError("Arguments 'edges' and 'groups' of scipp.bin are "
-                              "both empty. At least one must be set.");
+    throw except::BinnedDataError(
+        "Arguments 'edges' and 'groups' of scipp.bin are "
+        "both empty. At least one must be set.");
   for (const auto &edge : edges) {
     const auto dim = edge.dims().inner();
     if (edge.dims()[dim] < 2)

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -146,7 +146,7 @@ TEST_P(BinTest, group) {
 
 TEST_P(BinTest, no_edges_or_groups) {
   const auto table = GetParam();
-  EXPECT_THROW(bin(table, {}), except::BucketError);
+  EXPECT_THROW(bin(table, {}), except::BinnedDataError);
 }
 
 TEST_P(BinTest, edges_too_short) {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,6 +17,7 @@ pybind11_add_module(
   docstring.cpp
   dtype.cpp
   eigen.cpp
+  except.cpp
   geometry.cpp
   groupby.cpp
   histogram.cpp

--- a/python/except.cpp
+++ b/python/except.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+
+#include "scipp/core/except.h"
+#include "pybind11.h"
+#include "scipp/dataset/except.h"
+
+namespace py = pybind11;
+
+void init_exceptions(py::module &m) {
+  using namespace scipp;
+  py::register_exception<except::UnitError>(m, "UnitError");
+  py::register_exception<except::TypeError>(m, "DTypeError");
+  py::register_exception<except::DimensionError>(m, "DimensionError");
+  py::register_exception<except::BinnedDataError>(m, "BinnedDataError");
+  py::register_exception<except::CoordMismatchError>(m, "CoordError");
+}

--- a/python/except.cpp
+++ b/python/except.cpp
@@ -11,9 +11,13 @@ namespace py = pybind11;
 
 void init_exceptions(py::module &m) {
   using namespace scipp;
-  py::register_exception<except::UnitError>(m, "UnitError");
-  py::register_exception<except::TypeError>(m, "DTypeError");
-  py::register_exception<except::DimensionError>(m, "DimensionError");
-  py::register_exception<except::BinnedDataError>(m, "BinnedDataError");
-  py::register_exception<except::CoordMismatchError>(m, "CoordError");
+  py::register_exception<except::UnitError>(m, "UnitError", PyExc_RuntimeError);
+  py::register_exception<except::TypeError>(m, "DTypeError",
+                                            PyExc_RuntimeError);
+  py::register_exception<except::DimensionError>(m, "DimensionError",
+                                                 PyExc_RuntimeError);
+  py::register_exception<except::BinnedDataError>(m, "BinnedDataError",
+                                                  PyExc_RuntimeError);
+  py::register_exception<except::CoordMismatchError>(m, "CoordError",
+                                                     PyExc_RuntimeError);
 }

--- a/python/scipp.cpp
+++ b/python/scipp.cpp
@@ -16,6 +16,7 @@ void init_detail(py::module &);
 void init_dtype(py::module &);
 void init_eigen(py::module &);
 void init_element_array_view(py::module &);
+void init_exceptions(py::module &);
 void init_groupby(py::module &);
 void init_geometry(py::module &);
 void init_histogram(py::module &);
@@ -40,6 +41,7 @@ void init_core(py::module &m) {
   auto core = m.def_submodule("core");
   init_units_neutron(core);
   init_eigen(core);
+  init_exceptions(core);
   init_dtype(core);
   init_variable(core);
   init_buckets(core);

--- a/scipp-developer-no-mantid.yml
+++ b/scipp-developer-no-mantid.yml
@@ -40,6 +40,6 @@ dependencies:
   # Docs
   - ipython=7.2.0
   - pandoc
-  - sphinx>=1.6
+  - sphinx=3.4.3 # see https://github.com/sphinx-doc/sphinx/issues/8885
   - sphinx_rtd_theme
   - nbsphinx

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -41,6 +41,6 @@ dependencies:
   # Docs
   - ipython=7.2.0
   - pandoc
-  - sphinx>=1.6
+  - sphinx=3.4.3 # see https://github.com/sphinx-doc/sphinx/issues/8885
   - sphinx_rtd_theme
   - nbsphinx

--- a/variable/include/scipp/variable/bucket_variable.tcc
+++ b/variable/include/scipp/variable/bucket_variable.tcc
@@ -109,7 +109,7 @@ private:
   const VariableConstView
   bin_parent(const scipp::span<const VariableConstView> &parents) const {
     if (parents.empty())
-      throw except::BucketError("Bin cannot have zero parents");
+      throw except::BinnedDataError("Bin cannot have zero parents");
     return parents.front().dtype() == dtype<bucket<T>>
                ? parents.front()
                : bin_parent(parents.subspan(1));

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -391,9 +391,9 @@ TEST_F(TransformBinaryTest, events_size_fail) {
   auto a = make_bins(indicesA, Dim::Event, table);
   auto b = make_bins(indicesB, Dim::Event, table);
   ASSERT_THROW_DISCARD(transform<pair_self_t<double>>(a, b, op),
-                       except::BucketError);
+                       except::BinnedDataError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, b, op_in_place),
-               except::BucketError);
+               except::BinnedDataError);
 }
 
 TEST_F(TransformBinaryTest, in_place_unit_change) {
@@ -535,13 +535,13 @@ TEST_F(TransformTest_events_binary_values_variances_size_fail, baseline) {
 TEST_F(TransformTest_events_binary_values_variances_size_fail, a_size_bad) {
   a = b;
   ASSERT_THROW_DISCARD(transform<pair_self_t<double>>(a, val_var, op),
-                       except::BucketError);
+                       except::BinnedDataError);
   ASSERT_THROW_DISCARD(transform<pair_self_t<double>>(a, val, op),
-                       except::BucketError);
+                       except::BinnedDataError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val_var, op_in_place),
-               except::BucketError);
+               except::BinnedDataError);
   ASSERT_THROW(transform_in_place<pair_self_t<double>>(a, val, op_in_place),
-               except::BucketError);
+               except::BinnedDataError);
 }
 
 class TransformBucketsBinaryTest : public TransformBinaryTest {
@@ -712,7 +712,7 @@ protected:
 TEST_F(TransformInPlaceBucketsDryRunTest, events_length_fail) {
   const auto original(a);
   EXPECT_THROW(dry_run::transform_in_place<pair_self_t<double>>(a, b, binary),
-               except::BucketError);
+               except::BinnedDataError);
   EXPECT_EQ(a, original);
 }
 


### PR DESCRIPTION
Part of #1302. Not all our exceptions bound, since they need cleanup. I think these are the most important ones? Will add more as needed.