### PR TITLE
Concatenate and bin with single call to bin

### DIFF
--- a/dataset/include/scipp/dataset/bin.h
+++ b/dataset/include/scipp/dataset/bin.h
@@ -11,12 +11,14 @@ namespace scipp::dataset {
 SCIPP_DATASET_EXPORT DataArray
 bin(const DataArrayConstView &array,
     const std::vector<VariableConstView> &edges,
-    const std::vector<VariableConstView> &groups = {});
+    const std::vector<VariableConstView> &groups = {},
+    const std::vector<Dim> &clear = {});
 
 template <class Coords, class Masks, class Attrs>
 SCIPP_DATASET_EXPORT DataArray
 bin(const VariableConstView &data, const Coords &coords, const Masks &masks,
     const Attrs &attrs, const std::vector<VariableConstView> &edges,
-    const std::vector<VariableConstView> &groups = {});
+    const std::vector<VariableConstView> &groups = {},
+    const std::vector<Dim> &clear = {});
 
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/bin.h
+++ b/dataset/include/scipp/dataset/bin.h
@@ -12,13 +12,13 @@ SCIPP_DATASET_EXPORT DataArray
 bin(const DataArrayConstView &array,
     const std::vector<VariableConstView> &edges,
     const std::vector<VariableConstView> &groups = {},
-    const std::vector<Dim> &clear = {});
+    const std::vector<Dim> &erase = {});
 
 template <class Coords, class Masks, class Attrs>
 SCIPP_DATASET_EXPORT DataArray
 bin(const VariableConstView &data, const Coords &coords, const Masks &masks,
     const Attrs &attrs, const std::vector<VariableConstView> &edges,
     const std::vector<VariableConstView> &groups = {},
-    const std::vector<Dim> &clear = {});
+    const std::vector<Dim> &erase = {});
 
 } // namespace scipp::dataset

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -366,3 +366,15 @@ TEST_P(BinTest, rebin_various_edges_1d) {
     for (const auto &e1 : edges)
       bin(bin(table, {e0}), {e1});
 }
+
+TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
+  const auto table = GetParam();
+  const auto binned_along_x = bin(table, {edges_x});
+  const auto binned_along_y = bin(table, {edges_y});
+
+  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
+  EXPECT_EQ(bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension),
+            binned_along_y)
+      << "Expected result of clearing x binning and adding y binning to be the "
+         "same as binning the original data along y";
+}

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -375,7 +375,7 @@ TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
   const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
   const auto test_output =
       bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension);
-  EXPECT_EQ(test_output, binned_along_y)
-      << "Expected result of clearing x binning and adding y binning to be the "
-         "same as binning the original data along y";
+  // Expect result of clearing x binning and adding y binning to be the same
+  // as binning the original data along y
+  expect_near(test_output, binned_along_y);
 }

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -379,3 +379,13 @@ TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
   // as binning the original data along y
   expect_near(test_output, binned_along_y);
 }
+
+TEST_P(BinTest, error_if_clear_binning_and_try_rebin_along_same_dimension) {
+  const auto table = GetParam();
+  const auto binned_along_x = bin(table, {edges_x_coarse});
+
+  // Trying to rebin in X but also clear binning from X
+  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
+  EXPECT_THROW(bin(binned_along_x, {edges_x}, {}, clear_binning_from_dimension),
+               except::DimensionError);
+}

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -367,7 +367,7 @@ TEST_P(BinTest, rebin_various_edges_1d) {
       bin(bin(table, {e0}), {e1});
 }
 
-TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
+TEST_P(BinTest, erase_binning_and_bin_along_different_dimension) {
   const auto table = GetParam();
   const auto binned_along_x = bin(table, {edges_x});
   const auto binned_along_y = bin(table, {edges_y});
@@ -380,12 +380,12 @@ TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
   expect_near(test_output, binned_along_y);
 }
 
-TEST_P(BinTest, error_if_clear_binning_and_try_rebin_along_same_dimension) {
+TEST_P(BinTest, error_if_erase_binning_and_try_rebin_along_same_dimension) {
   const auto table = GetParam();
   const auto binned_along_x = bin(table, {edges_x_coarse});
 
   // Trying to rebin in X but also clear binning from X
-  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
-  EXPECT_THROW(bin(binned_along_x, {edges_x}, {}, clear_binning_from_dimension),
+  const std::vector<Dim> erase_binning_from_dimension = {Dim::X};
+  EXPECT_THROW(bin(binned_along_x, {edges_x}, {}, erase_binning_from_dimension),
                except::DimensionError);
 }

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -373,8 +373,9 @@ TEST_P(BinTest, clear_binning_and_bin_along_different_dimension) {
   const auto binned_along_y = bin(table, {edges_y});
 
   const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
-  EXPECT_EQ(bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension),
-            binned_along_y)
+  const auto test_output =
+      bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension);
+  EXPECT_EQ(test_output, binned_along_y)
       << "Expected result of clearing x binning and adding y binning to be the "
          "same as binning the original data along y";
 }

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -218,8 +218,8 @@ void init_buckets(py::module &m) {
       [](const DataArrayConstView &array,
          const std::vector<VariableConstView> &edges,
          const std::vector<VariableConstView> &groups,
-         const std::vector<Dim> &clear) {
-        return dataset::bin(array, edges, groups, clear);
+         const std::vector<Dim> &erase) {
+        return dataset::bin(array, edges, groups, erase);
       },
       py::call_guard<py::gil_scoped_release>());
   m.def("bin_with_coords", [](const VariableConstView &data,

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -217,8 +217,9 @@ void init_buckets(py::module &m) {
       "bin",
       [](const DataArrayConstView &array,
          const std::vector<VariableConstView> &edges,
-         const std::vector<VariableConstView> &groups) {
-        return dataset::bin(array, edges, groups);
+         const std::vector<VariableConstView> &groups,
+         const std::vector<Dim> &clear) {
+        return dataset::bin(array, edges, groups, clear);
       },
       py::call_guard<py::gil_scoped_release>());
   m.def("bin_with_coords", [](const VariableConstView &data,

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -158,8 +158,9 @@ def histogram(x, bins):
     return _call_cpp_func(_cpp.histogram, x, bins)
 
 
-def bin(x, edges=[], groups=[]):
+def bin(x, edges=[], groups=[], clear=[]):
     """Create binned data by binning data along all dimensions given by edges.
+    Can specify dimensions with existing binning to clear.
 
     This does not histogram the data, each output bin will contain a "list" of
     input values.
@@ -169,7 +170,7 @@ def bin(x, edges=[], groups=[]):
               :py:func:`scipp.bins` for creating binned data based on
               explicitly given index ranges.
     """
-    return _call_cpp_func(_cpp.bin, x, edges, groups)
+    return _call_cpp_func(_cpp.bin, x, edges, groups, clear)
 
 
 def bins(*args, **kwargs):

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -158,9 +158,9 @@ def histogram(x, bins):
     return _call_cpp_func(_cpp.histogram, x, bins)
 
 
-def bin(x, edges=[], groups=[], clear=[]):
+def bin(x, edges=[], groups=[], erase=[]):
     """Create binned data by binning data along all dimensions given by edges.
-    Can specify dimensions with existing binning to clear.
+    Can specify dimensions with existing binning to erase.
 
     This does not histogram the data, each output bin will contain a "list" of
     input values.
@@ -170,7 +170,7 @@ def bin(x, edges=[], groups=[], clear=[]):
               :py:func:`scipp.bins` for creating binned data based on
               explicitly given index ranges.
     """
-    return _call_cpp_func(_cpp.bin, x, edges, groups, clear)
+    return _call_cpp_func(_cpp.bin, x, edges, groups, erase)
 
 
 def bins(*args, **kwargs):


### PR DESCRIPTION
Closes #1627 

Interface currently looks like this
```python
events = sc.bin(events, groups=[det_ids], clear=['pulse'])
```
Maybe this is better?
```python
events = sc.bin(events, groups=[det_ids], clear_binning_from=['pulse'])
```
Something else?

Some benchmarking to check it has anticipated effect (I didn't add the benchmarks to the PR):
```cpp
static void BM_concat_and_bin(benchmark::State &state) {
  const scipp::index nx = state.range(0);
  const scipp::index nEvent = state.range(1);
  auto table = make_table(nEvent);
  auto edges_x = make_edges(Dim::X, nx);
  auto edges_y = make_edges(Dim::Y, nx);

  for (auto _ : state) {
    auto a = dataset::bin(table, {edges_x});
    auto concatenated_a = scipp::dataset::buckets::concatenate(a, Dim::X);
    auto b = dataset::bin(concatenated_a, {edges_y});
  }
}
BENCHMARK(BM_concat_and_bin)->RangeMultiplier(10)->Ranges({{10, 1e4}, {1e3, 1e8}});

static void BM_concat_and_bin_single_op(benchmark::State &state) {
  const scipp::index nx = state.range(0);
  const scipp::index nEvent = state.range(1);
  auto table = make_table(nEvent);
  auto edges_x = make_edges(Dim::X, nx);
  auto edges_y = make_edges(Dim::Y, nx);

  for (auto _ : state) {
    auto a = dataset::bin(table, {edges_x});
    auto b = dataset::bin(a, {edges_y}, {}, {Dim::X});
  }
}
BENCHMARK(BM_concat_and_bin_single_op)->RangeMultiplier(10)->Ranges({{10, 1e4}, {1e3, 1e8}});
```

Results:
```
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
BM_concat_and_bin/10/1000                       675130 ns       667175 ns         1061
BM_concat_and_bin/100/1000                      939934 ns       936656 ns          749
BM_concat_and_bin/1000/1000                    2142699 ns      2135666 ns          327
BM_concat_and_bin/10000/1000                  11031079 ns     11027394 ns           57
BM_concat_and_bin/10/10000                      806773 ns       806252 ns          868
BM_concat_and_bin/100/10000                    1063309 ns      1062967 ns          669
BM_concat_and_bin/1000/10000                   2198660 ns      2197723 ns          318
BM_concat_and_bin/10000/10000                 11373062 ns     11370788 ns           62
BM_concat_and_bin/10/100000                    2513881 ns      2513812 ns          268
BM_concat_and_bin/100/100000                   2648207 ns      2648122 ns          261
BM_concat_and_bin/1000/100000                  3968139 ns      3965712 ns          176
BM_concat_and_bin/10000/100000                13225729 ns     13223934 ns           52
BM_concat_and_bin/10/1000000                  26798078 ns     26797214 ns           26
BM_concat_and_bin/100/1000000                 26873312 ns     26852637 ns           26
BM_concat_and_bin/1000/1000000                28871642 ns     28871448 ns           24
BM_concat_and_bin/10000/1000000               44806819 ns     44806122 ns           15
BM_concat_and_bin/10/10000000                295890398 ns    295888671 ns            2
BM_concat_and_bin/100/10000000               300072436 ns    300044652 ns            2
BM_concat_and_bin/1000/10000000              330297021 ns    330224404 ns            2
BM_concat_and_bin/10000/10000000             418157534 ns    418137967 ns            2
BM_concat_and_bin/10/100000000              2875360936 ns   2874863638 ns            1
BM_concat_and_bin/100/100000000             2927704972 ns   2927488411 ns            1
BM_concat_and_bin/1000/100000000            3210347826 ns   3210151523 ns            1
BM_concat_and_bin/10000/100000000           4112982913 ns   4109643695 ns            1
BM_concat_and_bin_single_op/10/1000             607975 ns       607880 ns         1188
BM_concat_and_bin_single_op/100/1000            936442 ns       936405 ns          743
BM_concat_and_bin_single_op/1000/1000          7630264 ns      7629860 ns           91
BM_concat_and_bin_single_op/10000/1000      1006922793 ns    768046017 ns            1
BM_concat_and_bin_single_op/10/10000            672529 ns       672312 ns         1079
BM_concat_and_bin_single_op/100/10000          1034568 ns      1034487 ns          674
BM_concat_and_bin_single_op/1000/10000         7812155 ns      7809841 ns           88
BM_concat_and_bin_single_op/10000/10000      938467115 ns    810019901 ns            1
BM_concat_and_bin_single_op/10/100000          1086354 ns      1086349 ns          653
BM_concat_and_bin_single_op/100/100000         1399143 ns      1398875 ns          506
BM_concat_and_bin_single_op/1000/100000        8769968 ns      8769354 ns           79
BM_concat_and_bin_single_op/10000/100000     922196868 ns    823482192 ns            1
BM_concat_and_bin_single_op/10/1000000         8275518 ns      8272519 ns           84
BM_concat_and_bin_single_op/100/1000000        9326507 ns      9324947 ns           75
BM_concat_and_bin_single_op/1000/1000000      16935696 ns     16933666 ns           40
BM_concat_and_bin_single_op/10000/1000000    941340021 ns    845349978 ns            1
BM_concat_and_bin_single_op/10/10000000      102633001 ns    102543215 ns            7
BM_concat_and_bin_single_op/100/10000000     107519257 ns    107515498 ns            7
BM_concat_and_bin_single_op/1000/10000000    147051077 ns    146997894 ns            5
BM_concat_and_bin_single_op/10000/10000000  1074747249 ns    973376640 ns            1
BM_concat_and_bin_single_op/10/100000000    1017495254 ns   1017357481 ns            1
BM_concat_and_bin_single_op/100/100000000   1024369078 ns   1024120473 ns            1
BM_concat_and_bin_single_op/1000/100000000  1339282380 ns   1339187923 ns            1
BM_concat_and_bin_single_op/10000/100000000 2440517762 ns   2366221573 ns            1
```