### PR TITLE
Use matplotlib-base to avoid pulling in Qt during CI

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,7 +29,7 @@ test:
     - beautifulsoup4
     - h5py
     - ipywidgets
-    - matplotlib
+    - matplotlib-base
     - psutil
     - pytest
     - pythreejs

--- a/scipp-developer-no-mantid.yml
+++ b/scipp-developer-no-mantid.yml
@@ -17,7 +17,7 @@ dependencies:
   - appdirs
   - ipympl
   - ipywidgets
-  - matplotlib=3.2.2 # version 3.3.3 causes issues with nodejs in JupyterLab
+  - matplotlib-base=3.2.2 # version 3.3.3 causes issues with nodejs in JupyterLab
   - numpy >=1.15.3
   - python
   - python-configuration

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -18,7 +18,7 @@ dependencies:
   - ipympl
   - ipywidgets
   - mantid-framework
-  - matplotlib=3.2.2 # version 3.3.3 causes issues with nodejs in JupyterLab
+  - matplotlib-base=3.2.2 # version 3.3.3 causes issues with nodejs in JupyterLab
   - numpy >=1.15.3
   - python
   - python-configuration


### PR DESCRIPTION
Avoid about 100 MB download of `qt` (only on Windows, did not see this happending on other OS?), for every CI job.