### PR TITLE
Do not show 'bin-edge' for standalone Variables

### DIFF
--- a/variable/include/scipp/variable/string.h
+++ b/variable/include/scipp/variable/string.h
@@ -30,9 +30,10 @@ to_string(const std::pair<Dim, VariableConstView> &coord);
 SCIPP_VARIABLE_EXPORT std::string
 to_string(const std::pair<std::string, VariableConstView> &attr);
 
-SCIPP_VARIABLE_EXPORT std::string
-format_variable(const std::string &key, const VariableConstView &variable,
-                const Dimensions &datasetDims = Dimensions());
+SCIPP_VARIABLE_EXPORT std::string format_variable(
+    const std::string &key, const VariableConstView &variable,
+    std::optional<std::reference_wrapper<const Dimensions>> datasetDims =
+        std::nullopt);
 
 /// Abstract base class for formatters for variables with element types not in
 /// scipp-variable module.

--- a/variable/include/scipp/variable/string.h
+++ b/variable/include/scipp/variable/string.h
@@ -30,10 +30,9 @@ to_string(const std::pair<Dim, VariableConstView> &coord);
 SCIPP_VARIABLE_EXPORT std::string
 to_string(const std::pair<std::string, VariableConstView> &attr);
 
-SCIPP_VARIABLE_EXPORT std::string format_variable(
-    const std::string &key, const VariableConstView &variable,
-    std::optional<std::reference_wrapper<const Dimensions>> datasetDims =
-        std::nullopt);
+SCIPP_VARIABLE_EXPORT std::string
+format_variable(const std::string &key, const VariableConstView &variable,
+                std::optional<Dimensions> datasetDims = std::nullopt);
 
 /// Abstract base class for formatters for variables with element types not in
 /// scipp-variable module.

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -38,9 +38,8 @@ std::string make_dims_labels(const VariableConstView &variable,
   for (const auto dim : dims.labels()) {
     diminfo += to_string(dim);
     if (datasetDims) {
-      if ((datasetDims->contains(dim) &&
-           ((*datasetDims)[dim] + 1 == dims[dim])) ||
-          (datasetDims->empty() && dims[dim] == 2))
+      if ((datasetDims->contains(dim) ? (*datasetDims)[dim] : 1) + 1 ==
+          dims[dim])
         diminfo += " [bin-edge]";
     }
     diminfo += ", ";

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -29,9 +29,8 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable) {
 namespace {
 constexpr const char *tab = "  ";
 
-std::string make_dims_labels(
-    const VariableConstView &variable,
-    const std::optional<std::reference_wrapper<const Dimensions>> datasetDims) {
+std::string make_dims_labels(const VariableConstView &variable,
+                             const std::optional<Dimensions> datasetDims) {
   const auto &dims = variable.dims();
   if (dims.empty())
     return "()";
@@ -39,9 +38,9 @@ std::string make_dims_labels(
   for (const auto dim : dims.labels()) {
     diminfo += to_string(dim);
     if (datasetDims) {
-      if ((datasetDims->get().contains(dim) &&
-           (datasetDims->get()[dim] + 1 == dims[dim])) ||
-          (datasetDims->get().empty() && dims[dim] == 2))
+      if ((datasetDims->contains(dim) &&
+           ((*datasetDims)[dim] + 1 == dims[dim])) ||
+          (datasetDims->empty() && dims[dim] == 2))
         diminfo += " [bin-edge]";
     }
     diminfo += ", ";
@@ -81,9 +80,9 @@ auto apply(const DType dtype, Args &&... args) {
 }
 } // namespace
 
-std::string format_variable(
-    const std::string &key, const VariableConstView &variable,
-    const std::optional<std::reference_wrapper<const Dimensions>> datasetDims) {
+std::string format_variable(const std::string &key,
+                            const VariableConstView &variable,
+                            const std::optional<Dimensions> datasetDims) {
   if (!variable)
     return std::string(tab) + "invalid variable\n";
   std::stringstream s;


### PR DESCRIPTION
Before
```.py
print(sc.Variable(['x'], values=[0, 1]))
```
->
```
  <scipp.Variable>          int64      [dimensionless]  (x [bin-edge])  [0, 1]
```
The `[bin-edge]` is nonsense for a standalone Variable.
Now this is printed without `[bin-edge]` but bin edges are still detected in e.g.
```.py
print(sc.DataArray(sc.Variable(['x'], values=np.arange(2)),
                   coords={'x': sc.Variable(['x'], values=np.arange(3))}))
```
