### PR TITLE
Fix bad overload selection caused by implicit conversion

### DIFF
--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -85,12 +85,28 @@ def test_create_with_variances_from_numpy_1d():
     np.testing.assert_array_equal(var.variances, np.arange(4, 8))
 
 
-def test_create_scalar():
-    var = sc.Variable(1.2)
-    assert var.value == 1.2
+@pytest.mark.parametrize(
+    "value",
+    [1.2, np.float64(1.2), sc.Variable(1.2).value])
+def test_create_scalar(value):
+    var = sc.Variable(value)
+    assert var.value == value
     assert var.dims == []
     assert var.dtype == sc.dtype.float64
     assert var.unit == sc.units.dimensionless
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [sc.units.m,
+     sc.Unit('m'), 'm',
+     sc.Variable(1.2, unit=sc.units.m).unit])
+def test_create_scalar_with_dtype(unit):
+    var = sc.Variable(1.2, unit=unit)
+    assert var.value == 1.2
+    assert var.dims == []
+    assert var.dtype == sc.dtype.float64
+    assert var.unit == sc.units.m
 
 
 def test_create_scalar_Variable():

--- a/python/tests/test_variable.py
+++ b/python/tests/test_variable.py
@@ -101,7 +101,7 @@ def test_create_scalar(value):
     [sc.units.m,
      sc.Unit('m'), 'm',
      sc.Variable(1.2, unit=sc.units.m).unit])
-def test_create_scalar_with_dtype(unit):
+def test_create_scalar_with_unit(unit):
     var = sc.Variable(1.2, unit=unit)
     assert var.value == 1.2
     assert var.dims == []

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -69,7 +69,7 @@ void bind_init_0D_native_python_types(py::class_<Variable> &c) {
                                                         dtype);
           }
         }),
-        py::arg("value"), py::arg("variance") = std::nullopt,
+        py::arg("value").noconvert(), py::arg("variance") = std::nullopt,
         py::arg("unit") = units::one, py::arg("dtype") = py::none());
 }
 


### PR DESCRIPTION
Fixes this issue:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/12912489/108482900-5f0ab780-729a-11eb-8191-02b899a59e87.png">

Only happens with `unit='string'` since then the non-converting first round of pybind's overload resolution does not match, second round converts double to bool.