### PR TITLE
Less restrictive datetime dtype handling

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -124,7 +124,8 @@ inline void expect_scalar(const Dimensions &dims, const std::string_view name) {
   if (dims != Dimensions{}) {
     std::ostringstream oss;
     oss << "The '" << name << "' property cannot be used with non-scalar "
-        << "Variables. Got dimensions " << to_string(dims);
+        << "Variables. Got dimensions " << to_string(dims) << ". Did you mean '"
+        << name << "s'?";
     throw except::DimensionError(oss.str());
   }
 }

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -343,10 +343,10 @@ public:
   // Return a scalar variance from a variable, implicitly requiring that the
   // variable is 0-dimensional and thus has only a single item.
   template <class Var> static py::object variance(py::object &obj) {
-    if (!get_variances::valid<Var>(obj))
-      return py::none();
     auto &view = obj.cast<Var &>();
     expect_scalar(view.dims(), "variance");
+    if (!get_variances::valid<Var>(obj))
+      return py::none();
     return std::visit(GetScalarVisitor<decltype(view)>{obj, view},
                       get<get_variances>(view));
   }

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -125,7 +125,7 @@ inline void expect_scalar(const Dimensions &dims, const std::string_view name) {
     std::ostringstream oss;
     oss << "The '" << name << "' property cannot be used with non-scalar "
         << "Variables. Got dimensions " << to_string(dims);
-    throw py::type_error(oss.str());
+    throw std::runtime_error(oss.str());
   }
 }
 

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -125,7 +125,7 @@ inline void expect_scalar(const Dimensions &dims, const std::string_view name) {
     std::ostringstream oss;
     oss << "The '" << name << "' property cannot be used with non-scalar "
         << "Variables. Got dimensions " << to_string(dims);
-    throw std::runtime_error(oss.str());
+    throw except::DimensionError(oss.str());
   }
 }
 

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -3,6 +3,9 @@
 /// @file
 /// @author Simon Heybrock
 #include "dtype.h"
+
+#include <regex>
+
 #include "pybind11.h"
 #include "scipp/core/string.h"
 
@@ -63,34 +66,31 @@ scipp::core::DType scipp_dtype(const py::object &type) {
 // Awful handwritten parser. But std::regex does not support string_view and
 // you have to go through c-strings in order to extract the unit scale.
 [[nodiscard]] scipp::units::Unit
-parse_datetime_dtype(const std::string_view dtype_name) {
-  if (const auto length = std::size(dtype_name); length == 13 || length == 14) {
-    if (dtype_name.substr(0, 11) == "datetime64[" &&
-        dtype_name[length - 2] == 's' && dtype_name.back() == ']') {
-      if (length == 13) {
-        // no scale given
-        return scipp::units::s;
-      }
-      if (dtype_name[11] == 'n') {
-        return scipp::units::ns;
-      } else if (dtype_name[11] == 'u') {
-        return scipp::units::us;
-      } else if (dtype_name[11] == 'm') {
-        static const auto ms = units::Unit("ms");
-        return ms;
-      }
-      throw std::invalid_argument(
-          std::string("Unsupported unit in datetime: ") + dtype_name[11] + "s");
-    }
-  } else if (length == 10) {
-    if (dtype_name == "datetime64") {
-      return scipp::units::dimensionless;
-    }
+parse_datetime_dtype(const std::string &dtype_name) {
+  static std::regex datetime_regex{R"(datetime64(\[(\w+)\])?)"};
+  constexpr size_t unit_idx = 2;
+  std::smatch match;
+  if (!std::regex_match(dtype_name, match, datetime_regex) ||
+      match.size() != 3) {
+    throw std::invalid_argument("Invalid dtype, expected datetime64, got" +
+                                dtype_name);
   }
 
-  throw std::invalid_argument(
-      std::string("Invalid dtype, expected datetime64, got ")
-          .append(dtype_name));
+  if (match.length(unit_idx) == 0) {
+    return scipp::units::dimensionless;
+  } else if (match[unit_idx] == "s") {
+    return scipp::units::s;
+  } else if (match[unit_idx] == "ms") {
+    static const auto ms = units::Unit("ms");
+    return ms;
+  } else if (match[unit_idx] == "us") {
+    return scipp::units::us;
+  } else if (match[unit_idx] == "ns") {
+    return scipp::units::ns;
+  }
+
+  throw std::invalid_argument(std::string("Unsupported unit in datetime: ") +
+                              dtype_name[11] + "s");
 }
 
 [[nodiscard]] scipp::units::Unit
@@ -98,8 +98,8 @@ parse_datetime_dtype(const pybind11::object &dtype) {
   if (py::hasattr(dtype, "dtype")) {
     return parse_datetime_dtype(dtype.attr("dtype"));
   } else if (py::hasattr(dtype, "name")) {
-    return parse_datetime_dtype(dtype.attr("name").cast<std::string_view>());
+    return parse_datetime_dtype(dtype.attr("name").cast<std::string>());
   } else {
-    return parse_datetime_dtype(py::str(dtype).cast<std::string_view>());
+    return parse_datetime_dtype(py::str(dtype).cast<std::string>());
   }
 }

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -95,16 +95,11 @@ parse_datetime_dtype(const std::string_view dtype_name) {
 
 [[nodiscard]] scipp::units::Unit
 parse_datetime_dtype(const pybind11::object &dtype) {
-  if (py::isinstance<py::buffer>(dtype.get_type())) {
+  if (py::hasattr(dtype, "dtype")) {
     return parse_datetime_dtype(dtype.attr("dtype"));
-  } else if (py::isinstance<py::dtype>(dtype)) {
+  } else if (py::hasattr(dtype, "name")) {
     return parse_datetime_dtype(dtype.attr("name").cast<std::string_view>());
+  } else {
+    return parse_datetime_dtype(py::str(dtype).cast<std::string_view>());
   }
-  static const auto np_datetime64_type =
-      py::module::import("numpy").attr("datetime64").get_type();
-  if (py::isinstance(dtype.get_type(), np_datetime64_type)) {
-    return parse_datetime_dtype(dtype.attr("dtype"));
-  }
-  throw std::invalid_argument("Unable to extract time unit from " +
-                              py::str(dtype).cast<std::string>());
 }

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -63,8 +63,6 @@ scipp::core::DType scipp_dtype(const py::object &type) {
   }
 }
 
-// Awful handwritten parser. But std::regex does not support string_view and
-// you have to go through c-strings in order to extract the unit scale.
 [[nodiscard]] scipp::units::Unit
 parse_datetime_dtype(const std::string &dtype_name) {
   static std::regex datetime_regex{R"(datetime64(\[(\w+)\])?)"};

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -17,9 +17,7 @@ void init_dtype(py::module &m) {
       .def("__repr__", [](const DType self) { return to_string(self); });
   auto dtype = m.def_submodule("dtype");
   for (const auto &[key, name] : core::dtypeNameRegistry()) {
-    if (name != "datetime64") {
-      dtype.attr(name.c_str()) = key;
-    }
+    dtype.attr(name.c_str()) = key;
   }
 }
 

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -82,6 +82,10 @@ parse_datetime_dtype(const std::string_view dtype_name) {
       throw std::invalid_argument(
           std::string("Unsupported unit in datetime: ") + dtype_name[11] + "s");
     }
+  } else if (length == 10) {
+    if (dtype_name == "datetime64") {
+      return scipp::units::dimensionless;
+    }
   }
 
   throw std::invalid_argument(

--- a/python/dtype.h
+++ b/python/dtype.h
@@ -16,6 +16,6 @@ class dtype;
 scipp::core::DType scipp_dtype(const pybind11::object &type);
 
 [[nodiscard]] scipp::units::Unit
-parse_datetime_dtype(std::string_view dtype_name);
+parse_datetime_dtype(const std::string &dtype_name);
 [[nodiscard]] scipp::units::Unit
 parse_datetime_dtype(const pybind11::object &dtype);

--- a/python/make_variable.h
+++ b/python/make_variable.h
@@ -153,11 +153,11 @@ Variable makeVariableDefaultInit(const std::vector<Dim> &labels,
     if (variances) {
       throw except::VariancesError("datetimes cannot have variances.");
     }
-    const auto [actual_unit, value_factor] = get_time_unit(
-        std::nullopt,
-        dtype.is_none() ? std::optional<units::Unit>{}
-                        : parse_datetime_dtype(py::dtype::from_args(dtype)),
-        unit);
+    const auto [actual_unit, value_factor] =
+        get_time_unit(std::nullopt,
+                      dtype.is_none() ? std::optional<units::Unit>{}
+                                      : parse_datetime_dtype(dtype),
+                      unit);
     if (value_factor != 1) {
       throw std::invalid_argument(
           "Scaling datetimes is not supported. The units of the datetime64 "

--- a/python/numpy.cpp
+++ b/python/numpy.cpp
@@ -11,7 +11,7 @@ void ElementTypeMap<scipp::core::time_point>::check_assignable(
     const py::object &obj, const units::Unit unit) {
   const auto &dtype = obj.cast<py::array>().dtype();
   const auto np_unit =
-      parse_datetime_dtype(dtype.attr("name").cast<std::string_view>());
+      parse_datetime_dtype(dtype.attr("name").cast<std::string>());
   if (np_unit != unit) {
     std::ostringstream oss;
     oss << "Unable to assign datetime with unit " << to_string(np_unit)

--- a/python/tests/test_datetime.py
+++ b/python/tests/test_datetime.py
@@ -50,13 +50,13 @@ def test_construct_0d_datetime(unit):
                             value=value), sc.Variable(unit=unit, value=value),
                 sc.Variable(dtype=dtype,
                             value=value), sc.Variable(value=value)):
-        assert str(var.dtype) == 'datetime64'
+        assert var.dtype == sc.dtype.datetime64
         assert var.unit == unit
         assert var.value.dtype == dtype
         assert var.value == value
     # default init
     for var in (sc.Variable(dtype=dtype, unit=unit), sc.Variable(dtype=dtype)):
-        assert str(var.dtype) == 'datetime64'
+        assert var.dtype == sc.dtype.datetime64
         assert var.unit == unit
         assert var.value.dtype == dtype
 
@@ -70,6 +70,23 @@ def test_construct_0d_datetime_mismatch(unit1, unit2):
                     dtype=f'datetime64[{unit2}]')
     with pytest.raises(RuntimeError):
         sc.Variable(value=np.datetime64('now', unit1), unit=unit2)
+
+
+def test_construct_0d_datetime_nounit():
+    # Can make a datetime variable without unit but cannot do anything
+    # with it except set its unit.
+    var = sc.Variable(dtype=sc.dtype.datetime64)
+    assert var.dtype == sc.dtype.datetime64
+    assert var.unit == sc.units.one
+    with pytest.raises(sc.UnitError):
+        str(var)
+    with pytest.raises(TypeError):
+        var.value
+
+    var.unit = sc.units.s
+    value = np.datetime64(123, 's')
+    var.value = value
+    assert sc.is_equal(var, sc.Variable(value=value))
 
 
 @pytest.mark.parametrize("unit", _UNIT_STRINGS)
@@ -122,6 +139,23 @@ def test_construct_datetime_mismatch(unit1, unit2):
         sc.Variable(dims=['x'], values=values, dtype=f'datetime64[{unit2}]')
     with pytest.raises(RuntimeError):
         sc.Variable(dims=['x'], values=values, unit=unit2)
+
+
+def test_construct_datetime_nounit():
+    # Can make a datetime variable without unit but cannot do anything
+    # with it except set its unit.
+    var = sc.Variable(dims=['x'], shape=[2], dtype=sc.dtype.datetime64)
+    assert var.dtype == sc.dtype.datetime64
+    assert var.unit == sc.units.one
+    with pytest.raises(sc.UnitError):
+        str(var)
+    with pytest.raises(TypeError):
+        var.values
+
+    var.unit = sc.units.s
+    values = np.array([np.datetime64(123, 's'), np.datetime64(456, 's')])
+    var.values = values
+    assert sc.is_equal(var, sc.Variable(dims=['x'], values=values))
 
 
 @pytest.mark.parametrize("unit", _UNIT_STRINGS)

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -27,16 +27,17 @@ get_time_unit(const std::optional<scipp::units::Unit> value_unit,
     throw std::invalid_argument("Invalid unit for dtype=datetime64: " +
                                 to_string(sc_unit));
   }
-  if (dtype_unit && (sc_unit != units::one && *dtype_unit != sc_unit)) {
+  if (dtype_unit.value_or(units::one) != units::one &&
+      (sc_unit != units::one && *dtype_unit != sc_unit)) {
     throw std::invalid_argument(
-        "dtype (" + to_string(*dtype_unit) +
-        ") has a different time unit from 'unit' argument (" +
+        "dtype (datetime64[" + to_string(*dtype_unit) +
+        "]) has a different time unit from 'unit' argument (" +
         to_string(sc_unit) + ")");
   }
   units::Unit actual_unit;
   if (sc_unit != units::one)
     actual_unit = sc_unit;
-  else if (dtype_unit.has_value())
+  else if (dtype_unit.value_or(units::one) != units::one)
     actual_unit = *dtype_unit;
   else if (value_unit.has_value())
     actual_unit = *value_unit;

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -57,9 +57,8 @@ std::tuple<units::Unit, int64_t> get_time_unit(const py::buffer &value,
                                                const units::Unit unit) {
   return get_time_unit(value.is_none() ? std::optional<units::Unit>{}
                                        : parse_datetime_dtype(value),
-                       dtype.is_none()
-                           ? std::optional<units::Unit>{}
-                           : parse_datetime_dtype(py::dtype::from_args(dtype)),
+                       dtype.is_none() ? std::optional<units::Unit>{}
+                                       : parse_datetime_dtype(dtype),
                        unit);
 }
 

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -34,15 +34,13 @@ get_time_unit(const std::optional<scipp::units::Unit> value_unit,
         "]) has a different time unit from 'unit' argument (" +
         to_string(sc_unit) + ")");
   }
-  units::Unit actual_unit;
+  units::Unit actual_unit = units::one;
   if (sc_unit != units::one)
     actual_unit = sc_unit;
   else if (dtype_unit.value_or(units::one) != units::one)
     actual_unit = *dtype_unit;
   else if (value_unit.has_value())
     actual_unit = *value_unit;
-  else
-    throw std::invalid_argument("Unable to infer time unit from any argument.");
 
   // TODO implement
   if (value_unit && value_unit != actual_unit) {


### PR DESCRIPTION
Removes some requirements on specifying the unit in datetime64 dtypes. Also allows constructing variables with datetimes but no unit.  E.g.
```
sc.Variable(dtype=sc.dtype.datetime64)
```
is now possible but the resulting Variable is not usable until its unit is set to a time unit.