### PR TITLE
Don't include all of Eigen/Dense everywhere

### DIFF
--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -3,7 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
-#include <Eigen/Dense>
+#include <Eigen/Core>
 #include <unordered_map>
 
 #include "scipp-core_export.h"

--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -4,7 +4,7 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"

--- a/core/include/scipp/core/element/math.h
+++ b/core/include/scipp/core/element/math.h
@@ -6,7 +6,7 @@
 
 #include <cmath>
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 
 #include "scipp/common/overloaded.h"
 #include "scipp/core/element/arg_list.h"

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -8,7 +8,7 @@
 #include <optional>
 #include <string>
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 
 #include "scipp/units/unit.h"
 

--- a/python/eigen.cpp
+++ b/python/eigen.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Neil Vaytet
+#include <Eigen/Geometry>
 
 #include "numpy.h"
 #include "pybind11.h"

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Dense>
+#include <Eigen/Core>
 
 #include "scipp-variable_export.h"
 #include "scipp/common/index.h"

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <Eigen/Geometry>
 #include <gtest/gtest.h>
 #include <vector>
 


### PR DESCRIPTION
See https://eigen.tuxfamily.org/dox/group__QuickRefPage.html. We only need `Core`, usually.