### PR TITLE
Add ones and empty creation functions

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,6 +15,7 @@ Features
 * Add modulo operations [#1660](https://github.com/scipp/scipp/pull/1660).
 * Add scaling operations for Variables of type ``vector_3_float64``.
 * ``sum`` and ``mean`` implemented for Variables of type ``vector_3_float64``. 
+* Add ``ones`` and ``empty`` creation functions, similar to what is known from numpy `#1732 <https://github.com/scipp/scipp/pull/1732>`_.
 * ``scipp.neutron`` has been removed and is replaced by `scippneutron <https://scipp.github.io/scippneutron>`_
 * ``scipp.neutron`` (now ``scippneutron``)
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -9,24 +9,24 @@ Since v0.5
 Features
 ~~~~~~~~
 
-* Add ``sizes`` properties, an ordered ``dict`` to lookup the size of a specific dimension [#1636](https://github.com/scipp/scipp/pull/1636).
-* Add more functions for data arrays that were previously available only for variables [#1638](https://github.com/scipp/scipp/pull/1638) [#1660](https://github.com/scipp/scipp/pull/1660).
-* Add named versions of operators such as ``logical_and`` [#1660](https://github.com/scipp/scipp/pull/1660).
-* Add modulo operations [#1660](https://github.com/scipp/scipp/pull/1660).
+* Add ``sizes`` properties, an ordered ``dict`` to lookup the size of a specific dimension `#1636 <https://github.com/scipp/scipp/pull/1636>`_.
+* Add more functions for data arrays that were previously available only for variables `#1638 <https://github.com/scipp/scipp/pull/1638>`_ `#1660 <https://github.com/scipp/scipp/pull/1660>`_.
+* Add named versions of operators such as ``logical_and`` `#1660 <https://github.com/scipp/scipp/pull/1660>`_.
+* Add modulo operations `#1660 <https://github.com/scipp/scipp/pull/1660>`_.
 * Add scaling operations for Variables of type ``vector_3_float64``.
 * ``sum`` and ``mean`` implemented for Variables of type ``vector_3_float64``. 
 * Add ``ones`` and ``empty`` creation functions, similar to what is known from numpy `#1732 <https://github.com/scipp/scipp/pull/1732>`_.
 * ``scipp.neutron`` has been removed and is replaced by `scippneutron <https://scipp.github.io/scippneutron>`_
 * ``scipp.neutron`` (now ``scippneutron``)
 
-  * Support unit conversion to energy transfer, for inelastic TOF experiments [#1635](https://github.com/scipp/scipp/pull/1635).
-  * Support loading/converting Mantid ``WorkspaceGroup``, this will produce a ``dict`` of data arrays [#1654](https://github.com/scipp/scipp/pull/1654).
-  * Fixes to support loading/converting ``McStasNexus`` files [#1659](https://github.com/scipp/scipp/pull/1659).
+  * Support unit conversion to energy transfer, for inelastic TOF experiments `#1635 <https://github.com/scipp/scipp/pull/1635>`_.
+  * Support loading/converting Mantid ``WorkspaceGroup``, this will produce a ``dict`` of data arrays `#1654 <https://github.com/scipp/scipp/pull/1654>`_.
+  * Fixes to support loading/converting ``McStasNexus`` files `#1659 <https://github.com/scipp/scipp/pull/1659>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-* The ``plot`` module has been renamed to ``plotting``, and plotting is now achieved via ``sc.plot(data)``. Wrapper functions ``superplot``, ``image``, and ``scatter3d`` have been dropped [#1696](https://github.com/scipp/scipp/pull/1696).
+* The ``plot`` module has been renamed to ``plotting``, and plotting is now achieved via ``sc.plot(data)``. Wrapper functions ``superplot``, ``image``, and ``scatter3d`` have been dropped `#1696 <https://github.com/scipp/scipp/pull/1696>`_.
 * ``scipp.neutron`` has been removed and is replaced by `scippneutron <https://scipp.github.io/scippneutron>`_
 * ``scipp.neutron`` (now ``scippneutron``)
 

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -25,6 +25,8 @@ Creation functions
    array
    scalar
    zeros
+   ones
+   empty
 
 Free functions
 ==============

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,6 +11,7 @@ pybind11_add_module(
   choose.cpp
   comparison.cpp
   counts.cpp
+  creation.cpp
   cumulative.cpp
   dataset.cpp
   detail.cpp

--- a/python/creation.cpp
+++ b/python/creation.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/variable/creation.h"
+
+#include "dtype.h"
+#include "pybind11.h"
+
+using namespace scipp;
+
+namespace py = pybind11;
+
+void init_creation(py::module &m) {
+  m.def("empty", [](const std::vector<Dim> &dims,
+                    const std::vector<scipp::index> &shape,
+                    const units::Unit &unit, const py::object &dtype,
+                    const bool variances) {
+    const auto dtype_ = scipp_dtype(dtype);
+    py::gil_scoped_release release;
+    return variable::empty(Dimensions(dims, shape), unit, dtype_, variances);
+  });
+  m.def("ones", [](const std::vector<Dim> &dims,
+                   const std::vector<scipp::index> &shape,
+                   const units::Unit &unit, const py::object &dtype,
+                   const bool variances) {
+    const auto dtype_ = scipp_dtype(dtype);
+    py::gil_scoped_release release;
+    return variable::ones(Dimensions(dims, shape), unit, dtype_, variances);
+  });
+}

--- a/python/scipp.cpp
+++ b/python/scipp.cpp
@@ -10,6 +10,7 @@ void init_buckets(py::module &);
 void init_choose(py::module &);
 void init_comparison(py::module &);
 void init_counts(py::module &);
+void init_creation(py::module &);
 void init_cumulative(py::module &);
 void init_dataset(py::module &);
 void init_detail(py::module &);
@@ -46,6 +47,7 @@ void init_core(py::module &m) {
   init_buckets(core);
   init_choose(core);
   init_counts(core);
+  init_creation(core);
   init_cumulative(core);
   init_dataset(core);
   init_groupby(core);

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
 from . import units, Unit, dtype, Variable
+from ._scipp import core as _cpp
 from typing import Any, Sequence, Union
 import numpy
 
@@ -12,6 +13,9 @@ def scalar(value: Any,
            dtype: type(dtype.float64) = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
+
+    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
+              :py:func:`scipp.empty` :py:func:`scipp.array`
 
     :param value: Initial value.
     :param variance: Optional, initial variance, Default=None
@@ -48,6 +52,9 @@ def zeros(*,
     Optionally can add default initialised variances.
     Only keyword arguments accepted.
 
+    :seealso: :py:func:`scipp.ones` :py:func:`scipp.empty`
+              :py:func:`scipp.scalar` :py:func:`scipp.array`
+
     :param dims: Dimension labels.
     :param shape: Dimension sizes.
     :param unit: Optional, unit of contents. Default=dimensionless
@@ -64,6 +71,52 @@ def zeros(*,
                     variances=variances)
 
 
+def ones(*,
+         dims: Sequence[str],
+         shape: Sequence[int],
+         unit: Unit = units.dimensionless,
+         dtype: type(dtype.float64) = dtype.float64,
+         variances: bool = False) -> Variable:
+    """Constructs a :class:`Variable` with values initialized to 1 with
+    given dimension labels and shape.
+
+    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.empty`
+              :py:func:`scipp.scalar` :py:func:`scipp.array`
+
+    :param dims: Dimension labels.
+    :param shape: Dimension sizes.
+    :param unit: Optional, unit of contents. Default=dimensionless
+    :param dtype: Optional, type of underlying data. Default=float64
+    :param variances: Optional, boolean flag, if True includes variances
+                      initialised to 1. Default=False
+    """
+    return _cpp.ones(dims, shape, unit, dtype, variances)
+
+
+def empty(*,
+          dims: Sequence[str],
+          shape: Sequence[int],
+          unit: Unit = units.dimensionless,
+          dtype: type(dtype.float64) = dtype.float64,
+          variances: bool = False) -> Variable:
+    """Constructs a :class:`Variable` with uninitialized values with given
+    dimension labels and shape. USE WITH CARE! Uninitialized means that values
+    have undetermined values. Consider using :py:func:`scipp.zeros` unless you
+    know what you are doing and require maximum performance.
+
+    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
+              :py:func:`scipp.scalar` :py:func:`scipp.array`
+
+    :param dims: Dimension labels.
+    :param shape: Dimension sizes.
+    :param unit: Optional, unit of contents. Default=dimensionless
+    :param dtype: Optional, type of underlying data. Default=float64
+    :param variances: Optional, boolean flag, if True includes uninitialized
+                      variances. Default=False
+    """
+    return _cpp.empty(dims, shape, unit, dtype, variances)
+
+
 def array(*,
           dims: Sequence[str],
           values: Union[numpy.ndarray, list],
@@ -73,6 +126,9 @@ def array(*,
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
+
+    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
+              :py:func:`scipp.empty` :py:func:`scipp.scalar`
 
     :param dims: Dimension labels.
     :param values: Initial values.

--- a/variable/creation.cpp
+++ b/variable/creation.cpp
@@ -4,10 +4,24 @@
 /// @author Simon Heybrock
 #include "scipp/core/element/creation.h"
 #include "scipp/variable/creation.h"
+#include "scipp/variable/shape.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/variable_factory.h"
 
 namespace scipp::variable {
+
+Variable empty(const Dimensions &dims, const units::Unit &unit,
+               const DType type, const bool variances) {
+  return variableFactory().create(type, dims, unit, variances);
+}
+
+Variable ones(const Dimensions &dims, const units::Unit &unit, const DType type,
+              const bool variances) {
+  const auto prototype =
+      variances ? Variable{type, Dimensions{}, unit, Values{1}, Variances{1}}
+                : Variable{type, Dimensions{}, unit, Values{1}};
+  return broadcast(prototype, dims);
+}
 
 /// Create empty (uninitialized) variable with same parameters as prototype.
 ///

--- a/variable/include/scipp/variable/creation.h
+++ b/variable/include/scipp/variable/creation.h
@@ -11,6 +11,15 @@
 namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+empty(const Dimensions &dims, const units::Unit &unit, const DType type,
+      const bool variances = false);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable ones(const Dimensions &dims,
+                                                  const units::Unit &unit,
+                                                  const DType type,
+                                                  const bool variances = false);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 empty_like(const VariableConstView &prototype,
            const std::optional<Dimensions> &shape = std::nullopt,
            const VariableConstView &sizes = {});

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -21,7 +21,7 @@ void expect_same_volume(const Dimensions &old_dims,
 }
 
 Variable broadcast(const VariableConstView &var, const Dimensions &dims) {
-  Variable result(var, dims);
+  auto result = variableFactory().empty_like(var, dims);
   result.data().copy(var, result);
   return result;
 }

--- a/variable/test/creation_test.cpp
+++ b/variable/test/creation_test.cpp
@@ -7,6 +7,30 @@
 #include "test_variables.h"
 
 using namespace scipp;
+using namespace scipp::variable;
+
+TEST(CreationTest, empty) {
+  const auto dims = Dimensions(Dim::X, 2);
+  const auto var1 = variable::empty(dims, units::m, dtype<double>, true);
+  EXPECT_EQ(var1.dims(), dims);
+  EXPECT_EQ(var1.unit(), units::m);
+  EXPECT_EQ(var1.dtype(), dtype<double>);
+  EXPECT_EQ(var1.hasVariances(), true);
+  const auto var2 = variable::empty(dims, units::s, dtype<int32_t>);
+  EXPECT_EQ(var2.dims(), dims);
+  EXPECT_EQ(var2.unit(), units::s);
+  EXPECT_EQ(var2.dtype(), dtype<int32_t>);
+  EXPECT_EQ(var2.hasVariances(), false);
+}
+
+TEST(CreationTest, ones) {
+  const auto dims = Dimensions(Dim::X, 2);
+  EXPECT_EQ(
+      variable::ones(dims, units::m, dtype<double>, true),
+      makeVariable<double>(dims, units::m, Values{1, 1}, Variances{1, 1}));
+  EXPECT_EQ(variable::ones(dims, units::s, dtype<int32_t>),
+            makeVariable<int32_t>(dims, units::s, Values{1, 1}));
+}
 
 TEST_P(DenseVariablesTest, empty_like_fail_if_sizes) {
   const auto var = GetParam();


### PR DESCRIPTION
- Add `empty` and `ones`.
- Avoid writing to memory twice in `broadcast`.