### PR TITLE
Avoid mutable default args in python

### DIFF
--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -112,7 +112,7 @@ def from_dict(dict_obj):
     :rtype: Variable, DataArray, or Dataset
     """
     keys_as_set = set(dict_obj.keys())
-    if ({"coords", "data"}.issubset(keys_as_set)):
+    if {"coords", "data"}.issubset(keys_as_set):
         # Case of a DataArray-like dict (most-likely)
         return _dict_to_data_array(dict_obj)
     elif (keys_as_set.issubset(
@@ -160,7 +160,7 @@ def _dict_to_data_array(d):
     Convert a python dict to a scipp DataArray.
     """
     d = dict(d)
-    if ("data" not in d):
+    if "data" not in d:
         raise KeyError("To create a DataArray, the supplied dict must contain "
                        "'data'. Got {}.".format(d.keys()))
     out = {"coords": {}, "masks": {}, "attrs": {}}

--- a/python/src/scipp/io/hdf5.py
+++ b/python/src/scipp/io/hdf5.py
@@ -18,7 +18,7 @@ def _dtype_lut():
     return dict(zip(names, dtypes))
 
 
-class NumpyDataIO():
+class NumpyDataIO:
     @staticmethod
     def write(group, data):
         dset = group.create_dataset('values', data=data.values)
@@ -34,7 +34,7 @@ class NumpyDataIO():
             group['variances'].read_direct(data.variances)
 
 
-class EigenDataIO():
+class EigenDataIO:
     @staticmethod
     def write(group, data):
         import numpy as np
@@ -51,7 +51,7 @@ class EigenDataIO():
             data.values = np.asarray(group['values'])
 
 
-class BinDataIO():
+class BinDataIO:
     @staticmethod
     def write(group, data):
         from .. import sum as sc_sum
@@ -83,7 +83,7 @@ class BinDataIO():
         return sc.bins(begin=begin, end=end, dim=dim, data=data)
 
 
-class ScippDataIO():
+class ScippDataIO:
     @staticmethod
     def write(group, data):
         values = group.create_group('values')
@@ -104,7 +104,7 @@ class ScippDataIO():
                 data.values[i] = HDF5IO.read(values[f'value-{i}'])
 
 
-class StringDataIO():
+class StringDataIO:
     @staticmethod
     def write(group, data):
         import h5py
@@ -137,7 +137,7 @@ def _check_scipp_header(group, what):
     if 'scipp-version' not in group.attrs:
         raise RuntimeError(
             "This does not look like an HDF5 file/group written by scipp.")
-    if (group.attrs['scipp-type'] != what):
+    if group.attrs['scipp-type'] != what:
         raise RuntimeError(
             f"Attempt to read {what}, found {group.attrs['scipp-type']}.")
 

--- a/python/src/scipp/plotting/controller3d.py
+++ b/python/src/scipp/plotting/controller3d.py
@@ -65,7 +65,6 @@ class PlotController3d(PlotController):
         the axes limits, as well as the extent of the positions which will be
         use to show an outline/box around the points in space.
         """
-        axparams = {}
         if self.positions is not None:
             extents = self.model.get_positions_extents(self.pixel_size)
             axparams = {

--- a/python/src/scipp/plotting/figure1d.py
+++ b/python/src/scipp/plotting/figure1d.py
@@ -29,7 +29,7 @@ class PlotFigure1d(PlotFigure):
                  masks=None,
                  figsize=None,
                  picker=False,
-                 legend={"show": True},
+                 legend=None,
                  padding=None,
                  xlabel=None,
                  ylabel=None):
@@ -42,6 +42,8 @@ class PlotFigure1d(PlotFigure):
                          ylabel=ylabel,
                          toolbar=PlotToolbar1d)
 
+        if legend is None:
+            legend = {"show": True}
         # Matplotlib line containers
         self.data_lines = {}
         self.mask_lines = {}

--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -302,7 +302,7 @@ void main() {
         for axis, x in enumerate('xyz'):
             ticks = ticker_.tick_values(lims[x][0], lims[x][1])
             for tick in ticks:
-                if tick >= lims[x][0] and tick <= lims[x][1]:
+                if lims[x][0] <= tick <= lims[x][1]:
                     tick_pos = iden[axis] * tick * axparams[x][
                         "scaling"] + offsets[x]
                     ticks_and_labels.add(

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -102,7 +102,6 @@ class PlotModel:
         # scaling.
         formatter = {"linear": None, "log": None, "custom_locator": False}
 
-        coord = None
         contains_strings = False
         contains_vectors = False
 

--- a/python/src/scipp/plotting/plot1d.py
+++ b/python/src/scipp/plotting/plot1d.py
@@ -41,7 +41,7 @@ class SciPlot1d(SciPlot):
                  scipp_obj_dict=None,
                  axes=None,
                  errorbars=None,
-                 masks={"color": "k"},
+                 masks=None,
                  ax=None,
                  pax=None,
                  figsize=None,
@@ -55,6 +55,8 @@ class SciPlot1d(SciPlot):
                  xlabel=None,
                  ylabel=None):
 
+        if masks is None:
+            masks = {"color": "k"}
         view_ndims = 1
 
         super().__init__(scipp_obj_dict=scipp_obj_dict,

--- a/python/src/scipp/plotting/sciplot.py
+++ b/python/src/scipp/plotting/sciplot.py
@@ -79,9 +79,9 @@ class SciPlot:
         if (self.ndim > view_ndims) or ((vmin is not None) and
                                         (vmax is not None)):
             self.extend_cmap = "both"
-        elif (vmin is not None):
+        elif vmin is not None:
             self.extend_cmap = "min"
-        elif (vmax is not None):
+        elif vmax is not None:
             self.extend_cmap = "max"
 
         # Scan the input data and collect information

--- a/python/src/scipp/plotting/view2d.py
+++ b/python/src/scipp/plotting/view2d.py
@@ -64,13 +64,14 @@ class PlotView2d(PlotView):
         """
         self.xlim_updated = False
         self.ylim_updated = False
-        xylims = {}
+        xylims = {
+            "x": np.clip(self.figure.ax.get_xlim(),
+                         *sorted(self.global_lims["x"])),
+            "y": np.clip(self.figure.ax.get_ylim(),
+                         *sorted(self.global_lims["y"]))
+        }
 
         # Make sure we don't overrun the original array bounds
-        xylims["x"] = np.clip(self.figure.ax.get_xlim(),
-                              *sorted(self.global_lims["x"]))
-        xylims["y"] = np.clip(self.figure.ax.get_ylim(),
-                              *sorted(self.global_lims["y"]))
 
         dx = np.abs(self.current_lims["x"][1] - self.current_lims["x"][0])
         dy = np.abs(self.current_lims["y"][1] - self.current_lims["y"][0])

--- a/python/src/scipp/plotting/view2d.py
+++ b/python/src/scipp/plotting/view2d.py
@@ -64,14 +64,14 @@ class PlotView2d(PlotView):
         """
         self.xlim_updated = False
         self.ylim_updated = False
+
+        # Make sure we don't overrun the original array bounds
         xylims = {
             "x": np.clip(self.figure.ax.get_xlim(),
                          *sorted(self.global_lims["x"])),
             "y": np.clip(self.figure.ax.get_ylim(),
                          *sorted(self.global_lims["y"]))
         }
-
-        # Make sure we don't overrun the original array bounds
 
         dx = np.abs(self.current_lims["x"][1] - self.current_lims["x"][0])
         dy = np.abs(self.current_lims["y"][1] - self.current_lims["y"][0])

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -121,8 +121,10 @@ class VariableDrawer:
         height += 0.3 * depth
         return [width, height]
 
-    def _draw_array(self, color, offset=[0, 0]):
+    def _draw_array(self, color, offset=None):
         """Draw the array of boxes"""
+        if offset is None:
+            offset = [0, 0]
         dx = offset[0]
         dy = offset[1] + 0.3  # extra offset for top face of top row of cubes
         svg = ''


### PR DESCRIPTION
Found a few more cases of mutable default arg values, and cleaned up some superfluous parentheses whilst I was at it.