### PR TITLE
Add checks ensuring that llnl/units exponents do not overflow or underflow

### DIFF
--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -31,6 +31,18 @@ TEST(UnitTest, construct_bad_string) {
   EXPECT_THROW(Unit("abcde"), except::UnitError);
 }
 
+TEST(UnitTest, overflows) {
+  // These would run out of bits in llnl/units and wrap, ensure that scipp
+  // prevents this and throws instead.
+  Unit m4{units::m * units::m * units::m * units::m};
+  Unit inv_m8{units::one / m4 / m4};
+  EXPECT_THROW(m4 * m4, except::UnitError);
+  EXPECT_THROW(units::one / inv_m8, except::UnitError);
+  EXPECT_THROW(inv_m8 / units::m, except::UnitError);
+  EXPECT_THROW(inv_m8 % units::m, except::UnitError);
+  EXPECT_THROW(pow(units::m, 8), except::UnitError);
+}
+
 TEST(UnitTest, compare) {
   Unit u1{units::dimensionless};
   Unit u2{units::m};

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -105,6 +105,13 @@ TEST(UnitTest, divide_counts) {
   EXPECT_EQ(counts / counts, units::dimensionless);
 }
 
+TEST(UnitTest, pow) {
+  EXPECT_EQ(pow(units::m, 0), units::one);
+  EXPECT_EQ(pow(units::m, 1), units::m);
+  EXPECT_EQ(pow(units::m, 2), units::m * units::m);
+  EXPECT_EQ(pow(units::m, -1), units::one / units::m);
+}
+
 TEST(UnitTest, neutron_units) {
   Unit c(units::c);
   EXPECT_EQ(c * units::m, Unit(units::c * units::m));

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -146,6 +146,10 @@ TEST(UnitFunctionsTest, sqrt) {
   EXPECT_EQ(sqrt(units::one), units::one);
   EXPECT_THROW_MSG(sqrt(units::m), except::UnitError,
                    "Unsupported unit as result of sqrt: sqrt(m).");
+  EXPECT_THROW_MSG(sqrt(units::Unit("J")), except::UnitError,
+                   "Unsupported unit as result of sqrt: sqrt(J).");
+  EXPECT_THROW_MSG(sqrt(units::Unit("eV")), except::UnitError,
+                   "Unsupported unit as result of sqrt: sqrt(eV).");
 }
 
 TEST(UnitFunctionsTest, sin) {

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include <units/units.hpp>
+#include <units/units_util.hpp>
 
 #include "scipp/units/except.h"
 #include "scipp/units/unit.h"
@@ -63,19 +64,17 @@ Unit operator-(const Unit &a, const Unit &b) {
 }
 
 Unit operator*(const Unit &a, const Unit &b) {
-  auto out = Unit{a.underlying() * b.underlying()};
-  if (out == llnl::units::precise::error)
+  if (llnl::units::times_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of multiplication: (" +
                             a.name() + ") * (" + b.name() + ')');
-  return out;
+  return {a.underlying() * b.underlying()};
 }
 
 Unit operator/(const Unit &a, const Unit &b) {
-  auto out = Unit{a.underlying() / b.underlying()};
-  if (out == llnl::units::precise::error)
+  if (llnl::units::divides_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of division: (" +
                             a.name() + ") / (" + b.name() + ')');
-  return out;
+  return {a.underlying() / b.underlying()};
 }
 
 Unit operator%(const Unit &a, const Unit &b) { return a / b; }
@@ -93,11 +92,10 @@ Unit sqrt(const Unit &a) {
 }
 
 Unit pow(const Unit &a, const int64_t power) {
-  auto out = Unit{a.underlying().pow(power)};
-  if (out == llnl::units::precise::error)
+  if (llnl::units::pow_overflows(a.underlying(), power))
     throw except::UnitError("Unsupported unit as result of pow: pow(" +
                             a.name() + ", " + std::to_string(power) + ").");
-  return out;
+  return {a.underlying().pow(power)};
 }
 
 Unit trigonometric(const Unit &a) {

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -84,11 +84,10 @@ Unit operator-(const Unit &a) { return a; }
 Unit abs(const Unit &a) { return a; }
 
 Unit sqrt(const Unit &a) {
-  auto out = Unit{sqrt(a.underlying())};
-  if (out == llnl::units::precise::error)
+  if (llnl::units::is_error(sqrt(a.underlying())))
     throw except::UnitError("Unsupported unit as result of sqrt: sqrt(" +
                             a.name() + ").");
-  return out;
+  return {sqrt(a.underlying())};
 }
 
 Unit pow(const Unit &a, const int64_t power) {


### PR DESCRIPTION
My PR for addition of the required helpers has been merged upstream, so we can now have working checks here. The old one checking for error unit didn't actually have the desired effect, since llnl/units just silently overflows/underflows.