### PR TITLE
Allow construction of datetimes from int

### DIFF
--- a/core/include/scipp/core/tag_util.h
+++ b/core/include/scipp/core/tag_util.h
@@ -7,6 +7,7 @@
 #include <array>
 
 #include "scipp/core/dtype.h"
+#include "scipp/core/except.h"
 
 namespace scipp::core {
 
@@ -32,7 +33,7 @@ static auto callDType(const std::tuple<Ts...> &, const DType dtype,
   for (size_t i = 0; i < dtypes.size(); ++i)
     if (dtypes[i] == dtype)
       return funcs[i](std::forward<Args>(args)...);
-  throw std::runtime_error("Unsupported dtype.");
+  throw except::TypeError("Unsupported dtype.");
 }
 
 /// Apply Callable<T> to args, for any dtype T in Ts, determined by the

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -70,7 +70,7 @@ parse_datetime_dtype(const std::string &dtype_name) {
   std::smatch match;
   if (!std::regex_match(dtype_name, match, datetime_regex) ||
       match.size() != 3) {
-    throw std::invalid_argument("Invalid dtype, expected datetime64, got" +
+    throw std::invalid_argument("Invalid dtype, expected datetime64, got " +
                                 dtype_name);
   }
 

--- a/python/make_variable.h
+++ b/python/make_variable.h
@@ -56,19 +56,35 @@ template <class ST> struct MakeODFromNativePythonTypes {
   template <class T> struct Maker {
     static Variable apply(const units::Unit unit, const ST &value,
                           const std::optional<ST> &variance) {
-      auto var = variance ? makeVariable<T>(Values{T(value)},
-                                            Variances{T(variance.value())})
-                          : makeVariable<T>(Values{T(value)});
-      var.setUnit(unit);
-      return var;
+      if constexpr (std::is_same_v<T, core::time_point>) {
+        if constexpr (std::is_integral_v<ST>) {
+          if (variance.has_value()) {
+            throw except::VariancesError("datetimes cannot have variances.");
+          }
+          return makeVariable<core::time_point>(Values{core::time_point{value}},
+                                                unit);
+        } else {
+          throw except::TypeError(
+              "Unsupported dtype for constructing datetime64: " +
+              to_string(core::dtype<ST>));
+        }
+      } else {
+        auto var = variance ? makeVariable<T>(Values{T(value)},
+                                              Variances{T(variance.value())})
+                            : makeVariable<T>(Values{T(value)});
+        var.setUnit(unit);
+        return var;
+      }
     }
   };
 
   static Variable make(const units::Unit unit, const ST &value,
                        const std::optional<ST> &variance,
                        const py::object &dtype) {
-    return core::CallDType<double, float, int64_t, int32_t, bool>::apply<Maker>(
-        scipp_dtype(dtype), unit, value, variance);
+    return core::CallDType<double, float, int64_t, int32_t, bool,
+                           core::time_point>::apply<Maker>(scipp_dtype(dtype),
+                                                           unit, value,
+                                                           variance);
   }
 };
 

--- a/python/make_variable.h
+++ b/python/make_variable.h
@@ -146,6 +146,7 @@ Variable doMakeVariable(const std::vector<Dim> &labels, py::array &values,
       throw except::VariancesError("datetimes cannot have variances.");
     }
     const auto [actual_unit, value_factor] = get_time_unit(values, dtype, unit);
+
     if (value_factor != 1) {
       throw std::invalid_argument(
           "Scaling datetimes is not supported. The units of the datetime64 "

--- a/python/numpy.cpp
+++ b/python/numpy.cpp
@@ -10,6 +10,9 @@
 void ElementTypeMap<scipp::core::time_point>::check_assignable(
     const py::object &obj, const units::Unit unit) {
   const auto &dtype = obj.cast<py::array>().dtype();
+  if (dtype.attr("kind").cast<char>() == 'i') {
+    return; // just assume we can assign from int
+  }
   const auto np_unit =
       parse_datetime_dtype(dtype.attr("name").cast<std::string>());
   if (np_unit != unit) {

--- a/python/tests/test_datetime.py
+++ b/python/tests/test_datetime.py
@@ -61,6 +61,16 @@ def test_construct_0d_datetime(unit):
         assert var.value.dtype == dtype
 
 
+@pytest.mark.parametrize("unit", _UNIT_STRINGS)
+def test_construct_0d_datetime_from_int(unit):
+    value = np.random.randint(0, 1000)
+    var = sc.Variable(dtype=sc.dtype.datetime64, unit=unit, value=value)
+    assert var.dtype == sc.dtype.datetime64
+    assert var.unit == unit
+    assert var.value.dtype == f'datetime64[{unit}]'
+    assert var.value == np.datetime64(value, unit)
+
+
 @pytest.mark.parametrize("unit1,unit2", _mismatch_pairs(_UNIT_STRINGS))
 def test_construct_0d_datetime_mismatch(unit1, unit2):
     with pytest.raises(ValueError):
@@ -128,6 +138,20 @@ def test_construct_datetime(unit):
         assert str(var.dtype) == 'datetime64'
         assert var.unit == unit
         assert var.values.dtype == dtype
+
+
+@pytest.mark.parametrize("unit", _UNIT_STRINGS)
+def test_construct_datetime_from_int(unit):
+    values = np.random.randint(0, 1000, np.random.randint(5, 100))
+    var = sc.Variable(dims=['x'],
+                      dtype=sc.dtype.datetime64,
+                      unit=unit,
+                      values=values)
+    dtype_str = f'datetime64[{unit}]'
+    assert var.dtype == sc.dtype.datetime64
+    assert var.unit == unit
+    assert var.values.dtype == dtype_str
+    np.testing.assert_array_equal(var.values, values.astype(dtype_str))
 
 
 @pytest.mark.parametrize("unit1,unit2", _mismatch_pairs(_UNIT_STRINGS))

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -53,11 +53,13 @@ get_time_unit(const std::optional<scipp::units::Unit> value_unit,
 std::tuple<units::Unit, int64_t> get_time_unit(const py::buffer &value,
                                                const py::object &dtype,
                                                const units::Unit unit) {
-  return get_time_unit(value.is_none() ? std::optional<units::Unit>{}
-                                       : parse_datetime_dtype(value),
-                       dtype.is_none() ? std::optional<units::Unit>{}
-                                       : parse_datetime_dtype(dtype),
-                       unit);
+  return get_time_unit(
+      value.is_none() || value.attr("dtype").attr("kind").cast<char>() != 'M'
+          ? std::optional<units::Unit>{}
+          : parse_datetime_dtype(value),
+      dtype.is_none() ? std::optional<units::Unit>{}
+                      : parse_datetime_dtype(dtype),
+      unit);
 }
 
 std::string to_string_ascii_time(const scipp::units::Unit unit) {

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -98,7 +98,6 @@ void bind_init_0D_numpy_types(py::class_<Variable> &c) {
                 unit);
           } else if ((info.ndim == 1) &&
                      py::isinstance(b.get_type(), np_datetime64_type)) {
-            // TODO allow construction from int
             if (v.has_value()) {
               throw except::VariancesError("datetimes cannot have variances.");
             }


### PR DESCRIPTION
Convert ints in Variable constructors to datetime in Python bindings.

This should simplify the construction of Variables when the data does not already come in the form of  `np.datetime64` objects.