### PR TITLE
Avoid static-initialization order problem

### DIFF
--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -6,6 +6,7 @@
 
 #include <limits>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -4,56 +4,67 @@
 /// @author Simon Heybrock
 #include <limits>
 #include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
 
 #include "scipp/common/index.h"
 #include "scipp/units/dim.h"
 
 namespace scipp::units {
 
-std::unordered_map<std::string, Dim::Id> Dim::builtin_ids{
-    {"energy", Dim::Energy},
-    {"event", Dim::Event},
-    {"group", Dim::Group},
-    {"<invalid>", Dim::Invalid},
-    {"position", Dim::Position},
-    {"row", Dim::Row},
-    {"temperature", Dim::Temperature},
-    {"time", Dim::Time},
-    {"wavelength", Dim::Wavelength},
-    {"x", Dim::X},
-    {"y", Dim::Y},
-    {"z", Dim::Z}};
+namespace {
+const auto &builtin_ids() {
+  static std::unordered_map<std::string, Dim::Id> ids{
+      {"energy", Dim::Energy},
+      {"event", Dim::Event},
+      {"group", Dim::Group},
+      {"<invalid>", Dim::Invalid},
+      {"position", Dim::Position},
+      {"row", Dim::Row},
+      {"temperature", Dim::Temperature},
+      {"time", Dim::Time},
+      {"wavelength", Dim::Wavelength},
+      {"x", Dim::X},
+      {"y", Dim::Y},
+      {"z", Dim::Z}};
+  return ids;
+}
 
-std::unordered_map<std::string, Dim::Id> Dim::custom_ids;
-std::shared_mutex Dim::mutex;
+auto &custom_ids() {
+  static std::unordered_map<std::string, Dim::Id> ids;
+  return ids;
+}
+
+std::shared_mutex mutex;
+} // namespace
 
 Dim::Dim(const std::string &label) {
-  if (const auto it = builtin_ids.find(label); it != builtin_ids.end()) {
+  if (const auto it = builtin_ids().find(label); it != builtin_ids().end()) {
     m_id = it->second;
     return;
   }
   std::shared_lock read_lock(mutex);
-  if (const auto it = custom_ids.find(label); it != custom_ids.end()) {
+  if (const auto it = custom_ids().find(label); it != custom_ids().end()) {
     m_id = it->second;
     return;
   }
   read_lock.unlock();
   const std::unique_lock write_lock(mutex);
-  const auto id = scipp::size(custom_ids) + 1000;
+  const auto id = scipp::size(custom_ids()) + 1000;
   if (id > std::numeric_limits<std::underlying_type<Id>::type>::max())
     throw std::runtime_error(
         "Exceeded maximum number of different dimension labels.");
   m_id = static_cast<Id>(id);
-  custom_ids[label] = m_id;
+  custom_ids()[label] = m_id;
 }
 
 std::string Dim::name() const {
   if (static_cast<int64_t>(m_id) < 1000)
-    for (const auto &item : builtin_ids)
+    for (const auto &item : builtin_ids())
       if (item.second == m_id)
         return item.first;
   const std::shared_lock read_lock(mutex);
-  for (const auto &item : custom_ids)
+  for (const auto &item : custom_ids())
     if (item.second == m_id)
       return item.first;
   return "unreachable"; // throw or terminate?

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <functional>
-#include <shared_mutex>
-#include <unordered_map>
 
 #include "scipp-units_export.h"
 
@@ -61,9 +59,6 @@ public:
 
 private:
   Id m_id;
-  static std::unordered_map<std::string, Id> builtin_ids;
-  static std::unordered_map<std::string, Id> custom_ids;
-  static std::shared_mutex mutex;
 };
 
 SCIPP_UNITS_EXPORT std::string to_string(const Dim dim);


### PR DESCRIPTION
Still not sure whether this is causing the problems in scippneutron (still cannot reproduce), but I have a hunch that `builtin_ids` might not be initialized in time.