### PR TITLE
Allow sc.show with non-dim coords

### DIFF
--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -389,10 +389,16 @@ class DatasetDrawer:
                         area_y.append(item)
                     elif var.dims[-1] == dims[-3]:
                         area_z.append(item)
+                    else:
+                        # dirty hack to trigger error handling below
+                        raise IndexError()
                 except IndexError:
-                    # Happens whe var.dims[-1] does not match any of dims and
+                    # Happens when var.dims[-1] does not match any of dims and
                     # the DataArray has < 3 dimensions.
-                    pass
+                    raise sc.DimensionError(
+                        "Cannot show DataArray, it contains a coordinate with"
+                        f" a dimension label ('{var.dims[-1]}') that is not "
+                        "contained in the data") from None
 
         def draw_area(area, layout_direction, reverse=False, truncate=False):
             number_of_items = len(area)

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -380,14 +380,19 @@ class DatasetDrawer:
         for what, items in categories:
             for name, var in items.items():
                 item = DrawerItem(name, var, config.colors[what])
-                if len(var.dims) == 0:
-                    area_0d.append(item)
-                elif var.dims[-1] == dims[-1]:
-                    area_x.append(item)
-                elif var.dims[-1] == dims[-2]:
-                    area_y.append(item)
-                else:
-                    area_z.append(item)
+                try:
+                    if len(var.dims) == 0:
+                        area_0d.append(item)
+                    elif var.dims[-1] == dims[-1]:
+                        area_x.append(item)
+                    elif var.dims[-1] == dims[-2]:
+                        area_y.append(item)
+                    elif var.dims[-1] == dims[-3]:
+                        area_z.append(item)
+                except IndexError:
+                    # Happens whe var.dims[-1] does not match any of dims and
+                    # the DataArray has < 3 dimensions.
+                    pass
 
         def draw_area(area, layout_direction, reverse=False, truncate=False):
             number_of_items = len(area)


### PR DESCRIPTION
EDIT
Changed to throw a `DimensionError` instead of just not showing coords in the SVG.

Not sure if this still fixes issue #1499.