### PR TITLE
Disable altera-struct-pack-align diagnostic

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks:            '*,
                     -android-*,
+                    -altera-struct-pack-align,
                     -bugprone-bool-pointer-implicit-conversion,
                     -bugprone-exception-escape,
                     -bugprone-infinite-loop,


### PR DESCRIPTION
The diagnostic warns about the alignment of classes. This could be useful for optimisation. But it warns about every empty class that it should be aligned to 0 bytes, which is nonsense and happens quite a lot in scipp.