### PR TITLE
Add stddevs

### DIFF
--- a/cmake/LLNL-units.in
+++ b/cmake/LLNL-units.in
@@ -9,7 +9,7 @@ include(ExternalProject)
 externalproject_add(
   llnl-units
   GIT_REPOSITORY https://github.com/SimonHeybrock/units.git
-  GIT_TAG origin/dev
+  GIT_TAG origin/master
   SOURCE_DIR "${CMAKE_BINARY_DIR}/llnl-units-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/llnl-units-build"
   CONFIGURE_COMMAND ""

--- a/cmake/scipp-functions.cmake
+++ b/cmake/scipp-functions.cmake
@@ -14,6 +14,7 @@ setup_scipp_category(math)
 
 scipp_unary(util values NO_OUT)
 scipp_unary(util variances NO_OUT)
+scipp_unary(util stddevs NO_OUT)
 setup_scipp_category(util)
 
 scipp_unary(trigonometry sin SKIP_VARIABLE)

--- a/cmake/scipp-functions.cmake
+++ b/cmake/scipp-functions.cmake
@@ -12,8 +12,8 @@ scipp_unary(math reciprocal)
 scipp_unary(math sqrt)
 setup_scipp_category(math)
 
-scipp_unary(util values SKIP_VARIABLE NO_OUT)
-scipp_unary(util variances SKIP_VARIABLE NO_OUT)
+scipp_unary(util values NO_OUT)
+scipp_unary(util variances NO_OUT)
 setup_scipp_category(util)
 
 scipp_unary(trigonometry sin SKIP_VARIABLE)

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -81,6 +81,18 @@ constexpr auto variances = overloaded{
     },
     [](const units::Unit &u) { return u * u; }};
 
+constexpr auto stddevs = overloaded{
+    transform_flags::no_out_variance, core::element::arg_list<double, float>,
+    transform_flags::expect_variance_arg<0>,
+    [](const auto &x) {
+      using std::sqrt;
+      if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
+        return sqrt(x.variance);
+      else
+        return sqrt(x); // unreachable but required for instantiation
+    },
+    [](const units::Unit &u) { return u; }};
+
 constexpr auto is_sorted_common = overloaded{
     core::element::arg_list<
         std::tuple<bool, double, double>, std::tuple<bool, float, float>,

--- a/core/test/element_util_test.cpp
+++ b/core/test/element_util_test.cpp
@@ -65,13 +65,16 @@ TEST(ElementUtilTest, convertMaskedToZero_accepts_all_types) {
       std::is_same_v<decltype(convertMaskedToZero(int64_t{}, true)), int64_t>);
 }
 
-TEST(ElementUtilTest, values_variances) {
+TEST(ElementUtilTest, values_variances_stddev) {
   ValueAndVariance x{1.0, 2.0};
   EXPECT_EQ(values(units::m), units::m);
   EXPECT_EQ(values(x), 1.0);
   EXPECT_EQ(values(1.2), 1.2);
   EXPECT_EQ(variances(units::m), units::m * units::m);
   EXPECT_EQ(variances(x), 2.0);
+  EXPECT_EQ(stddevs(units::m), units::m);
+  EXPECT_EQ(stddevs(units::counts), units::counts);
+  EXPECT_EQ(stddevs(x), sqrt(2.0));
 }
 
 namespace {

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -27,6 +27,7 @@ Features
   * Support loading/converting Mantid ``WorkspaceGroup``, this will produce a ``dict`` of data arrays `#1654 <https://github.com/scipp/scipp/pull/1654>`_.
   * Fixes to support loading/converting ``McStasNexus`` files `#1659 <https://github.com/scipp/scipp/pull/1659>`_.
 * ``isclose`` added (``is_approx`` removed). Fuzzy data comparison ``isclose`` is an analogue to numpy's ``isclose``
+* ``stddevs`` added `#1762 <https://github.com/scipp/scipp/pull/1762>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -54,6 +54,7 @@ General
    slices
    sort
    sqrt
+   stddevs
    to_unit
    values
    variances

--- a/python/operations.cpp
+++ b/python/operations.cpp
@@ -115,20 +115,6 @@ void init_operations(py::module &m) {
   bind_sort_variable<Variable>(m);
   bind_is_sorted(m);
 
-  m.def("values", variable::values,
-        Docstring()
-            .description("Return the variable without variances.")
-            .seealso(":py:func:`scipp.variances`")
-            .c_str(),
-        py::call_guard<py::gil_scoped_release>());
-  m.def("variances", variable::variances,
-        Docstring()
-            .description("Return variable containing the variances of the "
-                         "input as values.")
-            .seealso(":py:func:`scipp.values`")
-            .c_str(),
-        py::call_guard<py::gil_scoped_release>());
-
   m.def("get_slice_params",
         [](const VariableConstView &var, const VariableConstView &coord,
            const VariableConstView &begin, const VariableConstView &end) {

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -123,6 +123,7 @@ def isclose(x, y, rtol=None, atol=None, equal_nan=False):
     be within the computed tolerance limits. That is:
 
     .. code-block:: python
+
         abs(x.value - y.value) <= atol + rtol * abs(y.value) and abs(
             sqrt(x.variance) - sqrt(y.variance)) \
                 <= atol + rtol * abs(sqrt(y.variance))

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -20,3 +20,32 @@ def sort(x, key, order='ascending'):
     :return: The sorted equivalent of the input.
     """
     return _call_cpp_func(_cpp.sort, x, key, order)
+
+
+def values(x):
+    """Return the object without variances.
+
+    :param x: Variable or DataArray
+    :seealso: :py:func:`scipp.variances`, :py:func:`scipp.stddevs`.
+    """
+    return _call_cpp_func(_cpp.values, x)
+
+
+def variances(x):
+    """Return object containing the variances of the input as values.
+
+    :param x: Variable or DataArray
+    :seealso: :py:func:`scipp.values`, :py:func:`scipp.stddevs`.
+    """
+    return _call_cpp_func(_cpp.variances, x)
+
+
+def stddevs(x):
+    """Return object containing the stddevs of the input as values.
+
+    This is essentially `sqrt(variances(x))`
+
+    :param x: Variable or DataArray
+    :seealso: :py:func:`scipp.values`, :py:func:`scipp.stddevs`.
+    """
+    return _call_cpp_func(_cpp.stddevs, x)

--- a/python/src/scipp/_unary.py
+++ b/python/src/scipp/_unary.py
@@ -46,8 +46,9 @@ def to_unit(x: _cpp.Variable, unit: Union[_cpp.Unit, str]) -> _cpp.Variable:
     Convert the variable to a different unit.
 
     Example:
-    .. highlight:: python
+
     .. code-block:: python
+
         var = 1.2 * sc.Unit('m')
         var_in_mm = sc.to_unit(var, unit='mm')
 

--- a/variable/comparison.cpp
+++ b/variable/comparison.cpp
@@ -23,8 +23,7 @@ Variable isclose(const VariableConstView &a, const VariableConstView &b,
   auto tol = atol + rtol * abs(b);
   if (a.hasVariances() && b.hasVariances()) {
     return isclose(values(a), values(b), rtol, atol, equal_nans) &
-           isclose(sqrt(variances(a)), sqrt(variances(b)), rtol, atol,
-                   equal_nans);
+           isclose(stddevs(a), stddevs(b), rtol, atol, equal_nans);
   } else {
     if (equal_nans == NanComparisons::Equal)
       return variable::transform(a, b, _values(std::move(tol)),

--- a/variable/include/scipp/variable/util.h
+++ b/variable/include/scipp/variable/util.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "scipp-variable_export.h"
+#include "scipp/variable/generated_util.h"
 #include "scipp/variable/variable.h"
 
 namespace scipp::variable {
@@ -15,10 +16,6 @@ linspace(const VariableConstView &start, const VariableConstView &stop,
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 is_linspace(const VariableConstView &var, const Dim dim);
-
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable values(const VariableConstView &x);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-variances(const VariableConstView &x);
 
 enum class SCIPP_VARIABLE_EXPORT SortOrder { Ascending, Descending };
 

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -54,6 +54,13 @@ TYPED_TEST(IsCloseTest, rtol_when_variables_outside_tolerance) {
   EXPECT_EQ(isclose(a, b, rtol, atol), false * units::one);
 }
 
+TEST(IsCloseTest, works_for_counts) {
+  const auto a = makeVariable<double>(Values{1}, Variances{1}, units::counts);
+  const auto rtol = 1e-5 * units::one;
+  const auto atol = 0.0 * units::counts;
+  EXPECT_NO_THROW_DISCARD(isclose(a, a, rtol, atol));
+}
+
 TEST(IsCloseTest, compare_variances_only) {
   // Tests setup so that value comparison does not affect output (a, b value
   // same)

--- a/variable/util.cpp
+++ b/variable/util.cpp
@@ -46,13 +46,6 @@ Variable is_linspace(const VariableConstView &var, const Dim dim) {
                    "is_linspace");
 }
 
-Variable values(const VariableConstView &x) {
-  return transform(x, element::values);
-}
-Variable variances(const VariableConstView &x) {
-  return transform(x, element::variances);
-}
-
 /// Return true if variable values are sorted along given dim.
 ///
 /// If `order` is SortOrder::Ascending, checks if values are non-decreasing.


### PR DESCRIPTION
Works around a problem with `isclose` which would otherwise throw `UnitError` since `counts**2` is currently not supported by our units library.