### PR TITLE
Minor docs update

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,13 @@ Generic functionality of scipp is provided in the **scipp** Python module.
 In addition, more specific functionality is made available in other modules.
 Currently the only example for this is `scippneutron <https://scipp.github.io/scippneutron>`_ for handling data from neutron-scattering experiments.
 
+News
+----
+
+- Scipp is moving from GPLv3 to the more permissive BSD-3 license which fits better into the Python eco system.
+- Looking for ``scipp.neutron``?
+  This submodule has been moved into its own package, `scippneutron <https://scipp.github.io/scippneutron>`_.
+
 Where can I get help?
 ---------------------
 

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -63,6 +63,13 @@
    "source": [
     "sc.Unit('m/s')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To convert data between units, such as `m` to `mm`, see [sc.to_unit](../generated/scipp.to_unit.html#scipp.to-unit)."
+   ]
   }
  ],
  "metadata": {
@@ -81,9 +88,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -212,9 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(scalar.value)\n",
@@ -438,9 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.show(d['a'])\n",
@@ -605,9 +601,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- Add news to front page. This is NOT meant as including all or even a fraction of the release notes, rather relevant items that may be pinned even longer than a release.
- Refer to `to_unit` to make it more findable.