### PR TITLE
Disable ufunc

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -47,28 +47,6 @@ std::vector<ssize_t> numpy_strides(const std::vector<scipp::index> &s) {
   return strides;
 }
 
-template <class T> struct MakePyBufferInfoT {
-  static py::buffer_info apply(VariableView &view) {
-    const auto &dims = view.dims();
-    return py::buffer_info(
-        view.template values<T>().data(), /* Pointer to buffer */
-        sizeof(T),                        /* Size of one scalar */
-        py::format_descriptor<
-            std::conditional_t<std::is_same_v<T, bool>, bool, T>>::
-            format(),              /* Python struct-style format descriptor */
-        scipp::size(dims.shape()), /* Number of dimensions */
-        dims.shape(),              /* Buffer dimensions */
-        numpy_strides<T>(view.strides()) /* Strides (in bytes) for each index */
-    );
-  }
-};
-
-inline py::buffer_info make_py_buffer_info(VariableView &view) {
-  return core::CallDType<double, float, int64_t, int32_t,
-                         scipp::core::time_point,
-                         bool>::apply<MakePyBufferInfoT>(view.dtype(), view);
-}
-
 template <class... Ts> class as_ElementArrayViewImpl;
 
 class DataAccessHelper {

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -92,3 +92,12 @@ setattr(DataArray, 'plot', plot)
 setattr(DataArrayConstView, 'plot', plot)
 setattr(Dataset, 'plot', plot)
 setattr(DatasetConstView, 'plot', plot)
+
+# Prevent unwanted conversion to numpy arrays by operations. Properly defining
+# __array_ufunc__ should be possible by converting non-scipp arguments to
+# variables. The most difficult part is probably mapping the ufunc to scipp
+# functions.
+for obj in [
+        Variable, VariableView, DataArray, DataArrayView, Dataset, DatasetView
+]:
+    setattr(obj, '__array_ufunc__', None)

--- a/python/tests/test_numpy.py
+++ b/python/tests/test_numpy.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import pytest
 import numpy as np
 import scipp as sc
 
@@ -67,3 +68,23 @@ def test_numpy_self_assign_shift_2d_flip_second():
     var['y', 1:3]['x', 1:3].values = np.flip(var['y', 0:2]['x', 0:2].values,
                                              axis=1)
     assert sc.is_equal(var, expected)
+
+
+a = np.arange(2)
+var = sc.Variable(dims=['x'], values=a)
+arr = sc.DataArray(var)
+ds = sc.Dataset({'a': arr})
+
+
+@pytest.mark.parametrize("obj",
+                         [var, var['x', :], arr, arr['x', :], ds, ds['x', :]])
+def test__array_ufunc___disabled(obj):
+    with pytest.raises(TypeError, match="does not support ufuncs"):
+        obj + a
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        a * obj
+    with pytest.raises(TypeError, match="does not support ufuncs"):
+        obj += a
+    with pytest.raises(TypeError, match="does not support ufuncs"):
+        b = np.arange(2)
+        b += obj

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -219,11 +219,10 @@ of variances.)");
       .def("__sizeof__",
            py::overload_cast<const VariableConstView &>(&size_of));
 
-  py::class_<VariableView, VariableConstView> variableView(
-      m, "VariableView", py::buffer_protocol(), R"(
+  py::class_<VariableView, VariableConstView> variableView(m, "VariableView",
+                                                           R"(
 View for Variable, representing a sliced or transposed view onto a variable;
 Mostly equivalent to Variable, see there for details.)");
-  variableView.def_buffer(&make_py_buffer_info);
   variableView.def(py::init<Variable &>())
       .def(
           "__radd__",


### PR DESCRIPTION
- Fixes #1740 by setting `__array_ufunc__` to `None`.
- Remove `buffer_protocol` support from `VariableView`. This was responsible for `numpy_array + var` working (but returning a numpy array). This does not seem very useful, since it was the same as `numpy_array + var.values`, but *silently* ignored variances. We should rather properly support `__array_ufunc__` so we can handle variances and return a scipp object. 