### PR TITLE
Fix ODR violations in Clang from dtype specialisations

### DIFF
--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -33,57 +33,69 @@ struct SCIPP_CORE_EXPORT DType {
 // force compiler error if not specialized
 template <class T> constexpr DType dtype{T::missing_specialization_of_dtype};
 // basics types start at 0
-template <> constexpr DType dtype<void>{0};
-template <> constexpr DType dtype<double>{1};
-template <> constexpr DType dtype<float>{2};
-template <> constexpr DType dtype<int64_t>{3};
-template <> constexpr DType dtype<int32_t>{4};
-template <> constexpr DType dtype<bool>{5};
-template <> constexpr DType dtype<std::string>{6};
-template <> constexpr DType dtype<time_point>{7};
-template <> constexpr DType dtype<Eigen::Vector3d>{8};
-template <> constexpr DType dtype<Eigen::Matrix3d>{9};
+template <> inline constexpr DType dtype<void>{0};
+template <> inline constexpr DType dtype<double>{1};
+template <> inline constexpr DType dtype<float>{2};
+template <> inline constexpr DType dtype<int64_t>{3};
+template <> inline constexpr DType dtype<int32_t>{4};
+template <> inline constexpr DType dtype<bool>{5};
+template <> inline constexpr DType dtype<std::string>{6};
+template <> inline constexpr DType dtype<time_point>{7};
+template <> inline constexpr DType dtype<Eigen::Vector3d>{8};
+template <> inline constexpr DType dtype<Eigen::Matrix3d>{9};
 class SubbinSizes;
-template <> constexpr DType dtype<SubbinSizes>{10};
+template <> inline constexpr DType dtype<SubbinSizes>{10};
 // span<T> start at 100
-template <> constexpr DType dtype<span<const double>>{100};
-template <> constexpr DType dtype<span<const float>>{101};
-template <> constexpr DType dtype<span<const int64_t>>{102};
-template <> constexpr DType dtype<span<const int32_t>>{103};
-template <> constexpr DType dtype<span<const bool>>{104};
-template <> constexpr DType dtype<span<const std::string>>{105};
-template <> constexpr DType dtype<span<const time_point>>{106};
-template <> constexpr DType dtype<span<const Eigen::Vector3d>>{107};
-// span<const T> start at 200
-template <> constexpr DType dtype<span<double>>{200};
-template <> constexpr DType dtype<span<float>>{201};
-template <> constexpr DType dtype<span<int64_t>>{202};
-template <> constexpr DType dtype<span<int32_t>>{203};
-template <> constexpr DType dtype<span<bool>>{204};
-template <> constexpr DType dtype<span<std::string>>{205};
-template <> constexpr DType dtype<span<time_point>>{206};
-template <> constexpr DType dtype<span<Eigen::Vector3d>>{207};
+template <> inline constexpr DType dtype<span<const double>>{100};
+template <> inline constexpr DType dtype<span<const float>>{101};
+template <> inline constexpr DType dtype<span<const int64_t>>{102};
+template <> inline constexpr DType dtype<span<const int32_t>>{103};
+template <> inline constexpr DType dtype<span<const bool>>{104};
+template <> inline constexpr DType dtype<span<const std::string>>{105};
+template <> inline constexpr DType dtype<span<const time_point>>{106};
+template <> inline constexpr DType dtype<span<const Eigen::Vector3d>>{107};
+// span<inline const T> start at 200
+template <> inline constexpr DType dtype<span<double>>{200};
+template <> inline constexpr DType dtype<span<float>>{201};
+template <> inline constexpr DType dtype<span<int64_t>>{202};
+template <> inline constexpr DType dtype<span<int32_t>>{203};
+template <> inline constexpr DType dtype<span<bool>>{204};
+template <> inline constexpr DType dtype<span<std::string>>{205};
+template <> inline constexpr DType dtype<span<time_point>>{206};
+template <> inline constexpr DType dtype<span<Eigen::Vector3d>>{207};
 // std containers start at 300
-template <> constexpr DType dtype<std::pair<int32_t, int32_t>>{300};
-template <> constexpr DType dtype<std::pair<int64_t, int64_t>>{301};
-template <> constexpr DType dtype<std::unordered_map<double, int64_t>>{302};
-template <> constexpr DType dtype<std::unordered_map<double, int32_t>>{303};
-template <> constexpr DType dtype<std::unordered_map<float, int64_t>>{304};
-template <> constexpr DType dtype<std::unordered_map<float, int32_t>>{305};
-template <> constexpr DType dtype<std::unordered_map<int64_t, int64_t>>{306};
-template <> constexpr DType dtype<std::unordered_map<int64_t, int32_t>>{307};
-template <> constexpr DType dtype<std::unordered_map<int32_t, int64_t>>{308};
-template <> constexpr DType dtype<std::unordered_map<int32_t, int32_t>>{309};
-template <> constexpr DType dtype<std::unordered_map<bool, int64_t>>{310};
-template <> constexpr DType dtype<std::unordered_map<bool, int32_t>>{311};
+template <> inline constexpr DType dtype<std::pair<int32_t, int32_t>>{300};
+template <> inline constexpr DType dtype<std::pair<int64_t, int64_t>>{301};
 template <>
-constexpr DType dtype<std::unordered_map<std::string, int64_t>>{312};
+inline constexpr DType dtype<std::unordered_map<double, int64_t>>{302};
 template <>
-constexpr DType dtype<std::unordered_map<std::string, int32_t>>{313};
+inline constexpr DType dtype<std::unordered_map<double, int32_t>>{303};
 template <>
-constexpr DType dtype<std::unordered_map<core::time_point, int64_t>>{314};
+inline constexpr DType dtype<std::unordered_map<float, int64_t>>{304};
 template <>
-constexpr DType dtype<std::unordered_map<core::time_point, int32_t>>{315};
+inline constexpr DType dtype<std::unordered_map<float, int32_t>>{305};
+template <>
+inline constexpr DType dtype<std::unordered_map<int64_t, int64_t>>{306};
+template <>
+inline constexpr DType dtype<std::unordered_map<int64_t, int32_t>>{307};
+template <>
+inline constexpr DType dtype<std::unordered_map<int32_t, int64_t>>{308};
+template <>
+inline constexpr DType dtype<std::unordered_map<int32_t, int32_t>>{309};
+template <>
+inline constexpr DType dtype<std::unordered_map<bool, int64_t>>{310};
+template <>
+inline constexpr DType dtype<std::unordered_map<bool, int32_t>>{311};
+template <>
+inline constexpr DType dtype<std::unordered_map<std::string, int64_t>>{312};
+template <>
+inline constexpr DType dtype<std::unordered_map<std::string, int32_t>>{313};
+template <>
+inline constexpr DType dtype<std::unordered_map<core::time_point, int64_t>>{
+    314};
+template <>
+inline constexpr DType dtype<std::unordered_map<core::time_point, int32_t>>{
+    315};
 // scipp::variable types start at 1000
 // scipp::dataset types start at 2000
 // scipp::python types start at 3000

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -749,19 +749,20 @@ SCIPP_DATASET_EXPORT void union_or_in_place(const MasksView &currentMasks,
 } // namespace scipp::dataset
 
 namespace scipp::core {
-template <> constexpr DType dtype<dataset::DataArray>{2000};
-template <> constexpr DType dtype<dataset::Dataset>{2001};
-template <> constexpr DType dtype<bucket<dataset::DataArray>>{2002};
-template <> constexpr DType dtype<bucket<dataset::DataArrayConstView>>{2003};
-template <> constexpr DType dtype<bucket<dataset::DataArrayView>>{2004};
-template <> constexpr DType dtype<bucket<dataset::Dataset>>{2005};
+template <> inline constexpr DType dtype<dataset::DataArray>{2000};
+template <> inline constexpr DType dtype<dataset::Dataset>{2001};
+template <> inline constexpr DType dtype<bucket<dataset::DataArray>>{2002};
 template <>
-constexpr DType dtype<dataset::DataArrayView>{
+inline constexpr DType dtype<bucket<dataset::DataArrayConstView>>{2003};
+template <> inline constexpr DType dtype<bucket<dataset::DataArrayView>>{2004};
+template <> inline constexpr DType dtype<bucket<dataset::Dataset>>{2005};
+template <>
+inline constexpr DType dtype<dataset::DataArrayView>{
     2002}; // hack for python bindings using
            // dtype<ElementArrayView<bucket<DataArray>>::value_type>
            // is setting same dtype ID correct?
 template <>
-constexpr DType dtype<dataset::DatasetView>{
+inline constexpr DType dtype<dataset::DatasetView>{
     2005}; // hack for python bindings using
            // dtype<ElementArrayView<bucket<Dataset>>::value_type>
            // is setting same dtype ID correct?

--- a/python/py_object.h
+++ b/python/py_object.h
@@ -41,5 +41,5 @@ private:
 } // namespace scipp::python
 
 namespace scipp::core {
-template <> constexpr DType dtype<python::PyObject>{3000};
+template <> inline constexpr DType dtype<python::PyObject>{3000};
 } // namespace scipp::core

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -369,15 +369,16 @@ SCIPP_VARIABLE_EXPORT VariableView copy(const VariableConstView &dataset,
 } // namespace scipp::variable
 
 namespace scipp::core {
-template <> constexpr DType dtype<variable::Variable>{1000};
+template <> inline constexpr DType dtype<variable::Variable>{1000};
 template <>
-constexpr DType dtype<variable::VariableView>{
+inline constexpr DType dtype<variable::VariableView>{
     1001}; // hack for python bindings using
            // dtype<ElementArrayView<bucket<Variable>>::value_type>
            // is setting same dtype ID correct?
-template <> constexpr DType dtype<bucket<variable::Variable>>{1001};
-template <> constexpr DType dtype<bucket<variable::VariableConstView>>{1002};
-template <> constexpr DType dtype<bucket<variable::VariableView>>{1003};
+template <> inline constexpr DType dtype<bucket<variable::Variable>>{1001};
+template <>
+inline constexpr DType dtype<bucket<variable::VariableConstView>>{1002};
+template <> inline constexpr DType dtype<bucket<variable::VariableView>>{1003};
 } // namespace scipp::core
 
 namespace scipp {


### PR DESCRIPTION
Clang requires specialisations of variable templates to be `inline` when in a header. I think this is consistent with the standard.