### PR TITLE
Reenable cppcheck and use 20.04 images in CI

### DIFF
--- a/.azure-pipelines/templates/code_quality_checks.yml
+++ b/.azure-pipelines/templates/code_quality_checks.yml
@@ -10,9 +10,6 @@ stages:
         steps:
           - bash: |
               set -ex
-              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-              sudo add-apt-repository --yes 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
-              sudo apt-get update
               sudo apt-get install --yes clang-format-10
             displayName: 'Install tooling'
           - bash: |

--- a/.azure-pipelines/templates/code_quality_checks.yml
+++ b/.azure-pipelines/templates/code_quality_checks.yml
@@ -6,7 +6,7 @@ stages:
       - job: 'cpp_checks'
         displayName: 'C++ Checks'
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-20.04'
         steps:
           - bash: |
               set -ex
@@ -27,8 +27,8 @@ stages:
             displayName: 'Run clang-format'
           - bash: |
               set -ex
-              #docker build ./tools -f ./tools/cppcheck.Dockerfile -t scipp_cppcheck
-              #docker run --rm -v "$PWD":/data scipp_cppcheck
+              docker build ./tools -f ./tools/cppcheck.Dockerfile -t scipp_cppcheck
+              docker run --rm -v "$PWD":/data scipp_cppcheck
             displayName: 'Run cppcheck'
 
       - job: 'cmake_checks'

--- a/.azure-pipelines/templates/documentation_build.yml
+++ b/.azure-pipelines/templates/documentation_build.yml
@@ -2,7 +2,7 @@ jobs:
   - job: 'documentation'
     displayName: 'Documentation'
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     variables:
       packages_dir: '$(Build.StagingDirectory)/packages'
       docs_build_dir: '$(Build.StagingDirectory)/docs_build'

--- a/.azure-pipelines/templates/test_can_install_and_import.yml
+++ b/.azure-pipelines/templates/test_can_install_and_import.yml
@@ -3,7 +3,7 @@ jobs:
     displayName: 'Can Install and Import - Linux'
     timeoutInMinutes: 10
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     variables:
       packages_dir: '$(Build.StagingDirectory)/packages'
     steps:


### PR DESCRIPTION
- Fixes #1674.
- Use 20.04 in images
- Use `clang-format-10` from Ubuntu (llvm one doesn't seem to work due to "clang-format-10 : Depends: libllvm10 (= 1:10.0.1~++20210313014516+ef32c611aa21-1~exp1~20210313125115.204) but 1:10.0.0-4ubuntu1 is to be installed").