### PR TITLE
Show to support bin edges of slices

### DIFF
--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -516,10 +516,14 @@ CoordsView DataArrayView::coords() const noexcept {
 }
 
 /// Return a const view to all aligned coordinates of the data array.
-CoordsConstView DataArray::coords() const { return get().coords(); }
+CoordsConstView DataArray::coords() const {
+  return make_coords(get(), CoordCategory::Aligned, false);
+}
 
 /// Return a view to all aligned coordinates of the data array.
-CoordsView DataArray::coords() { return m_holder.coords(); }
+CoordsView DataArray::coords() {
+  return make_coords(get(), CoordCategory::Aligned, false);
+}
 
 /// Return a const view to all unaligned coordinates of the data view.
 CoordsConstView DataArrayConstView::attrs() const noexcept {

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -323,20 +323,13 @@ class DatasetDrawer:
         self._dataset = dataset
 
     def _dims(self):
-        # The dimension-order in a dataset is not defined. However, here we
-        # need one for the practical purpose of drawing variables with
-        # consistent ordering. We simply use that of the item with highest
-        # dimension count.
+        dims = self._dataset.dims
         if is_data_array(self._dataset):
-            dims = self._dataset.dims
-        else:
-            dims = []
-            for item in self._dataset.values():
-                if len(item.dims) > len(dims):
-                    dims = item.dims
-            for dim in self._dataset.dims:
-                if dim not in dims:
-                    dims = [dim] + dims
+            # Handle, e.g., bin edges of a slice, where data lacks the edge dim
+            for item in self._dataset.meta.values():
+                for dim in item.dims:
+                    if dim not in dims:
+                        dims = [dim] + dims
         if len(dims) > 3:
             raise RuntimeError("Cannot visualize {}-D data".format(len(dims)))
         return dims


### PR DESCRIPTION
- Fixes #1499.
- Ensure `DataArray.coords` behaves like `DataArrayView.coords`, excluding coords that exceed data. I think this must have been intentional to handle the case of storing a bin-edge coords on a scalar (in that dimension) data array, but it is causing trouble here. Should revisit this with the ownership redesign, to see if we can do anything better.

Example to try:
```python
import scipp as sc
import numpy as np

data = sc.ones(dims=['x'], shape=[4])
edges = sc.ones(dims=['x'], shape=[5])
da = sc.DataArray(data, coords={'x':edges})
sc.show(da)
sc.show(da['x',3])
ds = sc.Dataset({'a':da})
ds.coords['y'] = sc.ones(dims=['y'], shape=[4])
ds.dims
sc.show(ds)
```

Results in: 
<img width="291" alt="image" src="https://user-images.githubusercontent.com/12912489/111617988-22bc6f80-87e4-11eb-86a4-94959e5efd87.png">
