### PR TITLE
Prototype for shallow-copy data structures

### DIFF
--- a/common/include/scipp/common/shared_deep_ptr.h
+++ b/common/include/scipp/common/shared_deep_ptr.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+#include <memory>
+#include <type_traits>
+
+namespace scipp {
+
+/// Like std::shared_ptr, but copy causes a deep copy.
+template <class T> class shared_deep_ptr {
+public:
+  using element_type = typename std::unique_ptr<T>::element_type;
+  shared_deep_ptr() = default;
+  shared_deep_ptr(std::shared_ptr<T> other) : m_data(std::move(other)) {}
+  shared_deep_ptr(const shared_deep_ptr<T> &other) {
+    if (other) {
+      if constexpr (std::is_abstract<T>())
+        *this = other->clone();
+      else
+        m_data = std::make_shared<T>(*other);
+    } else {
+      m_data = nullptr;
+    }
+  }
+  shared_deep_ptr(shared_deep_ptr<T> &&) = default;
+  constexpr shared_deep_ptr(std::nullptr_t){};
+  shared_deep_ptr<T> &operator=(const shared_deep_ptr<T> &other) {
+    if (&other != this)
+      *this = shared_deep_ptr(other);
+    return *this;
+  }
+  shared_deep_ptr<T> &operator=(shared_deep_ptr<T> &&) = default;
+
+  explicit operator bool() const noexcept { return bool(m_data); }
+  bool operator==(const shared_deep_ptr<T> &other) const noexcept {
+    return m_data == other.m_data;
+  }
+  bool operator!=(const shared_deep_ptr<T> &other) const noexcept {
+    return m_data != other.m_data;
+  }
+
+  T &operator*() const { return *m_data; }
+  T *operator->() const { return m_data.get(); }
+
+  const std::shared_ptr<T> &owner() const { return m_data; }
+
+private:
+  std::shared_ptr<T> m_data;
+};
+
+} // namespace scipp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRC_FILES
     except.cpp
     multi_index.cpp
     slice.cpp
+    strides.cpp
     string.cpp
     subbin_sizes.cpp
     view_index.cpp

--- a/core/include/scipp/core/element_array.h
+++ b/core/include/scipp/core/element_array.h
@@ -12,9 +12,9 @@
 
 namespace scipp::core {
 
-/// Replacement for C++20 std::make_shared_for_overwrite
-template <class T> auto make_shared_for_overwrite(const scipp::index size) {
-  return std::shared_ptr<T>(new std::remove_extent_t<T>[size]);
+/// Replacement for C++20 std::make_unique_default_init
+template <class T> auto make_unique_default_init(const scipp::index size) {
+  return std::unique_ptr<T>(new std::remove_extent_t<T>[size]);
 }
 
 /// Tag for requesting default-initialization in methods of class element_array.
@@ -81,7 +81,8 @@ public:
     other.m_size = -1;
   }
 
-  element_array(const element_array &) = default;
+  element_array(const element_array &other)
+      : element_array(from_other(other)) {}
 
   element_array &operator=(element_array &&other) noexcept {
     m_data = std::move(other.m_data);
@@ -90,24 +91,8 @@ public:
     return *this;
   }
 
-  element_array &operator=(const element_array &) = default;
-
-  element_array deepcopy() const {
-    if (size() == -1) {
-      return element_array();
-    } else if (size() == 0) {
-      return element_array(0);
-    } else {
-      return element_array(begin(), end());
-    }
-  }
-
-  bool operator==(const element_array &other) const noexcept {
-    return (size() == -1 && other.size() == -1) ||
-           std::equal(begin(), end(), other.begin(), other.end());
-  }
-  bool operator!=(const element_array &other) const noexcept {
-    return !operator==(other);
+  element_array &operator=(const element_array &other) {
+    return *this = element_array(other.begin(), other.end());
   }
 
   explicit operator bool() const noexcept { return m_size != -1; }
@@ -139,14 +124,23 @@ public:
       m_data.reset();
       m_size = 0;
     } else if (new_size != size()) {
-      m_data = make_shared_for_overwrite<T[]>(new_size);
+      m_data = make_unique_default_init<T[]>(new_size);
       m_size = new_size;
     }
   }
 
 private:
+  element_array from_other(const element_array &other) {
+    if (other.size() == -1) {
+      return element_array();
+    } else if (other.size() == 0) {
+      return element_array(0);
+    } else {
+      return element_array(other.begin(), other.end());
+    }
+  }
   scipp::index m_size{-1};
-  std::shared_ptr<T[]> m_data;
+  std::unique_ptr<T[]> m_data;
 };
 
 } // namespace scipp::core

--- a/core/include/scipp/core/strides.h
+++ b/core/include/scipp/core/strides.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp-core_export.h"
+#include "scipp/common/index.h"
+#include "scipp/common/span.h"
+#include "scipp/core/dimensions.h"
+
+namespace scipp::core {
+
+class SCIPP_CORE_EXPORT Strides {
+public:
+  Strides() = default;
+  Strides(const Dimensions &dims);
+
+  scipp::index operator[](const scipp::index i) const noexcept {
+    return m_strides.at(i);
+  }
+
+  auto begin() const { return m_strides.begin(); }
+
+private:
+  std::array<scipp::index, NDIM_MAX> m_strides;
+};
+
+} // namespace scipp::core
+
+namespace scipp {
+using core::Strides;
+}

--- a/core/include/scipp/core/strides.h
+++ b/core/include/scipp/core/strides.h
@@ -22,8 +22,10 @@ public:
 
   auto begin() const { return m_strides.begin(); }
 
+  void erase(const scipp::index i);
+
 private:
-  std::array<scipp::index, NDIM_MAX> m_strides;
+  std::array<scipp::index, NDIM_MAX> m_strides{0};
 };
 
 } // namespace scipp::core

--- a/core/strides.cpp
+++ b/core/strides.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/strides.h"
+
+namespace scipp::core {
+
+Strides::Strides(const Dimensions &dims) {
+  scipp::index offset{1};
+  for (scipp::index i = dims.ndim() - 1; i >= 0; --i) {
+    m_strides[i] = offset;
+    offset *= dims.size(i);
+  }
+}
+
+} // namespace scipp::core

--- a/core/strides.cpp
+++ b/core/strides.cpp
@@ -14,4 +14,10 @@ Strides::Strides(const Dimensions &dims) {
   }
 }
 
+void Strides::erase(const scipp::index i) {
+  for (scipp::index j = i; j < scipp::size(m_strides) - 1; ++j)
+    m_strides[j] = m_strides[j + 1];
+  m_strides.back() = 0;
+}
+
 } // namespace scipp::core

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   element_trigonometry_test.cpp
   element_util_test.cpp
   multi_index_test.cpp
+  prototype.cpp
   string_test.cpp
   subbin_sizes_test.cpp
   time_point_test.cpp

--- a/core/test/element_array_test.cpp
+++ b/core/test/element_array_test.cpp
@@ -180,3 +180,22 @@ TEST(ElementArrayTest, resize_default_init) {
   x.resize(0, default_init_elements);
   check_empty_element_array(x);
 }
+
+TEST(ElementArrayTest, deepcopy_null) {
+  const auto orig = element_array<double>();
+  auto x = element_array<double>();
+  auto y = x.deepcopy();
+  EXPECT_FALSE(x);
+  EXPECT_FALSE(y);
+}
+
+TEST(ElementArrayTest, deepcopy) {
+  const auto orig = make_element_array();
+  auto x = make_element_array();
+  auto y = x.deepcopy();
+  EXPECT_EQ(x, orig);
+  EXPECT_EQ(y, orig);
+  y.data()[0] += 1.0;
+  EXPECT_EQ(x, orig);
+  EXPECT_NE(y, orig);
+}

--- a/core/test/element_array_test.cpp
+++ b/core/test/element_array_test.cpp
@@ -180,22 +180,3 @@ TEST(ElementArrayTest, resize_default_init) {
   x.resize(0, default_init_elements);
   check_empty_element_array(x);
 }
-
-TEST(ElementArrayTest, deepcopy_null) {
-  const auto orig = element_array<double>();
-  auto x = element_array<double>();
-  auto y = x.deepcopy();
-  EXPECT_FALSE(x);
-  EXPECT_FALSE(y);
-}
-
-TEST(ElementArrayTest, deepcopy) {
-  const auto orig = make_element_array();
-  auto x = make_element_array();
-  auto y = x.deepcopy();
-  EXPECT_EQ(x, orig);
-  EXPECT_EQ(y, orig);
-  y.data()[0] += 1.0;
-  EXPECT_EQ(x, orig);
-  EXPECT_NE(y, orig);
-}

--- a/core/test/prototype.cpp
+++ b/core/test/prototype.cpp
@@ -2,27 +2,82 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
-#include <vector>
-
 #include "scipp/core/dimensions.h"
 #include "scipp/core/element_array.h"
 #include "scipp/units/dim.h"
+#include "scipp/units/unit.h"
+
+#include "test_macros.h"
 
 using namespace scipp;
 
-struct Variable {
+class Variable {
+private:
+  Dimensions m_dims;
+  scipp::index m_offset{0};
+  units::Unit m_unit;
+  element_array<double> m_values;
+  bool is_slice() const noexcept {
+    return m_offset != 0 || m_dims.volume() != m_values.size();
+  }
+
+public:
   Variable() = default;
-  Variable(const Dimensions &dims_, const std::vector<double> &values_)
-      : dims(dims_), values(values_) {}
+  Variable(const Dimensions &dims, const units::Unit &unit,
+           const element_array<double> &values)
+      : m_dims(dims), m_unit(unit), m_values(values) {
+    if (dims.volume() != values.size())
+      throw std::runtime_error("Dims do not match size");
+  }
+
+  const auto &dims() const { return m_dims; }
+  const auto &unit() const { return m_unit; }
+
+  auto begin() { return m_values.begin() + m_offset; }
+  auto end() { return m_values.begin() + m_offset + m_dims.volume(); }
+  auto begin() const { return m_values.begin() + m_offset; }
+  auto end() const { return m_values.begin() + m_offset + m_dims.volume(); }
+
+  scipp::span<const double> values() const { return {begin(), end()}; }
+  scipp::span<double> values() { return {begin(), end()}; }
+
   bool operator==(const Variable &other) const {
-    return dims == other.dims && values == other.values;
+    return dims() == other.dims() && unit() == other.unit() &&
+           std::equal(begin(), end(), other.begin(), other.end());
   }
-  bool operator!=(const Variable &other) const {
-    return dims != other.dims || values != other.values;
+  bool operator!=(const Variable &other) const { return !operator==(other); }
+
+  Variable slice(const Dim dim, const scipp::index offset) const {
+    Variable out(*this);
+    auto out_dims = dims();
+    out_dims.erase(dim);
+    out.m_dims = out_dims;
+    out.m_offset = offset;
+    return out;
   }
-  Dimensions dims;
-  element_array<double> values;
+
+  void setunit(const units::Unit &unit) {
+    if (m_unit == unit)
+      return;
+    if (m_dims.volume() != m_values.size())
+      throw std::runtime_error("Cannot set unit on slice");
+    m_unit = unit;
+  }
+
+  Variable deepcopy() const {
+    return is_slice() ? Variable{dims(), unit(), {begin(), end()}}
+                      : Variable{dims(), unit(), m_values.deepcopy()};
+  }
 };
+
+// coord must prevent length change (but switch to edges ok?)
+// data array data or dataset item data must prevent length change
+// coords of dataset item may no be added?
+// masks and attrs of dataset item CAN be added
+// ds['a'].coords['x'] = x # should fail
+// ds['a'].attrs['x'] = x # should NOT fail
+// ds['a'].masks['x'] = x # should NOT fail
+//
 
 class Coords {
 public:
@@ -42,12 +97,18 @@ private:
   std::unordered_map<Dim, Variable> items;
 };
 
-struct DataArray {
+class DataArray {
+public:
   DataArray() = default;
-  DataArray(Variable data_, Coords coords_)
-      : data(std::move(data_)), coords(std::move(coords_)) {}
-  Variable data;
-  Coords coords;
+  DataArray(Variable data, Coords coords)
+      : m_data(std::move(data)), m_coords(std::move(coords)) {}
+  const auto &data() const { return m_data; }
+  const auto &coords() const { return m_coords; }
+  auto &coords() { return m_coords; }
+
+private:
+  Variable m_data;
+  Coords m_coords;
 };
 
 struct Dataset {
@@ -55,8 +116,8 @@ struct Dataset {
     return items.at(name);
   }
   void setitem(const std::string &name, DataArray item) {
-    for (auto &&[dim, coord] : item.coords)
-      setcoord(dim, std::forward<Variable>(coord));
+    for (auto &&[dim, coord] : item.coords())
+      setcoord(dim, coord);
     items[name] = std::move(item);
   }
   // Note that we cannot set coords on
@@ -65,21 +126,15 @@ struct Dataset {
       throw std::runtime_error("Coords not aligned");
     coords.setitem(dim, coord);
     for (auto &existing : items)
-      if (existing.second.data.dims.contains(dim))
-        existing.second.coords.setitem(dim, coord);
+      if (existing.second.data().dims().contains(dim))
+        existing.second.coords().setitem(dim, coord);
   }
 
   Coords coords;
   std::unordered_map<std::string, DataArray> items;
 };
 
-Variable
-copy(const Variable &var) {
-  auto out(var);
-  out.values = out.values.deepcopy();
-  return out;
-}
-
+Variable copy(const Variable &var) { return var.deepcopy(); }
 DataArray copy(const DataArray &da) { return da; }
 Dataset copy(const Dataset &ds) { return ds; }
 
@@ -89,45 +144,59 @@ protected:
 };
 
 TEST_F(PrototypeTest, variable) {
-  const auto var = Variable(dimsX, {1, 2, 3});
-  EXPECT_EQ(Variable(var).values.data(), var.values.data()); // shallow copy
-  EXPECT_NE(copy(var).values.data(), var.values.data());     // deep copy
+  const auto var = Variable(dimsX, units::m, {1, 2, 3});
+  EXPECT_EQ(Variable(var).values().data(), var.values().data()); // shallow copy
+  EXPECT_NE(copy(var).values().data(), var.values().data());     // deep copy
+  auto shared = var;
+  shared.values()[0] = 1.1;
+  EXPECT_EQ(var.values()[0], 1.1);
+}
+
+TEST_F(PrototypeTest, variable_slice) {
+  const auto var = Variable(dimsX, units::m, {1, 2, 3});
+  auto slice = var.slice(Dim::X, 1);
+  EXPECT_EQ(slice, Variable(Dimensions(), units::m, {2}));
+  EXPECT_ANY_THROW(slice.setunit(units::s));
+  slice.values()[0] = 1.1;
+  EXPECT_EQ(var.values()[1], 1.1);
+  EXPECT_EQ(copy(slice), slice);
 }
 
 TEST_F(PrototypeTest, data_array) {
-  const auto var = Variable(dimsX, {1, 2, 3});
+  const auto var = Variable(dimsX, units::m, {1, 2, 3});
   auto da = DataArray(var, Coords{});
-  EXPECT_EQ(da.data.values.data(), var.values.data()); // shallow copy
-  da.coords.setitem(Dim::X, var);
-  EXPECT_EQ(da.coords[Dim::X].values.data(),
-            var.values.data()); // shallow copy
+  EXPECT_EQ(da.data().values().data(), var.values().data()); // shallow copy
+  da.coords().setitem(Dim::X, var);
+  EXPECT_EQ(da.coords()[Dim::X].values().data(),
+            var.values().data()); // shallow copy
   for (const auto da2 : {DataArray(da), copy(da)}) {
     // shallow copy of data and coords
-    EXPECT_EQ(da2.data.values.data(), da.data.values.data());
-    EXPECT_EQ(da2.coords[Dim::X].values.data(),
-              da.coords[Dim::X].values.data());
+    EXPECT_EQ(da2.data().values().data(), da.data().values().data());
+    EXPECT_EQ(da2.coords()[Dim::X].values().data(),
+              da.coords()[Dim::X].values().data());
   }
 }
 
 TEST_F(PrototypeTest, data_array_coord) {
-  const auto var = Variable(dimsX, {1, 2, 3});
-  auto da = DataArray(var, {{Dim::X, Variable(dimsX, {2, 4, 8})}});
-  const auto coord = da.coords[Dim::X];
+  const auto var = Variable(dimsX, units::m, {1, 2, 3});
+  auto da = DataArray(var, {{Dim::X, Variable(dimsX, units::m, {2, 4, 8})}});
+  const auto coord = da.coords()[Dim::X];
   da = DataArray(var, Coords{});
-  EXPECT_EQ(coord.values,
-            Variable(dimsX, {2, 4, 8}).values); // coord is sole owner
+  EXPECT_TRUE(equals(
+      coord.values(),
+      Variable(dimsX, units::m, {2, 4, 8}).values())); // coord is sole owner
 }
 
 TEST_F(PrototypeTest, dataset) {
-  auto da1 = DataArray(Variable(dimsX, {1, 2, 3}),
-                       {{Dim::X, Variable(dimsX, {1, 1, 1})}});
-  auto da2 = DataArray(Variable(dimsX, {1, 2, 3}), {});
+  auto da1 = DataArray(Variable(dimsX, units::m, {1, 2, 3}),
+                       {{Dim::X, Variable(dimsX, units::m, {1, 1, 1})}});
+  auto da2 = DataArray(Variable(dimsX, units::m, {1, 2, 3}), {});
   auto ds = Dataset();
   ds.setitem("a", da1);
   for (const auto ds2 : {Dataset(ds), copy(ds)}) {
     // shallow copy of items and coords
-    EXPECT_EQ(ds2["a"].data.values.data(), ds["a"].data.values.data());
-    EXPECT_EQ(ds2.coords[Dim::X].values.data(),
-              ds.coords[Dim::X].values.data());
+    EXPECT_EQ(ds2["a"].data().values().data(), ds["a"].data().values().data());
+    EXPECT_EQ(ds2.coords[Dim::X].values().data(),
+              ds.coords[Dim::X].values().data());
   }
 }

--- a/core/test/prototype.cpp
+++ b/core/test/prototype.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "scipp/core/dimensions.h"
+#include "scipp/core/element_array.h"
+#include "scipp/units/dim.h"
+
+using namespace scipp;
+
+struct Variable {
+  Variable() = default;
+  Variable(const Dimensions &dims_, const std::vector<double> &values_)
+      : dims(dims_), values(values_) {}
+  bool operator==(const Variable &other) const {
+    return dims == other.dims && values == other.values;
+  }
+  bool operator!=(const Variable &other) const {
+    return dims != other.dims || values != other.values;
+  }
+  Dimensions dims;
+  element_array<double> values;
+};
+
+class Coords {
+public:
+  Coords() = default;
+  Coords(std::initializer_list<std::pair<const Dim, Variable>> items_)
+      : items(std::move(items_)) {}
+  Coords(std::unordered_map<Dim, Variable> items_) : items(std::move(items_)) {}
+  const auto &operator[](const Dim dim) const { return items.at(dim); }
+  void setitem(const Dim dim, Variable coord) { items[dim] = coord; }
+  bool contains(const Dim dim) const { return items.count(dim) == 1; }
+  auto begin() const { return items.begin(); }
+  auto end() const { return items.end(); }
+  auto begin() { return items.begin(); }
+  auto end() { return items.end(); }
+
+private:
+  std::unordered_map<Dim, Variable> items;
+};
+
+struct DataArray {
+  DataArray() = default;
+  DataArray(Variable data_, Coords coords_)
+      : data(std::move(data_)), coords(std::move(coords_)) {}
+  Variable data;
+  Coords coords;
+};
+
+struct Dataset {
+  const auto &operator[](const std::string &name) const {
+    return items.at(name);
+  }
+  void setitem(const std::string &name, DataArray item) {
+    for (auto &&[dim, coord] : item.coords)
+      setcoord(dim, std::forward<Variable>(coord));
+    items[name] = std::move(item);
+  }
+  // Note that we cannot set coords on
+  void setcoord(const Dim dim, const Variable &coord) {
+    if (coords.contains(dim) && coords[dim] != coord)
+      throw std::runtime_error("Coords not aligned");
+    coords.setitem(dim, coord);
+    for (auto &existing : items)
+      if (existing.second.data.dims.contains(dim))
+        existing.second.coords.setitem(dim, coord);
+  }
+
+  Coords coords;
+  std::unordered_map<std::string, DataArray> items;
+};
+
+Variable
+copy(const Variable &var) {
+  auto out(var);
+  out.values = out.values.deepcopy();
+  return out;
+}
+
+DataArray copy(const DataArray &da) { return da; }
+Dataset copy(const Dataset &ds) { return ds; }
+
+class PrototypeTest : public ::testing::Test {
+protected:
+  Dimensions dimsX = Dimensions(Dim::X, 3);
+};
+
+TEST_F(PrototypeTest, variable) {
+  const auto var = Variable(dimsX, {1, 2, 3});
+  EXPECT_EQ(Variable(var).values.data(), var.values.data()); // shallow copy
+  EXPECT_NE(copy(var).values.data(), var.values.data());     // deep copy
+}
+
+TEST_F(PrototypeTest, data_array) {
+  const auto var = Variable(dimsX, {1, 2, 3});
+  auto da = DataArray(var, Coords{});
+  EXPECT_EQ(da.data.values.data(), var.values.data()); // shallow copy
+  da.coords.setitem(Dim::X, var);
+  EXPECT_EQ(da.coords[Dim::X].values.data(),
+            var.values.data()); // shallow copy
+  for (const auto da2 : {DataArray(da), copy(da)}) {
+    // shallow copy of data and coords
+    EXPECT_EQ(da2.data.values.data(), da.data.values.data());
+    EXPECT_EQ(da2.coords[Dim::X].values.data(),
+              da.coords[Dim::X].values.data());
+  }
+}
+
+TEST_F(PrototypeTest, data_array_coord) {
+  const auto var = Variable(dimsX, {1, 2, 3});
+  auto da = DataArray(var, {{Dim::X, Variable(dimsX, {2, 4, 8})}});
+  const auto coord = da.coords[Dim::X];
+  da = DataArray(var, Coords{});
+  EXPECT_EQ(coord.values,
+            Variable(dimsX, {2, 4, 8}).values); // coord is sole owner
+}
+
+TEST_F(PrototypeTest, dataset) {
+  auto da1 = DataArray(Variable(dimsX, {1, 2, 3}),
+                       {{Dim::X, Variable(dimsX, {1, 1, 1})}});
+  auto da2 = DataArray(Variable(dimsX, {1, 2, 3}), {});
+  auto ds = Dataset();
+  ds.setitem("a", da1);
+  for (const auto ds2 : {Dataset(ds), copy(ds)}) {
+    // shallow copy of items and coords
+    EXPECT_EQ(ds2["a"].data.values.data(), ds["a"].data.values.data());
+    EXPECT_EQ(ds2.coords[Dim::X].values.data(),
+              ds.coords[Dim::X].values.data());
+  }
+}

--- a/core/test/prototype.cpp
+++ b/core/test/prototype.cpp
@@ -71,17 +71,6 @@ public:
   }
 };
 
-// coord must prevent length change (but switch to edges ok?)
-// data array data or dataset item data must prevent length change
-// coords of dataset item may no be added?
-// masks and attrs of dataset item CAN be added
-// ds['a'].coords['x'] = x # should fail
-// ds['a'].attrs['x'] = x # should NOT fail
-// ds['a'].masks['x'] = x # should NOT fail
-//
-//
-//
-
 // Sibling of class Dimensions, but unordered
 class Sizes {
 public:
@@ -109,7 +98,11 @@ public:
     return true;
   }
 
-  void erase(const Dim dim) { m_sizes.erase(dim); }
+  Sizes slice(const Dim dim, const scipp::index) const {
+    auto sizes = m_sizes;
+    sizes.erase(dim);
+    return {sizes};
+  }
 
 private:
   std::unordered_map<Dim, scipp::index> m_sizes;
@@ -143,8 +136,6 @@ public:
   auto end() { return m_items->end(); }
 
   auto slice(const Dim dim, const scipp::index offset) const {
-    auto sizes = m_sizes;
-    sizes.erase(dim);
     map_type items;
     for (const auto &[key, value] : *this) {
       if (value.dims().contains(dim))
@@ -152,7 +143,7 @@ public:
       else
         items[key] = value;
     }
-    return Dict(sizes, std::move(items));
+    return Dict(m_sizes.slice(dim, offset), std::move(items));
   }
 
 private:

--- a/core/test/prototype.cpp
+++ b/core/test/prototype.cpp
@@ -329,6 +329,17 @@ TEST_F(VariableContractTest, shallow_copy_unit_can_be_set) {
   EXPECT_EQ(var.unit(), units::s);
 }
 
+TEST_F(VariableContractTest, slice_values_can_be_set) {
+  auto slice = var.slice(Dim::X, 1);
+  slice.values()[0] = 17;
+  EXPECT_EQ(var.values()[1], 17);
+}
+
+TEST_F(VariableContractTest, slice_unit_cannot_be_changed) {
+  auto slice = var.slice(Dim::X, 1);
+  EXPECT_ANY_THROW(slice.setunit(units::s));
+}
+
 class DataArrayContractTest : public ::testing::Test {
 protected:
   Dimensions dimsX = Dimensions(Dim::X, 3);

--- a/core/test/prototype.cpp
+++ b/core/test/prototype.cpp
@@ -540,3 +540,38 @@ TEST_F(DataArrayContractTest, slice_mask_unit_cannot_be_set) {
   auto slice = da.slice(Dim::X, 1);
   EXPECT_ANY_THROW(slice.masks()["mask"].setunit(units::s));
 }
+
+class DatasetContractTest : public ::testing::Test {
+protected:
+  DatasetContractTest() { ds.setitem("a", da); }
+  Dimensions dimsX = Dimensions(Dim::X, 3);
+  Variable var{dimsX, units::m, {1, 2, 3}};
+  DataArray da{var, {}};
+  Dataset ds;
+};
+
+TEST_F(DatasetContractTest, coords_can_be_added) {
+  ds.coords().setitem(Dim("new"), var);
+  EXPECT_TRUE(ds.coords().contains(Dim("new")));
+}
+
+TEST_F(DatasetContractTest, coord_values_can_be_set) {
+  ds.coords().setitem(Dim::X, var);
+  ds.coords()[Dim::X].values()[0] = 17;
+  EXPECT_EQ(ds.coords()[Dim::X].values()[0], 17);
+}
+
+TEST_F(DatasetContractTest, item_values_can_be_set) {
+  ds["a"].data().values()[0] = 17;
+  EXPECT_EQ(ds["a"].data().values()[0], 17);
+}
+
+TEST_F(DatasetContractTest, item_coord_cannot_be_added) {
+  ds["a"].coords().setitem(Dim("ignored"), var);
+  EXPECT_FALSE(ds["a"].coords().contains(Dim("ignored")));
+}
+
+TEST_F(DatasetContractTest, item_mask_can_be_added) {
+  ds["a"].masks().setitem("mask", var);
+  EXPECT_TRUE(ds["a"].masks().contains("mask"));
+}

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -144,8 +144,8 @@ Dataset resize_default_init(const DatasetConstView &parent, const Dim dim,
 
 template <class T>
 Variable make_bins_impl(Variable &&indices, const Dim dim, T &&buffer) {
-  return {std::make_unique<variable::DataModel<bucket<T>>>(
-      std::move(indices), dim, std::move(buffer))};
+  return {indices.dims(), std::make_unique<variable::DataModel<bucket<T>>>(
+                              std::move(indices), dim, std::move(buffer))};
 }
 
 /// Construct a bin-variable over a data array.
@@ -166,14 +166,16 @@ Variable make_bins(Variable indices, const Dim dim, Dataset buffer) {
 
 Variable make_non_owning_bins(const VariableView &indices, const Dim dim,
                               const DataArrayView &buffer) {
-  return {std::make_unique<variable::DataModel<bucket<DataArrayView>>>(
-      indices, dim, buffer)};
+  return {indices.dims(),
+          std::make_unique<variable::DataModel<bucket<DataArrayView>>>(
+              indices, dim, buffer)};
 }
 
 Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
                               const DataArrayConstView &buffer) {
-  return {std::make_unique<variable::DataModel<bucket<DataArrayConstView>>>(
-      indices, dim, buffer)};
+  return {indices.dims(),
+          std::make_unique<variable::DataModel<bucket<DataArrayConstView>>>(
+              indices, dim, buffer)};
 }
 
 namespace {
@@ -245,6 +247,7 @@ template <class T>
 auto concatenate_impl(const VariableConstView &var0,
                       const VariableConstView &var1) {
   return Variable{
+      merge(var0.dims(), var1.dims()),
       std::make_unique<variable::DataModel<bucket<T>>>(combine<T>(var0, var1))};
 }
 

--- a/templates/variable_inplace.cpp.in
+++ b/templates/variable_inplace.cpp.in
@@ -13,13 +13,13 @@ namespace scipp::variable {
 // Note: These will broadcast/transpose the RHS if required. We do not support
 // changing the dimensions of the LHS though!
 Variable &@NAME@(Variable &lhs, const VariableConstView &rhs) {
-  @NAME@(VariableView(lhs), rhs);
+  @NAME@(Variable(lhs), rhs);
   return lhs;
 }
 
-VariableView @NAME@(const VariableView &lhs, const VariableConstView &rhs) {
+Variable @NAME@(Variable &&lhs, const VariableConstView &rhs) {
   transform_in_place(lhs, rhs, core::element::@OPNAME@, std::string_view("@OPNAME@"));
-  return lhs;
+  return std::move(lhs);
 }
 
 } // namespace scipp::variable

--- a/templates/variable_inplace.h.in
+++ b/templates/variable_inplace.h.in
@@ -10,6 +10,6 @@
 namespace scipp::variable {
 
 SCIPP_VARIABLE_EXPORT Variable &@NAME@(Variable &lhs, const VariableConstView &rhs);
-SCIPP_VARIABLE_EXPORT VariableView @NAME@(const VariableView &lhs, const VariableConstView &rhs);
+SCIPP_VARIABLE_EXPORT Variable @NAME@(Variable &&lhs, const VariableConstView &rhs);
 
 } // namespace scipp::variable

--- a/templates/variable_unary.cpp.in
+++ b/templates/variable_unary.cpp.in
@@ -17,7 +17,7 @@ Variable @NAME@(const VariableConstView &var) {
 }
 
 #ifdef GENERATE_OUT
-VariableView @NAME@(const VariableConstView &var, const VariableView &out) {
+Variable &@NAME@(const VariableConstView &var, Variable &out) {
   transform_in_place(out, var, assign_unary{element::@OPNAME@}, std::string_view("@OPNAME@"));
   return out;
 }

--- a/templates/variable_unary.h.in
+++ b/templates/variable_unary.h.in
@@ -13,6 +13,6 @@ namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable @NAME@(const VariableConstView &var);
 #ifdef GENERATE_OUT
-SCIPP_VARIABLE_EXPORT VariableView @NAME@(const VariableConstView &var, const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &@NAME@(const VariableConstView &var, Variable &out);
 #endif
 } // namespace scipp::variable

--- a/variable/bin_detail.cpp
+++ b/variable/bin_detail.cpp
@@ -18,8 +18,7 @@ namespace scipp::variable::bin_detail {
 ///
 /// 0 if the coord is less than the first edge, nbin-1 if greater or equal last
 /// edge. Assumes both `edges` and `coord` are sorted.
-Variable begin_edge(const VariableConstView &coord,
-                    const VariableConstView &edges) {
+Variable begin_edge(const Variable &coord, const Variable &edges) {
   auto indices = makeVariable<scipp::index>(coord.dims());
   const auto dim = edges.dims().inner();
   if (indices.dims()[dim] == 0)
@@ -35,8 +34,7 @@ Variable begin_edge(const VariableConstView &coord,
 /// 1 if the coord is
 /// nbin if the coord is greater than the last edge. Assumes both `edges` and
 /// `coord` are sorted.
-Variable end_edge(const VariableConstView &coord,
-                  const VariableConstView &edges) {
+Variable end_edge(const Variable &coord, const Variable &edges) {
   auto indices = makeVariable<scipp::index>(coord.dims());
   const auto dim = edges.dims().inner();
   if (indices.dims()[dim] == 0)

--- a/variable/bins.cpp
+++ b/variable/bins.cpp
@@ -69,8 +69,9 @@ Variable resize_default_init(const VariableConstView &var, const Dim dim,
 /// Each bin is represented by a VariableView. `indices` defines the array of
 /// bins as slices of `buffer` along `dim`.
 Variable make_bins(Variable indices, const Dim dim, Variable buffer) {
-  return {std::make_unique<variable::DataModel<bucket<Variable>>>(
-      std::move(indices), dim, std::move(buffer))};
+  return {indices.dims(),
+          std::make_unique<variable::DataModel<bucket<Variable>>>(
+              std::move(indices), dim, std::move(buffer))};
 }
 
 /// Construct non-owning binned variable of a mutable buffer.
@@ -80,8 +81,9 @@ Variable make_bins(Variable indices, const Dim dim, Variable buffer) {
 /// data. This is, it does not own any or share ownership of any data.
 Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
                               const VariableView &buffer) {
-  return {std::make_unique<variable::DataModel<bucket<VariableView>>>(
-      indices, dim, buffer)};
+  return {indices.dims(),
+          std::make_unique<variable::DataModel<bucket<VariableView>>>(
+              indices, dim, buffer)};
 }
 
 /// Construct non-owning binned variable of a const buffer.
@@ -91,8 +93,9 @@ Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
 /// data. This is, it does not own any or share ownership of any data.
 Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
                               const VariableConstView &buffer) {
-  return {std::make_unique<variable::DataModel<bucket<VariableConstView>>>(
-      indices, dim, buffer)};
+  return {indices.dims(),
+          std::make_unique<variable::DataModel<bucket<VariableConstView>>>(
+              indices, dim, buffer)};
 }
 
 } // namespace scipp::variable

--- a/variable/bins.cpp
+++ b/variable/bins.cpp
@@ -36,8 +36,8 @@ constexpr auto copy_spans = overloaded{
     }};
 } // namespace
 
-void copy_slices(const VariableConstView &src, const VariableView &dst,
-                 const Dim dim, const VariableConstView &srcIndices,
+void copy_slices(const VariableConstView &src, Variable &dst, const Dim dim,
+                 const VariableConstView &srcIndices,
                  const VariableConstView &dstIndices) {
   const auto [begin0, end0] = unzip(srcIndices);
   const auto [begin1, end1] = unzip(dstIndices);
@@ -72,30 +72,6 @@ Variable make_bins(Variable indices, const Dim dim, Variable buffer) {
   return {indices.dims(),
           std::make_unique<variable::DataModel<bucket<Variable>>>(
               std::move(indices), dim, std::move(buffer))};
-}
-
-/// Construct non-owning binned variable of a mutable buffer.
-///
-/// This is intented for internal and short-lived variables. The returned
-/// variable stores *views* onto `indices` and `buffer` rather than copying the
-/// data. This is, it does not own any or share ownership of any data.
-Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
-                              const VariableView &buffer) {
-  return {indices.dims(),
-          std::make_unique<variable::DataModel<bucket<VariableView>>>(
-              indices, dim, buffer)};
-}
-
-/// Construct non-owning binned variable of a const buffer.
-///
-/// This is intented for internal and short-lived variables. The returned
-/// variable stores *views* onto `indices` and `buffer` rather than copying the
-/// data. This is, it does not own any or share ownership of any data.
-Variable make_non_owning_bins(const VariableConstView &indices, const Dim dim,
-                              const VariableConstView &buffer) {
-  return {indices.dims(),
-          std::make_unique<variable::DataModel<bucket<VariableConstView>>>(
-              indices, dim, buffer)};
 }
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/bins.h
+++ b/variable/include/scipp/variable/bins.h
@@ -9,7 +9,7 @@
 namespace scipp::variable {
 
 SCIPP_VARIABLE_EXPORT void copy_slices(const VariableConstView &src,
-                                       const VariableView &dst, const Dim dim,
+                                       Variable &dst, const Dim dim,
                                        const VariableConstView &srcIndices,
                                        const VariableConstView &dstIndices);
 
@@ -19,13 +19,5 @@ SCIPP_VARIABLE_EXPORT void copy_slices(const VariableConstView &src,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable make_bins(Variable indices,
                                                        const Dim dim,
                                                        Variable buffer);
-
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_non_owning_bins(const VariableConstView &indices, const Dim dim,
-                     const VariableView &buffer);
-
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_non_owning_bins(const VariableConstView &indices, const Dim dim,
-                     const VariableConstView &buffer);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -102,8 +102,8 @@ public:
 
   [[nodiscard]] bool equals(const VariableConstView &a,
                             const VariableConstView &b) const override;
-  void copy(const VariableConstView &src,
-            const VariableView &dest) const override;
+  void copy(const VariableConstView &src, Variable &dest) const override;
+  void copy(const VariableConstView &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;
 
   // TODO Should the mutable version return a view to prevent risk of clients
@@ -193,9 +193,9 @@ bool DataModel<bucket<T>>::equals(const VariableConstView &a,
 
 template <class T>
 void DataModel<bucket<T>>::copy(const VariableConstView &src,
-                                const VariableView &dest) const {
+                                Variable &dest) const {
   const auto &[indices0, dim0, buffer0] = src.constituents<bucket<T>>();
-  const auto &[indices1, dim1, buffer1] = dest.constituents<bucket<T>>();
+  auto &&[indices1, dim1, buffer1] = dest.constituents<bucket<T>>();
   static_cast<void>(dim1);
   if constexpr (is_view_v<T>) {
     // This is overly restrictive, could allow copy to non-const non-owning
@@ -204,6 +204,11 @@ void DataModel<bucket<T>>::copy(const VariableConstView &src,
   } else {
     copy_slices(buffer0, buffer1, dim0, indices0, indices1);
   }
+}
+template <class T>
+void DataModel<bucket<T>>::copy(const VariableConstView &src,
+                                Variable &&dest) const {
+  copy(src, dest);
 }
 
 template <class T>

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -20,8 +20,7 @@ namespace scipp::variable {
 template <class Indices> class BinModelBase : public VariableConcept {
 public:
   BinModelBase(const VariableConstView &indices, const Dim dim)
-      : VariableConcept(indices.dims(), units::one), m_indices(indices),
-        m_dim(dim) {}
+      : VariableConcept(units::one), m_indices(indices), m_dim(dim) {}
 
   bool hasVariances() const noexcept override { return false; }
   void setVariances(Variable &&) override {
@@ -62,7 +61,7 @@ public:
   }
 
   bool operator==(const DataModel &other) const noexcept {
-    return this->dims() == other.dims() && this->indices() == other.indices() &&
+    return this->indices() == other.indices() &&
            this->bin_dim() == other.bin_dim() && m_buffer == other.m_buffer;
   }
   bool operator!=(const DataModel &other) const noexcept {
@@ -70,9 +69,9 @@ public:
   }
 
   [[nodiscard]] VariableConceptHandle
-  makeDefaultFromParent(const Dimensions &dims) const override {
+  makeDefaultFromParent(const scipp::index size) const override {
     return std::make_unique<DataModel>(
-        makeVariable<range_type>(dims), this->bin_dim(),
+        makeVariable<range_type>(Dims{Dim::X}, Shape{size}), this->bin_dim(),
         T{m_buffer.slice({this->bin_dim(), 0, 0})});
   }
 
@@ -99,6 +98,7 @@ public:
   [[nodiscard]] DType dtype() const noexcept override {
     return scipp::dtype<bucket<T>>;
   }
+  scipp::index size() const override { return this->indices().dims().volume(); }
 
   [[nodiscard]] bool equals(const VariableConstView &a,
                             const VariableConstView &b) const override;

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -20,7 +20,8 @@ namespace scipp::variable {
 template <class Indices> class BinModelBase : public VariableConcept {
 public:
   BinModelBase(const VariableConstView &indices, const Dim dim)
-      : VariableConcept(indices.dims()), m_indices(indices), m_dim(dim) {}
+      : VariableConcept(indices.dims(), units::one), m_indices(indices),
+        m_dim(dim) {}
 
   bool hasVariances() const noexcept override { return false; }
   void setVariances(Variable &&) override {

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -23,7 +23,7 @@ public:
       : VariableConcept(units::one), m_indices(indices), m_dim(dim) {}
 
   bool hasVariances() const noexcept override { return false; }
-  void setVariances(Variable &&) override {
+  void setVariances(const Variable &) override {
     throw except::VariancesError("This data type cannot have variances.");
   }
   VariableConstView bin_indices() const override { return indices(); }

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -43,9 +43,10 @@ template <class T> class DataModel : public VariableConcept {
 public:
   using value_type = T;
 
-  DataModel(const Dimensions &dimensions, element_array<T> model,
+  DataModel(const Dimensions &dimensions, const units::Unit &unit,
+            element_array<T> model,
             std::optional<element_array<T>> variances = std::nullopt)
-      : VariableConcept(dimensions),
+      : VariableConcept(dimensions, unit),
         m_values(model ? std::move(model)
                        : element_array<T>(dimensions.volume(),
                                           default_init<T>::value())),
@@ -129,10 +130,11 @@ template <class T>
 VariableConceptHandle
 DataModel<T>::makeDefaultFromParent(const Dimensions &dims) const {
   if (hasVariances())
-    return std::make_unique<DataModel<T>>(dims, element_array<T>(dims.volume()),
+    return std::make_unique<DataModel<T>>(dims, unit(),
+                                          element_array<T>(dims.volume()),
                                           element_array<T>(dims.volume()));
   else
-    return std::make_unique<DataModel<T>>(dims,
+    return std::make_unique<DataModel<T>>(dims, unit(),
                                           element_array<T>(dims.volume()));
 }
 

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -78,7 +78,7 @@ public:
             const VariableView &dest) const override;
   void assign(const VariableConcept &other) override;
 
-  void setVariances(Variable &&variances) override;
+  void setVariances(const Variable &variances) override;
 
   VariableConceptHandle clone() const override {
     return std::make_unique<DataModel<T>>(*this);
@@ -173,16 +173,16 @@ template <class T> void DataModel<T>::assign(const VariableConcept &other) {
   *this = requireT<const DataModel<T>>(other);
 }
 
-template <class T> void DataModel<T>::setVariances(Variable &&variances) {
+template <class T> void DataModel<T>::setVariances(const Variable &variances) {
   if (!core::canHaveVariances<T>())
     throw except::VariancesError("This data type cannot have variances.");
   if (!variances)
     return m_variances.reset();
+  // TODO Could move if refcount is 1?
   if (variances.hasVariances())
     throw except::VariancesError(
         "Cannot set variances from variable with variances.");
-  m_variances.emplace(
-      std::move(requireT<DataModel>(variances.data()).m_values));
+  m_variances.emplace(requireT<const DataModel>(variances.data()).m_values);
 }
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -74,8 +74,8 @@ public:
 
   bool equals(const VariableConstView &a,
               const VariableConstView &b) const override;
-  void copy(const VariableConstView &src,
-            const VariableView &dest) const override;
+  void copy(const VariableConstView &src, Variable &dest) const override;
+  void copy(const VariableConstView &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;
 
   void setVariances(const Variable &variances) override;
@@ -161,12 +161,15 @@ bool DataModel<T>::equals(const VariableConstView &a,
 /// This method is using virtual dispatch as a trick to obtain T, such that
 /// transform can be called with any T.
 template <class T>
-void DataModel<T>::copy(const VariableConstView &src,
-                        const VariableView &dest) const {
+void DataModel<T>::copy(const VariableConstView &src, Variable &dest) const {
   transform_in_place<T>(
       dest, src,
       overloaded{core::transform_flags::expect_in_variance_if_out_variance,
                  [](auto &a, const auto &b) { a = b; }});
+}
+template <class T>
+void DataModel<T>::copy(const VariableConstView &src, Variable &&dest) const {
+  copy(src, dest);
 }
 
 template <class T> void DataModel<T>::assign(const VariableConcept &other) {

--- a/variable/include/scipp/variable/reduction.h
+++ b/variable/include/scipp/variable/reduction.h
@@ -12,14 +12,14 @@ namespace scipp::variable {
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable mean(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable mean(const VariableConstView &var,
                                                   const Dim dim);
-SCIPP_VARIABLE_EXPORT VariableView mean(const VariableConstView &var,
-                                        const Dim dim, const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &mean(const VariableConstView &var,
+                                     const Dim dim, Variable &out);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const VariableConstView &var,
                                                  const Dim dim);
-SCIPP_VARIABLE_EXPORT VariableView sum(const VariableConstView &var,
-                                       const Dim dim, const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &sum(const VariableConstView &var, const Dim dim,
+                                    Variable &out);
 
 // Logical reductions
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable any(const VariableConstView &var);
@@ -49,15 +49,13 @@ nanmin(const VariableConstView &var, const Dim dim);
 nansum(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 nansum(const VariableConstView &var, const Dim dim);
-SCIPP_VARIABLE_EXPORT VariableView nansum(const VariableConstView &var,
-                                          const Dim dim,
-                                          const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &nansum(const VariableConstView &var,
+                                       const Dim dim, Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 nanmean(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 nanmean(const VariableConstView &var, const Dim dim);
-SCIPP_VARIABLE_EXPORT VariableView nanmean(const VariableConstView &var,
-                                           const Dim dim,
-                                           const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &nanmean(const VariableConstView &var,
+                                        const Dim dim, Variable &out);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/shape.h
+++ b/variable/include/scipp/variable/shape.h
@@ -20,7 +20,7 @@ permute(const Variable &var, const Dim dim,
 resize(const VariableConstView &var, const Dim dim, const scipp::index size);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 resize(const VariableConstView &var, const VariableConstView &shape);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reverse(Variable var,
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reverse(const Variable &var,
                                                      const Dim dim);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reshape(const Variable &var,
                                                      const Dimensions &dims);

--- a/variable/include/scipp/variable/shape.h
+++ b/variable/include/scipp/variable/shape.h
@@ -22,9 +22,7 @@ resize(const VariableConstView &var, const Dim dim, const scipp::index size);
 resize(const VariableConstView &var, const VariableConstView &shape);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reverse(Variable var,
                                                      const Dim dim);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT VariableView
-reshape(Variable &var, const Dimensions &dims);
-[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reshape(Variable &&var,
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable reshape(const Variable &var,
                                                      const Dimensions &dims);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 reshape(const VariableConstView &view, const Dimensions &dims);

--- a/variable/include/scipp/variable/trigonometry.h
+++ b/variable/include/scipp/variable/trigonometry.h
@@ -11,32 +11,31 @@ namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sin(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sin(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView sin(const VariableConstView &var,
-                                       const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &sin(const VariableConstView &var,
+                                    Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable cos(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable cos(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView cos(const VariableConstView &var,
-                                       const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &cos(const VariableConstView &var,
+                                    Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable tan(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable tan(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView tan(const VariableConstView &var,
-                                       const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &tan(const VariableConstView &var,
+                                    Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable asin(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable asin(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView asin(const VariableConstView &var,
-                                        const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &asin(const VariableConstView &var,
+                                     Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable acos(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable acos(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView acos(const VariableConstView &var,
-                                        const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &acos(const VariableConstView &var,
+                                     Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable atan(const VariableConstView &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable atan(Variable &&var);
-SCIPP_VARIABLE_EXPORT VariableView atan(const VariableConstView &var,
-                                        const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &atan(const VariableConstView &var,
+                                     Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable atan2(const VariableConstView &y,
                                                    const VariableConstView &x);
-SCIPP_VARIABLE_EXPORT VariableView atan2(const VariableConstView &y,
-                                         const VariableConstView &x,
-                                         const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &
+atan2(const VariableConstView &y, const VariableConstView &x, Variable &out);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -145,7 +145,7 @@ public:
   VariableConcept &data() && = delete;
   VariableConcept &data() & { return *m_object; }
 
-  void setVariances(Variable v);
+  void setVariances(const Variable &v);
 
   core::ElementArrayViewParams array_params() const noexcept;
 
@@ -344,7 +344,7 @@ public:
   // (would this suffer from the same issue?).
   template <class T> VariableView assign(const T &other) const;
 
-  void setVariances(Variable v) const;
+  void setVariances(const Variable &v) const;
 
   void setUnit(const units::Unit &unit) const;
   void expectCanSetUnit(const units::Unit &unit) const;

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -90,8 +90,8 @@ public:
   explicit operator bool() const noexcept { return m_object.operator bool(); }
   Variable operator~() const;
 
-  units::Unit unit() const { return m_unit; }
-  void setUnit(const units::Unit &unit) { m_unit = unit; }
+  units::Unit unit() const { return m_object->unit(); }
+  void setUnit(const units::Unit &unit) { m_object->setUnit(unit); }
   constexpr void expectCanSetUnit(const units::Unit &) const noexcept {}
 
   Dimensions dims() const && { return m_object->dims(); }
@@ -163,7 +163,6 @@ private:
   template <class... Ts, class... Args>
   static Variable construct(const DType &type, Args &&... args);
 
-  units::Unit m_unit;
   VariableConceptHandle m_object;
 };
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -102,9 +102,7 @@ public:
 
   DType dtype() const noexcept { return data().dtype(); }
 
-  scipp::span<const scipp::index> strides() const {
-    return {m_strides.begin(), m_strides.begin() + dims().ndim()};
-  }
+  scipp::span<const scipp::index> strides() const;
 
   bool hasVariances() const noexcept { return data().hasVariances(); }
 
@@ -132,8 +130,7 @@ public:
   // ATTENTION: It is really important to avoid any function returning a
   // (Const)VariableView for rvalue Variable. Otherwise the resulting slice
   // will point to free'ed memory.
-  VariableConstView slice(const Slice slice) const &;
-  Variable slice(const Slice slice) const &&;
+  Variable slice(const Slice slice) const &;
   VariableView slice(const Slice slice) &;
   Variable slice(const Slice slice) &&;
 
@@ -150,16 +147,7 @@ public:
 
   void setVariances(Variable v);
 
-  core::ElementArrayViewParams array_params() const noexcept {
-    // TODO Translating strides into dims, which get translated back to
-    // (slightly different) strides in MultiIndex
-    Dimensions dataDims;
-    for (scipp::index i = dims().ndim() - 1; i >= 0; --i)
-      dataDims.add(dims().label(i),
-                   (i == 0 ? m_object->size() : strides()[i - 1]) /
-                       strides()[i]);
-    return {m_offset, dims(), dataDims, {}};
-  }
+  core::ElementArrayViewParams array_params() const noexcept;
 
   VariableConstView bin_indices() const;
 
@@ -238,7 +226,8 @@ public:
   VariableConstView(const Variable &variable) : m_variable(&variable) {
     if (variable) {
       m_dims = variable.dims();
-      m_dataDims = variable.dims();
+      m_dataDims = variable.array_params().dataDims();
+      m_offset = variable.array_params().offset();
     }
   }
   VariableConstView(const Variable &variable, const Dimensions &dims);

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -94,8 +94,8 @@ public:
   void setUnit(const units::Unit &unit) { m_object->setUnit(unit); }
   constexpr void expectCanSetUnit(const units::Unit &) const noexcept {}
 
-  Dimensions dims() const && { return m_object->dims(); }
-  const Dimensions &dims() const & { return m_object->dims(); }
+  Dimensions dims() const && { return m_dims; }
+  const Dimensions &dims() const & { return m_dims; }
   void setDims(const Dimensions &dimensions);
 
   DType dtype() const noexcept { return data().dtype(); }
@@ -163,6 +163,7 @@ private:
   template <class... Ts, class... Args>
   static Variable construct(const DType &type, Args &&... args);
 
+  Dimensions m_dims;
   VariableConceptHandle m_object;
 };
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -65,8 +65,8 @@ using bin_indices_t = std::conditional_t<is_view_v<typename T::buffer_type>,
 /// labels.
 class SCIPP_VARIABLE_EXPORT Variable {
 public:
-  using const_view_type = VariableConstView;
-  using view_type = VariableView;
+  using const_view_type = Variable;
+  using view_type = Variable;
 
   Variable() = default;
   explicit Variable(const VariableConstView &slice);
@@ -93,7 +93,7 @@ public:
   Variable operator~() const;
 
   units::Unit unit() const { return m_object->unit(); }
-  void setUnit(const units::Unit &unit) { m_object->setUnit(unit); }
+  void setUnit(const units::Unit &unit);
   constexpr void expectCanSetUnit(const units::Unit &) const noexcept {}
 
   Dimensions dims() const && { return m_dims; }
@@ -131,8 +131,6 @@ public:
   // (Const)VariableView for rvalue Variable. Otherwise the resulting slice
   // will point to free'ed memory.
   Variable slice(const Slice slice) const &;
-  VariableView slice(const Slice slice) &;
-  Variable slice(const Slice slice) &&;
 
   void rename(const Dim from, const Dim to);
 
@@ -355,6 +353,9 @@ public:
 
   template <class T> void replace_model(T model) const;
 
+  auto &underlying() const { return *m_mutableVariable; }
+  auto &underlying() { return *m_mutableVariable; }
+
 private:
   friend class dataset::DataArrayConstView;
   template <class T> friend typename T::view_type dataset::makeViewItem(T &);
@@ -368,7 +369,7 @@ private:
 
 SCIPP_VARIABLE_EXPORT Variable copy(const VariableConstView &var);
 SCIPP_VARIABLE_EXPORT VariableView copy(const VariableConstView &dataset,
-                                        const VariableView &out);
+                                        Variable &out);
 
 } // namespace scipp::variable
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -71,8 +71,9 @@ public:
   explicit Variable(const VariableConstView &slice);
   Variable(const Variable &parent, const Dimensions &dims);
   Variable(const VariableConstView &parent, const Dimensions &dims);
-  Variable(const VariableConstView &parent, VariableConceptHandle data);
-  Variable(VariableConceptHandle data);
+  Variable(const VariableConstView &parent, const Dimensions &dims,
+           VariableConceptHandle data);
+  Variable(const Dimensions &dims, VariableConceptHandle data);
   template <class T>
   Variable(const units::Unit unit, const Dimensions &dimensions, T values,
            std::optional<T> variances);

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -16,7 +16,7 @@ namespace scipp::variable {
 template <class T>
 Variable::Variable(const units::Unit unit, const Dimensions &dimensions,
                    T values_, std::optional<T> variances_)
-    : m_dims(dimensions),
+    : m_dims(dimensions), m_strides(dimensions),
       m_object(std::make_unique<DataModel<typename T::value_type>>(
           dimensions.volume(), unit, std::move(values_),
           std::move(variances_))) {}

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -16,9 +16,9 @@ namespace scipp::variable {
 template <class T>
 Variable::Variable(const units::Unit unit, const Dimensions &dimensions,
                    T values_, std::optional<T> variances_)
-    : m_unit{unit},
-      m_object(std::make_unique<DataModel<typename T::value_type>>(
-          std::move(dimensions), std::move(values_), std::move(variances_))) {}
+    : m_object(std::make_unique<DataModel<typename T::value_type>>(
+          std::move(dimensions), unit, std::move(values_),
+          std::move(variances_))) {}
 
 template <class T> ElementArrayView<const T> Variable::values() const {
   return cast<T>(*this).values(array_params());

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -16,7 +16,7 @@ namespace scipp::variable {
 template <class T>
 Variable::Variable(const units::Unit unit, const Dimensions &dimensions,
                    T values_, std::optional<T> variances_)
-    : m_object(std::make_unique<DataModel<typename T::value_type>>(
+    : m_dims(dimensions), m_object(std::make_unique<DataModel<typename T::value_type>>(
           std::move(dimensions), unit, std::move(values_),
           std::move(variances_))) {}
 

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -10,6 +10,7 @@
 #include "scipp/common/span.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/dtype.h"
+#include "scipp/units/unit.h"
 
 #include <memory>
 
@@ -38,7 +39,7 @@ public:
 /// data. More operations are supportd by the typed DataModel.
 class SCIPP_VARIABLE_EXPORT VariableConcept {
 public:
-  VariableConcept(const Dimensions &dimensions);
+  VariableConcept(const Dimensions &dimensions, const units::Unit &unit);
   virtual ~VariableConcept() = default;
 
   virtual VariableConceptHandle clone() const = 0;
@@ -49,6 +50,9 @@ public:
 
   virtual DType dtype() const noexcept = 0;
   const Dimensions &dims() const { return m_dimensions; }
+  const units::Unit &unit() const { return m_unit; }
+
+  void setUnit(const units::Unit &unit) { m_unit = unit; }
 
   virtual bool hasVariances() const noexcept = 0;
   virtual void setVariances(Variable &&variances) = 0;
@@ -66,6 +70,7 @@ public:
 
 private:
   Dimensions m_dimensions;
+  units::Unit m_unit;
 };
 
 template <class T>

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -21,6 +21,8 @@ class VariableConstView;
 class VariableView;
 class VariableConcept;
 
+using VariableConceptHandle = std::shared_ptr<VariableConcept>;
+/*
 class SCIPP_VARIABLE_EXPORT VariableConceptHandle
     : public scipp::deep_ptr<VariableConcept> {
 public:
@@ -31,6 +33,7 @@ public:
   VariableConceptHandle &operator=(VariableConceptHandle &&) = default;
   VariableConceptHandle &operator=(const VariableConceptHandle &other);
 };
+*/
 
 /// Abstract base class for any data that can be held by Variable. This is using
 /// so-called concept-based polymorphism, see talks by Sean Parent.
@@ -55,7 +58,7 @@ public:
   void setUnit(const units::Unit &unit) { m_unit = unit; }
 
   virtual bool hasVariances() const noexcept = 0;
-  virtual void setVariances(Variable &&variances) = 0;
+  virtual void setVariances(const Variable &variances) = 0;
 
   virtual bool equals(const VariableConstView &a,
                       const VariableConstView &b) const = 0;
@@ -72,9 +75,11 @@ private:
   units::Unit m_unit;
 };
 
+/*
 template <class T>
 VariableConceptHandle::VariableConceptHandle(T object)
     : VariableConceptHandle(
           std::unique_ptr<VariableConcept>(std::move(object))) {}
+          */
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -62,8 +62,8 @@ public:
 
   virtual bool equals(const VariableConstView &a,
                       const VariableConstView &b) const = 0;
-  virtual void copy(const VariableConstView &src,
-                    const VariableView &dest) const = 0;
+  virtual void copy(const VariableConstView &src, Variable &dest) const = 0;
+  virtual void copy(const VariableConstView &src, Variable &&dest) const = 0;
   virtual void assign(const VariableConcept &other) = 0;
   virtual scipp::index dtype_size() const = 0;
 

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -39,18 +39,18 @@ public:
 /// data. More operations are supportd by the typed DataModel.
 class SCIPP_VARIABLE_EXPORT VariableConcept {
 public:
-  VariableConcept(const Dimensions &dimensions, const units::Unit &unit);
+  VariableConcept(const units::Unit &unit);
   virtual ~VariableConcept() = default;
 
   virtual VariableConceptHandle clone() const = 0;
   virtual VariableConceptHandle
-  makeDefaultFromParent(const Dimensions &dims) const = 0;
+  makeDefaultFromParent(const scipp::index size) const = 0;
   virtual VariableConceptHandle
   makeDefaultFromParent(const VariableConstView &shape) const = 0;
 
   virtual DType dtype() const noexcept = 0;
-  const Dimensions &dims() const { return m_dimensions; }
   const units::Unit &unit() const { return m_unit; }
+  virtual scipp::index size() const = 0;
 
   void setUnit(const units::Unit &unit) { m_unit = unit; }
 
@@ -69,7 +69,6 @@ public:
   friend class Variable;
 
 private:
-  Dimensions m_dimensions;
   units::Unit m_unit;
 };
 

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -31,10 +31,8 @@ public:
   virtual void set_elem_unit(const VariableView &var,
                              const units::Unit &u) const = 0;
   virtual bool hasVariances(const VariableConstView &var) const = 0;
-  virtual VariableConstView data(const VariableConstView &) const {
-    throw unreachable();
-  }
-  virtual VariableView data(const VariableView &) const { throw unreachable(); }
+  virtual const Variable &data(const Variable &) const { throw unreachable(); }
+  virtual Variable &data(Variable &) const { throw unreachable(); }
   virtual core::ElementArrayViewParams
   array_params(const VariableConstView &) const {
     throw unreachable();
@@ -146,9 +144,11 @@ public:
                       const VariableConstView &sizes = {});
 
 private:
-  VariableConstView view(const VariableConstView &var) const { return var; }
-  VariableView view(Variable &var) const { return var; }
-  VariableView view(const VariableView &var) const { return var; }
+  const Variable &view(const VariableConstView &var) const {
+    return var.underlying();
+  }
+  Variable &view(Variable &var) const { return var; }
+  Variable &view(const VariableView &var) const { return var.underlying(); }
   std::map<DType, std::unique_ptr<AbstractVariableMaker>> m_makers;
 };
 

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -58,7 +58,7 @@ Variable filter(const Variable &var, const Variable &filter) {
 Variable copy(const VariableConstView &var) { return Variable(var); }
 
 /// Copy variable to output variable.
-VariableView copy(const VariableConstView &var, const VariableView &out) {
+VariableView copy(const VariableConstView &var, Variable &out) {
   var.underlying().data().copy(var, out);
   return out;
 }

--- a/variable/operations_common.h
+++ b/variable/operations_common.h
@@ -9,28 +9,29 @@
 namespace scipp::variable {
 
 // Helpers for in-place reductions and reductions with groupby.
-SCIPP_VARIABLE_EXPORT void sum_impl(const VariableView &summed,
+SCIPP_VARIABLE_EXPORT void sum_impl(Variable &summed,
                                     const VariableConstView &var);
-SCIPP_VARIABLE_EXPORT void all_impl(const VariableView &out,
+SCIPP_VARIABLE_EXPORT void all_impl(Variable &out,
                                     const VariableConstView &var);
-SCIPP_VARIABLE_EXPORT void any_impl(const VariableView &out,
+SCIPP_VARIABLE_EXPORT void any_impl(Variable &out,
                                     const VariableConstView &var);
-SCIPP_VARIABLE_EXPORT void max_impl(const VariableView &out,
+SCIPP_VARIABLE_EXPORT void max_impl(Variable &out,
                                     const VariableConstView &var);
-SCIPP_VARIABLE_EXPORT void min_impl(const VariableView &out,
+SCIPP_VARIABLE_EXPORT void min_impl(Variable &out,
                                     const VariableConstView &var);
 SCIPP_VARIABLE_EXPORT Variable mean_impl(const VariableConstView &var,
                                          const Dim dim,
                                          const VariableConstView &masks_sum);
-SCIPP_VARIABLE_EXPORT VariableView mean_impl(const VariableConstView &var,
-                                             const Dim dim,
-                                             const VariableConstView &masks_sum,
-                                             const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &mean_impl(const VariableConstView &var,
+                                          const Dim dim,
+                                          const VariableConstView &masks_sum,
+                                          Variable &out);
 SCIPP_VARIABLE_EXPORT Variable nanmean_impl(const VariableConstView &var,
                                             const Dim dim,
                                             const VariableConstView &masks_sum);
-SCIPP_VARIABLE_EXPORT VariableView
-nanmean_impl(const VariableConstView &var, const Dim dim,
-             const VariableConstView &masks_sum, const VariableView &out);
+SCIPP_VARIABLE_EXPORT Variable &nanmean_impl(const VariableConstView &var,
+                                             const Dim dim,
+                                             const VariableConstView &masks_sum,
+                                             Variable &out);
 
 } // namespace scipp::variable

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -37,8 +37,8 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
   const auto *xold = oldCoordT.values<T>().data();
   const auto *xnew = newCoordT.values<T>().data();
 
-  auto add_from_bin = [&](const auto &slice, const auto xn_low,
-                          const auto xn_high, const scipp::index iold) {
+  auto add_from_bin = [&](auto &&slice, const auto xn_low, const auto xn_high,
+                          const scipp::index iold) {
     auto xo_low = xold[iold];
     auto xo_high = xold[iold + 1];
     // delta is the overlap of the bins on the x axis
@@ -47,7 +47,7 @@ void rebin_non_inner(const Dim dim, const VariableConstView &oldT,
     const auto owidth = std::abs(xo_high - xo_low);
     slice += oldT.slice({dim, iold}) * ((delta / owidth) * units::one);
   };
-  auto accumulate_bin = [&](const auto &slice, const auto xn_low,
+  auto accumulate_bin = [&](auto &&slice, const auto xn_low,
                             const auto xn_high) {
     scipp::index begin =
         std::upper_bound(xold, xold + oldSize + 1, xn_low, less) - xold;

--- a/variable/reduction.cpp
+++ b/variable/reduction.cpp
@@ -42,11 +42,11 @@ Variable make_accumulant(const VariableConstView &var, const Dim dim,
 
 } // namespace
 
-void sum_impl(const VariableView &summed, const VariableConstView &var) {
+void sum_impl(Variable &summed, const VariableConstView &var) {
   accumulate_in_place(summed, var, element::plus_equals, "sum");
 }
 
-void nansum_impl(const VariableView &summed, const VariableConstView &var) {
+void nansum_impl(Variable &summed, const VariableConstView &var) {
   accumulate_in_place(summed, var, element::nan_plus_equals, "nansum");
 }
 
@@ -60,8 +60,8 @@ Variable sum_with_dim_impl(Op op, const VariableConstView &var, const Dim dim) {
 }
 
 template <typename Op>
-VariableView sum_with_dim_inplace_impl(Op op, const VariableConstView &var,
-                                       const Dim dim, const VariableView &out) {
+Variable &sum_with_dim_inplace_impl(Op op, const VariableConstView &var,
+                                    const Dim dim, Variable &out) {
   if (is_dtype_bool(var) && !is_dtype_int64(out))
     throw except::TypeError("In-place sum of dtype=bool must be stored in an "
                             "output variable with dtype=int64.");
@@ -86,19 +86,16 @@ Variable nansum(const VariableConstView &var, const Dim dim) {
   return sum_with_dim_impl(nansum_impl, var, dim);
 }
 
-VariableView sum(const VariableConstView &var, const Dim dim,
-                 const VariableView &out) {
+Variable &sum(const VariableConstView &var, const Dim dim, Variable &out) {
   return sum_with_dim_inplace_impl(sum_impl, var, dim, out);
 }
 
-VariableView nansum(const VariableConstView &var, const Dim dim,
-                    const VariableView &out) {
+Variable &nansum(const VariableConstView &var, const Dim dim, Variable &out) {
   return sum_with_dim_inplace_impl(nansum_impl, var, dim, out);
 }
 
-VariableView nanmean_impl(const VariableConstView &var, const Dim dim,
-                          const VariableConstView &count,
-                          const VariableView &out) {
+Variable &nanmean_impl(const VariableConstView &var, const Dim dim,
+                       const VariableConstView &count, Variable &out) {
   if (isInt(out.dtype()))
     throw except::TypeError(
         "Cannot calculate nanmean in-place when output dtype is integer");
@@ -129,9 +126,8 @@ Variable nanmean_impl(const VariableConstView &var, const Dim dim,
   return summed;
 }
 
-VariableView mean_impl(const VariableConstView &var, const Dim dim,
-                       const VariableConstView &count,
-                       const VariableView &out) {
+Variable &mean_impl(const VariableConstView &var, const Dim dim,
+                    const VariableConstView &count, Variable &out) {
   if (isInt(out.dtype()))
     throw except::TypeError(
         "Cannot calculate mean in-place when output dtype is integer");
@@ -151,8 +147,7 @@ Variable mean(const VariableConstView &var, const Dim dim) {
   return mean_impl(var, dim, sum(isfinite(var), dim));
 }
 
-VariableView mean(const VariableConstView &var, const Dim dim,
-                  const VariableView &out) {
+Variable &mean(const VariableConstView &var, const Dim dim, Variable &out) {
   using variable::isfinite;
   return mean_impl(var, dim, sum(isfinite(var), dim), out);
 }
@@ -167,14 +162,13 @@ Variable nanmean(const VariableConstView &var, const Dim dim) {
   return nanmean_impl(var, dim, sum(isfinite(var), dim));
 }
 
-VariableView nanmean(const VariableConstView &var, const Dim dim,
-                     const VariableView &out) {
+Variable &nanmean(const VariableConstView &var, const Dim dim, Variable &out) {
   using variable::isfinite;
   return nanmean_impl(var, dim, sum(isfinite(var), dim), out);
 }
 
 template <class Op>
-void reduce_impl(const VariableView &out, const VariableConstView &var, Op op,
+void reduce_impl(Variable &out, const VariableConstView &var, Op op,
                  const std::string_view name) {
   accumulate_in_place(out, var, op, name);
 }
@@ -193,7 +187,7 @@ Variable reduce_idempotent(const VariableConstView &var, const Dim dim, Op op,
   return out;
 }
 
-void any_impl(const VariableView &out, const VariableConstView &var) {
+void any_impl(Variable &out, const VariableConstView &var) {
   reduce_impl(out, var, core::element::logical_or_equals, "any");
 }
 
@@ -202,7 +196,7 @@ Variable any(const VariableConstView &var, const Dim dim) {
                            FillValue::False, "any");
 }
 
-void all_impl(const VariableView &out, const VariableConstView &var) {
+void all_impl(Variable &out, const VariableConstView &var) {
   reduce_impl(out, var, core::element::logical_and_equals, "all");
 }
 
@@ -211,7 +205,7 @@ Variable all(const VariableConstView &var, const Dim dim) {
                            FillValue::True, "all");
 }
 
-void max_impl(const VariableView &out, const VariableConstView &var) {
+void max_impl(Variable &out, const VariableConstView &var) {
   reduce_impl(out, var, core::element::max_equals, "max");
 }
 
@@ -233,7 +227,7 @@ Variable nanmax(const VariableConstView &var, const Dim dim) {
                            FillValue::Lowest, "nanmax");
 }
 
-void min_impl(const VariableView &out, const VariableConstView &var) {
+void min_impl(Variable &out, const VariableConstView &var) {
   reduce_impl(out, var, core::element::min_equals, "min");
 }
 

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -122,7 +122,8 @@ Variable resize(const VariableConstView &var, const Dim dim,
 /// ignored, i.e., only `shape.dims()` is used to determine the shape of the
 /// output.
 Variable resize(const VariableConstView &var, const VariableConstView &shape) {
-  return Variable(var, var.underlying().data().makeDefaultFromParent(shape));
+  return Variable(var, shape.dims(),
+                  var.underlying().data().makeDefaultFromParent(shape));
 }
 
 namespace {

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -135,11 +135,12 @@ void swap(Variable &var, const Dim dim, const scipp::index a,
 }
 } // namespace
 
-Variable reverse(Variable var, const Dim dim) {
-  const auto size = var.dims()[dim];
+Variable reverse(const Variable &var, const Dim dim) {
+  auto out = copy(var);
+  const auto size = out.dims()[dim];
   for (scipp::index i = 0; i < size / 2; ++i)
-    swap(var, dim, i, size - i - 1);
-  return var;
+    swap(out, dim, i, size - i - 1);
+  return out;
 }
 
 Variable reshape(const Variable &var, const Dimensions &dims) {

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -129,7 +129,7 @@ Variable resize(const VariableConstView &var, const VariableConstView &shape) {
 namespace {
 void swap(Variable &var, const Dim dim, const scipp::index a,
           const scipp::index b) {
-  const Variable tmp(var.slice({dim, a}));
+  const Variable tmp = copy(var.slice({dim, a}));
   var.slice({dim, a}).assign(var.slice({dim, b}));
   var.slice({dim, b}).assign(tmp);
 }
@@ -144,9 +144,10 @@ Variable reverse(const Variable &var, const Dim dim) {
 }
 
 Variable reshape(const Variable &var, const Dimensions &dims) {
-  // TODO must extract slice if not contiguous
   expect_same_volume(var.dims(), dims);
-  Variable reshaped(var);
+  // TODO This condition is not sufficient
+  Variable reshaped =
+      var.dims().volume() == var.data().size() ? var : copy(var);
   reshaped.setDims(dims);
   return reshaped;
 }

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -142,13 +142,10 @@ Variable reverse(Variable var, const Dim dim) {
   return var;
 }
 
-VariableView reshape(Variable &var, const Dimensions &dims) {
-  return {var, dims};
-}
-
-Variable reshape(Variable &&var, const Dimensions &dims) {
+Variable reshape(const Variable &var, const Dimensions &dims) {
+  // TODO must extract slice if not contiguous
   expect_same_volume(var.dims(), dims);
-  Variable reshaped(std::move(var));
+  Variable reshaped(var);
   reshaped.setDims(dims);
   return reshaped;
 }

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -73,8 +73,7 @@ auto apply(const DType dtype, Args &&... args) {
   return core::callDType<Callable>(
       std::tuple<double, float, int64_t, int32_t, std::string, bool,
                  scipp::core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
-                 Variable, bucket<Variable>, bucket<VariableConstView>,
-                 bucket<VariableView>, scipp::index_pair>{},
+                 Variable, bucket<Variable>, scipp::index_pair>{},
       dtype, std::forward<Args>(args)...);
 }
 } // namespace

--- a/variable/test/CMakeLists.txt
+++ b/variable/test/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(
   transform_test.cpp
   trigonometry_test.cpp
   util_test.cpp
-  variable_bucket_non_owning_test.cpp
+  #variable_bucket_non_owning_test.cpp
   variable_bucket_test.cpp
   variable_custom_type_test.cpp
   variable_keyword_args_constructor_test.cpp

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -77,7 +77,7 @@ TEST_F(BucketModelTest, comparison) {
   EXPECT_EQ(Model(indices, Dim::X, buffer), Model(indices, Dim::X, buffer));
   EXPECT_NE(Model(Variable(indices.slice({Dim::Y, 0})), Dim::X, buffer),
             Model(Variable(indices.slice({Dim::Y, 0, 1})), Dim::X, buffer));
-  auto indices2 = indices;
+  auto indices2 = copy(indices);
   indices2.values<std::pair<scipp::index, scipp::index>>()[0] = {0, 1};
   EXPECT_NE(Model(indices, Dim::X, buffer), Model(indices2, Dim::X, buffer));
   auto buffer2 = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},

--- a/variable/test/bucket_model_test.cpp
+++ b/variable/test/bucket_model_test.cpp
@@ -10,9 +10,8 @@ using namespace scipp;
 using namespace scipp::variable;
 
 TEST(BucketTest, member_types) {
-  static_assert(std::is_same_v<bucket<Variable>::element_type, VariableView>);
-  static_assert(
-      std::is_same_v<bucket<Variable>::const_element_type, VariableConstView>);
+  static_assert(std::is_same_v<bucket<Variable>::element_type, Variable>);
+  static_assert(std::is_same_v<bucket<Variable>::const_element_type, Variable>);
 }
 
 using Model = DataModel<bucket<Variable>>;
@@ -122,20 +121,4 @@ TEST_F(BucketModelTest, out_of_order_indices) {
   core::ElementArrayViewParams params(0, reverse.dims(), reverse.dims(), {});
   EXPECT_EQ(*(model.values(params).begin() + 0), buffer.slice({Dim::X, 2, 4}));
   EXPECT_EQ(*(model.values(params).begin() + 1), buffer.slice({Dim::X, 0, 2}));
-}
-
-class NonOwningBucketModelTest : public BucketModelTest {};
-
-TEST_F(NonOwningBucketModelTest, buffer_is_view) {
-  DataModel<bucket<VariableView>> model(indices, Dim::X, buffer);
-  core::ElementArrayViewParams params(0, indices.dims(), indices.dims(), {});
-  (*model.values(params).begin()) += 2.0 * units::one;
-  EXPECT_EQ(buffer, makeVariable<double>(buffer.dims(), Values{3, 4, 3, 4}));
-}
-
-TEST_F(NonOwningBucketModelTest, indices_is_view) {
-  DataModel<bucket<VariableView>> model(indices, Dim::X, buffer);
-  EXPECT_EQ(model.indices(), indices);
-  indices.values<index_pair>()[0] = std::pair{1, 2};
-  EXPECT_EQ(model.indices(), indices);
 }

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -115,7 +115,7 @@ TEST(Variable, operator_plus_equal_different_dimensions) {
 TEST(Variable, operator_plus_equal_different_unit) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.1, 2.2});
 
-  auto different_unit(a);
+  auto different_unit = copy(a);
   different_unit.setUnit(units::m);
   EXPECT_THROW(a += different_unit, except::UnitError);
 }
@@ -387,7 +387,7 @@ TEST(Variable, concatenate_fail) {
 TEST(Variable, concatenate_unit_fail) {
   Dimensions dims(Dim::X, 1);
   auto a = makeVariable<double>(Dimensions(dims), Values{1.0});
-  auto b(a);
+  auto b = copy(a);
   EXPECT_NO_THROW_DISCARD(concatenate(a, b, Dim::X));
   a.setUnit(units::m);
   EXPECT_THROW_MSG_DISCARD(concatenate(a, b, Dim::X), std::runtime_error,
@@ -433,7 +433,7 @@ TEST(VariableView, self_overlapping_view_operation) {
 TEST(VariableView, minus_equals_slice_const_outer) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});
-  const auto copy(var);
+  const auto copy = variable::copy(var);
 
   var -= copy.slice({Dim::Y, 0});
   const auto data = var.values<double>();
@@ -451,7 +451,7 @@ TEST(VariableView, minus_equals_slice_const_outer) {
 TEST(VariableView, minus_equals_slice_outer) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});
-  auto copy(var);
+  auto copy = variable::copy(var);
 
   var -= copy.slice({Dim::Y, 0});
   const auto data = var.values<double>();
@@ -469,7 +469,7 @@ TEST(VariableView, minus_equals_slice_outer) {
 TEST(VariableView, minus_equals_slice_inner) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});
-  auto copy(var);
+  auto copy = variable::copy(var);
 
   var -= copy.slice({Dim::X, 0});
   const auto data = var.values<double>();
@@ -487,7 +487,7 @@ TEST(VariableView, minus_equals_slice_inner) {
 TEST(VariableView, minus_equals_slice_of_slice) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                   Values{1.0, 2.0, 3.0, 4.0});
-  auto copy(var);
+  auto copy = variable::copy(var);
 
   var -= copy.slice({Dim::X, 1}).slice({Dim::Y, 1});
   const auto data = var.values<double>();

--- a/variable/test/subspan_view_test.cpp
+++ b/variable/test/subspan_view_test.cpp
@@ -33,7 +33,10 @@ TEST_F(SubspanViewTest, values) {
 }
 
 TEST_F(SubspanViewTest, values_length_0) {
-  auto view = subspan_view(var.slice({Dim::X, 0, 0}), Dim::X);
+  // TODO subspan_view does not take ownership, right now this is selecting from
+  // overload by converting to VariableConstView
+  auto slice = var.slice({Dim::X, 0, 0});
+  auto view = subspan_view(slice, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
   EXPECT_EQ(view.unit(), units::m);
   EXPECT_TRUE(view.values<span<double>>()[0].empty());
@@ -52,7 +55,9 @@ TEST_F(SubspanViewTest, values_and_errors) {
 }
 
 TEST_F(SubspanViewTest, values_and_errors_length_0) {
-  auto view = subspan_view(var_with_errors.slice({Dim::X, 0, 0}), Dim::X);
+  // TODO see above
+  auto slice = var_with_errors.slice({Dim::X, 0, 0});
+  auto view = subspan_view(slice, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
   EXPECT_EQ(view.unit(), units::m);
   EXPECT_TRUE(view.values<span<double>>()[0].empty());

--- a/variable/test/sum_test.cpp
+++ b/variable/test/sum_test.cpp
@@ -38,20 +38,18 @@ TEST_F(SumTest, sum_with_empty_dim) {
 
 TEST_F(SumTest, sum_in_place) {
   auto out = makeVariable<double>(Dims{Dim::Y}, Shape{2});
-  auto view = sum(var, Dim::X, out);
+  auto &view = sum(var, Dim::X, out);
   EXPECT_EQ(out, makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
                                       Values{3.0, 7.0}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST_F(SumTest, sum_in_place_bool) {
   auto out = makeVariable<int64_t>(Dims{Dim::Y}, Shape{2});
-  auto view = sum(var_bool, Dim::X, out);
+  auto &view = sum(var_bool, Dim::X, out);
   EXPECT_EQ(out, makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, units::m,
                                        Values{1, 2}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST_F(SumTest, sum_in_place_bool_incorrect_out_type) {

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -110,7 +110,7 @@ TEST_F(TransformUnaryTest, dense) {
       const auto initial = make_variable_for_test<double>(shape, variances);
 
       const auto result_return = transform<double>(initial, op);
-      Variable result_in_place = initial;
+      Variable result_in_place = copy(initial);
       transform_in_place<double>(result_in_place, op_in_place);
 
       EXPECT_TRUE(equals(result_in_place.values<double>(),
@@ -140,7 +140,7 @@ TEST_F(TransformUnaryTest, slice) {
         const auto initial = initial_buffer.slice(slice);
 
         const auto result_return = transform<double>(initial, op);
-        Variable result_in_place_buffer = initial_buffer;
+        Variable result_in_place_buffer = copy(initial_buffer);
         const auto result_in_place = result_in_place_buffer.slice(slice);
         transform_in_place<double>(result_in_place, op_in_place);
 
@@ -170,7 +170,7 @@ TEST_F(TransformUnaryTest, elements_of_bins) {
           const auto buffer = make_variable_for_test<double>(shape, variances);
           const auto bin_dim_label = buffer.dims().labels()[bin_dim];
           const auto indices = make_bin_indices(shape.data[bin_dim], n_bins);
-          auto var = make_bins(indices, bin_dim_label, buffer);
+          auto var = make_bins(indices, bin_dim_label, copy(buffer));
 
           const auto result = transform<double>(var, op);
           transform_in_place<double>(var, op_in_place);
@@ -197,12 +197,12 @@ TEST_F(TransformUnaryTest, in_place_unit_change) {
   auto op_ = [](auto &&a) { a *= a; };
   Variable result;
 
-  result = var;
+  result = copy(var);
   transform_in_place<double>(result, op_);
   EXPECT_EQ(result, expected);
 
   // Unit changes but we are transforming only parts of data -> not possible.
-  result = var;
+  result = copy(var);
   EXPECT_THROW(transform_in_place<double>(result.slice({Dim::X, 1}), op_),
                except::UnitError);
 }
@@ -364,7 +364,7 @@ TEST_F(TransformBinaryTest, dense_events) {
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 3}, std::pair{3, 4}});
   const auto table =
       makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4});
-  auto events = make_bins(indices, Dim::Event, table);
+  auto events = make_bins(indices, Dim::Event, copy(table));
   auto dense = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.5, 0.5});
 
   const auto ab = transform<pair_self_t<double>>(events, dense, op);
@@ -489,7 +489,7 @@ TEST(TransformTest, mixed_precision_in_place) {
 TEST(TransformTest, combined_uncertainty_propagation) {
   auto a =
       makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{2.0}, Variances{0.1});
-  auto a_2_step(a);
+  auto a_2_step = copy(a);
   const auto b = makeVariable<double>(Values{3.0}, Variances{0.2});
 
   const auto abb = transform<pair_self_t<double>>(
@@ -544,7 +544,7 @@ TEST_F(TransformTest_events_binary_values_variances_size_fail, a_size_bad) {
                except::BinnedDataError);
 }
 
-class TransformBucketsBinaryTest : public TransformBinaryTest {
+class TransformBinsBinaryTest : public TransformBinaryTest {
 protected:
   Variable indicesY = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::Y}, Shape{2}, Values{std::pair{0, 3}, std::pair{3, 4}});
@@ -554,11 +554,11 @@ protected:
   Variable tableB = makeVariable<double>(Dims{Dim::Event}, Shape{4},
                                          Values{0.1, 0.2, 0.3, 0.4},
                                          Variances{0.5, 0.6, 0.7, 0.8});
-  Variable a = make_bins(indicesY, Dim::Event, tableA);
-  Variable b = make_bins(indicesY, Dim::Event, tableB);
+  Variable a = make_bins(indicesY, Dim::Event, copy(tableA));
+  Variable b = make_bins(indicesY, Dim::Event, copy(tableB));
 };
 
-TEST_F(TransformBucketsBinaryTest, events_val_var_with_events_val_var) {
+TEST_F(TransformBinsBinaryTest, events_val_var_with_events_val_var) {
   const auto ab = transform<pair_self_t<double>>(a, b, op);
   transform_in_place<pair_self_t<double>>(a, b, op_in_place);
   // We rely on correctness of *dense* operations (Variable multiplication is
@@ -567,7 +567,7 @@ TEST_F(TransformBucketsBinaryTest, events_val_var_with_events_val_var) {
   EXPECT_EQ(ab, a);
 }
 
-TEST_F(TransformBucketsBinaryTest, events_val_var_with_events_val) {
+TEST_F(TransformBinsBinaryTest, events_val_var_with_events_val) {
   const auto table = values(tableB);
   b = make_bins(indicesY, Dim::Event, table);
   const auto ab = transform<pair_self_t<double>>(a, b, op);
@@ -576,7 +576,7 @@ TEST_F(TransformBucketsBinaryTest, events_val_var_with_events_val) {
   EXPECT_EQ(ab, a);
 }
 
-TEST_F(TransformBucketsBinaryTest, events_val_var_with_val_var) {
+TEST_F(TransformBinsBinaryTest, events_val_var_with_val_var) {
   b = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1.5, 1.6},
                            Variances{1.7, 1.8});
 
@@ -589,7 +589,7 @@ TEST_F(TransformBucketsBinaryTest, events_val_var_with_val_var) {
   EXPECT_EQ(ab, a);
 }
 
-TEST_F(TransformBucketsBinaryTest, events_val_var_with_val) {
+TEST_F(TransformBinsBinaryTest, events_val_var_with_val) {
   b = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1.5, 1.6});
 
   const auto ab = transform<pair_self_t<double>>(a, b, op);
@@ -601,7 +601,7 @@ TEST_F(TransformBucketsBinaryTest, events_val_var_with_val) {
   EXPECT_EQ(ab, a);
 }
 
-TEST_F(TransformBucketsBinaryTest, broadcast_events_val_var_with_val) {
+TEST_F(TransformBinsBinaryTest, broadcast_events_val_var_with_val) {
   b = makeVariable<float>(Dims{Dim::Z}, Shape{2}, Values{1.5, 1.6});
 
   const auto ab = transform<pair_custom_t<std::tuple<double, float>>>(a, b, op);
@@ -929,17 +929,17 @@ TEST(TransformEigenTest, is_eigen_type_test) {
   EXPECT_TRUE(scipp::variable::detail::is_eigen_type_v<Eigen::Matrix3d>);
 }
 
-class TransformBucketElementsTest : public ::testing::Test {
+class TransformBinElementsTest : public ::testing::Test {
 protected:
   Dimensions dims{Dim::Y, 2};
   Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       dims, Values{std::pair{0, 2}, std::pair{2, 4}});
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
-  Variable var = make_bins(indices, Dim::X, buffer);
+  Variable var = make_bins(indices, Dim::X, copy(buffer));
 };
 
-TEST_F(TransformBucketElementsTest, single_arg_in_place) {
+TEST_F(TransformBinElementsTest, single_arg_in_place) {
   transform_in_place<double>(
       var, scipp::overloaded{transform_flags::expect_no_variance_arg<0>,
                              [](auto &x) { x *= x; }});

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -141,7 +141,7 @@ TEST_F(TransformUnaryTest, slice) {
 
         const auto result_return = transform<double>(initial, op);
         Variable result_in_place_buffer = copy(initial_buffer);
-        const auto result_in_place = result_in_place_buffer.slice(slice);
+        auto result_in_place = result_in_place_buffer.slice(slice);
         transform_in_place<double>(result_in_place, op_in_place);
 
         EXPECT_TRUE(equals(result_return.values<double>(),
@@ -661,7 +661,7 @@ TEST_F(TransformInPlaceDryRunTest, unit_fail) {
 
 TEST_F(TransformInPlaceDryRunTest, slice_unit_fail) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
-  const auto original(a);
+  const auto original = copy(a);
 
   EXPECT_THROW(dry_run::transform_in_place<double>(a.slice({Dim::X, 0}), unary),
                except::UnitError);
@@ -675,7 +675,7 @@ TEST_F(TransformInPlaceDryRunTest, slice_unit_fail) {
 TEST_F(TransformInPlaceDryRunTest, dimensions_fail) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
   auto b = makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m);
-  const auto original(a);
+  const auto original = copy(a);
 
   EXPECT_THROW(dry_run::transform_in_place<pair_self_t<double>>(a, b, binary),
                except::NotFoundError);
@@ -686,7 +686,7 @@ TEST_F(TransformInPlaceDryRunTest, variances_fail) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
   auto b = makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{},
                                 Variances{});
-  const auto original(a);
+  const auto original = copy(a);
 
   EXPECT_THROW(dry_run::transform_in_place<pair_self_t<double>>(a, b, binary),
                except::VariancesError);

--- a/variable/test/trigonometry_test.cpp
+++ b/variable/test/trigonometry_test.cpp
@@ -39,22 +39,20 @@ TEST(Variable, sin_out_arg_rad) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
                                 Unit{units::rad});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = sin(x.slice({Dim::X, 0}), out);
+  auto &view = sin(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, sin_out_arg_deg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
                                 Unit{units::deg});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = sin(x.slice({Dim::X, 0}), out);
+  auto &view = sin(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, cos_rad) {
@@ -87,22 +85,20 @@ TEST(Variable, cos_out_arg_rad) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
                                 Unit{units::rad});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = cos(x.slice({Dim::X, 0}), out);
+  auto &view = cos(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, cos_out_arg_deg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
                                 Unit{units::deg});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = cos(x.slice({Dim::X, 0}), out);
+  auto &view = cos(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, tan_rad) {
@@ -135,22 +131,20 @@ TEST(Variable, tan_out_arg_rad) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
                                 Unit{units::rad});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = tan(x.slice({Dim::X, 0}), out);
+  auto &view = tan(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, tan_out_arg_deg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
                                 Unit{units::deg});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = tan(x.slice({Dim::X, 0}), out);
+  auto &view = tan(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, asin) {
@@ -171,12 +165,11 @@ TEST(Variable, asin_move) {
 TEST(Variable, asin_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = asin(x.slice({Dim::X, 0}), out);
+  auto &view = asin(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
             makeVariable<double>(Values{std::asin(1.0)}, Unit{units::rad}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, acos) {
@@ -197,12 +190,11 @@ TEST(Variable, acos_move) {
 TEST(Variable, acos_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = acos(x.slice({Dim::X, 0}), out);
+  auto &view = acos(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
             makeVariable<double>(Values{std::acos(1.0)}, Unit{units::rad}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, atan) {
@@ -223,12 +215,11 @@ TEST(Variable, atan_move) {
 TEST(Variable, atan_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
-  auto view = atan(x.slice({Dim::X, 0}), out);
+  auto &view = atan(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
             makeVariable<double>(Values{std::atan(1.0)}, Unit{units::rad}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(VariableTrigonometryTest, atan2) {

--- a/variable/test/variable_bucket_non_owning_test.cpp
+++ b/variable/test/variable_bucket_non_owning_test.cpp
@@ -37,7 +37,7 @@ TEST_F(VariableBucketNonOwningTest, copy) {
 }
 
 TEST_F(VariableBucketNonOwningTest, assign) {
-  Variable buffer_copy(buffer);
+  Variable buffer_copy = variable::copy(buffer);
   Variable copy =
       make_non_owning_bins(indices, Dim::X, VariableView(buffer_copy));
   view.values<bucket<VariableView>>()[0] +=

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -56,7 +56,7 @@ TEST_F(VariableBucketTest, basics) {
 }
 
 TEST_F(VariableBucketTest, view) {
-  VariableView view(var);
+  Variable view(var);
   EXPECT_EQ(view.values<bucket<Variable>>(), var.values<bucket<Variable>>());
   view = var.slice({Dim::Y, 1});
   const auto vals = view.values<bucket<Variable>>();

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -25,7 +25,7 @@ TEST_F(VariableBucketTest, comparison) {
 TEST_F(VariableBucketTest, copy) { EXPECT_EQ(Variable(var), var); }
 
 TEST_F(VariableBucketTest, assign) {
-  Variable copy(var);
+  Variable copy = variable::copy(var);
   var.values<bucket<Variable>>()[0] += var.values<bucket<Variable>>()[1];
   EXPECT_NE(copy, var);
   copy = var;

--- a/variable/test/variable_math_test.cpp
+++ b/variable/test/variable_math_test.cpp
@@ -41,23 +41,21 @@ TEST(Variable, abs_move) {
 TEST(Variable, abs_out_arg) {
   const auto x = -1.23 * units::m;
   auto out = 0.0 * units::dimensionless;
-  const auto view = abs(x, out);
+  const auto &view = abs(x, out);
 
   EXPECT_EQ(x, -1.23 * units::m);
-  EXPECT_EQ(view, out);
+  EXPECT_EQ(&view, &out);
   EXPECT_EQ(view, 1.23 * units::m);
-  EXPECT_EQ(view.underlying(), out);
 }
 
 TEST(Variable, abs_out_arg_self) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{-1.23, 0.0});
   auto out = x.slice({Dim::X, 1});
-  auto view = abs(x.slice({Dim::X, 0}), out);
+  auto &view = abs(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(x, makeVariable<double>(Dims{Dim::X}, Shape{2},
                                     Values{-1.23, element::abs(-1.23)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), x);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, norm_of_vector) {
@@ -95,12 +93,11 @@ TEST(Variable, sqrt_move) {
 TEST(Variable, sqrt_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.23, 0.0});
   auto out = x.slice({Dim::X, 1});
-  auto view = sqrt(x.slice({Dim::X, 0}), out);
+  auto &view = sqrt(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(x, makeVariable<double>(Dims{Dim::X}, Shape{2},
                                     Values{1.23, element::sqrt(1.23)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), x);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, dot_of_vector) {
@@ -135,24 +132,22 @@ TEST(Variable, reciprocal_move) {
 TEST(Variable, reciprocal_out_arg_full_in_place) {
   auto var =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 4, 9});
-  auto view = reciprocal(var, var);
+  auto &view = reciprocal(var, var);
   EXPECT_EQ(var, makeVariable<double>(Dims{Dim::X}, Shape{3},
                                       units::Unit(units::one / units::m),
                                       Values{1., 1. / 4., 1. / 9.}));
-  EXPECT_EQ(view, var);
-  EXPECT_EQ(view.underlying(), var);
+  EXPECT_EQ(&view, &var);
 }
 
 TEST(Variable, reciprocal_out_arg_partial) {
   const auto var =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 4, 9});
   auto out = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
-  auto view = reciprocal(var.slice({Dim::X, 1, 3}), out);
+  auto &view = reciprocal(var.slice({Dim::X, 1, 3}), out);
   EXPECT_EQ(out, makeVariable<double>(Dims{Dim::X}, Shape{2},
                                       units::Unit(units::one / units::m),
                                       Values{1. / 4., 1. / 9.}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TYPED_TEST(VariableMathTest, exp) {
@@ -168,13 +163,12 @@ TEST(Variable, exp_out_arg) {
   Shape shape{2};
   const auto x = makeVariable<double>(dims, shape, Values{1.23, 0.0});
   auto out = makeVariable<double>(dims, shape, Values{0.0, 0.0});
-  const auto view = exp(x, out);
+  const auto &view = exp(x, out);
 
   EXPECT_EQ(
       out, makeVariable<double>(dims, shape,
                                 Values{element::exp(1.23), element::exp(0.0)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, exp_bad_unit) {
@@ -194,13 +188,12 @@ TEST(Variable, log_out_arg) {
   Shape shape{2};
   const auto x = makeVariable<double>(dims, shape, Values{1.23, 3.21});
   auto out = makeVariable<double>(dims, shape, Values{0.0, 0.0});
-  const auto view = log(x, out);
+  const auto &view = log(x, out);
 
   EXPECT_EQ(out,
             makeVariable<double>(
                 dims, shape, Values{element::log(1.23), element::log(3.21)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, log_bad_unit) {
@@ -220,13 +213,12 @@ TEST(Variable, log10_out_arg) {
   Shape shape{2};
   const auto x = makeVariable<double>(dims, shape, Values{1.23, 3.21});
   auto out = makeVariable<double>(dims, shape, Values{0.0, 0.0});
-  const auto view = log10(x, out);
+  const auto &view = log10(x, out);
 
   EXPECT_EQ(out, makeVariable<double>(
                      dims, shape,
                      Values{element::log10(1.23), element::log10(3.21)}));
-  EXPECT_EQ(view, out);
-  EXPECT_EQ(view.underlying(), out);
+  EXPECT_EQ(&view, &out);
 }
 
 TEST(Variable, log10_bad_unit) {

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -517,34 +517,27 @@ TEST(VariableView, full_mutable_view) {
 
 TEST(VariableView, strides) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3});
-  EXPECT_EQ(var.slice({Dim::X, 0}).strides(), (std::vector<scipp::index>{3}));
-  EXPECT_EQ(var.slice({Dim::X, 1}).strides(), (std::vector<scipp::index>{3}));
-  EXPECT_EQ(var.slice({Dim::Y, 0}).strides(), (std::vector<scipp::index>{1}));
-  EXPECT_EQ(var.slice({Dim::Y, 1}).strides(), (std::vector<scipp::index>{1}));
-  EXPECT_EQ(var.slice({Dim::X, 0, 1}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::X, 1, 2}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::Y, 0, 1}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::Y, 1, 2}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::X, 0, 2}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::X, 1, 3}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::Y, 0, 2}).strides(),
-            (std::vector<scipp::index>{3, 1}));
-  EXPECT_EQ(var.slice({Dim::Y, 1, 3}).strides(),
-            (std::vector<scipp::index>{3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 0}).strides(), {3}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 1}).strides(), {3}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 0}).strides(), {1}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 1}).strides(), {1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 0, 1}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 1, 2}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 0, 1}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 1, 2}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 0, 2}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 1, 3}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 0, 2}).strides(), {3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::Y, 1, 3}).strides(), {3, 1}));
 
-  EXPECT_EQ(var.slice({Dim::X, 0, 1}).slice({Dim::Y, 0, 1}).strides(),
-            (std::vector<scipp::index>{3, 1}));
+  EXPECT_TRUE(equals(var.slice({Dim::X, 0, 1}).slice({Dim::Y, 0, 1}).strides(),
+                     {3, 1}));
 
   auto var3D =
       makeVariable<double>(Dims{Dim::Z, Dim::Y, Dim::X}, Shape{4, 3, 2});
-  EXPECT_EQ(var3D.slice({Dim::X, 0, 1}).slice({Dim::Z, 0, 1}).strides(),
-            (std::vector<scipp::index>{6, 2, 1}));
+  EXPECT_TRUE(
+      equals(var3D.slice({Dim::X, 0, 1}).slice({Dim::Z, 0, 1}).strides(),
+             std::vector<scipp::index>{6, 2, 1}));
 }
 
 TEST(VariableView, values_and_variances) {

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -282,19 +282,19 @@ TEST(Variable, assign_slice) {
   const auto empty = makeVariable<double>(
       Dimensions{{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}, Values{}, Variances{});
 
-  auto d(empty);
+  auto d = copy(empty);
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1, 2, 3})
     d.slice({Dim::X, index}).assign(parent.slice({Dim::X, index}));
   EXPECT_EQ(parent, d);
 
-  d = empty;
+  d = copy(empty);
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1})
     d.slice({Dim::Y, index}).assign(parent.slice({Dim::Y, index}));
   EXPECT_EQ(parent, d);
 
-  d = empty;
+  d = copy(empty);
   EXPECT_NE(parent, d);
   for (const scipp::index index : {0, 1, 2})
     d.slice({Dim::Z, index}).assign(parent.slice({Dim::Z, index}));
@@ -780,11 +780,11 @@ template <typename Var> void test_set_variances(Var &var) {
   var.setVariances(v);
   ASSERT_TRUE(equals(var.template variances<double>(), {2.0, 4.0, 6.0}));
 
-  Variable bad_dims(v);
+  Variable bad_dims = copy(v);
   bad_dims.rename(Dim::X, Dim::Y);
   EXPECT_THROW(var.setVariances(bad_dims), except::DimensionError);
 
-  Variable bad_unit(v);
+  Variable bad_unit = copy(v);
   bad_unit.setUnit(units::s);
   EXPECT_THROW(var.setVariances(bad_unit), except::UnitError);
 
@@ -795,14 +795,6 @@ TEST(VariableTest, set_variances) {
   Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
                                       Values{1.0, 2.0, 3.0});
   test_set_variances(var);
-}
-
-TEST(VariableTest, set_variances_moves) {
-  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3});
-  Variable variances(var);
-  const auto ptr = variances.values<double>().data();
-  var.setVariances(std::move(variances));
-  EXPECT_EQ(var.variances<double>().data(), ptr);
 }
 
 TEST(VariableTest, set_variances_remove) {

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -985,3 +985,22 @@ TEST(TransposeTest, reverse) {
                                         Values{0, 0}, Variances{1, 1});
   EXPECT_NO_THROW(tvar.slice({Dim::X, 0, 1}).assign(dummy));
 }
+
+TEST(VariableTest, array_params) {
+  const auto parent =
+      makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{4, 2, 3});
+
+  const Dimensions yz({Dim::Y, Dim::Z}, {8, 3});
+  const Dimensions xz({Dim::X, Dim::Z}, {4, 6});
+  Dimensions xy = parent.dims();
+  xy.relabel(2, Dim::Invalid);
+  EXPECT_EQ(parent.array_params().dataDims(), parent.dims());
+  EXPECT_EQ(parent.slice({Dim::X, 1}).array_params().dataDims(), yz);
+  EXPECT_EQ(parent.slice({Dim::Y, 1}).array_params().dataDims(), xz);
+  EXPECT_EQ(parent.slice({Dim::Z, 1}).array_params().dataDims(), xy);
+
+  const auto empty_1d = makeVariable<double>(Dims{Dim::X}, Shape{0});
+  EXPECT_EQ(empty_1d.array_params().dataDims(), empty_1d.dims());
+  const auto empty_2d = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 0});
+  EXPECT_EQ(empty_2d.array_params().dataDims(), empty_2d.dims());
+}

--- a/variable/trigonometry.cpp
+++ b/variable/trigonometry.cpp
@@ -28,7 +28,7 @@ Variable sin(Variable &&var) {
   return out;
 }
 
-VariableView sin(const VariableConstView &var, const VariableView &out) {
+Variable &sin(const VariableConstView &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
   out.assign(var);
   if (var.unit() == units::deg)
@@ -49,7 +49,7 @@ Variable cos(Variable &&var) {
   return out;
 }
 
-VariableView cos(const VariableConstView &var, const VariableView &out) {
+Variable &cos(const VariableConstView &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
   out.assign(var);
   if (var.unit() == units::deg)
@@ -70,7 +70,7 @@ Variable tan(Variable &&var) {
   return out;
 }
 
-VariableView tan(const VariableConstView &var, const VariableView &out) {
+Variable &tan(const VariableConstView &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
   out.assign(var);
   if (var.unit() == units::deg)
@@ -89,7 +89,7 @@ Variable asin(Variable &&var) {
   return out;
 }
 
-VariableView asin(const VariableConstView &var, const VariableView &out) {
+Variable &asin(const VariableConstView &var, Variable &out) {
   transform_in_place(out, var, element::asin_out_arg);
   return out;
 }
@@ -104,7 +104,7 @@ Variable acos(Variable &&var) {
   return out;
 }
 
-VariableView acos(const VariableConstView &var, const VariableView &out) {
+Variable &acos(const VariableConstView &var, Variable &out) {
   transform_in_place(out, var, element::acos_out_arg);
   return out;
 }
@@ -119,7 +119,7 @@ Variable atan(Variable &&var) {
   return out;
 }
 
-VariableView atan(const VariableConstView &var, const VariableView &out) {
+Variable &atan(const VariableConstView &var, Variable &out) {
   transform_in_place(out, var, element::atan_out_arg);
   return out;
 }
@@ -128,8 +128,8 @@ Variable atan2(const VariableConstView &y, const VariableConstView &x) {
   return transform(y, x, element::atan2);
 }
 
-VariableView atan2(const VariableConstView &y, const VariableConstView &x,
-                   const VariableView &out) {
+Variable &atan2(const VariableConstView &y, const VariableConstView &x,
+                Variable &out) {
   transform_in_place(out, y, x, element::atan2_out_arg);
   return out;
 }

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -235,18 +235,18 @@ void VariableConstView::rename(const Dim from, const Dim to) {
   }
 }
 
-void Variable::setVariances(Variable v) {
+void Variable::setVariances(const Variable &v) {
   if (v) {
     core::expect::equals(unit(), v.unit());
     core::expect::equals(dims(), v.dims());
   }
-  data().setVariances(std::move(v));
+  data().setVariances(v);
 }
 
-void VariableView::setVariances(Variable v) const {
+void VariableView::setVariances(const Variable &v) const {
   if (m_offset == 0 && m_dims == m_variable->dims() &&
       m_dataDims == m_variable->dims())
-    m_mutableVariable->setVariances(std::move(v));
+    m_mutableVariable->setVariances(v);
   else
     throw except::VariancesError(
         "Cannot add variances via sliced or reshaped view of Variable.");

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -24,15 +24,13 @@ Variable::Variable(const VariableConstView &slice)
 ///
 /// In the case of bucket variables the buffer size is set to zero.
 Variable::Variable(const Variable &parent, const Dimensions &dims)
-    : m_unit(parent.unit()),
-      m_object(parent.data().makeDefaultFromParent(dims)) {}
+    : m_object(parent.data().makeDefaultFromParent(dims)) {}
 
 Variable::Variable(const VariableConstView &parent, const Dimensions &dims)
-    : m_unit(parent.unit()),
-      m_object(parent.underlying().data().makeDefaultFromParent(dims)) {}
+    : m_object(parent.underlying().data().makeDefaultFromParent(dims)) {}
 
 Variable::Variable(const VariableConstView &parent, VariableConceptHandle data)
-    : m_unit(parent.unit()), m_object(std::move(data)) {}
+    : m_object(std::move(data)) {}
 
 Variable::Variable(VariableConceptHandle data) : m_object(std::move(data)) {}
 

--- a/variable/variable_concept.cpp
+++ b/variable/variable_concept.cpp
@@ -3,6 +3,7 @@
 
 namespace scipp::variable {
 
+/*
 VariableConceptHandle::VariableConceptHandle(const VariableConceptHandle &other)
     : VariableConceptHandle(other ? other->clone() : VariableConceptHandle()) {}
 
@@ -22,6 +23,7 @@ VariableConceptHandle::operator=(const VariableConceptHandle &other) {
   }
   return *this = other ? other->clone() : VariableConceptHandle();
 }
+*/
 
 VariableConcept::VariableConcept(const units::Unit &unit) : m_unit(unit) {}
 

--- a/variable/variable_concept.cpp
+++ b/variable/variable_concept.cpp
@@ -14,7 +14,7 @@ VariableConceptHandle::operator=(const VariableConceptHandle &other) {
     auto &varconcept = **this;
     auto &otherConcept = *other;
     if (varconcept.dtype() == otherConcept.dtype() &&
-        varconcept.dims() == otherConcept.dims() &&
+        varconcept.size() == otherConcept.size() &&
         varconcept.hasVariances() == otherConcept.hasVariances()) {
       varconcept.assign(otherConcept);
       return *this;
@@ -23,8 +23,6 @@ VariableConceptHandle::operator=(const VariableConceptHandle &other) {
   return *this = other ? other->clone() : VariableConceptHandle();
 }
 
-VariableConcept::VariableConcept(const Dimensions &dimensions,
-                                 const units::Unit &unit)
-    : m_dimensions(dimensions), m_unit(unit) {}
+VariableConcept::VariableConcept(const units::Unit &unit) : m_unit(unit) {}
 
 } // namespace scipp::variable

--- a/variable/variable_concept.cpp
+++ b/variable/variable_concept.cpp
@@ -23,7 +23,8 @@ VariableConceptHandle::operator=(const VariableConceptHandle &other) {
   return *this = other ? other->clone() : VariableConceptHandle();
 }
 
-VariableConcept::VariableConcept(const Dimensions &dimensions)
-    : m_dimensions(dimensions) {}
+VariableConcept::VariableConcept(const Dimensions &dimensions,
+                                 const units::Unit &unit)
+    : m_dimensions(dimensions), m_unit(unit) {}
 
 } // namespace scipp::variable


### PR DESCRIPTION
Prototype related #1617 

Behavior for meta data dicts summerized in the following table:
```
                    | coords attrs masks
-----------------------------------------
slice               | new    new    new
copy                | copy   copy  copy
ds.__getitem__(str) | new    share share
ds.__setitem__(str) | -      copy  copy
```
- `copy` means the dict is copied, which -- just like in Python -- means the buffers (unit and values) are *not* copied but shared, i.e., a shallow copy of the dict.
- `new` means a new dict, but again referencing buffers or slices of buffers without copies.