### PR TITLE
Table for scalar variables

### DIFF
--- a/python/src/scipp/_utils/is_type.py
+++ b/python/src/scipp/_utils/is_type.py
@@ -13,6 +13,13 @@ def is_variable(obj):
     return isinstance(obj, sc.Variable) or isinstance(obj, sc.VariableView)
 
 
+def is_scalar(obj):
+    """
+    Return True if the input is a scalar
+    """
+    return obj.dims == []
+
+
 def is_dataset(obj):
     """
     Return True if the input is of type scipp.core.Variable.

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -261,7 +261,10 @@ class TableViewer:
                 group = "{}D Variables".format(ndims)
                 if su.is_variable(scipp_obj):
                     self.headers = 1
-                    key = str(scipp_obj.dims[0])
+                    if su.is_scalar(scipp_obj):
+                        key = ''
+                    else:
+                        key = str(scipp_obj.dims[0])
                     var = scipp_obj
                 else:
                     self.headers = 0

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -261,10 +261,8 @@ class TableViewer:
                 group = "{}D Variables".format(ndims)
                 if su.is_variable(scipp_obj):
                     self.headers = 1
-                    if su.is_scalar(scipp_obj):
-                        key = ''
-                    else:
-                        key = str(scipp_obj.dims[0])
+                    key = '' if su.is_scalar(scipp_obj) else str(
+                        scipp_obj.dims[0])
                     var = scipp_obj
                 else:
                     self.headers = 0

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -182,3 +182,7 @@ def test_display_when_largest_coord_non_dimensional():
                                        values=np.random.random(10),
                                        unit=sc.units.counts))
     sc.table(da)
+
+
+def test_with_scalar():
+    sc.table(sc.scalar(value=1.0))

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -184,5 +184,18 @@ def test_display_when_largest_coord_non_dimensional():
     sc.table(da)
 
 
-def test_with_scalar():
+def test_with_scalar_variable():
     sc.table(sc.scalar(value=1.0))
+
+
+def test_with_scalar_dataarray():
+    x = sc.array(dims=['x'], values=[0, 1])
+    sc.table(sc.DataArray(data=sc.scalar(value=1.0), coords={'x': x}))
+
+
+def test_with_scalar_dataset():
+    ds = sc.Dataset(data={
+        'a': sc.scalar(value=1.0),
+        'b': sc.scalar(value=2.0)
+    })
+    sc.table(ds)


### PR DESCRIPTION
fixes #1694

Enables scalar variables to be shown as single rows with no dimension information