### PR TITLE
Kill zombie colorbar

### DIFF
--- a/python/src/scipp/plotting/sciplot.py
+++ b/python/src/scipp/plotting/sciplot.py
@@ -73,11 +73,11 @@ class SciPlot:
                                       view_ndims=view_ndims,
                                       positions=positions)
 
-        # Set cmap extend state: if we have sliders, then we need to extend.
+        # Set cmap extend state: if we have sliders (= key "0" is found in
+        # self.axes), then we need to extend.
         # We also need to extend if vmin or vmax are set.
         self.extend_cmap = "neither"
-        if (self.ndim > view_ndims) or ((vmin is not None) and
-                                        (vmax is not None)):
+        if (0 in self.axes) or ((vmin is not None) and (vmax is not None)):
             self.extend_cmap = "both"
         elif vmin is not None:
             self.extend_cmap = "min"


### PR DESCRIPTION
- Create and close the colorbar every time there is a range update instead fo keeping it alive, to avoid it showing up further down in the notebook.
- Also fix unextended cbar in 3d plots

Fixes #1791 