### PR TITLE
Simpler color generation for show and table

### DIFF
--- a/python/src/scipp/_utils/colors.py
+++ b/python/src/scipp/_utils/colors.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def hex_to_rgb(hex_color):
     rgb_hex = [hex_color[x:x + 2] for x in [1, 3, 5]]
-    return [int(hex_value, 16) for hex_value in rgb_hex]
+    return np.array([int(hex_value, 16) for hex_value in rgb_hex])
 
 
 def rgb_to_hex(rgb):

--- a/python/src/scipp/runtime_config.py
+++ b/python/src/scipp/runtime_config.py
@@ -81,12 +81,11 @@ defaults = {
     },
     # The colors for each dataset member used in table and show functions
     "colors": {
-        "coords": "#dde9af",
-        "data": "#ffe680",
-        "labels": "#afdde9",
-        "attrs": "#ff8080",
-        "masks": "#cccccc",
+        "attrs": "#ff5555",
+        "coords": "#c6e590",
+        "data": "#f6d028",
         "hover": "#d6eaf8",
+        "masks": "#c8c8c8",
     },
     "table_max_size": 50,
 }

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import colorsys
 from html import escape
-
 import numpy as np
 from ._scipp import core as sc
 from . import config
@@ -25,19 +23,13 @@ _smaller_font = round(0.6 * _svg_em, 2)
 
 
 def _color_variants(hex_color):
-    # Convert hex to rgb
-    [r, g, b] = hex_to_rgb(hex_color)
-    # Convert to HSV
-    h, s, v = colorsys.rgb_to_hsv(r, g, b)
-    # Colorize
-    s = min(1.0, max(0.0, s + 0.3))
-    r, g, b = colorsys.hsv_to_rgb(h, s, v)
-    top = rgb_to_hex([r, g, b])
-    # Darken
-    v = min(255, max(0, v - 50))
-    r, g, b = colorsys.hsv_to_rgb(h, s, v)
-    side = rgb_to_hex([r, g, b])
-    return [hex_color, top, side]
+    """
+    Produce darker and lighter color variants, given an input color.
+    """
+    rgb = hex_to_rgb(hex_color)
+    dark = rgb_to_hex(np.clip(rgb - 40, 0, 255))
+    light = rgb_to_hex(np.clip(rgb + 30, 0, 255))
+    return light, hex_color, dark
 
 
 def _truncate_long_string(long_string: str) -> str:


### PR DESCRIPTION
Just to simplify a bit of code.

Simply darken and lighten colors instead of using some more complicated colorize via colorsys and hsv.

Note that you would need to remove your config file for this to yield the correct colors, which may be a problem with current scipp users?
![Screenshot at 2021-03-26 14-37-18](https://user-images.githubusercontent.com/39047984/112639869-0bfbc580-8e41-11eb-8a6d-07b1835dc43c.png)
