### PR TITLE
Add close method to plots

### DIFF
--- a/python/src/scipp/plotting/__init__.py
+++ b/python/src/scipp/plotting/__init__.py
@@ -215,7 +215,7 @@ def plot(*args, **kwargs):
             output.hide_widgets()
         # Turn mpl figure into image if doc build
         if is_doc_build:
-            output.make_static()
+            output.close()
 
     # Turn auto figure display back on if needed.
     if interactive_on:

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -3,6 +3,7 @@
 # @author Neil Vaytet
 
 from .. import config
+from .tools import fig_to_bytes
 import ipywidgets as ipw
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -90,19 +91,15 @@ class PlotFigure:
             else:
                 return ipw.HBox([self.toolbar._to_widget(), self.fig.canvas])
         else:
-            return self._to_image()
+            if self.image is None:
+                self._to_image()
+            return self.image
 
-    def close(self):
+    def _to_image(self):
         """
         Convert the Matplotlib figure to a static image.
         """
-        buf = io.BytesIO()
-        self.fig.savefig(buf, format='png')
-        # Here we close the figure to prevent it from showing up again in
-        # cells further down the notebook.
-        plt.close(self.fig)
-        buf.seek(0)
-        self.image = ipw.Image(value=buf.getvalue(),
+        self.image = ipw.Image(value=fig_to_bytes(self.fig),
                                width=config.plot.width,
                                height=config.plot.height)
 

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -24,6 +24,7 @@ class PlotFigure:
                  ylabel=None,
                  toolbar=None):
         self.fig = None
+        self.image = None
         self.ax = ax
         self.cax = cax
         self.own_axes = True
@@ -76,7 +77,7 @@ class PlotFigure:
         """
         return self._to_widget()._ipython_display_()
 
-    def _to_widget(self, as_static=False):
+    def _to_widget(self):
         """
         Convert the Matplotlib figure to a widget. If the ipympl (widget)
         backend is in use, return the custom toolbar and the figure canvas.
@@ -84,14 +85,14 @@ class PlotFigure:
         Image container.
         """
         if self.is_widget():
-            if as_static:
-                return ipw.HBox([self.toolbar._to_widget(), self._to_image()])
+            if self.image is not None:
+                return ipw.HBox([self.toolbar._to_widget(), self.image])
             else:
                 return ipw.HBox([self.toolbar._to_widget(), self.fig.canvas])
         else:
             return self._to_image()
 
-    def _to_image(self):
+    def close(self):
         """
         Convert the Matplotlib figure to a static image.
         """
@@ -101,9 +102,9 @@ class PlotFigure:
         # cells further down the notebook.
         plt.close(self.fig)
         buf.seek(0)
-        return ipw.Image(value=buf.getvalue(),
-                         width=config.plot.width,
-                         height=config.plot.height)
+        self.image = ipw.Image(value=buf.getvalue(),
+                               width=config.plot.width,
+                               height=config.plot.height)
 
     def show(self):
         """

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 from .. import config
-from .tools import fig_to_bytes
+from .tools import fig_to_pngbytes
 import ipywidgets as ipw
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -98,7 +98,7 @@ class PlotFigure:
         """
         Convert the Matplotlib figure to a static image.
         """
-        self.image = ipw.Image(value=fig_to_bytes(self.fig),
+        self.image = ipw.Image(value=fig_to_pngbytes(self.fig),
                                width=config.plot.width,
                                height=config.plot.height)
 

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -7,7 +7,6 @@ from .tools import fig_to_bytes
 import ipywidgets as ipw
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
-import io
 
 
 class PlotFigure:

--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -14,7 +14,6 @@ from matplotlib.colors import Normalize, LogNorm
 from matplotlib.colorbar import ColorbarBase
 import pythreejs as p3
 from copy import copy
-import io
 
 
 class PlotFigure3d:
@@ -103,7 +102,7 @@ class PlotFigure3d:
         """
         return self._to_widget()._ipython_display_()
 
-    def _to_widget(self, as_static=False):
+    def _to_widget(self):
         """
         Return the renderer and the colorbar into a widget box.
         """
@@ -396,12 +395,6 @@ void main() {
         cbar_ax.set_ylabel(self.unit)
         cbar_ax.yaxis.set_label_coords(-0.9, 0.5)
         self.cbar_image.value = fig_to_bytes(cbar_fig)
-        # # Save to png
-        # buf = io.BytesIO()
-        # cbar_fig.savefig(buf, format='png', bbox_inches='tight')
-        # plt.close(cbar_fig)
-        # buf.seek(0)
-        # self.cbar_image.value = buf.getvalue()
 
     def reset_camera(self, owner=None):
         """

--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -4,7 +4,7 @@
 
 from .. import config
 from .toolbar import PlotToolbar3d
-from .tools import fig_to_bytes
+from .tools import fig_to_pngbytes
 from .._utils import value_to_string
 import numpy as np
 import ipywidgets as ipw
@@ -394,7 +394,7 @@ void main() {
                          extend=self.extend)
         cbar_ax.set_ylabel(self.unit)
         cbar_ax.yaxis.set_label_coords(-0.9, 0.5)
-        self.cbar_image.value = fig_to_bytes(cbar_fig)
+        self.cbar_image.value = fig_to_pngbytes(cbar_fig)
 
     def reset_camera(self, owner=None):
         """

--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -4,6 +4,7 @@
 
 from .. import config
 from .toolbar import PlotToolbar3d
+from .tools import fig_to_bytes
 from .._utils import value_to_string
 import numpy as np
 import ipywidgets as ipw
@@ -394,12 +395,13 @@ void main() {
                          extend=self.extend)
         cbar_ax.set_ylabel(self.unit)
         cbar_ax.yaxis.set_label_coords(-0.9, 0.5)
-        # Save to png
-        buf = io.BytesIO()
-        cbar_fig.savefig(buf, format='png', bbox_inches='tight')
-        plt.close(cbar_fig)
-        buf.seek(0)
-        self.cbar_image.value = buf.getvalue()
+        self.cbar_image.value = fig_to_bytes(cbar_fig)
+        # # Save to png
+        # buf = io.BytesIO()
+        # cbar_fig.savefig(buf, format='png', bbox_inches='tight')
+        # plt.close(cbar_fig)
+        # buf.seek(0)
+        # self.cbar_image.value = buf.getvalue()
 
     def reset_camera(self, owner=None):
         """

--- a/python/src/scipp/plotting/helpers.py
+++ b/python/src/scipp/plotting/helpers.py
@@ -40,9 +40,9 @@ class Plot(dict):
         for item in self.values():
             item.hide_widgets()
 
-    def make_static(self):
+    def close(self):
         for item in self.values():
-            item.make_static()
+            item.close()
 
 
 class PlotArray:

--- a/python/src/scipp/plotting/sciplot.py
+++ b/python/src/scipp/plotting/sciplot.py
@@ -50,7 +50,6 @@ class SciPlot:
         self.widgets = None
 
         self.show_widgets = True
-        self.as_static = False
         self.view_ndims = view_ndims
 
         # Shortcut access to the underlying figure for easier modification
@@ -172,7 +171,7 @@ class SciPlot:
         """
         Get the SciPlot object as an `ipywidget`.
         """
-        widget_list = [self.view._to_widget(self.as_static)]
+        widget_list = [self.view._to_widget()]
         if self.profile is not None:
             widget_list.append(self.profile._to_widget())
         if self.show_widgets:
@@ -188,8 +187,11 @@ class SciPlot:
         """
         self.show_widgets = False if self.view_ndims < 3 else True
 
-    def make_static(self):
-        self.as_static = True
+    def close(self):
+        """
+        Send close signal to the view.
+        """
+        self.view.close()
 
     def show(self):
         """

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -7,6 +7,7 @@ from .._utils import name_with_unit
 from .._scipp import core as sc
 import numpy as np
 from copy import copy
+import io
 
 
 def get_line_param(name=None, index=None):
@@ -194,3 +195,17 @@ def fix_empty_range(lims, replacement=None):
         else:
             dx = 0.5 * abs(lims[0])
     return [lims[0] - dx, lims[1] + dx]
+
+
+def fig_to_bytes(fig):
+    """
+    Convert figure to png image bytes.
+    We also close the figure to prevent it from showing up again in
+    cells further down the notebook.
+    """
+    import matplotlib.pyplot as plt
+    buf = io.BytesIO()
+    fig.savefig(buf, format='png')
+    plt.close(fig)
+    buf.seek(0)
+    return buf.getvalue()

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -197,7 +197,7 @@ def fix_empty_range(lims, replacement=None):
     return [lims[0] - dx, lims[1] + dx]
 
 
-def fig_to_bytes(fig):
+def fig_to_pngbytes(fig):
     """
     Convert figure to png image bytes.
     We also close the figure to prevent it from showing up again in

--- a/python/src/scipp/plotting/view.py
+++ b/python/src/scipp/plotting/view.py
@@ -39,7 +39,7 @@ class PlotView:
         """
         Close the figure.
         """
-        return self.figure.close()
+        return self.figure._to_image()
 
     def show(self):
         """

--- a/python/src/scipp/plotting/view.py
+++ b/python/src/scipp/plotting/view.py
@@ -29,11 +29,17 @@ class PlotView:
         """
         return self._to_widget()._ipython_display_()
 
-    def _to_widget(self, as_static=False):
+    def _to_widget(self):
         """
         The `view` as a widget is just the `figure` as a widget.
         """
-        return self.figure._to_widget(as_static=as_static)
+        return self.figure._to_widget()
+
+    def close(self):
+        """
+        Close the figure.
+        """
+        return self.figure.close()
 
     def show(self):
         """

--- a/python/src/scipp/plotting/view3d.py
+++ b/python/src/scipp/plotting/view3d.py
@@ -23,3 +23,10 @@ class PlotView3d(PlotView):
 
     def update_depth_test(self, *args, **kwargs):
         self.figure.update_depth_test(*args, **kwargs)
+
+    def close(self):
+        """
+        Dummy close function because 3d plots cannot be closed like mpl
+        figures.
+        """
+        return


### PR DESCRIPTION
To turn plots into static images and close the figures:
```Py
p = sc.plot(da)
p.close()
```
You should still be able to render the plot as a static image in the notebook after closing it by just typing `p` in a cell.