### PR TITLE
Add support for more time units

### DIFF
--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -66,7 +66,7 @@ class DataAccessHelper {
       if constexpr (std::is_same_v<T, scipp::core::time_point>) {
         // Need a custom implementation because py::dtype::of only works with
         // types supported by the buffer protocol.
-        return py::dtype("datetime64[" + to_string_ascii_time(view.unit()) +
+        return py::dtype("datetime64[" + to_numpy_time_string(view.unit()) +
                          ']');
       } else {
         static_cast<void>(view);
@@ -267,7 +267,7 @@ private:
         static const auto np_datetime64 =
             py::module::import("numpy").attr("datetime64");
         return np_datetime64(data[0].time_since_epoch(),
-                             to_string_ascii_time(view.unit()));
+                             to_numpy_time_string(view.unit()));
       } else {
         // Passing `obj` as parent so py::keep_alive works.
         return py::cast(data[0], py::return_value_policy::reference_internal,

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -88,7 +88,7 @@ parse_datetime_dtype(const std::string &dtype_name) {
   }
 
   throw std::invalid_argument(std::string("Unsupported unit in datetime: ") +
-                              dtype_name[11] + "s");
+                              std::string(match[unit_idx]));
 }
 
 [[nodiscard]] scipp::units::Unit

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -78,13 +78,16 @@ parse_datetime_dtype(const std::string &dtype_name) {
     return scipp::units::dimensionless;
   } else if (match[unit_idx] == "s") {
     return scipp::units::s;
-  } else if (match[unit_idx] == "ms") {
-    static const auto ms = units::Unit("ms");
-    return ms;
   } else if (match[unit_idx] == "us") {
     return scipp::units::us;
   } else if (match[unit_idx] == "ns") {
     return scipp::units::ns;
+  } else {
+    for (const char *name : {"ms", "D", "M", "Y"}) {
+      if (match[unit_idx] == name) {
+        return units::Unit(name);
+      }
+    }
   }
 
   throw std::invalid_argument(std::string("Unsupported unit in datetime: ") +

--- a/python/dtype.cpp
+++ b/python/dtype.cpp
@@ -82,8 +82,11 @@ parse_datetime_dtype(const std::string &dtype_name) {
     return scipp::units::us;
   } else if (match[unit_idx] == "ns") {
     return scipp::units::ns;
+  } else if (match[unit_idx] == "m") {
+    // In np.datetime64, m means minute.
+    return units::Unit("min");
   } else {
-    for (const char *name : {"ms", "D", "M", "Y"}) {
+    for (const char *name : {"ms", "h", "D", "M", "Y"}) {
       if (match[unit_idx] == name) {
         return units::Unit(name);
       }

--- a/python/tests/test_datetime.py
+++ b/python/tests/test_datetime.py
@@ -12,7 +12,7 @@ import pytest
 
 import scipp as sc
 
-_UNIT_STRINGS = ('s', 'ms', 'us', 'ns')
+_UNIT_STRINGS = ('s', 'ms', 'us', 'ns', 'D', 'M', 'Y')
 
 
 def _mismatch_pairs(units):

--- a/python/tests/test_datetime.py
+++ b/python/tests/test_datetime.py
@@ -250,21 +250,42 @@ def test_datetime_operations_mismatch():
 
 
 def test_datetime_formatting():
+    def fmt(time_point, scale, unit):
+        var = sc.scalar(int(time_point.timestamp() * scale),
+                        dtype=sc.datetime64,
+                        unit=unit)
+        match = re.search(r'\[[\dT\-:\.]+]', str(var))
+        assert match
+        return match[0][1:-1]
+
     # Time since epoch for a totally arbitrary date.
     # The timezone has an offset of 0 to emulate a timestamp obtained from
     # some source that is not aware of timezones.
-    timestamp = int(
-        datetime(year=1991,
-                 month=8,
-                 day=16,
-                 hour=1,
-                 minute=2,
-                 second=3,
-                 microsecond=456789,
-                 tzinfo=timezone(timedelta(hours=0))).timestamp() * 10**6)
-    var = sc.scalar(np.datetime64(timestamp, 'us'))
-    match = re.search(r'\[[\dT\-:\.]+]', str(var))
-    assert match
+    dt = datetime(year=1991,
+                  month=8,
+                  day=16,
+                  hour=1,
+                  minute=2,
+                  second=3,
+                  microsecond=456789,
+                  tzinfo=timezone(timedelta(hours=0)))
+
     # Make sure that date and time are printed unchanged,
     # i.e. there was no timezone conversion.
-    assert match[0][1:-1] == "1991-08-16T01:02:03.456789"
+    assert fmt(dt, 10**6, 'us') == "1991-08-16T01:02:03.456789"
+    # The unit determines the precision of the output.
+    dt = dt.replace(microsecond=456000)
+    assert fmt(dt, 10**3, 'ms') == "1991-08-16T01:02:03.456"
+    dt = dt.replace(microsecond=0)
+    assert fmt(dt, 1, 's') == "1991-08-16T01:02:03"
+    dt = dt.replace(second=0)
+    assert fmt(dt, 1 / 60, 'min') == "1991-08-16T01:02:00"
+    dt = dt.replace(second=0)
+    assert fmt(dt, 1 / (60 * 60), 'h') == "1991-08-16T01:00:00"
+    # Not supported yet
+    with pytest.raises(sc.UnitError):
+        fmt(dt, 1, 'day')
+    with pytest.raises(sc.UnitError):
+        fmt(dt, 1, 'month')
+    with pytest.raises(sc.UnitError):
+        fmt(dt, 1, 'year')

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 namespace {
 bool temporal_or_dimensionless(const units::Unit unit) {
-  return unit == units::one || unit.in_same_dimension(units::s);
+  return unit == units::one || unit.has_same_base(units::s);
 }
 } // namespace
 

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -59,6 +59,8 @@ std::tuple<units::Unit, int64_t> get_time_unit(const py::buffer &value,
       unit);
 }
 
-std::string to_string_ascii_time(const scipp::units::Unit unit) {
-  return unit == units::us ? std::string("us") : to_string(unit);
+std::string to_numpy_time_string(const scipp::units::Unit unit) {
+  return unit == units::us
+             ? std::string("us")
+             : unit == units::Unit("min") ? std::string("m") : to_string(unit);
 }

--- a/python/unit.cpp
+++ b/python/unit.cpp
@@ -11,11 +11,8 @@ using namespace scipp;
 namespace py = pybind11;
 
 namespace {
-// TODO proper dimension check
 bool temporal_or_dimensionless(const units::Unit unit) {
-  static const auto ms = units::Unit("ms");
-  return unit != units::one && unit != units::s && unit != units::ns &&
-         unit != units::us && unit != ms;
+  return unit == units::one || unit.in_same_dimension(units::s);
 }
 } // namespace
 
@@ -23,7 +20,7 @@ std::tuple<units::Unit, int64_t>
 get_time_unit(const std::optional<scipp::units::Unit> value_unit,
               const std::optional<scipp::units::Unit> dtype_unit,
               const units::Unit sc_unit) {
-  if (temporal_or_dimensionless(sc_unit)) {
+  if (!temporal_or_dimensionless(sc_unit)) {
     throw std::invalid_argument("Invalid unit for dtype=datetime64: " +
                                 to_string(sc_unit));
   }

--- a/python/unit.h
+++ b/python/unit.h
@@ -18,4 +18,4 @@ get_time_unit(const pybind11::buffer &value, const pybind11::object &dtype,
 /// Format a time unit as an ASCII string.
 /// Only time units are supported!
 // TODO Can be removed if / when the units library supports this.
-std::string to_string_ascii_time(scipp::units::Unit unit);
+std::string to_numpy_time_string(scipp::units::Unit const unit);

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -27,9 +27,7 @@ public:
   [[nodiscard]] bool isCounts() const;
   [[nodiscard]] bool isCountDensity() const;
 
-  [[nodiscard]] constexpr bool has_same_base(const Unit &other) const {
-    return m_unit.has_same_base(other.underlying());
-  }
+  [[nodiscard]] bool has_same_base(const Unit &other) const;
 
   bool operator==(const Unit &other) const;
   bool operator!=(const Unit &other) const;

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -16,15 +16,15 @@ namespace scipp::units {
 class SCIPP_UNITS_EXPORT Unit {
 public:
   constexpr Unit() = default;
-  constexpr Unit(const llnl::units::precise_unit &u) noexcept : m_unit(u) {}
-  Unit(const std::string &unit);
+  constexpr explicit Unit(const llnl::units::precise_unit &u) noexcept : m_unit(u) {}
+  explicit Unit(const std::string &unit);
 
-  constexpr auto underlying() const noexcept { return m_unit; }
+  [[nodiscard]] constexpr auto underlying() const noexcept { return m_unit; }
 
-  std::string name() const;
+  [[nodiscard]] std::string name() const;
 
-  bool isCounts() const;
-  bool isCountDensity() const;
+  [[nodiscard]] bool isCounts() const;
+  [[nodiscard]] bool isCountDensity() const;
 
   [[nodiscard]] constexpr bool in_same_dimension(const Unit& other) const {
     return m_unit.has_same_base(other.underlying());
@@ -51,7 +51,7 @@ SCIPP_UNITS_EXPORT Unit operator%(const Unit &a, const Unit &b);
 SCIPP_UNITS_EXPORT Unit operator-(const Unit &a);
 SCIPP_UNITS_EXPORT Unit abs(const Unit &a);
 SCIPP_UNITS_EXPORT Unit sqrt(const Unit &a);
-SCIPP_UNITS_EXPORT Unit pow(const Unit &a, const int64_t power);
+SCIPP_UNITS_EXPORT Unit pow(const Unit &a, int64_t power);
 SCIPP_UNITS_EXPORT Unit sin(const Unit &a);
 SCIPP_UNITS_EXPORT Unit cos(const Unit &a);
 SCIPP_UNITS_EXPORT Unit tan(const Unit &a);

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -16,7 +16,8 @@ namespace scipp::units {
 class SCIPP_UNITS_EXPORT Unit {
 public:
   constexpr Unit() = default;
-  constexpr explicit Unit(const llnl::units::precise_unit &u) noexcept : m_unit(u) {}
+  constexpr explicit Unit(const llnl::units::precise_unit &u) noexcept
+      : m_unit(u) {}
   explicit Unit(const std::string &unit);
 
   [[nodiscard]] constexpr auto underlying() const noexcept { return m_unit; }
@@ -26,7 +27,7 @@ public:
   [[nodiscard]] bool isCounts() const;
   [[nodiscard]] bool isCountDensity() const;
 
-  [[nodiscard]] constexpr bool in_same_dimension(const Unit& other) const {
+  [[nodiscard]] constexpr bool in_same_dimension(const Unit &other) const {
     return m_unit.has_same_base(other.underlying());
   }
 

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -27,7 +27,7 @@ public:
   [[nodiscard]] bool isCounts() const;
   [[nodiscard]] bool isCountDensity() const;
 
-  [[nodiscard]] constexpr bool in_same_dimension(const Unit &other) const {
+  [[nodiscard]] constexpr bool has_same_base(const Unit &other) const {
     return m_unit.has_same_base(other.underlying());
   }
 

--- a/units/include/scipp/units/unit.h
+++ b/units/include/scipp/units/unit.h
@@ -26,6 +26,10 @@ public:
   bool isCounts() const;
   bool isCountDensity() const;
 
+  [[nodiscard]] constexpr bool in_same_dimension(const Unit& other) const {
+    return m_unit.has_same_base(other.underlying());
+  }
+
   bool operator==(const Unit &other) const;
   bool operator!=(const Unit &other) const;
 

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -207,7 +207,7 @@ TEST(UnitParseTest, singular_plural) {
 
 TEST(UnitFormatTest, roundtrip_string) {
   for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts",
-                        "counts/meV", "1/counts", "counts/m", "Y", "D"}) {
+                        "counts/meV", "1/counts", "counts/m", "Y", "M", "D"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(to_string(unit), s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);
@@ -217,7 +217,7 @@ TEST(UnitFormatTest, roundtrip_string) {
 TEST(UnitFormatTest, roundtrip_unit) {
   // Some formattings use special characters, e.g., for micro and Angstrom, but
   // some are actually formatted badly right now, but at least roundtrip works.
-  for (const auto &s : {"us", "angstrom", "counts/us", "Y", "D"}) {
+  for (const auto &s : {"us", "angstrom", "counts/us", "Y", "M", "D"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);
   }

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -207,7 +207,7 @@ TEST(UnitParseTest, singular_plural) {
 
 TEST(UnitFormatTest, roundtrip_string) {
   for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts",
-                        "counts/meV", "1/counts", "counts/m"}) {
+                        "counts/meV", "1/counts", "counts/m", "Y", "D"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(to_string(unit), s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -217,7 +217,7 @@ TEST(UnitFormatTest, roundtrip_string) {
 TEST(UnitFormatTest, roundtrip_unit) {
   // Some formattings use special characters, e.g., for micro and Angstrom, but
   // some are actually formatted badly right now, but at least roundtrip works.
-  for (const auto &s : {"us", "angstrom", "counts/us"}) {
+  for (const auto &s : {"us", "angstrom", "counts/us", "Y", "D"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);
   }

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -1,3 +1,4 @@
+
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -18,12 +18,14 @@ namespace scipp::units {
 namespace {
 std::string map_unit_string(const std::string &unit) {
   // custom dimensionless name
-  return unit == "dimensionless" ? ""
-         // Use Gregorian months and years by default.
-         : unit == "y" || unit == "Y" || unit == "year" ? "a_g"
-         // Overwrite M to mean month instead of molarity for numpy interop.
-         : unit == "M" || unit == "month" ? "mog"
-                                          : unit;
+  return unit == "dimensionless"
+             ? ""
+             // Use Gregorian months and years by default.
+             : unit == "y" || unit == "Y" || unit == "year"
+                   ? "a_g"
+                   // Overwrite M to mean month instead of molarity for numpy
+                   // interop.
+                   : unit == "M" || unit == "month" ? "mog" : unit;
 }
 } // namespace
 

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -19,9 +19,11 @@ namespace {
 std::string map_unit_string(const std::string &unit) {
   // custom dimensionless name
   return unit == "dimensionless" ? ""
-         // use Gregorian years by default
+         // Use Gregorian months and years by default.
          : unit == "y" || unit == "Y" || unit == "year" ? "a_g"
-                                                        : unit;
+         // Overwrite M to mean month instead of molarity for numpy interop.
+         : unit == "M" || unit == "month" ? "mog"
+                                          : unit;
 }
 } // namespace
 

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -51,6 +51,10 @@ bool Unit::isCountDensity() const {
   return !isCounts() && m_unit.base_units().count() != 0;
 }
 
+bool Unit::has_same_base(const Unit &other) const {
+  return m_unit.has_same_base(other.underlying());
+}
+
 bool Unit::operator==(const Unit &other) const {
   return m_unit == other.m_unit;
 }

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -19,8 +19,9 @@ namespace {
 std::string map_unit_string(const std::string &unit) {
   // custom dimensionless name
   return unit == "dimensionless" ? ""
-                                 // use Gregorian years by default
-                                 : unit == "y" || unit == "year" ? "a_g" : unit;
+         // use Gregorian years by default
+         : unit == "y" || unit == "Y" || unit == "year" ? "a_g"
+                                                        : unit;
 }
 } // namespace
 

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -27,7 +27,7 @@ std::string Unit::name() const {
   repr = std::regex_replace(repr, std::regex("^u"), "µ");
   repr = std::regex_replace(repr, std::regex("item"), "count");
   repr = std::regex_replace(repr, std::regex("count(?!s)"), "counts");
-  return repr == "" ? "dimensionless" : repr;
+  return repr.empty() ? "dimensionless" : repr;
 }
 
 bool Unit::isCounts() const { return *this == counts; }
@@ -68,14 +68,14 @@ Unit operator*(const Unit &a, const Unit &b) {
   if (llnl::units::times_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of multiplication: (" +
                             a.name() + ") * (" + b.name() + ')');
-  return {a.underlying() * b.underlying()};
+  return Unit{a.underlying() * b.underlying()};
 }
 
 Unit operator/(const Unit &a, const Unit &b) {
   if (llnl::units::divides_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of division: (" +
                             a.name() + ") / (" + b.name() + ')');
-  return {a.underlying() / b.underlying()};
+  return Unit{a.underlying() / b.underlying()};
 }
 
 Unit operator%(const Unit &a, const Unit &b) { return a / b; }
@@ -88,14 +88,14 @@ Unit sqrt(const Unit &a) {
   if (llnl::units::is_error(sqrt(a.underlying())))
     throw except::UnitError("Unsupported unit as result of sqrt: sqrt(" +
                             a.name() + ").");
-  return {sqrt(a.underlying())};
+  return Unit{sqrt(a.underlying())};
 }
 
 Unit pow(const Unit &a, const int64_t power) {
   if (llnl::units::pow_overflows(a.underlying(), power))
     throw except::UnitError("Unsupported unit as result of pow: pow(" +
                             a.name() + ", " + std::to_string(power) + ").");
-  return {a.underlying().pow(power)};
+  return Unit{a.underlying().pow(power)};
 }
 
 Unit trigonometric(const Unit &a) {

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -15,8 +15,17 @@
 
 namespace scipp::units {
 
+namespace {
+std::string map_unit_string(const std::string &unit) {
+  // custom dimensionless name
+  return unit == "dimensionless" ? ""
+                                 // use Gregorian years by default
+                                 : unit == "y" || unit == "year" ? "a_g" : unit;
+}
+} // namespace
+
 Unit::Unit(const std::string &unit)
-    : Unit(llnl::units::unit_from_string(unit == "dimensionless" ? "" : unit)) {
+    : Unit(llnl::units::unit_from_string(map_unit_string(unit))) {
   if (!is_valid(m_unit))
     throw except::UnitError("Failed to convert string `" + unit +
                             "` to valid unit.");

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -32,10 +32,15 @@ Unit::Unit(const std::string &unit)
 }
 
 std::string Unit::name() const {
+  if (*this == Unit{"month"}) {
+    return "M";
+  }
   auto repr = to_string(m_unit);
   repr = std::regex_replace(repr, std::regex("^u"), "µ");
   repr = std::regex_replace(repr, std::regex("item"), "count");
   repr = std::regex_replace(repr, std::regex("count(?!s)"), "counts");
+  repr = std::regex_replace(repr, std::regex("day"), "D");
+  repr = std::regex_replace(repr, std::regex("a_g"), "Y");
   return repr.empty() ? "dimensionless" : repr;
 }
 

--- a/variable/test/to_unit_test.cpp
+++ b/variable/test/to_unit_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/variable/string.h"
 #include "scipp/variable/to_unit.h"
 #include "test_macros.h"
 
@@ -43,6 +44,32 @@ TEST(ToUnitTest, ints) {
   EXPECT_EQ(
       to_unit(var, units::Unit("um")),
       makeVariable<int32_t>(dims, units::Unit("um"), Values{100000, 2000000}));
+}
+
+TEST(ToUnitTest, time_point) {
+  const Dimensions dims(Dim::X, 8);
+  const auto var = makeVariable<core::time_point>(
+      dims, units::Unit("s"),
+      Values{core::time_point{10}, core::time_point{20}, core::time_point{30},
+             core::time_point{40}, core::time_point{10 + 60},
+             core::time_point{20 + 60}, core::time_point{30 + 60},
+             core::time_point{40 + 60}});
+  EXPECT_EQ(
+      to_unit(var, units::Unit("min")),
+      makeVariable<core::time_point>(
+          dims, units::Unit("min"),
+          Values{core::time_point{0}, core::time_point{0}, core::time_point{1},
+                 core::time_point{1}, core::time_point{1}, core::time_point{1},
+                 core::time_point{2}, core::time_point{2}}));
+  EXPECT_EQ(to_unit(var, units::Unit("ms")),
+            makeVariable<core::time_point>(
+                dims, units::Unit("ms"),
+                Values{core::time_point{10000}, core::time_point{20000},
+                       core::time_point{30000}, core::time_point{40000},
+                       core::time_point{10000 + 60000},
+                       core::time_point{20000 + 60000},
+                       core::time_point{30000 + 60000},
+                       core::time_point{40000 + 60000}}));
 }
 
 TEST(ToUnitTest, time_point_bad_units) {

--- a/variable/test/to_unit_test.cpp
+++ b/variable/test/to_unit_test.cpp
@@ -44,3 +44,31 @@ TEST(ToUnitTest, ints) {
       to_unit(var, units::Unit("um")),
       makeVariable<int32_t>(dims, units::Unit("um"), Values{100000, 2000000}));
 }
+
+TEST(ToUnitTest, time_point_bad_units) {
+  const auto do_to_unit = [](const char *initial, const char *final) {
+    return to_unit(makeVariable<core::time_point>(Dims{}, units::Unit(initial)),
+                   units::Unit(final));
+  };
+
+  // Conversions to or from time points with unit day or larger are complicated
+  // and not implemented.
+  const auto small_unit_names = {"h", "min", "s", "ns"};
+  const auto large_unit_names = {"Y", "M", "D"};
+  for (const char *initial : small_unit_names) {
+    for (const char *final : small_unit_names) {
+      EXPECT_NO_THROW_DISCARD(do_to_unit(initial, final));
+    }
+    for (const char *final : large_unit_names) {
+      EXPECT_THROW_DISCARD(do_to_unit(initial, final), except::UnitError);
+    }
+  }
+  for (const char *initial : large_unit_names) {
+    for (const char *final : small_unit_names) {
+      EXPECT_THROW_DISCARD(do_to_unit(initial, final), except::UnitError);
+    }
+    for (const char *final : large_unit_names) {
+      EXPECT_THROW_DISCARD(do_to_unit(initial, final), except::UnitError);
+    }
+  }
+}

--- a/variable/to_unit.cpp
+++ b/variable/to_unit.cpp
@@ -5,12 +5,16 @@
 #include <units/units.hpp>
 
 #include "scipp/core/element/to_unit.h"
+#include "scipp/core/time_point.h"
 #include "scipp/variable/arithmetic.h"
-#include "scipp/variable/misc_operations.h"
 #include "scipp/variable/to_unit.h"
 #include "scipp/variable/transform.h"
 
 namespace scipp::variable {
+
+namespace {
+constexpr double days_multiplier = llnl::units::precise::day.multiplier();
+}
 
 Variable to_unit(const VariableConstView &var, const units::Unit &unit) {
   const auto scale =
@@ -18,6 +22,14 @@ Variable to_unit(const VariableConstView &var, const units::Unit &unit) {
   if (std::isnan(scale))
     throw except::UnitError("Conversion from `" + to_string(var.unit()) +
                             "` to `" + to_string(unit) + "` is not valid.");
+  if (var.dtype() == dtype<core::time_point> &&
+      (var.unit().underlying().multiplier() >= days_multiplier ||
+       unit.underlying().multiplier() >= days_multiplier)) {
+    throw except::UnitError(
+        "Unit conversion for datetimes with a unit of days or greater"
+        " is not implemented. Attempted conversion from `" +
+        to_string(var.unit()) + "` to `" + to_string(unit) + "`.");
+  }
   return transform(var, scale * unit, core::element::to_unit);
 }
 


### PR DESCRIPTION
Needed for #1768

- Datetime variables can now be constructed with time units min, h, D, M, Y.
- Printing is not supported for D, M, Y because that would require a proper handling of calendars. It should be possible to do this with C++20, but that update to std::chrono is not available yet.
- The constructor of `Unit` and `Unit::name` were changed to provide less surprising defaults. LLNL units uses Julian years and Gregorian months by default. Also, unit names are not intuitive, Gregorian years are represented as `a_g` and months as `some-number * s`.