### PR TITLE
Fix bug in limits of 1d plots when more than 1 entry is on the same axes

### DIFF
--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -83,7 +83,7 @@ class PlotController:
             # Iterate through axes and collect dimensions
             for dim in self.axes.values():
 
-                coord, label, unit = self.model.get_data_coord(name, dim)
+                coord, label, unit = self.model.get_data_coord(key, dim)
 
                 # To allow for 2D coordinates, the histograms are
                 # stored as dicts, with one key per dimension of the coordinate


### PR DESCRIPTION
Try:
```Py
N = 50
a = sc.DataArray(
    coords={'x': sc.array(dims=['x'], values=np.arange(N).astype(np.float64),
                                unit=sc.units.us)},
    data=sc.array(dims=['x'], values=5.0 + 5.0*np.sin(np.arange(N, dtype=np.float64)/5.0),
                          unit=sc.units.counts))
b = sc.DataArray(
    coords={'x': sc.array(dims=['x'], values=np.arange(N).astype(np.float64) + 40.,
                                unit=sc.units.us)},
    data=sc.array(dims=['x'], values=5.0 + 5.0*np.sin(np.arange(N, dtype=np.float64)/5.0),
                          unit=sc.units.counts))

sc.plot({'a': a, 'b': b})
```
should have axis ranging from 0 to 95 (approximately) and not 0 to 50.