### PR TITLE
Wide units base

### DIFF
--- a/cmake/LLNL-units.cmake
+++ b/cmake/LLNL-units.cmake
@@ -31,6 +31,7 @@ set(UNITS_NAMESPACE
     CACHE STRING "" FORCE
 )
 set(UNITS_BUILD_SHARED_LIBRARY ON)
+set(UNITS_BASE_TYPE uint64_t)
 add_subdirectory(
   ${CMAKE_BINARY_DIR}/llnl-units-src ${CMAKE_BINARY_DIR}/llnl-units-build
   EXCLUDE_FROM_ALL

--- a/cmake/LLNL-units.in
+++ b/cmake/LLNL-units.in
@@ -9,7 +9,7 @@ include(ExternalProject)
 externalproject_add(
   llnl-units
   GIT_REPOSITORY https://github.com/SimonHeybrock/units.git
-  GIT_TAG origin/Add_64_bit_base_unit
+  GIT_TAG origin/master
   SOURCE_DIR "${CMAKE_BINARY_DIR}/llnl-units-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/llnl-units-build"
   CONFIGURE_COMMAND ""

--- a/cmake/LLNL-units.in
+++ b/cmake/LLNL-units.in
@@ -9,7 +9,7 @@ include(ExternalProject)
 externalproject_add(
   llnl-units
   GIT_REPOSITORY https://github.com/SimonHeybrock/units.git
-  GIT_TAG origin/master
+  GIT_TAG origin/Add_64_bit_base_unit
   SOURCE_DIR "${CMAKE_BINARY_DIR}/llnl-units-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/llnl-units-build"
   CONFIGURE_COMMAND ""

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -143,6 +143,7 @@ TEST(UnitFunctionsTest, abs) {
 
 TEST(UnitFunctionsTest, sqrt) {
   EXPECT_EQ(sqrt(units::m * units::m), units::m);
+  EXPECT_EQ(sqrt(units::counts * units::counts), units::counts);
   EXPECT_EQ(sqrt(units::one), units::one);
   EXPECT_THROW_MSG(sqrt(units::m), except::UnitError,
                    "Unsupported unit as result of sqrt: sqrt(m).");

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -82,6 +82,11 @@ TEST(UnitTest, multiply) {
   EXPECT_EQ(c * b, units::m * units::m * units::m);
 }
 
+TEST(UnitTest, counts_variances) {
+  Unit counts{units::counts};
+  EXPECT_EQ(counts * counts, units::Unit("counts**2"));
+}
+
 TEST(UnitTest, multiply_counts) {
   Unit counts{units::counts};
   Unit none{units::dimensionless};
@@ -207,8 +212,9 @@ TEST(UnitParseTest, singular_plural) {
 }
 
 TEST(UnitFormatTest, roundtrip_string) {
-  for (const auto &s : {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts",
-                        "counts/meV", "1/counts", "counts/m", "Y", "M", "D"}) {
+  for (const auto &s :
+       {"m", "m/s", "meV", "pAh", "mAh", "ns", "counts", "counts^2",
+        "counts/meV", "1/counts", "counts/m", "Y", "M", "D"}) {
     const auto unit = units::Unit(s);
     EXPECT_EQ(to_string(unit), s);
     EXPECT_EQ(units::Unit(to_string(unit)), unit);

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -34,13 +34,13 @@ TEST(UnitTest, construct_bad_string) {
 TEST(UnitTest, overflows) {
   // These would run out of bits in llnl/units and wrap, ensure that scipp
   // prevents this and throws instead.
-  Unit m4{units::m * units::m * units::m * units::m};
-  Unit inv_m8{units::one / m4 / m4};
-  EXPECT_THROW(m4 * m4, except::UnitError);
-  EXPECT_THROW(units::one / inv_m8, except::UnitError);
-  EXPECT_THROW(inv_m8 / units::m, except::UnitError);
-  EXPECT_THROW(inv_m8 % units::m, except::UnitError);
-  EXPECT_THROW(pow(units::m, 8), except::UnitError);
+  Unit m64{pow(units::m, 64)};
+  Unit inv_m128{units::one / m64 / m64};
+  EXPECT_THROW(m64 * m64, except::UnitError);
+  EXPECT_THROW(units::one / inv_m128, except::UnitError);
+  EXPECT_THROW(inv_m128 / units::m, except::UnitError);
+  EXPECT_THROW(inv_m128 % units::m, except::UnitError);
+  EXPECT_THROW(pow(units::m, 128), except::UnitError);
 }
 
 TEST(UnitTest, compare) {


### PR DESCRIPTION
https://github.com/LLNL/units/pull/142 added support for a wider base unit type. With this we can now support units such as `counts^2` as occuring, e.g., in variances of "counts" data.