### PR TITLE
Add readonly flag to Variable for conceptually correct slice handling

### DIFF
--- a/core/include/scipp/core/strides.h
+++ b/core/include/scipp/core/strides.h
@@ -17,6 +17,9 @@ public:
   Strides(const scipp::span<const scipp::index> &strides);
   Strides(const Dimensions &dims);
 
+  bool operator==(const Strides &other) const noexcept;
+  bool operator!=(const Strides &other) const noexcept;
+
   scipp::index operator[](const scipp::index i) const {
     return m_strides.at(i);
   }

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -82,6 +82,9 @@ Sizes merge(const Sizes &a, const Sizes &b) {
 bool is_edges(const Sizes &sizes, const Dimensions &dims, const Dim dim) {
   if (dim == Dim::Invalid)
     return false;
+  for (const auto &d : dims.labels())
+    if (d != dim && !sizes.contains(d))
+      return false;
   const auto size = dims[dim];
   return size == (sizes.contains(dim) ? sizes[dim] + 1 : 2);
 }

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -83,7 +83,7 @@ bool is_edges(const Sizes &sizes, const Dimensions &dims, const Dim dim) {
   if (dim == Dim::Invalid)
     return false;
   for (const auto &d : dims.labels())
-    if (d != dim && !sizes.contains(d))
+    if (d != dim && !(sizes.contains(d) && sizes[d] == dims[d]))
       return false;
   const auto size = dims[dim];
   return size == (sizes.contains(dim) ? sizes[dim] + 1 : 2);

--- a/core/strides.cpp
+++ b/core/strides.cpp
@@ -20,6 +20,14 @@ Strides::Strides(const Dimensions &dims) {
   }
 }
 
+bool Strides::operator==(const Strides &other) const noexcept {
+  return m_strides == other.m_strides;
+}
+
+bool Strides::operator!=(const Strides &other) const noexcept {
+  return !operator==(other);
+}
+
 void Strides::erase(const scipp::index i) {
   for (scipp::index j = i; j < scipp::size(m_strides) - 1; ++j)
     m_strides[j] = m_strides[j + 1];

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -138,4 +138,11 @@ void DataArray::rename(const Dim from, const Dim to) {
   m_attrs->rename(from, to);
 }
 
+DataArray DataArray::as_const() const {
+  return DataArray(data().as_const(), coords().as_const(), masks().as_const(),
+                   attrs().as_const(), name());
+}
+
+bool DataArray::is_readonly() const noexcept { return m_data->is_readonly(); }
+
 } // namespace scipp::dataset

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -101,7 +101,7 @@ DataArray DataArray::slice(const Slice &s) const {
 }
 
 DataArray &DataArray::setSlice(const Slice &s, const DataArray &array) {
-  expect::coordsAreSuperset(*this, array);
+  expect::coordsAreSuperset(slice(s), array);
   // TODO Need dry-run mechanism for mask handling?
   masks().setSlice(s, array.masks());
   return setSlice(s, array.data());

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -48,19 +48,6 @@ DataArray &DataArray::operator=(const DataArray &other) {
   return *this = DataArray(other);
 }
 
-DataArray &DataArray::assign(const DataArray &other) {
-  expect::coordsAreSuperset(*this, other);
-  // TODO Need dry-run mechanism for mask handling?
-  union_copy_in_place(masks(), other.masks());
-  assign(other.data());
-  return *this;
-}
-
-DataArray &DataArray::assign(const Variable &other) {
-  copy(other, data());
-  return *this;
-}
-
 void DataArray::setData(Variable data) {
   core::expect::equals(dims(), data.dims());
   *m_data = data;
@@ -111,6 +98,18 @@ DataArray DataArray::slice(const Slice &s) const {
     if (unaligned_by_dim_slice(*it, s))
       out.attrs().set(it->first, out.m_coords.extract(it->first));
   return out;
+}
+
+DataArray &DataArray::setSlice(const Slice &s, const DataArray &array) {
+  expect::coordsAreSuperset(*this, array);
+  // TODO Need dry-run mechanism for mask handling?
+  masks().setSlice(s, array.masks());
+  return setSlice(s, array.data());
+}
+
+DataArray &DataArray::setSlice(const Slice &s, const Variable &var) {
+  data().setSlice(s, var);
+  return *this;
 }
 
 DataArray DataArray::view_with_coords(const Coords &coords,

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -120,7 +120,8 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   out.m_coords = Coords(sizes, {});
   for (const auto &[dim, coord] : coords)
     if (dims().contains(coord.dims()) ||
-        is_edges(sizes, coord.dims(), dim_of_coord(coord, dim)))
+        (!coords.sizes().contains(coord.dims()) &&
+         is_edges(sizes, coord.dims(), dim_of_coord(coord, dim))))
       out.m_coords.set(dim, coord);
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -119,9 +119,7 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   const Sizes sizes(dims());
   out.m_coords = Coords(sizes, {});
   for (const auto &[dim, coord] : coords)
-    if (dims().contains(coord.dims()) ||
-        (!coords.sizes().contains(coord.dims()) &&
-         is_edges(sizes, coord.dims(), dim_of_coord(coord, dim))))
+    if (coords.item_applies_to(dim, dims()))
       out.m_coords.set(dim, coord);
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -96,7 +96,7 @@ DataArray DataArray::slice(const Slice &s) const {
                 m_attrs->slice(s), m_name};
   for (auto it = m_coords.begin(); it != m_coords.end(); ++it)
     if (unaligned_by_dim_slice(*it, s))
-      out.attrs().set(it->first, out.m_coords.extract(it->first));
+      out.attrs().set(it->first, out.m_coords.extract(it->first), true);
   return out;
 }
 

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -157,6 +157,14 @@ Dataset Dataset::slice(const Slice s) const {
   Dataset out;
   out.m_coords = m_coords.slice(s);
   out.m_data = slice_map(m_coords.sizes(), m_data, s);
+  for (auto it = m_coords.begin(); it != m_coords.end();) {
+    if (unaligned_by_dim_slice(*it, s)) {
+      auto extracted = out.m_coords.extract(it->first);
+      for (auto &item : out.m_data)
+        item.second.attrs().set(it->first, extracted);
+    }
+    ++it;
+  }
   return out;
 }
 

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -141,8 +141,7 @@ Dataset Dataset::slice(const Slice s) const {
     if (unaligned_by_dim_slice(*it, s)) {
       auto extracted = out.m_coords.extract(it->first);
       for (auto &item : out.m_data)
-        // TODO This can be check more efficiently
-        if (operator[](item.first).coords().contains(it->first))
+        if (m_coords.item_applies_to(it->first, m_data.at(item.first).dims()))
           item.second.attrs().set(it->first, extracted, true);
     }
     ++it;

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -141,7 +141,9 @@ Dataset Dataset::slice(const Slice s) const {
     if (unaligned_by_dim_slice(*it, s)) {
       auto extracted = out.m_coords.extract(it->first);
       for (auto &item : out.m_data)
-        item.second.attrs().set(it->first, extracted);
+        // TODO This can be check more efficiently
+        if (operator[](item.first).coords().contains(it->first))
+          item.second.attrs().set(it->first, extracted, true);
     }
     ++it;
   }

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -89,6 +89,10 @@ public:
   DataArray view_with_coords(const Coords &coords,
                              const std::string &name) const;
 
+  [[nodiscard]] DataArray as_const() const;
+
+  bool is_readonly() const noexcept;
+
 private:
   // Declared friend so gtest recognizes it
   friend SCIPP_DATASET_EXPORT std::ostream &operator<<(std::ostream &,

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -33,9 +33,6 @@ public:
   DataArray &operator=(const DataArray &other);
   DataArray &operator=(DataArray &&other) = default;
 
-  [[maybe_unused]] DataArray &assign(const DataArray &other);
-  [[maybe_unused]] DataArray &assign(const Variable &other);
-
   explicit operator bool() const noexcept {
     return m_data && m_data->operator bool();
   }
@@ -85,6 +82,8 @@ public:
   void setData(Variable data);
 
   DataArray slice(const Slice &s) const;
+  [[maybe_unused]] DataArray &setSlice(const Slice &s, const DataArray &array);
+  [[maybe_unused]] DataArray &setSlice(const Slice &s, const Variable &var);
 
   DataArray view_with_coords(const Coords &coords,
                              const std::string &name) const;

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -68,12 +68,16 @@ public:
   Variable data() { return *m_data; }
 
   /// Return typed const view for data values.
-  template <class T> auto values() const { return m_data->values<T>(); }
+  template <class T> auto values() const {
+    return std::as_const(*m_data).values<T>();
+  }
   /// Return typed view for data values.
   template <class T> auto values() { return m_data->values<T>(); }
 
   /// Return typed const view for data variances.
-  template <class T> auto variances() const { return m_data->variances<T>(); }
+  template <class T> auto variances() const {
+    return std::as_const(*m_data).variances<T>();
+  }
   /// Return typed view for data variances.
   template <class T> auto variances() { return m_data->variances<T>(); }
 

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -55,10 +55,6 @@ public:
       setCoord(dim, std::move(coord));
   }
 
-  [[maybe_unused]] Dataset &assign(const Dataset &other);
-  [[maybe_unused]] Dataset &assign(const DataArray &other);
-  [[maybe_unused]] Dataset &assign(const Variable &other);
-
   /// Return the number of data items in the dataset.
   ///
   /// This does not include coordinates or attributes, but only all named
@@ -162,6 +158,9 @@ public:
   void setData(const std::string &name, const DataArray &data);
 
   Dataset slice(const Slice s) const;
+  [[maybe_unused]] Dataset &setSlice(const Slice s, const Dataset &dataset);
+  [[maybe_unused]] Dataset &setSlice(const Slice s, const DataArray &array);
+  [[maybe_unused]] Dataset &setSlice(const Slice s, const Variable &var);
 
   void rename(const Dim from, const Dim to);
 
@@ -261,9 +260,6 @@ union_or(const Masks &currentMasks, const Masks &otherMasks);
 /// The result is stored in the first view.
 SCIPP_DATASET_EXPORT void union_or_in_place(Masks &masks,
                                             const Masks &otherMasks);
-
-SCIPP_DATASET_EXPORT void union_copy_in_place(Masks &masks,
-                                              const Masks &otherMasks);
 
 SCIPP_DATASET_EXPORT Dataset merge(const Dataset &a, const Dataset &b);
 

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -89,6 +89,10 @@ public:
        std::initializer_list<std::pair<const Key, Value>> items,
        const bool readonly = false);
   Dict(const Sizes &sizes, holder_type items, const bool readonly = false);
+  Dict(const Dict &other);
+  Dict(Dict &&other);
+  Dict &operator=(const Dict &other);
+  Dict &operator=(Dict &&other);
 
   /// Return the number of coordinates in the view.
   index size() const noexcept { return scipp::size(m_items); }

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -156,7 +156,7 @@ public:
 
   void setSizes(const Sizes &sizes);
   void rebuildSizes();
-  void set(const key_type &key, mapped_type coord, const bool force = false);
+  void set(const key_type &key, mapped_type coord);
   void erase(const key_type &key);
   mapped_type extract(const key_type &key);
 
@@ -167,6 +167,7 @@ public:
 
   bool is_readonly() const noexcept;
   [[nodiscard]] Dict as_const() const;
+  [[nodiscard]] Dict merge_from(const Dict &other) const;
 
   bool item_applies_to(const Key &key, const Dimensions &dims) const;
 

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -168,6 +168,8 @@ public:
   bool is_readonly() const noexcept;
   [[nodiscard]] Dict as_const() const;
 
+  bool item_applies_to(const Key &key, const Dimensions &dims) const;
+
 protected:
   Sizes m_sizes;
   holder_type m_items;

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -86,12 +86,9 @@ public:
 
   Dict() = default;
   Dict(const Sizes &sizes,
-       std::initializer_list<std::pair<const Key, Value>> items)
-      : Dict(sizes, holder_type(items)) {}
-  Dict(const Sizes &sizes, holder_type items) : m_sizes(sizes) {
-    for (auto &&[key, value] : items)
-      set(key, std::move(value));
-  }
+       std::initializer_list<std::pair<const Key, Value>> items,
+       const bool readonly = false);
+  Dict(const Sizes &sizes, holder_type items, const bool readonly = false);
 
   /// Return the number of coordinates in the view.
   index size() const noexcept { return scipp::size(m_items); }
@@ -155,7 +152,7 @@ public:
 
   void setSizes(const Sizes &sizes);
   void rebuildSizes();
-  void set(const key_type &key, mapped_type coord);
+  void set(const key_type &key, mapped_type coord, const bool force = false);
   void erase(const key_type &key);
   mapped_type extract(const key_type &key);
 
@@ -164,11 +161,13 @@ public:
 
   void rename(const Dim from, const Dim to);
 
+  bool is_readonly() const noexcept;
   [[nodiscard]] Dict as_const() const;
 
 protected:
   Sizes m_sizes;
   holder_type m_items;
+  bool m_readonly{false};
 };
 
 /// Returns the union of all masks with irreducible dimension `dim`.

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -71,7 +71,7 @@ auto slice_map(const Sizes &sizes, const T &map, const Slice &params) {
         out[key] = value.slice(Slice{params.dim(), params.begin(), end});
       }
     } else {
-      out[key] = value;
+      out[key] = value.as_const();
     }
   }
   return out;
@@ -162,6 +162,8 @@ public:
   Dict slice(const Slice &params) const;
 
   void rename(const Dim from, const Dim to);
+
+  [[nodiscard]] Dict as_const() const;
 
 protected:
   Sizes m_sizes;

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -160,6 +160,7 @@ public:
   mapped_type extract(const key_type &key);
 
   Dict slice(const Slice &params) const;
+  [[maybe_unused]] Dict &setSlice(const Slice s, const Dict &dict);
 
   void rename(const Dim from, const Dim to);
 

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -29,14 +29,14 @@ Dict<Key, Value>::Dict(const Sizes &sizes, holder_type items,
   m_readonly = readonly;
 }
 
-/*
 template <class Key, class Value>
 Dict<Key, Value>::Dict(const Dict &other)
     : Dict(other.m_sizes, other.m_items, false) {}
 
 template <class Key, class Value>
 Dict<Key, Value>::Dict(Dict &&other)
-    : Dict(std::move(other.m_sizes), std::move(other.m_items), false) {}
+    : Dict(std::move(other.m_sizes), std::move(other.m_items),
+           other.m_readonly) {}
 
 template <class Key, class Value>
 Dict<Key, Value> &Dict<Key, Value>::operator=(const Dict &other) {
@@ -55,7 +55,6 @@ Dict<Key, Value> &Dict<Key, Value>::operator=(Dict &&other) {
   // keep m_readonly unchanged?
   return *this;
 }
-*/
 
 template <class Key, class Value>
 bool Dict<Key, Value>::operator==(const Dict &other) const {
@@ -141,6 +140,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord,
   if (!m_sizes.contains(coord.dims())) {
     const auto dim = dim_of_coord(coord, key);
     auto dims = coord.dims();
+    // TODO can remove this with latest change to is_edges?
     if (dims.contains(dim))
       dims.erase(dim);
     if (!(is_edges(m_sizes, coord.dims(), dim) && m_sizes.contains(dims)))

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -121,6 +121,8 @@ template <class Key, class Value> void Dict<Key, Value>::rebuildSizes() {
 template <class Key, class Value>
 void Dict<Key, Value>::set(const key_type &key, mapped_type coord,
                            const bool force) {
+  if (contains(key) && at(key).is_same(coord))
+    return;
   if (!force)
     expectWritable(*this);
   // Is a good definition for things that are allowed: "would be possible to

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -129,11 +129,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord,
   // concat along existing dim or extra dim"?
   if (!m_sizes.contains(coord.dims())) {
     const auto dim = dim_of_coord(coord, key);
-    auto dims = coord.dims();
-    // TODO can remove this with latest change to is_edges?
-    if (dims.contains(dim))
-      dims.erase(dim);
-    if (!(is_edges(m_sizes, coord.dims(), dim) && m_sizes.contains(dims)))
+    if (!is_edges(m_sizes, coord.dims(), dim))
       throw except::DimensionError("Cannot add coord exceeding DataArray dims");
   }
   m_items.insert_or_assign(key, std::move(coord));

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -127,11 +127,9 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord,
     expectWritable(*this);
   // Is a good definition for things that are allowed: "would be possible to
   // concat along existing dim or extra dim"?
-  if (!m_sizes.contains(coord.dims())) {
-    const auto dim = dim_of_coord(coord, key);
-    if (!is_edges(m_sizes, coord.dims(), dim))
-      throw except::DimensionError("Cannot add coord exceeding DataArray dims");
-  }
+  if (!m_sizes.contains(coord.dims()) &&
+      !is_edges(m_sizes, coord.dims(), dim_of_coord(coord, key)))
+    throw except::DimensionError("Cannot add coord exceeding DataArray dims");
   m_items.insert_or_assign(key, std::move(coord));
 }
 

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -39,22 +39,10 @@ Dict<Key, Value>::Dict(Dict &&other)
            other.m_readonly) {}
 
 template <class Key, class Value>
-Dict<Key, Value> &Dict<Key, Value>::operator=(const Dict &other) {
-  expectWritable(*this);
-  m_sizes = other.m_sizes;
-  m_items = other.m_items;
-  // keep m_readonly unchanged?
-  return *this;
-}
+Dict<Key, Value> &Dict<Key, Value>::operator=(const Dict &other) = default;
 
 template <class Key, class Value>
-Dict<Key, Value> &Dict<Key, Value>::operator=(Dict &&other) {
-  expectWritable(*this);
-  m_sizes = std::move(other.m_sizes);
-  m_items = std::move(other.m_items);
-  // keep m_readonly unchanged?
-  return *this;
-}
+Dict<Key, Value> &Dict<Key, Value>::operator=(Dict &&other) = default;
 
 template <class Key, class Value>
 bool Dict<Key, Value>::operator==(const Dict &other) const {

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -209,6 +209,15 @@ Dict<Key, Value> Dict<Key, Value>::as_const() const {
   return {sizes(), std::move(items), readonly};
 }
 
+template <class Key, class Value>
+bool Dict<Key, Value>::item_applies_to(const Key &key,
+                                       const Dimensions &dims) const {
+  const auto &val = m_items.at(key);
+  return dims.contains(val.dims()) ||
+         (!sizes().contains(val.dims()) &&
+          is_edges(Sizes(dims), val.dims(), dim_of_coord(val, key)));
+}
+
 template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
 

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -128,6 +128,16 @@ void Dict<Key, Value>::rename(const Dim from, const Dim to) {
     item.second.rename(from, to);
 }
 
+template <class Key, class Value>
+Dict<Key, Value> Dict<Key, Value>::as_const() const {
+  holder_type items;
+  std::transform(m_items.begin(), m_items.end(),
+                 std::inserter(items, items.end()), [](const auto &item) {
+                   return std::pair(item.first, item.second.as_const());
+                 });
+  return {sizes(), std::move(items)};
+}
+
 template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
 

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(TARGET_NAME "scipp-dataset-test")
 add_dependencies(all-tests ${TARGET_NAME})
 add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
-  assign_test.cpp
   attributes_test.cpp
   binned_arithmetic_test.cpp
   binned_creation_test.cpp
@@ -36,6 +35,7 @@ add_executable(
   merge_test.cpp
   rebin_test.cpp
   self_assignment_test.cpp
+  set_slice_test.cpp
   shape_test.cpp
   size_of_test.cpp
   slice_by_value_test.cpp

--- a/dataset/test/assign_test.cpp
+++ b/dataset/test/assign_test.cpp
@@ -24,6 +24,15 @@ TEST_F(AssignTest, self) {
   // EXPECT_EQ(array.setSlice(array), original);
 }
 
+TEST_F(AssignTest, copy_slice) {
+  ASSERT_NO_THROW(array.slice({Dim::X, 0}));
+  ASSERT_NO_THROW(array.slice({Dim::X, 0}).masks());
+  EXPECT_THROW(array.slice({Dim::X, 0})
+                   .masks()
+                   .set("abc", makeVariable<bool>(Values{false})),
+               std::runtime_error);
+}
+
 TEST_F(AssignTest, coord_fail) {
   const auto original = copy(array);
   // EXPECT_THROW(array.setSlice(array.slice({Dim::X, 0, 1})),

--- a/dataset/test/assign_test.cpp
+++ b/dataset/test/assign_test.cpp
@@ -21,15 +21,15 @@ protected:
 
 TEST_F(AssignTest, self) {
   const auto original = copy(array);
-  EXPECT_EQ(array.assign(array), original);
+  // EXPECT_EQ(array.setSlice(array), original);
 }
 
 TEST_F(AssignTest, coord_fail) {
   const auto original = copy(array);
-  EXPECT_THROW(array.assign(array.slice({Dim::X, 0, 1})),
-               except::CoordMismatchError);
-  EXPECT_EQ(array, original);
-  EXPECT_THROW(array.slice({Dim::X, 0, 1}).assign(array.slice({Dim::X, 2, 3})),
+  // EXPECT_THROW(array.setSlice(array.slice({Dim::X, 0, 1})),
+  //             except::CoordMismatchError);
+  // EXPECT_EQ(array, original);
+  EXPECT_THROW(array.setSlice({Dim::X, 0, 1}, array.slice({Dim::X, 2, 3})),
                except::CoordMismatchError);
   EXPECT_EQ(array, original);
 }
@@ -37,24 +37,24 @@ TEST_F(AssignTest, coord_fail) {
 TEST_F(AssignTest, mask_propagation) {
   const auto original = copy(array);
   // Mask values get copied
-  array.slice({Dim::X, 0}).assign(original.slice({Dim::X, 1}));
+  array.setSlice({Dim::X, 0}, original.slice({Dim::X, 1}));
   EXPECT_EQ(array.masks()["mask"],
             makeVariable<bool>(dims, Values{false, false, true}));
-  array.slice({Dim::X, 0}).assign(original.slice({Dim::X, 2}));
+  array.setSlice({Dim::X, 0}, original.slice({Dim::X, 2}));
   EXPECT_EQ(array.masks()["mask"],
             makeVariable<bool>(dims, Values{true, false, true}));
   // Mask not in source is preserved unchanged
   array.masks().set("other", copy(mask));
-  array.slice({Dim::X, 0}).assign(original.slice({Dim::X, 1}));
+  array.setSlice({Dim::X, 0}, original.slice({Dim::X, 1}));
   EXPECT_EQ(array.masks()["other"], mask);
   // Extra mask is added
   auto extra_mask = copy(array);
   extra_mask.masks().set("extra", copy(mask));
-  EXPECT_NO_THROW(array.assign(extra_mask.slice({Dim::X, 1})));
-  EXPECT_TRUE(array.masks().contains("extra"));
+  // EXPECT_NO_THROW(array.setSlice(extra_mask.slice({Dim::X, 1})));
+  // EXPECT_TRUE(array.masks().contains("extra"));
   // Extra masks added to mask dict of slice => silently dropped
   extra_mask.masks().set("dropped", copy(mask));
-  EXPECT_THROW(array.slice({Dim::X, 0}).assign(extra_mask.slice({Dim::X, 1})),
+  EXPECT_THROW(array.setSlice({Dim::X, 0}, extra_mask.slice({Dim::X, 1})),
                except::NotFoundError);
   EXPECT_FALSE(array.masks().contains("dropped"));
 }
@@ -62,8 +62,8 @@ TEST_F(AssignTest, mask_propagation) {
 TEST_F(AssignTest, lower_dimensional_mask_cannot_be_overridden) {
   auto other = copy(array.slice({Dim::X, 1}));
   array.masks().set("scalar", makeVariable<bool>(Values{true}));
-  EXPECT_NO_THROW(array.slice({Dim::X, 0}).assign(other));
+  EXPECT_NO_THROW(array.setSlice({Dim::X, 0}, other));
   other.masks().set("scalar", makeVariable<bool>(Values{false}));
   // Setting a slice must not change mask values of unrelated data points
-  EXPECT_THROW(array.slice({Dim::X, 0}).assign(other), except::DimensionError);
+  EXPECT_THROW(array.setSlice({Dim::X, 0}, other), except::DimensionError);
 }

--- a/dataset/test/dataset_arithmetic_test.cpp
+++ b/dataset/test/dataset_arithmetic_test.cpp
@@ -775,17 +775,16 @@ TEST(DatasetSetData, dense_to_empty) {
 
 TEST(DatasetSetData, labels) {
   auto dense = datasetFactory().make();
-  dense.setCoord(
-      Dim("l"),
-      makeVariable<double>(
-          Dims{Dim::X}, Shape{dense.coords()[Dim::X].values<double>().size()}));
+  dense.setCoord(Dim("l"), makeVariable<double>(
+                               Dims{Dim::X},
+                               Shape{dense.coords()[Dim::X].dims().volume()}));
   auto d = copy(dense.slice({Dim::Y, 0}));
   dense.setData("data_x_1", dense["data_x"]);
   EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
 
-  d.setCoord(Dim("l1"), makeVariable<double>(
-                            Dims{Dim::X},
-                            Shape{d.coords()[Dim::X].values<double>().size()}));
+  d.setCoord(Dim("l1"),
+             makeVariable<double>(Dims{Dim::X},
+                                  Shape{d.coords()[Dim::X].dims().volume()}));
   EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), except::NotFoundError);
 }
 

--- a/dataset/test/dataset_arithmetic_test.cpp
+++ b/dataset/test/dataset_arithmetic_test.cpp
@@ -785,7 +785,8 @@ TEST(DatasetSetData, labels) {
   d.setCoord(Dim("l1"),
              makeVariable<double>(Dims{Dim::X},
                                   Shape{d.coords()[Dim::X].dims().volume()}));
-  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), except::NotFoundError);
+  dense.setData("data_x_2", d["data_x"]);
+  EXPECT_TRUE(dense.coords().contains(Dim("l1")));
 }
 
 TEST(DatasetInPlaceStrongExceptionGuarantee, events) {

--- a/dataset/test/dataset_view_test.cpp
+++ b/dataset/test/dataset_view_test.cpp
@@ -80,9 +80,9 @@ TYPED_TEST(DatasetViewTest, find_in_slice) {
 
   EXPECT_EQ(slice.find("a")->name(), "a");
   EXPECT_EQ(*slice.find("a"), slice["a"]);
-  EXPECT_EQ(slice.find("b"), slice.end());
+  EXPECT_NE(slice.find("b"), slice.end()); // not removed by slicing
   EXPECT_TRUE(slice.contains("a"));
-  EXPECT_FALSE(slice.contains("b"));
+  EXPECT_TRUE(slice.contains("b"));
 }
 
 TYPED_TEST(DatasetViewTest, iterators_empty_dataset) {

--- a/dataset/test/set_slice_test.cpp
+++ b/dataset/test/set_slice_test.cpp
@@ -8,8 +8,8 @@
 using namespace scipp;
 using namespace scipp::dataset;
 
-struct AssignTest : public ::testing::Test {
-  AssignTest() {}
+struct SetSliceTest : public ::testing::Test {
+  SetSliceTest() {}
 
 protected:
   Dimensions dims{Dim::X, 3};
@@ -19,12 +19,12 @@ protected:
   DataArray array{data, {{Dim::X, copy(x)}}, {{"mask", copy(mask)}}};
 };
 
-TEST_F(AssignTest, self) {
+TEST_F(SetSliceTest, self) {
   const auto original = copy(array);
-  // EXPECT_EQ(array.setSlice(array), original);
+  EXPECT_EQ(array.setSlice({Dim::X, 0, 3}, array), original);
 }
 
-TEST_F(AssignTest, copy_slice) {
+TEST_F(SetSliceTest, copy_slice) {
   ASSERT_NO_THROW(array.slice({Dim::X, 0}));
   ASSERT_NO_THROW(array.slice({Dim::X, 0}).masks());
   EXPECT_THROW(array.slice({Dim::X, 0})
@@ -33,17 +33,14 @@ TEST_F(AssignTest, copy_slice) {
                std::runtime_error);
 }
 
-TEST_F(AssignTest, coord_fail) {
+TEST_F(SetSliceTest, coord_fail) {
   const auto original = copy(array);
-  // EXPECT_THROW(array.setSlice(array.slice({Dim::X, 0, 1})),
-  //             except::CoordMismatchError);
-  // EXPECT_EQ(array, original);
   EXPECT_THROW(array.setSlice({Dim::X, 0, 1}, array.slice({Dim::X, 2, 3})),
                except::CoordMismatchError);
   EXPECT_EQ(array, original);
 }
 
-TEST_F(AssignTest, mask_propagation) {
+TEST_F(SetSliceTest, mask_propagation) {
   const auto original = copy(array);
   // Mask values get copied
   array.setSlice({Dim::X, 0}, original.slice({Dim::X, 1}));
@@ -56,23 +53,47 @@ TEST_F(AssignTest, mask_propagation) {
   array.masks().set("other", copy(mask));
   array.setSlice({Dim::X, 0}, original.slice({Dim::X, 1}));
   EXPECT_EQ(array.masks()["other"], mask);
-  // Extra mask is added
-  auto extra_mask = copy(array);
-  extra_mask.masks().set("extra", copy(mask));
-  // EXPECT_NO_THROW(array.setSlice(extra_mask.slice({Dim::X, 1})));
-  // EXPECT_TRUE(array.masks().contains("extra"));
-  // Extra masks added to mask dict of slice => silently dropped
-  extra_mask.masks().set("dropped", copy(mask));
-  EXPECT_THROW(array.setSlice({Dim::X, 0}, extra_mask.slice({Dim::X, 1})),
-               except::NotFoundError);
-  EXPECT_FALSE(array.masks().contains("dropped"));
 }
 
-TEST_F(AssignTest, lower_dimensional_mask_cannot_be_overridden) {
+TEST_F(SetSliceTest, new_meta_data_cannot_be_added) {
+  const auto original = copy(array);
+  auto extra_mask = copy(array.slice({Dim::X, 1}));
+  extra_mask.masks().set("extra", copy(mask.slice({Dim::X, 1})));
+  EXPECT_THROW(array.setSlice({Dim::X, 0}, extra_mask), except::NotFoundError);
+  EXPECT_EQ(array, original);
+}
+
+TEST_F(SetSliceTest, new_meta_data_cannot_be_added_arithmetic) {
+  const auto original = copy(array);
+  auto extra_mask = copy(array.slice({Dim::X, 1}));
+  extra_mask.masks().set("extra", copy(mask.slice({Dim::X, 1})));
+  EXPECT_THROW(array.slice({Dim::X, 0}) += extra_mask, except::NotFoundError);
+  EXPECT_EQ(array, original);
+}
+
+TEST_F(SetSliceTest, lower_dimensional_mask_cannot_be_overridden) {
   auto other = copy(array.slice({Dim::X, 1}));
   array.masks().set("scalar", makeVariable<bool>(Values{true}));
   EXPECT_NO_THROW(array.setSlice({Dim::X, 0}, other));
+  other.masks().set("scalar", makeVariable<bool>(Values{true}));
+  EXPECT_NO_THROW(array.setSlice({Dim::X, 0}, other)); // ok, no change
   other.masks().set("scalar", makeVariable<bool>(Values{false}));
   // Setting a slice must not change mask values of unrelated data points
+  const auto original = copy(array);
   EXPECT_THROW(array.setSlice({Dim::X, 0}, other), except::DimensionError);
+  EXPECT_EQ(array, original);
+}
+
+TEST_F(SetSliceTest, lower_dimensional_mask_cannot_be_overridden_arithmetic) {
+  auto other = copy(array.slice({Dim::X, 0}));
+  array.masks().set("scalar", makeVariable<bool>(Values{false}));
+  const auto original = copy(array);
+  EXPECT_NO_THROW(array.slice({Dim::X, 1}) += other);
+  other.masks().set("scalar", makeVariable<bool>(Values{false}));
+  EXPECT_NO_THROW(array.slice({Dim::X, 1}) += other); // ok, no change
+  other.masks().set("scalar", makeVariable<bool>(Values{true}));
+  // Setting a slice must not change mask values of unrelated data points
+  array = copy(original);
+  EXPECT_THROW(array.slice({Dim::X, 1}) += other, except::DimensionError);
+  EXPECT_EQ(array, original);
 }

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -292,6 +292,9 @@ TEST_P(Dataset3DTest_slice_y, slice) {
       reference[name].attrs().set(
           Dim(attr), dataset.coords()[Dim(attr)].slice({Dim::Y, pos}));
   }
+  for (const auto &item : dataset)
+    if (!reference.contains(item.name()))
+      reference.setData(item.name(), copy(item));
 
   EXPECT_EQ(dataset.slice({Dim::Y, pos}), reference);
 }
@@ -311,6 +314,9 @@ TEST_P(Dataset3DTest_slice_z, slice) {
       reference[name].attrs().set(
           Dim(attr), dataset.coords()[Dim(attr)].slice({Dim::Z, pos}));
   }
+  for (const auto &item : dataset)
+    if (!reference.contains(item.name()))
+      reference.setData(item.name(), copy(item));
 
   EXPECT_EQ(dataset.slice({Dim::Z, pos}), reference);
 }

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -152,6 +152,9 @@ protected:
     d.setData("data_xy", dataset["data_xy"].slice({Dim::X, pos}));
     d.setData("data_zyx", dataset["data_zyx"].slice({Dim::X, pos}));
     d.setData("data_xyz", dataset["data_xyz"].slice({Dim::X, pos}));
+    for (const auto &item : dataset)
+      if (!d.contains(item.name()))
+        d.setData(item.name(), copy(item));
     return d;
   }
 };
@@ -182,6 +185,9 @@ protected:
     d.setData("data_xy", dataset["data_xy"].slice({Dim::Y, begin, end}));
     d.setData("data_zyx", dataset["data_zyx"].slice({Dim::Y, begin, end}));
     d.setData("data_xyz", dataset["data_xyz"].slice({Dim::Y, begin, end}));
+    for (const auto &item : dataset)
+      if (!d.contains(item.name()))
+        d.setData(item.name(), copy(item));
     return d;
   }
 };
@@ -201,6 +207,9 @@ protected:
                dataset.coords()[Dim("labels_z")].slice({Dim::Z, begin, end}));
     d.setData("data_zyx", dataset["data_zyx"].slice({Dim::Z, begin, end}));
     d.setData("data_xyz", dataset["data_xyz"].slice({Dim::Z, begin, end}));
+    for (const auto &item : dataset)
+      if (!d.contains(item.name()))
+        d.setData(item.name(), copy(item));
     return d;
   }
 };
@@ -328,6 +337,9 @@ TEST_P(Dataset3DTest_slice_range_x, slice) {
                     dataset["data_zyx"].slice({Dim::X, begin, end}));
   reference.setData("data_xyz",
                     dataset["data_xyz"].slice({Dim::X, begin, end}));
+  for (const auto &item : dataset)
+    if (!reference.contains(item.name()))
+      reference.setData(item.name(), copy(item));
 
   EXPECT_EQ(dataset.slice({Dim::X, begin, end}), reference);
 }

--- a/dataset/test/sort_test.cpp
+++ b/dataset/test/sort_test.cpp
@@ -111,14 +111,13 @@ TEST(SortTest, dataset_1d) {
                                        Values{3, 1, 2}, Variances{6, 4, 5}));
   expected.setData("b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
                                              Values{0.3, 0.1, 0.2}));
+  expected.setData("scalar", makeVariable<double>(Values{1.2}));
   expected.setCoord(Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3},
                                                  units::m, Values{3, 1, 2}));
 
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
 
-  EXPECT_THROW(sort(d, key), except::NotFoundError); // scalar has no 'x' coord
-  d.erase("scalar");
   EXPECT_EQ(sort(d, key), expected);
 }
 
@@ -138,13 +137,12 @@ TEST(SortTest, dataset_1d_descending) {
                                        Values{2, 1, 3}, Variances{5, 4, 6}));
   expected.setData("b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
                                              Values{0.2, 0.1, 0.3}));
+  expected.setData("scalar", makeVariable<double>(Values{1.2}));
   expected.setCoord(Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3},
                                                  units::m, Values{2, 1, 3}));
 
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
 
-  EXPECT_THROW(sort(d, key, SortOrder::Descending), except::NotFoundError);
-  d.erase("scalar");
   EXPECT_EQ(sort(d, key, SortOrder::Descending), expected);
 }

--- a/dataset/test/sort_test.cpp
+++ b/dataset/test/sort_test.cpp
@@ -117,9 +117,8 @@ TEST(SortTest, dataset_1d) {
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
 
-  // Note that the result does not contain `scalar`. Is this a bug or a feature?
-  // - Should we throw if there is any scalar data/coord?
-  // - Should we preserve scalars?
+  EXPECT_THROW(sort(d, key), except::NotFoundError); // scalar has no 'x' coord
+  d.erase("scalar");
   EXPECT_EQ(sort(d, key), expected);
 }
 
@@ -145,8 +144,7 @@ TEST(SortTest, dataset_1d_descending) {
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
 
-  // Note that the result does not contain `scalar`. Is this a bug or a feature?
-  // - Should we throw if there is any scalar data/coord?
-  // - Should we preserve scalars?
+  EXPECT_THROW(sort(d, key, SortOrder::Descending), except::NotFoundError);
+  d.erase("scalar");
   EXPECT_EQ(sort(d, key, SortOrder::Descending), expected);
 }

--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -73,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "array = sc.DataArray(\n",
@@ -134,9 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dataset['c'] = dataset['b']['x', 2]\n",
@@ -163,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.plot(dataset)"
@@ -232,9 +226,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -189,9 +189,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we now set this scalar `val` on a slice at `x=0`, using, e.g., `=` or `+=` we need to update the mask.\n",
-    "However, the mask in this example depends only on `y` so it also masks the slices `x=1` and `x=2`.\n",
-    "If we would allow updating the mask, the following would *unmask data for all `x`*: "
+    "If we now assign this scalar `val` to a slice at `x=0`, using `=` we need to update the mask.\n",
+    "However, the mask in this example depends only on `y` so it also applies to the slices `x=1` and `x=2`.\n",
+    "If we would allow updating the mask, the following would *unmask data for all* `x`:"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If `a['x',0]` had an `x` coordinate this would fail due to a coord mismatch.\n",
+    "If `a['x', 0]` had an `x` coordinate this would fail due to a coord mismatch.\n",
     "If coord checking is required, use a range-slice such as `a['x', 1:2]`. Compare the two cases shown in the following and make sure to inspect the `dims` and `shape` of all variables (data and coordinates) of the resulting slice views (note the tooltip shown when moving the mouse over the name also contains this information):"
    ]
   },

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -16,11 +16,15 @@
    "source": [
     "## Positional indexing\n",
     "\n",
+    "### Overview\n",
+    "\n",
     "Data in a [variable](../generated/scipp.Variable.rst#scipp.Variable), [dataset](../generated/scipp.Dataset.rst#scipp.Dataset) or [data array](../generated/scipp.DataArray.rst#scipp.DataArray) can be indexed in a similar manner to NumPy and xarray.\n",
     "The dimension to be sliced is specified using a dimension label and, in contrast to NumPy, positional dimension lookup is not available.\n",
     "Positional indexing with an integer or an integer range is made via `__getitem__` and `__setitem__` with a dimension label as first argument.\n",
     "This is available for variables, data arrays, datasets, as well as items of a dataset.\n",
     "In all cases a *view* is returned, i.e., just like when slicing a [numpy.ndarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html#numpy.ndarray) no copy is performed.\n",
+    "\n",
+    "### Variables\n",
     "\n",
     "Consider the following variable:"
    ]
@@ -69,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "s = var['x', 1:3]\n",
@@ -94,7 +96,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -107,7 +109,162 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Slicing for datasets works in the same way, but some additional rules apply:"
+    "### Data arrays\n",
+    "\n",
+    "Slicing for data arrays works in the same way, but some additional rules apply.\n",
+    "Consider:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = sc.DataArray(\n",
+    "    data=sc.array(dims=['y', 'x'], values=np.random.rand(2, 3)),\n",
+    "    coords={\n",
+    "        'x': sc.array(dims=['x'], values=np.arange(3.0), unit=sc.units.m),\n",
+    "        'y': sc.array(dims=['y'], values=np.arange(2.0), unit=sc.units.m)},\n",
+    "    masks={\n",
+    "        'mask': sc.array(dims=['x'], values=[True, False, False])},\n",
+    "    attrs={\n",
+    "        'aux_x': sc.array(dims=['x'], values=np.arange(3.0), unit=sc.units.m),\n",
+    "        'aux_y': sc.array(dims=['y'], values=np.arange(2.0), unit=sc.units.m)})\n",
+    "sc.show(a)\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As when slicing a variable, the sliced dimension is removed when slicing without range, and kept when slicing with range.\n",
+    "\n",
+    "When slicing a data array the following additional rule applies:\n",
+    "\n",
+    "- Meta data (coords, masks, attrs) that *do not depend on the slice dimension* are marked as *readonly*\n",
+    "- Slicing **without range**:\n",
+    "  - The *coordinates* for the sliced dimension are *removed* and inserted as *attributes* instead.\n",
+    "- Slicing **with a range**:\n",
+    "  - The *coordinates* for the sliced dimension are *kept*.\n",
+    "\n",
+    "The rationale behind this mechanism is as follows.\n",
+    "Meta data is often of a lower dimensionality than data, such as in this example where coords, masks, and attrs are 1-D whereas data is 2-D.\n",
+    "Elements of meta data entries are thus shared by many data elements, and we must be careful to not apply operations to subsets of data while unintentionally modifying meta data for other unrelated data elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a['x', 0:1].coords['x'] *= 2  # ok, modifies only coord value \"private\" to this x-slice\n",
+    "try:\n",
+    "    a['x', 0:1].coords['y'] *= 2  # not ok, would modify coord value \"shared\" by all x-slices\n",
+    "except sc.VariableError as e:\n",
+    "    print(f'\\'y\\' is shared with other \\'x\\'-slices and should not be modified by the slice, so we get an error:\\n{e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In practice, a much more dangerous issue this mechanism protects from is unintentional changes to masks.\n",
+    "Consider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val = a['x', 1]['y', 0].copy()\n",
+    "val"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we now set this scalar `val` on a slice at `x=0`, using, e.g., `=` or `+=` we need to update the mask.\n",
+    "However, the mask in this example depends only on `y` so it also masks the slices `x=1` and `x=2`.\n",
+    "If we would allow updating the mask, the following would *unmask data for all `x`*: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    a['x', 0] = val\n",
+    "except sc.DimensionError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we cannot update the mask in a consistent manner the entire operation fails.\n",
+    "Data is not modified.\n",
+    "The same mechanism is applied for binary arithmetic operations such as `+=` where the masks would be updated using a logical OR operation.\n",
+    "\n",
+    "The purpose for turning coords into attrs when slicing *without* a range is to support useful operations such as:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "a - a['x', 1]  # compute difference compared to data at x=1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `a['x',0]` had an `x` coordinate this would fail due to a coord mismatch.\n",
+    "If coord checking is required, use a range-slice such as `a['x', 1:2]`. Compare the two cases shown in the following and make sure to inspect the `dims` and `shape` of all variables (data and coordinates) of the resulting slice views (note the tooltip shown when moving the mouse over the name also contains this information):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.show(a['y', 1:2])  # Range of length 1\n",
+    "a['y', 1:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.show(a['y', 1])  # No range\n",
+    "a['y', 1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Datasets\n",
+    "\n",
+    "Slicing for datasets works just like for data arrays.\n",
+    "In addition to changing certain coords into attrs and marking certain meta data entries as read-only, slicing a dataset also marks lower-dimensional *data entries* readonly.\n",
+    "Consider a dataset `d`:"
    ]
   },
   {
@@ -117,15 +274,13 @@
    "outputs": [],
    "source": [
     "d = sc.Dataset(\n",
-    "    {'a': sc.array(dims=['x', 'y'], values=np.random.rand(2, 3)),\n",
-    "     'b': sc.array(dims=['y', 'x'], values=np.random.rand(3, 2)),\n",
-    "     'c': sc.array(dims=['x'], values=np.random.rand(2)),\n",
+    "    {'a': sc.array(dims=['y', 'x'], values=np.random.rand(2, 3)),\n",
+    "     'b': sc.array(dims=['x', 'y'], values=np.random.rand(3, 2)),\n",
+    "     'c': sc.array(dims=['y'], values=np.random.rand(2)),\n",
     "     '0d-data': sc.scalar(1.0)},\n",
     "    coords={\n",
-    "        'x': sc.array(dims=['x'], values=np.arange(2.0), unit=sc.units.m),\n",
-    "        'y': sc.array(dims=['y'], values=np.arange(3.0), unit=sc.units.m),\n",
-    "        'aux_x': sc.array(dims=['x'], values=np.arange(2.0), unit=sc.units.m),\n",
-    "        'aux_y': sc.array(dims=['y'], values=np.arange(3.0), unit=sc.units.m)})\n",
+    "        'x': sc.array(dims=['x'], values=np.arange(3.0), unit=sc.units.m),\n",
+    "        'y': sc.array(dims=['y'], values=np.arange(2.0), unit=sc.units.m)})\n",
     "sc.show(d)"
    ]
   },
@@ -133,18 +288,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As when slicing a variable, the sliced dimension is removed when slicing without range, and kept when slicing with range.\n",
-    "\n",
-    "When slicing a dataset a number of other things happen as well:\n",
-    "\n",
-    "- Any data item that does not depend on the sliced dimension is removed.\n",
-    "- Slicing **without range**:\n",
-    "  - The *coordinates* for the sliced dimension are *removed*.\n",
-    "- Slicing **with a range**:\n",
-    "  - The *coordinates* for the sliced dimension are *kept*.\n",
-    "\n",
-    "The rationale behind this mechanism is as follows.\n",
-    "We may want to modify slices independently, e.g., by adding an offset to certain slices:"
+    "and a slice of `d`:"
    ]
   },
   {
@@ -153,53 +297,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d['x', 0] += 1.0\n",
-    "d['x', 1] += 2.0"
+    "sc.show(d['y', 0])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By excluding scalar items from the slice view (see below for a visual representation), we prevent unintentional addition of multiple offsets to the same scalar.\n",
-    "\n",
+    "By marking lower-dimensional entries in the slice as read-only we prevent unintentional multiple modifications of the same scalar:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    d['y', 0] += 1  # would add 1 to `0d-data`\n",
+    "    d['y', 1] += 2  # would add 2 to `0d-data`\n",
+    "except sc.VariableError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This is an important aspect and it is worthwhile to take some time and think through the mechanism.\n",
-    "Consider the following example, contrasting slicing with and without range:\n",
     "\n",
-    "- We slice dimension `'x'`, so the data item `'0d-data'` which does not depend on dimension `'x'` is not visible in the slice views.\n",
-    "- In the second case (without range) the coord for dimension `'x'` is also not part of the slice view\n",
-    "\n",
-    "Make sure to inspect the `dims` and `shape` of all variables (data and coordinates) of the resulting slice views (note the tooltip shown when moving the mouse over the name also contains this information):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Range of length 1\n",
-    "sc.show(d['x', 1:2])\n",
-    "d['x', 1:2]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# No range\n",
-    "sc.show(d['x', 1])\n",
-    "d['x', 1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Slicing a data item of a dataset should not bring any surprises.\n",
-    "Essentially this behaves like slicing a dataset with just a single data item:"
+    "Essentially this behaves like slicing a data array:"
    ]
   },
   {
@@ -483,9 +611,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -75,7 +75,7 @@ class DataAccessHelper {
       auto array =
           py::array{get_dtype(), dims.shape(), get_strides(),
                     Getter::template get<T>(std::as_const(view)).data(), obj};
-      reinterpret_cast<py::detail::PyArray_Proxy *>(array.ptr())->flags &=
+      py::detail::array_proxy(array.ptr())->flags &=
           ~py::detail::npy_api::NPY_ARRAY_WRITEABLE_;
       return array;
     } else {

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -11,8 +11,7 @@
 #include "scipp/core/tag_util.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/slice.h"
-#include "scipp/dataset/util.h"  // assign_from
-#include "scipp/variable/util.h" // assign_from
+#include "scipp/variable/slice.h"
 #include "scipp/variable/variable.h"
 
 namespace py = pybind11;
@@ -63,7 +62,7 @@ template <class View> struct SetData {
 
 // Helpers wrapped in struct to avoid unresolvable overloads.
 template <class T> struct slicer {
-  static auto get(T &self, const std::tuple<Dim, scipp::index> &index) {
+  static auto get_slice(T &self, const std::tuple<Dim, scipp::index> &index) {
     auto [dim, i] = index;
     auto sz = dim_extent(self, dim);
     if (i < -sz || i >= sz) // index is out of range
@@ -74,16 +73,26 @@ template <class T> struct slicer {
           std::to_string(sz - 1) + "].");
     if (i < 0)
       i = sz + i;
-    return self.slice(Slice(dim, i));
+    return Slice(dim, i);
+  }
+
+  static auto get(T &self, const std::tuple<Dim, scipp::index> &index) {
+    return self.slice(get_slice(self, index));
+  }
+
+  static auto get_slice_by_value(T &self,
+                                 const std::tuple<Dim, Variable> &value) {
+    auto [dim, i] = value;
+    return std::make_from_tuple<Slice>(
+        get_slice_params(Dimensions(self.dims()), self.coords()[dim], i));
   }
 
   static auto get_by_value(T &self, const std::tuple<Dim, Variable> &value) {
-    auto [dim, i] = value;
-    return slice(self, dim, i);
+    return self.slice(get_slice_by_value(self, value));
   }
 
-  static auto get_range(T &self,
-                        const std::tuple<Dim, const py::slice> &index) {
+  static auto get_slice_range(T &self,
+                              const std::tuple<Dim, const py::slice> &index) {
     auto [dim, py_slice] = index;
     if constexpr (std::is_same_v<T, DataArray> || std::is_same_v<T, Dataset>) {
       try {
@@ -103,13 +112,20 @@ template <class T> struct slicer {
                               ? Variable{}
                               : py::getattr(py_slice, "stop").cast<Variable>();
 
-          return slice(self, dim, start_var, stop_var);
+          return std::make_from_tuple<Slice>(
+              get_slice_params(Dimensions(self.dims()), self.coords()[dim],
+                               start_var, stop_var));
         }
       } catch (const py::cast_error &) {
       }
     }
 
-    return self.slice(from_py_slice(self, index));
+    return from_py_slice(self, index);
+  }
+
+  static auto get_range(T &self,
+                        const std::tuple<Dim, const py::slice> &index) {
+    return self.slice(get_slice_range(self, index));
   }
 
   static void set_from_numpy(T &self,
@@ -131,20 +147,20 @@ template <class T> struct slicer {
   template <class Other>
   static void set_from_view(T &self, const std::tuple<Dim, scipp::index> &index,
                             const Other &data) {
-    slicer<T>::get(self, index).assign(data);
+    self.setSlice(slicer<T>::get_slice(self, index), data);
   }
 
   template <class Other>
   static void set_from_view(T &self,
                             const std::tuple<Dim, const py::slice> &index,
                             const Other &data) {
-    slicer<T>::get_range(self, index).assign(data);
+    self.setSlice(slicer<T>::get_slice_range(self, index), data);
   }
 
   template <class Other>
   static void set_by_value(T &self, const std::tuple<Dim, Variable> &value,
                            const Other &data) {
-    slicer<T>::get_by_value(self, value).assign(data);
+    self.setSlice(slicer<T>::get_slice_by_value(self, value), data);
   }
 
   // Manually dispatch based on the object we are assigning from in order to

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -58,13 +58,14 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
       .def("__iter__", [](const ElementArrayView<T> &self) {
         return py::make_iterator(self.begin(), self.end());
       });
-  view.def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
-                             const T value) {
-    if constexpr (is_bins<T>::value)
-      throw std::runtime_error("Assigning bin contents is not possible.");
-    else
-      self[i] = value;
-  });
+  view.def("__setitem__",
+           [](ElementArrayView<T> &self, const scipp::index i, const T value) {
+             if constexpr (is_bins<T>::value || std::is_const_v<T>)
+               throw std::runtime_error(
+                   "Assigning to readonly elements is not possible.");
+             else
+               self[i] = value;
+           });
 }
 
 void init_element_array_view(py::module &m) {
@@ -87,6 +88,7 @@ void init_element_array_view(py::module &m) {
   declare_ElementArrayView<int64_t>(m, "int64");
   declare_ElementArrayView<int32_t>(m, "int32");
   declare_ElementArrayView<std::string>(m, "string");
+  declare_ElementArrayView<const std::string>(m, "string_const");
   declare_ElementArrayView<bool>(m, "bool");
   declare_ElementArrayView<Variable>(m, "Variable");
   declare_ElementArrayView<DataArray>(m, "DataArray");

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -49,14 +49,28 @@ void init_element_array_view(py::module &m) {
   declare_ElementArrayView<int64_t>(m, "int64");
   declare_ElementArrayView<int32_t>(m, "int32");
   declare_ElementArrayView<std::string>(m, "string");
-  declare_ElementArrayView<const std::string>(m, "string_const");
   declare_ElementArrayView<bool>(m, "bool");
   declare_ElementArrayView<Variable>(m, "Variable");
   declare_ElementArrayView<DataArray>(m, "DataArray");
   declare_ElementArrayView<Dataset>(m, "Dataset");
   declare_ElementArrayView<Eigen::Vector3d>(m, "Eigen_Vector3d");
   declare_ElementArrayView<Eigen::Matrix3d>(m, "Eigen_Matrix3d");
-  declare_ElementArrayView<bucket<Variable>>(m, "bucket_Variable");
-  declare_ElementArrayView<bucket<DataArray>>(m, "bucket_DataArray");
-  declare_ElementArrayView<bucket<Dataset>>(m, "bucket_Dataset");
+  declare_ElementArrayView<bucket<Variable>>(m, "bin_Variable");
+  declare_ElementArrayView<bucket<DataArray>>(m, "bin_DataArray");
+  declare_ElementArrayView<bucket<Dataset>>(m, "bin_Dataset");
+
+  declare_ElementArrayView<const double>(m, "double_const");
+  declare_ElementArrayView<const float>(m, "float_const");
+  declare_ElementArrayView<const int64_t>(m, "int64_const");
+  declare_ElementArrayView<const int32_t>(m, "int32_const");
+  declare_ElementArrayView<const std::string>(m, "string_const");
+  declare_ElementArrayView<const bool>(m, "bool_const");
+  declare_ElementArrayView<const Variable>(m, "Variable_const");
+  declare_ElementArrayView<const DataArray>(m, "DataArray_const");
+  declare_ElementArrayView<const Dataset>(m, "Dataset_const");
+  declare_ElementArrayView<const Eigen::Vector3d>(m, "Eigen_Vector3d_const");
+  declare_ElementArrayView<const Eigen::Matrix3d>(m, "Eigen_Matrix3d_const");
+  declare_ElementArrayView<const bucket<Variable>>(m, "bin_Variable_const");
+  declare_ElementArrayView<const bucket<DataArray>>(m, "bin_DataArray_const");
+  declare_ElementArrayView<const bucket<Dataset>>(m, "bin_Dataset_const");
 }

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -36,8 +36,8 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
   view.def("__setitem__",
            [](ElementArrayView<T> &self, const scipp::index i, const T value) {
              if constexpr (is_bins<T>::value || std::is_const_v<T>)
-               throw std::runtime_error(
-                   "Assigning to readonly elements is not possible.");
+               throw std::invalid_argument(
+                   "assignment destination is read-only");
              else
                self[i] = value;
            });

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -15,31 +15,6 @@ using namespace scipp::core;
 
 namespace py = pybind11;
 
-template <class T> struct mutable_span_methods {
-  static void add(py::class_<scipp::span<T>> &span) {
-    span.def("__setitem__", [](scipp::span<T> &self, const scipp::index i,
-                               const T value) { self[i] = value; });
-  }
-};
-template <class T> struct mutable_span_methods<const T> {
-  static void add(py::class_<scipp::span<const T>> &) {}
-};
-
-template <class T> void declare_span(py::module &m, const std::string &suffix) {
-  py::class_<scipp::span<T>> span(m, (std::string("span_") + suffix).c_str());
-  span.def("__getitem__", &scipp::span<T>::operator[],
-           py::return_value_policy::reference)
-      .def("size", &scipp::span<T>::size)
-      .def("__len__", &scipp::span<T>::size)
-      .def("__iter__",
-           [](const scipp::span<T> &self) {
-             return py::make_iterator(self.begin(), self.end());
-           })
-      .def("__repr__",
-           [](const scipp::span<T> &self) { return array_to_string(self); });
-  mutable_span_methods<T>::add(span);
-}
-
 namespace {
 template <class T> struct is_bins : std::false_type {};
 template <class T> struct is_bins<core::bin<T>> : std::true_type {};
@@ -69,20 +44,6 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
 }
 
 void init_element_array_view(py::module &m) {
-  declare_span<double>(m, "double");
-  declare_span<float>(m, "float");
-  declare_span<bool>(m, "bool");
-  declare_span<const double>(m, "double_const");
-  declare_span<const long>(m, "long_const");
-  declare_span<long>(m, "long");
-  declare_span<const std::string>(m, "string_const");
-  declare_span<std::string>(m, "string");
-  declare_span<const Dim>(m, "Dim_const");
-  declare_span<Variable>(m, "Variable");
-  declare_span<DataArray>(m, "DataArray");
-  declare_span<Dataset>(m, "Dataset");
-  declare_span<Eigen::Vector3d>(m, "Eigen_Vector3d");
-  declare_span<Eigen::Matrix3d>(m, "Eigen_Matrix3d");
   declare_ElementArrayView<double>(m, "double");
   declare_ElementArrayView<float>(m, "float");
   declare_ElementArrayView<int64_t>(m, "int64");

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -33,14 +33,13 @@ void declare_ElementArrayView(py::module &m, const std::string &suffix) {
       .def("__iter__", [](const ElementArrayView<T> &self) {
         return py::make_iterator(self.begin(), self.end());
       });
-  view.def("__setitem__",
-           [](ElementArrayView<T> &self, const scipp::index i, const T value) {
-             if constexpr (is_bins<T>::value || std::is_const_v<T>)
-               throw std::invalid_argument(
-                   "assignment destination is read-only");
-             else
-               self[i] = value;
-           });
+  view.def("__setitem__", [](ElementArrayView<T> &self, const scipp::index i,
+                             const T value) {
+    if constexpr (is_bins<T>::value || std::is_const_v<T>)
+      throw std::invalid_argument("assignment destination is read-only");
+    else
+      self[i] = value;
+  });
 }
 
 void init_element_array_view(py::module &m) {

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -128,7 +128,8 @@ def test_del_item_missing():
 def test_coord_setitem():
     var = sc.Variable(dims=['x'], values=np.arange(4))
     d = sc.Dataset({'a': var}, coords={'x': var})
-    d['x', 2:3].coords['y'] = sc.Variable(1.0)  # no effect
+    with pytest.raises(RuntimeError):
+        d['x', 2:3].coords['y'] = sc.Variable(1.0)
     assert 'y' not in d.coords
     d.coords['y'] = sc.Variable(1.0)
     assert len(d) == 1
@@ -221,12 +222,11 @@ def test_slice():
         coords={'x': sc.Variable(dims=['x'], values=np.arange(10.0))})
     expected = sc.Dataset({
         'a':
-        sc.DataArray(1.0 * sc.units.one, attrs={'x': 1.0 * sc.units.one})
+        sc.DataArray(1.0 * sc.units.one, attrs={'x': 1.0 * sc.units.one}),
+        'b':
+        sc.Variable(1.0)
     })
-
     assert sc.identical(d['x', 1], expected)
-    assert 'a' in d['x', 1]
-    assert 'b' not in d['x', 1]
 
 
 def test_chained_slicing():

--- a/python/tests/test_setitem.py
+++ b/python/tests/test_setitem.py
@@ -32,12 +32,12 @@ def test_setitem_coords_required_for_inplace_ops():
     var = sc.zeros(dims=['x'], shape=(4, ), dtype=sc.dtype.int64)
     da = sc.DataArray(data=var)
     da.coords['x'] = var
-    da['x', 2:].coords['x'] += 1
+    da.coords['x']['x', 2:] += 1
     assert sc.identical(
         da.coords['x'],
         sc.array(dims=['x'], dtype=sc.dtype.int64, values=[0, 0, 1, 1]))
     ds = sc.Dataset({'a': da})
-    ds['x', 2:].coords['x'] += 1
+    ds.coords['x']['x', 2:] += 1
     assert sc.identical(
         ds.coords['x'],
         sc.array(dims=['x'], dtype=sc.dtype.int64, values=[0, 0, 2, 2]))

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -135,6 +135,7 @@ public:
 
   bool is_slice() const;
   bool is_readonly() const noexcept;
+  bool is_same(const Variable &other) const noexcept;
 
   [[nodiscard]] Variable as_const() const;
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -58,8 +58,6 @@ public:
   /// should be prefered where possible, since it generates less code.
   template <class... Ts> Variable(const DType &type, Ts &&... args);
 
-  [[maybe_unused]] Variable &assign(const Variable &other);
-
   explicit operator bool() const noexcept { return m_object.operator bool(); }
   Variable operator~() const;
 
@@ -97,7 +95,8 @@ public:
     return variances<T>()[0];
   }
 
-  Variable slice(const Slice slice) const;
+  Variable slice(const Slice params) const;
+  [[maybe_unused]] Variable &setSlice(const Slice params, const Variable &data);
 
   void rename(const Dim from, const Dim to);
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -108,7 +108,10 @@ public:
   const VariableConcept &data() const && = delete;
   const VariableConcept &data() const & { return *m_object; }
   VariableConcept &data() && = delete;
-  VariableConcept &data() & { return *m_object; }
+  VariableConcept &data() & {
+    expectWritable();
+    return *m_object;
+  }
   const auto &data_handle() const { return m_object; }
   void setDataHandle(VariableConceptHandle object);
 
@@ -132,6 +135,9 @@ public:
   [[nodiscard]] Variable transpose(const std::vector<Dim> &order) const;
 
   bool is_slice() const;
+  bool is_readonly() const noexcept;
+
+  [[nodiscard]] Variable as_const() const;
 
 private:
   // Declared friend so gtest recognizes it
@@ -140,10 +146,13 @@ private:
   template <class... Ts, class... Args>
   static Variable construct(const DType &type, Args &&... args);
 
+  void expectWritable() const;
+
   Dimensions m_dims;
   Strides m_strides;
   scipp::index m_offset{0};
   VariableConceptHandle m_object;
+  bool m_readonly{false};
 };
 
 /// Factory function for Variable supporting "keyword arguments"

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -54,7 +54,6 @@ void Variable::setDims(const Dimensions &dimensions) {
 }
 
 void Variable::expectCanSetUnit(const units::Unit &unit) const {
-  // TODO readonly flag?
   if (this->unit() != unit && is_slice())
     throw except::UnitError("Partial view on data of variable cannot be used "
                             "to change the unit.");

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -152,6 +152,12 @@ bool Variable::is_slice() const {
 
 bool Variable::is_readonly() const noexcept { return m_readonly; }
 
+bool Variable::is_same(const Variable &other) const noexcept {
+  return std::tie(m_dims, m_strides, m_offset, m_object) ==
+         std::tie(other.m_dims, other.m_strides, other.m_offset,
+                  other.m_object);
+}
+
 void Variable::setVariances(const Variable &v) {
   if (is_slice())
     throw except::VariancesError(

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -28,11 +28,6 @@ Variable::Variable(const Dimensions &dims, VariableConceptHandle data)
 Variable::Variable(const llnl::units::precise_measurement &m)
     : Variable(m.value() * units::Unit(m.units())) {}
 
-Variable &Variable::assign(const Variable &other) {
-  copy(other, *this);
-  return *this;
-}
-
 void Variable::setDataHandle(VariableConceptHandle object) {
   if (object->size() != m_object->size())
     throw except::DimensionError("Cannot replace by model of different size.");
@@ -113,12 +108,12 @@ core::ElementArrayViewParams Variable::array_params() const noexcept {
   return {m_offset, dims(), dataDims, {}};
 }
 
-Variable Variable::slice(const Slice slice) const {
-  core::expect::validSlice(dims(), slice);
+Variable Variable::slice(const Slice params) const {
+  core::expect::validSlice(dims(), params);
   Variable out(*this);
-  const auto dim = slice.dim();
-  const auto begin = slice.begin();
-  const auto end = slice.end();
+  const auto dim = params.dim();
+  const auto begin = params.begin();
+  const auto end = params.end();
   const auto index = out.m_dims.index(dim);
   out.m_offset += begin * m_strides[index];
   if (end == -1) {
@@ -127,6 +122,11 @@ Variable Variable::slice(const Slice slice) const {
   } else
     out.m_dims.resize(dim, end - begin);
   return out;
+}
+
+Variable &Variable::setSlice(const Slice params, const Variable &data) {
+  copy(data, slice(params));
+  return *this;
 }
 
 Variable Variable::transpose(const std::vector<Dim> &order) const {


### PR DESCRIPTION
Quite a number of tests failing right now, mainly because dataset slices now preserve lower-dimensional items.

- Slicing marks lower-dimensionsal items (dataset items, coords, masks, and attrs) as read-only.
- `union_op_in_place` throws if an incompatible change would be required.
- `union_op_in_place` throws if a new item from the RHS would need to be added. I think this is too restrictive when operating on whole objects rather than slices, so I need to come up with a slightly better mechanism.
- `assign` refactored to `setSlice`, parallelling `__setitem__`.

Please try in a notebook!