### PR TITLE
List some supported units in docs

### DIFF
--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -193,26 +193,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is a limit to the supported powers.\n",
-    "However it should be large enough in practice."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    sc.units.m**1000\n",
-    "except sc.UnitError as err:\n",
-    "    print(err)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The Scipp units library is built on top of LLNL [Units](https://units.readthedocs.io/en/latest/index.html).\n",
     "You can take a look at the page on [Defined Units](https://units.readthedocs.io/en/latest/user-guide/defined_units.html) for a more complete list of supported units.\n",
     "However, this should be considered an implementation detail and it is best not to rely on the more specialized unit systems."

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -52,6 +52,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can get a list of all predefined units (accessible through `sc.units`) with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[unit for unit in dir(sc.units) if not unit.startswith('_')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Units can also be created directly from strings:"
    ]
   },
@@ -65,10 +81,140 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.Unit('count')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To convert data between units, such as `m` to `mm`, see [sc.to_unit](../generated/scipp.to_unit.html#scipp.to-unit)."
+    "To convert data between compatible units, such as `m` to `mm`, see [sc.to_unit](../generated/scipp.to_unit.html#scipp.to-unit)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.to_unit(1 * sc.Unit('m'), 'mm')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supported Units\n",
+    "\n",
+    "### Base Units\n",
+    "All SI base units are supported with the following names:\n",
+    "\n",
+    "Name | Unit\n",
+    "---|---\n",
+    "'m' | meter\n",
+    "'s' | second\n",
+    "'kg' | kilogram\n",
+    "'K' | kelvin\n",
+    "'A' | ampere\n",
+    "'mol' | mole\n",
+    "'cd' | candela"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.Unit('K')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, these base units are supported for cases not covered by SI:\n",
+    "\n",
+    "name | Unit\n",
+    "---|---\n",
+    "'rad' | radian\n",
+    "'count' | single object counting\n",
+    "\n",
+    "### Derived units\n",
+    "A great number of derived units can also be specified as arguments to `sc.Unit`.\n",
+    "Some examples are\n",
+    "\n",
+    "Name | Unit\n",
+    "---|---\n",
+    "'Hz' | hertz\n",
+    "'J' | joule\n",
+    "'V' | volt\n",
+    "'W' | watt\n",
+    "'angstrom' / 'Å' | ångström\n",
+    "'L' | liter\n",
+    "'min' | minute\n",
+    "'D' / 'day' | day\n",
+    "\n",
+    "Units can be modified with SI prefixes, for instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sc.Unit('mm'), sc.Unit('micros'), sc.Unit('MJ'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also specify exponents for units or exponentiate them explicitly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sc.Unit('m^2'), sc.Unit('m**2'), sc.Unit('m')**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a limit to the supported powers.\n",
+    "However it should be large enough in practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    sc.units.m**1000\n",
+    "except sc.UnitError as err:\n",
+    "    print(err)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Scipp units library is built on top of LLNL [Units](https://units.readthedocs.io/en/latest/index.html).\n",
+    "You can take a look at the page on [Defined Units](https://units.readthedocs.io/en/latest/user-guide/defined_units.html) for a more complete list of supported units.\n",
+    "However, this should be considered an implementation detail and it is best not to rely on the more specialized unit systems."
    ]
   }
  ],

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(sc.Unit('mm'), sc.Unit('micros'), sc.Unit('MJ'))"
+    "print(sc.Unit('mm'), sc.Unit('microsecond'), sc.Unit('micro s'), sc.Unit('MJ'))"
    ]
   },
   {

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.Unit('count')"
+    "sc.Unit('counts')"
    ]
   },
   {

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -156,6 +156,7 @@
     "'V' | volt\n",
     "'W' | watt\n",
     "'angstrom' / 'Å' | ångström\n",
+    "'eV' | electron volt\n",
     "'L' | liter\n",
     "'min' | minute\n",
     "'D' / 'day' | day\n",


### PR DESCRIPTION
Is this a good set of units or should we add / remove some?

Referring to LLNL/Units is a bit risky in terms of encapsulation. But we rely on its parsing function anyway, so maybe we have to be compatible with it anyways going into the future. What to you think?