### PR TITLE
Cannot import scipp after building on rhel7

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,9 +48,13 @@ target_compile_definitions(_scipp PRIVATE SCIPP_EXPORT=)
 # pybind11 FAQ.
 set_target_properties(_scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
 if(UNIX AND NOT APPLE)
-  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+  set_target_properties(
+    _scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
+  )
 elseif(APPLE)
-  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+  set_target_properties(
+    _scipp PROPERTIES INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}"
+  )
 endif()
 
 if(PRECOMPILED_HEADERS)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,9 +48,9 @@ target_compile_definitions(_scipp PRIVATE SCIPP_EXPORT=)
 # pybind11 FAQ.
 set_target_properties(_scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
 if(UNIX AND NOT APPLE)
-  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 elseif(APPLE)
-  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "@loader_path/../lib")
+  set_target_properties(_scipp PROPERTIES INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 if(PRECOMPILED_HEADERS)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -47,15 +47,10 @@ target_compile_definitions(_scipp PRIVATE SCIPP_EXPORT=)
 # Set symbol visibility to hidden to reduce binary size, as recommended in
 # pybind11 FAQ.
 set_target_properties(_scipp PROPERTIES CXX_VISIBILITY_PRESET hidden)
-if(UNIX AND NOT APPLE)
-  set_target_properties(
-    _scipp PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
-  )
-elseif(APPLE)
-  set_target_properties(
-    _scipp PROPERTIES INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}"
-  )
-endif()
+set_target_properties(
+  _scipp PROPERTIES INSTALL_RPATH
+                    "${CMAKE_INSTALL_RPATH}/../${CMAKE_INSTALL_LIBDIR}"
+)
 
 if(PRECOMPILED_HEADERS)
   target_precompile_headers(_scipp PRIVATE pybind11.h)


### PR DESCRIPTION
Cannot import scipp after building on rhel7

On 64bit rhel7, libraries go to `lib64` as instructed by `include(GNUInstallDirs)`. These are therefore missing from hard-coded rpath.  Let cmake figure this out via `CMAKE_INSTALL_LIBDIR`

This is a simple fix, and should be applied after the upcoming changes from `dev` branch are merged.