### PR TITLE
Support datetime64 in event map and scale and in histogram

### DIFF
--- a/core/include/scipp/core/element/event_operations.h
+++ b/core/include/scipp/core/element/event_operations.h
@@ -11,6 +11,7 @@
 
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/histogram.h"
+#include "scipp/core/time_point.h"
 #include "scipp/core/transform_common.h"
 #include "scipp/core/value_and_variance.h"
 
@@ -28,27 +29,29 @@ template <class Coord, class Edge, class Weight>
 using args = std::tuple<Coord, span<const Edge>, span<const Weight>>;
 } // namespace map_detail
 
-constexpr auto map =
-    overloaded{element::arg_list<map_detail::args<int64_t, int64_t, double>,
-                                 map_detail::args<int64_t, int64_t, float>,
-                                 map_detail::args<int32_t, int32_t, double>,
-                                 map_detail::args<int32_t, int32_t, float>,
-                                 map_detail::args<int64_t, double, double>,
-                                 map_detail::args<int64_t, double, float>,
-                                 map_detail::args<int32_t, double, double>,
-                                 map_detail::args<int32_t, double, float>,
-                                 map_detail::args<double, double, double>,
-                                 map_detail::args<double, double, float>,
-                                 map_detail::args<float, double, double>,
-                                 map_detail::args<float, float, float>,
-                                 map_detail::args<double, float, float>>,
-               transform_flags::expect_no_variance_arg<0>,
-               transform_flags::expect_no_variance_arg<1>,
-               [](const units::Unit &x, const units::Unit &edges,
-                  const units::Unit &weights) {
-                 expect::equals(x, edges);
-                 return weights;
-               }};
+constexpr auto map = overloaded{
+    element::arg_list<map_detail::args<int64_t, int64_t, double>,
+                      map_detail::args<int64_t, int64_t, float>,
+                      map_detail::args<int32_t, int32_t, double>,
+                      map_detail::args<int32_t, int32_t, float>,
+                      map_detail::args<time_point, time_point, double>,
+                      map_detail::args<time_point, time_point, float>,
+                      map_detail::args<int64_t, double, double>,
+                      map_detail::args<int64_t, double, float>,
+                      map_detail::args<int32_t, double, double>,
+                      map_detail::args<int32_t, double, float>,
+                      map_detail::args<double, double, double>,
+                      map_detail::args<double, double, float>,
+                      map_detail::args<float, double, double>,
+                      map_detail::args<float, float, float>,
+                      map_detail::args<double, float, float>>,
+    transform_flags::expect_no_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    [](const units::Unit &x, const units::Unit &edges,
+       const units::Unit &weights) {
+      expect::equals(x, edges);
+      return weights;
+    }};
 
 constexpr auto map_linspace = overloaded{
     map, [](const auto &coord, const auto &edges, const auto &weights) {
@@ -71,10 +74,16 @@ using args = std::tuple<Data, Coord, span<const Edge>, span<const Weight>>;
 } // namespace map_and_mul_detail
 
 constexpr auto map_and_mul = overloaded{
-    element::arg_list<map_and_mul_detail::args<double, double, double, double>,
-                      map_and_mul_detail::args<float, double, double, double>,
-                      map_and_mul_detail::args<float, double, double, float>,
-                      map_and_mul_detail::args<double, float, float, double>>,
+    element::arg_list<
+        map_and_mul_detail::args<double, double, double, double>,
+        map_and_mul_detail::args<double, double, double, float>,
+        map_and_mul_detail::args<float, double, double, double>,
+        map_and_mul_detail::args<float, double, double, float>,
+        map_and_mul_detail::args<double, float, float, double>,
+        map_and_mul_detail::args<double, time_point, time_point, double>,
+        map_and_mul_detail::args<double, time_point, time_point, float>,
+        map_and_mul_detail::args<float, time_point, time_point, double>,
+        map_and_mul_detail::args<float, time_point, time_point, float>>,
     transform_flags::expect_in_variance_if_out_variance,
     transform_flags::expect_no_variance_arg<1>,
     transform_flags::expect_no_variance_arg<2>,

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -35,12 +35,17 @@ using args = std::tuple<span<Out>, span<const Coord>, span<const Weight>,
 }
 
 static constexpr auto histogram = overloaded{
-    element::arg_list<histogram_detail::args<float, double, float, double>,
-                      histogram_detail::args<float, int64_t, float, double>,
-                      histogram_detail::args<double, double, double, double>,
-                      histogram_detail::args<double, float, double, double>,
-                      histogram_detail::args<double, float, double, float>,
-                      histogram_detail::args<double, double, float, double>>,
+    element::arg_list<
+        histogram_detail::args<float, double, float, double>,
+        histogram_detail::args<float, int64_t, float, double>,
+        histogram_detail::args<double, double, double, double>,
+        histogram_detail::args<double, float, double, double>,
+        histogram_detail::args<double, float, double, float>,
+        histogram_detail::args<double, double, float, double>,
+        histogram_detail::args<double, time_point, double, time_point>,
+        histogram_detail::args<double, time_point, float, time_point>,
+        histogram_detail::args<float, time_point, double, time_point>,
+        histogram_detail::args<float, time_point, float, time_point>>,
     [](const auto &data, const auto &events, const auto &weights,
        const auto &edges) {
       zero(data);

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -11,11 +11,22 @@ Features
 
 * Can now control the position and visibility of the legend in 1d plots with ``plot(da, legend={"show": True, "loc": 4})`` `#1790 <https://github.com/scipp/scipp/pull/1790>`_.
 
+Bugfixes
+~~~~~~~~
+
+* ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
 Contributors
 ~~~~~~~~~~~~
+
+Owen Arnold,
+Simon Heybrock,
+Matthew D. Jones,
+Neil Vaytet,
+and Jan-Lukas Wynen
 
 v0.6.0 (March 2021)
 -------------------

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,6 +15,7 @@ Bugfixes
 ~~~~~~~~
 
 * ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
+* ``bin`` now works on previously binned data with 2-D edges, even if the outer dimensions(s) are not rebinned `#1836 <https://github.com/scipp/scipp/pull/1836>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #1832 and also related problem for scaling event data and histogramming.

We should think about ways of ensuring in a better way that all required type combinations are available, and also go systematically through our operations to ensure they work.