### PR TITLE
Set readonly flag when turning dataset coord into item attrs

### DIFF
--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -145,7 +145,7 @@ Dataset Dataset::slice(const Slice s) const {
     Attrs item_attrs(out.m_coords.sizes(), {});
     for (const auto &[dim, coord] : out_attrs)
       if (m_coords.item_applies_to(dim, m_data.at(item.first).dims()))
-        item_attrs.set(dim, coord);
+        item_attrs.set(dim, coord.as_const());
     item.second.attrs() = item.second.attrs().merge_from(item_attrs);
   }
   return out;

--- a/dataset/test/attributes_test.cpp
+++ b/dataset/test/attributes_test.cpp
@@ -65,6 +65,18 @@ TEST_F(AttributesTest, slice_dataset_item_attrs) {
   ASSERT_TRUE(d["a"].slice({Dim::Y, 0, 1}).attrs().contains(Dim("x")));
 }
 
+TEST_F(AttributesTest, attrs_from_coord_slice_is_readonly) {
+  Dataset d;
+  d.setData("a", copy(varX));
+  d.coords().set(Dim::X, copy(varX));
+  ASSERT_FALSE(d.slice({Dim::X, 0})["a"].coords().contains(Dim::X));
+  ASSERT_TRUE(d.slice({Dim::X, 0})["a"].attrs().contains(Dim::X));
+  ASSERT_TRUE(d.slice({Dim::X, 0})["a"].attrs()[Dim::X].is_readonly());
+  ASSERT_TRUE(d.slice({Dim::X, 0, 1})["a"].coords().contains(Dim::X));
+  ASSERT_TRUE(d.slice({Dim::X, 0, 1})["a"].coords()[Dim::X].is_readonly());
+  ASSERT_FALSE(d.slice({Dim::X, 0, 1})["a"].attrs().contains(Dim::X));
+}
+
 TEST_F(AttributesTest, binary_ops_matching_attrs_preserved) {
   Dataset d;
   d.setData("a", varX);


### PR DESCRIPTION
```python
ds['x', 0:2]['a'].coords['x']  # readonly
```
is read-only, since it is (or may be) shared by multiple dataset entries.

Slicing without a range turns coords into attrs, so for consistency we also need to mark these as read-only:
```python
ds['x', 0]['a'].coords['x']  # readonly after this PR
```