### PR TITLE
Fix usages of copy constructors

### DIFF
--- a/core/test/element_trigonometry_test.cpp
+++ b/core/test/element_trigonometry_test.cpp
@@ -117,6 +117,8 @@ TEST(ElementAsinTest, unit) {
 TEST(ElementAsinTest, value) {
   EXPECT_EQ(element::asin(1.0), std::asin(1.0));
   EXPECT_EQ(element::asin(1.0f), std::asin(1.0f));
+  EXPECT_TRUE(std::isnan(element::asin(1.2)));
+  EXPECT_TRUE(std::isnan(element::asin(1.2f)));
 }
 
 TEST(ElementAsinOutArgTest, unit) {
@@ -154,6 +156,8 @@ TEST(ElementAcosTest, unit) {
 TEST(ElementAcosTest, value) {
   EXPECT_EQ(element::acos(1.0), std::acos(1.0));
   EXPECT_EQ(element::acos(1.0f), std::acos(1.0f));
+  EXPECT_TRUE(std::isnan(element::acos(1.2)));
+  EXPECT_TRUE(std::isnan(element::acos(1.2f)));
 }
 
 TEST(ElementAcosOutArgTest, unit) {

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -38,7 +38,8 @@ DataArray::DataArray(Variable data, Coords coords, Masks masks, Attrs attrs,
 
 DataArray::DataArray(Variable data, typename Coords::holder_type coords,
                      typename Masks::holder_type masks,
-                     typename Attrs::holder_type attrs, const std::string_view name)
+                     typename Attrs::holder_type attrs,
+                     const std::string_view name)
     : m_name(name), m_data(std::make_shared<Variable>(std::move(data))),
       m_coords(dims(), std::move(coords)),
       m_masks(std::make_shared<Masks>(dims(), std::move(masks))),
@@ -83,9 +84,10 @@ Coords DataArray::meta() const { return attrs().merge_from(coords()); }
 DataArray DataArray::slice(const Slice &s) const {
   auto out_coords = m_coords.slice(s);
   Attrs out_attrs(out_coords.sizes(), {});
-  for (auto it = m_coords.begin(); it != m_coords.end(); ++it)
-    if (unaligned_by_dim_slice(*it, s))
-      out_attrs.set(it->first, out_coords.extract(it->first));
+  for (auto &coord : m_coords) {
+    if (unaligned_by_dim_slice(coord, s))
+      out_attrs.set(coord.first, out_coords.extract(coord.first));
+  }
   return {m_data->slice(s), std::move(out_coords), m_masks->slice(s),
           m_attrs->slice(s).merge_from(out_attrs), m_name};
 }

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -25,7 +25,7 @@ DataArray::DataArray(const DataArray &other)
     : DataArray(other, AttrPolicy::Keep) {}
 
 DataArray::DataArray(Variable data, Coords coords, Masks masks, Attrs attrs,
-                     const std::string &name)
+                     const std::string_view name)
     : m_name(name), m_data(std::make_shared<Variable>(std::move(data))),
       m_coords(std::move(coords)),
       m_masks(std::make_shared<Masks>(std::move(masks))),
@@ -38,7 +38,7 @@ DataArray::DataArray(Variable data, Coords coords, Masks masks, Attrs attrs,
 
 DataArray::DataArray(Variable data, typename Coords::holder_type coords,
                      typename Masks::holder_type masks,
-                     typename Attrs::holder_type attrs, const std::string &name)
+                     typename Attrs::holder_type attrs, const std::string_view name)
     : m_name(name), m_data(std::make_shared<Variable>(std::move(data))),
       m_coords(dims(), std::move(coords)),
       m_masks(std::make_shared<Masks>(dims(), std::move(masks))),
@@ -76,7 +76,7 @@ bool operator!=(const DataArray &a, const DataArray &b) {
 /// in the dataset. Note that comparison operations ignore the name.
 const std::string &DataArray::name() const { return m_name; }
 
-void DataArray::setName(const std::string &name) { m_name = name; }
+void DataArray::setName(const std::string_view name) { m_name = name; }
 
 Coords DataArray::meta() const { return attrs().merge_from(coords()); }
 

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -48,7 +48,7 @@ DataArray &DataArray::operator=(const DataArray &other) {
   return *this = DataArray(other);
 }
 
-void DataArray::setData(Variable data) {
+void DataArray::setData(const Variable &data) {
   core::expect::equals(dims(), data.dims());
   *m_data = data;
 }

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "scipp/dataset/map_view.h"
 #include "scipp/variable/variable.h"
@@ -24,11 +25,11 @@ public:
   DataArray(DataArray &&other) = default;
 
   DataArray(Variable data, Coords coords, Masks masks, Attrs attrs,
-            const std::string &name = "");
+            std::string_view name = "");
   explicit DataArray(Variable data, typename Coords::holder_type coords = {},
                      typename Masks::holder_type masks = {},
                      typename Attrs::holder_type attrs = {},
-                     const std::string &name = "");
+                     std::string_view name = "");
 
   DataArray &operator=(const DataArray &other);
   DataArray &operator=(DataArray &&other) = default;
@@ -38,7 +39,7 @@ public:
   }
 
   const std::string &name() const;
-  void setName(const std::string &name);
+  void setName(std::string_view name);
 
   const Coords &coords() const { return m_coords; }
   // TODO either ensure Dict does not allow changing sizes, or return by value

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -19,7 +19,7 @@ enum class AttrPolicy { Keep, Drop };
 class SCIPP_DATASET_EXPORT DataArray {
 public:
   DataArray() = default;
-  DataArray(const DataArray &other, const AttrPolicy attrPolicy);
+  DataArray(const DataArray &other, AttrPolicy attrPolicy);
   DataArray(const DataArray &other);
   DataArray(DataArray &&other) = default;
 
@@ -81,7 +81,7 @@ public:
   /// Return typed view for data variances.
   template <class T> auto variances() { return m_data->variances<T>(); }
 
-  void rename(const Dim from, const Dim to);
+  void rename(Dim from, Dim to);
 
   void setData(const Variable &data);
 
@@ -111,7 +111,7 @@ SCIPP_DATASET_EXPORT bool operator==(const DataArray &a, const DataArray &b);
 SCIPP_DATASET_EXPORT bool operator!=(const DataArray &a, const DataArray &b);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
-copy(const DataArray &array, const AttrPolicy attrPolicy = AttrPolicy::Keep);
+copy(const DataArray &array, AttrPolicy attrPolicy = AttrPolicy::Keep);
 
 } // namespace scipp::dataset
 

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -83,7 +83,7 @@ public:
 
   void rename(const Dim from, const Dim to);
 
-  void setData(Variable data);
+  void setData(const Variable &data);
 
   DataArray slice(const Slice &s) const;
   [[maybe_unused]] DataArray &setSlice(const Slice &s, const DataArray &array);

--- a/dataset/test/dataset_arithmetic_test.cpp
+++ b/dataset/test/dataset_arithmetic_test.cpp
@@ -520,7 +520,7 @@ TYPED_TEST(DatasetViewBinaryEqualsOpTest,
   }
 }
 
-TYPED_TEST(DatasetViewBinaryEqualsOpTest, rhs_Dataset_coord_mismatch) {
+TYPED_TEST(DatasetViewBinaryEqualsOpTest, rhs_slice_coord_mismatch) {
   auto dataset = datasetFactory().make();
 
   // Non-range sliced throws for X and Y due to multi-dimensional coords.

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -253,30 +253,6 @@ TEST(DatasetTest, const_iterators_return_types) {
   ASSERT_TRUE((std::is_same_v<decltype(*d.end()), DataArray>));
 }
 
-TEST(DatasetTest, construct_from_view) {
-  DatasetFactory3D factory;
-  const auto dataset = factory.make();
-  const Dataset view(dataset);
-  Dataset from_view(view);
-  ASSERT_EQ(from_view, dataset);
-}
-
-TEST(DatasetTest, construct_from_slice) {
-  DatasetFactory3D factory;
-  const auto dataset = factory.make();
-  const auto slice = dataset.slice({Dim::X, 1});
-  Dataset from_slice(slice);
-  ASSERT_EQ(from_slice, dataset.slice({Dim::X, 1}));
-}
-
-TEST(DataArrayTest, construct_from_slice) {
-  DatasetFactory3D factory;
-  const auto dataset = factory.make();
-  const auto slice = dataset["data_xyz"].slice({Dim::X, 1});
-  DataArray from_slice(slice);
-  ASSERT_EQ(from_slice, dataset["data_xyz"].slice({Dim::X, 1}));
-}
-
 TEST(DatasetTest, slice_temporary) {
   DatasetFactory3D factory;
   auto dataset = factory.make().slice({Dim::X, 1});
@@ -344,7 +320,7 @@ TEST(DatasetTest, sum_and_mean) {
 TEST(DatasetTest, extract_coord) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
-  Dataset ds(ref);
+  Dataset ds = copy(ref);
   auto coord = ds.coords()[Dim::X];
   auto ptr = ds.coords()[Dim::X].values<double>().data();
   auto var = ds.coords().extract(Dim::X);
@@ -362,7 +338,7 @@ TEST(DatasetTest, extract_coord) {
 TEST(DatasetTest, erase_item_coord_cannot_erase_coord) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
-  Dataset ds(ref);
+  Dataset ds = copy(ref);
   auto coord = ds.coords()[Dim::X];
   ASSERT_TRUE(ds.contains("data_x"));
   ASSERT_NO_THROW(ds["data_x"].coords().erase(Dim::X));
@@ -383,7 +359,7 @@ TEST(DatasetTest, item_coord_cannot_change_coord) {
 TEST(DatasetTest, extract_labels) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
-  Dataset ds(ref);
+  Dataset ds = copy(ref);
   auto labels = ds.coords()[Dim("labels_x")];
   ds.coords().extract(Dim("labels_x"));
   EXPECT_FALSE(ds.coords().contains(Dim("labels_x")));

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -345,7 +345,7 @@ TEST(DatasetTest, extract_coord) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
   Dataset ds(ref);
-  auto coord = Variable(ds.coords()[Dim::X]);
+  auto coord = ds.coords()[Dim::X];
   auto ptr = ds.coords()[Dim::X].values<double>().data();
   auto var = ds.coords().extract(Dim::X);
   EXPECT_EQ(var.values<double>().data(), ptr);
@@ -363,7 +363,7 @@ TEST(DatasetTest, erase_item_coord_cannot_erase_coord) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
   Dataset ds(ref);
-  auto coord = Variable(ds.coords()[Dim::X]);
+  auto coord = ds.coords()[Dim::X];
   ASSERT_TRUE(ds.contains("data_x"));
   ASSERT_NO_THROW(ds["data_x"].coords().erase(Dim::X));
   // Coord was erased in DataArray returned by ds["data_x"], but not from coord
@@ -384,7 +384,7 @@ TEST(DatasetTest, extract_labels) {
   DatasetFactory3D factory;
   const auto ref = factory.make();
   Dataset ds(ref);
-  auto labels = Variable(ds.coords()[Dim("labels_x")]);
+  auto labels = ds.coords()[Dim("labels_x")];
   ds.coords().extract(Dim("labels_x"));
   EXPECT_FALSE(ds.coords().contains(Dim("labels_x")));
   ds.setCoord(Dim("labels_x"), labels);

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -259,6 +259,22 @@ TEST(DatasetTest, slice_temporary) {
   ASSERT_TRUE((std::is_same_v<decltype(dataset), Dataset>));
 }
 
+TEST(DatasetTest, construct_from_slice) {
+  DatasetFactory3D factory;
+  const auto dataset = factory.make();
+  const auto slice = dataset.slice({Dim::X, 1});
+  Dataset from_slice = copy(slice);
+  ASSERT_EQ(from_slice, dataset.slice({Dim::X, 1}));
+}
+
+TEST(DatasetTest, construct_dataarray_from_slice) {
+  DatasetFactory3D factory;
+  const auto dataset = factory.make();
+  const auto slice = dataset["data_xyz"].slice({Dim::X, 1});
+  DataArray from_slice = copy(slice);
+  ASSERT_EQ(from_slice, dataset["data_xyz"].slice({Dim::X, 1}));
+}
+
 TEST(DatasetTest, slice_no_data) {
   Dataset d;
   d.setCoord(Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{4}));

--- a/dataset/test/dataset_test_common.cpp
+++ b/dataset/test/dataset_test_common.cpp
@@ -56,7 +56,7 @@ void DatasetFactory3D::seed(const uint32_t value) {
 }
 
 Dataset DatasetFactory3D::make(const bool randomMasks) {
-  Dataset dataset(base);
+  Dataset dataset = copy(base);
   dataset.setData("values_x", makeVariable<double>(Dimensions{m_dim, lx},
                                                    Values(rand(lx))));
   dataset.setData("data_x",

--- a/dataset/test/event_data_operations_consistency_test.cpp
+++ b/dataset/test/event_data_operations_consistency_test.cpp
@@ -56,7 +56,7 @@ TEST(EventsDataOperationsConsistencyTest, multiply) {
   EXPECT_EQ(ab, ba);
 
   hist = make_histogram();
-  edges = Variable(hist.coords()[Dim::X]);
+  edges = hist.coords()[Dim::X];
   scaled = copy(events);
   buckets::scale(scaled, hist);
   ab = histogram(scaled, edges);

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -549,7 +549,7 @@ struct GroupbyLogicalTest : public ::testing::Test {
 };
 
 TEST_F(GroupbyLogicalTest, no_reduction) {
-  Dataset expected(d);
+  Dataset expected = copy(d);
   expected.rename(Dim::X, Dim("labels1"));
   expected.setCoord(Dim("labels1"), expected.coords()[Dim("labels1")]);
   expected.coords().erase(Dim("labels2"));
@@ -592,7 +592,7 @@ struct GroupbyMinMaxTest : public ::testing::Test {
 };
 
 TEST_F(GroupbyMinMaxTest, no_reduction) {
-  Dataset expected(d);
+  Dataset expected = copy(d);
   expected.rename(Dim::X, Dim("labels1"));
   expected.setCoord(Dim("labels1"), expected.coords()[Dim("labels1")]);
   expected.coords().erase(Dim("labels2"));

--- a/templates/dataset_inplace.cpp.in
+++ b/templates/dataset_inplace.cpp.in
@@ -26,7 +26,7 @@ DataArray @NAME@(DataArray &&lhs, const Variable &rhs) {
 DataArray @NAME@(DataArray &&lhs, const DataArray &rhs) {
   expect::coordsAreSuperset(lhs, rhs);
   union_or_in_place(lhs.masks(), rhs.masks());
-  return std::move(@NAME@(lhs, rhs.data()));
+  return @NAME@(std::move(lhs), rhs.data());
 }
 
 } // namespace scipp::dataset

--- a/templates/dataset_inplace.cpp.in
+++ b/templates/dataset_inplace.cpp.in
@@ -26,7 +26,7 @@ DataArray @NAME@(DataArray &&lhs, const Variable &rhs) {
 DataArray @NAME@(DataArray &&lhs, const DataArray &rhs) {
   expect::coordsAreSuperset(lhs, rhs);
   union_or_in_place(lhs.masks(), rhs.masks());
-  return @NAME@(lhs, rhs.data());
+  return std::move(@NAME@(lhs, rhs.data()));
 }
 
 } // namespace scipp::dataset

--- a/variable/slice.cpp
+++ b/variable/slice.cpp
@@ -26,20 +26,20 @@ scipp::index get_count(const Variable &coord, const Dim dim,
 scipp::index get_index(const Variable &coord, const Dim dim,
                        const Variable &value, const bool ascending,
                        const bool edges) {
-  auto i = get_count(coord, dim, value, edges ? ascending : !ascending);
+  auto i = get_count(coord, dim, value, edges == ascending);
   i = edges ? i - 1 : coord.dims()[dim] - i;
   return std::clamp<scipp::index>(0, i, coord.dims()[dim]);
 }
 
-auto get_1d_coord(const Variable &coord) {
+const Variable &get_1d_coord(const Variable &coord) {
   if (coord.dims().ndim() != 1)
     throw except::DimensionError("Multi-dimensional coordinates cannot be used "
                                  "for label-based indexing.");
   return coord;
 }
 
-auto get_coord(Variable coord, const Dim dim) {
-  coord = get_1d_coord(coord);
+auto get_coord(const Variable &coord, const Dim dim) {
+  get_1d_coord(coord);
   const bool ascending = issorted(coord, dim, variable::SortOrder::Ascending);
   const bool descending = issorted(coord, dim, variable::SortOrder::Descending);
   if (!(ascending ^ descending))

--- a/variable/test/trigonometry_test.cpp
+++ b/variable/test/trigonometry_test.cpp
@@ -37,19 +37,19 @@ protected:
 };
 
 TEST_F(VariableTrigonometryTest, sin_rad) {
-  const auto var = input_in_rad();
+  const auto var = copy(input_in_rad());
   EXPECT_EQ(sin(var), expected_for_op(std::sin));
   EXPECT_EQ(var, input_in_rad());
 }
 
 TEST_F(VariableTrigonometryTest, sin_deg) {
-  const auto var = input_in_deg();
+  const auto var = copy(input_in_deg());
   EXPECT_EQ(sin(var), expected_for_op(std::sin));
   EXPECT_EQ(var, input_in_deg());
 }
 
 TEST_F(VariableTrigonometryTest, sin_move_rad) {
-  auto var = input_in_rad();
+  auto var = copy(input_in_rad());
   const auto ptr = var.values<double>().data();
   auto out = sin(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::sin));
@@ -57,7 +57,7 @@ TEST_F(VariableTrigonometryTest, sin_move_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, sin_move_deg) {
-  auto var = input_in_deg();
+  auto var = copy(input_in_deg());
   const auto ptr = var.values<double>().data();
   auto out = sin(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::sin));
@@ -65,7 +65,7 @@ TEST_F(VariableTrigonometryTest, sin_move_deg) {
 }
 
 TEST_F(VariableTrigonometryTest, sin_out_arg_rad) {
-  const auto in = input_in_rad();
+  const auto in = copy(input_in_rad());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = sin(in, out);
 
@@ -75,7 +75,7 @@ TEST_F(VariableTrigonometryTest, sin_out_arg_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, sin_out_arg_deg) {
-  const auto in = input_in_deg();
+  const auto in = copy(input_in_deg());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = sin(in, out);
 
@@ -85,19 +85,19 @@ TEST_F(VariableTrigonometryTest, sin_out_arg_deg) {
 }
 
 TEST_F(VariableTrigonometryTest, cos_rad) {
-  const auto var = input_in_rad();
+  const auto var = copy(input_in_rad());
   EXPECT_EQ(cos(var), expected_for_op(std::cos));
   EXPECT_EQ(var, input_in_rad());
 }
 
 TEST_F(VariableTrigonometryTest, cos_deg) {
-  const auto var = input_in_deg();
+  const auto var = copy(input_in_deg());
   EXPECT_EQ(cos(var), expected_for_op(std::cos));
   EXPECT_EQ(var, input_in_deg());
 }
 
 TEST_F(VariableTrigonometryTest, cos_move_rad) {
-  auto var = input_in_rad();
+  auto var = copy(input_in_rad());
   const auto ptr = var.values<double>().data();
   auto out = cos(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::cos));
@@ -105,7 +105,7 @@ TEST_F(VariableTrigonometryTest, cos_move_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, cos_move_deg) {
-  auto var = input_in_deg();
+  auto var = copy(input_in_deg());
   const auto ptr = var.values<double>().data();
   auto out = cos(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::cos));
@@ -113,7 +113,7 @@ TEST_F(VariableTrigonometryTest, cos_move_deg) {
 }
 
 TEST_F(VariableTrigonometryTest, cos_out_arg_rad) {
-  const auto in = input_in_rad();
+  const auto in = copy(input_in_rad());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = cos(in, out);
 
@@ -123,7 +123,7 @@ TEST_F(VariableTrigonometryTest, cos_out_arg_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, cos_out_arg_deg) {
-  const auto in = input_in_deg();
+  const auto in = copy(input_in_deg());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = cos(in, out);
 
@@ -133,19 +133,19 @@ TEST_F(VariableTrigonometryTest, cos_out_arg_deg) {
 }
 
 TEST_F(VariableTrigonometryTest, tan_rad) {
-  const auto var = input_in_rad();
+  const auto var = copy(input_in_rad());
   EXPECT_EQ(tan(var), expected_for_op(std::tan));
   EXPECT_EQ(var, input_in_rad());
 }
 
 TEST_F(VariableTrigonometryTest, tan_deg) {
-  const auto var = input_in_deg();
+  const auto var = copy(input_in_deg());
   EXPECT_EQ(tan(var), expected_for_op(std::tan));
   EXPECT_EQ(var, input_in_deg());
 }
 
 TEST_F(VariableTrigonometryTest, tan_move_rad) {
-  auto var = input_in_rad();
+  auto var = copy(input_in_rad());
   const auto ptr = var.values<double>().data();
   auto out = tan(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::tan));
@@ -153,7 +153,7 @@ TEST_F(VariableTrigonometryTest, tan_move_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, tan_move_deg) {
-  auto var = input_in_deg();
+  auto var = copy(input_in_deg());
   const auto ptr = var.values<double>().data();
   auto out = tan(std::move(var));
   EXPECT_EQ(out, expected_for_op(std::tan));
@@ -161,7 +161,7 @@ TEST_F(VariableTrigonometryTest, tan_move_deg) {
 }
 
 TEST_F(VariableTrigonometryTest, tan_out_arg_rad) {
-  const auto in = input_in_rad();
+  const auto in = copy(input_in_rad());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = tan(in, out);
 
@@ -171,7 +171,7 @@ TEST_F(VariableTrigonometryTest, tan_out_arg_rad) {
 }
 
 TEST_F(VariableTrigonometryTest, tan_out_arg_deg) {
-  const auto in = input_in_deg();
+  const auto in = copy(input_in_deg());
   auto out = special_like(in, FillValue::ZeroNotBool);
   auto &view = tan(in, out);
 

--- a/variable/test/trigonometry_test.cpp
+++ b/variable/test/trigonometry_test.cpp
@@ -3,157 +3,190 @@
 #include <gtest/gtest.h>
 
 #include "scipp/common/constants.h"
+#include "scipp/variable/creation.h"
+#include "scipp/variable/to_unit.h"
 #include "scipp/variable/trigonometry.h"
 
 using namespace scipp;
 using namespace scipp::variable;
 using namespace scipp::units;
 
-TEST(VariableTrigonometryTest, sin_rad) {
-  const auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
-  EXPECT_EQ(sin(var), makeVariable<double>(Values{std::sin(pi<double>)}));
+class VariableTrigonometryTest : public ::testing::Test {
+protected:
+  [[nodiscard]] static Variable input_in_rad() {
+    return makeVariable<double>(Dims{Dim::X}, Shape{7},
+                                Values{0.0, pi<double> / 2.0, pi<double>,
+                                       -pi<double> * 3.0 / 2.0,
+                                       2.0 * pi<double>, -0.123, 1.654},
+                                Unit{units::rad});
+  }
+
+  [[nodiscard]] static Variable input_in_deg() {
+    return to_unit(input_in_rad(), units::deg);
+  }
+
+  [[nodiscard]] static Variable expected_for_op(double (*op)(const double)) {
+    std::vector<double> res;
+    const auto var = input_in_rad();
+    auto values_in_rad = var.values<double>();
+    std::transform(values_in_rad.begin(), values_in_rad.end(),
+                   back_inserter(res),
+                   [&op](double x_in_rad) { return op(x_in_rad); });
+    return makeVariable<double>(Dims{Dim::X}, Shape{res.size()}, Values(res));
+  }
+};
+
+TEST_F(VariableTrigonometryTest, sin_rad) {
+  const auto var = input_in_rad();
+  EXPECT_EQ(sin(var), expected_for_op(std::sin));
+  EXPECT_EQ(var, input_in_rad());
 }
 
-TEST(VariableTrigonometryTest, sin_deg) {
-  const auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
-  EXPECT_EQ(sin(var), makeVariable<double>(Values{std::sin(pi<double>)}));
+TEST_F(VariableTrigonometryTest, sin_deg) {
+  const auto var = input_in_deg();
+  EXPECT_EQ(sin(var), expected_for_op(std::sin));
+  EXPECT_EQ(var, input_in_deg());
 }
 
-TEST(Variable, sin_move_rad) {
-  auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
+TEST_F(VariableTrigonometryTest, sin_move_rad) {
+  auto var = input_in_rad();
   const auto ptr = var.values<double>().data();
   auto out = sin(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::sin));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, sin_move_deg) {
-  auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
+TEST_F(VariableTrigonometryTest, sin_move_deg) {
+  auto var = input_in_deg();
   const auto ptr = var.values<double>().data();
   auto out = sin(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::sin));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, sin_out_arg_rad) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
-                                Unit{units::rad});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = sin(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, sin_out_arg_rad) {
+  const auto in = input_in_rad();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = sin(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::sin));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_rad());
 }
 
-TEST(Variable, sin_out_arg_deg) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
-                                Unit{units::deg});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = sin(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, sin_out_arg_deg) {
+  const auto in = input_in_deg();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = sin(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::sin(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::sin));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_deg());
 }
 
-TEST(VariableTrigonometryTest, cos_rad) {
-  const auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
-  EXPECT_EQ(cos(var), makeVariable<double>(Values{std::cos(pi<double>)}));
+TEST_F(VariableTrigonometryTest, cos_rad) {
+  const auto var = input_in_rad();
+  EXPECT_EQ(cos(var), expected_for_op(std::cos));
+  EXPECT_EQ(var, input_in_rad());
 }
 
-TEST(VariableTrigonometryTest, cos_deg) {
-  const auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
-  EXPECT_EQ(cos(var), makeVariable<double>(Values{std::cos(pi<double>)}));
+TEST_F(VariableTrigonometryTest, cos_deg) {
+  const auto var = input_in_deg();
+  EXPECT_EQ(cos(var), expected_for_op(std::cos));
+  EXPECT_EQ(var, input_in_deg());
 }
 
-TEST(Variable, cos_move_rad) {
-  auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
+TEST_F(VariableTrigonometryTest, cos_move_rad) {
+  auto var = input_in_rad();
   const auto ptr = var.values<double>().data();
   auto out = cos(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::cos));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, cos_move_deg) {
-  auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
+TEST_F(VariableTrigonometryTest, cos_move_deg) {
+  auto var = input_in_deg();
   const auto ptr = var.values<double>().data();
   auto out = cos(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::cos));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, cos_out_arg_rad) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
-                                Unit{units::rad});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = cos(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, cos_out_arg_rad) {
+  const auto in = input_in_rad();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = cos(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::cos));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_rad());
 }
 
-TEST(Variable, cos_out_arg_deg) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
-                                Unit{units::deg});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = cos(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, cos_out_arg_deg) {
+  const auto in = input_in_deg();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = cos(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::cos(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::cos));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_deg());
 }
 
-TEST(VariableTrigonometryTest, tan_rad) {
-  const auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
-  EXPECT_EQ(tan(var), makeVariable<double>(Values{std::tan(pi<double>)}));
+TEST_F(VariableTrigonometryTest, tan_rad) {
+  const auto var = input_in_rad();
+  EXPECT_EQ(tan(var), expected_for_op(std::tan));
+  EXPECT_EQ(var, input_in_rad());
 }
 
-TEST(VariableTrigonometryTest, tan_deg) {
-  const auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
-  EXPECT_EQ(tan(var), makeVariable<double>(Values{std::tan(pi<double>)}));
+TEST_F(VariableTrigonometryTest, tan_deg) {
+  const auto var = input_in_deg();
+  EXPECT_EQ(tan(var), expected_for_op(std::tan));
+  EXPECT_EQ(var, input_in_deg());
 }
 
-TEST(Variable, tan_move_rad) {
-  auto var = makeVariable<double>(Values{pi<double>}, Unit{units::rad});
+TEST_F(VariableTrigonometryTest, tan_move_rad) {
+  auto var = input_in_rad();
   const auto ptr = var.values<double>().data();
   auto out = tan(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::tan));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, tan_move_deg) {
-  auto var = makeVariable<double>(Values{180.0}, Unit{units::deg});
+TEST_F(VariableTrigonometryTest, tan_move_deg) {
+  auto var = input_in_deg();
   const auto ptr = var.values<double>().data();
   auto out = tan(std::move(var));
-  EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::tan));
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, tan_out_arg_rad) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{pi<double>, 0.0},
-                                Unit{units::rad});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = tan(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, tan_out_arg_rad) {
+  const auto in = input_in_rad();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = tan(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::tan));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_rad());
 }
 
-TEST(Variable, tan_out_arg_deg) {
-  auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{180.0, 0.0},
-                                Unit{units::deg});
-  auto out = makeVariable<double>(Values{0.0});
-  auto &view = tan(x.slice({Dim::X, 0}), out);
+TEST_F(VariableTrigonometryTest, tan_out_arg_deg) {
+  const auto in = input_in_deg();
+  auto out = special_like(in, FillValue::ZeroNotBool);
+  auto &view = tan(in, out);
 
-  EXPECT_EQ(out, makeVariable<double>(Values{std::tan(pi<double>)}));
+  EXPECT_EQ(out, expected_for_op(std::tan));
   EXPECT_EQ(&view, &out);
+  EXPECT_EQ(in, input_in_deg());
 }
 
-TEST(VariableTrigonometryTest, asin) {
+TEST_F(VariableTrigonometryTest, asin) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(asin(var),
             makeVariable<double>(Values{std::asin(1.0)}, Unit{units::rad}));
 }
 
-TEST(Variable, asin_move) {
+TEST_F(VariableTrigonometryTest, asin_move) {
   auto var = makeVariable<double>(Values{1.0});
   const auto ptr = var.values<double>().data();
   auto out = asin(std::move(var));
@@ -162,7 +195,7 @@ TEST(Variable, asin_move) {
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, asin_out_arg) {
+TEST_F(VariableTrigonometryTest, asin_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
   auto &view = asin(x.slice({Dim::X, 0}), out);
@@ -172,13 +205,13 @@ TEST(Variable, asin_out_arg) {
   EXPECT_EQ(&view, &out);
 }
 
-TEST(VariableTrigonometryTest, acos) {
+TEST_F(VariableTrigonometryTest, acos) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(acos(var),
             makeVariable<double>(Values{std::acos(1.0)}, Unit{units::rad}));
 }
 
-TEST(Variable, acos_move) {
+TEST_F(VariableTrigonometryTest, acos_move) {
   auto var = makeVariable<double>(Values{1.0});
   const auto ptr = var.values<double>().data();
   auto out = acos(std::move(var));
@@ -187,7 +220,7 @@ TEST(Variable, acos_move) {
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, acos_out_arg) {
+TEST_F(VariableTrigonometryTest, acos_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
   auto &view = acos(x.slice({Dim::X, 0}), out);
@@ -197,13 +230,13 @@ TEST(Variable, acos_out_arg) {
   EXPECT_EQ(&view, &out);
 }
 
-TEST(VariableTrigonometryTest, atan) {
+TEST_F(VariableTrigonometryTest, atan) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(atan(var),
             makeVariable<double>(Values{std::atan(1.0)}, Unit{units::rad}));
 }
 
-TEST(Variable, atan_move) {
+TEST_F(VariableTrigonometryTest, atan_move) {
   auto var = makeVariable<double>(Values{1.0});
   const auto ptr = var.values<double>().data();
   auto out = atan(std::move(var));
@@ -212,7 +245,7 @@ TEST(Variable, atan_move) {
   EXPECT_EQ(out.values<double>().data(), ptr);
 }
 
-TEST(Variable, atan_out_arg) {
+TEST_F(VariableTrigonometryTest, atan_out_arg) {
   auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 0.0});
   auto out = makeVariable<double>(Values{0.0});
   auto &view = atan(x.slice({Dim::X, 0}), out);
@@ -222,7 +255,7 @@ TEST(Variable, atan_out_arg) {
   EXPECT_EQ(&view, &out);
 }
 
-TEST(VariableTrigonometryTest, atan2) {
+TEST_F(VariableTrigonometryTest, atan2) {
   auto x = makeVariable<double>(units::m, Values{1.0});
   auto y = x;
   auto expected =
@@ -230,7 +263,7 @@ TEST(VariableTrigonometryTest, atan2) {
   EXPECT_EQ(atan2(y, x), expected);
 }
 
-TEST(VariableTrigonometryTest, atan2_out_arg) {
+TEST_F(VariableTrigonometryTest, atan2_out_arg) {
   auto x = makeVariable<double>(units::m, Values{1.0});
   auto y = x;
   auto expected =

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -268,11 +268,11 @@ TEST(VariableTest, copy_and_move) {
       makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, units::m,
                            Values{1.1, 2.2}, Variances{0.1, 0.2});
 
-  const auto copy(var);
-  EXPECT_EQ(copy, reference);
+  const Variable shallow(var);
+  EXPECT_EQ(shallow, reference);
 
-  const Variable copy_via_slice{Variable(var)};
-  EXPECT_EQ(copy_via_slice, reference);
+  const auto deep = copy(var);
+  EXPECT_EQ(deep, reference);
 
   const auto moved(std::move(var));
   EXPECT_EQ(moved, reference);
@@ -811,14 +811,14 @@ TEST(VariableViewTest, set_variances) {
   auto view(var);
   test_set_variances(view);
   EXPECT_THROW(
-      var.slice({Dim::X, 0}).setVariances(Variable(var.slice({Dim::X, 0}))),
+      var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
       except::VariancesError);
 }
 
 TEST(VariableViewTest, set_variances_slice_fail) {
   Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3});
   EXPECT_THROW(
-      var.slice({Dim::X, 0}).setVariances(Variable(var.slice({Dim::X, 0}))),
+      var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
       except::VariancesError);
 }
 
@@ -903,7 +903,7 @@ TEST(TransposeTest, make_transposed_2d) {
                                   Values{1, 2, 3, 4, 5, 6},
                                   Variances{11, 12, 13, 14, 15, 16});
 
-  const auto constVar = Variable(var);
+  const auto constVar = copy(var);
 
   auto ref = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
                                   Values{1, 3, 5, 2, 4, 6},
@@ -924,7 +924,7 @@ TEST(TransposeTest, make_transposed_multiple_d) {
                                   Values{1, 2, 3, 4, 5, 6},
                                   Variances{11, 12, 13, 14, 15, 16});
 
-  const auto constVar = Variable(var);
+  const auto constVar = copy(var);
 
   auto ref = makeVariable<double>(Dims{Dim::Y, Dim::Z, Dim::X}, Shape{2, 1, 3},
                                   Values{1, 3, 5, 2, 4, 6},

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -810,16 +810,14 @@ TEST(VariableViewTest, set_variances) {
                                       Values{1.0, 2.0, 3.0});
   auto view(var);
   test_set_variances(view);
-  EXPECT_THROW(
-      var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
-      except::VariancesError);
+  EXPECT_THROW(var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
+               except::VariancesError);
 }
 
 TEST(VariableViewTest, set_variances_slice_fail) {
   Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3});
-  EXPECT_THROW(
-      var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
-      except::VariancesError);
+  EXPECT_THROW(var.slice({Dim::X, 0}).setVariances(var.slice({Dim::X, 0})),
+               except::VariancesError);
 }
 
 TEST(VariableViewTest, create_with_variance) {

--- a/variable/trigonometry.cpp
+++ b/variable/trigonometry.cpp
@@ -4,7 +4,6 @@
 /// @author Simon Heybrock
 #include <cmath>
 
-#include "scipp/common/constants.h"
 #include "scipp/core/element/trigonometry.h"
 #include "scipp/variable/creation.h"
 #include "scipp/variable/to_unit.h"

--- a/variable/trigonometry.cpp
+++ b/variable/trigonometry.cpp
@@ -29,11 +29,7 @@ Variable sin(Variable &&var) {
 
 Variable &sin(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  if (var.unit() == units::deg) {
-    transform_in_place(out, to_unit(var, units::rad), element::sin_out_arg);
-  } else {
-    transform_in_place(out, var, element::sin_out_arg);
-  }
+  transform_in_place(out, to_unit(var, units::rad), element::sin_out_arg);
   return out;
 }
 
@@ -51,11 +47,7 @@ Variable cos(Variable &&var) {
 
 Variable &cos(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  if (var.unit() == units::deg) {
-    transform_in_place(out, to_unit(var, units::rad), element::cos_out_arg);
-  } else {
-    transform_in_place(out, var, element::cos_out_arg);
-  }
+  transform_in_place(out, to_unit(var, units::rad), element::cos_out_arg);
   return out;
 }
 
@@ -73,11 +65,7 @@ Variable tan(Variable &&var) {
 
 Variable &tan(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  if (var.unit() == units::deg) {
-    transform_in_place(out, to_unit(var, units::rad), element::tan_out_arg);
-  } else {
-    transform_in_place(out, var, element::tan_out_arg);
-  }
+  transform_in_place(out, to_unit(var, units::rad), element::tan_out_arg);
   return out;
 }
 

--- a/variable/trigonometry.cpp
+++ b/variable/trigonometry.cpp
@@ -6,6 +6,8 @@
 
 #include "scipp/common/constants.h"
 #include "scipp/core/element/trigonometry.h"
+#include "scipp/variable/creation.h"
+#include "scipp/variable/to_unit.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/trigonometry.h"
 
@@ -13,12 +15,9 @@ using namespace scipp::core;
 
 namespace scipp::variable {
 
-const auto deg_to_rad = makeVariable<double>(
-    Dims(), Shape(), units::rad / units::deg, Values{pi<double> / 180.0});
-
 Variable sin(const Variable &var) {
-  Variable out(var);
-  sin(out, out);
+  auto out = empty(var.dims(), units::one, var.dtype());
+  sin(var, out);
   return out;
 }
 
@@ -30,16 +29,17 @@ Variable sin(Variable &&var) {
 
 Variable &sin(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  copy(var, out);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  transform_in_place(out, out, element::sin_out_arg);
+  if (var.unit() == units::deg) {
+    transform_in_place(out, to_unit(var, units::rad), element::sin_out_arg);
+  } else {
+    transform_in_place(out, var, element::sin_out_arg);
+  }
   return out;
 }
 
 Variable cos(const Variable &var) {
-  Variable out(var);
-  cos(out, out);
+  auto out = empty(var.dims(), units::one, var.dtype());
+  cos(var, out);
   return out;
 }
 
@@ -51,16 +51,17 @@ Variable cos(Variable &&var) {
 
 Variable &cos(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  copy(var, out);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  transform_in_place(out, out, element::cos_out_arg);
+  if (var.unit() == units::deg) {
+    transform_in_place(out, to_unit(var, units::rad), element::cos_out_arg);
+  } else {
+    transform_in_place(out, var, element::cos_out_arg);
+  }
   return out;
 }
 
 Variable tan(const Variable &var) {
-  Variable out(var);
-  tan(out, out);
+  auto out = empty(var.dims(), units::one, var.dtype());
+  tan(var, out);
   return out;
 }
 
@@ -72,10 +73,11 @@ Variable tan(Variable &&var) {
 
 Variable &tan(const Variable &var, Variable &out) {
   core::expect::unit_any_of(var, {units::rad, units::deg});
-  copy(var, out);
-  if (var.unit() == units::deg)
-    out *= deg_to_rad;
-  transform_in_place(out, out, element::tan_out_arg);
+  if (var.unit() == units::deg) {
+    transform_in_place(out, to_unit(var, units::rad), element::tan_out_arg);
+  } else {
+    transform_in_place(out, var, element::tan_out_arg);
+  }
   return out;
 }
 


### PR DESCRIPTION
Variable's copy ctor does not copy the buffer which means that `sin`, etc. modify their input even though it is const.