### PR TITLE
Fixes related to `sc.bin`

### DIFF
--- a/common/include/scipp/common/numeric.h
+++ b/common/include/scipp/common/numeric.h
@@ -19,16 +19,23 @@ template <class Range> bool islinspace(const Range &range) {
     return false;
 
   using T = typename Range::value_type;
-  const T delta = (range.back() - range.front()) / (scipp::size(range) - 1);
-  constexpr int32_t ulp = 4;
-  const T epsilon = std::numeric_limits<T>::epsilon() *
-                    (std::abs(range.front()) + std::abs(range.back())) * ulp;
-
-  return std::adjacent_find(range.begin(), range.end(),
-                            [epsilon, delta](const auto &a, const auto &b) {
-                              return std::abs(std::abs(b - a) - delta) >
-                                     epsilon;
-                            }) == range.end();
+  if constexpr (std::is_floating_point_v<T>) {
+    const T delta = (range.back() - range.front()) / (scipp::size(range) - 1);
+    constexpr int32_t ulp = 4;
+    const T epsilon = std::numeric_limits<T>::epsilon() *
+                      (std::abs(range.front()) + std::abs(range.back())) * ulp;
+    return std::adjacent_find(range.begin(), range.end(),
+                              [epsilon, delta](const auto &a, const auto &b) {
+                                return std::abs(std::abs(b - a) - delta) >
+                                       epsilon;
+                              }) == range.end();
+  } else {
+    const auto delta = range[1] - range[0];
+    return std::adjacent_find(range.begin(), range.end(),
+                              [delta](const auto &a, const auto &b) {
+                                return std::abs(b - a) != delta;
+                              }) == range.end();
+  }
 }
 
 // Division like Python's __truediv__

--- a/core/include/scipp/core/element/bin.h
+++ b/core/include/scipp/core/element/bin.h
@@ -18,23 +18,27 @@
 
 namespace scipp::core::element {
 
-template <class Index, class T>
+template <class Index, class Coord, class Edges = Coord>
 using update_indices_by_binning_arg =
-    std::tuple<Index, T, scipp::span<const T>>;
+    std::tuple<Index, Coord, scipp::span<const Edges>>;
 
 static constexpr auto update_indices_by_binning = overloaded{
-    element::arg_list<
-        update_indices_by_binning_arg<int64_t, double>,
-        update_indices_by_binning_arg<int64_t, float>,
-        std::tuple<int64_t, int64_t, scipp::span<const double>>,
-        std::tuple<int64_t, time_point, scipp::span<const time_point>>,
-        update_indices_by_binning_arg<int32_t, double>,
-        update_indices_by_binning_arg<int32_t, float>,
-        std::tuple<int32_t, int64_t, scipp::span<const double>>,
-        std::tuple<int32_t, int32_t, scipp::span<const double>>,
-        std::tuple<int32_t, int64_t, scipp::span<const int64_t>>,
-        std::tuple<int32_t, int32_t, scipp::span<const int64_t>>,
-        std::tuple<int32_t, time_point, scipp::span<const time_point>>>,
+    element::arg_list<update_indices_by_binning_arg<int64_t, double>,
+                      update_indices_by_binning_arg<int32_t, double>,
+                      update_indices_by_binning_arg<int64_t, float>,
+                      update_indices_by_binning_arg<int32_t, float>,
+                      update_indices_by_binning_arg<int64_t, int64_t>,
+                      update_indices_by_binning_arg<int32_t, int64_t>,
+                      update_indices_by_binning_arg<int64_t, int32_t>,
+                      update_indices_by_binning_arg<int32_t, int32_t>,
+                      update_indices_by_binning_arg<int64_t, time_point>,
+                      update_indices_by_binning_arg<int32_t, time_point>,
+                      update_indices_by_binning_arg<int64_t, int64_t, double>,
+                      update_indices_by_binning_arg<int32_t, int64_t, double>,
+                      update_indices_by_binning_arg<int64_t, int32_t, double>,
+                      update_indices_by_binning_arg<int32_t, int32_t, double>,
+                      update_indices_by_binning_arg<int64_t, int32_t, int64_t>,
+                      update_indices_by_binning_arg<int32_t, int32_t, int64_t>>,
     [](units::Unit &indices, const units::Unit &coord,
        const units::Unit &groups) {
       expect::equals(coord, groups);

--- a/core/include/scipp/core/element/bin.h
+++ b/core/include/scipp/core/element/bin.h
@@ -31,6 +31,9 @@ static constexpr auto update_indices_by_binning = overloaded{
         update_indices_by_binning_arg<int32_t, double>,
         update_indices_by_binning_arg<int32_t, float>,
         std::tuple<int32_t, int64_t, scipp::span<const double>>,
+        std::tuple<int32_t, int32_t, scipp::span<const double>>,
+        std::tuple<int32_t, int64_t, scipp::span<const int64_t>>,
+        std::tuple<int32_t, int32_t, scipp::span<const int64_t>>,
         std::tuple<int32_t, time_point, scipp::span<const time_point>>>,
     [](units::Unit &indices, const units::Unit &coord,
        const units::Unit &groups) {

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -38,10 +38,13 @@ static constexpr auto histogram = overloaded{
     element::arg_list<
         histogram_detail::args<float, double, float, double>,
         histogram_detail::args<float, int64_t, float, double>,
+        histogram_detail::args<float, int32_t, float, double>,
         histogram_detail::args<double, double, double, double>,
         histogram_detail::args<double, float, double, double>,
         histogram_detail::args<double, float, double, float>,
         histogram_detail::args<double, double, float, double>,
+        histogram_detail::args<double, int64_t, double, int64_t>,
+        histogram_detail::args<double, int32_t, double, int64_t>,
         histogram_detail::args<double, time_point, double, time_point>,
         histogram_detail::args<double, time_point, float, time_point>,
         histogram_detail::args<float, time_point, double, time_point>,

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -45,6 +45,8 @@ static constexpr auto histogram = overloaded{
         histogram_detail::args<double, double, float, double>,
         histogram_detail::args<double, int64_t, double, int64_t>,
         histogram_detail::args<double, int32_t, double, int64_t>,
+        histogram_detail::args<double, int64_t, double, int32_t>,
+        histogram_detail::args<double, int32_t, double, int32_t>,
         histogram_detail::args<double, time_point, double, time_point>,
         histogram_detail::args<double, time_point, float, time_point>,
         histogram_detail::args<float, time_point, double, time_point>,

--- a/core/include/scipp/core/element/util.h
+++ b/core/include/scipp/core/element/util.h
@@ -17,22 +17,6 @@
 #include "scipp/units/except.h"
 #include "scipp/units/unit.h"
 
-namespace scipp::numeric {
-template <> inline bool islinspace(const span<const core::time_point> &range) {
-  if (scipp::size(range) < 2)
-    return false;
-  if (range.back() <= range.front())
-    return false;
-
-  const auto delta = range[1] - range[0];
-
-  return std::adjacent_find(range.begin(), range.end(),
-                            [delta](const auto &a, const auto &b) {
-                              return std::abs(b - a) != delta;
-                            }) == range.end();
-}
-} // namespace scipp::numeric
-
 namespace scipp::core::element {
 
 /// Sets any masked elements to 0 to handle special FP vals
@@ -116,7 +100,8 @@ constexpr auto issorted_nonascending = overloaded{
     }};
 
 constexpr auto islinspace = overloaded{
-    arg_list<span<const double>, span<const float>, span<const time_point>>,
+    arg_list<span<const double>, span<const float>, span<const int64_t>,
+             span<const int32_t>, span<const time_point>>,
     transform_flags::expect_no_variance_arg<0>,
     [](const units::Unit &) { return units::one; },
     [](const auto &range) { return numeric::islinspace(range); }};

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,7 +16,7 @@ Bugfixes
 
 * ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
 * ``bin`` now works on previously binned data with 2-D edges, even if the outer dimensions(s) are not rebinned `#1836 <https://github.com/scipp/scipp/pull/1836>`_.
-* ``bin`` and ``histogram`` now work with ``int32``-valued coordinates and support binning with ``int64``-valued bin edges.
+* ``bin`` and ``histogram`` now work with ``int32``-valued coordinates and support binning with ``int64``- or ``int32``-valued bin edges.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Bugfixes
 
 * ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
 * ``bin`` now works on previously binned data with 2-D edges, even if the outer dimensions(s) are not rebinned `#1836 <https://github.com/scipp/scipp/pull/1836>`_.
+* ``bin`` and ``histogram`` now work with ``int32``-valued coordinates and support binning with ``int64``-valued bin edges.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include "scipp/variable/subspan_view.h"
 #include "scipp/core/except.h"
+#include "scipp/variable/transform.h"
 
 namespace scipp::variable {
 
@@ -29,14 +30,17 @@ auto make_empty_subspans(const ElementArrayView<T> &, const Dimensions &dims) {
 template <class T>
 auto make_subspans(T *base, const VariableConstView &indices,
                    const scipp::index stride) {
-  const auto &offset = indices.values<core::bucket_base::range_type>();
-  const auto len = offset.size();
-  std::vector<span<T>> spans;
-  spans.reserve(len);
-  for (scipp::index i = 0; i < len; ++i)
-    spans.emplace_back(scipp::span(base + stride * offset[i].first,
-                                   base + stride * offset[i].second));
-  return spans;
+  const auto spans = variable::transform<scipp::index_pair>(
+      indices, overloaded{core::transform_flags::expect_no_variance_arg<0>,
+                          [](const units::Unit &) { return units::one; },
+                          [base, stride](const auto &offset) {
+                            return scipp::span(base + stride * offset.first,
+                                               base + stride * offset.second);
+                          }});
+  const auto vals = spans.template values<span<T>>().as_span();
+  // TODO This is slightly backwards: Extract span from variable, just to put
+  // them into another one in make_subspan_view.
+  return std::vector<span<T>>(vals.begin(), vals.end());
 }
 
 template <class T, class Var, class ValuesMaker, class VariancesMaker>


### PR DESCRIPTION
- `sc.bin` and `sc.histogram` now work with `int32`-valued coordinates and support binning with `int64`-valued bin edges.
- Avoid performance issue in `subspan_view` creation, which impacts performance of `sc.bin`.

