### PR TITLE
Do not put things into :root to avoid bad performance of _repr_html_

### DIFF
--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -450,7 +450,7 @@ def _obj_repr(header_components, sections):
 
     return ("<div>"
             f"{load_icons()}<style>{load_style()}</style>"
-            "<div class='sc-wrap'>"
+            "<div class='sc-wrap sc-root'>"
             f"{header}"
             f"<ul class='sc-sections'>{sections}</ul>"
             "</div>"

--- a/python/src/scipp/html/resources.py
+++ b/python/src/scipp/html/resources.py
@@ -16,13 +16,25 @@ def _format_style(template: str) -> str:
            for key, val in config['colors'].items()})
 
 
+def _preprocess_style(template: str) -> str:
+    css = _format_style(template)
+    import re
+    # line breaks are not needed
+    css = css.replace('\n', '')
+    # remove comments
+    css = re.sub(r'/\*(\*(?!/)|[^*])*\*/', '', css)
+    # remove space around special characters
+    css = re.sub(r'\s*([;{}:,])\s*', r'\1', css)
+    return css
+
+
 def load_style() -> str:
     """
     Load the bundled CSS style and return it as a string.
     The string is cached upon first call.
     """
     if load_style.style is None:
-        load_style.style = _format_style(
+        load_style.style = _preprocess_style(
             pkg_resources.read_text('scipp.html', 'style.css.template'))
     return load_style.style
 

--- a/python/src/scipp/html/style.css.template
+++ b/python/src/scipp/html/style.css.template
@@ -3,7 +3,7 @@
 * https://github.com/jsignell/xarray/blob/1d960933ab252e0f79f7e050e6c9261d55568057/xarray/static/css/style.css
 */
 
-:root {
+.sc-wrap {
   --sc-background-color0: var(--jp-layout-color0, #fff);
   --sc-background-color1: var(--jp-layout-color1, #fcfcfc);
   --sc-background-color2: var(--jp-layout-color2, #efefef);
@@ -17,9 +17,6 @@
   --sc-table-masks-color: $masks_color;
   --sc-table-attrs-color: $attrs_color;
   --sc-table-header-font-color: $header_text_color;
-}
-
-.sc-wrap {
   font-size: 14px;
   min-width: 300px;
   max-width: 800px;
@@ -405,7 +402,7 @@ label.sc-hide-icon svg{
 }
 
 .sc-table th.sc-masks {
-  background-color: var(--sc-table-masks-color);;
+  background-color: var(--sc-table-masks-color);
   color: var(--sc-table-header-font-color);
 }
 

--- a/python/src/scipp/html/style.css.template
+++ b/python/src/scipp/html/style.css.template
@@ -3,7 +3,7 @@
 * https://github.com/jsignell/xarray/blob/1d960933ab252e0f79f7e050e6c9261d55568057/xarray/static/css/style.css
 */
 
-.sc-wrap {
+.sc-root {
   --sc-background-color0: var(--jp-layout-color0, #fff);
   --sc-background-color1: var(--jp-layout-color1, #fcfcfc);
   --sc-background-color2: var(--jp-layout-color2, #efefef);
@@ -17,6 +17,9 @@
   --sc-table-masks-color: $masks_color;
   --sc-table-attrs-color: $attrs_color;
   --sc-table-header-font-color: $header_text_color;
+}
+
+.sc-wrap {
   font-size: 14px;
   min-width: 300px;
   max-width: 800px;

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -41,7 +41,8 @@ def _truncate_long_string(long_string: str) -> str:
 
 def _build_svg(content, left, top, width, height):
     return (
-        f'<svg width={_svg_width}em viewBox="{left} {top} {width} {height}">'
+        f'<svg width={_svg_width}em viewBox="{left} {top} {width} {height}"'
+        ' class="sc-root">'
         f'<defs><style>{load_style()}</style></defs>{content}</svg>')
 
 

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -314,6 +314,7 @@ class TableViewer:
                                          width="auto",
                                          display='flex',
                                          flex_flow='column'))
+        self.box.add_class('sc-root')  # needed to apply style
         return
 
     def make_dict(self):


### PR DESCRIPTION
After #1794 creating HTML output had become laggy, and it got worse the more cells a notebook contained. Lag was in the `0.5 s` to `> 1 s` range, once a notebooks contained dozens of cells or more.

The root cause seems to be placement of CSS custom propoerties (colors in this case) in `:root`.

