### PR TITLE
Update docs for patch release 0.6.1

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -8,7 +8,7 @@
               style="height: 30px; color: #27a54b; background-color: #403d3d;
                     border: 0px; box-shadow: none;">
         <option value="https://scipp.github.io" selected>latest (unstable)</option>
-        <option value="https://scipp.github.io/release/0.6.0">v0.6</option>
+        <option value="https://scipp.github.io/release/0.6.1">v0.6</option>
         <option value="https://scipp.github.io/release/0.5.0">v0.5</option>
         <option value="https://scipp.github.io/release/0.4.0">v0.4</option>
         <option value="https://scipp.github.io/release/0.3.0">v0.3</option>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -7,7 +7,8 @@
       <select onchange="location = this.value;"
               style="height: 30px; color: #27a54b; background-color: #403d3d;
                     border: 0px; box-shadow: none;">
-        <option value="https://scipp.github.io" selected>latest (unstable)</option>
+        <option value="" selected>Pick version</option>
+        <option value="https://scipp.github.io">latest (unstable)</option>
         <option value="https://scipp.github.io/release/0.6.1">v0.6</option>
         <option value="https://scipp.github.io/release/0.5.0">v0.5</option>
         <option value="https://scipp.github.io/release/0.4.0">v0.4</option>

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -14,10 +14,6 @@ Features
 Bugfixes
 ~~~~~~~~
 
-* ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
-* ``bin`` now works on previously binned data with 2-D edges, even if the outer dimensions(s) are not rebinned `#1836 <https://github.com/scipp/scipp/pull/1836>`_.
-* ``bin`` and ``histogram`` now work with ``int32``-valued coordinates and support binning with ``int64``- or ``int32``-valued bin edges.
-
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
@@ -29,6 +25,16 @@ Simon Heybrock,
 Matthew D. Jones,
 Neil Vaytet,
 and Jan-Lukas Wynen
+
+v0.6.1 (April 2021)
+-------------------
+
+Bugfixes
+~~~~~~~~
+
+* ``map`` and ``scale`` operations as well as ``histogram`` for binned data now also work with ``datetime64`` `#1834 <https://github.com/scipp/scipp/pull/1834>`_.
+* ``bin`` now works on previously binned data with 2-D edges, even if the outer dimensions(s) are not rebinned `#1836 <https://github.com/scipp/scipp/pull/1836>`_.
+* ``bin`` and ``histogram`` now work with ``int32``-valued coordinates and support binning with ``int64``- or ``int32``-valued bin edges.
 
 v0.6.0 (March 2021)
 -------------------


### PR DESCRIPTION
After this is merged I would create the patch release by tagging `0.6.1`. I think there is no reason for big announcements or other changes?

Also fix/bypass two problems with version select menu:
- Used to always display "latest", which was misleading if a release was selected.
- Did not support switching back to "latest", since it was always selected and thus did not trigger the redirect.