### PR TITLE
Optimize groupby

### DIFF
--- a/benchmark/groupby_benchmark.cpp
+++ b/benchmark/groupby_benchmark.cpp
@@ -89,6 +89,7 @@ static void BM_groupby_large_table(benchmark::State &state) {
   d.setData("a", column);
   d.setData("b", column);
   d.setData("c", column);
+  d["a"].masks().set("mask", makeVariable<bool>(Dims{Dim::X}, Shape{nRow}));
   auto group = makeVariable<int64_t>(Dims{Dim::X}, Shape{nRow},
                                      Values(group_.begin(), group_.end()));
   d.coords().set(Dim("group"),

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -11,7 +11,6 @@
 
 #include "scipp/variable/indexed_slice_view.h"
 #include "scipp/variable/operations.h"
-#include "scipp/variable/slice_generator.h"
 #include "scipp/variable/util.h"
 
 #include "scipp/dataset/bins.h"
@@ -85,9 +84,10 @@ T GroupBy<T>::reduce(Op op, const Dim reductionDim) const {
   };
   const auto process_data_array = [&](const auto &range, const auto &out_data,
                                       const auto &data) {
+    const auto &mask = get_mask(data);
     for (scipp::index group = range.begin(); group != range.end(); ++group) {
       auto out_slice = out_data.slice({dim(), group});
-      op(out_slice, data, groups()[group], reductionDim, get_mask(data));
+      op(out_slice, data, groups()[group], reductionDim, mask);
     }
   };
   // Apply to each group, storing result in output slice

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -11,6 +11,7 @@
 
 #include "scipp/variable/indexed_slice_view.h"
 #include "scipp/variable/operations.h"
+#include "scipp/variable/slice_generator.h"
 #include "scipp/variable/util.h"
 
 #include "scipp/dataset/bins.h"
@@ -108,12 +109,12 @@ static constexpr auto sum = [](DataArray &out, const auto &data_container,
                                const GroupByGrouping::group &group, const Dim,
                                const Variable &mask) {
   for (const auto &slice : group) {
-    const auto data_slice = data_container.slice(slice);
+    const auto data_slice = data_container.data().slice(slice);
     auto data = out.data();
     if (mask)
-      sum_impl(data, data_slice.data() * mask.slice(slice));
+      sum_impl(data, data_slice * mask.slice(slice));
     else
-      sum_impl(data, data_slice.data());
+      sum_impl(data, data_slice);
   }
 };
 
@@ -128,16 +129,16 @@ struct wrap {
          const Variable &mask) {
         bool first = true;
         for (const auto &slice : group) {
-          const auto data_slice = data_container.slice(slice);
+          const auto data_slice = data_container.data().slice(slice);
           if (mask)
             throw std::runtime_error(
                 "This operation does not support masks yet.");
           if (first) {
-            copy(data_slice.data().slice({reductionDim, 0}), out.data());
+            copy(data_slice.slice({reductionDim, 0}), out.data());
             first = false;
           }
           auto data = out.data();
-          Func(data, data_slice.data());
+          Func(data, data_slice);
         }
       };
 };

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -85,14 +85,18 @@ T GroupBy<T>::reduce(Op op, const Dim reductionDim) const {
   };
   // Apply to each group, storing result in output slice
   const auto process_groups = [&](const auto &range) {
-    for (scipp::index group = range.begin(); group != range.end(); ++group) {
-      if constexpr (std::is_same_v<T, Dataset>) {
-        for (const auto &item : m_data) {
-          auto out_item = out[item.name()].data().slice({dim(), group});
-          op(out_item, item, groups()[group], reductionDim,
+    if constexpr (std::is_same_v<T, Dataset>) {
+      for (const auto &item : m_data) {
+        auto out_item = out[item.name()].data();
+        for (scipp::index group = range.begin(); group != range.end();
+             ++group) {
+          auto out_slice = out_item.slice({dim(), group});
+          op(out_slice, item, groups()[group], reductionDim,
              get_mask(m_data[item.name()]));
         }
-      } else {
+      }
+    } else {
+      for (scipp::index group = range.begin(); group != range.end(); ++group) {
         auto out_slice = out.data().slice({dim(), group});
         op(out_slice, m_data, groups()[group], reductionDim, get_mask(m_data));
       }

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -75,16 +75,12 @@ template <class T>
 template <class Op>
 T GroupBy<T>::reduce(Op op, const Dim reductionDim) const {
   auto out = makeReductionOutput(reductionDim);
-  const auto get_mask = [&](const auto &data) {
+  const auto process_data_array = [&](const auto &range, const auto &out_data,
+                                      const auto &data) {
     auto mask = irreducible_mask(data.masks(), reductionDim);
     if (mask)
       mask = ~std::move(
           mask); // `op` multiplies mask into data to zero masked elements
-    return mask;
-  };
-  const auto process_data_array = [&](const auto &range, const auto &out_data,
-                                      const auto &data) {
-    const auto &mask = get_mask(data);
     for (scipp::index group = range.begin(); group != range.end(); ++group) {
       auto out_slice = out_data.slice({dim(), group});
       op(out_slice, data, groups()[group], reductionDim, mask);


### PR DESCRIPTION
With recent changes introducing a sharing mechanism for variable buffers and data arrays, `groupby` has become slower as expected (about 3x, see bottom).

My original idea for solving this is described in #1851, but it turns out that there were a number of other improvements that could be done that were sufficient to recover the performance. I *did* implement the panning mechanism but did not observe further speedup, so I did not include this here.

Also found and fixed major bottleneck from how `groupby` handled masks, which crippled performance (but only if masks were present). I have modified the benchmark to include a mask.

Baseline (`main`):
```
BM_groupby_large_table/64         7696745 ns      7365749 ns           85 bytes_per_second=8.48548G/s groups=64 items_per_second=284.717M/s
BM_groupby_large_table/128        7725970 ns      6663502 ns           99 bytes_per_second=9.38002G/s groups=128 items_per_second=314.722M/s
BM_groupby_large_table/256        7551342 ns      6793377 ns          103 bytes_per_second=9.20126G/s groups=256 items_per_second=308.705M/s
BM_groupby_large_table/512        8022354 ns      6949491 ns          108 bytes_per_second=8.99566G/s groups=512 items_per_second=301.771M/s
BM_groupby_large_table/1024       7951892 ns      7113297 ns           93 bytes_per_second=8.79065G/s groups=1024 items_per_second=294.821M/s
BM_groupby_large_table/2048       8382938 ns      7541427 ns           82 bytes_per_second=8.29565G/s groups=2.048k items_per_second=278.084M/s
BM_groupby_large_table/4096       9673002 ns      8658595 ns           68 bytes_per_second=7.23236G/s groups=4.096k items_per_second=242.205M/s
BM_groupby_large_table/8192      12954204 ns     11238968 ns           61 bytes_per_second=5.58273G/s groups=8.192k items_per_second=186.596M/s
BM_groupby_large_table/16384     19217421 ns     16552042 ns           38 bytes_per_second=3.80547G/s groups=16.384k items_per_second=126.701M/s
BM_groupby_large_table/32768     35313644 ns     32048024 ns           24 bytes_per_second=1.98067G/s groups=32.768k items_per_second=65.4378M/s
BM_groupby_large_table/65536     66494261 ns     63226340 ns           10 bytes_per_second=1043.87M/s groups=65.536k items_per_second=33.169M/s
BM_groupby_large_table/131072   120391980 ns    110042075 ns            6 bytes_per_second=617.945M/s groups=131.072k items_per_second=19.0577M/s
BM_groupby_large_table/262144   257527666 ns    236599592 ns            3 bytes_per_second=304.312M/s groups=262.144k items_per_second=8.86372M/s
BM_groupby_large_table/524288   506598666 ns    476661814 ns            2 bytes_per_second=167.834M/s groups=524.288k items_per_second=4.39966M/s
BM_groupby_large_table/1048576 1055887002 ns   1005963324 ns            1 bytes_per_second=95.4309M/s groups=1048.58k items_per_second=2.08472M/s
BM_groupby_large_table/2097152 1954317275 ns   1944255418 ns            1 bytes_per_second=65.835M/s groups=2.09715M items_per_second=1078.64k/s
```

`dev`, about 3x slower for the worst case (many small groups):
```
# dev
BM_groupby_large_table/64         6852476 ns      6494000 ns           94 bytes_per_second=9.62456G/s groups=64 items_per_second=322.937M/s
BM_groupby_large_table/128        7131805 ns      6453466 ns          104 bytes_per_second=9.68531G/s groups=128 items_per_second=324.965M/s
BM_groupby_large_table/256        8626885 ns      8088082 ns           84 bytes_per_second=7.72836G/s groups=256 items_per_second=259.289M/s
BM_groupby_large_table/512        9838578 ns      8893919 ns           87 bytes_per_second=7.02899G/s groups=512 items_per_second=235.796M/s
BM_groupby_large_table/1024      12729331 ns     11652348 ns           62 bytes_per_second=5.36634G/s groups=1024 items_per_second=179.977M/s
BM_groupby_large_table/2048      15468610 ns     12492032 ns           53 bytes_per_second=5.00808G/s groups=2.048k items_per_second=167.879M/s
BM_groupby_large_table/4096      25600796 ns     19100457 ns           35 bytes_per_second=3.27856G/s groups=4.096k items_per_second=109.796M/s
BM_groupby_large_table/8192      43690968 ns     32023145 ns           22 bytes_per_second=1.95934G/s groups=8.192k items_per_second=65.4886M/s
BM_groupby_large_table/16384     81308769 ns     56812692 ns           10 bytes_per_second=1.1087G/s groups=16.384k items_per_second=36.9134M/s
BM_groupby_large_table/32768    153160830 ns    106563876 ns            7 bytes_per_second=609.963M/s groups=32.768k items_per_second=19.6798M/s
BM_groupby_large_table/65536    253957862 ns    192776941 ns            4 bytes_per_second=342.365M/s groups=65.536k items_per_second=10.8786M/s
BM_groupby_large_table/131072   511805547 ns    372127702 ns            2 bytes_per_second=182.733M/s groups=131.072k items_per_second=5.63557M/s
BM_groupby_large_table/262144  1000311129 ns    731623560 ns            1 bytes_per_second=98.4113M/s groups=262.144k items_per_second=2.86644M/s
BM_groupby_large_table/524288  1960698366 ns   1545488396 ns            1 bytes_per_second=51.7636M/s groups=524.288k items_per_second=1.35695M/s
BM_groupby_large_table/1048576 3896926492 ns   3049809945 ns            1 bytes_per_second=31.4774M/s groups=1048.58k items_per_second=687.634k/s
BM_groupby_large_table/2097152 7812441178 ns   5945219901 ns            1 bytes_per_second=21.5299M/s groups=2.09715M items_per_second=352.746k/s
```

This branch:
```
BM_groupby_large_table/64         7245033 ns      6996094 ns           95 bytes_per_second=8.93383G/s groups=64 items_per_second=299.76M/s
BM_groupby_large_table/128        6429622 ns      6080642 ns           97 bytes_per_second=10.2791G/s groups=128 items_per_second=344.89M/s
BM_groupby_large_table/256        6549309 ns      6251186 ns          116 bytes_per_second=9.99932G/s groups=256 items_per_second=335.481M/s
BM_groupby_large_table/512        6812576 ns      6404419 ns          110 bytes_per_second=9.76127G/s groups=512 items_per_second=327.454M/s
BM_groupby_large_table/1024       7319737 ns      6742774 ns          105 bytes_per_second=9.27371G/s groups=1024 items_per_second=311.022M/s
BM_groupby_large_table/2048       8059351 ns      7288644 ns           95 bytes_per_second=8.58336G/s groups=2.048k items_per_second=287.729M/s
BM_groupby_large_table/4096      10184408 ns      9229264 ns           78 bytes_per_second=6.78516G/s groups=4.096k items_per_second=227.229M/s
BM_groupby_large_table/8192      13609620 ns     12514770 ns           59 bytes_per_second=5.01361G/s groups=8.192k items_per_second=167.574M/s
BM_groupby_large_table/16384     22119495 ns     19625863 ns           37 bytes_per_second=3.20945G/s groups=16.384k items_per_second=106.857M/s
BM_groupby_large_table/32768     37516094 ns     34677134 ns           20 bytes_per_second=1.8305G/s groups=32.768k items_per_second=60.4765M/s
BM_groupby_large_table/65536     73955329 ns     65116824 ns           11 bytes_per_second=1013.56M/s groups=65.536k items_per_second=32.206M/s
BM_groupby_large_table/131072   137111157 ns    128086003 ns            6 bytes_per_second=530.893M/s groups=131.072k items_per_second=16.373M/s
BM_groupby_large_table/262144   286746167 ns    233404836 ns            3 bytes_per_second=308.477M/s groups=262.144k items_per_second=8.98504M/s
BM_groupby_large_table/524288   591231463 ns    499737386 ns            2 bytes_per_second=160.084M/s groups=524.288k items_per_second=4.19651M/s
BM_groupby_large_table/1048576 1148839191 ns    996781765 ns            1 bytes_per_second=96.3099M/s groups=1048.58k items_per_second=2.10392M/s
BM_groupby_large_table/2097152 2368335530 ns   2088099756 ns            1 bytes_per_second=61.2998M/s groups=2.09715M items_per_second=1004.34k/s
```

Closes  #1851.