### PR TITLE
MultiIndex fix for `var.dims().ndim() == NDIM_MAX`

### DIFF
--- a/cmake/scipp-install.cmake
+++ b/cmake/scipp-install.cmake
@@ -8,6 +8,7 @@ function(scipp_install_component)
   cmake_parse_arguments(
     PARSE_ARGV 0 SCIPP_INSTALL_COMPONENT "${options}" "${oneValueArgs}" ""
   )
+  add_sanitizers(${SCIPP_INSTALL_COMPONENT_TARGET})
   if(DYNAMIC_LIB)
     install(TARGETS ${SCIPP_INSTALL_COMPONENT_TARGET} EXPORT ${EXPORT_NAME})
     install(DIRECTORY include/ DESTINATION ${INCLUDEDIR})

--- a/core/include/scipp/core/multi_index.h
+++ b/core/include/scipp/core/multi_index.h
@@ -197,7 +197,8 @@ public:
   /// iterated data.
   constexpr void set_index(const scipp::index offset) noexcept {
     auto remainder{offset};
-    for (scipp::index d = 0; d < NDIM_MAX; ++d) {
+    // This loop is until NDIM_MAX inclusive to handle the end index
+    for (scipp::index d = 0; d < NDIM_MAX + 1; ++d) {
       if (has_bins() && d < m_ndim_nested) {
         m_coord[d] = 0;
       } else {
@@ -270,7 +271,7 @@ public:
   }
 
   [[nodiscard]] bool has_bins() const noexcept {
-    return m_ndim_nested != NDIM_MAX;
+    return m_ndim_nested != NDIM_MAX + 1;
   }
 
   /// Return true if the first subindex has a 0 stride
@@ -294,12 +295,12 @@ private:
   };
   std::array<scipp::index, N> m_data_index = {};
   std::array<std::array<scipp::index, NDIM_MAX>, N> m_stride = {};
-  std::array<scipp::index, NDIM_MAX> m_coord = {};
-  std::array<scipp::index, NDIM_MAX> m_shape = {};
+  std::array<scipp::index, NDIM_MAX + 1> m_coord = {};
+  std::array<scipp::index, NDIM_MAX + 1> m_shape = {};
   /// End-sentinel, essentially the volume of the iteration dimensions.
   scipp::index m_end_sentinel{1};
   /// Number of dimensions within bucket, NDIM_MAX if no buckets.
-  scipp::index m_ndim_nested{NDIM_MAX};
+  scipp::index m_ndim_nested{NDIM_MAX + 1};
   /// Stride in buckets along dim referred to by indices, e.g., 2D buckets
   /// slicing along first or second dim.
   scipp::index m_nested_stride = {};

--- a/core/test/multi_index_test.cpp
+++ b/core/test/multi_index_test.cpp
@@ -135,6 +135,14 @@ TEST_F(MultiIndexTest, slice_outer) { check({x, yx}, {0, 1}); }
 
 TEST_F(MultiIndexTest, 2d) { check({xy, xy}, {0, 1, 2, 3, 4, 5}); }
 
+TEST_F(MultiIndexTest, 6d) {
+  Dimensions dims({Dim("1"), Dim("2"), Dim("3"), Dim("4"), Dim("5"), Dim("6")},
+                  {1, 2, 1, 2, 1, 2});
+  MultiIndex i{dims, dims};
+  i.end();
+  check({dims, dims}, {0, 1, 2, 3, 4, 5, 6, 7});
+}
+
 TEST_F(MultiIndexTest, 2d_transpose) { check({yx, xy}, {0, 3, 1, 4, 2, 5}); }
 
 TEST_F(MultiIndexTest, slice_and_broadcast) {

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -1021,3 +1021,15 @@ TEST(VariableTest, masked_to_zero) {
 
   EXPECT_EQ(masked_var, expected_var);
 }
+
+TEST(Variable, 6d) {
+  ASSERT_EQ(core::NDIM_MAX, 6); // update this test if limit is increased
+  auto a = makeVariable<double>(
+      Dims{Dim("1"), Dim("2"), Dim("3"), Dim("4"), Dim("5"), Dim("6")},
+      Shape{1, 2, 3, 4, 5, 6});
+  auto b = makeVariable<double>(
+      Dims{Dim("3"), Dim("2"), Dim("1"), Dim("4"), Dim("6"), Dim("5")},
+      Shape{3, 2, 1, 4, 6, 5});
+  copy(a, b);
+  a += b;
+}


### PR DESCRIPTION
Fixes #1835.