### PR TITLE
Share bins buffer

### DIFF
--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -17,7 +17,8 @@ template <class T> auto copy_shared(const std::shared_ptr<T> &obj) {
 
 DataArray::DataArray(const DataArray &other, const AttrPolicy attrPolicy)
     : m_name(other.m_name), m_data(copy_shared(other.m_data)),
-      m_coords(other.m_coords), m_masks(copy_shared(other.m_masks)),
+      m_coords(copy_shared(other.m_coords)),
+      m_masks(copy_shared(other.m_masks)),
       m_attrs(attrPolicy == AttrPolicy::Keep ? copy_shared(other.m_attrs)
                                              : std::make_shared<Attrs>()) {}
 
@@ -27,11 +28,11 @@ DataArray::DataArray(const DataArray &other)
 DataArray::DataArray(Variable data, Coords coords, Masks masks, Attrs attrs,
                      const std::string_view name)
     : m_name(name), m_data(std::make_shared<Variable>(std::move(data))),
-      m_coords(std::move(coords)),
+      m_coords(std::make_shared<Coords>(std::move(coords))),
       m_masks(std::make_shared<Masks>(std::move(masks))),
       m_attrs(std::make_shared<Attrs>(std::move(attrs))) {
   const Sizes sizes(dims());
-  m_coords.setSizes(sizes);
+  m_coords->setSizes(sizes);
   m_masks->setSizes(sizes);
   m_attrs->setSizes(sizes);
 }
@@ -41,7 +42,7 @@ DataArray::DataArray(Variable data, typename Coords::holder_type coords,
                      typename Attrs::holder_type attrs,
                      const std::string_view name)
     : m_name(name), m_data(std::make_shared<Variable>(std::move(data))),
-      m_coords(dims(), std::move(coords)),
+      m_coords(std::make_shared<Coords>(dims(), std::move(coords))),
       m_masks(std::make_shared<Masks>(dims(), std::move(masks))),
       m_attrs(std::make_shared<Attrs>(dims(), std::move(attrs))) {}
 
@@ -82,9 +83,9 @@ void DataArray::setName(const std::string_view name) { m_name = name; }
 Coords DataArray::meta() const { return attrs().merge_from(coords()); }
 
 DataArray DataArray::slice(const Slice &s) const {
-  auto out_coords = m_coords.slice(s);
+  auto out_coords = m_coords->slice(s);
   Attrs out_attrs(out_coords.sizes(), {});
-  for (auto &coord : m_coords) {
+  for (auto &coord : *m_coords) {
     if (unaligned_by_dim_slice(coord, s))
       out_attrs.set(coord.first, out_coords.extract(coord.first));
   }
@@ -112,15 +113,26 @@ DataArray &DataArray::setSlice(const Slice &s, const Variable &var) {
   return *this;
 }
 
+DataArray DataArray::view() const {
+  DataArray out;
+  out.m_data = m_data;   // share data
+  out.m_coords = m_coords; // share coords
+  out.m_masks = m_masks; // share masks
+  out.m_attrs = m_attrs; // share attrs
+  out.m_name = m_name;
+  return out;
+}
+
 DataArray DataArray::view_with_coords(const Coords &coords,
                                       const std::string &name) const {
   DataArray out;
   out.m_data = m_data; // share data
   const Sizes sizes(dims());
-  out.m_coords = Coords(sizes, {});
+  out.m_coords =
+      std::make_shared<Coords>(sizes, typename Coords::holder_type{});
   for (const auto &[dim, coord] : coords)
     if (coords.item_applies_to(dim, dims()))
-      out.m_coords.set(dim, coord.as_const());
+      out.m_coords->set(dim, coord.as_const());
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs
   out.m_name = name;
@@ -131,7 +143,7 @@ void DataArray::rename(const Dim from, const Dim to) {
   if ((from != to) && dims().contains(to))
     throw except::DimensionError("Duplicate dimension.");
   m_data->rename(from, to);
-  m_coords.rename(from, to);
+  m_coords->rename(from, to);
   m_masks->rename(from, to);
   m_attrs->rename(from, to);
 }

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -115,10 +115,10 @@ DataArray &DataArray::setSlice(const Slice &s, const Variable &var) {
 
 DataArray DataArray::view() const {
   DataArray out;
-  out.m_data = m_data;   // share data
+  out.m_data = m_data;     // share data
   out.m_coords = m_coords; // share coords
-  out.m_masks = m_masks; // share masks
-  out.m_attrs = m_attrs; // share attrs
+  out.m_masks = m_masks;   // share masks
+  out.m_attrs = m_attrs;   // share attrs
   out.m_name = m_name;
   return out;
 }

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -41,10 +41,10 @@ public:
   const std::string &name() const;
   void setName(std::string_view name);
 
-  const Coords &coords() const { return m_coords; }
+  const Coords &coords() const { return *m_coords; }
   // TODO either ensure Dict does not allow changing sizes, or return by value
   // here
-  Coords &coords() { return m_coords; }
+  Coords &coords() { return *m_coords; }
 
   const Masks &masks() const { return *m_masks; }
   Masks &masks() { return *m_masks; }
@@ -91,6 +91,7 @@ public:
   [[maybe_unused]] DataArray &setSlice(const Slice &s, const DataArray &array);
   [[maybe_unused]] DataArray &setSlice(const Slice &s, const Variable &var);
 
+  DataArray view() const;
   DataArray view_with_coords(const Coords &coords,
                              const std::string &name) const;
 
@@ -104,7 +105,7 @@ private:
                                                        const DataArray &);
   std::string m_name;
   std::shared_ptr<Variable> m_data;
-  Coords m_coords;
+  std::shared_ptr<Coords> m_coords;
   std::shared_ptr<Masks> m_masks;
   std::shared_ptr<Attrs> m_attrs;
 };

--- a/dataset/test/data_array_test.cpp
+++ b/dataset/test/data_array_test.cpp
@@ -94,3 +94,32 @@ TEST(DataArrayTest, astype) {
   EXPECT_EQ(x.data(),
             makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1., 2., 3.}));
 }
+
+TEST(DataArrayTest, view) {
+  const auto var = makeVariable<double>(Values{1});
+  const DataArray a(copy(var), {{Dim::X, copy(var)}}, {{"mask", copy(var)}},
+                    {{Dim("attr"), copy(var)}});
+  const auto b = a.view();
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(&a.data(), &b.data());
+  EXPECT_EQ(&a.coords(), &b.coords());
+  EXPECT_EQ(&a.masks(), &b.masks());
+  EXPECT_EQ(&a.attrs(), &b.attrs());
+  EXPECT_EQ(a.name(), b.name());
+}
+
+TEST(DataArrayTest, as_const) {
+  const auto var = makeVariable<double>(Values{1});
+  const DataArray a(copy(var), {{Dim::X, copy(var)}}, {{"mask", copy(var)}},
+                    {{Dim("attr"), copy(var)}});
+  const auto b = a.as_const();
+  EXPECT_EQ(a, b);
+  EXPECT_TRUE(b.is_readonly());
+  EXPECT_TRUE(b.coords().is_readonly());
+  EXPECT_TRUE(b.masks().is_readonly());
+  EXPECT_TRUE(b.attrs().is_readonly());
+  EXPECT_TRUE(b.coords()[Dim::X].is_readonly());
+  EXPECT_TRUE(b.masks()["mask"].is_readonly());
+  EXPECT_TRUE(b.attrs()[Dim("attr")].is_readonly());
+  EXPECT_EQ(a.name(), b.name());
+}

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -89,11 +89,6 @@ template <class T> auto bin_dim(const Variable &var) {
   return py::cast(std::string(dim.name()));
 }
 
-template <class T> auto get_buffer(py::object &obj) {
-  auto &view = obj.cast<Variable &>();
-  return py::cast(view.bin_buffer<T>());
-}
-
 template <class T>
 void bind_bins_map_view(py::module &m, const std::string &name) {
   py::class_<T> c(m, name.c_str());
@@ -155,11 +150,12 @@ void init_buckets(py::module &m) {
   m.def("bins_data", [](py::object &obj) -> py::object {
     auto &var = obj.cast<Variable &>();
     if (var.dtype() == dtype<bucket<Variable>>)
-      return get_buffer<Variable>(obj);
+      return py::cast(obj.cast<Variable &>().bin_buffer<Variable>());
     if (var.dtype() == dtype<bucket<DataArray>>)
-      return get_buffer<DataArray>(obj);
+      return py::cast(obj.cast<Variable &>().bin_buffer<DataArray>().view());
     if (var.dtype() == dtype<bucket<Dataset>>)
-      return get_buffer<Dataset>(obj);
+      // TODO Provide mechanism for creating sharing view as for DataArray above
+      return py::cast(obj.cast<Variable &>().bin_buffer<Dataset>());
     return py::none();
   });
 

--- a/python/tests/test_bins.py
+++ b/python/tests/test_bins.py
@@ -49,6 +49,11 @@ def test_bins_buffer_access():
     del binned.bins.constituents['data'].coords['coord']
     del binned.bins.constituents['data'].masks['mask']
     del binned.bins.constituents['data'].attrs['attr']
+    # sc.bins makes a (shallow) copy of `data`
+    assert 'coord' in data.coords
+    assert 'mask' in data.masks
+    assert 'attr' in data.attrs
+    # ... but when buffer is accessed we can insert/delete meta data
     assert 'coord' not in binned.bins.constituents['data'].coords
     assert 'mask' not in binned.bins.constituents['data'].masks
     assert 'attr' not in binned.bins.constituents['data'].attrs

--- a/python/tests/test_bins.py
+++ b/python/tests/test_bins.py
@@ -34,6 +34,32 @@ def test_bins_fail_only_end():
         sc.bins(end=end, dim='x', data=data)
 
 
+def test_bins_buffer_access():
+    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
+    data = sc.DataArray(data=var,
+                        coords={'coord': var},
+                        masks={'mask': var},
+                        attrs={'attr': var})
+    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
+    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
+    binned = sc.bins(begin=begin, end=end, dim='x', data=data)
+    assert 'coord' in binned.bins.constituents['data'].coords
+    assert 'mask' in binned.bins.constituents['data'].masks
+    assert 'attr' in binned.bins.constituents['data'].attrs
+    del binned.bins.constituents['data'].coords['coord']
+    del binned.bins.constituents['data'].masks['mask']
+    del binned.bins.constituents['data'].attrs['attr']
+    assert 'coord' not in binned.bins.constituents['data'].coords
+    assert 'mask' not in binned.bins.constituents['data'].masks
+    assert 'attr' not in binned.bins.constituents['data'].attrs
+    binned.bins.constituents['data'].coords['coord'] = var
+    binned.bins.constituents['data'].masks['mask'] = var
+    binned.bins.constituents['data'].attrs['attr'] = var
+    assert 'coord' in binned.bins.constituents['data'].coords
+    assert 'mask' in binned.bins.constituents['data'].masks
+    assert 'attr' in binned.bins.constituents['data'].attrs
+
+
 def test_bins():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
     begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)


### PR DESCRIPTION
This restores the old behavior which allows for inserting/deleting meta data entries on the flat underlying buffer.

See added unit test for detailed behavior.