### PR TITLE
Remove `filter` and `split`

### DIFF
--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -39,17 +39,20 @@ T GroupBy<T>::copy(const scipp::index group,
     size += slice.end() - slice.begin();
   // This is just the slicing dim, but `slices` may be empty
   const Dim slice_dim = m_data.coords()[dim()].dims().inner();
-  auto out =
-      scipp::dataset::copy(m_data.slice({slice_dim, 0, size}), attrPolicy);
+  auto out = dataset::copy(m_data.slice({slice_dim, 0, size}), attrPolicy);
   scipp::index current = 0;
+  auto out_slices = slices;
+  for (auto &slice : out_slices) {
+    const auto thickness = slice.end() - slice.begin();
+    slice = Slice(slice.dim(), current, current + thickness);
+    current += thickness;
+  }
   const auto copy_slice = [&](const auto &range) {
     for (scipp::index i = range.begin(); i != range.end(); ++i) {
       const auto &slice = slices[i];
-      const auto thickness = slice.end() - slice.begin();
-      const Slice out_slice(slice_dim, current, current + thickness);
+      const auto &out_slice = out_slices[i];
       scipp::dataset::copy(m_data.slice(slice), out.slice(out_slice),
                            attrPolicy);
-      current += thickness;
     }
   };
   core::parallel::parallel_for(core::parallel::blocked_range(0, slices.size()),

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -69,6 +69,36 @@ TEST_F(GroupbyTest, copy) {
   EXPECT_EQ(two_groups.copy(1), d.slice({Dim::X, 2, 3}));
 }
 
+TEST_F(GroupbyTest, copy_multiple_subgroups) {
+  const auto var =
+      makeVariable<double>(Dims{Dim("x")}, Shape{12}, units::m,
+                           Values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+  const auto labels = makeVariable<double>(
+      Dims{Dim::X}, Shape{12}, Values{0, 1, 1, 0, 2, 2, 0, 0, 1, 0, 1, 2});
+  const auto da = DataArray(var, {{Dim("labels"), labels}});
+
+  auto grouped = groupby(da, Dim("labels"));
+
+  const auto var0 = makeVariable<double>(Dims{Dim("x")}, Shape{5}, units::m,
+                                         Values{0, 3, 6, 7, 9});
+  const auto var1 = makeVariable<double>(Dims{Dim("x")}, Shape{4}, units::m,
+                                         Values{1, 2, 8, 10});
+  const auto var2 = makeVariable<double>(Dims{Dim("x")}, Shape{3}, units::m,
+                                         Values{4, 5, 11});
+  const auto labels0 =
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{0, 0, 0, 0, 0});
+  const auto labels1 =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 1, 1, 1});
+  const auto labels2 =
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{2, 2, 2});
+  const auto da0 = DataArray(var0, {{Dim("labels"), labels0}});
+  const auto da1 = DataArray(var1, {{Dim("labels"), labels1}});
+  const auto da2 = DataArray(var2, {{Dim("labels"), labels2}});
+  EXPECT_EQ(grouped.copy(0), da0);
+  EXPECT_EQ(grouped.copy(1), da1);
+  EXPECT_EQ(grouped.copy(2), da2);
+}
+
 TEST_F(GroupbyTest, fail_2d_coord) {
   d.setCoord(Dim("2d"), makeVariable<float>(Dims{Dim::X, Dim::Z}, Shape{3, 2}));
   EXPECT_NO_THROW(groupby(d, Dim("labels2")));

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -17,6 +17,8 @@ Bugfixes
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+* ``filter`` and ``split`` removed. Identical functionality can be achieved using ``groupby`` and/or slicing.
+
 Contributors
 ~~~~~~~~~~~~
 

--- a/docs/python-reference/api.rst
+++ b/docs/python-reference/api.rst
@@ -42,7 +42,6 @@ General
    collapse
    dot
    exp
-   filter
    histogram
    log
    log10

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -123,9 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = sc.DataArray(\n",
@@ -195,6 +193,47 @@
     "grouped = sc.groupby(data, group=param, bins=bins).mean('x') # note the lack of quotes around param!\n",
     "sc.plot(grouped)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage examples\n",
+    "\n",
+    "### Filtering a variable using `groupby.copy`\n",
+    "\n",
+    "Apart from reduction operations discussed above, `groupby` also supports `copy`, which allows us to extract a group without changes.\n",
+    "We can use this, e.g., to filter data.\n",
+    "This can be used for filtering variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var = sc.array(dims=['x'], values=np.random.rand(100))\n",
+    "select = var < 0.5 * sc.Unit('')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use a temporary data array pass `1` to `copy` to extract the second group (group indices start at 0).\n",
+    "Finally, the `data` property returns only the filtered variable without the temporary coords that were required for `groupby`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_var = sc.groupby(sc.DataArray(var, coords={'dummy':select}), group='dummy').copy(1).data\n",
+    "filtered_var"
+   ]
   }
  ],
  "metadata": {
@@ -213,9 +252,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -221,8 +221,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use a temporary data array pass `1` to `copy` to extract the second group (group indices start at 0).\n",
-    "Finally, the `data` property returns only the filtered variable without the temporary coords that were required for `groupby`:"
+    "We proceed as follows:\n",
+    "1. Create a helper data array with a dummy coord that will be used to group the data elements.\n",
+    "2. Call `groupby`, grouping by the `dummy` coord.  Here `select` contains two distinct values, `False` and `True`, so `groupby` returns an object with two groups.\n",
+    "2. Pass `1` to `copy` to extract the second group (group indices start at 0) which contains all elements where the dummy coord value is `True`.\n",
+    "3. Finally, the `data` property returns only the filtered variable without the temporary coords that were required for `groupby`."
    ]
   },
   {
@@ -231,8 +234,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filtered_var = sc.groupby(sc.DataArray(var, coords={'dummy':select}), group='dummy').copy(1).data\n",
+    "helper = sc.DataArray(var, coords={'dummy':select})\n",
+    "grouped = sc.groupby(helper, group='dummy')\n",
+    "filtered_var = grouped.copy(1).data\n",
     "filtered_var"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we can also avoid the named helpers `helper` and `grouped` and write:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_var = sc.groupby(sc.DataArray(var, coords={'dummy':select}), group='dummy').copy(1).data"
    ]
   }
  ],

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -242,31 +242,6 @@ of variances.)");
   py::implicitly_convertible<std::string, Dim>();
 
   m.def(
-      "filter", py::overload_cast<const Variable &, const Variable &>(&filter),
-      py::arg("x"), py::arg("filter"), py::call_guard<py::gil_scoped_release>(),
-      Docstring()
-          .description(
-              "Selects elements for a Variable using a filter (mask).\n\n"
-              "The filter variable must be 1D and of bool type. "
-              "A true value in the filter means the corresponding element in "
-              "the input is "
-              "selected and will be copied to the output. "
-              "A false value in the filter discards the corresponding element "
-              "in the input.")
-          .raises("If the filter variable is not 1 dimensional.")
-          .returns("New variable containing the data selected by the filter.")
-          .rtype("Variable")
-          .param("x", "Variable to filter.", "Variable.")
-          .param("filter", "Variable which defines the filter.", "Variable.")
-          .c_str());
-
-  m.def("split",
-        py::overload_cast<const Variable &, const Dim,
-                          const std::vector<scipp::index> &>(&split),
-        py::call_guard<py::gil_scoped_release>(),
-        "Split a Variable along a given Dimension.");
-
-  m.def(
       "islinspace",
       [](const Variable &x) {
         if (x.dims().ndim() != 1)

--- a/variable/include/scipp/variable/misc_operations.h
+++ b/variable/include/scipp/variable/misc_operations.h
@@ -11,12 +11,6 @@ namespace scipp::variable {
 
 SCIPP_VARIABLE_EXPORT Variable astype(const Variable &var, const DType type);
 
-SCIPP_VARIABLE_EXPORT std::vector<Variable>
-split(const Variable &var, const Dim dim,
-      const std::vector<scipp::index> &indices);
-SCIPP_VARIABLE_EXPORT Variable filter(const Variable &var,
-                                      const Variable &filter);
-
 SCIPP_VARIABLE_EXPORT Variable masked_to_zero(const Variable &var,
                                               const Variable &mask);
 


### PR DESCRIPTION
As part of cleanup I encountered these very old and slightly unconventional functions. Since we can achieve the same in a more generic way by other means I remove remove.

- Add documentation on how to filter using `groupby`.
- Multi-threading in `groupby.copy`.