### PR TITLE
Fix squeeze

### DIFF
--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -184,7 +184,7 @@ DataArray add_metadata(std::tuple<DataArray, Variable> &&proto,
                        const std::vector<Variable> &groups,
                        const std::vector<Dim> &erase) {
   auto &[buffer, bin_sizes] = proto;
-  squeeze(bin_sizes, erase);
+  bin_sizes = squeeze(bin_sizes, erase);
   const auto end = cumsum(bin_sizes);
   const auto buffer_dim = buffer.dims().inner();
   // TODO We probably want to omit the coord used for grouping in the non-edge
@@ -464,7 +464,7 @@ template <class T> Variable concat_bins(const Variable &var, const Dim dim) {
 
   builder.build(*target_bins, std::map<Dim, Variable>{});
   auto [buffer, bin_sizes] = bin<DataArray>(var, *target_bins, builder);
-  squeeze(bin_sizes, {dim});
+  bin_sizes = squeeze(bin_sizes, {dim});
   const auto end = cumsum(bin_sizes);
   const auto buffer_dim = buffer.dims().inner();
   return make_bins(zip(end - bin_sizes, end), buffer_dim, std::move(buffer));

--- a/variable/include/scipp/variable/shape.h
+++ b/variable/include/scipp/variable/shape.h
@@ -35,7 +35,8 @@ flatten(const Variable &view, const scipp::span<const Dim> &from_labels,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
 transpose(const Variable &var, const std::vector<Dim> &dims = {});
 
-SCIPP_VARIABLE_EXPORT void squeeze(Variable &var, const std::vector<Dim> &dims);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+squeeze(const Variable &var, const std::vector<Dim> &dims);
 
 SCIPP_VARIABLE_EXPORT void expect_same_volume(const Dimensions &old_dims,
                                               const Dimensions &new_dims);

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -163,15 +163,15 @@ Variable transpose(const Variable &var, const std::vector<Dim> &dims) {
   return var.transpose(dims);
 }
 
-void squeeze(Variable &var, const std::vector<Dim> &dims) {
-  auto squeezed = var.dims();
+Variable squeeze(const Variable &var, const std::vector<Dim> &dims) {
+  auto squeezed = var;
   for (const auto &dim : dims) {
-    if (squeezed[dim] != 1)
+    if (squeezed.dims()[dim] != 1)
       throw except::DimensionError("Cannot squeeze '" + to_string(dim) +
                                    "' since it is not of length 1.");
-    squeezed.erase(dim);
+    squeezed = squeezed.slice({dim, 0});
   }
-  var.setDims(squeezed);
+  return squeezed;
 }
 
 } // namespace scipp::variable

--- a/variable/test/shape_test.cpp
+++ b/variable/test/shape_test.cpp
@@ -40,32 +40,33 @@ protected:
 };
 
 TEST_F(SqueezeTest, fail) {
-  EXPECT_THROW(squeeze(var, {Dim::Y}), except::DimensionError);
+  EXPECT_THROW_DISCARD(squeeze(var, {Dim::Y}), except::DimensionError);
   EXPECT_EQ(var, original);
-  EXPECT_THROW(squeeze(var, {Dim::X, Dim::Y}), except::DimensionError);
+  EXPECT_THROW_DISCARD(squeeze(var, {Dim::X, Dim::Y}), except::DimensionError);
   EXPECT_EQ(var, original);
-  EXPECT_THROW(squeeze(var, {Dim::Y, Dim::Z}), except::DimensionError);
+  EXPECT_THROW_DISCARD(squeeze(var, {Dim::Y, Dim::Z}), except::DimensionError);
   EXPECT_EQ(var, original);
 }
 
-TEST_F(SqueezeTest, none) {
-  squeeze(var, {});
-  EXPECT_EQ(var, original);
-}
+TEST_F(SqueezeTest, none) { EXPECT_EQ(squeeze(var, {}), original); }
 
 TEST_F(SqueezeTest, outer) {
-  squeeze(var, {Dim::X});
-  EXPECT_EQ(var, sum(original, Dim::X));
+  EXPECT_EQ(squeeze(var, {Dim::X}), sum(original, Dim::X));
 }
 
 TEST_F(SqueezeTest, inner) {
-  squeeze(var, {Dim::Z});
-  EXPECT_EQ(var, sum(original, Dim::Z));
+  EXPECT_EQ(squeeze(var, {Dim::Z}), sum(original, Dim::Z));
 }
 
 TEST_F(SqueezeTest, both) {
-  squeeze(var, {Dim::X, Dim::Z});
-  EXPECT_EQ(var, sum(sum(original, Dim::Z), Dim::X));
+  EXPECT_EQ(squeeze(var, {Dim::X, Dim::Z}), sum(sum(original, Dim::Z), Dim::X));
+}
+
+TEST_F(SqueezeTest, slice) {
+  Variable xy = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                     Values{1, 2, 3, 4});
+  const auto sliced = xy.slice({Dim::Y, 1, 2});
+  EXPECT_EQ(squeeze(sliced, {Dim::Y}), sum(sliced, Dim::Y));
 }
 
 TEST(ShapeTest, reshape) {


### PR DESCRIPTION
Fixes #1868. `Variable::setDims()` did not take into account strides.

Note that `reshape` has the same bug since it also used `setDims()`, but there the fix is more complicated and I will provide it separately.