### PR TITLE
Prevent setting bins unit

### DIFF
--- a/core/include/scipp/core/tag_util.h
+++ b/core/include/scipp/core/tag_util.h
@@ -11,24 +11,10 @@
 
 namespace scipp::core {
 
-/**
- * At the time of writing older clang 6 lacks support for template
- * argument deduction of class templates (OSX only?)
- * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0620r0.html
- * https://clang.llvm.org/cxx_status.html
- *
- * This make helper uses function template argument deduction to solve
- * for std::array declarations.
- */
-template <typename... T> constexpr auto make_array(T &&... values) {
-  return std::array<std::decay_t<std::common_type_t<T...>>, sizeof...(T)>{
-      std::forward<T>(values)...};
-}
-
 template <template <class> class Callable, class... Ts, class... Args>
 static auto callDType(const std::tuple<Ts...> &, const DType dtype,
                       Args &&... args) {
-  auto funcs = make_array(Callable<Ts>::apply...);
+  std::array funcs{Callable<Ts>::apply...};
   std::array<DType, sizeof...(Ts)> dtypes{scipp::core::dtype<Ts>...};
   for (size_t i = 0; i < dtypes.size(); ++i)
     if (dtypes[i] == dtype)

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -66,7 +66,7 @@ auto copy_impl(const Slices &slices, const Data &data, const Dim dim,
 template <class T>
 T GroupBy<T>::copy(const scipp::index group,
                    const AttrPolicy attrPolicy) const {
-  return copy_impl(groups()[group], m_data, dim());
+  return copy_impl(groups()[group], m_data, dim(), attrPolicy);
 }
 
 /// Helper for creating output for "combine" step for "apply" steps that reduce

--- a/dataset/util.cpp
+++ b/dataset/util.cpp
@@ -7,6 +7,7 @@
 #include "scipp/variable/misc_operations.h"
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/util.h"
+#include "scipp/variable/variable_concept.h"
 
 using namespace scipp::variable;
 namespace scipp {

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -11,6 +11,7 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
 #include "scipp/variable/variable.h"
+#include "scipp/variable/variable_concept.h"
 
 #include "dtype.h"
 #include "numpy.h"

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -64,10 +64,12 @@ setattr(Variable, 'sizes', property(_make_sizes))
 setattr(DataArray, 'sizes', property(_make_sizes))
 setattr(Dataset, 'sizes', property(_make_sizes))
 
-from ._bins import _bins, _set_bins
+from ._bins import _bins, _set_bins, _events
 setattr(Variable, 'bins', property(_bins, _set_bins))
 setattr(DataArray, 'bins', property(_bins, _set_bins))
 setattr(Dataset, 'bins', property(_bins, _set_bins))
+setattr(Variable, 'events', property(_events))
+setattr(DataArray, 'events', property(_events))
 
 from ._bins import _groupby_bins
 setattr(GroupByDataArray, 'bins', property(_groupby_bins))

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -151,6 +151,20 @@ class GroupbyBins:
         return self._obj.concatenate(dim)
 
 
+def _events(obj):
+    """
+    Returns the underlying data the bins stored in the object, or None if the
+    object stores dense data.
+    """
+    if _cpp.is_bins(obj):
+        if isinstance(obj, _cpp.Variable):
+            return _cpp.bins_data(obj)
+        else:
+            return _cpp.bins_data(obj.data)
+    else:
+        return None
+
+
 def _bins(obj):
     """
     Returns helper :py:class:`scipp.Bins` allowing bin-wise operations

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -153,7 +153,7 @@ class GroupbyBins:
 
 def _events(obj):
     """
-    Returns the underlying data the bins stored in the object, or None if the
+    Returns the data underlying the bins stored in the object, or None if the
     object stores dense data.
     """
     if _cpp.is_bins(obj):

--- a/python/tests/test_bins.py
+++ b/python/tests/test_bins.py
@@ -8,6 +8,12 @@ from .nexus_helpers import (find_by_nx_class,
                             in_memory_nexus_file_with_event_data)
 
 
+def test_dense_data_properties_are_none():
+    var = sc.scalar(1)
+    assert var.bins is None
+    assert var.events is None
+
+
 def test_bins_default_begin_end():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
     var = sc.bins(dim='x', data=data)
@@ -34,7 +40,7 @@ def test_bins_fail_only_end():
         sc.bins(end=end, dim='x', data=data)
 
 
-def test_bins_buffer_access():
+def test_events_property():
     var = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
     data = sc.DataArray(data=var,
                         coords={'coord': var},
@@ -43,26 +49,26 @@ def test_bins_buffer_access():
     begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
     end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
     binned = sc.bins(begin=begin, end=end, dim='x', data=data)
-    assert 'coord' in binned.bins.constituents['data'].coords
-    assert 'mask' in binned.bins.constituents['data'].masks
-    assert 'attr' in binned.bins.constituents['data'].attrs
-    del binned.bins.constituents['data'].coords['coord']
-    del binned.bins.constituents['data'].masks['mask']
-    del binned.bins.constituents['data'].attrs['attr']
+    assert 'coord' in binned.events.coords
+    assert 'mask' in binned.events.masks
+    assert 'attr' in binned.events.attrs
+    del binned.events.coords['coord']
+    del binned.events.masks['mask']
+    del binned.events.attrs['attr']
     # sc.bins makes a (shallow) copy of `data`
     assert 'coord' in data.coords
     assert 'mask' in data.masks
     assert 'attr' in data.attrs
     # ... but when buffer is accessed we can insert/delete meta data
-    assert 'coord' not in binned.bins.constituents['data'].coords
-    assert 'mask' not in binned.bins.constituents['data'].masks
-    assert 'attr' not in binned.bins.constituents['data'].attrs
-    binned.bins.constituents['data'].coords['coord'] = var
-    binned.bins.constituents['data'].masks['mask'] = var
-    binned.bins.constituents['data'].attrs['attr'] = var
-    assert 'coord' in binned.bins.constituents['data'].coords
-    assert 'mask' in binned.bins.constituents['data'].masks
-    assert 'attr' in binned.bins.constituents['data'].attrs
+    assert 'coord' not in binned.events.coords
+    assert 'mask' not in binned.events.masks
+    assert 'attr' not in binned.events.attrs
+    binned.events.coords['coord'] = var
+    binned.events.masks['mask'] = var
+    binned.events.attrs['attr'] = var
+    assert 'coord' in binned.events.coords
+    assert 'mask' in binned.events.masks
+    assert 'attr' in binned.events.attrs
 
 
 def test_bins():
@@ -122,7 +128,7 @@ def test_bins_arithmetic():
         coords={'x': sc.Variable(dims=['x'], values=[1.0, 3.0, 5.0])})
     binned.bins *= sc.lookup(func=hist, dim='x')
     assert sc.identical(
-        binned.bins.constituents['data'].data,
+        binned.events.data,
         sc.Variable(dims=['event'], values=[1.0, 2.0, 6.0, 8.0]))
 
 

--- a/variable/bins.cpp
+++ b/variable/bins.cpp
@@ -13,6 +13,7 @@
 #include "scipp/variable/subspan_view.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/util.h"
+#include "scipp/variable/variable_concept.h"
 
 namespace scipp::variable {
 

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -24,6 +24,14 @@ public:
 
   scipp::index size() const override { return indices()->size(); }
 
+  void setUnit(const units::Unit &unit) override {
+    if (unit != units::one)
+      throw except::UnitError(
+          "Bins cannot have a unit. Did you mean to set the unit of the bin "
+          "elements? This can be set, e.g., with `array.bins.data.unit = "
+          "'m'`.");
+  }
+
   bool hasVariances() const noexcept override { return false; }
   void setVariances(const Variable &) override {
     throw except::VariancesError("This data type cannot have variances.");

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -28,8 +28,7 @@ public:
     if (unit != units::one)
       throw except::UnitError(
           "Bins cannot have a unit. Did you mean to set the unit of the bin "
-          "elements? This can be set, e.g., with `array.bins.data.unit = "
-          "'m'`.");
+          "elements? This can be set, e.g., with `array.events.unit = 'm'`.");
   }
 
   bool hasVariances() const noexcept override { return false; }

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -23,7 +23,6 @@
 #include "scipp/core/except.h"
 #include "scipp/core/slice.h"
 #include "scipp/core/strides.h"
-#include "scipp/core/tag_util.h"
 
 #include "scipp/variable/variable_keyword_arg_constructor.h"
 

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -25,7 +25,6 @@
 #include "scipp/core/strides.h"
 #include "scipp/core/tag_util.h"
 
-#include "scipp/variable/variable_concept.h"
 #include "scipp/variable/variable_keyword_arg_constructor.h"
 
 namespace llnl::units {
@@ -33,6 +32,9 @@ class precise_measurement;
 }
 
 namespace scipp::variable {
+
+class VariableConcept;
+using VariableConceptHandle = std::shared_ptr<VariableConcept>;
 
 namespace detail {
 SCIPP_VARIABLE_EXPORT void expect0D(const Dimensions &dims);
@@ -58,21 +60,21 @@ public:
   /// should be prefered where possible, since it generates less code.
   template <class... Ts> Variable(const DType &type, Ts &&... args);
 
-  explicit operator bool() const noexcept { return m_object.operator bool(); }
+  explicit operator bool() const noexcept;
   Variable operator~() const;
 
-  units::Unit unit() const { return m_object->unit(); }
+  units::Unit unit() const;
   void setUnit(const units::Unit &unit);
   void expectCanSetUnit(const units::Unit &) const;
 
   const Dimensions &dims() const;
   void setDims(const Dimensions &dimensions);
 
-  DType dtype() const { return data().dtype(); }
+  DType dtype() const;
 
   scipp::span<const scipp::index> strides() const;
 
-  bool hasVariances() const { return data().hasVariances(); }
+  bool hasVariances() const;
 
   template <class T> ElementArrayView<const T> values() const;
   template <class T> ElementArrayView<T> values();
@@ -106,13 +108,10 @@ public:
   Variable operator-() const;
 
   const VariableConcept &data() const && = delete;
-  const VariableConcept &data() const & { return *m_object; }
+  const VariableConcept &data() const &;
   VariableConcept &data() && = delete;
-  VariableConcept &data() & {
-    expectWritable();
-    return *m_object;
-  }
-  const auto &data_handle() const { return m_object; }
+  VariableConcept &data() &;
+  const VariableConceptHandle &data_handle() const;
   void setDataHandle(VariableConceptHandle object);
 
   void setVariances(const Variable &v);

--- a/variable/include/scipp/variable/variable_concept.h
+++ b/variable/include/scipp/variable/variable_concept.h
@@ -40,7 +40,7 @@ public:
   const units::Unit &unit() const { return m_unit; }
   virtual scipp::index size() const = 0;
 
-  void setUnit(const units::Unit &unit) { m_unit = unit; }
+  virtual void setUnit(const units::Unit &unit) { m_unit = unit; }
 
   virtual bool hasVariances() const noexcept = 0;
   virtual void setVariances(const Variable &variances) = 0;

--- a/variable/operations.cpp
+++ b/variable/operations.cpp
@@ -8,6 +8,7 @@
 #include "scipp/variable/creation.h"
 #include "scipp/variable/misc_operations.h"
 #include "scipp/variable/transform.h"
+#include "scipp/variable/variable_concept.h"
 
 #include "operations_common.h"
 

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -9,6 +9,7 @@
 #include "scipp/variable/except.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/util.h"
+#include "scipp/variable/variable_concept.h"
 #include "scipp/variable/variable_factory.h"
 
 using namespace scipp::core;

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -71,9 +71,13 @@ TEST_F(VariableBinsTest, copy_slice) {
   EXPECT_EQ(copy(var.slice({Dim::Y, 1, 2})), var.slice({Dim::Y, 1, 2}));
 }
 
+TEST_F(VariableBinsTest, cannot_set_unit) {
+  EXPECT_EQ(var.unit(), units::one);
+  EXPECT_THROW(var.setUnit(units::m), except::UnitError);
+  EXPECT_EQ(var.unit(), units::one);
+}
+
 TEST_F(VariableBinsTest, basics) {
-  // TODO Probably it would be a good idea to prevent having any other unit.
-  // Does this imply unit should move from Variable into VariableConcept?
   EXPECT_EQ(var.unit(), units::one);
   EXPECT_EQ(var.dims(), dims);
   const auto vals = var.values<bucket<Variable>>();

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -34,11 +34,17 @@ void Variable::setDataHandle(VariableConceptHandle object) {
   m_object = object;
 }
 
+Variable::operator bool() const noexcept { return m_object.operator bool(); }
+
 const Dimensions &Variable::dims() const {
   if (!*this)
     throw std::runtime_error("invalid variable");
   return m_dims;
 }
+
+DType Variable::dtype() const { return data().dtype(); }
+
+bool Variable::hasVariances() const { return data().hasVariances(); }
 
 void Variable::setDims(const Dimensions &dimensions) {
   if (dimensions.volume() == dims().volume()) {
@@ -59,6 +65,8 @@ void Variable::expectCanSetUnit(const units::Unit &unit) const {
                             "to change the unit.");
 }
 
+units::Unit Variable::unit() const { return m_object->unit(); }
+
 void Variable::setUnit(const units::Unit &unit) {
   expectCanSetUnit(unit);
   expectWritable();
@@ -75,6 +83,15 @@ bool Variable::operator==(const Variable &other) const {
 bool Variable::operator!=(const Variable &other) const {
   return !(*this == other);
 }
+
+const VariableConcept &Variable::data() const & { return *m_object; }
+
+VariableConcept &Variable::data() & {
+  expectWritable();
+  return *m_object;
+}
+
+const VariableConceptHandle &Variable::data_handle() const { return m_object; }
 
 scipp::span<const scipp::index> Variable::strides() const {
   return scipp::span<const scipp::index>(&*m_strides.begin(),


### PR DESCRIPTION
- Resolving a small TODO.
- Add `events` property. This is partially (and may fully) replace `array.bins.constituents`, but for now I am keeping both, since there are more things to consider. I suggest we try this in practice for a while.