### PR TITLE
Cleanup `subspan_view`

### DIFF
--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -21,53 +21,26 @@ auto make_subspans(T *base, const Variable &indices,
         "span only supports stride=1, this should be "
         "unreachable due to an earlier check, may want to generalize this "
         "later to support in particular stride=0 for broadcasted buffers");
-  const auto spans = variable::transform<scipp::index_pair>(
+  return variable::transform<scipp::index_pair>(
       indices, overloaded{core::transform_flags::expect_no_variance_arg<0>,
                           [](const units::Unit &) { return units::one; },
                           [base, stride](const auto &offset) {
                             return scipp::span(base + stride * offset.first,
                                                base + stride * offset.second);
                           }});
-  const auto vals = spans.template values<span<T>>().as_span();
-  // TODO This is slightly backwards: Extract span from variable, just to put
-  // them into another one in make_subspan_view.
-  return std::vector<span<T>>(vals.begin(), vals.end());
-}
-
-template <class T, class Var, class ValuesMaker, class VariancesMaker>
-Variable make_subspan_view(Var &var, const Dimensions &dims,
-                           ValuesMaker make_values,
-                           VariancesMaker make_variances) {
-  std::conditional_t<std::is_const_v<T>, const Var, Var> &var_ref = var;
-  using MaybeConstT =
-      std::conditional_t<std::is_const_v<Var>, std::add_const_t<T>, T>;
-  auto valuesView = make_values(var_ref);
-  if (var.hasVariances()) {
-    auto variancesView = make_variances(var_ref);
-    return makeVariable<span<MaybeConstT>>(
-        Dimensions{dims}, var.unit(),
-        Values(valuesView.begin(), valuesView.end()),
-        Variances(variancesView.begin(), variancesView.end()));
-  } else
-    return makeVariable<span<MaybeConstT>>(
-        Dimensions{dims}, var.unit(),
-        Values(valuesView.begin(), valuesView.end()));
 }
 
 /// Return Variable containing spans with extents given by indices over given
 /// dimension as elements.
 template <class T, class Var>
 Variable subspan_view(Var &var, const Dim dim, const Variable &indices) {
-  using E = std::remove_const_t<T>;
-  const auto values_view = [dim, &indices](auto &v) {
-    return make_subspans(v.template values<E>().data(), indices,
-                         v.dims().offset(dim));
-  };
-  const auto variances_view = [dim, &indices](auto &v) {
-    return make_subspans(v.template variances<E>().data(), indices,
-                         v.dims().offset(dim));
-  };
-  return make_subspan_view<T>(var, indices.dims(), values_view, variances_view);
+  auto subspans = make_subspans(var.template values<T>().data(), indices,
+                                var.dims().offset(dim));
+  if (var.hasVariances())
+    subspans.setVariances(make_subspans(var.template variances<T>().data(),
+                                        indices, var.dims().offset(dim)));
+  subspans.setUnit(var.unit());
+  return subspans;
 }
 
 /// Return Variable containing spans over given dimension as elements.


### PR DESCRIPTION
Turns things inside out to simplify code significantly.

Also includding a cherry-picked commit from #1861 fixing a stride issue.