### PR TITLE
More flexibility in scipp ci

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -19,4 +19,4 @@ extends:
       windows: ['3.7']
     deploy: true
     conda_label: 'dev'
-    publish_documentation: true
+    publish_docs: true

--- a/.azure-pipelines/next.yml
+++ b/.azure-pipelines/next.yml
@@ -19,4 +19,4 @@ extends:
       windows: ['3.7']
     deploy: true
     conda_label: 'next'
-    publish_documentation: false
+    publish_docs: false

--- a/.azure-pipelines/next.yml
+++ b/.azure-pipelines/next.yml
@@ -5,7 +5,7 @@ parameters:
   default: false
 
 trigger:
-  - main
+  - next-ci # TODO change
 
 pr: none
 
@@ -18,5 +18,5 @@ extends:
       osx: ['3.7']
       windows: ['3.7']
     deploy: true
-    conda_label: 'dev'
-    publish_documentation: true
+    conda_label: 'next'
+    publish_documentation: false

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -59,7 +59,7 @@ stages:
               displayName: 'Deploy ${{ package.Key }}'
 
           - task: DownloadBuildArtifacts@0
-            condition: ${{ parameters.publish_docs }}
+            condition: eq(${{ parameters.publish_docs }}, 'true') 
             inputs:
               buildType: 'current'
               specificBuildWithTriggering: true
@@ -68,7 +68,7 @@ stages:
               downloadPath: '$(Build.StagingDirectory)'
             displayName: 'Retrieve built documentation'
           - task: InstallSSHKey@0
-            condition: ${{ parameters.publish_docs }}
+            condition: eq(${{ parameters.publish_docs }}, 'true') 
             inputs:
               knownHostsEntry: '|1|RUYRgOQOM1Elf2P4avx8YNBvtI8=|QKQU0rsDA0sdvfZeayvuQ3l7XjE= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
               sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQD1k29WMh5uvP5TRihav1ilNbm3Z/KXvoBA9q3YmNkSKFOubvb/y+Tc2S6vqVWxpUDC0CWFyFdUp+WUGy9Cx2aQ0DzmJWUoXJz5woS48e2o/091HpSyvSfYXikBVpTpxJFOYB4lCDclsz4jG1HfuHlf763ajp0EBoTeJspT2kiIdXD47nSpHt/vl47PxwVLgTPVYT1fbwBXwmPNldupph0PkP+fV3uw+DJkXzIR5Uo+3iJu7wrZTKx4W4E4r1bInHjLd4/XP/MbaX0ds47Il27yACZSdrSBZg2Q4E8nVkZUO1VA1sWrcpI39V4Zh7e+Ab9MeUtLa6hR5pSp54Eg0HxnHwDkKpyQsCApueUw7FJ9vZiIKZRqRRhK6mEpQQ+jl+a5pyPH8/20un7C20FUu5CqUFOrY1gncsoyiYevsLumCRu7Nh99oFbAQzxydiNbtpXXsDA6ZWO5BLLA+rvftoQqFPjvnM7nrArg3ATYyZXlK904OmUwWcAs5BPJlG8Rv1c/wrJzAW0RsZqanNmvsgOVrHTLUHhDTxKmWBzQwAomOqOddx86scCU0Bqr3UPRhf8deSIajIa30wADbVRLrwkp0BHBdY5lukzhwc3swBIfu4aiikIHe+Mj99oh17F5X5za7Iyu2+Gv5oSf7gZR43bzSz0dW6XTfcCrRR9H6OHXew=='

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -58,68 +58,68 @@ stages:
                 ANACONDA_TOKEN: $(anaconda_token_secret)
               displayName: 'Deploy ${{ package.Key }}'
 
-          - task: DownloadBuildArtifacts@0
-            condition: eq(${{ parameters.publish_docs }}, 'true') 
-            inputs:
-              buildType: 'current'
-              specificBuildWithTriggering: true
-              downloadType: 'single'
-              artifactName: 'documentation'
-              downloadPath: '$(Build.StagingDirectory)'
-            displayName: 'Retrieve built documentation'
-          - task: InstallSSHKey@0
-            condition: eq(${{ parameters.publish_docs }}, 'true') 
-            inputs:
-              knownHostsEntry: '|1|RUYRgOQOM1Elf2P4avx8YNBvtI8=|QKQU0rsDA0sdvfZeayvuQ3l7XjE= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-              sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQD1k29WMh5uvP5TRihav1ilNbm3Z/KXvoBA9q3YmNkSKFOubvb/y+Tc2S6vqVWxpUDC0CWFyFdUp+WUGy9Cx2aQ0DzmJWUoXJz5woS48e2o/091HpSyvSfYXikBVpTpxJFOYB4lCDclsz4jG1HfuHlf763ajp0EBoTeJspT2kiIdXD47nSpHt/vl47PxwVLgTPVYT1fbwBXwmPNldupph0PkP+fV3uw+DJkXzIR5Uo+3iJu7wrZTKx4W4E4r1bInHjLd4/XP/MbaX0ds47Il27yACZSdrSBZg2Q4E8nVkZUO1VA1sWrcpI39V4Zh7e+Ab9MeUtLa6hR5pSp54Eg0HxnHwDkKpyQsCApueUw7FJ9vZiIKZRqRRhK6mEpQQ+jl+a5pyPH8/20un7C20FUu5CqUFOrY1gncsoyiYevsLumCRu7Nh99oFbAQzxydiNbtpXXsDA6ZWO5BLLA+rvftoQqFPjvnM7nrArg3ATYyZXlK904OmUwWcAs5BPJlG8Rv1c/wrJzAW0RsZqanNmvsgOVrHTLUHhDTxKmWBzQwAomOqOddx86scCU0Bqr3UPRhf8deSIajIa30wADbVRLrwkp0BHBdY5lukzhwc3swBIfu4aiikIHe+Mj99oh17F5X5za7Iyu2+Gv5oSf7gZR43bzSz0dW6XTfcCrRR9H6OHXew=='
-              sshKeySecureFile: 'gh_pages_deploy_key'
-            displayName: 'Add GitHub Pages deploy key'
-          - bash: |
-              set -ex
-              # Publishing documentation involves a Git commit, this sets the identity for that commit
-              git config --global user.name 'The Great Documentation Generation Entity'
-              git config --global user.email 'nobody@localhost'
-            displayName: 'Git config'
-          - bash: |
-              set -ex
-              git clone git@github.com:scipp/scipp.github.io ${{ parameters.documentation_repo_path }}
-            displayName: 'Clone documentation repository'
-          - bash: |
-              set -ex
-              cd ${{ parameters.documentation_repo_path }}
-              # Stage removal of everything
-              git rm -rf .
-              git status
-              # Unstage deletion of and recover "release" directory
-              git reset -- release || true
-              git checkout -- release || true
-              git status
-            displayName: 'Remove old documentation, keeping releases'
-          - bash: |
-              set -ex
-              cd ${{ parameters.documentation_repo_path }}
-              # The .nojekyll file is used to turn off GitHub Pages building
-              touch .nojekyll
-              rsync -av "${{ parameters.documentation_artefact_path }}/" .
-              git add .
-              git status
-            displayName: 'Copy new documentation'
-          - bash: |
-              set -ex
-              release_docs_dir="release/$(git describe --tags)"
-              cd ${{ parameters.documentation_repo_path }}
-              mkdir -p "$release_docs_dir"
-              rsync -av "${{ parameters.documentation_artefact_path }}/" "$release_docs_dir"
-              git add .
-              git status
-            condition: and(succeeded(), ${{ parameters.release }})
-            displayName: 'Copy new documentation for release'
-          - bash: |
-              set -ex
-              cd ${{ parameters.documentation_repo_path }}
-              # Amend last commit to keep repository size down
-              git commit --amend --date="$(date)" --message='Auto commit from CI'
-              git status
-              git push --force-with-lease
-              git status
-            displayName: 'Push to GitHub Pages'
+          - ${{ if eq(parameters.publish_docs, true) }}:
+            - task: DownloadBuildArtifacts@0
+              inputs:
+                buildType: 'current'
+                specificBuildWithTriggering: true
+                downloadType: 'single'
+                artifactName: 'documentation'
+                downloadPath: '$(Build.StagingDirectory)'
+              displayName: 'Retrieve built documentation'
+          - ${{ if eq(parameters.publish_docs, true) }}:
+            - task: InstallSSHKey@0
+              inputs:
+                knownHostsEntry: '|1|RUYRgOQOM1Elf2P4avx8YNBvtI8=|QKQU0rsDA0sdvfZeayvuQ3l7XjE= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+                sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQD1k29WMh5uvP5TRihav1ilNbm3Z/KXvoBA9q3YmNkSKFOubvb/y+Tc2S6vqVWxpUDC0CWFyFdUp+WUGy9Cx2aQ0DzmJWUoXJz5woS48e2o/091HpSyvSfYXikBVpTpxJFOYB4lCDclsz4jG1HfuHlf763ajp0EBoTeJspT2kiIdXD47nSpHt/vl47PxwVLgTPVYT1fbwBXwmPNldupph0PkP+fV3uw+DJkXzIR5Uo+3iJu7wrZTKx4W4E4r1bInHjLd4/XP/MbaX0ds47Il27yACZSdrSBZg2Q4E8nVkZUO1VA1sWrcpI39V4Zh7e+Ab9MeUtLa6hR5pSp54Eg0HxnHwDkKpyQsCApueUw7FJ9vZiIKZRqRRhK6mEpQQ+jl+a5pyPH8/20un7C20FUu5CqUFOrY1gncsoyiYevsLumCRu7Nh99oFbAQzxydiNbtpXXsDA6ZWO5BLLA+rvftoQqFPjvnM7nrArg3ATYyZXlK904OmUwWcAs5BPJlG8Rv1c/wrJzAW0RsZqanNmvsgOVrHTLUHhDTxKmWBzQwAomOqOddx86scCU0Bqr3UPRhf8deSIajIa30wADbVRLrwkp0BHBdY5lukzhwc3swBIfu4aiikIHe+Mj99oh17F5X5za7Iyu2+Gv5oSf7gZR43bzSz0dW6XTfcCrRR9H6OHXew=='
+                sshKeySecureFile: 'gh_pages_deploy_key'
+              displayName: 'Add GitHub Pages deploy key'
+            - bash: |
+                set -ex
+                # Publishing documentation involves a Git commit, this sets the identity for that commit
+                git config --global user.name 'The Great Documentation Generation Entity'
+                git config --global user.email 'nobody@localhost'
+              displayName: 'Git config'
+            - bash: |
+                set -ex
+                git clone git@github.com:scipp/scipp.github.io ${{ parameters.documentation_repo_path }}
+              displayName: 'Clone documentation repository'
+            - bash: |
+                set -ex
+                cd ${{ parameters.documentation_repo_path }}
+                # Stage removal of everything
+                git rm -rf .
+                git status
+                # Unstage deletion of and recover "release" directory
+                git reset -- release || true
+                git checkout -- release || true
+                git status
+              displayName: 'Remove old documentation, keeping releases'
+            - bash: |
+                set -ex
+                cd ${{ parameters.documentation_repo_path }}
+                # The .nojekyll file is used to turn off GitHub Pages building
+                touch .nojekyll
+                rsync -av "${{ parameters.documentation_artefact_path }}/" .
+                git add .
+                git status
+              displayName: 'Copy new documentation'
+            - bash: |
+                set -ex
+                release_docs_dir="release/$(git describe --tags)"
+                cd ${{ parameters.documentation_repo_path }}
+                mkdir -p "$release_docs_dir"
+                rsync -av "${{ parameters.documentation_artefact_path }}/" "$release_docs_dir"
+                git add .
+                git status
+              condition: and(succeeded(), ${{ parameters.release }})
+              displayName: 'Copy new documentation for release'
+            - bash: |
+                set -ex
+                cd ${{ parameters.documentation_repo_path }}
+                # Amend last commit to keep repository size down
+                git commit --amend --date="$(date)" --message='Auto commit from CI'
+                git status
+                git push --force-with-lease
+                git status
+              displayName: 'Push to GitHub Pages'

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -45,7 +45,6 @@ stages:
             displayName: 'Install anaconda-client'
           - ${{ each package in parameters.package_list }}:
             - task: DownloadBuildArtifacts@0
-              condition: ${{ parameters.publish_docs }}
               inputs:
                 buildType: 'current'
                 specificBuildWithTriggering: true
@@ -69,6 +68,7 @@ stages:
               downloadPath: '$(Build.StagingDirectory)'
             displayName: 'Retrieve built documentation'
           - task: InstallSSHKey@0
+            condition: ${{ parameters.publish_docs }}
             inputs:
               knownHostsEntry: '|1|RUYRgOQOM1Elf2P4avx8YNBvtI8=|QKQU0rsDA0sdvfZeayvuQ3l7XjE= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
               sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQD1k29WMh5uvP5TRihav1ilNbm3Z/KXvoBA9q3YmNkSKFOubvb/y+Tc2S6vqVWxpUDC0CWFyFdUp+WUGy9Cx2aQ0DzmJWUoXJz5woS48e2o/091HpSyvSfYXikBVpTpxJFOYB4lCDclsz4jG1HfuHlf763ajp0EBoTeJspT2kiIdXD47nSpHt/vl47PxwVLgTPVYT1fbwBXwmPNldupph0PkP+fV3uw+DJkXzIR5Uo+3iJu7wrZTKx4W4E4r1bInHjLd4/XP/MbaX0ds47Il27yACZSdrSBZg2Q4E8nVkZUO1VA1sWrcpI39V4Zh7e+Ab9MeUtLa6hR5pSp54Eg0HxnHwDkKpyQsCApueUw7FJ9vZiIKZRqRRhK6mEpQQ+jl+a5pyPH8/20un7C20FUu5CqUFOrY1gncsoyiYevsLumCRu7Nh99oFbAQzxydiNbtpXXsDA6ZWO5BLLA+rvftoQqFPjvnM7nrArg3ATYyZXlK904OmUwWcAs5BPJlG8Rv1c/wrJzAW0RsZqanNmvsgOVrHTLUHhDTxKmWBzQwAomOqOddx86scCU0Bqr3UPRhf8deSIajIa30wADbVRLrwkp0BHBdY5lukzhwc3swBIfu4aiikIHe+Mj99oh17F5X5za7Iyu2+Gv5oSf7gZR43bzSz0dW6XTfcCrRR9H6OHXew=='

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -17,7 +17,7 @@ parameters:
 - name: package_list
   type: object
   default: []
-- name: publish_documentation
+- name: publish_docs
   type: boolean
   default: True
 
@@ -45,7 +45,7 @@ stages:
             displayName: 'Install anaconda-client'
           - ${{ each package in parameters.package_list }}:
             - task: DownloadBuildArtifacts@0
-              condition: ${{ parameters.publish_documentation }}
+              condition: ${{ parameters.publish_docs }}
               inputs:
                 buildType: 'current'
                 specificBuildWithTriggering: true
@@ -60,7 +60,7 @@ stages:
               displayName: 'Deploy ${{ package.Key }}'
 
           - task: DownloadBuildArtifacts@0
-            condition: ${{ parameters.publish_documentation }}
+            condition: ${{ parameters.publish_docs }}
             inputs:
               buildType: 'current'
               specificBuildWithTriggering: true

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -17,6 +17,9 @@ parameters:
 - name: package_list
   type: object
   default: []
+- name: publish_documentation
+  type: boolean
+  default: True
 
 stages:
   - stage: 'deploy'
@@ -42,6 +45,7 @@ stages:
             displayName: 'Install anaconda-client'
           - ${{ each package in parameters.package_list }}:
             - task: DownloadBuildArtifacts@0
+              condition: ${{ parameters.publish_documentation }}
               inputs:
                 buildType: 'current'
                 specificBuildWithTriggering: true
@@ -56,6 +60,7 @@ stages:
               displayName: 'Deploy ${{ package.Key }}'
 
           - task: DownloadBuildArtifacts@0
+            condition: ${{ parameters.publish_documentation }}
             inputs:
               buildType: 'current'
               specificBuildWithTriggering: true

--- a/.azure-pipelines/templates/stages.yml
+++ b/.azure-pipelines/templates/stages.yml
@@ -3,8 +3,8 @@ parameters:
   type: object
   default:
     linux: ['3.7']
-    osx: ['3.7']
-    windows: ['3.7']
+    #osx: ['3.7']
+    #windows: ['3.7']
 - name: 'settings'
   type: object
   default:

--- a/.azure-pipelines/templates/stages.yml
+++ b/.azure-pipelines/templates/stages.yml
@@ -33,6 +33,9 @@ parameters:
 - name: verbose
   type: boolean
   default: false
+- name: publish_docs
+  type: boolean
+  default: true
 
 stages:
   - template: code_quality_checks.yml
@@ -65,6 +68,7 @@ stages:
         image: ${{ parameters.settings.linux.image }}
         release: ${{ parameters.release }}
         conda_label: ${{ parameters.conda_label }}
+        publish_docs: ${{ parameters.publish_docs }}
         package_list:
           ${{ each os in parameters.py_versions }}:
             ${{ each py in os.Value }}:

--- a/.azure-pipelines/templates/stages.yml
+++ b/.azure-pipelines/templates/stages.yml
@@ -3,8 +3,8 @@ parameters:
   type: object
   default:
     linux: ['3.7']
-    #osx: ['3.7']
-    #windows: ['3.7']
+    osx: ['3.7']
+    windows: ['3.7']
 - name: 'settings'
   type: object
   default:


### PR DESCRIPTION
We have historically needed long-running development branches (similar to `main`) to accommodate major changes, such as the recent `dev` branch for shallow copies.

This small changes demonstrates that we can utilise much of the existing infrastructure for this with a small change to prevent publication of latest documentation.

1. We can use full ci to do full integration testing on accumulated changes on the branch across all platforms (and docs), not just PR by PR. We can also merge in changes from `main` and check those if required.
1. Publishing to some other label i.e `next` (as done below) allow us to test and work on downstream projects such as scippneutron ahead of the next upstream release. `next` seems to be a convenient label to use for the channel.

* See example "Next" pipeline. built from `next.yml`
* **Note that the next pipeline and file should be removed before these changes are merged**
