### PR TITLE
Copy bug

### DIFF
--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -23,7 +23,7 @@ void Dataset::clear() {
 
 void Dataset::setCoords(Coords other) {
   scipp::expect::contains(other.sizes(), m_coords.sizes());
-  m_coords = other;
+  m_coords = std::move(other);
 }
 /// Return a const view to all coordinates of the dataset.
 const Coords &Dataset::coords() const noexcept { return m_coords; }

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -21,6 +21,10 @@ void Dataset::clear() {
   rebuildDims();
 }
 
+void Dataset::setCoords(Coords other) {
+  scipp::expect::contains(other.sizes(), m_coords.sizes());
+  m_coords = other;
+}
 /// Return a const view to all coordinates of the dataset.
 const Coords &Dataset::coords() const noexcept { return m_coords; }
 

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -55,6 +55,8 @@ public:
       setCoord(dim, std::move(coord));
   }
 
+  void setCoords(Coords other);
+
   /// Return the number of data items in the dataset.
   ///
   /// This does not include coordinates or attributes, but only all named

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -49,7 +49,7 @@ DataArray copy(const DataArray &array, const AttrPolicy attrPolicy) {
 
 /// Return a deep copy of a Dataset.
 Dataset copy(const Dataset &dataset, const AttrPolicy attrPolicy) {
-  Dataset out({}, copy(dataset.coords()));
+  Dataset out{};
   for (const auto &item : dataset)
     out.setData(item.name(), copy(item, attrPolicy));
   return out;

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -50,8 +50,10 @@ DataArray copy(const DataArray &array, const AttrPolicy attrPolicy) {
 /// Return a deep copy of a Dataset.
 Dataset copy(const Dataset &dataset, const AttrPolicy attrPolicy) {
   Dataset out{};
-  for (const auto &item : dataset)
+  out.setCoords(copy(dataset.coords()));
+  for (const auto &item : dataset) {
     out.setData(item.name(), copy(item, attrPolicy));
+  }
   return out;
 }
 

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -230,6 +230,7 @@ TEST(ConcatenateTest, concat_2d_coord) {
       makeVariable<bool>(Dims{Dim::X}, Shape{3}, Values{false, true, false}));
 
   Dataset b = copy(a);
+  EXPECT_EQ(a, b);
   b.coords()[Dim::X] += 3 * units::one;
   b["data_1"].data() += 100 * units::one;
 

--- a/dataset/test/copy_test.cpp
+++ b/dataset/test/copy_test.cpp
@@ -22,9 +22,23 @@ protected:
   DataArray array;
   Variable attr = makeVariable<double>(Values{1});
 };
-
 TEST_F(CopyTest, data_array) { EXPECT_EQ(copy(array), array); }
 TEST_F(CopyTest, dataset) { EXPECT_EQ(copy(dataset), dataset); }
+DataArray make_dataarray_with_bin_edges() {
+  return DataArray(makeVariable<double>(Dimensions{Dim::X, 2}, Values({0, 1})),
+                   {{Dim::X, makeVariable<double>(Dimensions{Dim::X, 3},
+                                                  Values({0, 1, 2}))}});
+}
+TEST_F(CopyTest, dataarray_with_bin_edge_coord) {
+  auto a = make_dataarray_with_bin_edges();
+  auto b = copy(a);
+  EXPECT_EQ(a, b);
+}
+TEST_F(CopyTest, dataset_with_bin_edge_coord) {
+  auto a = Dataset{make_dataarray_with_bin_edges()};
+  auto b = copy(a);
+  EXPECT_EQ(a, b);
+}
 
 TEST_F(CopyTest, data_array_drop_attrs) {
   auto copied = copy(array, AttrPolicy::Drop);

--- a/dataset/test/copy_test.cpp
+++ b/dataset/test/copy_test.cpp
@@ -38,6 +38,10 @@ TEST_F(CopyTest, dataset_with_bin_edge_coord) {
   auto a = Dataset{make_dataarray_with_bin_edges()};
   auto b = copy(a);
   EXPECT_EQ(a, b);
+  for (const auto &[dim, item] : b.coords()) {
+    EXPECT_NE(a.coords().at(dim).values<double>().data(),
+              item.values<double>().data());
+  }
 }
 
 TEST_F(CopyTest, data_array_drop_attrs) {


### PR DESCRIPTION
Found bug while getting `scippneutron` working with shallow-copy changes:

```python
import scipp as sc
import numpy as np

ds = sc.Dataset(
        data={'a':sc.DataArray(data=sc.Variable(['tof'], values=np.arange(10)),
        coords={'tof': sc.Variable(['tof'], values=np.arange(11))})})
ds.copy()
```
```bash
DimensionError: Inconsistent size for dim 'tof', given 11, requested 10
```
