### PR TITLE
Variable API cleanup

### DIFF
--- a/dataset/arithmetic.cpp
+++ b/dataset/arithmetic.cpp
@@ -79,7 +79,7 @@ decltype(auto) apply_with_delay(const Op &op, A &&a, const B &b) {
     else
       op(item, b);
   }
-  if (delayed)
+  if (delayed.is_valid())
     op(delayed, b);
   return std::forward<A>(a);
 }

--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -417,7 +417,7 @@ public:
     auto [begin, end] = unzip(begin_end);
     for (const auto dim : dims.labels()) {
       auto mask = irreducible_mask(masks, dim);
-      if (mask) {
+      if (mask.is_valid()) {
         begin *= ~mask;
         end *= ~mask;
       }
@@ -481,9 +481,9 @@ template Variable concat_bins<DataArray>(const Variable &, const Dim);
 DataArray groupby_concat_bins(const DataArray &array, const Variable &edges,
                               const Variable &groups, const Dim reductionDim) {
   TargetBinBuilder builder;
-  if (edges)
+  if (edges.is_valid())
     builder.bin(edges);
-  if (groups)
+  if (groups.is_valid())
     builder.group(groups);
   builder.erase(reductionDim);
   const auto dims = array.dims();

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -416,7 +416,8 @@ Variable sum(const Variable &data) {
   if (data.dtype() == dtype<bucket<DataArray>>) {
     const auto &&[indices, dim, buffer] =
         data.constituents<bucket<DataArray>>();
-    if (const auto mask_union = irreducible_mask(buffer.masks(), dim)) {
+    if (const auto mask_union = irreducible_mask(buffer.masks(), dim);
+        mask_union.is_valid()) {
       variable::sum_impl(summed, applyMask(buffer, indices, dim, mask_union));
     } else {
       variable::sum_impl(summed, data);

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -34,9 +34,7 @@ public:
   DataArray &operator=(const DataArray &other);
   DataArray &operator=(DataArray &&other) = default;
 
-  explicit operator bool() const noexcept {
-    return m_data && m_data->operator bool();
-  }
+  bool is_valid() const noexcept { return m_data && m_data->is_valid(); }
 
   const std::string &name() const;
   void setName(std::string_view name);

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -188,7 +188,7 @@ template <class Masks>
   Variable union_;
   for (const auto &mask : masks)
     if (mask.second.dims().contains(dim))
-      union_ = union_ ? union_ | mask.second : copy(mask.second);
+      union_ = union_.is_valid() ? union_ | mask.second : copy(mask.second);
   return union_;
 }
 

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -107,7 +107,7 @@ Dataset copy(const Dataset &dataset, Dataset &&out,
 /// Only in the latter case a copy is returned.
 Variable masked_data(const DataArray &array, const Dim dim) {
   const auto mask = irreducible_mask(array.masks(), dim);
-  if (mask)
+  if (mask.is_valid())
     return array.data() * ~mask;
   else
     return array.data();

--- a/dataset/test/string_test.cpp
+++ b/dataset/test/string_test.cpp
@@ -11,7 +11,7 @@ using namespace scipp::dataset;
 
 TEST(StringTest, null_variable) {
   Variable var;
-  ASSERT_FALSE(var);
+  ASSERT_FALSE(var.is_valid());
   ASSERT_NO_THROW(to_string(var));
 }
 

--- a/dataset/variable_reduction.cpp
+++ b/dataset/variable_reduction.cpp
@@ -16,7 +16,8 @@
 namespace scipp::dataset {
 
 Variable sum(const Variable &var, const Dim dim, const Masks &masks) {
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     return sum(masked_to_zero(var, mask_union), dim);
   }
   return sum(var, dim);
@@ -24,14 +25,16 @@ Variable sum(const Variable &var, const Dim dim, const Masks &masks) {
 
 Variable &sum(const Variable &var, const Dim dim, const Masks &masks,
               Variable &out) {
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     return sum(masked_to_zero(var, mask_union), dim, out);
   }
   return sum(var, dim, out);
 }
 
 Variable nansum(const Variable &var, const Dim dim, const Masks &masks) {
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     return nansum(masked_to_zero(var, mask_union), dim);
   }
   return nansum(var, dim);
@@ -39,14 +42,16 @@ Variable nansum(const Variable &var, const Dim dim, const Masks &masks) {
 
 Variable &nansum(const Variable &var, const Dim dim, const Masks &masks,
                  Variable &out) {
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     return nansum(masked_to_zero(var, mask_union), dim, out);
   }
   return nansum(var, dim, out);
 }
 
 Variable mean(const Variable &var, const Dim dim, const Masks &masks) {
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     return mean_impl(masked_to_zero(var, mask_union), dim,
                      sum(~mask_union, dim));
   }
@@ -55,7 +60,8 @@ Variable mean(const Variable &var, const Dim dim, const Masks &masks) {
 
 Variable nanmean(const Variable &var, const Dim dim, const Masks &masks) {
   using variable::isfinite;
-  if (const auto mask_union = irreducible_mask(masks, dim)) {
+  if (const auto mask_union = irreducible_mask(masks, dim);
+      mask_union.is_valid()) {
     const auto count = sum(masked_to_zero(isfinite(var), mask_union), dim);
     return nanmean_impl(masked_to_zero(var, mask_union), dim, count);
   }

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -221,5 +221,11 @@ void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
   if constexpr (std::is_same_v<T, Dataset>) {
     c.def("__getitem__", &slicer<T>::get_by_value);
     c.def("__setitem__", &slicer<T>::template set_by_value<Dataset>);
+  } else {
+    c.def("__len__", [](const T &self) {
+      if (self.dims().ndim() == 0)
+        throw except::TypeError("len() of unsized object");
+      return self.dims().size(0);
+    });
   }
 }

--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -382,7 +382,7 @@ def _mapping_section(mapping,
                      details_func=None,
                      max_items_collapse=None,
                      enabled=True):
-    n_items = len(mapping) if hasattr(mapping, "__len__") else 1
+    n_items = 1 if is_data_array(mapping) else len(mapping)
     collapsed = n_items >= max_items_collapse
 
     return collapsible_section(
@@ -469,7 +469,7 @@ def dataset_repr(ds):
     if len(ds.coords) > 0:
         sections.append(coord_section(ds.coords, ds))
 
-    sections.append(data_section(ds if hasattr(ds, '__len__') else {'': ds}))
+    sections.append(data_section(ds if is_dataset(ds) else {'': ds}))
 
     if not is_dataset(ds):
         if len(ds.masks) > 0:

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -76,6 +76,17 @@ def test_init_from_variable_views():
     assert sc.identical(a, c)
 
 
+@pytest.mark.parametrize("make", [lambda x: x, sc.DataArray])
+def test_builtin_len(make):
+    var = sc.Variable(dims=['x', 'y'], shape=[3, 2])
+    obj = make(var)
+    assert len(obj) == 3
+    assert len(obj['x', 0]) == 2
+    assert len(obj['y', 0]) == 3
+    with pytest.raises(TypeError):
+        len(obj['x', 0]['y', 0])
+
+
 def test_coords():
     da = make_dataarray()
     assert len(dict(da.meta)) == 4

--- a/variable/include/scipp/variable/bin_variable.tcc
+++ b/variable/include/scipp/variable/bin_variable.tcc
@@ -68,7 +68,7 @@ public:
           "must be given by shape of `sizes`.");
     const auto [indices, dim, buf] = prototype.constituents<bucket<T>>();
     auto sizes_ = sizes;
-    if (!sizes) {
+    if (!sizes.is_valid()) {
       const auto &[begin, end] = unzip(indices);
       sizes_ = end - begin;
     }

--- a/variable/include/scipp/variable/data_model.h
+++ b/variable/include/scipp/variable/data_model.h
@@ -190,7 +190,7 @@ template <class T> void DataModel<T>::assign(const VariableConcept &other) {
 template <class T> void DataModel<T>::setVariances(const Variable &variances) {
   if (!core::canHaveVariances<T>())
     throw except::VariancesError("This data type cannot have variances.");
-  if (!variances)
+  if (!variances.is_valid())
     return m_variances.reset();
   // TODO Could move if refcount is 1?
   if (variances.hasVariances())

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -59,7 +59,6 @@ public:
   /// should be prefered where possible, since it generates less code.
   template <class... Ts> Variable(const DType &type, Ts &&... args);
 
-  explicit operator bool() const noexcept;
   Variable operator~() const;
 
   units::Unit unit() const;
@@ -132,6 +131,7 @@ public:
 
   [[nodiscard]] Variable transpose(const std::vector<Dim> &order) const;
 
+  bool is_valid() const noexcept;
   bool is_slice() const;
   bool is_readonly() const noexcept;
   bool is_same(const Variable &other) const noexcept;
@@ -188,7 +188,7 @@ Variable Variable::construct(const DType &type, Args &&... args) {
                       ? makeVariable<Ts>(std::forward<Args>(args)...)
                       : Variable()...};
   for (auto &var : vars)
-    if (var)
+    if (var.is_valid())
       return std::move(var);
   throw except::TypeError("Unsupported dtype for constructing a Variable: " +
                           to_string(type));

--- a/variable/include/scipp/variable/variable_factory.h
+++ b/variable/include/scipp/variable/variable_factory.h
@@ -75,7 +75,7 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   Variable empty_like(const Variable &prototype,
                       const std::optional<Dimensions> &shape,
                       const Variable &sizes) const override {
-    if (sizes)
+    if (sizes.is_valid())
       throw except::TypeError(
           "Cannot specify sizes in `empty_like` for non-bin prototype.");
     return create(prototype.dtype(), shape ? *shape : prototype.dims(),

--- a/variable/slice.cpp
+++ b/variable/slice.cpp
@@ -73,18 +73,18 @@ std::tuple<Dim, scipp::index> get_slice_params(const Dimensions &dims,
 std::tuple<Dim, scipp::index, scipp::index>
 get_slice_params(const Dimensions &dims, const Variable &coord_,
                  const Variable &begin, const Variable &end) {
-  if (begin)
+  if (begin.is_valid())
     core::expect::equals(begin.dims(), Dimensions{});
-  if (end)
+  if (end.is_valid())
     core::expect::equals(end.dims(), Dimensions{});
   const auto dim = coord_.dims().inner();
   const auto &[coord, ascending] = get_coord(coord_, dim);
   scipp::index first = 0;
   scipp::index last = dims[dim];
   const auto bin_edges = last + 1 == coord.dims()[dim];
-  if (begin)
+  if (begin.is_valid())
     first = get_index(coord, dim, begin, ascending, bin_edges);
-  if (end)
+  if (end.is_valid())
     last = get_index(coord, dim, end, ascending, bin_edges);
   // Note: Here the bin containing `end` is included
   return {dim, first, std::min(dims[dim], last + (bin_edges ? 1 : 0))};

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -72,7 +72,7 @@ auto apply(const DType dtype, Args &&... args) {
 
 std::string format_variable(const std::string &key, const Variable &variable,
                             const std::optional<Dimensions> datasetDims) {
-  if (!variable)
+  if (!variable.is_valid())
     return std::string(tab) + "invalid variable\n";
   std::stringstream s;
   const std::string colSep("  ");

--- a/variable/test/variable_bucket_test.cpp
+++ b/variable/test/variable_bucket_test.cpp
@@ -151,7 +151,7 @@ TEST_F(VariableBinsTest, to_constituents) {
   auto idx_ptr = idx0.values<std::pair<scipp::index, scipp::index>>().data();
   auto buf_ptr = buf0.values<double>().data();
   auto [idx1, dim1, buf1] = var.to_constituents<bucket<Variable>>();
-  EXPECT_FALSE(var);
+  EXPECT_FALSE(var.is_valid());
   EXPECT_EQ((idx1.values<std::pair<scipp::index, scipp::index>>().data()),
             idx_ptr);
   EXPECT_EQ(buf1.values<double>().data(), buf_ptr);

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -18,7 +18,7 @@ using namespace scipp;
 TEST(Variable, construct_default) {
   ASSERT_NO_THROW(Variable{});
   Variable var;
-  ASSERT_FALSE(var);
+  ASSERT_FALSE(var.is_valid());
 }
 
 TEST(Variable, construct) {
@@ -46,7 +46,7 @@ TEST(Variable, construct_fail) {
 TEST(Variable, move) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{2});
   Variable moved(std::move(var));
-  EXPECT_FALSE(var);
+  EXPECT_FALSE(var.is_valid());
   EXPECT_NE(moved, var);
 }
 


### PR DESCRIPTION
- Fixes #1741.
- Fixes #448. Not added on the C++ side since I see little use for it. Added `__len__` for consistency with numpy and xarray. Note that `__len__` is undefined for `Dataset` since it has no defined dimension order.