### PR TITLE
Avoid near-global inclusion of Eigen/Core 

### DIFF
--- a/core/include/scipp/core/array_to_string.h
+++ b/core/include/scipp/core/array_to_string.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <Eigen/Core>
+
+#include "scipp/units/unit.h"
+
+#include "scipp/core/string.h"
+
+namespace scipp::core {
+
+template <class T>
+std::string
+array_to_string(const T &arr,
+                const std::optional<units::Unit> &unit = std::nullopt);
+
+template <class T>
+std::string
+element_to_string(const T &item,
+                  const std::optional<units::Unit> &unit = std::nullopt) {
+  using core::to_string;
+  using std::to_string;
+  if constexpr (std::is_same_v<T, std::string>)
+    return {'"' + item + "\", "};
+  else if constexpr (std::is_same_v<T, bool>)
+    return core::to_string(item) + ", ";
+  else if constexpr (std::is_same_v<T, scipp::core::time_point>) {
+    return core::to_string(to_iso_date(item, unit.value())) + ", ";
+  } else if constexpr (std::is_same_v<T, Eigen::Vector3d>)
+    return {"(" + to_string(item[0]) + ", " + to_string(item[1]) + ", " +
+            to_string(item[2]) + "), "};
+  else if constexpr (std::is_same_v<T, Eigen::Matrix3d>)
+    return {"(" + element_to_string(Eigen::Vector3d(item.row(0))) + ", " +
+            element_to_string(Eigen::Vector3d(item.row(1))) + ", " +
+            element_to_string(Eigen::Vector3d(item.row(2))) + "), "};
+  else
+    return to_string(item) + ", ";
+}
+
+template <class T>
+std::string array_to_string(const T &arr,
+                            const std::optional<units::Unit> &unit) {
+  const auto size = scipp::size(arr);
+  if (size == 0)
+    return std::string("[]");
+  std::string s = "[";
+  for (scipp::index i = 0; i < scipp::size(arr); ++i) {
+    if (i == 2 && size > 4) {
+      s += "..., ";
+      i = size - 2;
+    }
+    s += element_to_string(arr[i], unit);
+  }
+  s.resize(s.size() - 2);
+  s += "]";
+  return s;
+}
+
+} // namespace scipp::core

--- a/core/include/scipp/core/dtype.h
+++ b/core/include/scipp/core/dtype.h
@@ -3,7 +3,6 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
-#include <Eigen/Core>
 #include <unordered_map>
 
 #include "scipp-core_export.h"
@@ -41,8 +40,6 @@ template <> inline constexpr DType dtype<int32_t>{4};
 template <> inline constexpr DType dtype<bool>{5};
 template <> inline constexpr DType dtype<std::string>{6};
 template <> inline constexpr DType dtype<time_point>{7};
-template <> inline constexpr DType dtype<Eigen::Vector3d>{8};
-template <> inline constexpr DType dtype<Eigen::Matrix3d>{9};
 class SubbinSizes;
 template <> inline constexpr DType dtype<SubbinSizes>{10};
 // span<T> start at 100
@@ -53,7 +50,6 @@ template <> inline constexpr DType dtype<span<const int32_t>>{103};
 template <> inline constexpr DType dtype<span<const bool>>{104};
 template <> inline constexpr DType dtype<span<const std::string>>{105};
 template <> inline constexpr DType dtype<span<const time_point>>{106};
-template <> inline constexpr DType dtype<span<const Eigen::Vector3d>>{107};
 // span<inline const T> start at 200
 template <> inline constexpr DType dtype<span<double>>{200};
 template <> inline constexpr DType dtype<span<float>>{201};
@@ -62,7 +58,6 @@ template <> inline constexpr DType dtype<span<int32_t>>{203};
 template <> inline constexpr DType dtype<span<bool>>{204};
 template <> inline constexpr DType dtype<span<std::string>>{205};
 template <> inline constexpr DType dtype<span<time_point>>{206};
-template <> inline constexpr DType dtype<span<Eigen::Vector3d>>{207};
 // std containers start at 300
 template <> inline constexpr DType dtype<std::pair<int32_t, int32_t>>{300};
 template <> inline constexpr DType dtype<std::pair<int64_t, int64_t>>{301};
@@ -99,6 +94,7 @@ inline constexpr DType dtype<std::unordered_map<core::time_point, int32_t>>{
 // scipp::variable types start at 1000
 // scipp::dataset types start at 2000
 // scipp::python types start at 3000
+// Eigen types start at 4000
 // User types should start at 10000
 
 SCIPP_CORE_EXPORT bool isInt(DType tp);

--- a/core/include/scipp/core/eigen.h
+++ b/core/include/scipp/core/eigen.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+#include <Eigen/Core>
+
+#include "scipp/core/dtype.h"
+
+namespace scipp::core {
+
+template <> inline constexpr DType dtype<Eigen::Vector3d>{4000};
+template <> inline constexpr DType dtype<Eigen::Matrix3d>{4001};
+template <> inline constexpr DType dtype<span<const Eigen::Vector3d>>{4100};
+template <> inline constexpr DType dtype<span<Eigen::Vector3d>>{4200};
+
+} // namespace scipp::core

--- a/core/include/scipp/core/element/arithmetic.h
+++ b/core/include/scipp/core/element/arithmetic.h
@@ -4,10 +4,9 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <Eigen/Core>
-
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/subbin_sizes.h"
 #include "scipp/core/transform_common.h"
@@ -62,6 +61,10 @@ constexpr auto times_equals =
     overloaded{mul_inplace_types, [](auto &&a, const auto &b) { a *= b; }};
 constexpr auto divide_equals =
     overloaded{div_inplace_types, [](auto &&a, const auto &b) { a /= b; }};
+
+using arithmetic_and_matrix_type_pairs = decltype(
+    std::tuple_cat(std::declval<arithmetic_type_pairs>(),
+                   std::tuple<std::tuple<Eigen::Vector3d, Eigen::Vector3d>>()));
 
 struct add_types_t {
   constexpr void operator()() const noexcept;

--- a/core/include/scipp/core/element/bin.h
+++ b/core/include/scipp/core/element/bin.h
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/element/util.h"
 #include "scipp/core/histogram.h"

--- a/core/include/scipp/core/element/creation.h
+++ b/core/include/scipp/core/element/creation.h
@@ -8,6 +8,7 @@
 
 #include "scipp/common/initialization.h"
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/subbin_sizes.h"
 #include "scipp/core/transform_common.h"

--- a/core/include/scipp/core/element/geometric_operations.h
+++ b/core/include/scipp/core/element/geometric_operations.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 

--- a/core/include/scipp/core/element/math.h
+++ b/core/include/scipp/core/element/math.h
@@ -6,9 +6,8 @@
 
 #include <cmath>
 
-#include <Eigen/Core>
-
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 

--- a/core/include/scipp/core/element/special_values.h
+++ b/core/include/scipp/core/element/special_values.h
@@ -9,6 +9,7 @@
 
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/transform_common.h"
 

--- a/core/include/scipp/core/has_eval.h
+++ b/core/include/scipp/core/has_eval.h
@@ -6,13 +6,10 @@
 
 namespace scipp::core {
 
-template <class T> struct has_eval {
-  template <class U>
-  static auto test(int) -> decltype(std::declval<U>().eval(), std::true_type());
-  template <class> static std::false_type test(...);
-  static constexpr bool value =
-      std::is_same<decltype(test<T>(0)), std::true_type>::value;
-};
+template <class T, class = void> struct has_eval : std::false_type {};
+template <class T>
+struct has_eval<T, std::void_t<decltype(std::declval<T>().eval())>>
+    : std::true_type {};
 
 /// True if T has an eval() method. Used by `transform` to detect expression
 /// templates (from Eigen).

--- a/core/include/scipp/core/has_eval.h
+++ b/core/include/scipp/core/has_eval.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+namespace scipp::core {
+
+template <class T> struct has_eval {
+  template <class U>
+  static auto test(int) -> decltype(std::declval<U>().eval(), std::true_type());
+  template <class> static std::false_type test(...);
+  static constexpr bool value =
+      std::is_same<decltype(test<T>(0)), std::true_type>::value;
+};
+
+/// True if T has an eval() method. Used by `transform` to detect expression
+/// templates (from Eigen).
+template <class T> inline constexpr bool has_eval_v = has_eval<T>::value;
+
+} // namespace scipp::core

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -8,8 +8,6 @@
 #include <optional>
 #include <string>
 
-#include <Eigen/Core>
-
 #include "scipp/units/unit.h"
 
 #include "scipp-core_export.h"
@@ -56,59 +54,12 @@ std::string to_string(const MutableView<T, U> &mutableView) {
   return ss.str();
 }
 
-template <class T>
-std::string
-array_to_string(const T &arr,
-                const std::optional<units::Unit> &unit = std::nullopt);
-
 // Format a time point according to ISO 8601 including sub-second precision
 // depending on the unit.
 // No timezone conversion is performed and the result does not show a
 // timezone offset.
 SCIPP_CORE_EXPORT std::string to_iso_date(const scipp::core::time_point &item,
                                           const units::Unit &unit);
-
-template <class T>
-std::string
-element_to_string(const T &item,
-                  const std::optional<units::Unit> &unit = std::nullopt) {
-  using core::to_string;
-  using std::to_string;
-  if constexpr (std::is_same_v<T, std::string>)
-    return {'"' + item + "\", "};
-  else if constexpr (std::is_same_v<T, bool>)
-    return core::to_string(item) + ", ";
-  else if constexpr (std::is_same_v<T, scipp::core::time_point>) {
-    return core::to_string(to_iso_date(item, unit.value())) + ", ";
-  } else if constexpr (std::is_same_v<T, Eigen::Vector3d>)
-    return {"(" + to_string(item[0]) + ", " + to_string(item[1]) + ", " +
-            to_string(item[2]) + "), "};
-  else if constexpr (std::is_same_v<T, Eigen::Matrix3d>)
-    return {"(" + element_to_string(Eigen::Vector3d(item.row(0))) + ", " +
-            element_to_string(Eigen::Vector3d(item.row(1))) + ", " +
-            element_to_string(Eigen::Vector3d(item.row(2))) + "), "};
-  else
-    return to_string(item) + ", ";
-}
-
-template <class T>
-std::string array_to_string(const T &arr,
-                            const std::optional<units::Unit> &unit) {
-  const auto size = scipp::size(arr);
-  if (size == 0)
-    return std::string("[]");
-  std::string s = "[";
-  for (scipp::index i = 0; i < scipp::size(arr); ++i) {
-    if (i == 2 && size > 4) {
-      s += "..., ";
-      i = size - 2;
-    }
-    s += element_to_string(arr[i], unit);
-  }
-  s.resize(s.size() - 2);
-  s += "]";
-  return s;
-}
 
 /// Return the global dtype name registry instance
 SCIPP_CORE_EXPORT std::map<DType, std::string> &dtypeNameRegistry();

--- a/core/include/scipp/core/string.h
+++ b/core/include/scipp/core/string.h
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include <iosfwd>
 #include <map>
 #include <optional>
 #include <string>
@@ -19,9 +20,6 @@
 
 namespace scipp::core {
 
-template <class Id, class Key, class Value> class ConstView;
-template <class T, class U> class MutableView;
-
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const Dimensions &dims);
 
@@ -33,26 +31,6 @@ SCIPP_CORE_EXPORT std::string to_string(const DType dtype);
 SCIPP_CORE_EXPORT std::string to_string(const Dimensions &dims);
 SCIPP_CORE_EXPORT std::string to_string(const Slice &slice);
 SCIPP_CORE_EXPORT std::string to_string(const scipp::index_pair &index);
-
-template <class Id, class Key, class Value>
-std::string to_string(const ConstView<Id, Key, Value> &view) {
-  std::stringstream ss;
-
-  for (const auto &[key, item] : view) {
-    ss << "<scipp.ConstView> (" << key << "):\n" << to_string(item);
-  }
-  return ss.str();
-}
-
-template <class T, class U>
-std::string to_string(const MutableView<T, U> &mutableView) {
-  std::stringstream ss;
-
-  for (const auto &[key, item] : mutableView) {
-    ss << "<scipp.MutableView> (" << key << "):\n" << to_string(item);
-  }
-  return ss.str();
-}
 
 // Format a time point according to ISO 8601 including sub-second precision
 // depending on the unit.

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/core/value_and_variance.h"
 #include "scipp/core/values_and_variances.h"

--- a/core/include/scipp/core/transform_common.h
+++ b/core/include/scipp/core/transform_common.h
@@ -7,7 +7,6 @@
 #include <tuple>
 
 #include "scipp/common/overloaded.h"
-#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/core/value_and_variance.h"
 #include "scipp/core/values_and_variances.h"
@@ -41,10 +40,6 @@ using arithmetic_type_pairs = pair_product_t<float, double, int32_t, int64_t>;
 using arithmetic_type_pairs_with_bool =
     decltype(std::tuple_cat(std::declval<arithmetic_type_pairs>(),
                             std::declval<pair_numerical_with_t<bool>>()));
-
-using arithmetic_and_matrix_type_pairs = decltype(
-    std::tuple_cat(std::declval<arithmetic_type_pairs>(),
-                   std::tuple<std::tuple<Eigen::Vector3d, Eigen::Vector3d>>()));
 
 static constexpr auto keep_unit =
     overloaded{[](const units::Unit &) {},

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_dependencies(all-tests ${TARGET_NAME})
 add_executable(
   ${TARGET_NAME} EXCLUDE_FROM_ALL
   dimensions_test.cpp
+  eigen_test.cpp
   element_array_test.cpp
   element_array_view_test.cpp
   element_arithmetic_test.cpp

--- a/core/test/eigen_test.cpp
+++ b/core/test/eigen_test.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/eigen.h"
+#include "scipp/core/has_eval.h"
+
+using namespace scipp::core;
+
+TEST(EigenTest, has_eval) {
+  // has_eval is used in variable/transform.h to detect Eigen types, ensure it
+  // works for all types we use. Currently only Vector3d and Matrix3d.
+  Eigen::Vector3d vec;
+  ASSERT_FALSE(has_eval_v<double>);
+  ASSERT_TRUE(has_eval_v<Eigen::Vector3d>);
+  ASSERT_TRUE(has_eval_v<Eigen::Matrix3d>);
+  ASSERT_TRUE(has_eval_v<std::decay_t<decltype(vec + vec)>>);
+}

--- a/dataset/include/scipp/dataset/string.h
+++ b/dataset/include/scipp/dataset/string.h
@@ -23,15 +23,7 @@ SCIPP_DATASET_EXPORT std::ostream &operator<<(std::ostream &os,
 
 SCIPP_DATASET_EXPORT std::string to_string(const DataArray &data);
 SCIPP_DATASET_EXPORT std::string to_string(const Dataset &dataset);
-
-template <class Key, class Value>
-std::string to_string(const Dict<Key, Value> &view) {
-  std::stringstream ss;
-  ss << "<scipp.Dict>\n";
-  for (const auto &[key, item] : view) {
-    ss << "  " << key << ":" << to_string(item);
-  }
-  return ss.str();
-}
+SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
+SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
 
 } // namespace scipp::dataset

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include <algorithm> // for std::sort
 #include <set>
+#include <sstream>
 
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
@@ -100,5 +101,18 @@ std::string to_string(const DataArray &data) {
 std::string to_string(const Dataset &dataset) {
   return do_to_string(dataset, "<scipp.Dataset>", Dimensions(dataset.sizes()));
 }
+
+template <class Key, class Value>
+std::string dict_to_string(const Dict<Key, Value> &view) {
+  std::stringstream ss;
+  ss << "<scipp.Dict>\n";
+  for (const auto &[key, item] : view) {
+    ss << "  " << key << ":" << to_string(item);
+  }
+  return ss.str();
+}
+
+std::string to_string(const Coords &coords) { return dict_to_string(coords); }
+std::string to_string(const Masks &masks) { return dict_to_string(masks); }
 
 } // namespace scipp::dataset

--- a/dataset/test/size_of_test.cpp
+++ b/dataset/test/size_of_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/core/eigen.h"
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/util.h"

--- a/dataset/variable_instantiate_bin_elements.cpp
+++ b/dataset/variable_instantiate_bin_elements.cpp
@@ -73,15 +73,10 @@ class BinVariableMakerDataset
   }
 };
 
+REGISTER_FORMATTER(bin_DataArray, core::bin<DataArray>)
+REGISTER_FORMATTER(bin_Dataset, core::bin<Dataset>)
+
 namespace {
-auto register_dataset_types(
-    (variable::formatterRegistry().emplace(
-         dtype<bucket<Dataset>>,
-         std::make_unique<variable::Formatter<bucket<Dataset>>>()),
-     variable::formatterRegistry().emplace(
-         dtype<bucket<DataArray>>,
-         std::make_unique<variable::Formatter<bucket<DataArray>>>()),
-     0));
 auto register_variable_maker_bucket_DataArray(
     (variable::variableFactory().emplace(
          dtype<bucket<DataArray>>,

--- a/dataset/variable_instantiate_dataset.cpp
+++ b/dataset/variable_instantiate_dataset.cpp
@@ -15,15 +15,6 @@ INSTANTIATE_VARIABLE(DataArray, scipp::dataset::DataArray)
 } // namespace scipp::variable
 
 namespace scipp::dataset {
-namespace {
-// Insert classes from scipp::dataset into formatting registry. The objects
-// themselves do nothing, but the constructor call with comma operator does the
-// insertion.
-auto register_dataset_types(
-    (variable::formatterRegistry().emplace(
-         dtype<Dataset>, std::make_unique<variable::Formatter<Dataset>>()),
-     variable::formatterRegistry().emplace(
-         dtype<DataArray>, std::make_unique<variable::Formatter<DataArray>>()),
-     0));
-} // namespace
+REGISTER_FORMATTER(DataArray, DataArray)
+REGISTER_FORMATTER(Dataset, Dataset)
 } // namespace scipp::dataset

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -7,6 +7,7 @@
 #include <variant>
 
 #include "scipp/core/dtype.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/tag_util.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"

--- a/python/element_array_view.cpp
+++ b/python/element_array_view.cpp
@@ -3,7 +3,9 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/core/element_array_view.h"
+#include "scipp/core/array_to_string.h"
 #include "scipp/core/dtype.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"

--- a/python/variable_instantiate_py_object.cpp
+++ b/python/variable_instantiate_py_object.cpp
@@ -15,13 +15,5 @@ INSTANTIATE_VARIABLE(PyObject, scipp::python::PyObject)
 } // namespace scipp::variable
 
 namespace scipp::python {
-namespace {
-// Insert classes from scipp::python into formatting registry. The objects
-// themselves do nothing, but the constructor call with comma operator does the
-// insertion.
-auto register_python_types(
-    (variable::formatterRegistry().emplace(
-         dtype<PyObject>, std::make_unique<variable::Formatter<PyObject>>()),
-     0));
-} // namespace
+REGISTER_FORMATTER(PyObject, PyObject)
 } // namespace scipp::python

--- a/variable/include/scipp/variable/string.h
+++ b/variable/include/scipp/variable/string.h
@@ -40,9 +40,7 @@ public:
 /// Concrete class for formatting variables with element types not in
 /// scipp-variable.
 template <class T> class Formatter : public AbstractFormatter {
-  std::string format(const Variable &var) const override {
-    return array_to_string(var.template values<T>());
-  }
+  std::string format(const Variable &var) const override;
 };
 
 /// Registry of formatters.

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -36,6 +36,7 @@
 
 #include "scipp/common/overloaded.h"
 
+#include "scipp/core/has_eval.h"
 #include "scipp/core/multi_index.h"
 #include "scipp/core/parallel.h"
 #include "scipp/core/transform_common.h"
@@ -70,12 +71,6 @@ static constexpr decltype(auto) value_maybe_variance(T &&range,
     return range.data()[i];
   }
 }
-
-template <class T> struct is_eigen_type : std::false_type {};
-template <class T, int Rows, int Cols>
-struct is_eigen_type<Eigen::Matrix<T, Rows, Cols>> : std::true_type {};
-template <class T>
-inline constexpr bool is_eigen_type_v = is_eigen_type<T>::value;
 
 // Helpers for handling a tuple of indices (integers or ViewIndex).
 namespace iter {
@@ -290,12 +285,8 @@ static void transform_elements(Op op, Out &&out, Ts &&... other) {
                                run_parallel);
 }
 
-template <class T>
-struct is_eigen_expression
-    : std::is_base_of<Eigen::MatrixBase<std::decay_t<T>>, std::decay_t<T>> {};
-
 template <class T> static constexpr auto maybe_eval(T &&_) {
-  if constexpr (is_eigen_expression<T>::value)
+  if constexpr (core::has_eval_v<std::decay_t<T>>)
     return _.eval();
   else
     return std::forward<T>(_);
@@ -424,7 +415,7 @@ struct tuple_cat<C<Ts1...>, C<Ts2...>, Ts3...>
 template <class Op> struct wrap_eigen : Op {
   const Op &base_op() const noexcept { return *this; }
   template <class... Ts> constexpr auto operator()(Ts &&... args) const {
-    if constexpr ((is_eigen_type_v<std::decay_t<Ts>> || ...))
+    if constexpr ((core::has_eval_v<std::decay_t<Ts>> || ...))
       // WARNING! The explicit specification of the template arguments of
       // operator() is EXTREMELY IMPORTANT. It ensures that Eigen types are
       // passed BY REFERENCE and NOT BY VALUE. Passing by value leads to

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Core>
-
 #include "scipp-variable_export.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
@@ -196,9 +194,9 @@ Variable Variable::construct(const DType &type, Args &&... args) {
 
 template <class... Ts>
 Variable::Variable(const DType &type, Ts &&... args)
-    : Variable{construct<double, float, int64_t, int32_t, bool, Eigen::Vector3d,
-                         Eigen::Matrix3d, std::string, scipp::core::time_point>(
-          type, std::forward<Ts>(args)...)} {}
+    : Variable{construct<double, float, int64_t, int32_t, bool, std::string,
+                         scipp::core::time_point>(type,
+                                                  std::forward<Ts>(args)...)} {}
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable copy(const Variable &var);
 [[maybe_unused]] SCIPP_VARIABLE_EXPORT Variable &copy(const Variable &var,

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/array_to_string.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/element_array_view.h"
 #include "scipp/core/except.h"
@@ -60,9 +61,13 @@ template <class T> ElementArrayView<T> Variable::variances() {
   Variable::variances() const;                                                 \
   template SCIPP_EXPORT ElementArrayView<__VA_ARGS__> Variable::variances();
 
-// Insert classes into formatting registry. The objects themselves do nothing,
-// but the constructor call with comma operator does the insertion. Calling this
-// is required for formatting all but basic builtin types.
+template <class T> std::string Formatter<T>::format(const Variable &var) const {
+  return array_to_string(var.template values<T>());
+}
+
+/// Insert classes into formatting registry. The objects themselves do nothing,
+/// but the constructor call with comma operator does the insertion. Calling
+/// this is required for formatting all but basic builtin types.
 #define REGISTER_FORMATTER(name, ...)                                          \
   namespace {                                                                  \
   auto register_##name(                                                        \

--- a/variable/include/scipp/variable/variable.tcc
+++ b/variable/include/scipp/variable/variable.tcc
@@ -60,4 +60,16 @@ template <class T> ElementArrayView<T> Variable::variances() {
   Variable::variances() const;                                                 \
   template SCIPP_EXPORT ElementArrayView<__VA_ARGS__> Variable::variances();
 
+// Insert classes into formatting registry. The objects themselves do nothing,
+// but the constructor call with comma operator does the insertion. Calling this
+// is required for formatting all but basic builtin types.
+#define REGISTER_FORMATTER(name, ...)                                          \
+  namespace {                                                                  \
+  auto register_##name(                                                        \
+      (variable::formatterRegistry().emplace(                                  \
+           dtype<__VA_ARGS__>,                                                 \
+           std::make_unique<variable::Formatter<__VA_ARGS__>>()),              \
+       0));                                                                    \
+  }
+
 } // namespace scipp::variable

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -8,6 +8,7 @@
 
 #include "scipp/core/array_to_string.h"
 #include "scipp/core/bucket_array_view.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/string.h"
 #include "scipp/core/tag_util.h"
 #include "scipp/variable/string.h"

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <set>
 
+#include "scipp/core/array_to_string.h"
 #include "scipp/core/bucket_array_view.h"
 #include "scipp/core/string.h"
 #include "scipp/core/tag_util.h"

--- a/variable/subspan_view.cpp
+++ b/variable/subspan_view.cpp
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #include "scipp/variable/subspan_view.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/cumulative.h"
 #include "scipp/variable/shape.h"

--- a/variable/test/sum_test.cpp
+++ b/variable/test/sum_test.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/core/eigen.h"
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/string.h"
 #include "scipp/variable/variable.h"

--- a/variable/test/transform_test.cpp
+++ b/variable/test/transform_test.cpp
@@ -5,6 +5,7 @@
 
 #include "test_macros.h"
 
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 
 #include "scipp/variable/arithmetic.h"
@@ -942,11 +943,6 @@ TEST(TransformFlagsTest, expect_no_in_variance_if_out_cannot_have_variance) {
   EXPECT_THROW(out = transform(var_with_variance, op_has_flags),
                except::VariancesError);
   EXPECT_NO_THROW(out = transform(var_no_variance, op_has_flags));
-}
-
-TEST(TransformEigenTest, is_eigen_type_test) {
-  EXPECT_TRUE(scipp::variable::detail::is_eigen_type_v<Eigen::Vector3d>);
-  EXPECT_TRUE(scipp::variable::detail::is_eigen_type_v<Eigen::Matrix3d>);
 }
 
 class TransformBinElementsTest : public ::testing::Test {

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -5,6 +5,7 @@
 
 #include "test_macros.h"
 
+#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/variable.h"
 

--- a/variable/variable_instantiate_basic.cpp
+++ b/variable/variable_instantiate_basic.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include <string>
 
+#include "scipp/core/eigen.h"
 #include "scipp/variable/variable.h"
 #include "scipp/variable/variable.tcc"
 

--- a/variable/variable_instantiate_view_elements.cpp
+++ b/variable/variable_instantiate_view_elements.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/eigen.h"
 #include "scipp/variable/variable.h"
 #include "scipp/variable/variable.tcc"
 


### PR DESCRIPTION
Not sure this makes much of a difference in practice, but it is certainly nicer.

The only change C++ users should see is that `Variable(dtype, ....)` constructor does not support `Eigen` anymore, but in practice this does not appear to be used.

~Note that anything including `transform.h` still includes `Eigen/Core`. In principle we could also avoid this by moving some specializations into an `Eigen`-specific `transform_eigen.h` helper file.~ found a solution now.

Also removed some minor dead formatting code (`ConstView` and `MutableView`).