### PR TITLE
Improve various string formatting problems with variables

### DIFF
--- a/core/string.cpp
+++ b/core/string.cpp
@@ -23,13 +23,13 @@ std::ostream &operator<<(std::ostream &os, const Dimensions &dims) {
 
 std::string to_string(const Dimensions &dims) {
   if (dims.empty())
-    return "{}";
-  std::string s = "{{";
+    return "()";
+  std::string s = "(";
   for (int32_t i = 0; i < scipp::size(dims.shape()); ++i)
-    s += to_string(dims.labels()[i]) + ", " + std::to_string(dims.shape()[i]) +
-         "}, {";
-  s.resize(s.size() - 3);
-  s += "}";
+    s += to_string(dims.labels()[i]) + ": " + std::to_string(dims.shape()[i]) +
+         ", ";
+  s.resize(s.size() - 2);
+  s += ")";
   return s;
 }
 

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -29,7 +29,7 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
 
   for (const auto item : b) {
     if (const auto it = a.find(item.first); it != a.end()) {
-      core::expect::equals(item, *it);
+      expect::matchingCoord(it->first, it->second, item.second);
     } else
       out.emplace(item.first, item.second);
   }

--- a/dataset/except.cpp
+++ b/dataset/except.cpp
@@ -25,17 +25,11 @@ void throw_mismatch_error(const dataset::Dataset &expected,
                      to_string(actual) + '.');
 }
 
-CoordMismatchError::CoordMismatchError(
-    const std::pair<const Dim, Variable> &expected,
-    const std::pair<const Dim, Variable> &actual)
-    : DatasetError{"Mismatch in coordinate, expected " + to_string(expected) +
-                   ", got " + to_string(actual)} {}
-
-template <>
-void throw_mismatch_error(const std::pair<const Dim, Variable> &expected,
-                          const std::pair<const Dim, Variable> &actual) {
-  throw CoordMismatchError(expected, actual);
-}
+CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
+                                       const Variable &actual)
+    : DatasetError{"Mismatch in coordinate '" + to_string(dim) +
+                   "', expected\n" + format_variable(expected) + ", got\n" +
+                   format_variable(actual)} {}
 
 } // namespace scipp::except
 
@@ -43,12 +37,18 @@ namespace scipp::dataset::expect {
 void coordsAreSuperset(const Coords &a_coords, const Coords &b_coords) {
   for (const auto b_coord : b_coords) {
     if (a_coords[b_coord.first] != b_coord.second)
-      throw except::CoordMismatchError(*a_coords.find(b_coord.first), b_coord);
+      throw except::CoordMismatchError(b_coord.first, a_coords[b_coord.first],
+                                       b_coord.second);
   }
 }
 
 void coordsAreSuperset(const DataArray &a, const DataArray &b) {
   coordsAreSuperset(a.coords(), b.coords());
+}
+
+void matchingCoord(const Dim dim, const Variable &a, const Variable &b) {
+  if (a != b)
+    throw except::CoordMismatchError(dim, a, b);
 }
 
 void isKey(const Variable &key) {

--- a/dataset/include/scipp/dataset/except.h
+++ b/dataset/include/scipp/dataset/except.h
@@ -42,14 +42,9 @@ throw_mismatch_error(const dataset::Dataset &expected,
                      const dataset::Dataset &actual);
 
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
-  CoordMismatchError(const std::pair<const Dim, Variable> &expected,
-                     const std::pair<const Dim, Variable> &actual);
+  CoordMismatchError(const Dim dim, const Variable &expected,
+                     const Variable &actual);
 };
-
-template <>
-[[noreturn]] SCIPP_DATASET_EXPORT void
-throw_mismatch_error(const std::pair<const Dim, Variable> &expected,
-                     const std::pair<const Dim, Variable> &actual);
 
 } // namespace scipp::except
 
@@ -58,6 +53,8 @@ namespace scipp::dataset::expect {
 SCIPP_DATASET_EXPORT void coordsAreSuperset(const DataArray &a,
                                             const DataArray &b);
 SCIPP_DATASET_EXPORT void coordsAreSuperset(const Coords &a, const Coords &b);
+SCIPP_DATASET_EXPORT void matchingCoord(const Dim dim, const Variable &a,
+                                        const Variable &b);
 
 SCIPP_DATASET_EXPORT void isKey(const Variable &key);
 

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -3,6 +3,7 @@
 /// @file
 /// @author Simon Heybrock
 #include <algorithm> // for std::sort
+#include <iomanip>
 #include <set>
 #include <sstream>
 
@@ -36,6 +37,17 @@ template <class T> auto sorted(const T &map) {
   return elems;
 }
 
+namespace {
+std::string format_variable(const std::string &key, const Variable &variable,
+                            const std::optional<Dimensions> datasetDims) {
+  std::stringstream s;
+  const std::string colSep("  ");
+  s << tab << std::left << std::setw(24) << key
+    << format_variable(variable, datasetDims);
+  return s.str();
+}
+} // namespace
+
 template <class Key>
 auto format_data_view(const Key &name, const DataArray &data,
                       const Dimensions &datasetDims, const std::string &shift,
@@ -48,12 +60,12 @@ auto format_data_view(const Key &name, const DataArray &data,
   if (!data.masks().empty()) {
     s << header_shift << "Masks:\n";
     for (const auto &[key, var] : sorted(data.masks()))
-      s << data_shift << format_variable(key, var, datasetDims);
+      s << data_shift << format_variable(key, var, datasetDims) << '\n';
   }
   if (!data.attrs().empty()) {
     s << header_shift << "Attributes:\n";
     for (const auto &[key, var] : sorted(data.attrs()))
-      s << data_shift << format_variable(key, var, datasetDims);
+      s << data_shift << format_variable(key, var, datasetDims) << '\n';
   }
   return s.str();
 }
@@ -74,7 +86,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
     else
       map = dataset.coords();
     for (const auto &[name, var] : sorted(map))
-      s << shift << format_variable(name, var, dims);
+      s << shift << format_variable(name, var, dims) << '\n';
   }
 
   if constexpr (std::is_same_v<D, DataArray>) {

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -41,7 +41,6 @@ namespace {
 std::string format_variable(const std::string &key, const Variable &variable,
                             const std::optional<Dimensions> datasetDims) {
   std::stringstream s;
-  const std::string colSep("  ");
   s << tab << std::left << std::setw(24) << key
     << format_variable(variable, datasetDims) << '\n';
   return s.str();

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -43,7 +43,7 @@ std::string format_variable(const std::string &key, const Variable &variable,
   std::stringstream s;
   const std::string colSep("  ");
   s << tab << std::left << std::setw(24) << key
-    << format_variable(variable, datasetDims);
+    << format_variable(variable, datasetDims) << '\n';
   return s.str();
 }
 } // namespace
@@ -60,12 +60,12 @@ auto format_data_view(const Key &name, const DataArray &data,
   if (!data.masks().empty()) {
     s << header_shift << "Masks:\n";
     for (const auto &[key, var] : sorted(data.masks()))
-      s << data_shift << format_variable(key, var, datasetDims) << '\n';
+      s << data_shift << format_variable(key, var, datasetDims);
   }
   if (!data.attrs().empty()) {
     s << header_shift << "Attributes:\n";
     for (const auto &[key, var] : sorted(data.attrs()))
-      s << data_shift << format_variable(key, var, datasetDims) << '\n';
+      s << data_shift << format_variable(key, var, datasetDims);
   }
   return s.str();
 }
@@ -86,7 +86,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
     else
       map = dataset.coords();
     for (const auto &[name, var] : sorted(map))
-      s << shift << format_variable(name, var, dims) << '\n';
+      s << shift << format_variable(name, var, dims);
   }
 
   if constexpr (std::is_same_v<D, DataArray>) {

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -143,7 +143,7 @@ class TestSliceByValue:
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless] = sc.Variable(
                              dims=['x'], values=[6.0, 6.0], unit=sc.units.m)
-        assert str(e_info.value) == 'Expected {{x, 3}} to contain {{x, 2}}.'
+        assert str(e_info.value) == 'Expected (x: 3) to contain (x: 2).'
 
     def test_assign_incompatible_dataarray(self):
         with pytest.raises(RuntimeError):

--- a/variable/except.cpp
+++ b/variable/except.cpp
@@ -11,7 +11,7 @@ VariableError::VariableError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const variable::Variable &expected,
                           const variable::Variable &actual) {
-  throw VariableError("Expected Variable " + to_string(expected) + ", got " +
+  throw VariableError("Expected\n" + to_string(expected) + ", got\n" +
                       to_string(actual) + '.');
 }
 } // namespace scipp::except

--- a/variable/include/scipp/variable/string.h
+++ b/variable/include/scipp/variable/string.h
@@ -26,7 +26,7 @@ SCIPP_VARIABLE_EXPORT std::string
 to_string(const std::pair<std::string, Variable> &attr);
 
 SCIPP_VARIABLE_EXPORT std::string
-format_variable(const std::string &key, const Variable &variable,
+format_variable(const Variable &variable,
                 std::optional<Dimensions> datasetDims = std::nullopt);
 
 /// Abstract base class for formatters for variables with element types not in

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -21,7 +21,6 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable) {
 }
 
 namespace {
-constexpr const char *tab = "  ";
 
 std::string make_dims_labels(const Variable &variable,
                              const std::optional<Dimensions> datasetDims) {
@@ -72,26 +71,27 @@ auto apply(const DType dtype, Args &&... args) {
 }
 } // namespace
 
-std::string format_variable(const std::string &key, const Variable &variable,
+std::string format_variable(const Variable &variable,
                             const std::optional<Dimensions> datasetDims) {
   if (!variable.is_valid())
-    return std::string(tab) + "invalid variable\n";
+    return "invalid variable\n";
   std::stringstream s;
   const std::string colSep("  ");
-  s << tab << std::left << std::setw(24) << key;
-  s << colSep << std::setw(9) << to_string(variable.dtype());
+  if (!datasetDims)
+    s << to_string(variable.dims()) << colSep;
+  s << std::setw(9) << to_string(variable.dtype());
   s << colSep << std::setw(15) << '[' + variable.unit().name() + ']';
-  s << colSep << make_dims_labels(variable, datasetDims);
+  if (datasetDims)
+    s << colSep << make_dims_labels(variable, datasetDims);
   s << colSep;
   s << apply<ValuesToString>(variable.dtype(), variable);
   if (variable.hasVariances())
     s << colSep << apply<VariancesToString>(variable.dtype(), variable);
-  s << '\n';
   return s.str();
 }
 
 std::string to_string(const Variable &variable) {
-  return format_variable(std::string("<scipp.Variable>"), variable);
+  return std::string("<scipp.Variable> ") + format_variable(variable);
 }
 
 std::string to_string(const std::pair<Dim, Variable> &coord) {

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -109,7 +109,7 @@ TEST(Variable, operator_plus_equal_different_dimensions) {
   auto different_dimensions =
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1.1, 2.2});
   EXPECT_THROW_MSG(a += different_dimensions, std::runtime_error,
-                   "Expected {{x, 2}} to contain {{y, 2}}.");
+                   "Expected (x: 2) to contain (y: 2).");
 }
 
 TEST(Variable, operator_plus_equal_different_unit) {
@@ -412,7 +412,7 @@ TEST(VariableView, minus_equals_failures) {
                                   Values{1.0, 2.0, 3.0, 4.0});
 
   EXPECT_THROW_MSG(var -= var.slice({Dim::X, 0, 1}), std::runtime_error,
-                   "Expected {{x, 2}, {y, 2}} to contain {{x, 1}, {y, 2}}.");
+                   "Expected (x: 2, y: 2) to contain (x: 1, y: 2).");
 }
 
 TEST(VariableView, self_overlapping_view_operation) {


### PR DESCRIPTION
- Fixes #1814
- Print dimension extents when printing a variable, previously it listed only dims, not shape.
- Print dimension in "Python style" for consistency, instead of C++ style `{{'x', 4}, {'y', 5}}`.