### PR TITLE
Pin boost 1.75

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,2 +1,5 @@
 python:
   - 3.7
+
+boost:
+  - 1.75 # pinning is temporary solution to issue https://github.com/scipp/scipp/issues/1888

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 requirements:
   build:
-    - boost-cpp
+    - boost-cpp {{ boost }}
     - cmake
     - gxx_linux-64 9.3.* [linux64]
     - git

--- a/scipp-developer-minimal.yml
+++ b/scipp-developer-minimal.yml
@@ -10,7 +10,7 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp
+  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
   - ninja
   - tbb-devel
 

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -9,7 +9,7 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp
+  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
   - ninja
   - tbb-devel
 


### PR DESCRIPTION
Relates to **but does not properly solve** #1888

After packages for this have been obtained, tester should ensure compatibility with `scipp/label/main::mantid-framework` importing `mantid.simpleapi` in an env containing scipp should be sufficient.