### PR TITLE
Fix clang's warnings

### DIFF
--- a/dataset/except.cpp
+++ b/dataset/except.cpp
@@ -41,7 +41,7 @@ void throw_mismatch_error(const std::pair<const Dim, Variable> &expected,
 
 namespace scipp::dataset::expect {
 void coordsAreSuperset(const Coords &a_coords, const Coords &b_coords) {
-  for (const auto b_coord : b_coords) {
+  for (const auto &b_coord : b_coords) {
     if (a_coords[b_coord.first] != b_coord.second)
       throw except::CoordMismatchError(*a_coords.find(b_coord.first), b_coord);
   }

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -71,9 +71,8 @@ Dataset histogram(const Dataset &dataset, const Variable &binEdges) {
 /// Return the dimensions of the given data array that have an "bin edge"
 /// coordinate.
 std::set<Dim> edge_dimensions(const DataArray &a) {
-  const auto coords = a.coords();
   std::set<Dim> dims;
-  for (const auto [d, coord] : a.coords())
+  for (const auto &[d, coord] : a.coords())
     if (a.dims().contains(d) && coord.dims().contains(d) &&
         coord.dims()[d] == a.dims()[d] + 1)
       dims.insert(d);

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -134,13 +134,13 @@ DataArray strip_if_broadcast_along(DataArray &&a, const Dim dim) {
   strip_if_broadcast_along(a.coords(), dim);
   strip_if_broadcast_along(a.masks(), dim);
   strip_if_broadcast_along(a.attrs(), dim);
-  return a;
+  return std::move(a);
 }
 
 Dataset strip_if_broadcast_along(Dataset &&d, const Dim dim) {
   strip_if_broadcast_along(d.coords(), dim);
   strip_if_broadcast_along(d, dim);
-  return d;
+  return std::move(d);
 }
 
 } // namespace scipp::dataset

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -63,7 +63,7 @@ void copy_item(const DataArray &from, T &&to, const AttrPolicy attrPolicy) {
   for (const auto &[name, mask] : from.masks())
     copy(mask, to.masks()[name]);
   if (attrPolicy == AttrPolicy::Keep)
-    for (const auto [dim, attr] : from.attrs())
+    for (const auto &[dim, attr] : from.attrs())
       copy(attr, to.attrs()[dim]);
   copy(from.data(), to.data());
 }
@@ -72,7 +72,7 @@ void copy_item(const DataArray &from, T &&to, const AttrPolicy attrPolicy) {
 /// Copy data array to output data array
 DataArray &copy(const DataArray &array, DataArray &out,
                 const AttrPolicy attrPolicy) {
-  for (const auto [dim, coord] : array.coords())
+  for (const auto &[dim, coord] : array.coords())
     copy(coord, out.coords()[dim]);
   copy_item(array, out, attrPolicy);
   return out;
@@ -88,7 +88,7 @@ DataArray copy(const DataArray &array, DataArray &&out,
 /// Copy dataset to output dataset
 Dataset &copy(const Dataset &dataset, Dataset &out,
               const AttrPolicy attrPolicy) {
-  for (const auto [dim, coord] : dataset.coords())
+  for (const auto &[dim, coord] : dataset.coords())
     copy(coord, out.coords()[dim]);
   for (const auto &array : dataset)
     copy_item(array, out[array.name()], attrPolicy);

--- a/dataset/util.cpp
+++ b/dataset/util.cpp
@@ -43,14 +43,14 @@ scipp::index size_of(const Variable &view) {
 scipp::index size_of(const DataArray &dataarray, bool include_aligned_coords) {
   scipp::index size = 0;
   size += size_of(dataarray.data());
-  for (const auto coord : dataarray.attrs()) {
+  for (const auto &coord : dataarray.attrs()) {
     size += size_of(coord.second);
   }
-  for (const auto mask : dataarray.masks()) {
+  for (const auto &mask : dataarray.masks()) {
     size += size_of(mask.second);
   }
   if (include_aligned_coords) {
-    for (const auto coord : dataarray.coords()) {
+    for (const auto &coord : dataarray.coords()) {
       size += size_of(coord.second);
     }
   }
@@ -62,7 +62,7 @@ scipp::index size_of(const Dataset &dataset) {
   for (const auto &data : dataset) {
     size += size_of(data, false);
   }
-  for (const auto coord : dataset.coords()) {
+  for (const auto &coord : dataset.coords()) {
     size += size_of(coord.second);
   }
   return size;


### PR DESCRIPTION
clang warned about a bunch of places where we copied variables instead of taking references or use move.