### PR TITLE
Flag dataset item coords as readonly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ if(NOT WIN32)
     -Wold-style-cast
     -Wcast-qual
     -Wcast-align
+    -Werror=return-type
   )
   add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -51,6 +51,10 @@ private:
   std::unordered_map<Dim, scipp::index> m_sizes;
 };
 
+[[nodiscard]] SCIPP_CORE_EXPORT Sizes concatenate(const Sizes &a,
+                                                  const Sizes &b,
+                                                  const Dim dim);
+
 [[nodiscard]] SCIPP_CORE_EXPORT Sizes merge(const Sizes &a, const Sizes &b);
 
 SCIPP_CORE_EXPORT bool is_edges(const Sizes &sizes, const Dimensions &dims,

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -72,6 +72,12 @@ Sizes Sizes::slice(const Slice &params) const {
   return {sizes};
 }
 
+Sizes concatenate(const Sizes &a, const Sizes &b, const Dim dim) {
+  Sizes out = a.contains(dim) ? a.slice({dim, 0}) : a;
+  out.set(dim, (a.contains(dim) ? a[dim] : 1) + (b.contains(dim) ? b[dim] : 1));
+  return out;
+}
+
 Sizes merge(const Sizes &a, const Sizes &b) {
   auto out(a);
   for (const auto &[dim, size] : b)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   element_trigonometry_test.cpp
   element_util_test.cpp
   multi_index_test.cpp
+  slice_test.cpp
   string_test.cpp
   subbin_sizes_test.cpp
   time_point_test.cpp

--- a/core/test/slice_test.cpp
+++ b/core/test/slice_test.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/except.h"
+#include "scipp/core/slice.h"
+
+using namespace scipp;
+
+TEST(SliceTest, test_construction) {
+  Slice point(Dim::X, 0);
+  EXPECT_EQ(point.dim(), Dim::X);
+  EXPECT_EQ(point.begin(), 0);
+  EXPECT_EQ(point.end(), -1);
+  EXPECT_TRUE(!point.isRange());
+
+  Slice range(Dim::X, 0, 1);
+  EXPECT_EQ(range.dim(), Dim::X);
+  EXPECT_EQ(range.begin(), 0);
+  EXPECT_EQ(range.end(), 1);
+  EXPECT_TRUE(range.isRange());
+}
+
+TEST(SliceTest, test_equals) {
+  Slice ref{Dim::X, 1, 2};
+
+  EXPECT_EQ(ref, ref);
+  EXPECT_EQ(ref, (Slice{Dim::X, 1, 2}));
+  EXPECT_NE(ref, (Slice{Dim::Y, 1, 2}));
+  EXPECT_NE(ref, (Slice{Dim::X, 0, 2}));
+  EXPECT_NE(ref, (Slice{Dim::X, 1, 3}));
+}
+
+TEST(SliceTest, test_assignment) {
+  Slice a{Dim::X, 1, 2};
+  Slice b{Dim::Y, 2, 3};
+  a = b;
+  EXPECT_EQ(a, b);
+}
+
+TEST(SliceTest, test_begin_valid) {
+  EXPECT_THROW((Slice{Dim::X, -1 /*invalid begin index*/, 1}),
+               except::SliceError);
+}
+
+TEST(SliceTest, test_end_valid) {
+  EXPECT_THROW((Slice{
+                   Dim::X, 2, 1 /*invalid end index*/
+               }),
+               except::SliceError);
+}

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -128,11 +128,12 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   DataArray out;
   out.m_data = m_data; // share data
   const Sizes sizes(dims());
-  out.m_coords =
-      std::make_shared<Coords>(sizes, typename Coords::holder_type{});
+  typename Coords::holder_type selected;
   for (const auto &[dim, coord] : coords)
     if (coords.item_applies_to(dim, dims()))
-      out.m_coords->set(dim, coord.as_const());
+      selected[dim] = coord.as_const();
+  const bool readonly = true;
+  out.m_coords = std::make_shared<Coords>(sizes, selected, readonly);
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs
   out.m_name = name;

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -83,14 +83,9 @@ void DataArray::setName(const std::string_view name) { m_name = name; }
 Coords DataArray::meta() const { return attrs().merge_from(coords()); }
 
 DataArray DataArray::slice(const Slice &s) const {
-  auto out_coords = m_coords->slice(s);
-  Attrs out_attrs(out_coords.sizes(), {});
-  for (auto &coord : *m_coords) {
-    if (unaligned_by_dim_slice(coord, s))
-      out_attrs.set(coord.first, out_coords.extract(coord.first));
-  }
-  return {m_data->slice(s), std::move(out_coords), m_masks->slice(s),
-          m_attrs->slice(s).merge_from(out_attrs), m_name};
+  auto [coords, attrs] = m_coords->slice_coords(s);
+  return {m_data->slice(s), std::move(coords), m_masks->slice(s),
+          m_attrs->slice(s).merge_from(attrs), m_name};
 }
 
 void DataArray::validateSlice(const Slice &s, const DataArray &array) const {

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -139,15 +139,12 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
 /// Return slice of the dataset along given dimension with given extents.
 Dataset Dataset::slice(const Slice s) const {
   Dataset out;
-  out.m_coords = m_coords.slice(s);
   out.m_data = slice_map(m_coords.sizes(), m_data, s);
-  Attrs out_attrs(out.m_coords.sizes(), {});
-  for (auto it = m_coords.begin(); it != m_coords.end(); ++it)
-    if (unaligned_by_dim_slice(*it, s))
-      out_attrs.set(it->first, out.m_coords.extract(it->first));
+  auto [coords, attrs] = m_coords.slice_coords(s);
+  out.m_coords = std::move(coords);
   for (auto &item : out.m_data) {
     Attrs item_attrs(out.m_coords.sizes(), {});
-    for (const auto &[dim, coord] : out_attrs)
+    for (const auto &[dim, coord] : attrs)
       if (m_coords.item_applies_to(dim, m_data.at(item.first).dims()))
         item_attrs.set(dim, coord.as_const());
     item.second.attrs() = item.second.attrs().merge_from(item_attrs);

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -167,7 +167,7 @@ template <class T, class Func> DataArray transform(const T &a, Func func) {
                    transform_map(a.attrs(), func), a.name());
 }
 
-DataArray strip_if_broadcast_along(DataArray a, const Dim dim);
+DataArray strip_if_broadcast_along(const DataArray &a, const Dim dim);
 Dataset strip_if_broadcast_along(const Dataset &d, const Dim dim);
 
 // Helpers for reductions for DataArray and Dataset, which include masks.

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -167,8 +167,8 @@ template <class T, class Func> DataArray transform(const T &a, Func func) {
                    transform_map(a.attrs(), func), a.name());
 }
 
-DataArray strip_if_broadcast_along(DataArray &&a, const Dim dim);
-Dataset strip_if_broadcast_along(Dataset &&d, const Dim dim);
+DataArray strip_if_broadcast_along(DataArray a, const Dim dim);
+Dataset strip_if_broadcast_along(const Dataset &d, const Dim dim);
 
 // Helpers for reductions for DataArray and Dataset, which include masks.
 [[nodiscard]] Variable mean(const Variable &var, const Dim dim,

--- a/dataset/dataset_operations_common.h
+++ b/dataset/dataset_operations_common.h
@@ -12,15 +12,6 @@
 
 namespace scipp::dataset {
 
-constexpr auto unaligned_by_dim_slice = [](const auto &item,
-                                           const Slice &params) {
-  if (params.end() != -1)
-    return false;
-  const Dim dim = params.dim();
-  const auto &[key, var] = item;
-  return var.dims().contains(dim) && dim_of_coord(var, key) == dim;
-};
-
 template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
   std::unordered_map<typename T1::key_type, typename T1::mapped_type> out;
 

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -161,6 +161,7 @@ public:
   mapped_type extract(const key_type &key);
 
   Dict slice(const Slice &params) const;
+  std::tuple<Dict, Dict> slice_coords(const Slice &params) const;
   void validateSlice(const Slice s, const Dict &dict) const;
   [[maybe_unused]] Dict &setSlice(const Slice s, const Dict &dict);
 

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -10,7 +10,8 @@ namespace scipp::dataset {
 namespace {
 template <class T> void expectWritable(const T &dict) {
   if (dict.is_readonly())
-    throw std::runtime_error("Read-only flag is set, cannot mutate dict.");
+    throw except::DataArrayError(
+        "Read-only flag is set, cannot mutate metadata dict.");
 }
 } // namespace
 
@@ -133,6 +134,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
 
 template <class Key, class Value>
 void Dict<Key, Value>::erase(const key_type &key) {
+  expectWritable(*this);
   scipp::expect::contains(*this, key);
   m_items.erase(key);
 }

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -116,31 +116,29 @@ Variable masked_data(const DataArray &array, const Dim dim) {
 namespace {
 template <class Dict> void strip_if_broadcast_along(Dict &dict, const Dim dim) {
   std::vector<typename Dict::key_type> erase;
-  for (const auto &item : dict) {
-    if constexpr (std::is_same_v<Dict, Dataset>) {
-      if (!item.dims().contains(dim))
-        erase.emplace_back(item.name());
-    } else {
-      if (!item.second.dims().contains(dim))
-        erase.emplace_back(item.first);
-    }
-  }
+  for (const auto &item : dict)
+    if (!item.second.dims().contains(dim))
+      erase.emplace_back(item.first);
   for (const auto &key : erase)
     dict.erase(key);
 }
 } // namespace
 
-DataArray strip_if_broadcast_along(DataArray &&a, const Dim dim) {
+DataArray strip_if_broadcast_along(DataArray a, const Dim dim) {
   strip_if_broadcast_along(a.coords(), dim);
   strip_if_broadcast_along(a.masks(), dim);
   strip_if_broadcast_along(a.attrs(), dim);
   return std::move(a);
 }
 
-Dataset strip_if_broadcast_along(Dataset &&d, const Dim dim) {
-  strip_if_broadcast_along(d.coords(), dim);
-  strip_if_broadcast_along(d, dim);
-  return std::move(d);
+Dataset strip_if_broadcast_along(const Dataset &d, const Dim dim) {
+  Dataset stripped;
+  stripped.setCoords(d.coords());
+  strip_if_broadcast_along(stripped.coords(), dim);
+  for (auto &&item : d)
+    if (item.dims().contains(dim))
+      stripped.setData(item.name(), strip_if_broadcast_along(item, dim));
+  return stripped;
 }
 
 } // namespace scipp::dataset

--- a/dataset/operations.cpp
+++ b/dataset/operations.cpp
@@ -114,27 +114,23 @@ Variable masked_data(const DataArray &array, const Dim dim) {
 }
 
 namespace {
-template <class Dict> void strip_if_broadcast_along(Dict &dict, const Dim dim) {
-  std::vector<typename Dict::key_type> erase;
-  for (const auto &item : dict)
-    if (!item.second.dims().contains(dim))
-      erase.emplace_back(item.first);
-  for (const auto &key : erase)
-    dict.erase(key);
+template <class Dict> auto strip_(const Dict &dict, const Dim dim) {
+  Dict stripped(dict.sizes(), {});
+  for (const auto &[key, value] : dict)
+    if (value.dims().contains(dim))
+      stripped.set(key, value);
+  return stripped;
 }
 } // namespace
 
-DataArray strip_if_broadcast_along(DataArray a, const Dim dim) {
-  strip_if_broadcast_along(a.coords(), dim);
-  strip_if_broadcast_along(a.masks(), dim);
-  strip_if_broadcast_along(a.attrs(), dim);
-  return std::move(a);
+DataArray strip_if_broadcast_along(const DataArray &a, const Dim dim) {
+  return {a.data(), strip_(a.coords(), dim), strip_(a.masks(), dim),
+          strip_(a.attrs(), dim), a.name()};
 }
 
 Dataset strip_if_broadcast_along(const Dataset &d, const Dim dim) {
   Dataset stripped;
-  stripped.setCoords(d.coords());
-  strip_if_broadcast_along(stripped.coords(), dim);
+  stripped.setCoords(strip_(d.coords(), dim));
   for (auto &&item : d)
     if (item.dims().contains(dim))
       stripped.setData(item.name(), strip_if_broadcast_along(item, dim));

--- a/dataset/shape.cpp
+++ b/dataset/shape.cpp
@@ -101,11 +101,11 @@ Dataset concatenate(const Dataset &a, const Dataset &b, const Dim dim) {
   // coords to dataset (which is not desirable for a variety of reasons). It is
   // unlikely that this will cause trouble in practice. Users can just use a
   // range slice of thickness 1.
-  auto result =
-      a.empty()
-          ? Dataset(std::map<std::string, Variable>(),
-                    concat(a.coords(), b.coords(), dim, a.sizes(), b.sizes()))
-          : Dataset();
+  Dataset result;
+  if (a.empty())
+    result.setCoords(
+        Coords(concatenate(a.sizes(), b.sizes(), dim),
+               concat(a.coords(), b.coords(), dim, a.sizes(), b.sizes())));
   for (const auto &item : a)
     if (b.contains(item.name())) {
       if (!item.dims().contains(dim) && item == b[item.name()])

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(
   except_test.cpp
   groupby_test.cpp
   histogram_test.cpp
-  masks_view_test.cpp
+  masks_test.cpp
   math_test.cpp
   mean_test.cpp
   merge_test.cpp

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   slice_test.cpp
   sort_test.cpp
   string_test.cpp
+  test_data_arrays.cpp
   sum_test.cpp
 )
 include_directories(SYSTEM ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR})

--- a/dataset/test/concatenate_test.cpp
+++ b/dataset/test/concatenate_test.cpp
@@ -95,10 +95,10 @@ protected:
               makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{11, 12}));
     a.setCoord(Dim::X,
                makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}));
-    a["data_1"].coords().set(
+    a["data_1"].attrs().set(
         Dim("edge_labels"),
         makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{21, 22, 23}));
-    a["data_1"].coords().set(
+    a["data_1"].attrs().set(
         Dim("labels"),
         makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{21, 22}));
     a["data_1"].masks().set("masks", makeVariable<bool>(Dims{Dim::X}, Shape{2},
@@ -107,10 +107,10 @@ protected:
               makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{13, 14}));
     b.setCoord(Dim::X,
                makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{3, 4, 5}));
-    b["data_1"].coords().set(
+    b["data_1"].attrs().set(
         Dim("edge_labels"),
         makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{23, 24, 25}));
-    b["data_1"].coords().set(
+    b["data_1"].attrs().set(
         Dim("labels"),
         makeVariable<int>(Dims{Dim::X}, Shape{2}, Values{24, 25}));
     b["data_1"].masks().set("masks", makeVariable<bool>(Dims{Dim::X}, Shape{2},
@@ -127,10 +127,10 @@ TEST_F(Concatenate1DHistogramTest, simple_1d) {
                                                Values{11, 12, 13, 14}));
   expected.setCoord(
       Dim::X, makeVariable<int>(Dims{Dim::X}, Shape{5}, Values{1, 2, 3, 4, 5}));
-  expected["data_1"].coords().set(
+  expected["data_1"].attrs().set(
       Dim("edge_labels"),
       makeVariable<int>(Dims{Dim::X}, Shape{5}, Values{21, 22, 23, 24, 25}));
-  expected["data_1"].coords().set(
+  expected["data_1"].attrs().set(
       Dim("labels"),
       makeVariable<int>(Dims{Dim::X}, Shape{4}, Values{21, 22, 24, 25}));
   expected["data_1"].masks().set(

--- a/dataset/test/data_array_comparison_test.cpp
+++ b/dataset/test/data_array_comparison_test.cpp
@@ -42,11 +42,11 @@ protected:
     dataset.setData("val_and_var",
                     makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
                                          Values(12), Variances(12)));
-    dataset["val_and_var"].coords().set(Dim("attr"),
-                                        makeVariable<int>(Values{int{}}));
+    dataset["val_and_var"].attrs().set(Dim("attr"),
+                                       makeVariable<int>(Values{int{}}));
 
     dataset.setData("val", makeVariable<double>(Dims{Dim::X}, Shape{4}));
-    dataset["val"].coords().set(Dim("attr"), makeVariable<int>(Values{int{}}));
+    dataset["val"].attrs().set(Dim("attr"), makeVariable<int>(Values{int{}}));
     for (const auto &item : {"val_and_var", "val"})
       dataset[item].masks().set("mask",
                                 makeVariable<bool>(Dims{Dim::X}, Shape{4}));

--- a/dataset/test/dataset_arithmetic_test.cpp
+++ b/dataset/test/dataset_arithmetic_test.cpp
@@ -719,39 +719,6 @@ TYPED_TEST(DatasetBinaryOpTest, masks_not_shared) {
   }
 }
 
-TEST(DatasetSetData, dense_to_dense) {
-  auto dense = datasetFactory().make();
-  auto d = copy(dense.slice({Dim::X, 0, 2}));
-  dense.setData("data_x_1", dense["data_x"]);
-  EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
-
-  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), except::DimensionError);
-}
-
-TEST(DatasetSetData, dense_to_empty) {
-  auto ds = Dataset();
-  auto dense = datasetFactory().make();
-  ds.setData("data_x", dense["data_x"]);
-  EXPECT_EQ(dense["data_x"].coords(), ds["data_x"].coords());
-  EXPECT_EQ(dense["data_x"].data(), ds["data_x"].data());
-}
-
-TEST(DatasetSetData, labels) {
-  auto dense = datasetFactory().make();
-  dense.setCoord(Dim("l"), makeVariable<double>(
-                               Dims{Dim::X},
-                               Shape{dense.coords()[Dim::X].dims().volume()}));
-  auto d = copy(dense.slice({Dim::Y, 0}));
-  dense.setData("data_x_1", dense["data_x"]);
-  EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
-
-  d.setCoord(Dim("l1"),
-             makeVariable<double>(Dims{Dim::X},
-                                  Shape{d.coords()[Dim::X].dims().volume()}));
-  dense.setData("data_x_2", d["data_x"]);
-  EXPECT_TRUE(dense.coords().contains(Dim("l1")));
-}
-
 TEST(DatasetInPlaceStrongExceptionGuarantee, events) {
   Variable indicesGood = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 3}});

--- a/dataset/test/dataset_arithmetic_test.cpp
+++ b/dataset/test/dataset_arithmetic_test.cpp
@@ -797,11 +797,11 @@ TEST(DatasetInPlaceStrongExceptionGuarantee, events) {
 TEST(DataArrayMasks, can_contain_any_type_but_only_OR_bools) {
   DataArray a(makeVariable<double>(Values{1}));
   a.masks().set("double", makeVariable<double>(Values{1}));
-  ASSERT_THROW(a += a, std::runtime_error);
-  ASSERT_THROW_DISCARD(a + a, std::runtime_error);
+  ASSERT_THROW(a += a, except::TypeError);
+  ASSERT_THROW_DISCARD(a + a, except::TypeError);
   a.masks().set("bool", makeVariable<bool>(Values{false}));
-  ASSERT_THROW(a += a, std::runtime_error);
-  ASSERT_THROW_DISCARD(a + a, std::runtime_error);
+  ASSERT_THROW(a += a, except::TypeError);
+  ASSERT_THROW_DISCARD(a + a, except::TypeError);
   a.masks().erase("double");
   ASSERT_NO_THROW(a += a);
   ASSERT_NO_THROW_DISCARD(a + a);

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -429,3 +429,36 @@ TEST_F(DatasetRenameTest, rename) {
   factory.seed(0);
   EXPECT_EQ(d, factory.make());
 }
+
+TEST(DatasetSetData, dense_to_dense) {
+  auto dense = DatasetFactory3D().make();
+  auto d = copy(dense.slice({Dim::X, 0, 2}));
+  dense.setData("data_x_1", dense["data_x"]);
+  EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
+
+  EXPECT_THROW(dense.setData("data_x_2", d["data_x"]), except::DimensionError);
+}
+
+TEST(DatasetSetData, dense_to_empty) {
+  auto ds = Dataset();
+  auto dense = DatasetFactory3D().make();
+  ds.setData("data_x", dense["data_x"]);
+  EXPECT_EQ(dense["data_x"].coords(), ds["data_x"].coords());
+  EXPECT_EQ(dense["data_x"].data(), ds["data_x"].data());
+}
+
+TEST(DatasetSetData, labels) {
+  auto dense = DatasetFactory3D().make();
+  dense.setCoord(Dim("l"), makeVariable<double>(
+                               Dims{Dim::X},
+                               Shape{dense.coords()[Dim::X].dims().volume()}));
+  auto d = copy(dense.slice({Dim::Y, 0}));
+  dense.setData("data_x_1", dense["data_x"]);
+  EXPECT_EQ(dense["data_x"], dense["data_x_1"]);
+
+  d.setCoord(Dim("l1"),
+             makeVariable<double>(Dims{Dim::X},
+                                  Shape{d.coords()[Dim::X].dims().volume()}));
+  dense.setData("data_x_2", d["data_x"]);
+  EXPECT_TRUE(dense.coords().contains(Dim("l1")));
+}

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -194,7 +194,7 @@ TEST(DatasetTest, setData_from_DataArray_replace) {
   Dataset ds;
   ds.setData("a", array1);
   ds.setData("a", array2);
-  EXPECT_EQ(array1, original); // setData does not copy elements
+  EXPECT_EQ(array1, original);     // setData does not copy elements
   const bool shared_coord = false; // coord exists in dataset, not replaced
   check_array_shared(ds, "a", array2, shared_coord);
 }

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -39,7 +39,7 @@ TEST(DatasetTest, clear) {
 TEST(DatasetTest, erase_non_existant) {
   Dataset d;
   ASSERT_THROW(d.erase("not an item"), except::NotFoundError);
-  ASSERT_THROW(auto _ = d.extract("not an item"), except::NotFoundError);
+  ASSERT_THROW_DISCARD(d.extract("not an item"), except::NotFoundError);
 }
 
 TEST(DatasetTest, erase) {
@@ -134,8 +134,8 @@ TEST(DatasetTest, set_item_mask) {
   d.setData("scalar", 1.2 * units::one);
   const auto var =
       makeVariable<bool>(Dims{Dim::X}, Shape{3}, Values{false, true, false});
-  d["x"].masks().set("unaligned", var);
-  EXPECT_TRUE(d["x"].masks().contains("unaligned"));
+  d["x"].masks().set("mask", var);
+  EXPECT_TRUE(d["x"].masks().contains("mask"));
 }
 
 TEST(DatasetTest, setData_with_and_without_variances) {

--- a/dataset/test/dataset_test.cpp
+++ b/dataset/test/dataset_test.cpp
@@ -11,7 +11,6 @@
 #include "scipp/core/dimensions.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
-#include "scipp/dataset/reduction.h"
 #include "scipp/variable/operations.h"
 
 #include "dataset_test_common.h"
@@ -317,20 +316,6 @@ TEST(DatasetTest, slice_validation_complex) {
   // Reverse order. Invalid slice creation should be caught up front.
   EXPECT_THROW(ds.slice(Slice{Dim::X, 1, 2}).slice(Slice{Dim::X, 0, 3}),
                except::SliceError);
-}
-
-TEST(DatasetTest, sum_and_mean) {
-  auto ds = make_1_values_and_variances<float>("a", {Dim::X, 3}, units::one,
-                                               {1, 2, 3}, {12, 15, 18});
-  EXPECT_EQ(dataset::sum(ds, Dim::X)["a"].data(),
-            makeVariable<float>(Values{6}, Variances{45}));
-  EXPECT_EQ(dataset::sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(Values{3}, Variances{27}));
-
-  EXPECT_EQ(dataset::mean(ds, Dim::X)["a"].data(),
-            makeVariable<float>(Values{2}, Variances{5.0}));
-  EXPECT_EQ(dataset::mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
-            makeVariable<float>(Values{1.5}, Variances{6.75}));
 }
 
 TEST(DatasetTest, extract_coord) {

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -117,7 +117,7 @@ TEST_F(GroupbyTest, dataset_1d_and_2d) {
   expected.setData("c",
                    makeVariable<double>(Dims{Dim(Dim::Z), dim}, Shape{2, 2},
                                         units::s, Values{1.5, 3.0, 4.5, 6.0}));
-  expected["a"].coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+  expected["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
   expected.setCoord(
       dim, makeVariable<double>(Dims{dim}, Shape{2}, units::m, Values{1, 3}));
 
@@ -435,8 +435,6 @@ TEST_F(GroupbyWithBinsTest, two_bin) {
 
   auto group0 =
       concatenate(d.slice({Dim::X, 0, 2}), d.slice({Dim::X, 4, 5}), Dim::X);
-  // concatenate does currently not preserve attributes
-  group0["a"].coords().set(Dim("scalar"), d["a"].attrs()[Dim("scalar")]);
   EXPECT_EQ(groups.sum(Dim::X).slice({Dim::Z, 0}),
             add_bins(sum(group0, Dim::X), 0));
   EXPECT_EQ(groups.mean(Dim::X).slice({Dim::Z, 0}),

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -23,7 +23,7 @@ struct GroupbyTest : public ::testing::Test {
                                         Values{0.1, 0.2, 0.3}));
     d.setData("c", makeVariable<double>(Dimensions{{Dim::Z, 2}, {Dim::X, 3}},
                                         units::s, Values{1, 2, 3, 4, 5, 6}));
-    d["a"].coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+    d["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
     d.setCoord(Dim("labels1"), makeVariable<double>(Dimensions{Dim::X, 3},
                                                     units::m, Values{1, 2, 3}));
     d.setCoord(Dim("labels2"), makeVariable<double>(Dimensions{Dim::X, 3},
@@ -177,7 +177,7 @@ TEST_F(GroupbyMaskedTest, sum) {
                                              units::s, Values{1, 3, 4, 6}));
   expected.setCoord(
       dim, makeVariable<double>(Dimensions{dim, 2}, units::m, Values{1, 3}));
-  expected["a"].coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+  expected["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
   for (const auto &item : {"a", "c"})
     expected[item].masks().set(
         "mask_z",
@@ -202,7 +202,7 @@ TEST_F(GroupbyMaskedTest, sum_irrelevant_mask) {
                                              units::s, Values{3, 3, 9, 6}));
   expected.setCoord(
       dim, makeVariable<double>(Dimensions{dim, 2}, units::m, Values{1, 3}));
-  expected["a"].coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+  expected["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
   for (const auto &item : {"a", "c"})
     expected[item].masks().set(
         "mask_z",
@@ -237,7 +237,7 @@ TEST_F(GroupbyMaskedTest, mean_mask_ignores_values_properly) {
                                              units::s, Values{1, 3, 4, 6}));
   expected.setCoord(
       dim, makeVariable<double>(Dimensions{dim, 2}, units::m, Values{1, 3}));
-  expected["a"].coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
+  expected["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
   for (const auto &item : {"a", "c"})
     expected[item].masks().set(
         "mask_z",

--- a/dataset/test/masks_test.cpp
+++ b/dataset/test/masks_test.cpp
@@ -2,14 +2,12 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
-#include "scipp/core/dimensions.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/variable/logical.h"
-#include "test_macros.h"
 
 using namespace scipp;
 
-TEST(MasksViewTest, irreducible_mask) {
+TEST(MasksTest, irreducible_mask) {
   DataArray a(
       makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{2, 3, 4}));
   const auto x =

--- a/dataset/test/mean_test.cpp
+++ b/dataset/test/mean_test.cpp
@@ -1,14 +1,31 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
-#include "fix_typed_test_suite_warnings.h"
-#include "scipp/dataset/reduction.h"
-#include "test_nans.h"
 #include <gtest/gtest.h>
-#include <scipp/common/overloaded.h>
+
+#include "scipp/common/overloaded.h"
+#include "scipp/dataset/reduction.h"
+
+#include "fix_typed_test_suite_warnings.h"
+#include "test_nans.h"
+
+using namespace scipp;
+
+TEST(DatasetTest, sum_and_mean) {
+  Dataset ds;
+  ds.setData("a", makeVariable<float>(Dimensions{Dim::X, 3}, units::one,
+                                      Values{1, 2, 3}, Variances{12, 15, 18}));
+  EXPECT_EQ(sum(ds, Dim::X)["a"].data(),
+            makeVariable<float>(Values{6}, Variances{45}));
+  EXPECT_EQ(sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
+            makeVariable<float>(Values{3}, Variances{27}));
+
+  EXPECT_EQ(mean(ds, Dim::X)["a"].data(),
+            makeVariable<float>(Values{2}, Variances{5.0}));
+  EXPECT_EQ(mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
+            makeVariable<float>(Values{1.5}, Variances{6.75}));
+}
 
 namespace {
-using namespace scipp;
-using namespace scipp::dataset;
 
 using MeanTestTypes = testing::Types<int32_t, int64_t, float, double>;
 TYPED_TEST_SUITE(MeanTest, MeanTestTypes);

--- a/dataset/test/slice_test.cpp
+++ b/dataset/test/slice_test.cpp
@@ -15,49 +15,6 @@
 using namespace scipp;
 using namespace scipp::dataset;
 
-TEST(SliceTest, test_construction) {
-  Slice point(Dim::X, 0);
-  EXPECT_EQ(point.dim(), Dim::X);
-  EXPECT_EQ(point.begin(), 0);
-  EXPECT_EQ(point.end(), -1);
-  EXPECT_TRUE(!point.isRange());
-
-  Slice range(Dim::X, 0, 1);
-  EXPECT_EQ(range.dim(), Dim::X);
-  EXPECT_EQ(range.begin(), 0);
-  EXPECT_EQ(range.end(), 1);
-  EXPECT_TRUE(range.isRange());
-}
-
-TEST(SliceTest, test_equals) {
-  Slice ref{Dim::X, 1, 2};
-
-  EXPECT_EQ(ref, ref);
-  EXPECT_EQ(ref, (Slice{Dim::X, 1, 2}));
-  EXPECT_NE(ref, (Slice{Dim::Y, 1, 2}));
-  EXPECT_NE(ref, (Slice{Dim::X, 0, 2}));
-  EXPECT_NE(ref, (Slice{Dim::X, 1, 3}));
-}
-
-TEST(SliceTest, test_assignment) {
-  Slice a{Dim::X, 1, 2};
-  Slice b{Dim::Y, 2, 3};
-  a = b;
-  EXPECT_EQ(a, b);
-}
-
-TEST(SliceTest, test_begin_valid) {
-  EXPECT_THROW((Slice{Dim::X, -1 /*invalid begin index*/, 1}),
-               except::SliceError);
-}
-
-TEST(SliceTest, test_end_valid) {
-  EXPECT_THROW((Slice{
-                   Dim::X, 2, 1 /*invalid end index*/
-               }),
-               except::SliceError);
-}
-
 class Dataset3DTest : public ::testing::Test {
 protected:
   Dataset3DTest() : dataset(factory.make()) {}

--- a/dataset/test/test_data_arrays.cpp
+++ b/dataset/test/test_data_arrays.cpp
@@ -4,20 +4,27 @@
 /// @author Simon Heybrock
 #include <gtest/gtest.h>
 
+#include "scipp/variable/arithmetic.h"
+
 #include "test_data_arrays.h"
 
 using namespace scipp;
 
-DataArray make_data_array_1d() {
+DataArray make_data_array_1d(const int64_t seed) {
   auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
-                                   Values{1, 2}, Variances{3, 4});
+                                   Values{seed + 1, seed + 2},
+                                   Variances{seed + 3, seed + 4});
   auto coord =
       makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
   auto mask = makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{true, false});
+  const auto name = std::to_string(seed);
   auto scalar_coord = makeVariable<int64_t>(Values{12});
   auto scalar_mask = makeVariable<bool>(Values{false});
-  return DataArray(data, {{Dim::X, coord}, {Dim("scalar"), scalar_coord}},
-                   {{"mask", mask}, {"scalar_mask", scalar_mask}},
-                   {{Dim("attr"), coord + coord},
-                    {Dim("scalar_attr"), scalar_coord + scalar_coord}});
+  return DataArray(
+      data, {{Dim::X, coord}, {Dim("scalar"), scalar_coord}},
+      {{"mask", mask}, {"mask" + seed, mask}, {"scalar_mask", scalar_mask}},
+      {{Dim("attr"), coord + coord},
+       {Dim("attr" + seed), coord + seed * units::m},
+       {Dim("scalar_attr"), scalar_coord + scalar_coord}},
+      "array" + name);
 }

--- a/dataset/test/test_data_arrays.cpp
+++ b/dataset/test/test_data_arrays.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <gtest/gtest.h>
+
+#include "test_data_arrays.h"
+
+using namespace scipp;
+
+DataArray make_data_array_1d() {
+  auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
+                                   Values{1, 2}, Variances{3, 4});
+  auto coord =
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
+  auto mask = makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{true, false});
+  auto scalar_coord = makeVariable<int64_t>(Values{12});
+  auto scalar_mask = makeVariable<bool>(Values{false});
+  return DataArray(data, {{Dim::X, coord}, {Dim("scalar"), scalar_coord}},
+                   {{"mask", mask}, {"scalar_mask", scalar_mask}},
+                   {{Dim("attr"), coord + coord},
+                    {Dim("scalar_attr"), scalar_coord + scalar_coord}});
+}

--- a/dataset/test/test_data_arrays.h
+++ b/dataset/test/test_data_arrays.h
@@ -6,4 +6,9 @@
 
 #include "scipp/dataset/data_array.h"
 
-scipp::DataArray make_data_array_1d();
+/// Create a data array with coord, masks, and attrs.
+///
+/// Different but compatible arrays can be created using different seeds. The
+/// seed does not affect coords to ensure that the produced arrays can be
+/// inserted into the same dataset or be used in binary operations.
+scipp::DataArray make_data_array_1d(int64_t seed = 0);

--- a/dataset/test/test_data_arrays.h
+++ b/dataset/test/test_data_arrays.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include <gtest/gtest.h>
+
+#include "scipp/dataset/data_array.h"
+
+scipp::DataArray make_data_array_1d();

--- a/docs/developer/concepts.ipynb
+++ b/docs/developer/concepts.ipynb
@@ -307,7 +307,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds['a'].coords['fail'] = 1.0 * sc.units.m\n",
+    "try:\n",
+    "    ds['a'].coords['fail'] = 1.0 * sc.units.m\n",
+    "except sc.DataArrayError:\n",
+    "    ok = False\n",
+    "else:\n",
+    "    ok = True\n",
+    "assert not ok\n",
     "assert 'fail' not in ds.coords"
    ]
   },
@@ -319,8 +325,37 @@
    "source": [
     "ds.coords['xx'] = 1.0 * sc.units.m\n",
     "assert 'xx' in ds['a'].coords\n",
-    "del ds['a'].coords['xx']\n",
+    "try:\n",
+    "    del ds['a'].coords['xx']\n",
+    "except sc.DataArrayError:\n",
+    "    ok = False\n",
+    "else:\n",
+    "    ok = True\n",
+    "assert not ok\n",
     "assert 'xx' in ds.coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same mechanism applies for coords, masks, and attrs of slices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    da['x', 0].coords['fail'] = 1.0 * sc.units.m\n",
+    "except sc.DataArrayError:\n",
+    "    ok = False\n",
+    "else:\n",
+    "    ok = True\n",
+    "assert not ok\n",
+    "assert 'fail' not in da.coords"
    ]
   },
   {


### PR DESCRIPTION
Changing the behavior of the dataset item coord dicts to be readonly:
```python
del ds['a'].coords['x']
```

now raises instead of doing nothing. This is then consistent with slices:

```python
del da['x', 17].coords['x']   # raises already
```

You can shallow-copy to clear the readonly flags.
```python
a = ds['a'].copy(deep=False)
del a.coords['x']   # works
```

Note that this change exposes some "bugs" that krept into our unit tests as part of the recent `DataArray` and `Dataset` refactor. A number of tests was adding coords to items of datasets, which previously set item attrs, whereas after the rewrite it silently dropped them.

This was discovered as part of a small dataset-test cleanup, so a number of unrelated cleanup/refactor is contained (see individual earlier commits).