### PR TITLE
Define __str__ for nicer plot titles for variables

### DIFF
--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -77,6 +77,18 @@ setattr(Variable, 'sizes', property(_make_sizes))
 setattr(DataArray, 'sizes', property(_make_sizes))
 setattr(Dataset, 'sizes', property(_make_sizes))
 
+
+def _str_factory(cls):
+    def _str(obj):
+        return f'scipp.{cls.__name__}(sizes={obj.sizes})'
+
+    return _str
+
+
+setattr(Variable, '__str__', _str_factory(Variable))
+setattr(DataArray, '__str__', _str_factory(DataArray))
+setattr(Dataset, '__str__', _str_factory(Dataset))
+
 from ._bins import _bins, _set_bins, _events
 setattr(Variable, 'bins', property(_bins, _set_bins))
 setattr(DataArray, 'bins', property(_bins, _set_bins))

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -80,7 +80,9 @@ setattr(Dataset, 'sizes', property(_make_sizes))
 
 def _str_factory(cls):
     def _str(obj):
-        return f'scipp.{cls.__name__}(sizes={obj.sizes})'
+        sizes = ', '.join(
+            [f'{dim}: {size}' for dim, size in obj.sizes.items()])
+        return f'scipp.{cls.__name__}({sizes})'
 
     return _str
 

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -77,20 +77,6 @@ setattr(Variable, 'sizes', property(_make_sizes))
 setattr(DataArray, 'sizes', property(_make_sizes))
 setattr(Dataset, 'sizes', property(_make_sizes))
 
-
-def _str_factory(cls):
-    def _str(obj):
-        sizes = ', '.join(
-            [f'{dim}: {size}' for dim, size in obj.sizes.items()])
-        return f'scipp.{cls.__name__}({sizes})'
-
-    return _str
-
-
-setattr(Variable, '__str__', _str_factory(Variable))
-setattr(DataArray, '__str__', _str_factory(DataArray))
-setattr(Dataset, '__str__', _str_factory(Dataset))
-
 from ._bins import _bins, _set_bins, _events
 setattr(Variable, 'bins', property(_bins, _set_bins))
 setattr(DataArray, 'bins', property(_bins, _set_bins))

--- a/python/src/scipp/plotting/plot.py
+++ b/python/src/scipp/plotting/plot.py
@@ -40,6 +40,11 @@ def _make_plot_key(plt_key, all_keys):
     return plt_key
 
 
+def _brief_str(obj):
+    sizes = ', '.join([f'{dim}: {size}' for dim, size in obj.sizes.items()])
+    return f'scipp.{type(obj).__name__}({sizes})'
+
+
 def _input_to_data_array(item, all_keys, key=None):
     """
     Convert an input for the plot function to a DataArray or a dict of
@@ -54,7 +59,7 @@ def _input_to_data_array(item, all_keys, key=None):
     elif su.is_variable(item):
         if su.numeric_type(item):
             if key is None:
-                key = str(item)
+                key = _brief_str(item)
             to_plot[_make_plot_key(key,
                                    all_keys)] = _variable_to_data_array(item)
     elif su.is_data_array(item):

--- a/python/src/scipp/plotting/plot.py
+++ b/python/src/scipp/plotting/plot.py
@@ -54,7 +54,7 @@ def _input_to_data_array(item, all_keys, key=None):
     elif su.is_variable(item):
         if su.numeric_type(item):
             if key is None:
-                key = str(type(item))
+                key = str(item)
             to_plot[_make_plot_key(key,
                                    all_keys)] = _variable_to_data_array(item)
     elif su.is_data_array(item):


### PR DESCRIPTION
Avoid confusing class name in plot titles.

Before:
<img width="510" alt="image" src="https://user-images.githubusercontent.com/12912489/117775181-8a1dfb00-b23a-11eb-92ca-fa9fe006ff8e.png">

After:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/12912489/117775121-77a3c180-b23a-11eb-924e-6389de77ac0b.png">
