### PR TITLE
Refactor classes `Sizes` and `Dimensions`

### DIFF
--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -58,18 +58,6 @@ scipp::index &Dimensions::at(const Dim dim) {
 }
 */
 
-/// Return true if all dimensions of other contained in *this, ignoring order.
-/*
-bool Dimensions::contains(const Dimensions &other) const noexcept {
-  if (*this == other)
-    return true;
-  for (const auto &dim : other.labels())
-    if (!contains(dim) || other[dim] != operator[](dim))
-      return false;
-  return true;
-}
-*/
-
 /// Return true if *this forms a contiguous block within parent.
 ///
 /// Specifically, dimensions are not transposed, missing dimensions are outer

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -34,8 +34,8 @@ Dimensions::Dimensions(const std::vector<Dim> &labels,
 }
 
 Dimensions::Dimensions(const Sizes &sizes) {
-  for (const auto &[label, size] : sizes)
-    addInner(label, size);
+  for (const auto &label : sizes)
+    addInner(label, sizes[label]);
 }
 
 /// Return the extent of `dim`. Throws if the space defined by this does not

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -34,11 +34,6 @@ Dimensions::Dimensions(const std::vector<Dim> &labels,
     addInner(labels[i], shape[i]);
 }
 
-Dimensions::Dimensions(const Sizes &sizes) {
-  for (const auto &label : sizes)
-    addInner(label, sizes[label]);
-}
-
 /// Return the extent of `dim`. Throws if the space defined by this does not
 /// contain `dim`.
 // scipp::index Dimensions::operator[](const Dim dim) const { return at(dim); }

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -109,12 +109,9 @@ scipp::index Dimensions::size(const scipp::index i) const { return shape()[i]; }
 /// array defined by this.
 scipp::index Dimensions::offset(const Dim label) const {
   scipp::index offset{1};
-  for (int32_t i = ndim() - 1; i >= 0; --i) {
-    if (labels()[i] == label)
-      return offset;
+  for (int32_t i = index(label) + 1; i < ndim(); ++i)
     offset *= shape()[i];
-  }
-  except::throw_dimension_not_found_error(*this, label);
+  return offset;
 }
 
 void Dimensions::resize(const Dim label, const scipp::index size) {
@@ -149,14 +146,6 @@ Dim Dimensions::inner() const noexcept {
   if (empty())
     return Dim::Invalid;
   return labels().back();
-}
-
-int32_t Dimensions::index(const Dim dim) const {
-  expect::validDim(dim);
-  for (int32_t i = 0; i < NDIM_MAX; ++i)
-    if (labels()[i] == dim)
-      return i;
-  except::throw_dimension_not_found_error(*this, dim);
 }
 
 /// Return the direct sum, i.e., the combination of dimensions in a and b.

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -88,7 +88,7 @@ bool Dimensions::isContiguousIn(const Dimensions &parent) const {
 Dim Dimensions::label(const scipp::index i) const { return labels()[i]; }
 
 void Dimensions::relabel(const scipp::index i, const Dim label) {
-  relabel(labels()[i], label);
+  replace_key(labels()[i], label);
 }
 
 scipp::index Dimensions::size(const scipp::index i) const { return shape()[i]; }
@@ -129,7 +129,7 @@ void Dimensions::addInner(const Dim label, const scipp::index size) {
   insert_right(label, size);
 }
 
-/// Return the innermost dimension. Throws if *this is empty.
+/// Return the innermost dimension. Returns Dim::Invalid if *this is empty
 Dim Dimensions::inner() const noexcept {
   if (empty())
     return Dim::Invalid;

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -16,12 +16,6 @@ void expectUnique(const Dimensions &dims, const Dim label) {
     throw except::DimensionError("Duplicate dimension.");
 }
 
-void expectExtendable(const Dimensions &dims) {
-  if (dims.shape().size() == NDIM_MAX)
-    throw except::DimensionError(
-        "Maximum number of allowed dimensions exceeded.");
-}
-
 Dimensions::Dimensions(const std::vector<Dim> &labels,
                        const std::vector<scipp::index> &shape) {
   if (labels.size() != shape.size())
@@ -33,30 +27,6 @@ Dimensions::Dimensions(const std::vector<Dim> &labels,
   for (scipp::index i = 0; i < scipp::size(shape); ++i)
     addInner(labels[i], shape[i]);
 }
-
-/// Return the extent of `dim`. Throws if the space defined by this does not
-/// contain `dim`.
-// scipp::index Dimensions::operator[](const Dim dim) const { return at(dim); }
-
-/// Return the extent of `dim`. Throws if the space defined by this does not
-/// contain `dim`.
-/*
-scipp::index Dimensions::at(const Dim dim) const {
-  for (int32_t i = 0; i < m_ndim; ++i)
-    if (m_dims[i] == dim)
-      return m_shape[i];
-  except::throw_dimension_not_found_error(*this, dim);
-}
-
-/// Return a mutable reference to the extent of `dim`. Throws if the space
-/// defined by this does not contain `dim`.
-scipp::index &Dimensions::at(const Dim dim) {
-  for (int32_t i = 0; i < m_ndim; ++i)
-    if (m_dims[i] == dim)
-      return m_shape[i];
-  except::throw_dimension_not_found_error(*this, dim);
-}
-*/
 
 Dim Dimensions::label(const scipp::index i) const { return labels()[i]; }
 
@@ -71,20 +41,9 @@ scipp::index Dimensions::offset(const Dim label) const {
   return offset;
 }
 
-void Dimensions::resize(const Dim label, const scipp::index size) {
-  expect::validExtent(size);
-  at(label) = size;
-}
-
-void Dimensions::resize(const scipp::index i, const scipp::index size) {
-  resize(label(i), size);
-}
-
 /// Add a new dimension, which will be the outermost dimension.
 void Dimensions::add(const Dim label, const scipp::index size) {
   expect::validDim(label);
-  expectUnique(*this, label);
-  expectExtendable(*this);
   expect::validExtent(size);
   insert_left(label, size);
 }
@@ -92,9 +51,7 @@ void Dimensions::add(const Dim label, const scipp::index size) {
 /// Add a new dimension, which will be the innermost dimension.
 void Dimensions::addInner(const Dim label, const scipp::index size) {
   expect::validDim(label);
-  expectUnique(*this, label);
   expect::validExtent(size);
-  expectExtendable(*this);
   insert_right(label, size);
 }
 

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -58,38 +58,7 @@ scipp::index &Dimensions::at(const Dim dim) {
 }
 */
 
-/// Return true if *this forms a contiguous block within parent.
-///
-/// Specifically, dimensions are not transposed, missing dimensions are outer
-/// dimensions in parent, and only the outermost dimensions may be shorter than
-/// the corresponding dimension in parent.
-bool Dimensions::isContiguousIn(const Dimensions &parent) const {
-  if (volume() == 0 || parent == *this)
-    return true;
-  int32_t offset = parent.ndim() - ndim();
-  if (offset < 0)
-    return false;
-  for (int32_t i = 0; i < ndim(); ++i) {
-    // All shared dimension labels must match.
-    if (parent.label(i + offset) != label(i))
-      return false;
-    // Outermost dimension of *this can be a section of parent.
-    // All but outermost must match.
-    if (i == 0) {
-      if (parent.size(offset) < size(0))
-        return false;
-    } else if (parent.size(i + offset) != size(i)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 Dim Dimensions::label(const scipp::index i) const { return labels()[i]; }
-
-void Dimensions::relabel(const scipp::index i, const Dim label) {
-  replace_key(labels()[i], label);
-}
 
 scipp::index Dimensions::size(const scipp::index i) const { return shape()[i]; }
 

--- a/core/dimensions.cpp
+++ b/core/dimensions.cpp
@@ -7,6 +7,7 @@
 
 #include "scipp/core/dimensions.h"
 #include "scipp/core/except.h"
+#include "scipp/core/sizes.h"
 
 namespace scipp::core {
 

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -68,15 +68,11 @@ void dimensionMatches(const Dimensions &dims, const Dim dim,
     except::throw_dimension_length_error(dims, dim, length);
 }
 
-void validSlice(const Dimensions &dims, const Slice &slice) {
+void validSlice(const Sizes &dims, const Slice &slice) {
   const auto end = slice.end() < 0 ? slice.begin() + 1 : slice.end();
   if (!dims.contains(slice.dim()) || end > dims[slice.dim()])
     throw except::SliceError("Expected " + to_string(slice) + " to be in " +
                              to_string(dims) + ".");
-}
-
-void validSlice(const Sizes &dims, const Slice &slice) {
-  validSlice(Dimensions(dims), slice);
 }
 
 void notCountDensity(const units::Unit &unit) {

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -7,9 +7,6 @@
 #include "scipp/core/dimensions.h"
 #include "scipp/core/slice.h"
 
-#include <cmath>
-#include <set>
-
 namespace scipp::except {
 
 TypeError::TypeError(const std::string &msg) : Error{msg} {}
@@ -45,8 +42,7 @@ void throw_mismatch_error(const core::Dimensions &expected,
                        format_dims(actual) + '.');
 }
 
-void throw_dimension_not_found_error(const core::Dimensions &expected,
-                                     Dim actual) {
+void throw_dimension_not_found_error(const core::Sizes &expected, Dim actual) {
   throw DimensionError{"Expected dimension to be in " + to_string(expected) +
                        ", got " + to_string(actual) + '.'};
 }

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -42,11 +42,6 @@ void throw_mismatch_error(const core::Dimensions &expected,
                        format_dims(actual) + '.');
 }
 
-void throw_dimension_not_found_error(const core::Sizes &expected, Dim actual) {
-  throw DimensionError{"Expected dimension to be in " + to_string(expected) +
-                       ", got " + to_string(actual) + '.'};
-}
-
 void throw_dimension_length_error(const core::Dimensions &expected, Dim actual,
                                   index length) {
   throw DimensionError{"Expected dimension to be in " + to_string(expected) +

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -4,10 +4,6 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <limits>
-#include <memory>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "scipp-core_export.h"

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -48,8 +48,6 @@ public:
     return !(*this == other);
   }
 
-  // constexpr bool empty() const noexcept { return m_ndim == 0; }
-
   /// Return the shape of the space defined by *this.
   constexpr scipp::span<const scipp::index> shape() const &noexcept {
     return sizes();
@@ -68,19 +66,6 @@ public:
 
   Dim inner() const noexcept;
 
-  /// Return true if `dim` is one of the labels in *this.
-  // constexpr bool contains(const Dim dim) const noexcept ;
-
-  /// Returns the number of occurences of `dim` in *this.
-  ///
-  /// This exists for convenience so generic code supporting std::unordered_map
-  /// can be written.
-  // constexpr scipp::index count(const Dim dim) const noexcept {
-  //  return contains(dim) ? 1 : 0;
-  //}
-
-  // bool contains(const Dimensions &other) const noexcept;
-
   bool isContiguousIn(const Dimensions &parent) const;
 
   // TODO Some of the following methods are probably legacy and should be
@@ -96,25 +81,6 @@ public:
   // TODO Better names required.
   void add(const Dim label, const scipp::index size);
   void addInner(const Dim label, const scipp::index size);
-
-  int32_t index(const Dim label) const;
-
-private:
-  // TODO
-  // scipp::index &at(const Dim dim);
-  // This is 56 Byte, or would be 40 Byte for small size 1.
-  // boost::container::small_vector<std::pair<Dim, scipp::index>, 2> m_dims;
-  // Support at most 6 dimensions, should be sufficient?
-  // 6*8 Byte = 48 Byte
-  // TODO: can we find a good way to initialise the values automatically when
-  // NDIM_MAX is changed?
-  /*
-  scipp::index m_shape[NDIM_MAX]{-1, -1, -1, -1, -1, -1};
-  int16_t m_ndim{0};
-  /// Dimensions labels.
-  Dim m_dims[NDIM_MAX]{Dim::Invalid, Dim::Invalid, Dim::Invalid,
-                       Dim::Invalid, Dim::Invalid, Dim::Invalid};
-                       */
 };
 
 [[nodiscard]] SCIPP_CORE_EXPORT constexpr Dimensions

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -32,7 +32,6 @@ public:
     for (const auto &[label, size] : dims)
       addInner(label, size);
   }
-  explicit Dimensions(const Sizes &sizes);
 
   constexpr bool operator==(const Dimensions &other) const noexcept {
     if (ndim() != other.ndim())

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -56,8 +56,8 @@ public:
   /// Return the volume of the space defined by *this.
   constexpr scipp::index volume() const noexcept {
     scipp::index volume{1};
-    for (int32_t dim = 0; dim < ndim(); ++dim)
-      volume *= shape()[dim];
+    for (const auto &length : shape())
+      volume *= length;
     return volume;
   }
 
@@ -66,13 +66,9 @@ public:
 
   Dim inner() const noexcept;
 
-  // TODO
-  // - remove resize (just use non-const at()?)
   Dim label(const scipp::index i) const;
   scipp::index size(const scipp::index i) const;
   scipp::index offset(const Dim label) const;
-  void resize(const Dim label, const scipp::index size);
-  void resize(const scipp::index i, const scipp::index size);
 
   // TODO Better names required.
   void add(const Dim label, const scipp::index size);

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -12,20 +12,16 @@
 
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
-#include "scipp/common/span.h"
+#include "scipp/core/sizes.h"
 #include "scipp/units/dim.h"
 
 namespace scipp::core {
-
-constexpr int32_t NDIM_MAX = 6;
-
-class Sizes;
 
 /// Dimensions are accessed very frequently, so packing everything into a single
 /// (64 Byte) cacheline should be advantageous.
 /// We follow the numpy convention: First dimension is outer dimension, last
 /// dimension is inner dimension.
-class SCIPP_CORE_EXPORT Dimensions {
+class SCIPP_CORE_EXPORT Dimensions : public Sizes {
 public:
   constexpr Dimensions() noexcept {}
   Dimensions(const Dim dim, const scipp::index size)
@@ -39,12 +35,12 @@ public:
   explicit Dimensions(const Sizes &sizes);
 
   constexpr bool operator==(const Dimensions &other) const noexcept {
-    if (m_ndim != other.m_ndim)
+    if (ndim() != other.ndim())
       return false;
-    for (int32_t i = 0; i < NDIM_MAX; ++i) {
-      if (m_shape[i] != other.m_shape[i])
+    for (int32_t i = 0; i < ndim(); ++i) {
+      if (shape()[i] != other.shape()[i])
         return false;
-      if (m_dims[i] != other.m_dims[i])
+      if (labels()[i] != other.labels()[i])
         return false;
     }
     return true;
@@ -53,65 +49,50 @@ public:
     return !(*this == other);
   }
 
-  constexpr bool empty() const noexcept { return m_ndim == 0; }
+  // constexpr bool empty() const noexcept { return m_ndim == 0; }
+
+  /// Return the shape of the space defined by *this.
+  constexpr scipp::span<const scipp::index> shape() const &noexcept {
+    return sizes();
+  }
 
   /// Return the volume of the space defined by *this.
   constexpr scipp::index volume() const noexcept {
     scipp::index volume{1};
-    for (int32_t dim = 0; dim < m_ndim; ++dim)
-      volume *= m_shape[dim];
+    for (int32_t dim = 0; dim < ndim(); ++dim)
+      volume *= shape()[dim];
     return volume;
   }
 
-  scipp::span<const scipp::index> shape() const && = delete;
-  /// Return the shape of the space defined by *this.
-  constexpr scipp::span<const scipp::index> shape() const &noexcept {
-    return {m_shape, m_shape + m_ndim};
-  }
-
   /// Return number of dims
-  constexpr uint16_t ndim() const noexcept { return m_ndim; }
-
-  scipp::span<const Dim> labels() const && = delete;
-  /// Return the labels of the space defined by *this.
-  constexpr scipp::span<const Dim> labels() const &noexcept {
-    return {m_dims, m_dims + m_ndim};
-  }
-
-  scipp::index operator[](const Dim dim) const;
-  scipp::index at(const Dim dim) const;
+  constexpr scipp::index ndim() const noexcept { return Sizes::size(); }
 
   Dim inner() const noexcept;
 
   /// Return true if `dim` is one of the labels in *this.
-  constexpr bool contains(const Dim dim) const noexcept {
-    for (int32_t i = 0; i < m_ndim; ++i)
-      if (m_dims[i] == dim)
-        return true;
-    return false;
-  }
+  // constexpr bool contains(const Dim dim) const noexcept ;
 
   /// Returns the number of occurences of `dim` in *this.
   ///
   /// This exists for convenience so generic code supporting std::unordered_map
   /// can be written.
-  constexpr scipp::index count(const Dim dim) const noexcept {
-    return contains(dim) ? 1 : 0;
-  }
+  // constexpr scipp::index count(const Dim dim) const noexcept {
+  //  return contains(dim) ? 1 : 0;
+  //}
 
-  bool contains(const Dimensions &other) const noexcept;
+  // bool contains(const Dimensions &other) const noexcept;
 
   bool isContiguousIn(const Dimensions &parent) const;
 
   // TODO Some of the following methods are probably legacy and should be
   // considered for removal.
   Dim label(const scipp::index i) const;
+  using Sizes::relabel;
   void relabel(const scipp::index i, const Dim label);
   scipp::index size(const scipp::index i) const;
   scipp::index offset(const Dim label) const;
   void resize(const Dim label, const scipp::index size);
   void resize(const scipp::index i, const scipp::index size);
-  void erase(const Dim label);
 
   // TODO Better names required.
   void add(const Dim label, const scipp::index size);
@@ -120,18 +101,21 @@ public:
   int32_t index(const Dim label) const;
 
 private:
-  scipp::index &at(const Dim dim);
+  // TODO
+  // scipp::index &at(const Dim dim);
   // This is 56 Byte, or would be 40 Byte for small size 1.
   // boost::container::small_vector<std::pair<Dim, scipp::index>, 2> m_dims;
   // Support at most 6 dimensions, should be sufficient?
   // 6*8 Byte = 48 Byte
   // TODO: can we find a good way to initialise the values automatically when
   // NDIM_MAX is changed?
+  /*
   scipp::index m_shape[NDIM_MAX]{-1, -1, -1, -1, -1, -1};
   int16_t m_ndim{0};
   /// Dimensions labels.
   Dim m_dims[NDIM_MAX]{Dim::Invalid, Dim::Invalid, Dim::Invalid,
                        Dim::Invalid, Dim::Invalid, Dim::Invalid};
+                       */
 };
 
 [[nodiscard]] SCIPP_CORE_EXPORT constexpr Dimensions

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -70,6 +70,9 @@ public:
 
   // TODO Some of the following methods are probably legacy and should be
   // considered for removal.
+  // TODO
+  // - remove resize (just use non-const at()?)
+  // - remove relabel?
   Dim label(const scipp::index i) const;
   using Sizes::relabel;
   void relabel(const scipp::index i, const Dim label);

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -74,7 +74,6 @@ public:
   // - remove resize (just use non-const at()?)
   // - remove relabel?
   Dim label(const scipp::index i) const;
-  using Sizes::relabel;
   void relabel(const scipp::index i, const Dim label);
   scipp::index size(const scipp::index i) const;
   scipp::index offset(const Dim label) const;

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -66,15 +66,9 @@ public:
 
   Dim inner() const noexcept;
 
-  bool isContiguousIn(const Dimensions &parent) const;
-
-  // TODO Some of the following methods are probably legacy and should be
-  // considered for removal.
   // TODO
   // - remove resize (just use non-const at()?)
-  // - remove relabel?
   Dim label(const scipp::index i) const;
-  void relabel(const scipp::index i, const Dim label);
   scipp::index size(const scipp::index i) const;
   scipp::index offset(const Dim label) const;
   void resize(const Dim label, const scipp::index size);

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -49,9 +49,6 @@ throw_mismatch_error(const core::Dimensions &expected,
                      const core::Dimensions &actual);
 
 [[noreturn]] SCIPP_CORE_EXPORT void
-throw_dimension_not_found_error(const core::Dimensions &expected, Dim actual);
-
-[[noreturn]] SCIPP_CORE_EXPORT void
 throw_dimension_length_error(const core::Dimensions &expected, Dim actual,
                              scipp::index length);
 

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -84,6 +84,12 @@ template <class A, class B> void contains(const A &a, const B &b) {
     throw except::NotFoundError("Expected " + to_string(a) + " to contain " +
                                 to_string(b) + ".");
 }
+template <class A, class B> void includes(const A &a, const B &b) {
+  using core::to_string;
+  if (!a.includes(b))
+    throw except::NotFoundError("Expected " + to_string(a) + " to include " +
+                                to_string(b) + ".");
+}
 } // namespace scipp::expect
 
 namespace scipp::core::expect {

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -11,9 +11,7 @@
 #include "scipp-core_export.h"
 #include "scipp/common/except.h"
 #include "scipp/common/index.h"
-#include "scipp/core/dimensions.h"
 #include "scipp/core/dtype.h"
-#include "scipp/core/sizes.h"
 #include "scipp/core/string.h"
 #include "scipp/units/except.h"
 #include "scipp/units/unit.h"
@@ -21,6 +19,7 @@
 namespace scipp::core {
 
 class Dimensions;
+class Sizes;
 class Slice;
 
 } // namespace scipp::core

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -128,7 +128,6 @@ template <class T> void countsOrCountsDensity(const T &object) {
 }
 
 // TODO maybe just provide a `slice` function/method and check via that?
-void SCIPP_CORE_EXPORT validSlice(const Dimensions &dims, const Slice &slice);
 void SCIPP_CORE_EXPORT validSlice(const Sizes &sizes, const Slice &slice);
 
 void SCIPP_CORE_EXPORT notCountDensity(const units::Unit &unit);

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -19,10 +19,10 @@ constexpr int32_t NDIM_MAX = 6;
 class Dimensions;
 
 /// Small (fixed maximum size) and stable (preserving key order) map
-template <class Key, class Value, int16_t MaxSize, class Except = int>
+template <class Key, class Value, int16_t Capacity>
 class SCIPP_CORE_EXPORT small_stable_map {
 public:
-  static constexpr auto capacity = MaxSize;
+  static constexpr auto capacity = Capacity;
 
   small_stable_map() = default;
 
@@ -31,7 +31,7 @@ public:
 
   auto begin() const noexcept { return m_keys.begin(); }
   auto end() const noexcept { return m_keys.begin() + size(); }
-  typename std::array<Key, MaxSize>::const_iterator find(const Key &key) const;
+  typename std::array<Key, Capacity>::const_iterator find(const Key &key) const;
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
   constexpr scipp::index size() const noexcept { return m_size; }
   bool contains(const Key &key) const noexcept;
@@ -53,8 +53,8 @@ public:
 
 private:
   int16_t m_size{0};
-  std::array<Key, MaxSize> m_keys{};
-  std::array<Value, MaxSize> m_values{};
+  std::array<Key, Capacity> m_keys{};
+  std::array<Value, Capacity> m_values{};
 };
 
 /// Similar to class Dimensions but without implied ordering

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -18,13 +18,14 @@ constexpr int32_t NDIM_MAX = 6;
 
 class Dimensions;
 
+/// Small (fixed maximum size) and stable (preserving key order) map
 template <class Key, class Value, int16_t MaxSize, class Except = int>
-class SCIPP_CORE_EXPORT small_map {
+class SCIPP_CORE_EXPORT small_stable_map {
 public:
-  small_map() = default;
+  small_stable_map() = default;
 
-  bool operator==(const small_map &other) const noexcept;
-  bool operator!=(const small_map &other) const noexcept;
+  bool operator==(const small_stable_map &other) const noexcept;
+  bool operator!=(const small_stable_map &other) const noexcept;
 
   auto begin() const { return m_keys.begin(); }
   auto end() const { return m_keys.begin() + size(); }
@@ -55,10 +56,11 @@ private:
   std::array<Value, MaxSize> m_values{};
 };
 
-/// Sibling of class Dimensions, but unordered.
-class SCIPP_CORE_EXPORT Sizes : public small_map<Dim, scipp::index, NDIM_MAX> {
+/// Similar to class Dimensions but without implied ordering
+class SCIPP_CORE_EXPORT Sizes
+    : public small_stable_map<Dim, scipp::index, NDIM_MAX> {
 private:
-  using base = small_map<Dim, scipp::index, NDIM_MAX>;
+  using base = small_stable_map<Dim, scipp::index, NDIM_MAX>;
 
 protected:
   using base::insert_left;

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -32,7 +32,7 @@ public:
   typename std::array<Key, Capacity>::const_iterator find(const Key &key) const;
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
   constexpr scipp::index size() const noexcept { return m_size; }
-  bool contains(const Key &key) const noexcept;
+  bool contains(const Key &key) const;
   scipp::index index(const Key &key) const;
   const Value &operator[](const Key &key) const;
   const Value &at(const Key &key) const;

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -72,7 +72,6 @@ public:
   scipp::index count(const Dim dim) const noexcept { return contains(dim); }
 
   void set(const Dim dim, const scipp::index size);
-  void relabel(const Dim from, const Dim to);
   bool includes(const Sizes &sizes) const;
   Sizes slice(const Slice &params) const;
 

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -22,26 +22,27 @@ class Dimensions;
 template <class Key, class Value, int16_t MaxSize, class Except = int>
 class SCIPP_CORE_EXPORT small_stable_map {
 public:
+  static constexpr auto capacity = MaxSize;
+
   small_stable_map() = default;
 
   bool operator==(const small_stable_map &other) const noexcept;
   bool operator!=(const small_stable_map &other) const noexcept;
 
-  auto begin() const { return m_keys.begin(); }
-  auto end() const { return m_keys.begin() + size(); }
+  auto begin() const noexcept { return m_keys.begin(); }
+  auto end() const noexcept { return m_keys.begin() + size(); }
   typename std::array<Key, MaxSize>::const_iterator find(const Key &key) const;
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
   constexpr scipp::index size() const noexcept { return m_size; }
   bool contains(const Key &key) const noexcept;
   scipp::index index(const Key &key) const;
   const Value &operator[](const Key &key) const;
-  Value &operator[](const Key &key);
   const Value &at(const Key &key) const;
-  Value &at(const Key &key);
+  void assign(const Key &key, const Value &value);
   void insert_left(const Key &key, const Value &value);
   void insert_right(const Key &key, const Value &value);
   void erase(const Key &key);
-  void clear();
+  void clear() noexcept;
   void replace_key(const Key &from, const Key &to);
   constexpr scipp::span<const Key> keys() const &noexcept {
     return {m_keys.data(), static_cast<size_t>(size())};
@@ -63,6 +64,7 @@ private:
   using base = small_stable_map<Dim, scipp::index, NDIM_MAX>;
 
 protected:
+  using base::assign;
   using base::insert_left;
   using base::insert_right;
 
@@ -72,6 +74,7 @@ public:
   scipp::index count(const Dim dim) const noexcept { return contains(dim); }
 
   void set(const Dim dim, const scipp::index size);
+  void resize(const Dim dim, const scipp::index size);
   bool includes(const Sizes &sizes) const;
   Sizes slice(const Slice &params) const;
 

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -23,7 +23,7 @@ public:
   bool operator!=(const small_map &other) const noexcept;
 
   auto begin() const { return m_keys.begin(); }
-  auto end() const { return m_keys.end(); }
+  auto end() const { return m_keys.begin() + size(); }
   typename std::array<Key, MaxSize>::const_iterator find(const Key &key) const;
   [[nodiscard]] bool empty() const noexcept;
   scipp::index size() const noexcept { return m_size; }

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -32,12 +32,13 @@ public:
   Value &operator[](const Key &key);
   const Value &at(const Key &key) const;
   Value &at(const Key &key);
-  void insert(const Key &key, const Value &value);
+  void insert_left(const Key &key, const Value &value);
+  void insert_right(const Key &key, const Value &value);
   void erase(const Key &key);
   void clear();
 
 private:
-  int64_t m_size{0};
+  int16_t m_size{0};
   std::array<Key, MaxSize> m_keys{};
   std::array<Value, MaxSize> m_values{};
 };
@@ -46,7 +47,8 @@ private:
 class SCIPP_CORE_EXPORT Sizes : public small_map<Dim, scipp::index, NDIM_MAX> {
 private:
   using base = small_map<Dim, scipp::index, NDIM_MAX>;
-  using base::insert;
+  using base::insert_left;
+  using base::insert_right;
 
 public:
   Sizes() = default;

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -35,7 +35,6 @@ public:
   void insert(const Key &key, const Value &value);
   void erase(const Key &key);
   void clear();
-  // void relabel(const Dim from, const Dim to);
 
 private:
   int64_t m_size{0};
@@ -47,6 +46,7 @@ private:
 class SCIPP_CORE_EXPORT Sizes : public small_map<Dim, scipp::index, NDIM_MAX> {
 private:
   using base = small_map<Dim, scipp::index, NDIM_MAX>;
+  using base::insert;
 
 public:
   Sizes() = default;

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -32,6 +32,7 @@ public:
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
   constexpr scipp::index size() const noexcept { return m_size; }
   bool contains(const Key &key) const noexcept;
+  scipp::index index(const Key &key) const;
   const Value &operator[](const Key &key) const;
   Value &operator[](const Key &key);
   const Value &at(const Key &key) const;
@@ -65,7 +66,6 @@ protected:
 
 public:
   Sizes() = default;
-  Sizes(const std::unordered_map<Dim, scipp::index> &sizes);
 
   scipp::index count(const Dim dim) const noexcept { return contains(dim); }
 

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -4,8 +4,6 @@
 /// @author Simon Heybrock
 #pragma once
 
-#include <unordered_map>
-
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
@@ -70,8 +68,6 @@ protected:
 
 public:
   Sizes() = default;
-
-  scipp::index count(const Dim dim) const noexcept { return contains(dim); }
 
   void set(const Dim dim, const scipp::index size);
   void resize(const Dim dim, const scipp::index size);

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -87,7 +87,7 @@ public:
 
 [[nodiscard]] SCIPP_CORE_EXPORT Sizes merge(const Sizes &a, const Sizes &b);
 
-SCIPP_CORE_EXPORT bool is_edges(const Sizes &sizes, const Dimensions &dims,
+SCIPP_CORE_EXPORT bool is_edges(const Sizes &sizes, const Sizes &dataSizes,
                                 const Dim dim);
 
 SCIPP_CORE_EXPORT std::string to_string(const Sizes &sizes);

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -71,8 +71,7 @@ public:
 
   void set(const Dim dim, const scipp::index size);
   void relabel(const Dim from, const Dim to);
-  using base::contains;
-  bool contains(const Sizes &sizes) const;
+  bool includes(const Sizes &sizes) const;
   Sizes slice(const Slice &params) const;
 
   /// Return the labels of the space defined by *this.

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -2,31 +2,103 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include <algorithm>
+
 #include "scipp/core/sizes.h"
 #include "scipp/core/except.h"
 
 namespace scipp::core {
 
+template <class Key, class Value, int16_t MaxSize>
+bool small_map<Key, Value, MaxSize>::operator==(
+    const small_map &other) const noexcept {
+  if (size() != other.size())
+    return false;
+  for (const auto &key : *this)
+    if (!other.contains(key) && at(key) != other.at(key))
+      return false;
+  return true;
+}
+
+template <class Key, class Value, int16_t MaxSize>
+bool small_map<Key, Value, MaxSize>::operator!=(
+    const small_map &other) const noexcept {
+  return !operator==(other);
+}
+
+template <class Key, class Value, int16_t MaxSize>
+typename std::array<Key, MaxSize>::const_iterator
+small_map<Key, Value, MaxSize>::find(const Key &key) const {
+  return std::find(begin(), end(), key);
+}
+
+template <class Key, class Value, int16_t MaxSize>
+bool small_map<Key, Value, MaxSize>::empty() const noexcept {
+  return m_size == 0;
+}
+
+template <class Key, class Value, int16_t MaxSize>
+bool small_map<Key, Value, MaxSize>::contains(const Key &key) const noexcept {
+  return std::find(begin(), end(), key) != end();
+}
+
+template <class Key, class Value, int16_t MaxSize>
+const Value &small_map<Key, Value, MaxSize>::operator[](const Key &key) const {
+  return at(key);
+}
+
+template <class Key, class Value, int16_t MaxSize>
+Value &small_map<Key, Value, MaxSize>::operator[](const Key &key) {
+  return at(key);
+}
+
+template <class Key, class Value, int16_t MaxSize>
+const Value &small_map<Key, Value, MaxSize>::at(const Key &key) const {
+  return m_values[std::distance(begin(), find(key))];
+}
+
+template <class Key, class Value, int16_t MaxSize>
+Value &small_map<Key, Value, MaxSize>::at(const Key &key) {
+  return m_values[std::distance(begin(), find(key))];
+}
+
+template <class Key, class Value, int16_t MaxSize>
+void small_map<Key, Value, MaxSize>::insert(const Key &key,
+                                            const Value &value) {
+  if (contains(key))
+    return;
+  if (size() == MaxSize)
+    throw std::runtime_error("Exceeding builtin map size");
+  m_keys[m_size] = key;
+  m_values[m_size] = value;
+  m_size++;
+}
+
+template <class Key, class Value, int16_t MaxSize>
+void small_map<Key, Value, MaxSize>::erase(const Key &key) {
+  // scipp::expect::contains(*this, key);
+  m_size--;
+  for (scipp::index i = std::distance(begin(), find(key)); i < size(); ++i) {
+    m_keys[i] = m_keys[i + 1];
+    m_values[i] = m_values[i + 1];
+  }
+}
+
+template <class Key, class Value, int16_t MaxSize>
+void small_map<Key, Value, MaxSize>::clear() {
+  m_size = 0;
+}
+
+template class small_map<Dim, scipp::index, NDIM_MAX>;
+
 Sizes::Sizes(const Dimensions &dims) {
   for (const auto dim : dims.labels())
-    m_sizes[dim] = dims[dim];
+    insert(dim, dims[dim]);
 }
 
-bool Sizes::operator==(const Sizes &other) const {
-  return m_sizes == other.m_sizes;
-}
-
-bool Sizes::operator!=(const Sizes &other) const { return !operator==(other); }
-
-void Sizes::clear() { m_sizes.clear(); }
-
-scipp::index Sizes::operator[](const Dim dim) const { return at(dim); }
-
-scipp::index &Sizes::operator[](const Dim dim) { return at(dim); }
-
-scipp::index Sizes::at(const Dim dim) const {
-  scipp::expect::contains(*this, dim);
-  return m_sizes.at(dim);
+Sizes::Sizes(const std::unordered_map<Dim, scipp::index> &sizes) {
+  for (const auto &[dim, size] : sizes)
+    insert(dim, size);
 }
 
 scipp::index &Sizes::at(const Dim dim) {
@@ -39,44 +111,39 @@ void Sizes::set(const Dim dim, const scipp::index size) {
     throw except::DimensionError(
         "Inconsistent size for dim '" + to_string(dim) + "', given " +
         std::to_string(at(dim)) + ", requested " + std::to_string(size));
-  m_sizes[dim] = size;
-}
-
-void Sizes::erase(const Dim dim) {
-  scipp::expect::contains(*this, dim);
-  m_sizes.erase(dim);
+  at(dim) = size;
 }
 
 void Sizes::relabel(const Dim from, const Dim to) {
   if (!contains(from))
     return;
-  auto node = m_sizes.extract(from);
-  node.key() = to;
-  m_sizes.insert(std::move(node));
+  auto size = at(from);
+  erase(from);
+  insert(to, size);
 }
 
 bool Sizes::contains(const Dimensions &dims) const {
   for (const auto &dim : dims.labels())
-    if (m_sizes.count(dim) == 0 || m_sizes.at(dim) != dims[dim])
+    if (!contains(dim) || at(dim) != dims[dim])
       return false;
   return true;
 }
 
 bool Sizes::contains(const Sizes &sizes) const {
-  for (const auto &[dim, size] : sizes)
-    if (m_sizes.count(dim) == 0 || m_sizes.at(dim) != size)
+  for (const auto &dim : sizes)
+    if (!contains(dim) || at(dim) != sizes[dim])
       return false;
   return true;
 }
 
 Sizes Sizes::slice(const Slice &params) const {
   core::expect::validSlice(*this, params);
-  auto sizes = m_sizes;
+  Sizes sliced(*this);
   if (params.isRange())
-    sizes.at(params.dim()) = params.end() - params.begin();
+    sliced.at(params.dim()) = params.end() - params.begin();
   else
-    sizes.erase(params.dim());
-  return {sizes};
+    sliced.erase(params.dim());
+  return sliced;
 }
 
 Sizes concatenate(const Sizes &a, const Sizes &b, const Dim dim) {
@@ -87,8 +154,8 @@ Sizes concatenate(const Sizes &a, const Sizes &b, const Dim dim) {
 
 Sizes merge(const Sizes &a, const Sizes &b) {
   auto out(a);
-  for (const auto &[dim, size] : b)
-    out.set(dim, size);
+  for (const auto &dim : b)
+    out.set(dim, b[dim]);
   return out;
 }
 
@@ -104,8 +171,8 @@ bool is_edges(const Sizes &sizes, const Dimensions &dims, const Dim dim) {
 
 std::string to_string(const Sizes &sizes) {
   std::string repr("Sizes[");
-  for (const auto &[dim, size] : sizes)
-    repr += to_string(dim) + ":" + std::to_string(size) + ", ";
+  for (const auto &dim : sizes)
+    repr += to_string(dim) + ":" + std::to_string(sizes[dim]) + ", ";
   repr += "]";
   return repr;
 }

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -191,13 +191,13 @@ Sizes merge(const Sizes &a, const Sizes &b) {
   return out;
 }
 
-bool is_edges(const Sizes &sizes, const Dimensions &dims, const Dim dim) {
+bool is_edges(const Sizes &sizes, const Sizes &dataSizes, const Dim dim) {
   if (dim == Dim::Invalid)
     return false;
-  for (const auto &d : dims.labels())
-    if (d != dim && !(sizes.contains(d) && sizes[d] == dims[d]))
+  for (const auto &d : dataSizes)
+    if (d != dim && !(sizes.contains(d) && sizes[d] == dataSizes[d]))
       return false;
-  const auto size = dims[dim];
+  const auto size = dataSizes[dim];
   return size == (sizes.contains(dim) ? sizes[dim] + 1 : 2);
 }
 

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -62,15 +62,14 @@ small_stable_map<Key, Value, Capacity>::find(const Key &key) const {
 }
 
 template <class Key, class Value, int16_t Capacity>
-bool small_stable_map<Key, Value, Capacity>::contains(
-    const Key &key) const noexcept {
-  return std::find(begin(), end(), key) != end();
+bool small_stable_map<Key, Value, Capacity>::contains(const Key &key) const {
+  return find(key) != end();
 }
 
 template <class Key, class Value, int16_t Capacity>
 scipp::index
 small_stable_map<Key, Value, Capacity>::index(const Key &key) const {
-  auto it = std::find(begin(), end(), key);
+  const auto it = find(key);
   if (it == end())
     throw_dimension_not_found_error(*this, key);
   return std::distance(begin(), it);
@@ -84,17 +83,13 @@ small_stable_map<Key, Value, Capacity>::operator[](const Key &key) const {
 
 template <class Key, class Value, int16_t Capacity>
 const Value &small_stable_map<Key, Value, Capacity>::at(const Key &key) const {
-  if (!contains(key))
-    throw_dimension_not_found_error(*this, key);
-  return m_values[std::distance(begin(), find(key))];
+  return m_values[index(key)];
 }
 
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::assign(const Key &key,
                                                     const Value &value) {
-  if (!contains(key))
-    throw_dimension_not_found_error(*this, key);
-  m_values[std::distance(begin(), find(key))] = value;
+  m_values[index(key)] = value;
 }
 
 template <class Key, class Value, int16_t Capacity>
@@ -123,13 +118,11 @@ void small_stable_map<Key, Value, Capacity>::insert_right(const Key &key,
 
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::erase(const Key &key) {
-  if (!contains(key))
-    throw_dimension_not_found_error(*this, key);
-  m_size--;
-  for (scipp::index i = std::distance(begin(), find(key)); i < size(); ++i) {
+  for (scipp::index i = index(key); i < size() - 1; ++i) {
     m_keys[i] = m_keys[i + 1];
     m_values[i] = m_values[i + 1];
   }
+  m_size--;
 }
 
 template <class Key, class Value, int16_t Capacity>
@@ -140,12 +133,9 @@ void small_stable_map<Key, Value, Capacity>::clear() noexcept {
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::replace_key(const Key &key,
                                                          const Key &new_key) {
-  if (!contains(key))
-    throw_dimension_not_found_error(*this, key);
   if (key != new_key)
     expectUnique(*this, new_key);
-  auto it = std::find(m_keys.begin(), m_keys.end(), key);
-  *it = new_key;
+  m_keys[index(key)] = new_key;
 }
 
 template class small_stable_map<Dim, scipp::index, NDIM_MAX>;

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -4,8 +4,8 @@
 /// @author Simon Heybrock
 #include <algorithm>
 
-#include "scipp/core/sizes.h"
 #include "scipp/core/except.h"
+#include "scipp/core/sizes.h"
 
 namespace scipp::core {
 
@@ -16,8 +16,8 @@ template <class T> void expectUnique(const T &map, const Dim label) {
 }
 } // namespace
 
-template <class Key, class Value, int16_t MaxSize>
-bool small_map<Key, Value, MaxSize>::operator==(
+template <class Key, class Value, int16_t MaxSize, class Except>
+bool small_map<Key, Value, MaxSize, Except>::operator==(
     const small_map &other) const noexcept {
   if (size() != other.size())
     return false;
@@ -27,58 +27,55 @@ bool small_map<Key, Value, MaxSize>::operator==(
   return true;
 }
 
-template <class Key, class Value, int16_t MaxSize>
-bool small_map<Key, Value, MaxSize>::operator!=(
+template <class Key, class Value, int16_t MaxSize, class Except>
+bool small_map<Key, Value, MaxSize, Except>::operator!=(
     const small_map &other) const noexcept {
   return !operator==(other);
 }
 
-template <class Key, class Value, int16_t MaxSize>
+template <class Key, class Value, int16_t MaxSize, class Except>
 typename std::array<Key, MaxSize>::const_iterator
-small_map<Key, Value, MaxSize>::find(const Key &key) const {
+small_map<Key, Value, MaxSize, Except>::find(const Key &key) const {
   return std::find(begin(), end(), key);
 }
 
-template <class Key, class Value, int16_t MaxSize>
-bool small_map<Key, Value, MaxSize>::empty() const noexcept {
-  return m_size == 0;
-}
-
-template <class Key, class Value, int16_t MaxSize>
-bool small_map<Key, Value, MaxSize>::contains(const Key &key) const noexcept {
+template <class Key, class Value, int16_t MaxSize, class Except>
+bool small_map<Key, Value, MaxSize, Except>::contains(
+    const Key &key) const noexcept {
   return std::find(begin(), end(), key) != end();
 }
 
-template <class Key, class Value, int16_t MaxSize>
-const Value &small_map<Key, Value, MaxSize>::operator[](const Key &key) const {
+template <class Key, class Value, int16_t MaxSize, class Except>
+const Value &
+small_map<Key, Value, MaxSize, Except>::operator[](const Key &key) const {
   return at(key);
 }
 
-template <class Key, class Value, int16_t MaxSize>
-Value &small_map<Key, Value, MaxSize>::operator[](const Key &key) {
+template <class Key, class Value, int16_t MaxSize, class Except>
+Value &small_map<Key, Value, MaxSize, Except>::operator[](const Key &key) {
   return at(key);
 }
 
-template <class Key, class Value, int16_t MaxSize>
-const Value &small_map<Key, Value, MaxSize>::at(const Key &key) const {
+template <class Key, class Value, int16_t MaxSize, class Except>
+const Value &small_map<Key, Value, MaxSize, Except>::at(const Key &key) const {
   if (!contains(key))
-    throw std::runtime_error("Key not found");
+    throw except::DimensionError("Key not found");
   return m_values[std::distance(begin(), find(key))];
 }
 
-template <class Key, class Value, int16_t MaxSize>
-Value &small_map<Key, Value, MaxSize>::at(const Key &key) {
+template <class Key, class Value, int16_t MaxSize, class Except>
+Value &small_map<Key, Value, MaxSize, Except>::at(const Key &key) {
   if (!contains(key))
-    throw std::runtime_error("Key not found");
+    throw except::DimensionError("Key not found");
   return m_values[std::distance(begin(), find(key))];
 }
 
-template <class Key, class Value, int16_t MaxSize>
-void small_map<Key, Value, MaxSize>::insert_left(const Key &key,
-                                                 const Value &value) {
+template <class Key, class Value, int16_t MaxSize, class Except>
+void small_map<Key, Value, MaxSize, Except>::insert_left(const Key &key,
+                                                         const Value &value) {
   expectUnique(*this, key);
   if (size() == MaxSize)
-    throw std::runtime_error("Exceeding builtin map size");
+    throw except::DimensionError("Exceeding builtin map size");
   for (scipp::index i = size(); i > 0; --i) {
     m_keys[i] = m_keys[i - 1];
     m_values[i] = m_values[i - 1];
@@ -88,21 +85,21 @@ void small_map<Key, Value, MaxSize>::insert_left(const Key &key,
   m_size++;
 }
 
-template <class Key, class Value, int16_t MaxSize>
-void small_map<Key, Value, MaxSize>::insert_right(const Key &key,
-                                                  const Value &value) {
+template <class Key, class Value, int16_t MaxSize, class Except>
+void small_map<Key, Value, MaxSize, Except>::insert_right(const Key &key,
+                                                          const Value &value) {
   expectUnique(*this, key);
   if (size() == MaxSize)
-    throw std::runtime_error("Exceeding builtin map size");
+    throw except::DimensionError("Exceeding builtin map size");
   m_keys[m_size] = key;
   m_values[m_size] = value;
   m_size++;
 }
 
-template <class Key, class Value, int16_t MaxSize>
-void small_map<Key, Value, MaxSize>::erase(const Key &key) {
+template <class Key, class Value, int16_t MaxSize, class Except>
+void small_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
   if (!contains(key))
-    throw std::runtime_error("Key not found");
+    throw except::DimensionError("Key not found");
   m_size--;
   for (scipp::index i = std::distance(begin(), find(key)); i < size(); ++i) {
     m_keys[i] = m_keys[i + 1];
@@ -110,17 +107,21 @@ void small_map<Key, Value, MaxSize>::erase(const Key &key) {
   }
 }
 
-template <class Key, class Value, int16_t MaxSize>
-void small_map<Key, Value, MaxSize>::clear() {
+template <class Key, class Value, int16_t MaxSize, class Except>
+void small_map<Key, Value, MaxSize, Except>::clear() {
   m_size = 0;
 }
 
-template class small_map<Dim, scipp::index, NDIM_MAX>;
-
-Sizes::Sizes(const Dimensions &dims) {
-  for (const auto dim : dims.labels())
-    insert_right(dim, dims[dim]);
+template <class Key, class Value, int16_t MaxSize, class Except>
+void small_map<Key, Value, MaxSize, Except>::replace_key(const Key &key,
+                                                         const Key &new_key) {
+  if (!contains(key))
+    throw except::DimensionError("Key not found");
+  auto it = std::find(m_keys.begin(), m_keys.end(), key);
+  *it = new_key;
 }
+
+template class small_map<Dim, scipp::index, NDIM_MAX, int>;
 
 Sizes::Sizes(const std::unordered_map<Dim, scipp::index> &sizes) {
   for (const auto &[dim, size] : sizes)
@@ -141,18 +142,9 @@ void Sizes::set(const Dim dim, const scipp::index size) {
 }
 
 void Sizes::relabel(const Dim from, const Dim to) {
-  if (!contains(from))
-    return;
-  auto size = at(from);
-  erase(from);
-  insert_right(to, size);
-}
-
-bool Sizes::contains(const Dimensions &dims) const {
-  for (const auto &dim : dims.labels())
-    if (!contains(dim) || at(dim) != dims[dim])
-      return false;
-  return true;
+  if (to != Dim::Invalid)
+    expectUnique(*this, to);
+  replace_key(from, to);
 }
 
 bool Sizes::contains(const Sizes &sizes) const {

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -115,6 +115,8 @@ void small_map<Key, Value, MaxSize, Except>::clear() {
 template <class Key, class Value, int16_t MaxSize, class Except>
 void small_map<Key, Value, MaxSize, Except>::replace_key(const Key &key,
                                                          const Key &new_key) {
+  // TODO no check for duplicate here, which is inconsistent, but needed to
+  // relabel to Dim::Invalid
   if (!contains(key))
     throw except::DimensionError("Key not found");
   auto it = std::find(m_keys.begin(), m_keys.end(), key);
@@ -138,13 +140,15 @@ void Sizes::set(const Dim dim, const scipp::index size) {
     throw except::DimensionError(
         "Inconsistent size for dim '" + to_string(dim) + "', given " +
         std::to_string(at(dim)) + ", requested " + std::to_string(size));
-  insert_right(dim, size);
+  if (!contains(dim))
+    insert_right(dim, size);
 }
 
 void Sizes::relabel(const Dim from, const Dim to) {
-  if (to != Dim::Invalid)
+  if (to != Dim::Invalid && from != to)
     expectUnique(*this, to);
-  replace_key(from, to);
+  if (contains(from))
+    replace_key(from, to);
 }
 
 bool Sizes::contains(const Sizes &sizes) const {

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -166,11 +166,11 @@ void Sizes::relabel(const Dim from, const Dim to) {
     replace_key(from, to);
 }
 
-bool Sizes::contains(const Sizes &sizes) const {
-  for (const auto &dim : sizes)
-    if (!contains(dim) || at(dim) != sizes[dim])
-      return false;
-  return true;
+/// Return true if all dimensions of other contained in *this, with same size.
+bool Sizes::includes(const Sizes &sizes) const {
+  return std::all_of(sizes.begin(), sizes.end(), [&](const auto &dim) {
+    return contains(dim) && at(dim) == sizes[dim];
+  });
 }
 
 Sizes Sizes::slice(const Slice &params) const {

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -142,10 +142,10 @@ void small_stable_map<Key, Value, MaxSize, Except>::clear() {
 template <class Key, class Value, int16_t MaxSize, class Except>
 void small_stable_map<Key, Value, MaxSize, Except>::replace_key(
     const Key &key, const Key &new_key) {
-  // TODO no check for duplicate here, which is inconsistent, but needed to
-  // relabel to Dim::Invalid
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
+  if (key != new_key)
+    expectUnique(*this, new_key);
   auto it = std::find(m_keys.begin(), m_keys.end(), key);
   *it = new_key;
 }
@@ -159,13 +159,6 @@ void Sizes::set(const Dim dim, const scipp::index size) {
         std::to_string(at(dim)) + ", requested " + std::to_string(size));
   if (!contains(dim))
     insert_right(dim, size);
-}
-
-void Sizes::relabel(const Dim from, const Dim to) {
-  if (to != Dim::Invalid && from != to)
-    expectUnique(*this, to);
-  if (contains(from))
-    replace_key(from, to);
 }
 
 /// Return true if all dimensions of other contained in *this, with same size.

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -33,8 +33,8 @@ void throw_dimension_not_found_error(const T &expected, Dim actual) {
 } // namespace
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_map<Key, Value, MaxSize, Except>::operator==(
-    const small_map &other) const noexcept {
+bool small_stable_map<Key, Value, MaxSize, Except>::operator==(
+    const small_stable_map &other) const noexcept {
   if (size() != other.size())
     return false;
   for (const auto &key : *this)
@@ -44,26 +44,26 @@ bool small_map<Key, Value, MaxSize, Except>::operator==(
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_map<Key, Value, MaxSize, Except>::operator!=(
-    const small_map &other) const noexcept {
+bool small_stable_map<Key, Value, MaxSize, Except>::operator!=(
+    const small_stable_map &other) const noexcept {
   return !operator==(other);
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
 typename std::array<Key, MaxSize>::const_iterator
-small_map<Key, Value, MaxSize, Except>::find(const Key &key) const {
+small_stable_map<Key, Value, MaxSize, Except>::find(const Key &key) const {
   return std::find(begin(), end(), key);
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_map<Key, Value, MaxSize, Except>::contains(
+bool small_stable_map<Key, Value, MaxSize, Except>::contains(
     const Key &key) const noexcept {
   return std::find(begin(), end(), key) != end();
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
 scipp::index
-small_map<Key, Value, MaxSize, Except>::index(const Key &key) const {
+small_stable_map<Key, Value, MaxSize, Except>::index(const Key &key) const {
   auto it = std::find(begin(), end(), key);
   if (it == end())
     throw_dimension_not_found_error(*this, key);
@@ -71,33 +71,35 @@ small_map<Key, Value, MaxSize, Except>::index(const Key &key) const {
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
+const Value &small_stable_map<Key, Value, MaxSize, Except>::operator[](
+    const Key &key) const {
+  return at(key);
+}
+
+template <class Key, class Value, int16_t MaxSize, class Except>
+Value &
+small_stable_map<Key, Value, MaxSize, Except>::operator[](const Key &key) {
+  return at(key);
+}
+
+template <class Key, class Value, int16_t MaxSize, class Except>
 const Value &
-small_map<Key, Value, MaxSize, Except>::operator[](const Key &key) const {
-  return at(key);
-}
-
-template <class Key, class Value, int16_t MaxSize, class Except>
-Value &small_map<Key, Value, MaxSize, Except>::operator[](const Key &key) {
-  return at(key);
-}
-
-template <class Key, class Value, int16_t MaxSize, class Except>
-const Value &small_map<Key, Value, MaxSize, Except>::at(const Key &key) const {
+small_stable_map<Key, Value, MaxSize, Except>::at(const Key &key) const {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   return m_values[std::distance(begin(), find(key))];
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-Value &small_map<Key, Value, MaxSize, Except>::at(const Key &key) {
+Value &small_stable_map<Key, Value, MaxSize, Except>::at(const Key &key) {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   return m_values[std::distance(begin(), find(key))];
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-void small_map<Key, Value, MaxSize, Except>::insert_left(const Key &key,
-                                                         const Value &value) {
+void small_stable_map<Key, Value, MaxSize, Except>::insert_left(
+    const Key &key, const Value &value) {
   expectUnique(*this, key);
   if (size() == MaxSize)
     throw std::runtime_error("Exceeding builtin map size");
@@ -111,8 +113,8 @@ void small_map<Key, Value, MaxSize, Except>::insert_left(const Key &key,
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-void small_map<Key, Value, MaxSize, Except>::insert_right(const Key &key,
-                                                          const Value &value) {
+void small_stable_map<Key, Value, MaxSize, Except>::insert_right(
+    const Key &key, const Value &value) {
   expectUnique(*this, key);
   if (size() == MaxSize)
     throw std::runtime_error("Exceeding builtin map size");
@@ -122,7 +124,7 @@ void small_map<Key, Value, MaxSize, Except>::insert_right(const Key &key,
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-void small_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
+void small_stable_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   m_size--;
@@ -133,13 +135,13 @@ void small_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-void small_map<Key, Value, MaxSize, Except>::clear() {
+void small_stable_map<Key, Value, MaxSize, Except>::clear() {
   m_size = 0;
 }
 
 template <class Key, class Value, int16_t MaxSize, class Except>
-void small_map<Key, Value, MaxSize, Except>::replace_key(const Key &key,
-                                                         const Key &new_key) {
+void small_stable_map<Key, Value, MaxSize, Except>::replace_key(
+    const Key &key, const Key &new_key) {
   // TODO no check for duplicate here, which is inconsistent, but needed to
   // relabel to Dim::Invalid
   if (!contains(key))
@@ -148,7 +150,7 @@ void small_map<Key, Value, MaxSize, Except>::replace_key(const Key &key,
   *it = new_key;
 }
 
-template class small_map<Dim, scipp::index, NDIM_MAX, int>;
+template class small_stable_map<Dim, scipp::index, NDIM_MAX, int>;
 
 void Sizes::set(const Dim dim, const scipp::index size) {
   if (contains(dim) && operator[](dim) != size)

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -38,8 +38,8 @@ void throw_dimension_not_found_error(const T &expected, Dim actual) {
 
 } // namespace
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_stable_map<Key, Value, MaxSize, Except>::operator==(
+template <class Key, class Value, int16_t Capacity>
+bool small_stable_map<Key, Value, Capacity>::operator==(
     const small_stable_map &other) const noexcept {
   if (size() != other.size())
     return false;
@@ -49,58 +49,57 @@ bool small_stable_map<Key, Value, MaxSize, Except>::operator==(
   return true;
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_stable_map<Key, Value, MaxSize, Except>::operator!=(
+template <class Key, class Value, int16_t Capacity>
+bool small_stable_map<Key, Value, Capacity>::operator!=(
     const small_stable_map &other) const noexcept {
   return !operator==(other);
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-typename std::array<Key, MaxSize>::const_iterator
-small_stable_map<Key, Value, MaxSize, Except>::find(const Key &key) const {
+template <class Key, class Value, int16_t Capacity>
+typename std::array<Key, Capacity>::const_iterator
+small_stable_map<Key, Value, Capacity>::find(const Key &key) const {
   return std::find(begin(), end(), key);
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-bool small_stable_map<Key, Value, MaxSize, Except>::contains(
+template <class Key, class Value, int16_t Capacity>
+bool small_stable_map<Key, Value, Capacity>::contains(
     const Key &key) const noexcept {
   return std::find(begin(), end(), key) != end();
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
+template <class Key, class Value, int16_t Capacity>
 scipp::index
-small_stable_map<Key, Value, MaxSize, Except>::index(const Key &key) const {
+small_stable_map<Key, Value, Capacity>::index(const Key &key) const {
   auto it = std::find(begin(), end(), key);
   if (it == end())
     throw_dimension_not_found_error(*this, key);
   return std::distance(begin(), it);
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-const Value &small_stable_map<Key, Value, MaxSize, Except>::operator[](
-    const Key &key) const {
+template <class Key, class Value, int16_t Capacity>
+const Value &
+small_stable_map<Key, Value, Capacity>::operator[](const Key &key) const {
   return at(key);
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-const Value &
-small_stable_map<Key, Value, MaxSize, Except>::at(const Key &key) const {
+template <class Key, class Value, int16_t Capacity>
+const Value &small_stable_map<Key, Value, Capacity>::at(const Key &key) const {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   return m_values[std::distance(begin(), find(key))];
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::assign(const Key &key,
-                                                           const Value &value) {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::assign(const Key &key,
+                                                    const Value &value) {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   m_values[std::distance(begin(), find(key))] = value;
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::insert_left(
-    const Key &key, const Value &value) {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::insert_left(const Key &key,
+                                                         const Value &value) {
   expectUnique(*this, key);
   expectExtendable(*this);
   for (scipp::index i = size(); i > 0; --i) {
@@ -112,9 +111,9 @@ void small_stable_map<Key, Value, MaxSize, Except>::insert_left(
   m_size++;
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::insert_right(
-    const Key &key, const Value &value) {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::insert_right(const Key &key,
+                                                          const Value &value) {
   expectUnique(*this, key);
   expectExtendable(*this);
   m_keys[m_size] = key;
@@ -122,8 +121,8 @@ void small_stable_map<Key, Value, MaxSize, Except>::insert_right(
   m_size++;
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::erase(const Key &key) {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   m_size--;
@@ -133,14 +132,14 @@ void small_stable_map<Key, Value, MaxSize, Except>::erase(const Key &key) {
   }
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::clear() noexcept {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::clear() noexcept {
   m_size = 0;
 }
 
-template <class Key, class Value, int16_t MaxSize, class Except>
-void small_stable_map<Key, Value, MaxSize, Except>::replace_key(
-    const Key &key, const Key &new_key) {
+template <class Key, class Value, int16_t Capacity>
+void small_stable_map<Key, Value, Capacity>::replace_key(const Key &key,
+                                                         const Key &new_key) {
   if (!contains(key))
     throw_dimension_not_found_error(*this, key);
   if (key != new_key)
@@ -149,7 +148,7 @@ void small_stable_map<Key, Value, MaxSize, Except>::replace_key(
   *it = new_key;
 }
 
-template class small_stable_map<Dim, scipp::index, NDIM_MAX, int>;
+template class small_stable_map<Dim, scipp::index, NDIM_MAX>;
 
 void Sizes::set(const Dim dim, const scipp::index size) {
   expect::validDim(dim);

--- a/core/strides.cpp
+++ b/core/strides.cpp
@@ -39,8 +39,9 @@ void Strides::erase(const scipp::index i) {
 
 Strides transpose(const Strides &strides, Dimensions from,
                   const span<const Dim> order) {
-  for (scipp::index i = 0; i < from.ndim(); ++i)
-    from.resize(i, strides[i]);
+  scipp::index i = 0;
+  for (const auto &dim : from)
+    from.resize(dim, strides[i++]);
   from = core::transpose(from, std::vector<Dim>{order.begin(), order.end()});
   return Strides(from.shape());
 }

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   element_util_test.cpp
   multi_index_test.cpp
   slice_test.cpp
+  sizes_test.cpp
   string_test.cpp
   subbin_sizes_test.cpp
   time_point_test.cpp

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -97,38 +97,6 @@ TEST(DimensionsTest, includes) {
   EXPECT_TRUE(a.includes(b));
 }
 
-TEST(DimensionsTest, isContiguousIn) {
-  Dimensions parent({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}});
-
-  EXPECT_TRUE(parent.isContiguousIn(parent));
-
-  EXPECT_TRUE(Dimensions({Dim::X, 0}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({Dim::X, 1}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({Dim::X, 2}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({Dim::X, 4}).isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({Dim::X, 5}).isContiguousIn(parent));
-
-  EXPECT_TRUE(Dimensions({{Dim::Y, 0}, {Dim::X, 4}}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({{Dim::Y, 1}, {Dim::X, 4}}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({{Dim::Y, 2}, {Dim::X, 4}}).isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({{Dim::Y, 3}, {Dim::X, 4}}).isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({{Dim::Y, 4}, {Dim::X, 4}}).isContiguousIn(parent));
-
-  EXPECT_TRUE(Dimensions({{Dim::Z, 0}, {Dim::Y, 3}, {Dim::X, 4}})
-                  .isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({{Dim::Z, 1}, {Dim::Y, 3}, {Dim::X, 4}})
-                  .isContiguousIn(parent));
-  EXPECT_TRUE(Dimensions({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}})
-                  .isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({{Dim::Z, 3}, {Dim::Y, 3}, {Dim::X, 4}})
-                   .isContiguousIn(parent));
-
-  EXPECT_FALSE(Dimensions({Dim::Y, 3}).isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({Dim::Z, 2}).isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::X, 4}}).isContiguousIn(parent));
-  EXPECT_FALSE(Dimensions({{Dim::Z, 2}, {Dim::Y, 3}}).isContiguousIn(parent));
-}
-
 TEST(DimensionsTest, index_access) {
   Dimensions denseXY({Dim::X, Dim::Y}, {2, 3});
   Dimensions denseXYZ({Dim::X, Dim::Y, Dim::Z}, {2, 3, 4});

--- a/core/test/dimensions_test.cpp
+++ b/core/test/dimensions_test.cpp
@@ -80,21 +80,21 @@ TEST(DimensionsTest, erase_inner) {
   EXPECT_EQ(dims.volume(), 12);
 }
 
-TEST(DimensionsTest, contains_other) {
+TEST(DimensionsTest, includes) {
   Dimensions a;
   a.add(Dim::X, 3);
   a.add(Dim::Y, 2);
 
-  EXPECT_TRUE(a.contains(Dimensions{}));
-  EXPECT_TRUE(a.contains(a));
-  EXPECT_TRUE(a.contains(Dimensions(Dim::Y, 2)));
-  EXPECT_FALSE(a.contains(Dimensions(Dim::Y, 3)));
+  EXPECT_TRUE(a.includes(Dimensions{}));
+  EXPECT_TRUE(a.includes(a));
+  EXPECT_TRUE(a.includes(Dimensions(Dim::Y, 2)));
+  EXPECT_FALSE(a.includes(Dimensions(Dim::Y, 3)));
 
   Dimensions b;
   b.add(Dim::Y, 2);
   b.add(Dim::X, 3);
   // Order does not matter.
-  EXPECT_TRUE(a.contains(b));
+  EXPECT_TRUE(a.includes(b));
 }
 
 TEST(DimensionsTest, isContiguousIn) {

--- a/core/test/sizes_test.cpp
+++ b/core/test/sizes_test.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+
+#include "scipp/core/sizes.h"
+
+using namespace scipp;
+
+using SmallMap = scipp::core::small_map<Dim, scipp::index, core::NDIM_MAX>;
+
+TEST(SmallMapTest, empty_size) {
+  SmallMap map;
+  EXPECT_TRUE(map.empty());
+  EXPECT_EQ(map.size(), 0);
+}
+
+class SizesTest : public ::testing::Test {
+protected:
+};
+
+TEST_F(SizesTest, 0d) {
+  Sizes sizes;
+  EXPECT_TRUE(sizes.empty());
+  EXPECT_EQ(sizes.size(), 0);
+  EXPECT_EQ(std::distance(sizes.begin(), sizes.end()), 0);
+  EXPECT_FALSE(sizes.contains(Dim::X));
+}
+
+TEST_F(SizesTest, 1d) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  EXPECT_FALSE(sizes.empty());
+  EXPECT_EQ(sizes.size(), 1);
+  EXPECT_EQ(std::distance(sizes.begin(), sizes.end()), 1);
+  EXPECT_EQ(*sizes.begin(), Dim::X);
+  EXPECT_TRUE(sizes.contains(Dim::X));
+  EXPECT_EQ(sizes[Dim::X], 2);
+}
+
+TEST_F(SizesTest, 2d) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  EXPECT_FALSE(sizes.empty());
+  EXPECT_EQ(sizes.size(), 2);
+  EXPECT_EQ(std::distance(sizes.begin(), sizes.end()), 2);
+  auto it = sizes.begin();
+  EXPECT_TRUE(*it == Dim::X || *it == Dim::Y);
+  ++it;
+  EXPECT_TRUE(*it == Dim::X || *it == Dim::Y);
+  EXPECT_TRUE(sizes.contains(Dim::X));
+  EXPECT_TRUE(sizes.contains(Dim::Y));
+  EXPECT_EQ(sizes[Dim::X], 2);
+  EXPECT_EQ(sizes[Dim::Y], 3);
+}
+
+TEST_F(SizesTest, max_dims) {
+  Sizes sizes;
+  sizes.set(Dim("axis-0"), 2);
+  sizes.set(Dim("axis-1"), 2);
+  sizes.set(Dim("axis-2"), 2);
+  sizes.set(Dim("axis-3"), 2);
+  sizes.set(Dim("axis-4"), 2);
+  sizes.set(Dim("axis-5"), 2);
+  EXPECT_THROW(sizes.set(Dim("axis-6"), 2), std::runtime_error);
+}
+
+TEST_F(SizesTest, comparison) {
+  Sizes a;
+  a.set(Dim::X, 2);
+  a.set(Dim::Y, 3);
+  Sizes b;
+  b.set(Dim::Y, 3);
+  b.set(Dim::X, 2);
+  EXPECT_EQ(a, b);
+}
+
+TEST_F(SizesTest, erase) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  auto original(sizes);
+  EXPECT_THROW(sizes.erase(Dim::Time), std::runtime_error);
+  EXPECT_EQ(sizes, original);
+  sizes.erase(Dim::X);
+  Sizes yz;
+  yz.set(Dim::Y, 3);
+  yz.set(Dim::Z, 4);
+  EXPECT_EQ(sizes, yz);
+}
+
+TEST_F(SizesTest, clear) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  sizes.clear();
+  EXPECT_TRUE(sizes.empty());
+  EXPECT_EQ(sizes.begin(), sizes.end());
+}

--- a/core/test/sizes_test.cpp
+++ b/core/test/sizes_test.cpp
@@ -8,7 +8,8 @@
 
 using namespace scipp;
 
-using SmallMap = scipp::core::small_map<Dim, scipp::index, core::NDIM_MAX>;
+using SmallMap =
+    scipp::core::small_stable_map<Dim, scipp::index, core::NDIM_MAX>;
 
 TEST(SmallMapTest, empty_size) {
   SmallMap map;

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -339,7 +339,8 @@ Variable histogram(const Variable &data, const Variable &binEdges) {
   for (const auto &d : indices.dims().labels())
     nonclashing_name += d.name();
   const Dim dummy = Dim(nonclashing_name);
-  indices.rename(hist_dim, dummy);
+  if (indices.dims().contains(hist_dim))
+    indices.rename(hist_dim, dummy);
   const auto masked = masked_data(buffer, dim);
   auto hist = variable::transform_subspan(
       buffer.dtype(), hist_dim, binEdges.dims()[hist_dim] - 1,

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -169,8 +169,7 @@ Variable make_bins_no_validate(Variable indices, const Dim dim,
 /// Each bin is represented by a Variable slice. `indices` defines the array of
 /// bins as slices of `buffer` along `dim`.
 Variable make_bins(Variable indices, const Dim dim, Dataset buffer) {
-  expect_valid_bin_indices(indices.data_handle(), dim,
-                           Dimensions(buffer.sizes()));
+  expect_valid_bin_indices(indices.data_handle(), dim, buffer.sizes());
   return make_bins_no_validate(std::move(indices), dim, std::move(buffer));
 }
 

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -186,7 +186,8 @@ void Dataset::rename(const Dim from, const Dim to) {
     throw except::DimensionError("Duplicate dimension.");
   m_coords.rename(from, to);
   for (auto &item : m_data)
-    item.second.rename(from, to);
+    if (item.second.dims().contains(from))
+      item.second.rename(from, to);
 }
 
 /// Return true if the datasets have identical content.

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -73,21 +73,21 @@ DataArray Dataset::operator[](const std::string &name) const {
 /// extent of a replaced item is not excluded from the check, so even if that
 /// replaced item is the only one in the dataset with that dimension it cannot
 /// be "resized" in this way.
-void Dataset::setDims(const Dimensions &dims, const Dim coordDim) {
-  if (coordDim != Dim::Invalid && is_edges(m_coords.sizes(), dims, coordDim))
+void Dataset::setSizes(const Sizes &sizes, const Dim coordDim) {
+  if (coordDim != Dim::Invalid && is_edges(m_coords.sizes(), sizes, coordDim))
     return;
-  m_coords.setSizes(merge(m_coords.sizes(), Sizes(dims)));
+  m_coords.setSizes(merge(m_coords.sizes(), sizes));
 }
 
 void Dataset::rebuildDims() {
   m_coords.rebuildSizes();
   for (const auto &d : *this)
-    setDims(d.dims());
+    setSizes(d.dims());
 }
 
 /// Set (insert or replace) the coordinate for the given dimension.
 void Dataset::setCoord(const Dim dim, Variable coord) {
-  setDims(coord.dims(), dim_of_coord(coord, dim));
+  setSizes(coord.dims(), dim_of_coord(coord, dim));
   m_coords.set(dim, std::move(coord));
 }
 
@@ -98,7 +98,7 @@ void Dataset::setCoord(const Dim dim, Variable coord) {
 /// AttrPolicy::Keep is specified.
 void Dataset::setData(const std::string &name, Variable data,
                       const AttrPolicy attrPolicy) {
-  setDims(data.dims());
+  setSizes(data.dims());
   const auto replace = contains(name);
   if (replace && attrPolicy == AttrPolicy::Keep)
     m_data[name] = DataArray(data, {}, m_data[name].masks().items(),
@@ -116,7 +116,7 @@ void Dataset::setData(const std::string &name, Variable data,
 /// attributes. Throws if the provided data brings the dataset into an
 /// inconsistent state (mismatching dtype, unit, or dimensions).
 void Dataset::setData(const std::string &name, const DataArray &data) {
-  setDims(data.dims());
+  setSizes(data.dims());
   for (auto &&[dim, coord] : data.coords()) {
     if (const auto it = m_coords.find(dim); it != m_coords.end())
       core::expect::equals(coord, it->second);

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -22,7 +22,7 @@ void Dataset::clear() {
 }
 
 void Dataset::setCoords(Coords other) {
-  scipp::expect::contains(other.sizes(), m_coords.sizes());
+  scipp::expect::includes(other.sizes(), m_coords.sizes());
   m_coords = std::move(other);
 }
 /// Return a const view to all coordinates of the dataset.
@@ -218,7 +218,7 @@ typename Masks::holder_type union_or(const Masks &currentMasks,
     const auto it = currentMasks.find(key);
     if (it == currentMasks.end())
       out.emplace(key, copy(item));
-    else if (out[key].dims().contains(item.dims()))
+    else if (out[key].dims().includes(item.dims()))
       out[key] |= item;
     else
       out[key] = out[key] | item;

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -404,8 +404,8 @@ GroupBy<Dataset> groupby(const Dataset &dataset, const Dim dim,
 /// new coordinate to the output in a later apply/combine step.
 GroupBy<Dataset> groupby(const Dataset &dataset, const Variable &key,
                          const Variable &bins) {
-  for (const auto &n : dataset.sizes()) {
-    Dimensions dims(n.first, n.second);
+  for (const auto &dim : dataset.sizes()) {
+    Dimensions dims(dim, dataset.sizes()[dim]);
     if (dims.contains(key.dims()))
       // Found compatible Dimension.
       return call_groupby(dataset, key, bins);

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -370,7 +370,7 @@ GroupBy<DataArray> groupby(const DataArray &array, const Dim dim,
 /// new coordinate to the output in a later apply/combine step.
 GroupBy<DataArray> groupby(const DataArray &array, const Variable &key,
                            const Variable &bins) {
-  if (!array.dims().contains(key.dims()))
+  if (!array.dims().includes(key.dims()))
     throw except::DimensionError("Size of Group-by key is incorrect.");
 
   return call_groupby(array, key, bins);
@@ -406,7 +406,7 @@ GroupBy<Dataset> groupby(const Dataset &dataset, const Variable &key,
                          const Variable &bins) {
   for (const auto &dim : dataset.sizes()) {
     Dimensions dims(dim, dataset.sizes()[dim]);
-    if (dims.contains(key.dims()))
+    if (dims.includes(key.dims()))
       // Found compatible Dimension.
       return call_groupby(dataset, key, bins);
   }

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -93,7 +93,7 @@ namespace {
 template <typename T> bool is_histogram_impl(const T &a, const Dim dim) {
   const auto dims = a.dims();
   const auto coords = a.coords();
-  return dims.count(dim) == 1 && coords.contains(dim) &&
+  return dims.contains(dim) && coords.contains(dim) &&
          coords[dim].dims().contains(dim) &&
          coords[dim].dims()[dim] == dims.at(dim) + 1;
 }

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -191,7 +191,7 @@ private:
   // Declared friend so gtest recognizes it
   friend SCIPP_DATASET_EXPORT std::ostream &operator<<(std::ostream &,
                                                        const Dataset &);
-  void setDims(const Dimensions &dims, const Dim coordDim = Dim::Invalid);
+  void setSizes(const Sizes &sizes, const Dim coordDim = Dim::Invalid);
   void rebuildDims();
 
   Coords m_coords; // aligned coords

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -221,7 +221,8 @@ void Dict<Key, Value>::rename(const Dim from, const Dim to) {
     }
   }
   for (auto &item : m_items)
-    item.second.rename(from, to);
+    if (item.second.dims().contains(from))
+      item.second.rename(from, to);
 }
 
 /// Return true if the dict is readonly. Does not imply that items are readonly.

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -98,7 +98,7 @@ template <class Key, class Value> Value Dict<Key, Value>::at(const Key &key) {
 
 template <class Key, class Value>
 void Dict<Key, Value>::setSizes(const Sizes &sizes) {
-  scipp::expect::contains(sizes, m_sizes);
+  scipp::expect::includes(sizes, m_sizes);
   m_sizes = sizes;
 }
 
@@ -125,7 +125,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
   expectWritable(*this);
   // Is a good definition for things that are allowed: "would be possible to
   // concat along existing dim or extra dim"?
-  if (!m_sizes.contains(coord.dims()) &&
+  if (!m_sizes.includes(coord.dims()) &&
       !is_edges(m_sizes, coord.dims(), dim_of_coord(coord, key)))
     throw except::DimensionError("Cannot add coord exceeding DataArray dims");
   m_items.insert_or_assign(key, std::move(coord));
@@ -264,8 +264,8 @@ template <class Key, class Value>
 bool Dict<Key, Value>::item_applies_to(const Key &key,
                                        const Dimensions &dims) const {
   const auto &val = m_items.at(key);
-  return dims.contains(val.dims()) ||
-         (!sizes().contains(val.dims()) &&
+  return dims.includes(val.dims()) ||
+         (!sizes().includes(val.dims()) &&
           is_edges(Sizes(dims), val.dims(), dim_of_coord(val, key)));
 }
 

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -211,7 +211,7 @@ Dict<Key, Value> &Dict<Key, Value>::setSlice(const Slice s, const Dict &dict) {
 
 template <class Key, class Value>
 void Dict<Key, Value>::rename(const Dim from, const Dim to) {
-  m_sizes.relabel(from, to);
+  m_sizes.replace_key(from, to);
   // TODO relabel only if coords (not attrs?)?
   if constexpr (std::is_same_v<Key, Dim>) {
     if (m_items.count(from)) {

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -104,16 +104,16 @@ void Dict<Key, Value>::setSizes(const Sizes &sizes) {
 
 template <class Key, class Value> void Dict<Key, Value>::rebuildSizes() {
   Sizes new_sizes = m_sizes;
-  for (const auto &size : m_sizes) {
+  for (const auto &dim : m_sizes) {
     bool erase = true;
     for (const auto &item : *this) {
-      if (item.second.dims().contains(size.first)) {
+      if (item.second.dims().contains(dim)) {
         erase = false;
         break;
       }
     }
     if (erase)
-      new_sizes.erase(size.first);
+      new_sizes.erase(dim);
   }
   m_sizes = std::move(new_sizes);
 }

--- a/dataset/shape.cpp
+++ b/dataset/shape.cpp
@@ -36,8 +36,8 @@ namespace {
 constexpr auto is_bin_edges = [](const auto &coord, const auto &dims,
                                  const Dim dim) {
   return coord.dims().contains(dim) &&
-         ((dims.count(dim) == 1) ? coord.dims()[dim] != dims.at(dim)
-                                 : coord.dims()[dim] == 2);
+         ((dims.contains(dim) == 1) ? coord.dims()[dim] != dims.at(dim)
+                                    : coord.dims()[dim] == 2);
 };
 template <class T1, class T2, class DimT>
 auto concat(const T1 &a, const T2 &b, const Dim dim, const DimT &dimsA,
@@ -48,8 +48,7 @@ auto concat(const T1 &a, const T2 &b, const Dim dim, const DimT &dimsA,
       if (is_bin_edges(a_, dimsA, dim) != is_bin_edges(b[key], dimsB, dim)) {
         throw except::BinEdgeError(
             "Either both or neither of the inputs must be bin edges.");
-      } else if (a_.dims()[dim] ==
-                 ((dimsA.count(dim) == 1) ? dimsA.at(dim) : 1)) {
+      } else if (a_.dims()[dim] == (dimsA.contains(dim) ? dimsA.at(dim) : 1)) {
         out.emplace(key, concatenate(a_, b[key], dim));
       } else {
         out.emplace(key, join_edges(a_, b[key], dim));
@@ -63,11 +62,11 @@ auto concat(const T1 &a, const T2 &b, const Dim dim, const DimT &dimsA,
         out.emplace(
             key,
             concatenate(
-                broadcast(a_, merge(dimsA.count(dim)
+                broadcast(a_, merge(dimsA.contains(dim)
                                         ? Dimensions(dim, dimsA.at(dim))
                                         : Dimensions(),
                                     a_.dims())),
-                broadcast(b[key], merge(dimsB.count(dim)
+                broadcast(b[key], merge(dimsB.contains(dim)
                                             ? Dimensions(dim, dimsB.at(dim))
                                             : Dimensions(),
                                         b[key].dims())),

--- a/dataset/slice.cpp
+++ b/dataset/slice.cpp
@@ -11,8 +11,7 @@ namespace {
 
 template <class T>
 T slice(const T &data, const Dim dim, const Variable &value) {
-  const auto [d, i] =
-      get_slice_params(Dimensions(data.dims()), data.coords()[dim], value);
+  const auto [d, i] = get_slice_params(data.dims(), data.coords()[dim], value);
   return data.slice({d, i});
 }
 
@@ -20,7 +19,7 @@ template <class T>
 T slice(const T &data, const Dim dim, const Variable &begin,
         const Variable &end) {
   const auto [d, b, e] =
-      get_slice_params(Dimensions(data.dims()), data.coords()[dim], begin, end);
+      get_slice_params(data.dims(), data.coords()[dim], begin, end);
   return data.slice({d, b, e});
 }
 

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -23,10 +23,6 @@ std::ostream &operator<<(std::ostream &os, const Dataset &dataset) {
 
 constexpr const char *tab = "  ";
 
-template <class D>
-std::string do_to_string(const D &dataset, const std::string &id,
-                         const Dimensions &dims, const std::string &shift = "");
-
 template <class T> auto sorted(const T &map) {
   using core::to_string;
   std::vector<std::pair<std::string, Variable>> elems;
@@ -49,29 +45,29 @@ std::string format_variable(const std::string &key, const Variable &variable,
 
 template <class Key>
 auto format_data_view(const Key &name, const DataArray &data,
-                      const Dimensions &datasetDims, const std::string &shift,
+                      const Sizes &datasetSizes, const std::string &shift,
                       const bool inline_meta) {
   std::stringstream s;
-  s << shift << format_variable(name, data.data(), datasetDims);
+  s << shift << format_variable(name, data.data(), datasetSizes);
 
   const std::string header_shift = inline_meta ? shift : (shift + tab + tab);
   const std::string data_shift = inline_meta ? shift : (header_shift + tab);
   if (!data.masks().empty()) {
     s << header_shift << "Masks:\n";
     for (const auto &[key, var] : sorted(data.masks()))
-      s << data_shift << format_variable(key, var, datasetDims);
+      s << data_shift << format_variable(key, var, datasetSizes);
   }
   if (!data.attrs().empty()) {
     s << header_shift << "Attributes:\n";
     for (const auto &[key, var] : sorted(data.attrs()))
-      s << data_shift << format_variable(key, var, datasetDims);
+      s << data_shift << format_variable(key, var, datasetSizes);
   }
   return s.str();
 }
 
 template <class D>
 std::string do_to_string(const D &dataset, const std::string &id,
-                         const Dimensions &dims, const std::string &shift) {
+                         const Sizes &dims, const std::string &shift = "") {
   std::stringstream s;
   if (!id.empty())
     s << shift << id + '\n';
@@ -110,7 +106,7 @@ std::string to_string(const DataArray &data) {
 }
 
 std::string to_string(const Dataset &dataset) {
-  return do_to_string(dataset, "<scipp.Dataset>", Dimensions(dataset.sizes()));
+  return do_to_string(dataset, "<scipp.Dataset>", dataset.sizes());
 }
 
 template <class Key, class Value>

--- a/dataset/string.cpp
+++ b/dataset/string.cpp
@@ -35,10 +35,10 @@ template <class T> auto sorted(const T &map) {
 
 namespace {
 std::string format_variable(const std::string &key, const Variable &variable,
-                            const std::optional<Dimensions> datasetDims) {
+                            const std::optional<Sizes> datasetSizes) {
   std::stringstream s;
   s << tab << std::left << std::setw(24) << key
-    << format_variable(variable, datasetDims) << '\n';
+    << format_variable(variable, datasetSizes) << '\n';
   return s.str();
 }
 } // namespace

--- a/dataset/variable_reduction.cpp
+++ b/dataset/variable_reduction.cpp
@@ -73,7 +73,7 @@ Variable nanmean(const Variable &var, const Dim dim, const Masks &masks) {
 Variable masks_merge_if_contained(const Masks &masks, const Dimensions &dims) {
   auto mask_union = makeVariable<bool>(Values{false});
   for (const auto &mask : masks) {
-    if (dims.contains(mask.second.dims()))
+    if (dims.includes(mask.second.dims()))
       mask_union = mask_union | mask.second;
   }
   return mask_union;

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -22,7 +22,7 @@ using namespace scipp::dataset;
 template <class T> auto dim_extent(const T &object, const Dim dim) {
   if constexpr (std::is_same_v<T, Dataset>) {
     scipp::index extent = -1;
-    if (object.sizes().count(dim) > 0)
+    if (object.sizes().contains(dim))
       extent = object.sizes().at(dim);
     return extent;
   } else {

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -84,7 +84,7 @@ template <class T> struct slicer {
                                  const std::tuple<Dim, Variable> &value) {
     auto [dim, i] = value;
     return std::make_from_tuple<Slice>(
-        get_slice_params(Dimensions(self.dims()), self.coords()[dim], i));
+        get_slice_params(self.dims(), self.coords()[dim], i));
   }
 
   static auto get_by_value(T &self, const std::tuple<Dim, Variable> &value) {
@@ -112,9 +112,8 @@ template <class T> struct slicer {
                               ? Variable{}
                               : py::getattr(py_slice, "stop").cast<Variable>();
 
-          return std::make_from_tuple<Slice>(
-              get_slice_params(Dimensions(self.dims()), self.coords()[dim],
-                               start_var, stop_var));
+          return std::make_from_tuple<Slice>(get_slice_params(
+              self.dims(), self.coords()[dim], start_var, stop_var));
         }
       } catch (const py::cast_error &) {
       }

--- a/python/dataset.cpp
+++ b/python/dataset.cpp
@@ -75,7 +75,7 @@ void bind_dataset_view_methods(py::class_<T, Ignored...> &c) {
       [](const T &self) {
         std::vector<std::string> dims;
         for (const auto &dim : self.sizes()) {
-          dims.push_back(dim.first.name());
+          dims.push_back(dim.name());
         }
         return dims;
       },
@@ -85,8 +85,8 @@ void bind_dataset_view_methods(py::class_<T, Ignored...> &c) {
       "shape",
       [](const T &self) {
         std::vector<int64_t> shape;
-        for (const auto &dim : self.sizes()) {
-          shape.push_back(dim.second);
+        for (const auto &size : self.sizes().sizes()) {
+          shape.push_back(size);
         }
         return shape;
       },

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -143,7 +143,7 @@ class TestSliceByValue:
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless] = sc.Variable(
                              dims=['x'], values=[6.0, 6.0], unit=sc.units.m)
-        assert str(e_info.value) == 'Expected (x: 3) to contain (x: 2).'
+        assert str(e_info.value) == 'Expected (x: 3) to include (x: 2).'
 
     def test_assign_incompatible_dataarray(self):
         with pytest.raises(RuntimeError):

--- a/variable/bins.cpp
+++ b/variable/bins.cpp
@@ -46,7 +46,7 @@ void copy_slices(const Variable &src, Variable dst, const Dim dim,
   core::expect::equals(src.unit(), dst.unit());
   // May broadcast `src` but not `dst` since that would result in
   // multiple/conflicting writes to same bucket.
-  expect::contains(sizes1.dims(), sizes0.dims());
+  expect::includes(sizes1.dims(), sizes0.dims());
   core::expect::equals(all(equal(sizes0, sizes1)),
                        makeVariable<bool>(Values{true}));
   transform_in_place(subspan_view(dst, dim, dstIndices),

--- a/variable/include/scipp/variable/bucket_model.h
+++ b/variable/include/scipp/variable/bucket_model.h
@@ -55,7 +55,7 @@ template <class T> auto clone_impl(const DataModel<bucket<T>> &model) {
 
 SCIPP_VARIABLE_EXPORT void
 expect_valid_bin_indices(const VariableConceptHandle &indices, const Dim dim,
-                         const Dimensions &buffer_dims);
+                         const Sizes &buffer_sizes);
 
 /// Specialization of DataModel for "binned" data. T could be Variable,
 /// DataArray, or Dataset.

--- a/variable/include/scipp/variable/slice.h
+++ b/variable/include/scipp/variable/slice.h
@@ -9,10 +9,10 @@
 namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT std::tuple<Dim, scipp::index>
-get_slice_params(const Dimensions &dims, const Variable &coord,
+get_slice_params(const Sizes &sizes, const Variable &coord,
                  const Variable &value);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT std::tuple<Dim, scipp::index, scipp::index>
-get_slice_params(const Dimensions &dims, const Variable &coord,
+get_slice_params(const Sizes &sizes, const Variable &coord,
                  const Variable &begin, const Variable &end);
 
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/string.h
+++ b/variable/include/scipp/variable/string.h
@@ -27,7 +27,7 @@ to_string(const std::pair<std::string, Variable> &attr);
 
 SCIPP_VARIABLE_EXPORT std::string
 format_variable(const Variable &variable,
-                std::optional<Dimensions> datasetDims = std::nullopt);
+                std::optional<Sizes> datasetSizes = std::nullopt);
 
 /// Abstract base class for formatters for variables with element types not in
 /// scipp-variable module.

--- a/variable/include/scipp/variable/transform.h
+++ b/variable/include/scipp/variable/transform.h
@@ -623,7 +623,7 @@ template <bool dry_run> struct in_place {
   static void transform(Op op, const std::string_view &name, Var &&var,
                         const Other &... other) {
     using namespace detail;
-    (scipp::expect::contains(var.dims(), other.dims()), ...);
+    (scipp::expect::includes(var.dims(), other.dims()), ...);
     auto unit = variableFactory().elem_unit(var);
     op(unit, variableFactory().elem_unit(other)...);
     // Stop early in bad cases of changing units (if `var` is a slice):

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -18,8 +18,7 @@ using namespace scipp::core::element;
 namespace scipp::variable {
 
 bool isBinEdge(const Dim dim, Dimensions edges, const Dimensions &toMatch) {
-  edges.resize(dim, edges[dim] - 1);
-  return edges[dim] == toMatch[dim];
+  return edges[dim] - 1 == toMatch[dim];
 }
 
 // Workaround VS C7526 (undefined inline variable) with dtype<> in template.

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -150,7 +150,7 @@ Variable flatten(const Variable &view,
   for (const auto &from : from_labels) {
     size *= out.dims().size(to);
     if (from == from_labels.back()) {
-      out.unchecked_dims().relabel(to, to_dim);
+      out.unchecked_dims().replace_key(from, to_dim);
       out.unchecked_dims().resize(to, size);
     } else {
       if (out.strides()[to] != out.dims().size(to + 1) * out.strides()[to + 1])

--- a/variable/shape.cpp
+++ b/variable/shape.cpp
@@ -150,8 +150,8 @@ Variable flatten(const Variable &view,
   for (const auto &from : from_labels) {
     size *= out.dims().size(to);
     if (from == from_labels.back()) {
+      out.unchecked_dims().resize(from, size);
       out.unchecked_dims().replace_key(from, to_dim);
-      out.unchecked_dims().resize(to, size);
     } else {
       if (out.strides()[to] != out.dims().size(to + 1) * out.strides()[to + 1])
         return flatten(copy(view), from_labels, to_dim);

--- a/variable/slice.cpp
+++ b/variable/slice.cpp
@@ -50,7 +50,7 @@ auto get_coord(const Variable &coord, const Dim dim) {
 
 } // namespace
 
-std::tuple<Dim, scipp::index> get_slice_params(const Dimensions &dims,
+std::tuple<Dim, scipp::index> get_slice_params(const Sizes &dims,
                                                const Variable &coord_,
                                                const Variable &value) {
   core::expect::equals(value.dims(), Dimensions{});
@@ -71,7 +71,7 @@ std::tuple<Dim, scipp::index> get_slice_params(const Dimensions &dims,
 }
 
 std::tuple<Dim, scipp::index, scipp::index>
-get_slice_params(const Dimensions &dims, const Variable &coord_,
+get_slice_params(const Sizes &dims, const Variable &coord_,
                  const Variable &begin, const Variable &end) {
   if (begin.is_valid())
     core::expect::equals(begin.dims(), Dimensions{});

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -23,15 +23,15 @@ std::ostream &operator<<(std::ostream &os, const Variable &variable) {
 namespace {
 
 std::string make_dims_labels(const Variable &variable,
-                             const std::optional<Dimensions> datasetDims) {
+                             const std::optional<Sizes> datasetSizes) {
   const auto &dims = variable.dims();
   if (dims.empty())
     return "()";
   std::string diminfo = "(";
   for (const auto &dim : dims.labels()) {
     diminfo += to_string(dim);
-    if (datasetDims) {
-      if ((datasetDims->contains(dim) ? (*datasetDims)[dim] : 1) + 1 ==
+    if (datasetSizes) {
+      if ((datasetSizes->contains(dim) ? (*datasetSizes)[dim] : 1) + 1 ==
           dims[dim])
         diminfo += " [bin-edge]";
     }
@@ -72,7 +72,7 @@ auto apply(const DType dtype, Args &&... args) {
 } // namespace
 
 std::string format_variable(const Variable &variable,
-                            const std::optional<Dimensions> datasetDims) {
+                            const std::optional<Sizes> datasetSizes) {
   if (!variable.is_valid())
     return "invalid variable\n";
   std::stringstream s;
@@ -81,8 +81,8 @@ std::string format_variable(const Variable &variable,
     s << to_string(variable.dims()) << colSep;
   s << std::setw(9) << to_string(variable.dtype());
   s << colSep << std::setw(15) << '[' + variable.unit().name() + ']';
-  if (datasetDims)
-    s << colSep << make_dims_labels(variable, datasetDims);
+  if (datasetSizes)
+    s << colSep << make_dims_labels(variable, datasetSizes);
   s << colSep;
   s << apply<ValuesToString>(variable.dtype(), variable);
   if (variable.hasVariances())

--- a/variable/string.cpp
+++ b/variable/string.cpp
@@ -77,7 +77,7 @@ std::string format_variable(const Variable &variable,
     return "invalid variable\n";
   std::stringstream s;
   const std::string colSep("  ");
-  if (!datasetDims)
+  if (!datasetSizes)
     s << to_string(variable.dims()) << colSep;
   s << std::setw(9) << to_string(variable.dtype());
   s << colSep << std::setw(15) << '[' + variable.unit().name() + ']';

--- a/variable/test/operations_test.cpp
+++ b/variable/test/operations_test.cpp
@@ -109,7 +109,7 @@ TEST(Variable, operator_plus_equal_different_dimensions) {
   auto different_dimensions =
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1.1, 2.2});
   EXPECT_THROW_MSG(a += different_dimensions, std::runtime_error,
-                   "Expected (x: 2) to contain (y: 2).");
+                   "Expected (x: 2) to include (y: 2).");
 }
 
 TEST(Variable, operator_plus_equal_different_unit) {
@@ -412,7 +412,7 @@ TEST(VariableView, minus_equals_failures) {
                                   Values{1.0, 2.0, 3.0, 4.0});
 
   EXPECT_THROW_MSG(var -= var.slice({Dim::X, 0, 1}), std::runtime_error,
-                   "Expected (x: 2, y: 2) to contain (x: 1, y: 2).");
+                   "Expected (x: 2, y: 2) to include (x: 1, y: 2).");
 }
 
 TEST(VariableView, self_overlapping_view_operation) {

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -165,8 +165,7 @@ Variable Variable::transpose(const std::vector<Dim> &order) const {
 }
 
 void Variable::rename(const Dim from, const Dim to) {
-  if (dims().contains(from))
-    m_dims.relabel(dims().index(from), to);
+  m_dims.replace_key(from, to);
 }
 
 bool Variable::is_valid() const noexcept { return m_object.operator bool(); }

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -133,7 +133,7 @@ Variable &Variable::setSlice(const Slice params, const Variable &data) {
 }
 
 Variable Variable::broadcast(const Dimensions &target) const {
-  expect::contains(target, dims());
+  expect::includes(target, dims());
   auto out = as_const();
   out.m_dims = target;
   scipp::index i = 0;

--- a/variable/variable_instantiate_bin_elements.cpp
+++ b/variable/variable_instantiate_bin_elements.cpp
@@ -29,12 +29,12 @@ private:
 };
 
 void expect_valid_bin_indices(const VariableConceptHandle &indices,
-                              const Dim dim, const Dimensions &buffer_dims) {
+                              const Dim dim, const Sizes &buffer_sizes) {
   auto copy = requireT<const DataModel<scipp::index_pair>>(*indices);
   const auto vals = copy.values();
   std::sort(vals.begin(), vals.end());
   if ((!vals.empty() && (vals.begin()->first < 0)) ||
-      (!vals.empty() && ((vals.end() - 1)->second > buffer_dims[dim])))
+      (!vals.empty() && ((vals.end() - 1)->second > buffer_sizes[dim])))
     throw except::SliceError("Bin indices out of range");
   if (std::adjacent_find(vals.begin(), vals.end(),
                          [](const auto a, const auto b) {


### PR DESCRIPTION
Fixes #1839.

Not entirely happy with every aspect here, but I hope it is a step in the right direction:

- `Sizes` is now the base class of `Dimensions`. This is possibly a bit awkward and using composition might be the ultimate solution, but as it is now the class structure is hopefully simple enough and avoids a lot of boilerplate code for wrapping. It furthermore allows for passing `Dimensions` to functions that require `Sizes`, which is useful.
- Improve naming of a number of functions.
- Add more tests, even though still not complete.
- `small_ordered_map` is a separate class used as the base of `Sizes`. This is not really necessary and we could have done everything directly in `Sizes`, but this way we may have it easier to turn this into a generic small map, if one is required in the future?