### PR TITLE
Fix move includes in packaging for windows

### DIFF
--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -8,6 +8,6 @@ move %INSTALL_PREFIX%\Lib\scipp-*.lib %CONDA_PREFIX%\Lib\
 move %INSTALL_PREFIX%\Lib\units-shared.lib %CONDA_PREFIX%\Lib\
 move %INSTALL_PREFIX%\Lib\cmake\scipp %CONDA_PREFIX%\Lib\cmake\
 move %INSTALL_PREFIX%\include\scipp %CONDA_PREFIX%\include\
-move %INSTALL_PREFIX%\include\scipp* %CONDA_PREFIX%\include\
+move %INSTALL_PREFIX%\include\scipp-* %CONDA_PREFIX%\include\
 move %INSTALL_PREFIX%\include\Eigen %CONDA_PREFIX%\include\
 move %INSTALL_PREFIX%\include\units %CONDA_PREFIX%\include\

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -7,6 +7,7 @@ move %INSTALL_PREFIX%\bin\units-shared.dll %CONDA_PREFIX%\bin\
 move %INSTALL_PREFIX%\Lib\scipp-*.lib %CONDA_PREFIX%\Lib\
 move %INSTALL_PREFIX%\Lib\units-shared.lib %CONDA_PREFIX%\Lib\
 move %INSTALL_PREFIX%\Lib\cmake\scipp %CONDA_PREFIX%\Lib\cmake\
+move %INSTALL_PREFIX%\include\scipp %CONDA_PREFIX%\include\
 move %INSTALL_PREFIX%\include\scipp* %CONDA_PREFIX%\include\
 move %INSTALL_PREFIX%\include\Eigen %CONDA_PREFIX%\include\
 move %INSTALL_PREFIX%\include\units %CONDA_PREFIX%\include\


### PR DESCRIPTION
CMake of scippneutron `next` breaks because certain includes cannot be found https://github.com/scipp/scippneutron/pull/73.

It turns out that dos `move` does not move directories matched via wilcard, so the `scipp` directory never makes it into include during the `conda-build` stage for windows.

Simple fix, but a real pain to find.

[before](https://dev.azure.com/scipp/scipp/_build/results?buildId=5056&view=logs&j=d5c58a2e-1ae4-501e-e421-b21c980eb30a&t=7c4cba8d-b07c-5019-f73d-89e315067969&l=325) note scipp dir not moved
[after](https://dev.azure.com/scipp/scipp/_build/results?buildId=5070&view=logs&j=d5c58a2e-1ae4-501e-e421-b21c980eb30a&t=7c4cba8d-b07c-5019-f73d-89e315067969&l=336) note scipp dir incl sub directories moved

