### PR TITLE
nbsphinx error prevent documentation build

### DIFF
--- a/docs/about/whats-new/whats-new-0.5.0.ipynb
+++ b/docs/about/whats-new/whats-new-0.5.0.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# What's new in scipp 0.5.0\n",
     "\n",
@@ -19,7 +21,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Run logs now stored natively\n",
     "\n",
@@ -52,7 +56,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Many time-dependent logs are just data arrays, so we can access, modify, plot, ... them.\n",
     "Remember that the `value` property has to be used to access the only value of a scalar variable:"
@@ -69,7 +75,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Improved instrument view\n",
     "\n",
@@ -89,7 +97,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Improved plotting\n",
     "\n",
@@ -129,7 +139,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Slider and \"Profile\" button show up when data is 3-D (or higher):"
    ]
@@ -145,7 +157,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Creation functions\n",
     "\n",
@@ -182,7 +196,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "All of these also take keyword arguments.\n",
     "Note that we can still support creating scalars by multiplying with a unit:"
@@ -199,7 +215,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Label-based indexing\n",
     "\n",
@@ -222,7 +240,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Dataset items and masks\n",
     "\n",
@@ -250,7 +270,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## HDF5 I/O\n",
     "\n",
@@ -281,7 +303,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Event data\n",
     "\n",
@@ -342,7 +366,8 @@
   },
   "nbsphinx": {
    "execute": "never"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/about/whats-new/whats-new-0.6.0.ipynb
+++ b/docs/about/whats-new/whats-new-0.6.0.ipynb
@@ -33,14 +33,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## scipp-0.6.0"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Support for datetime64\n",
     "\n",
@@ -65,7 +69,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Data loaded from Nexus files now uses `datetime64` for `pulse_times` and time-series logs such as sample temperature logs:"
    ]
@@ -103,7 +109,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### HTML view readability improvements\n",
     "\n",
@@ -121,7 +129,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### SVG view readability improvements\n",
     "\n",
@@ -140,7 +150,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Unit conversions\n",
     "\n",
@@ -168,7 +180,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### `fold` and `flatten`\n",
     "\n",
@@ -202,7 +216,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Binned data meta data access\n",
     "\n",
@@ -221,7 +237,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This could be used, e.g., to access the `tof` coordinate of the events.\n",
     "However, this does not give information on which bin (pixel in this case) an event belongs to, so this is not sufficient if, e.g., a computation involving beamline geometry should be performed.\n",
@@ -245,21 +263,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that at this point things such as the HTML representation are not supported for these bin components."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## scippneutron-0.1.0"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Various\n",
     "\n",
@@ -274,7 +298,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Mandatory `scatter` argument for unit conversion\n",
     "\n",
@@ -298,7 +324,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Beamline geometry parameters for unit conversions\n",
     "\n",
@@ -325,7 +353,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In above example we used a scalar `L2` coord.\n",
     "This is then broadcast to all pixels and thus implies that all pixels are effectively on a sphere around the sample.\n",
@@ -353,7 +383,8 @@
   },
   "nbsphinx": {
    "execute": "never"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/developer/concepts.ipynb
+++ b/docs/developer/concepts.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Concepts\n",
     "\n",
@@ -29,7 +31,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Consider a data array `da` and a dataset `ds` with an aligned coord and an aligned mask.\n",
     "The following conditions must hold:"
@@ -80,7 +84,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In operations, coords are compared:"
    ]
@@ -100,7 +106,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Mismatching attrs (\"unaligned coords\") are dropped:"
    ]
@@ -116,7 +124,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Masks are ORed, there is no concept of \"unaligned masks\":"
    ]
@@ -132,7 +142,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "A missing attr is interpreted as mismatch to ensure that:"
    ]
@@ -151,7 +163,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Insertion order does not matter for attrs:"
    ]
@@ -177,7 +191,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Insert into dataset with mismatching attrs drops attr:"
    ]
@@ -196,7 +212,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Masks of dataset items are independent:"
    ]
@@ -220,7 +238,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If there is no coord it is preserved for all items.\n",
     "Adding a coord later makes the `meta` property invalid because of ambiguous name shadowing:"
@@ -266,7 +286,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "2-D coords for a dimension prevent operations between slices that are not along that dimension:"
    ]
@@ -296,7 +318,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "`coords` always refers to (aligned) coords in dataset, cannot add or erase via item since a new coord dict is created when getting a dataset item:"
    ]
@@ -337,7 +361,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The same mechanism applies for coords, masks, and attrs of slices:"
    ]
@@ -360,7 +386,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "`meta` contains dataset coordinates as well as item attributes, cannot add or erase, since ambiguous:"
    ]
@@ -389,7 +417,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Attributes are independent for each item, and show up in `meta` of the items:"
    ]
@@ -428,7 +458,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Quick start\n",
     "\n",
@@ -22,7 +24,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We start by creating some variables:"
    ]
@@ -39,7 +43,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Type the name of a variable at the end of a cell to generate an HTML respresentation:"
    ]
@@ -65,7 +71,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We combine the variables into a data array:"
    ]
@@ -85,7 +93,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Variables can have uncertainties.\n",
     "Scipp stores these as variances (the square of the standard deviation):"
@@ -103,7 +113,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We create a dataset:"
    ]
@@ -124,7 +136,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can slice variables, data arrays, and datasets using a dimension label and an index or a slice object like `i:j`:"
    ]
@@ -142,7 +156,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can also generate table representations (only 0-D and 1-D) and plots:"
    ]
@@ -167,7 +183,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Arithmetic operations can be combined with slicing and handle propagation of uncertainties and units:"
    ]
@@ -194,7 +212,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Finally, type the imported name of the `scipp` module at the end of a cell for a list of all current scipp objects (variables, data arrays, datasets).\n",
     "Click on entries to expand nested sections:"
@@ -227,7 +247,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/python-reference/dtype.ipynb
+++ b/docs/python-reference/dtype.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Data types\n",
     "\n",
@@ -35,7 +37,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `dtype` may also be specified using a keyword argument.\n",
     "It is possible to use scipp's own `scipp.dtype`, [numpy.dtype](https://docs.scipy.org/doc/numpy/reference/generated/numpy.dtype.html#numpy.dtype), or a string:"
@@ -73,7 +77,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If no data is provided the default is `float64`, i.e. double precision float:"
    ]
@@ -90,7 +96,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Scipp supports common dtypes like\n",
     "- `float32`, `float64`\n",
@@ -110,7 +118,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Dates and Times\n",
     "\n",
@@ -138,7 +148,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Datetime variables always need a temporal unit and that unit determines how the integer that is passed to `value=` is interpreted:"
    ]
@@ -155,7 +167,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Datetime elements are automatically converted to and from [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html#basic-datetimes) objects:"
    ]
@@ -181,7 +195,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that `now` has unit `s` even though we did not specify it.\n",
     "The unit was deduced from the `numpy.datetime64` object which encodes a unit of its own."
@@ -189,7 +205,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Operations\n",
     "\n",
@@ -232,7 +250,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Time zones\n",
     "\n",
@@ -268,7 +288,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.7"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/python-reference/runtime-configuration.ipynb
+++ b/docs/python-reference/runtime-configuration.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Runtime Configuration\n",
     "\n",
@@ -23,7 +25,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "When the `scipp` module is imported and no configuiration file exists a default one is created. If a configuration file already exists it will not be modified, i.e. new options will not automatically be added to it when Scipp is updated.\n",
     "\n",
@@ -45,7 +49,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that changes made via the Python API are not persisted in the configuration file.\n",
     "Permanent changes must be made to the file directly."
@@ -69,7 +75,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.9"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/python-reference/units.ipynb
+++ b/docs/python-reference/units.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Physical units\n",
     "\n",
@@ -50,7 +52,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "You can get a list of all predefined units (accessible through `sc.units`) with"
    ]
@@ -66,7 +70,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Units can also be created directly from strings:"
    ]
@@ -91,7 +97,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "To convert data between compatible units, such as `m` to `mm`, see [sc.to_unit](../generated/scipp.to_unit.html#scipp.to_unit)."
    ]
@@ -107,7 +115,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Supported Units\n",
     "\n",
@@ -136,7 +146,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In addition, these base units are supported for cases not covered by SI:\n",
     "\n",
@@ -175,7 +187,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "You can also specify exponents for units or exponentiate them explicitly:"
    ]
@@ -191,7 +205,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The Scipp units library is built on top of LLNL [Units](https://units.readthedocs.io/en/latest/index.html).\n",
     "You can take a look at the page on [Defined Units](https://units.readthedocs.io/en/latest/user-guide/defined_units.html) for a more complete list of supported units.\n",
@@ -216,7 +232,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# 1-D datasets and tables\n",
     "\n",
@@ -41,7 +43,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We start by creating an empty dataset:"
    ]
@@ -58,7 +62,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Using `Dataset` as a table\n",
     "We can think about, and indeed use a dataset as a table.\n",
@@ -79,7 +85,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The column for `'alice'` contains two sub-columns with values and associated variances (uncertainties).\n",
     "The uncertainties are optional.\n",
@@ -89,7 +97,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "For many practicle purposes we want to associate a set of values (optionally a unit and variances also) with our dimension. Lets introduce a coordinate for `row` so that we can assign a row number starting at zero."
    ]
@@ -106,14 +116,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Here the coord acts as a row header for the table. Note that the coordinate is itself just a variable."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "More details of the dataset are visible in its string representation:"
    ]
@@ -129,7 +143,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "A data item (column) in a dataset (table) is identified by its name (`'alice'`).\n",
     "Note how each coordinate and data item is associated with named dimensions, in this case `'row'`, and also a shape:"
@@ -149,7 +165,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "It is important to understand the difference between items in a dataset, the variable that holds the data of the item, and the actual values.\n",
     "The following illustrates the differences:"
@@ -168,7 +186,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Each variable (column) comes with a physical unit, which we should set up correctly as early as possible:"
    ]
@@ -195,7 +215,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Units and uncertainties are handled automatically in operations:"
    ]
@@ -212,7 +234,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note how the coordinate is unchanged by this operations.\n",
     "As a rule, operations *compare* coordinates (and fail if there is a mismatch).\n",
@@ -233,7 +257,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "For small datasets, the `show()` function provides a quick graphical preview on the structure of a dataset:"
    ]
@@ -259,7 +285,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The contents of a dataset can also be displayed on a graph using the `plot` function:"
    ]
@@ -275,7 +303,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This plot demonstrates the advantage of \"labeled\" data, provided by a dataset:\n",
     "Axes are automatically labeled and multiple items identified by their name are plotted.\n",
@@ -327,7 +357,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note the key advantage over `numpy` or `MATLAB`:\n",
     "We specify the index dimension, so we always know which dimension we are slicing.\n",
@@ -362,7 +394,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 1\n",
     "1. Combining row slicing and \"column\" indexing, add the last row of the data for `'alice'` to the first row of data for `'bob'`.\n",
@@ -371,7 +405,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 1"
    ]
@@ -388,7 +424,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If a range is given when slicing, the corresponding coordinate is preserved, and operations between misaligned data is prevented."
    ]
@@ -407,7 +445,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "To circumvent the safety catch we can operate on the underlying variables containing the data.\n",
     "The data is accessed using the `data` property:"
@@ -425,7 +465,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 2\n",
     "\n",
@@ -446,14 +488,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Using the slicing notation, create a new table (or replace the existing dataset `d`) by one that does not contain the first and last row of `d`."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 2"
    ]
@@ -475,7 +521,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that the call to `copy()` is essential.\n",
     "If it is omitted we simply have a view onto the same data, and the orignal data is modified if the view is modified:"
@@ -495,7 +543,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Appending rows and columns\n",
     "We can append rows using `concatenate`, and add columns using `merge`:"
@@ -517,7 +567,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 3\n",
     "Add the sum of the data for `alice` and `bob` as a new variable (column) to the dataset."
@@ -525,7 +577,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 3"
    ]
@@ -542,7 +596,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Interaction with `numpy` and scalars\n",
     "\n",
@@ -570,7 +626,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can directly hand the buffers to `numpy` functions:"
    ]
@@ -587,7 +645,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 4\n",
     "1. As above for `np.exp` applied to the data for Eve, apply a `numpy` function to the data for Alice.\n",
@@ -596,7 +656,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 4"
    ]
@@ -613,7 +675,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Numpy operations are not aware of the unit and uncertainties. Therefore the result is \"garbage\", unless the user has ensured herself that units and uncertainties are handled manually.\n",
     "\n",
@@ -622,7 +686,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 5\n",
     "1. Try adding a scalar value such as `1.5` to the `values` for `'eve'` or and `'alice'`.\n",
@@ -632,7 +698,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 5"
    ]
@@ -650,7 +718,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Instead of `values` we can use the `data` property.\n",
     "This will also correctly deal with variances, if applicable, whereas the direction operation with `values` is unaware of the presence of variances:"
@@ -667,7 +737,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `data` for Alice has a unit, so a direct addition with a dimensionless quantity fails:"
    ]
@@ -686,7 +758,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can use `Variable` to provide a scalar quantity with attached unit:"
    ]
@@ -702,7 +776,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As a short-hand for creating a scalar variable, just multiply a value by a unit:"
    ]
@@ -721,7 +797,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Continue to [Part 2 - Multi-dimensional datasets](multi-d-datasets.ipynb) to see how datasets are used with multi-dimensional data."
    ]
@@ -747,7 +825,8 @@
   },
   "nbsphinx": {
    "allow_errors": true
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/tutorials/multi-d-datasets.ipynb
+++ b/docs/tutorials/multi-d-datasets.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Multi-dimensional datasets\n",
     "\n",
@@ -23,7 +25,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "To create variables with more than one dimension we specify a list of dimension labels and provide data with a corresponding shape.\n",
     "When inserted into a dataset it is important to note that while the dimensions extents have to match, individual variables may have transposed memory layout."
@@ -50,7 +54,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that in this example the coordinates are exceeding the shape of the data by 1.\n",
     " This means that the coordinates represent bin edges:"
@@ -68,7 +74,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "To slice in multiple dimensions, we can simply chain the slicing notation used previously for 1D data.\n",
     "This gives us a number of different options for visualizing our data:"
@@ -85,7 +93,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can plot and item of a `Dataset` using:"
    ]
@@ -101,7 +111,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Plotting a 3-dimensional data cube will show a 2D image with a slider to navigate through the third dimension (note that interactive sliders will only appear in a Jupyter notebook and not in the documentation pages):"
    ]
@@ -117,7 +129,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Finally, by extracting a 1D variable, we obtain a 1D plot:"
    ]
@@ -133,7 +147,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that this is now plotted as a histogram since the coordinate in the dataset represents bin edges, in contrast to the 1D data plotted in [1-D datasets and tables](introduction.ipynb).\n",
     "\n",
@@ -156,7 +172,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 1\n",
     "\n",
@@ -165,7 +183,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 1"
    ]
@@ -182,7 +202,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note the important call to `copy()`.\n",
     "If we omit it, `d` will just be a multi-dimensional slice of the larger volume (which is kept alive), wasting memory and preventing further modification, such as insertion of other variables.\n",
@@ -192,7 +214,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## More advanced operations with multi-dimensional datasets\n",
     "Operations like `concatenate` and `merge` work just like with one-dimensional datasets."
@@ -200,7 +224,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 2\n",
     "- Try to concatenate the dataset with itself along the X dimensions. Why does this fail?\n",
@@ -209,7 +235,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 2"
    ]
@@ -228,7 +256,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "With a data extent of, e.g. `8` in this case, bin edges have extent `9`.\n",
     "Naive concatenation would thus lead a new data extent of `16` and a coordinate extent of `18`, which is meaningless and thus prevented.\n",
@@ -249,7 +279,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Another available operation is `rebin`.\n",
     " This is only for count-data or count-density-data, so we have to set an appropriate unit first:"
@@ -267,7 +299,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Before `rebin` we have the following:"
    ]
@@ -284,7 +318,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We rebin onto a coarser grid, in this case combining two neightboring bins:"
    ]
@@ -301,7 +337,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The result looks as follows:"
    ]
@@ -318,7 +356,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Interaction with `numpy`\n",
     "\n",
@@ -336,7 +376,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In contrast to the 1-D case considered earlier, the `values` are now a multi-dimensional array:"
    ]
@@ -352,7 +394,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Exercise 3\n",
     " 1. Use `sc.mean` to compute the mean of the data for Alice along the Z dimension.\n",
@@ -361,7 +405,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Solution 3"
    ]
@@ -386,7 +432,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "When using `numpy` to compute the mean:\n",
     "- We must remember (or lookup) which dimension corresponds to the Z dimensions.\n",
@@ -419,7 +467,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Continue to [Neutron Powder Diffraction](neutron-diffraction.ipynb) to see how datasets are used with neutron-event data."
    ]
@@ -445,7 +495,8 @@
   },
   "nbsphinx": {
    "allow_errors": true
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/user-guide/binned-data/binned-data.ipynb
+++ b/docs/user-guide/binned-data/binned-data.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Binned Data\n",
     "\n",
@@ -54,7 +56,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Consider a list of measurements at various \"points\" in space.\n",
     "Here we restrict ourselves to the X-Y plane for visualization purposes:"
@@ -79,7 +83,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "For every point we measured at the auxiliary coordinates `'x'` and `'y'` give the position in the X-Y plane.\n",
     "These are *not* dimension-coordinates, since our measurements are *not* on a 2-D grid, but rather points with an irregular distribution.\n",
@@ -97,7 +103,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can plot this data:"
    ]
@@ -113,7 +121,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `'position'` dimension is not a continuous dimension but essentially just a row in our table.\n",
     "In practice, such a figure and this representation of data in general may therefore not be very useful.\n",
@@ -142,7 +152,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This shows the distribution in space, but for real datasets with millions of points this may not be convenient.\n",
     "Furthermore, operating with scattered data is often inconvenient and may require knowledge of the underlying representation.\n",
@@ -164,7 +176,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "`binned` is a 2-D data array, but it contains the original table of \"unaligned\" data:"
    ]
@@ -180,7 +194,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The binning procedure based on bin edges for `'x'` and `'y'` is *not* performing the actual histogramming step.\n",
     "However, since its dimensions are defined by the bin-edge coordinates for `'x'` and `'y'`, we will see below that it behaves much like normal dense data for operations such as slicing.\n",
@@ -212,7 +228,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This is essentially the same figure as the scatter plot for the original `data`.\n",
     "The differences are:\n",
@@ -235,7 +253,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Here `sum` performs histogramming for all \"binned\" dimensions, in this case `x` and `y`.\n",
     "The resulting values in the X-Y bins are the counts accumulated from measurements at all points falling in a given bucket.\n",
@@ -255,7 +275,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Working with binned data\n",
     "\n",
@@ -275,7 +297,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Just like slicing dense variables, a slice of binned data \"drops\" all unaligned data falling into areas outside the slice:"
    ]
@@ -295,14 +319,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This can provide an intuitive way of \"filtering\" lists of data based on some property of the list items."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Masking\n",
     "\n",
@@ -329,7 +357,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As usual, more masks can be added if required, and masks can be removed as long as no reduction operation such as summing or histogramming took place.\n",
     "\n",
@@ -350,7 +380,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Plotting higher dimensions\n",
     "\n",
@@ -379,7 +411,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Arithmetic operations\n",
     "\n",
@@ -404,7 +438,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/binned-data/computation.ipynb
+++ b/docs/user-guide/binned-data/computation.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Computation with Binned Data\n",
     "\n",
@@ -18,7 +20,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Overview and Quick Reference\n",
     "\n",
@@ -45,7 +49,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Concepts\n",
     "\n",
@@ -70,7 +76,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The events in the table can then be mapped into bins.\n",
     "Note that this copies `table`:"
@@ -91,7 +99,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Each element of the resulting \"bin variable\" references a section of the underlying table:"
    ]
@@ -109,7 +119,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Bin-centric arithmetic\n",
     "\n",
@@ -149,7 +161,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In practice scattered data requires more than one \"column\" of information.\n",
     "Typically we need at least one coordinate such as the detection time in addition to weights.\n",
@@ -180,7 +194,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This table is then mapped into bins.\n",
     "The resulting \"bin variable\" can, e.g., be used as the data in a data array, and can be combined with coordinates as usual:"
@@ -199,7 +215,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -212,7 +230,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In the graphical representation of the data array we can see the dense coordinate (green), and the bins (yellow):"
    ]
@@ -230,7 +250,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As before, each bin references a section of the underlying table:"
    ]
@@ -248,7 +270,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Event-centric arithmetic\n",
     "\n",
@@ -272,7 +296,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-warning\">\n",
     "    <b>WARNING:</b>\n",
@@ -285,7 +311,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Addition"
    ]
@@ -304,7 +332,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Subtraction"
    ]
@@ -324,7 +354,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Multiplication and division\n",
     "\n",
@@ -345,7 +377,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The helper `sc.lookup` provides a wrapper for a discrete \"function\", given by a data array depending on a specified dimension.\n",
     "The binary arithmetic operators on the `bins` property support this function-like object:"
@@ -379,7 +413,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Filtering\n",
     "\n",
@@ -26,7 +28,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -102,7 +106,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Filtering based on existing coords\n",
     "\n",
@@ -124,7 +130,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Extracting/splitting data based on multiple intervals\n",
     "\n",
@@ -144,7 +152,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Events in each of the subintervals can then be accessed using the usual slicing syntax:"
    ]
@@ -160,7 +170,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Filtering based on arbitrary metadata\n",
     "### Step 1: Preprocess metadata\n",
@@ -180,7 +192,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This is a timeseries with noisy measurements, as could be obtained, e.g., from a temperature sensor.\n",
     "For event filtering we require intervals with a fixed temperature.\n",
@@ -204,7 +218,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -217,7 +233,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Step 2: Map time stamps\n",
     "\n",
@@ -237,7 +255,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The event lists with temperature values created by `scipp.map` have been added as a new coordinate:"
    ]
@@ -253,7 +273,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Step 3: Filter with `scipp.bin`\n",
     "\n",
@@ -275,7 +297,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Filtering is then performed by slicing and, if desired, copying:"
    ]
@@ -292,7 +316,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Slicing combined with histogramming also performs a filter operation since all events outside the histogram bounds are dropped:"
    ]
@@ -317,7 +343,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Results from filter operations can also be inserted into a dataset for convenient handling of further operations such as histogramming, summing, or plotting:"
    ]
@@ -336,7 +364,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can also bin without the time-of-flight coordinate to obtain the temperature dependence of the total event count, e.g., for normalization purposes:"
    ]
@@ -369,7 +399,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/binned-data/histogramming-grouping-and-binning.ipynb
+++ b/docs/user-guide/binned-data/histogramming-grouping-and-binning.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Histogramming, grouping, and binning\n",
     "\n",
@@ -36,7 +38,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We may now be interested in the total intensity (counts) as a function of `'x'`.\n",
     "There are three ways to do this:"
@@ -58,7 +62,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In the above plot we can only see a single line, since the three solutions yield exactly the same result (neglecting floating-point rounding errors):\n",
     "\n",
@@ -104,7 +110,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Another capability of `histogram` is to histogram a dimension that has previously been binned with a different or higher resolution, i.e. different bin edges.\n",
     "Compare to the plot of the initial example:"
@@ -123,7 +131,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Grouping\n",
     "\n",
@@ -151,7 +161,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Each output bin is a combination of multiple input bins:"
    ]
@@ -167,7 +179,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Binning\n",
     "  \n",
@@ -194,7 +208,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If we omit the call to `bins.sum` in the original example, we can subsequently apply another [histogramming](#Histogramming) or binning operation to the data:"
    ]
@@ -211,7 +227,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As in the 1-D example above, summing the bins is equivalent to histogramming binned data:"
    ]
@@ -243,7 +261,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.7"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/computation.ipynb
+++ b/docs/user-guide/computation.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Computation\n",
     "\n",
@@ -49,7 +51,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Propagation of uncertainties\n",
     "\n",
@@ -95,7 +99,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The implementation assumes uncorrelated data and is otherwise based on, e.g., [Wikipedia: Propagation of uncertainty](https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae>).\n",
     "See also [Propagation of uncertainties](../python-reference/error-propagation.rst) for the concrete equations used for error propagation.\n",
@@ -138,7 +144,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Since `var_y` did not depend on dimension `'x'` it is considered as \"constant\" along that dimension.\n",
     "That is, the *same* `var_y` values are subtracted *from all slices of dimension* `'x'` in `var_xy`.\n",
@@ -169,7 +177,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Both operands may be broadcast, creating an output with the combination of input dimensions:"
    ]
@@ -187,7 +197,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that in-place operations such as `+=` will never change the shape of the left-hand-side.\n",
     "That is only the right-hand-side operation can be broadcast, and the operation fails of a broadcast of the left-hand-side would be required.\n",
@@ -211,7 +223,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Coordinate and name matching\n",
     "\n",
@@ -296,7 +310,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Arithmetics\n",
     "\n",
@@ -306,7 +322,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Trigonometrics\n",
     "\n",
@@ -332,7 +350,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Other\n",
     "\n",
@@ -357,7 +377,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Data Structures\n",
     "\n",
@@ -44,7 +46,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -100,7 +104,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Variances must have the same shape as values, and units are specified using the [scipp.units](../python-reference/units.rst) module or with a string:"
    ]
@@ -138,7 +144,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "A scipp.Variable object can also be created with the [scipp.array](../generated/scipp.array.html#scipp-array) creation function. \n",
     "This function mirrors the [numpy.array](https://numpy.org/doc/stable/reference/generated/numpy.array.html) function, always producing an object with at least 1-dimension (and as a result a `dims` argument must always be given). "
@@ -194,7 +202,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### 0-D variables (scalars)\n",
     "\n",
@@ -215,7 +225,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Singular versions of the `values` and `variances` properties are provided:"
    ]
@@ -232,7 +244,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "An exception is raised from the `value` and `variance` properties if the variable is not 0-dimensional.\n",
     "Note that a variable with one or more dimension extent(s) of 1 contains just a single value as well, but the `value` property will nevertheless raise an exception."
@@ -240,7 +254,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Creating scalar variables with variances or with custom `dtype` or variances is possible using [scipp.scalar](../generated/scipp.array.html#scipp-scalar):"
    ]
@@ -267,7 +283,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## DataArray\n",
     "\n",
@@ -309,7 +327,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note how the `'aux'` attribute is essentially a secondary coordinate for the x dimension.\n",
     "The dict-like `coords` and `masks` properties give access to the respective underlying variables:"
@@ -335,7 +355,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Access to coords and attrs in a unified manner is possible with the `meta` property.\n",
     "Essentially this allows us to ignore whether a coordinate is aligned or not:"
@@ -361,7 +383,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Unlike `values` when creating a variable, `data` as well as entries in the meta data dicts (`coords`, `masks`, and `attrs`) are *not* deep-copied on insertion into a data array.\n",
     "To avoid unwanted sharing, call the `copy()` method.\n",
@@ -383,7 +407,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Meta data can be removed in the same way as in Python dicts:"
    ]
@@ -399,7 +425,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Distinction between dimension coords and non-dimension coords, and coords and attrs\n",
     "\n",
@@ -420,7 +448,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Dataset\n",
     "\n",
@@ -474,7 +504,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The name of a data item serves as a dict key.\n",
     "Item access returns a new data array which is a view onto the data in the dataset and its corresponding coordinates, i.e., no deep copy is made:"
@@ -492,7 +524,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Use the `copy()` method to turn the view into an independent object:"
    ]
@@ -510,7 +544,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Each data item is linked to its corresponding coordinates, masks, and attributes.\n",
     "These are accessed using the `coords` , `masks`, and `attrs` properties.\n",
@@ -528,7 +564,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "For convenience, properties of the data variable are also properties of the data item:"
    ]
@@ -562,7 +600,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Coordinates of a data item include only those that are relevant to the item's dimensions, all others are hidden.\n",
     "For example, when accessing `'b'`, which does not depend on the `'y'` dimension, the coord for `'y'` as well as the `'aux'` coord are not part of the item's `coords`:"
@@ -579,7 +619,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Similarly, when accessing a 0-dimensional data item, it will have no coordinates:"
    ]
@@ -595,7 +637,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "All variables in a dataset must have consistent dimensions.\n",
     "Thanks to labeled dimensions, transposed data is supported:"
@@ -614,7 +658,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "When inserting a data array or variable into a dataset ownership is shared by default.\n",
     "Use the `copy()` method to avoid this if undesirable:"
@@ -634,7 +680,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The usual `dict`-like methods are available for `Dataset`:"
    ]
@@ -687,7 +735,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# GroupBy\n",
     "\n",
@@ -41,7 +43,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If we store this data as a data array we obtain the following plot:"
    ]
@@ -63,7 +67,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that we chose the \"measured\" values such that the three distinct values of the underlying parameter are visible.\n",
     "We can now use the split-apply-combine mechanism to transform our data into a more useful representation.\n",
@@ -81,7 +87,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Next, we call `scipp.groupby` to split the data and call `mean` on each of the groups:"
    ]
@@ -98,7 +106,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Apart from `mean`, `groupby` also supports `sum`, `concatenate`, and more. See [GroupByDataArray](../generated/scipp.GroupByDataArray.rst) and [GroupByDataset](../generated/scipp.GroupByDataset.rst) for a full list.\n",
     "\n",
@@ -137,7 +147,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We create a variable defining the desired binning:"
    ]
@@ -153,7 +165,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As before, we can now use `groupby` and `mean` to transform the data:"
    ]
@@ -171,7 +185,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The values in the white rows are `NaN`.\n",
     "This is the result of empty bins, which do not have a meaningful mean value."
@@ -179,7 +195,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Alternatively, grouping can be done based on groups defined as Variables rather than strings. This, however, requires bins to be specified, since bins define the new dimension label."
    ]
@@ -196,7 +214,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Usage examples\n",
     "\n",
@@ -219,7 +239,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We proceed as follows:\n",
     "1. Create a helper data array with a dummy coord that will be used to group the data elements.\n",
@@ -242,7 +264,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that we can also avoid the named helpers `helper` and `grouped` and write:"
    ]
@@ -274,7 +298,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/how_to.ipynb
+++ b/docs/user-guide/how_to.ipynb
@@ -12,7 +12,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# How to...\n",
     "## Create variables\n",
@@ -30,7 +32,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Scalar variable from Python object"
    ]
@@ -64,7 +68,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Initialized with default values"
    ]
@@ -80,7 +86,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### From Python list or NumPy array"
    ]
@@ -107,7 +115,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Create a data array"
    ]
@@ -133,7 +143,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Create an empty dataset"
    ]
@@ -150,7 +162,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Add / insert a data item, a coord, a mask, or an attr\n"
    ]
@@ -182,7 +196,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Get a data item, a coord, or a mask"
    ]
@@ -234,7 +250,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Delete / remove a data item, a coord, a mask, or an attr"
    ]
@@ -255,7 +273,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Copy variables, data arrays, or dataset\n",
     "\n",
@@ -277,7 +297,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Again, note that all three options result in a deep copy.\n",
     "The syntax is the same for variables, data arrays, and datasets."
@@ -285,7 +307,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Create stand-alone objects from (slice) views\n",
     "\n",
@@ -332,7 +356,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/user-guide/masking.ipynb
+++ b/docs/user-guide/masking.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Masking"
    ]
@@ -19,7 +21,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Creating and manipulating masks\n",
     "\n",
@@ -38,7 +42,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Boolean operators can be used to manipulate such variables:"
    ]
@@ -57,7 +63,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Comparison operators such as `==`, `!=`, `<`, or `>=` (see also the [list of comparison functions](../python-reference/api.rst#comparison)) are a common method of defining masks:"
    ]
@@ -75,7 +83,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Masks in data arrays and items of dataset\n",
     "\n",
@@ -114,7 +124,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that setting a mask does *not* affect the data.\n",
     "\n",
@@ -133,7 +145,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Operations with masked objects\n",
     "\n",
@@ -154,7 +168,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Reduction operations\n",
     "\n",
@@ -173,7 +189,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `mean` operation takes into account that masking is reducing the number of points in the mean, i.e., masked elements are not counted (in contrast to, e.g., treating them as 0):"
    ]
@@ -189,7 +207,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If a mask does not depend on the dimension used for the `sum` or `mean` operation, it is preserved.\n",
     "Here `b` has two masks, one that is applied and one that is preserved:"
@@ -224,7 +244,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/user-guide/reading-and-writing-files.ipynb
+++ b/docs/user-guide/reading-and-writing-files.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Reading and Writing Files\n",
     "\n",
@@ -61,7 +63,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## NeXus\n",
     "\n",
@@ -87,7 +91,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Slicing\n",
     "\n",
@@ -12,7 +14,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Positional indexing\n",
     "\n",
@@ -47,7 +51,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As when slicing a `numpy.ndarray`, the dimension `'x'` is removed since no range is specified:"
    ]
@@ -65,7 +71,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "When a range is specified, the dimension is kept, even if it has extent 1:"
    ]
@@ -87,7 +95,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Slicing can be chained arbitrarily:"
    ]
@@ -107,7 +117,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `copy()` method turns a view obtained from a slice into an independent object:`"
    ]
@@ -125,7 +137,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Data arrays\n",
     "\n",
@@ -155,7 +169,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "As when slicing a variable, the sliced dimension is removed when slicing without range, and kept when slicing with range.\n",
     "\n",
@@ -187,7 +203,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In practice, a much more dangerous issue this mechanism protects from is unintentional changes to masks.\n",
     "Consider"
@@ -205,7 +223,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If we now assign this scalar `val` to a slice at `y=0`, using `=` we need to update the mask.\n",
     "However, the mask in this example depends only on `x` so it also applies to the slices `y=1`.\n",
@@ -226,7 +246,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Since we cannot update the mask in a consistent manner the entire operation fails.\n",
     "Data is not modified.\n",
@@ -248,7 +270,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If `a['x', 0]` had an `x` coordinate this would fail due to a coord mismatch.\n",
     "If coord checking is required, use a range-slice such as `a['x', 1:2]`. Compare the two cases shown in the following and make sure to inspect the `dims` and `shape` of all variables (data and coordinates) of the resulting slice views (note the tooltip shown when moving the mouse over the name also contains this information):"
@@ -276,7 +300,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Datasets\n",
     "\n",
@@ -304,7 +330,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "and a slice of `d`:"
    ]
@@ -320,7 +348,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "By marking lower-dimensional entries in the slice as read-only we prevent unintentional multiple modifications of the same scalar:"
    ]
@@ -340,7 +370,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This is an important aspect and it is worthwhile to take some time and think through the mechanism.\n",
     "\n",
@@ -359,7 +391,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Slicing and item access can be done in arbitrary order with identical results:"
    ]
@@ -376,7 +410,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Label-based indexing\n",
     "\n",
@@ -413,7 +449,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can select a slice of `da` based on the `'year'` labels:"
    ]
@@ -430,7 +468,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In this case `2023` is the second element of the coordinate so this is equivalent to positionally slicing `data['year', 1]` and [the usual rules](#Positional-indexing) regarding dropping dimensions and converting dimension coordinates to attributes apply:"
    ]
@@ -446,7 +486,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-warning\">\n",
     "    \n",
@@ -505,7 +547,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The selection includes the bounds on the \"left\" but excludes the bounds on the \"right\", i.e., we select the half-open interval $x \\in [x_{\\text{left}},x_{\\text{right}})$, closed on the left and open on the right.\n",
     "\n",
@@ -525,7 +569,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Just like when slicing positionally one of the bounds can be omitted, to include either everything from the start, or everything until the end:"
    ]
@@ -541,7 +587,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Coordinates used for label-based indexing must be monotonically ordered.\n",
     "While it is natural to think of slicing in terms of ascending coordinates, the slicing mechanism also works for descending coordinates.\n",
@@ -567,7 +615,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Here `'x'` is a bin-edge coordinate, i.e., its length exceeds the array dimensions by one.\n",
     "Label-based slicing with a single coord value finds and returns the bin that contains the given coord value:"
@@ -585,7 +635,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "If an interval is provided when slicing with a bin-edge coordinate, the range of bins *containing* the interval bounds (*including* the left as well as the right bin) is selected:"
    ]
@@ -603,7 +655,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Limitations\n",
     "\n",
@@ -634,7 +688,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
+++ b/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
@@ -12,7 +12,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Tips, tricks, and anti-patterns\n",
     "## Choose dimensions wisely\n",
@@ -36,7 +38,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "For irregularly spaced detectors this may well be the correct or only choice.\n",
     "If however the pixels are actually forming a regular 2-D image sensor we should probably prefer"
@@ -56,7 +60,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "With this layout we can naturally perform slices, access neighboring pixel rows or columns, or sum over rows or columns.\n",
     "\n",
@@ -82,7 +88,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Slices such as"
    ]
@@ -98,7 +106,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "will then have data for all pixels in a contiguous chunk of memory.\n",
     "Note that in scipp the first listed dimension in `dims` is always the *outermost* dimension (numpy's default).\n",
@@ -127,7 +137,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "with"
    ]
@@ -143,7 +155,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that a this point numpy provides more powerful functions such as [numpy.roll](https://numpy.org/doc/stable/reference/generated/numpy.roll.html).\n",
     "Scipp's toolset for such purposes is not fully developed yet."
@@ -151,7 +165,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Seek advice from numpy\n",
     "\n",
@@ -174,7 +190,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `values` property can also be used as the `out` argument that many numpy functions support:"
    ]
@@ -191,7 +209,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-warning\">\n",
     "    <b>WARNING</b>\n",
@@ -202,7 +222,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Use helper dimensions or reshaped data\n",
     "\n",
@@ -224,7 +246,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In the case of only two neighbors, the same could be achieved using slicing with strides, however scipp does not support strides yet.\n",
     "\n",
@@ -262,7 +286,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that in-place operations cannot be used if a broadcast is required or a dtype change happens, since in-place operations may only change the data contained in a variable."
    ]
@@ -285,7 +311,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting-overview.ipynb
+++ b/docs/visualization/plotting-overview.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Plotting Overview\n",
     "\n",
@@ -54,7 +56,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The information in a data array or dataset is typically enough to create meaningful plots:"
    ]
@@ -70,7 +74,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Notice in above that the dataset contains three data items.\n",
     "The two 1-D items with dimension y are combined into a single 1-D plot.\n",
@@ -83,7 +89,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Plotting slices or items of a dataset\n",
     "\n",
@@ -103,7 +111,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "or alternatively"
    ]
@@ -119,7 +129,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Plot a slice range"
    ]
@@ -135,7 +147,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Plot a 1-D slice of 2-D data\n",
     "\n",
@@ -154,7 +168,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Logarithmic scale\n",
     "\n",
@@ -172,7 +188,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Axis labels and axis order\n",
     "\n",
@@ -195,7 +213,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This also works for attributes."
    ]
@@ -212,7 +232,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -242,7 +264,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting/customizing-figures.ipynb
+++ b/docs/visualization/plotting/customizing-figures.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Customizing figures\n",
     "\n",
@@ -48,7 +50,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The `out` object is a `SciPlot` object which is made up of several pieces:\n",
     "- some `widgets` that are used to interact with the displayed figure via buttons and sliders to control slicing of higher dimensions or flipping the axes of the plot\n",
@@ -70,7 +74,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "and they are still connected to the figure above.\n",
     "\n",
@@ -90,7 +96,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "A line color may be modified by accessing the members of the figure, which is in turn a member of the `view` attribute:"
    ]
@@ -107,7 +115,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -123,7 +133,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Placing figures inside existing Matplotlib axes\n",
     "\n",
@@ -146,7 +158,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Then a `Dataset` with some 2D data:"
    ]
@@ -174,7 +188,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Next, we attach the 2D image plot to the first subplot, and display the colorbar in the third subplot:"
    ]
@@ -190,7 +206,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This has just returned a `SciPlot` object, but then we can check that our original figure has been updated:"
    ]
@@ -206,7 +224,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can add a 1D plot of a slice through the 2D data in the middle panel, and check once again the original figure:"
    ]
@@ -223,7 +243,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Next we create a second dataset with some more 1D data and add it to the middle panel:"
    ]
@@ -252,7 +274,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can now for example modify the axes labels:"
    ]
@@ -269,7 +293,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "You can then also access the individual plot objects and change their properties. For example, if we wish to show a line connecting the green `'Sample'` markers, we can do:"
    ]
@@ -302,7 +328,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting/datetime_handling.ipynb
+++ b/docs/visualization/plotting/datetime_handling.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Datetime handling\n",
     "\n",
@@ -28,7 +30,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## More than 100 years"
    ]
@@ -48,7 +52,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 100 years"
    ]
@@ -68,7 +74,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 years"
    ]
@@ -88,7 +96,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 6 months"
    ]
@@ -108,7 +118,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 days"
    ]
@@ -143,7 +155,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 hours"
    ]
@@ -178,7 +192,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 minutes"
    ]
@@ -213,7 +229,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 seconds"
    ]
@@ -262,7 +280,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 milliseconds"
    ]
@@ -311,7 +331,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Less than 4 microseconds"
    ]
@@ -376,7 +398,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.7"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting/plotting-1d-data.ipynb
+++ b/docs/visualization/plotting/plotting-1d-data.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Plotting 1-D data\n",
     "\n",
@@ -21,7 +23,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Basic plot\n",
     "\n",
@@ -48,7 +52,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## With error bars\n",
     "\n",
@@ -67,7 +73,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that the length of the errors bars is the standard-deviation, i.e., the square root of the variances stored in the data.\n",
     "\n",
@@ -91,7 +99,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "It is possible to hide the error bars with"
    ]
@@ -107,7 +117,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We can always plot just a single item of the dataset."
    ]
@@ -123,7 +135,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Overplotting using a dict of DataArrays\n",
     "\n",
@@ -142,7 +156,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that the newly supplied names (keys) have also been adopted as the graph names.\n",
     "\n",
@@ -160,7 +176,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "This overplotting is useful for plotting slices of a 2D data array:"
    ]
@@ -189,7 +207,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Or using the `collapse` helper function, which returns a `dict` of data arrays:"
    ]
@@ -205,7 +225,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Customizing linestyles, markers and colors\n",
     "\n",
@@ -224,7 +246,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Marker colors and symbols can be changed via the `color` and `marker` keyword arguments:"
    ]
@@ -240,7 +264,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The supplied `color` and `marker` arguments can also be a list of integers, which correspond to one of the pre-defined [colors](https://matplotlib.org/3.1.1/users/dflt_style_changes.html) or [markers](https://matplotlib.org/3.1.1/api/markers_api.html) (which were taken from matplotlib). In addition, the grid can also be displayed:"
    ]
@@ -256,7 +282,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Logarithmic scales\n",
     "\n",
@@ -274,7 +302,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Histograms\n",
     "Histograms are automatically generated if the coordinate is bin edges:"
@@ -295,7 +325,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "and with error bars"
    ]
@@ -312,7 +344,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The histogram color can be customized:"
    ]
@@ -328,7 +362,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Multiple 1D variables with different dimensions\n",
     "\n",
@@ -357,7 +393,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Custom labels along x axis\n",
     "\n",
@@ -388,7 +426,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Plotting masks\n",
     "\n",
@@ -419,7 +459,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Checkboxes below the plot can be used to hide/show the individual masks.\n",
     "A global toggle button is also available to hide/show all masks in one go.\n",
@@ -438,7 +480,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Masks on histograms\n",
     "\n",
@@ -461,7 +505,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Plotting time series\n",
     "\n",
@@ -487,7 +533,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Saving figures\n",
     "Static `pdf` or `png` copies of the figures can be saved to file (note that any buttons displayed under a figure are not saved to file). This is achieved as follows:"
@@ -520,7 +568,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting/plotting-2d-data.ipynb
+++ b/docs/visualization/plotting/plotting-2d-data.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Plotting 2-D data\n",
     "\n",
@@ -21,7 +23,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Basic image plot\n",
     "\n",
@@ -52,7 +56,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "The dimension displayed along each axis of the image can be selected with the `axes` keyword argument via which we specify which dimension we want along the `x` axis:"
    ]
@@ -68,7 +74,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Changing the colorscale\n",
     "\n",
@@ -87,7 +95,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "A logarithmic colorscale is obtained by setting `norm` to `'log'`:"
    ]
@@ -103,7 +113,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Upper and lower limits on the colorscale can be placed using `vmin` and `vmax`:"
    ]
@@ -119,7 +131,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Using labels along some axis\n",
     "\n",
@@ -140,7 +154,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Collapsing dimensions\n",
     "\n",
@@ -179,7 +195,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Image aspect ratio\n",
     "By default, the aspect ratio of 2D images is not preserved; images are stretched to the size of the figure.\n",
@@ -198,7 +216,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "You can also make this a permanent setting by editing the [config file](../python-reference/runtime-configuration.ipynb) (possible options are `'equal'` and `'auto'`):"
    ]
@@ -215,7 +235,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Plotting masks\n",
     "\n",
@@ -246,7 +268,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that hovering over a masked region still yields the underlying value of the element on the display.\n",
     "\n",
@@ -266,7 +290,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "We also note that any 1D mask will automatically broadcast onto a 2D image.\n",
     "This is due to underlying behavior of scipp around broadcasting rather than special handling in plotting:"
@@ -284,7 +310,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Saving figures\n",
     "Static `pdf` or `png` copies of the figures can be saved to file (note that any buttons displayed under a figure are not saved to file). This is achieved as follows:"
@@ -317,7 +345,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/plotting/plotting-nd-data.ipynb
+++ b/docs/visualization/plotting/plotting-nd-data.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Plotting N-D data\n",
     "\n",
@@ -21,7 +23,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Default representation\n",
     "\n",
@@ -59,7 +63,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Slider controls\n",
     "\n",
@@ -103,7 +109,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Profile picking\n",
     "\n",
@@ -116,14 +124,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 3D visualization"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -140,7 +152,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "It is also possible to use a 3d projection with `projection=\"3d\"`.\n",
     "If the data is a dense 3(+)D data array, a mesh of points filling the space will be created:"
@@ -157,7 +171,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "You can adjust opacities and create a cut surface to slice your data in 3D using the control buttons below the scene. When using a cut surface, the upper value of the opacity slider controls the opacity of the slice, while the lower value of the slider controls the opacity of the background.\n",
     "\n",
@@ -192,7 +208,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## LAMP's Superplot\n",
     "A `1d` projection is also available for multi-dimensional data, with the possibility to keep/remove lines that are plotted, a behavior we copied from LAMP's [Superplot](https://github.com/mantidproject/documents/blob/master/Requirements/Visualisation_and_Analysis/superplot.md) which was very popular in the neutron physics community."
@@ -225,7 +243,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/visualization/representations-and-tables.ipynb
+++ b/docs/visualization/representations-and-tables.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Representations and Tables\n",
     "\n",
@@ -53,7 +55,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Simply typing the name of a variable, data array, or dataset will show the HTML representation:"
    ]
@@ -69,7 +73,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Note that (as usual) Jupyter only shows the last variable mentioned in a cell:"
    ]
@@ -87,7 +93,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In this case, `to_html` can be used to retain the HTML view, e.g., to show multiple objects in a single cell:"
    ]
@@ -104,7 +112,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "Typing the scipp module name at the end of a cell yields an HTML view of all scipp objects (variables, data arrays, and datasets):"
    ]
@@ -120,7 +130,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## SVG representation\n",
     "\n",
@@ -140,7 +152,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Table representation\n",
     "\n",
@@ -159,7 +173,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "In such cases slicing can be used to produce tables from higher-dimensional entries:"
    ]
@@ -191,7 +207,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  }
+  },
+  "widgets": ""
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
Fix generated from python code applied to notebooks in docs/:

```python
import nbformat as nbf 
from glob import glob

# Collect a list of all notebooks in the content folder
notebooks = glob("./**/*.ipynb", recursive=True)

for ipath in notebooks:
    ntbk = nbf.read(ipath, as_version=nbf.NO_CONVERT)
    ntbk.metadata['widgets'] = ''
    for cell in ntbk.cells:
        if cell.get('cell_type') == 'markdown':
            cell_tags = cell.get('metadata', {})['tags'] = []
   
    nbf.write(ntbk, ipath)

```