### PR TITLE
Improvements to conda-build and upload settings

### DIFF
--- a/.azure-pipelines/templates/build.yml
+++ b/.azure-pipelines/templates/build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - bash: |
           set -ex
-          conda build $VERBOSE_OPTION --channel conda-forge --python=${{ parameters.py_version }} --no-anaconda-upload conda
+          conda build $VERBOSE_OPTION --channel conda-forge --python=${{ parameters.py_version }} --no-anaconda-upload --override-channels conda
         displayName: 'Python tests and conda build'
 
       - task: PublishBuildArtifacts@1

--- a/.azure-pipelines/templates/deploy.yml
+++ b/.azure-pipelines/templates/deploy.yml
@@ -50,7 +50,7 @@ stages:
                 downloadPath: '$(Build.StagingDirectory)/packages'
               displayName: 'Retrieve built conda package'
             - bash: |
-                anaconda --token "$ANACONDA_TOKEN" upload --user scipp --label ${{ parameters.conda_label }} '$(Build.StagingDirectory)/packages/${{ package.Key }}/'scipp-*.tar.bz2
+                anaconda --token "$ANACONDA_TOKEN" upload --user scipp --label ${{ parameters.conda_label }} '$(Build.StagingDirectory)/packages/${{ package.Key }}/'scipp-*.tar.bz2 --force
               env:
                 ANACONDA_TOKEN: $(anaconda_token_secret)
               displayName: 'Deploy ${{ package.Key }}'


### PR DESCRIPTION
Upload even if one already exists. This is the default behaviour for `conda-build` which can be disabled via ` --no-force-upload`.

This is important because we may wish to run the CI to to generate scipp/label/dev (or release) against the same git SHA1, following say an update to one of the dependent packages. 