### PR TITLE
Change `DataArray.data` setter to set data variable rather than copying values

### DIFF
--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -25,7 +25,8 @@ DataArray::DataArray(const DataArray &other, const AttrPolicy attrPolicy)
       m_coords(copy_shared(other.m_coords)),
       m_masks(copy_shared(other.m_masks)),
       m_attrs(attrPolicy == AttrPolicy::Keep ? copy_shared(other.m_attrs)
-                                             : std::make_shared<Attrs>()) {}
+                                             : std::make_shared<Attrs>()),
+      m_readonly(false) {}
 
 DataArray::DataArray(const DataArray &other)
     : DataArray(other, AttrPolicy::Keep) {}
@@ -129,7 +130,8 @@ DataArray DataArray::view() const {
 }
 
 DataArray DataArray::view_with_coords(const Coords &coords,
-                                      const std::string &name) const {
+                                      const std::string &name,
+                                      const bool readonly) const {
   DataArray out;
   out.m_data = m_data; // share data
   const Sizes sizes(dims());
@@ -137,11 +139,12 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   for (const auto &[dim, coord] : coords)
     if (coords.item_applies_to(dim, dims()))
       selected[dim] = coord.as_const();
-  const bool readonly = true;
-  out.m_coords = std::make_shared<Coords>(sizes, selected, readonly);
+  const bool readonly_coords = true;
+  out.m_coords = std::make_shared<Coords>(sizes, selected, readonly_coords);
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs
   out.m_name = name;
+  out.m_readonly = readonly;
   return out;
 }
 

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -57,6 +57,7 @@ DataArray &DataArray::operator=(const DataArray &other) {
 }
 
 void DataArray::setData(const Variable &data) {
+  // Return early on self assign to avoid exceptions from Python inplace ops
   if (m_data->is_same(data))
     return;
   expectWritable(*this);

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -14,7 +14,7 @@ namespace scipp::dataset {
 namespace {
 template <class T> void expectWritable(const T &dict) {
   if (dict.is_readonly())
-    throw except::DataArrayError(
+    throw except::DatasetError(
         "Read-only flag is set, cannot insert new or erase existing items.");
 }
 } // namespace

--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -135,10 +135,11 @@ void Dataset::setData(const std::string &name, Variable data,
 /// attributes. Throws if the provided data brings the dataset into an
 /// inconsistent state (mismatching dimensions).
 void Dataset::setData(const std::string &name, const DataArray &data) {
+  // Return early on self assign to avoid exceptions from Python inplace ops
   if (const auto it = find(name); it != end()) {
     if (it->data().is_same(data.data()) && it->masks() == data.masks() &&
         it->attrs() == data.attrs() && it->coords() == data.coords())
-      return; // self-assignment
+      return;
   }
   expectWritable(*this);
   setSizes(data.dims());

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -106,6 +106,7 @@ private:
   std::shared_ptr<Coords> m_coords;
   std::shared_ptr<Masks> m_masks;
   std::shared_ptr<Attrs> m_attrs;
+  bool m_readonly{false};
 };
 
 SCIPP_DATASET_EXPORT bool operator==(const DataArray &a, const DataArray &b);

--- a/dataset/include/scipp/dataset/data_array.h
+++ b/dataset/include/scipp/dataset/data_array.h
@@ -90,8 +90,8 @@ public:
   [[maybe_unused]] DataArray &setSlice(const Slice &s, const Variable &var);
 
   DataArray view() const;
-  DataArray view_with_coords(const Coords &coords,
-                             const std::string &name) const;
+  DataArray view_with_coords(const Coords &coords, const std::string &name,
+                             const bool readonly) const;
 
   [[nodiscard]] DataArray as_const() const;
 

--- a/python/bind_data_access.h
+++ b/python/bind_data_access.h
@@ -81,7 +81,7 @@ class DataAccessHelper {
     };
     auto &&var = get_data_variable(view);
     const auto &dims = view.dims();
-    if (view.is_readonly()) {
+    if (var.is_readonly()) {
       auto array =
           py::array{get_dtype(), dims.shape(), numpy_strides<T>(var.strides()),
                     Getter::template get<T>(std::as_const(view)).data(),
@@ -183,7 +183,7 @@ public:
   template <class Getter, class View>
   static py::object get_py_array_t(py::object &obj) {
     auto &view = obj.cast<View &>();
-    if (!std::is_const_v<View> && view.is_readonly())
+    if (!std::is_const_v<View> && get_data_variable(view).is_readonly())
       return as_ElementArrayViewImpl<const Ts...>::template get_py_array_t<
           Getter, const View>(obj);
     const DType type = view.dtype();
@@ -320,7 +320,7 @@ public:
   // variable is 0-dimensional and thus has only a single item.
   template <class Var> static py::object value(py::object &obj) {
     auto &view = obj.cast<Var &>();
-    if (!std::is_const_v<Var> && view.is_readonly())
+    if (!std::is_const_v<Var> && get_data_variable(view).is_readonly())
       return as_ElementArrayViewImpl<const Ts...>::template value<const Var>(
           obj);
     expect_scalar(view.dims(), "value");
@@ -331,7 +331,7 @@ public:
   // variable is 0-dimensional and thus has only a single item.
   template <class Var> static py::object variance(py::object &obj) {
     auto &view = obj.cast<Var &>();
-    if (!std::is_const_v<Var> && view.is_readonly())
+    if (!std::is_const_v<Var> && get_data_variable(view).is_readonly())
       return as_ElementArrayViewImpl<const Ts...>::template variance<const Var>(
           obj);
     expect_scalar(view.dims(), "variance");

--- a/python/bind_data_array.h
+++ b/python/bind_data_array.h
@@ -107,12 +107,7 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
       "data",
       py::cpp_function([](T &self) { return self.data(); },
                        py::return_value_policy::copy),
-      [](T &self, const Variable &data) {
-        if constexpr (std::is_convertible_v<T, DataArray>)
-          copy(data, self.data());
-        else // bins_view
-          self.setData(data);
-      },
+      [](T &self, const Variable &data) { self.setData(data); },
       R"(Underlying data item.)");
   c.def_property_readonly(
       "coords", [](T &self) -> decltype(auto) { return self.coords(); },

--- a/python/tests/readonly_test.py
+++ b/python/tests/readonly_test.py
@@ -7,7 +7,7 @@ import pytest
 import scipp as sc
 
 
-def assert_variable_writeable(var):
+def assert_variable_writable(var):
     assert var.values.flags['WRITEABLE']
     if var.variances is not None:
         assert var.variances.flags['WRITEABLE']
@@ -39,14 +39,37 @@ def assert_variable_readonly(var):
     assert sc.identical(var, original)
 
 
+def assert_dict_writable(d):
+    key = list(d.keys())[0]
+    del d[key]
+    assert key not in d
+    d['new'] = sc.scalar(4)
+    assert 'new' in d
+
+
+def assert_dict_readonly(d, error=sc.DataArrayError):
+    with pytest.raises(error):
+        d['new'] = sc.scalar(4)
+    assert 'new' not in d
+    key = list(d.keys())[0]
+    with pytest.raises(error):
+        del d[key]
+    assert key in d
+
+
 def assert_readonly_data_array(da, readonly_data: bool):
     N = da.sizes['x']
     da2 = da.copy(deep=False)
     var = sc.array(dims=['x'], values=np.arange(N))
     with pytest.raises(sc.DataArrayError):
         da.data = var  # slice is readonly
+    assert_dict_readonly(da.coords)
+    assert_dict_readonly(da.masks)
+    assert_dict_readonly(da.attrs)
     if readonly_data:
         assert_variable_readonly(da.data)
+        assert_variable_readonly(da.copy(deep=False).data)
+        assert_variable_writable(da.copy().data)
     else:
         expected = da.data + var
         da.data += var  # slice is readonly but self-assign ok
@@ -57,94 +80,98 @@ def assert_readonly_data_array(da, readonly_data: bool):
         vals = np.arange(2, N + 2)
         da2.values = vals  # values reference original
         assert sc.identical(da.data, sc.array(dims=['x'], values=vals))
-        da2.data = var  # shallow-copy clears readonly flag...
-        # ... but data setter sets new data, rather than overwriting original
-        assert sc.identical(da.data, sc.array(dims=['x'], values=vals))
-        assert_variable_writeable(da.data)
+        assert_variable_writable(da.data)
+    da2.data = var + var  # shallow-copy clears readonly flag...
+    # ... but data setter sets new data, rather than overwriting original
+    assert not sc.identical(da2.data, da.data)
 
 
 def test_readonly_variable_unit_and_variances():
     var = sc.array(dims=['x'], values=np.arange(4.), variances=np.arange(4.))
-    assert_variable_writeable(var)
+    assert_variable_writable(var)
 
 
 def test_readonly_variable():
     var = sc.broadcast(sc.scalar(value=1., variance=1.), dims=['x'], shape=[4])
     assert_variable_readonly(var)
     assert_variable_readonly(var.copy(deep=False))
-    assert_variable_writeable(var.copy())
+    assert_variable_writable(var.copy())
 
 
 def _make_data_array():
     var = sc.array(dims=['x'], values=np.arange(4))
-    scalar = sc.scalar(value=4)
     return sc.DataArray(data=var.copy(),
-                        coords={
-                            'x': var.copy(),
-                            'scalar': scalar
-                        },
-                        masks={
-                            'm': var.copy(),
-                            'scalar': scalar
-                        },
-                        attrs={
-                            'a': var.copy(),
-                            'scalar_attr': scalar
-                        })
+                        coords={'x': var.copy()},
+                        masks={'m': var.copy()},
+                        attrs={'a': var.copy()})
 
 
-def test_readonly_data_array():
+def _make_dataset():
+    return sc.Dataset({
+        'a': _make_data_array(),
+        'scalar': _make_data_array()['x', 0].copy()
+    })
+
+
+def test_readonly_data_array_slice():
     assert_readonly_data_array(_make_data_array()['x', 1:4],
                                readonly_data=False)
 
 
-class TestReadonlyMetadata:
-    def test_coords(self):
-        da = _make_data_array()
-        with pytest.raises(sc.DataArrayError):
-            da['x', 1].coords['new'] = sc.scalar(4)
-        assert 'new' not in da.coords
-        with pytest.raises(sc.DataArrayError):
-            del da['x', 1].coords['x']
-        assert 'x' in da.coords
-
-    def test_masks(self):
-        da = _make_data_array()
-        with pytest.raises(sc.DataArrayError):
-            da['x', 1].masks['new'] = sc.scalar(4)
-        assert 'new' not in da.masks
-        with pytest.raises(sc.DataArrayError):
-            del da['x', 1].masks['m']
-        assert 'm' in da.masks
-
-    def test_attrs(self):
-        da = _make_data_array()
-        with pytest.raises(sc.DataArrayError):
-            da['x', 1].attrs['new'] = sc.scalar(4)
-        assert 'new' not in da.attrs
-        with pytest.raises(sc.DataArrayError):
-            del da['x', 1].attrs['a']
-        assert 'a' in da.attrs
-
-    def test_broadcast_sets_readonly_flag(self):
-        da = _make_data_array()
-        da = sc.concatenate(da, da, 'y')
-        assert_variable_readonly(da['y', 1].coords['x'])
-        assert_variable_readonly(da['y', 1].masks['m'])
-        assert_variable_readonly(da['y', 1].attrs['a'])
+def test_readonly_metadata():
+    da = _make_data_array()
+    assert_dict_readonly(da['x', 1:2].coords)
+    assert_dict_readonly(da['x', 1:2].masks)
+    assert_dict_readonly(da['x', 1:2].attrs)
+    # Shallow copy makes dict writable
+    assert_dict_writable(da['x', 1:2].copy(deep=False).coords)
+    assert_dict_writable(da['x', 1:2].copy(deep=False).masks)
+    assert_dict_writable(da['x', 1:2].copy(deep=False).attrs)
 
 
-def test_readonly_dataset():
-    ds = sc.Dataset({
-        'a': _make_data_array(),
-        'scalar': _make_data_array()['x', 0].copy()
-    })
-    with pytest.raises(sc.DatasetError):
-        del ds['x', 0]['a']
-    assert 'a' in ds
-    with pytest.raises(sc.DatasetError):
-        ds['x', 0]['b'] = ds['scalar'].copy()
-    assert 'b' not in ds
-    ds['b'] = sc.broadcast(ds['a'].data, dims=['y', 'x'], shape=[2, 4]).copy()
-    assert_readonly_data_array(ds['y', 0]['b'], readonly_data=False)
+def test_readonly_metadata_broadcast_sets_readonly_flag():
+    da = _make_data_array()
+    da = sc.concatenate(da, da, 'y')
+    assert_variable_readonly(da['y', 1].coords['x'])
+    assert_variable_readonly(da['y', 1].masks['m'])
+    assert_variable_readonly(da['y', 1].attrs['a'])
+    # Shallow copy makes dict writable but not the items (buffers)
+    assert_variable_readonly(da['y', 1].copy(deep=False).coords['x'])
+    assert_variable_readonly(da['y', 1].copy(deep=False).masks['m'])
+    assert_variable_readonly(da['y', 1].copy(deep=False).attrs['a'])
+    # Deep copy copies buffers
+    assert_variable_writable(da['y', 1].copy().coords['x'])
+    assert_variable_writable(da['y', 1].copy().masks['m'])
+    assert_variable_writable(da['y', 1].copy().attrs['a'])
+
+
+def test_dataset_readonly_metadata_dicts():
+    ds = _make_dataset()
+    # Coords dicts are shared and thus readonly
+    assert_dict_readonly(ds['a'].coords)
+    assert_dict_writable(ds['a'].masks)
+    assert_dict_writable(ds['a'].attrs)
+
+
+def test_dataset_readonly_metadata_items():
+    ds = _make_dataset()
+    # Coords are shared and thus readonly
+    assert_variable_readonly(ds['a'].coords['x'])
+    assert_variable_writable(ds['a'].masks['m'])
+    assert_variable_writable(ds['a'].attrs['a'])
+
+
+def test_readonly_dataset_slice():
+    ds = _make_dataset()
+    assert_dict_readonly(ds['x', 0], sc.DatasetError)
+    assert_dict_writable(ds['x', 0].copy(deep=False))
+
+
+def test_readonly_dataset_slice_items():
+    ds = _make_dataset()
+    xy = sc.broadcast(ds['a'].data, dims=['y', 'x'], shape=[2, 4]).copy()
+    ds['b'] = sc.DataArray(data=xy,
+                           masks={'m': xy.copy()},
+                           attrs={'a': xy.copy()})
     assert_readonly_data_array(ds['y', 0]['a'], readonly_data=True)
+    assert_readonly_data_array(ds['y', 0]['b'], readonly_data=False)

--- a/python/tests/readonly_test.py
+++ b/python/tests/readonly_test.py
@@ -39,6 +39,26 @@ def assert_variable_readonly(var):
     assert sc.identical(var, original)
 
 
+def assert_readonly_data_array(da, readonly_data: bool):
+    da2 = da['x', 1].copy(deep=False)
+    var = sc.array(dims=['x'], values=np.arange(4))
+    with pytest.raises(sc.DataArrayError):
+        da['x', 1].data = var['x', 1]  # slice is readonly
+    if readonly_data:
+        assert_variable_readonly(da.data)
+    else:
+        da['x', 1].data += var['x', 1]  # slice is readonly but self-assign ok
+        assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+        da['x', 1].values = 1  # slice is readonly, but not the slice values
+        assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
+        da2.values = 2  # values reference original
+        assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+        da2.data = var['x', 0]  # shallow-copy clears readonly flag...
+        # ... but data setter sets new data, rather than overwriting original
+        assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+        assert_variable_writeable(da.data)
+
+
 def test_readonly_variable_unit_and_variances():
     var = sc.array(dims=['x'], values=np.arange(4.), variances=np.arange(4.))
     assert_variable_writeable(var)
@@ -70,20 +90,7 @@ def _make_data_array():
 
 
 def test_readonly_data_array():
-    var = sc.array(dims=['x'], values=np.arange(4))
-    da = _make_data_array()
-    with pytest.raises(sc.DataArrayError):
-        da['x', 1].data = var['x', 1]  # slice is readonly
-    da['x', 1].data += var['x', 1]  # slice is readonly but self-assign ok
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
-    da['x', 1].values = 1  # slice is readonly, but not the slice values
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
-    da2 = da['x', 1].copy(deep=False)
-    da2.values = 2  # values reference original
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
-    da2.data = var['x', 0]  # shallow-copy clears readonly flag...
-    # ... but data setter sets new data, rather than overwriting original
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+    assert_readonly_data_array(_make_data_array(), readonly_data=False)
 
 
 class TestReadonlyMetadata:
@@ -120,3 +127,19 @@ class TestReadonlyMetadata:
         assert_variable_readonly(da['y', 1].coords['x'])
         assert_variable_readonly(da['y', 1].masks['m'])
         assert_variable_readonly(da['y', 1].attrs['a'])
+
+
+def test_readonly_dataset():
+    ds = sc.Dataset({
+        'a': _make_data_array(),
+        'scalar': _make_data_array()['x', 0].copy()
+    })
+    with pytest.raises(sc.DatasetError):
+        del ds['x', 0]['a']
+    assert 'a' in ds
+    with pytest.raises(sc.DatasetError):
+        ds['x', 0]['b'] = ds['scalar'].copy()
+    assert 'b' not in ds
+    ds['b'] = sc.broadcast(ds['a'].data, dims=['y', 'x'], shape=[2, 4]).copy()
+    assert_readonly_data_array(ds['y', 0]['b'], readonly_data=False)
+    assert_readonly_data_array(ds['y', 0]['a'], readonly_data=True)

--- a/python/tests/readonly_test.py
+++ b/python/tests/readonly_test.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import numpy as np
+import pytest
+
+import scipp as sc
+
+
+def test_readonly_variable_unit_and_variances():
+    var = sc.array(dims=['x'], values=np.arange(4.), variances=np.arange(4.))
+    assert var.values.flags['WRITEABLE']
+    assert var.variances.flags['WRITEABLE']
+    with pytest.raises(sc.VariancesError):
+        var['x', 1].variances = None
+    with pytest.raises(sc.UnitError):
+        var['x', 1].unit = 'm'  # unit of slice is readonly
+    assert var['x', 1].values.flags['WRITEABLE']
+    assert var['x', 1].variances.flags['WRITEABLE']
+    var['x', 1] = var['x', 0]  # slice is writable
+    assert sc.identical(var['x', 1], var['x', 0])
+
+
+def test_readonly_variable():
+    var = sc.broadcast(sc.scalar(value=1., variance=1.), dims=['x'], shape=[4])
+    original = var.copy()
+    assert not var.values.flags['WRITEABLE']
+    assert not var.variances.flags['WRITEABLE']
+    with pytest.raises(sc.VariableError):
+        var['x', 1].variances = None
+    with pytest.raises(sc.VariableError):
+        var['x', 1].unit = 'm'
+    assert not var['x', 1].values.flags['WRITEABLE']
+    assert not var['x', 1].variances.flags['WRITEABLE']
+    with pytest.raises(sc.VariableError):
+        var['x', 1] = var['x', 0]
+    assert sc.identical(var, original)
+    shallow = var.copy(deep=False)
+    assert not shallow.values.flags['WRITEABLE']
+    assert not shallow.variances.flags['WRITEABLE']
+    deep = var.copy()
+    assert deep.values.flags['WRITEABLE']
+    assert deep.variances.flags['WRITEABLE']
+
+
+def test_readonly():
+    var = sc.array(dims=['x'], values=np.arange(4))
+    da = sc.DataArray(data=var.copy(),
+                      coords={'x': var.copy()},
+                      masks={'m': var.copy()},
+                      attrs={'a': var.copy()})
+    with pytest.raises(sc.DataArrayError):
+        da['x', 1].data = var['x', 1]  # slice is readonly
+    da['x', 1].data += var['x', 1]  # slice is readonly but self-assign ok
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+    da['x', 1].values = 1  # slice is readonly, but not the slice values
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
+    da2 = da['x', 1].copy(deep=False)
+    da2.values = 2  # values reference original
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
+    da2.data = var['x', 0]  # shallow-copy clears readonly flag...
+    # ... but data setter sets new data, rather than overwriting original
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -280,6 +280,8 @@ def test_readonly():
     da['x', 1].values = 1  # slice is readonly, but not the slice values
     assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
     da2 = da['x', 1].copy(deep=False)
+    da2.values = 2  # values reference original
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
     da2.data = var['x', 0]  # shallow-copy clears readonly flag...
-    # ... but data setter sets new data, rather than overwriting old
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
+    # ... but data setter sets new data, rather than overwriting original
+    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))

--- a/python/tests/test_data_array.py
+++ b/python/tests/test_data_array.py
@@ -265,23 +265,3 @@ def test_sizes():
     assert a.sizes == {'x': 2}
     a = sc.DataArray(data=sc.Variable(['x', 'z'], values=np.ones((2, 4))))
     assert a.sizes == {'x': 2, 'z': 4}
-
-
-def test_readonly():
-    var = sc.array(dims=['x'], values=np.arange(4))
-    da = sc.DataArray(data=var.copy(),
-                      coords={'x': var.copy()},
-                      masks={'m': var.copy()},
-                      attrs={'a': var.copy()})
-    with pytest.raises(sc.DataArrayError):
-        da['x', 1].data = var['x', 1]  # slice is readonly
-    da['x', 1].data += var['x', 1]  # slice is readonly but self-assign ok
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
-    da['x', 1].values = 1  # slice is readonly, but not the slice values
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 1, 2, 3]))
-    da2 = da['x', 1].copy(deep=False)
-    da2.values = 2  # values reference original
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))
-    da2.data = var['x', 0]  # shallow-copy clears readonly flag...
-    # ... but data setter sets new data, rather than overwriting original
-    assert sc.identical(da.data, sc.array(dims=['x'], values=[0, 2, 2, 3]))

--- a/python/tests/test_ownership_dataset.py
+++ b/python/tests/test_ownership_dataset.py
@@ -53,7 +53,11 @@ def test_own_darr_set():
             coords={'x': sc.array(dims=['x'], values=[3, 4], unit='s')},
             attrs={'a': sc.array(dims=['x'], values=[300, 400])},
             masks={'m': sc.array(dims=['x'], values=[True, True])}))
-    assert sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    # Assignment replaces data
+    assert not sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    assert sc.identical(da.data, sc.array(dims=['x'],
+                                          values=[11, 22],
+                                          unit='m'))
     assert sc.identical(c, sc.array(dims=['x'], values=[-1, -2], unit='J'))
     assert sc.identical(a, sc.array(dims=['x'], values=[-100, -200]))
     assert sc.identical(m, sc.array(dims=['x'], values=[False, True]))
@@ -100,7 +104,11 @@ def test_own_darr_get():
             coords={'x': sc.array(dims=['x'], values=[3, 4], unit='s')},
             attrs={'a': sc.array(dims=['x'], values=[300, 400])},
             masks={'m': sc.array(dims=['x'], values=[True, True])}))
-    assert sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    # Assignment replaces data
+    assert not sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    assert sc.identical(da.data, sc.array(dims=['x'],
+                                          values=[11, 22],
+                                          unit='m'))
     assert sc.identical(c, sc.array(dims=['x'], values=[-1, -2], unit='J'))
     assert sc.identical(a, sc.array(dims=['x'], values=[-100, -200]))
     assert sc.identical(m, sc.array(dims=['x'], values=[False, True]))
@@ -141,7 +149,11 @@ def test_own_darr_get_meta():
             sc.array(dims=['x'], values=[11, 22], unit='m'),
             coords={'x': sc.array(dims=['x'], values=[3, 4], unit='s')},
             attrs={'a': sc.array(dims=['x'], values=[300, 400])}))
-    assert sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    # Assignment replaces data
+    assert not sc.identical(v, sc.array(dims=['x'], values=[11, 22], unit='m'))
+    assert sc.identical(da.data, sc.array(dims=['x'],
+                                          values=[11, 22],
+                                          unit='m'))
     assert sc.identical(c, sc.array(dims=['x'], values=[-1, -2], unit='J'))
     assert sc.identical(a, sc.array(dims=['x'], values=[-100, -200]))
 

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -78,7 +78,7 @@ class TestSliceByValue:
         test(self._d['a'])
         test(self._d)
 
-    def test_assign_variable_to_range_dataarray(self):
+    def test_assign_variable_to_range_dataarray_fails(self):
         with pytest.raises(sc.DataArrayError):  # readonly
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless].data = sc.Variable(
@@ -86,7 +86,7 @@ class TestSliceByValue:
                              values=[6.0, 6.0, 6.0],
                              unit=sc.units.m)
 
-    def test_assign_variable_to_range_dataset(self):
+    def test_assign_variable_to_range_dataset_fails(self):
         with pytest.raises(sc.DataArrayError):  # readonly
             self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                     sc.units.dimensionless]['a'].data = sc.Variable(

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -112,11 +112,10 @@ class TestSliceByValue:
 
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
-    def test_on_dataset_assign_dataarray_to_range_no_effect(self):
-        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
-                sc.units.dimensionless]['a'] = self._d['b']['x', 1:-1]
-        # Sets a new item in the dict of the slice, no effect on original
-        assert self._d['a'].data.values.tolist() == [1.0, 1.1, 1.2, 1.3, 1.4]
+    def test_on_dataset_assign_dataarray_to_range_fails(self):
+        with pytest.raises(sc.DataArrayError):  # readonly
+            self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                    sc.units.dimensionless]['a'] = self._d['b']['x', 1:-1]
 
     def test_on_dataarray_modify_range_in_place_from_dataarray(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -113,7 +113,7 @@ class TestSliceByValue:
         assert self._d['a'].data.values.tolist() == [1.0, 2.0, 3.0, 4.0, 1.4]
 
     def test_on_dataset_assign_dataarray_to_range_fails(self):
-        with pytest.raises(sc.DataArrayError):  # readonly
+        with pytest.raises(sc.DatasetError):  # readonly
             self._d['x', 1.5 * sc.units.dimensionless:4.5 *
                     sc.units.dimensionless]['a'] = self._d['b']['x', 1:-1]
 

--- a/python/tests/test_slicebyvalue.py
+++ b/python/tests/test_slicebyvalue.py
@@ -79,18 +79,18 @@ class TestSliceByValue:
         test(self._d)
 
     def test_assign_variable_to_range_dataarray(self):
-        self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
-                     sc.units.dimensionless].data = sc.Variable(
-                         dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
-
-        assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
+        with pytest.raises(sc.DataArrayError):  # readonly
+            self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
+                         sc.units.dimensionless].data = sc.Variable(
+                             dims=['x'],
+                             values=[6.0, 6.0, 6.0],
+                             unit=sc.units.m)
 
     def test_assign_variable_to_range_dataset(self):
-        self._d['x', 1.5 * sc.units.dimensionless:4.5 *
-                sc.units.dimensionless]['a'].data = sc.Variable(
-                    dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
-
-        assert self._d['a'].data.values.tolist() == [1.0, 6.0, 6.0, 6.0, 1.4]
+        with pytest.raises(sc.DataArrayError):  # readonly
+            self._d['x', 1.5 * sc.units.dimensionless:4.5 *
+                    sc.units.dimensionless]['a'].data = sc.Variable(
+                        dims=['x'], values=[6.0, 6.0, 6.0], unit=sc.units.m)
 
     def test_on_dataarray_modify_range_in_place_from_variable(self):
         self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -59,6 +59,8 @@ void Variable::setUnit(const units::Unit &unit) {
 }
 
 bool Variable::operator==(const Variable &other) const {
+  if (is_same(other))
+    return true;
   if (!is_valid() || !other.is_valid())
     return is_valid() == other.is_valid();
   // Note: Not comparing strides

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -53,8 +53,8 @@ void Variable::expectCanSetUnit(const units::Unit &unit) const {
 const units::Unit &Variable::unit() const { return m_object->unit(); }
 
 void Variable::setUnit(const units::Unit &unit) {
-  expectCanSetUnit(unit);
   expectWritable();
+  expectCanSetUnit(unit);
   m_object->setUnit(unit);
 }
 
@@ -186,6 +186,7 @@ bool Variable::is_same(const Variable &other) const noexcept {
 }
 
 void Variable::setVariances(const Variable &v) {
+  expectWritable();
   if (is_slice())
     throw except::VariancesError(
         "Cannot add variances via sliced view of Variable.");


### PR DESCRIPTION
This brings the behavior inline with what we have elsewhere. This allows us to:
- `da.data = new_data`, sharing `new_data`.
- Change the `dtype` of a data array
- Assign data with different bin sizes
- ...

As elsewhere, we run into unexpected behavior when working with slices, such as
```python
da['x', 17].data = new_data
```
which would silently do nothing.

Therefore this PR also adds read-only flags to `DataArray` and `Dataset`. Note that, e.g., the read-only flag of a data array does *not* imply that the values are readonly:

```python
readonly_da = da['x', 17]
readonly_da.values = np.arange(4)  # ok
readonly_da.data = var  # not ok
```
Note that we have to add special handling for self-assignment, otherwise this would fail:
```python
da['x', 17].data += 1.2  # calls data setter as above with `var`, but values modified already
```
An exception here is a general issue with Python (since data gets modified), and the exception would be very misleading. We avoid it by checking for self-assign.