### PR TITLE
Return shallow copy in to_unit if unit is unchanged

### DIFF
--- a/python/bind_operators.h
+++ b/python/bind_operators.h
@@ -45,7 +45,10 @@ void bind_astype(py::class_<T, Ignored...> &c) {
       [](const T &self, const scipp::DType type) { return astype(self, type); },
       py::call_guard<py::gil_scoped_release>(),
       R"(
-        Converts a Variable or DataArray to a different type.
+        Converts a Variable or DataArray to a different dtype.
+
+        If the dtype is unchanged the object is returned without making a
+        deep copy.
 
         :raises: If the variable cannot be converted to the requested dtype.
         :return: New variable or data array with specified dtype.

--- a/python/src/scipp/_unary.py
+++ b/python/src/scipp/_unary.py
@@ -52,6 +52,8 @@ def to_unit(x: _cpp.Variable, unit: _Union[_cpp.Unit, str]) -> _cpp.Variable:
         var = 1.2 * sc.Unit('m')
         var_in_mm = sc.to_unit(var, unit='mm')
 
+    If the unit us unchanged the object is returned without making a deep copy.
+
     Raises an error if the input unit is not compatible with the provided
     unit, e.g., `m` cannot be converted to `s`.
 

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -734,6 +734,14 @@ TYPED_TEST(AsTypeTest, variable_astype) {
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
 }
 
+TEST(AsTypeTest, buffer_handling) {
+  const auto var = makeVariable<float>(Values{1});
+  const auto same = astype(var, dtype<float>);
+  EXPECT_TRUE(same.is_same(var)); // not modified => not copied
+  const auto different = astype(var, dtype<double>);
+  EXPECT_FALSE(different.is_same(var)); // modified => copied
+}
+
 TEST(VariableTest, array_params) {
   const auto parent =
       makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{4, 2, 3});

--- a/variable/to_unit.cpp
+++ b/variable/to_unit.cpp
@@ -17,6 +17,8 @@ constexpr double days_multiplier = llnl::units::precise::day.multiplier();
 }
 
 Variable to_unit(const Variable &var, const units::Unit &unit) {
+  if (unit == var.unit())
+    return var; // no copy
   const auto scale = llnl::units::quick_convert(
       variableFactory().elem_unit(var).underlying(), unit.underlying());
   if (std::isnan(scale))

--- a/variable/type_conversion.cpp
+++ b/variable/type_conversion.cpp
@@ -39,7 +39,6 @@ struct MakeVariableWithType {
 };
 
 Variable astype(const Variable &var, DType type) {
-  return type == var.dtype() ? Variable(var)
-                             : MakeVariableWithType::make(var, type);
+  return type == var.dtype() ? var : MakeVariableWithType::make(var, type);
 }
 } // namespace scipp::variable


### PR DESCRIPTION
- Fixes #1796.
- Add tests to `astype`, which already had this behavior.