### PR TITLE
Avoid read-only problem in comparision for structured (matrix) dtypes

### DIFF
--- a/variable/include/scipp/variable/structure_array_model.h
+++ b/variable/include/scipp/variable/structure_array_model.h
@@ -99,8 +99,7 @@ template <class T, class Elem>
 bool StructureArrayModel<T, Elem>::equals(const Variable &a,
                                           const Variable &b) const {
   return a.dtype() == dtype() && b.dtype() == dtype() &&
-         equals_impl(a.elements<T>().template values<Elem>(),
-                     b.elements<T>().template values<Elem>());
+         a.elements<T>() == b.elements<T>();
 }
 
 template <class T, class Elem>


### PR DESCRIPTION
Fix recent issue found via `scippneutron` (next): Positions compared (after coord -> attribute) which are read-only. Problem introduced via  #1905 changes.

This restructure avoids cast.

