### PR TITLE
Fix datetime scalar constructor

### DIFF
--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -52,7 +52,7 @@ def scalar(value: _Any,
             # Raise a more comprehensible error message in the case
             # where a dtype cannot be specified.
             raise TypeError(f"Cannot convert {value} to {dtype}. "
-                            f"Try omitting the 'dtype=' parameter.")
+                            f"Try omitting the 'dtype=' parameter.") from None
 
 
 def zeros(*,

--- a/python/tests/test_variable_creation.py
+++ b/python/tests/test_variable_creation.py
@@ -39,6 +39,15 @@ def test_scalar_throws_if_dtype_provided_for_str_types():
         sc.scalar(value='temp', unit=sc.units.one, dtype=sc.dtype.float64)
 
 
+def test_scalar_of_numpy_array():
+    value = np.array([1, 2, 3])
+    with pytest.raises(sc.VariableError):
+        sc.scalar(value)
+    var = sc.scalar(value, dtype=sc.dtype.PyObject)
+    assert var.dtype == sc.dtype.PyObject
+    np.testing.assert_array_equal(var.value, value)
+
+
 def test_zeros_creates_variable_with_correct_dims_and_shape():
     var = sc.zeros(dims=['x', 'y', 'z'], shape=[1, 2, 3])
     expected = sc.Variable(dims=['x', 'y', 'z'], shape=[1, 2, 3])


### PR DESCRIPTION
Fixes #1817

Making the lambda in `bind_init_0D_numpy_types` take its input as `py::array` makes it not match `np.datetime64`. That instead 
calls the constructor for `PyObject`. But converting the buffer to an array works just fine and gives access to the dtype.

All this custom dtype handling mixed with pybind11's builtin handling makes me think that we would be better off doing the whole thing ourselves so that we can freely match the types of the arguments and the user-specified dtype.