### PR TITLE
Fix HTML repr fails with bin edge coords

### DIFF
--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -114,7 +114,10 @@ def _ordered_dict(data):
 
 def inline_variable_repr(var, has_variances=False):
     if var.bins is None:
-        return _format_non_events(var, has_variances)
+        if is_data_array(var):
+            return _format_non_events(var.data, has_variances)
+        else:
+            return _format_non_events(var, has_variances)
     else:
         return _format_events(var, has_variances)
 


### PR DESCRIPTION
It is a mystery why the docs build did not cause the previous PRs to fail. I cannot find any relevant metadata flag in the offending notebook that would disable fails on exceptions.