### PR TITLE
Named fields

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -26,7 +26,8 @@ Features
   * Direct creation and initialization of 2-D (or higher) arrays of matrices and vectors is now possible from numpy arrays.
   * Fix extremely slow initialization of array of vectors or matrices from numpy arrays.
   * The ``values`` property now returns a numpy array with ``ndim+1`` (vectors) or ``ndim+2``` (matrices) axes, with the inner 1 (vectors) or 2 (matrices) axes corresponding o the vector or matrix axes.
-  * Vector or matrix element can now be accessed and modified directly using the new properties of ``Variable``, ``x1``, ``x2``, ``x3`` (for variables containing vectors) or ``x11``, ``x12``, ..., ``x33`` (for matrices).
+  * Vector or matrix element can now be accessed and modified directly using the new ``fields`` property of ``Variable``.
+    The ``fields`` property provides properties ``x``, ``y``, ``z`` (for variables containing vectors) or ``xx``, ``xy``, ..., ``zz`` (for matrices) that can be read as well as set.
 
 * Reduction operations such as ``sum`` and ``mean`` are now also multi-threaded and thus considerably faster `#1923 <https://github.com/scipp/scipp/pull/1923>`_.
 
@@ -41,7 +42,7 @@ Breaking changes
 * Scipp's data structures now behave mostly like normal nested Python objects, i.e., copies are shallow by default `#1823 <https://github.com/scipp/scipp/pull/1823>`_.
 * ``filter`` and ``split`` removed. Identical functionality can be achieved using ``groupby`` and/or slicing.
 * ``reshape`` has been removed. Use ``fold`` and ``flatten`` instead `#1861 <https://github.com/scipp/scipp/pull/1861>`_.
-* ``geometry.x``, ``geometry.y``, and ``geometry.z`` have been removed. Use the ``x1``, ``x2``, and ``x3`` properties instead `#1925 <https://github.com/scipp/scipp/pull/1925>`_.
+* ``geometry.x``, ``geometry.y``, and ``geometry.z`` have been removed. Use the ``Variable.fields`` property instead `#1925 <https://github.com/scipp/scipp/pull/1925>`_.
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/python-reference/linear-algebra.ipynb
+++ b/docs/python-reference/linear-algebra.ipynb
@@ -55,7 +55,7 @@
    "id": "a9bc14bc-d100-4bfb-bcfd-fd89ebd743d1",
    "metadata": {},
    "source": [
-    "Access to individual vector components is provided using the special `x1`, `x2` and `x3` properties:"
+    "Access to individual vector components `x`, `y`, and `z` is provided using the special `fields` property:"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vecs.x1"
+    "vecs.fields.x"
    ]
   },
   {
@@ -83,8 +83,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vecs.x1 = 123.0 * sc.units.m\n",
-    "vecs.x2 += 0.123 * sc.units.m\n",
+    "vecs.fields.x = 123.0 * sc.units.m\n",
+    "vecs.fields.y += 0.123 * sc.units.m\n",
     "vecs.values"
    ]
   },
@@ -93,7 +93,7 @@
    "id": "60e1b618-ec63-4da2-8374-a4655fdb0a66",
    "metadata": {},
    "source": [
-    "This works in an identical manner for matrices with the properties `x11`, `x12`, `x13`, `x21`, `x22`, `x23`, `x31`, `x32`, and `x33`.\n",
+    "This works in an identical manner for matrices with the properties `xx`, `xy`, `xz`, `yx`, `yy`, `yz`, `zx`, `zy`, and `zz`.\n",
     "The `values` property allows for use of, e.g., numpy functionality.\n",
     "We may, e.g., compute the inverse using `numpy.linalg.inv`, which is not supported in scipp yet:"
    ]
@@ -155,8 +155,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.coords['position']['x',5:].x1 += 0.1 * sc.units.m\n",
-    "da.coords['position']['y',5:].x2 += 0.05 * sc.units.m\n",
+    "da.coords['position']['x',5:].fields.x += 0.1 * sc.units.m\n",
+    "da.coords['position']['y',5:].fields.y += 0.05 * sc.units.m\n",
     "\n",
     "sc.plot(da, projection=\"3d\", positions=\"position\")"
    ]

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -89,7 +89,13 @@ setattr(DataArray, 'events', property(_events))
 
 from ._structured import _fields
 
-setattr(Variable, 'fields', property(_fields))
+setattr(
+    Variable, 'fields',
+    property(
+        _fields,
+        doc=
+        """Provides access to fields of structured types such as vectors or matrices."""
+    ))
 
 from ._bins import _groupby_bins
 

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -102,3 +102,35 @@ setattr(Dataset, 'plot', plot)
 # functions.
 for _obj in [Variable, DataArray, Dataset]:
     setattr(_obj, '__array_ufunc__', None)
+
+
+def _property(func):
+    def getter(fields):
+        var = fields._var
+        return func.__get__(var, var.__class__)
+
+    def setter(fields, x):
+        var = fields._var
+        return func.__set__(var, x)
+
+    return property(getter, setter)
+
+
+class FieldsMeta(type):
+    def __new__(cls, clsname, bases, dct):
+        dct['x'] = _property(Variable.x1)
+        return super(FieldsMeta, cls).__new__(cls, clsname, bases, dct)
+
+
+class Fields(object, metaclass=FieldsMeta):
+    def __init__(self, var):
+        self._var = var
+
+
+def _make_fields(self):
+    if self.dtype == dtype.vector_3_float64:
+        return Fields(self)
+    return None
+
+
+setattr(Variable, 'fields', property(_make_fields))

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -87,6 +87,10 @@ setattr(Dataset, 'bins', property(_bins, _set_bins))
 setattr(Variable, 'events', property(_events))
 setattr(DataArray, 'events', property(_events))
 
+from ._structured import _fields
+
+setattr(Variable, 'fields', property(_fields))
+
 from ._bins import _groupby_bins
 
 setattr(GroupByDataArray, 'bins', property(_groupby_bins))
@@ -102,35 +106,3 @@ setattr(Dataset, 'plot', plot)
 # functions.
 for _obj in [Variable, DataArray, Dataset]:
     setattr(_obj, '__array_ufunc__', None)
-
-
-def _property(func):
-    def getter(fields):
-        var = fields._var
-        return func.__get__(var, var.__class__)
-
-    def setter(fields, x):
-        var = fields._var
-        return func.__set__(var, x)
-
-    return property(getter, setter)
-
-
-class FieldsMeta(type):
-    def __new__(cls, clsname, bases, dct):
-        dct['x'] = _property(Variable.x1)
-        return super(FieldsMeta, cls).__new__(cls, clsname, bases, dct)
-
-
-class Fields(object, metaclass=FieldsMeta):
-    def __init__(self, var):
-        self._var = var
-
-
-def _make_fields(self):
-    if self.dtype == dtype.vector_3_float64:
-        return Fields(self)
-    return None
-
-
-setattr(Variable, 'fields', property(_make_fields))

--- a/python/src/scipp/_structured.py
+++ b/python/src/scipp/_structured.py
@@ -15,23 +15,17 @@ def _prop(key):
     return property(getter, setter)
 
 
-class FieldsMeta(type):
-    def __call__(cls, var):
-        for key in _element_keys(var):
-            setattr(cls, key, _prop(key))
-        return type.__call__(cls, var)
-
-
-class Fields(object, metaclass=FieldsMeta):
-    def __init__(self, var):
-        self._var = var
-
-
 def is_structured(obj):
     return obj.dtype in [dtype.vector_3_float64, dtype.matrix_3_float64]
 
 
-def _fields(self):
-    if is_structured(self):
-        return Fields(self)
+def _fields(obj):
+    class Fields():
+        def __init__(self, var):
+            self._var = var
+
+    if is_structured(obj):
+        for key in _element_keys(obj):
+            setattr(Fields, key, _prop(key))
+        return Fields(obj)
     return None

--- a/python/src/scipp/_structured.py
+++ b/python/src/scipp/_structured.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from . import dtype
+from ._scipp.core import _element_keys, _get_elements, _set_elements
+
+
+def _prop(key):
+    def getter(fields):
+        return _get_elements(fields._var, key)
+
+    def setter(fields, x):
+        return _set_elements(fields._var, key, x)
+
+    return property(getter, setter)
+
+
+class FieldsMeta(type):
+    def __call__(cls, var):
+        for key in _element_keys(var):
+            setattr(cls, key, _prop(key))
+        return type.__call__(cls, var)
+
+
+class Fields(object, metaclass=FieldsMeta):
+    def __init__(self, var):
+        self._var = var
+
+
+def is_structured(obj):
+    return obj.dtype in [dtype.vector_3_float64, dtype.matrix_3_float64]
+
+
+def _fields(self):
+    if is_structured(self):
+        return Fields(self)
+    return None

--- a/python/src/scipp/_structured.py
+++ b/python/src/scipp/_structured.py
@@ -3,6 +3,7 @@
 # @author Simon Heybrock
 from . import dtype
 from ._scipp.core import _element_keys, _get_elements, _set_elements
+from ._utils.typing import is_variable
 
 
 def _prop(key):
@@ -16,6 +17,8 @@ def _prop(key):
 
 
 def is_structured(obj):
+    if obj.events is not None and is_variable(obj.events):
+        return True
     return obj.dtype in [dtype.vector_3_float64, dtype.matrix_3_float64]
 
 

--- a/python/src/scipp/_structured.py
+++ b/python/src/scipp/_structured.py
@@ -3,7 +3,6 @@
 # @author Simon Heybrock
 from . import dtype
 from ._scipp.core import _element_keys, _get_elements, _set_elements
-from ._utils.typing import is_variable
 
 
 def _prop(key):
@@ -17,8 +16,8 @@ def _prop(key):
 
 
 def is_structured(obj):
-    if obj.events is not None and is_variable(obj.events):
-        return True
+    if obj.events is not None:
+        return is_structured(obj.events)
     return obj.dtype in [dtype.vector_3_float64, dtype.matrix_3_float64]
 
 

--- a/python/src/scipp/plotting/model3d.py
+++ b/python/src/scipp/plotting/model3d.py
@@ -182,8 +182,8 @@ class PlotModel3d(PlotModel):
         Find the extents of the box that contains all the positions.
         """
         extents = {}
-        pos = self.pos_coord
-        for xyz, x in zip(['x', 'y', 'z'], [pos.x1, pos.x2, pos.x3]):
+        pos = self.pos_coord.fields
+        for xyz, x in zip(['x', 'y', 'z'], [pos.x, pos.y, pos.z]):
             xmin = sc.min(x).value
             xmax = sc.max(x).value
             if pixel_size is not None:

--- a/python/tests/linalg_test.py
+++ b/python/tests/linalg_test.py
@@ -219,3 +219,21 @@ def test_matrix_elements_setter():
     values[:, 1, 2] = 1
     expected = sc.matrices(dims=['x'], values=values, unit=sc.units.m)
     assert sc.identical(m, expected)
+
+
+def test_elements_binned():
+    data = sc.array(dims=['x'], values=[1, 2, 3, 4])
+    var = sc.bins(dim='x', data=data)
+    assert var.fields is None
+
+    data = sc.vectors(dims=['x'], values=np.arange(6).reshape(2, 3))
+    var = sc.bins(dim='x', data=data)
+    assert var.fields is not None
+    y = sc.bins(dim='x', data=sc.array(dims=['x'], values=[1., 4.]))
+    assert sc.identical(var.fields.y, y)
+
+    data = sc.matrices(dims=['x'], values=np.arange(18).reshape(2, 3, 3))
+    var = sc.bins(dim='x', data=data)
+    assert var.fields is not None
+    yz = sc.bins(dim='x', data=sc.array(dims=['x'], values=[5., 14.]))
+    assert sc.identical(var.fields.yz, yz)

--- a/python/tests/linalg_test.py
+++ b/python/tests/linalg_test.py
@@ -185,7 +185,8 @@ def test_matrix_elements():
     m = sc.matrices(dims=['x'],
                     values=np.arange(18).reshape(2, 3, 3),
                     unit=sc.units.m)
-    elems = [m.x11, m.x12, m.x13, m.x21, m.x22, m.x23, m.x31, m.x32, m.x33]
+    f = m.fields
+    elems = [f.xx, f.xy, f.xz, f.yx, f.yy, f.yz, f.zx, f.zy, f.zz]
     offsets = range(9)
     for elem, offset in zip(elems, offsets):
         assert sc.identical(

--- a/python/tests/linalg_test.py
+++ b/python/tests/linalg_test.py
@@ -69,17 +69,14 @@ def test_vector_elements():
                      values=np.array([[1, 2, 3], [4, 5, 6]]),
                      unit=sc.units.m)
     assert sc.identical(
-        var.x1, sc.array(dims=['x'],
-                         values=np.array([1., 4.]),
-                         unit=sc.units.m))
+        var.fields.x,
+        sc.array(dims=['x'], values=np.array([1., 4.]), unit=sc.units.m))
     assert sc.identical(
-        var.x2, sc.array(dims=['x'],
-                         values=np.array([2., 5.]),
-                         unit=sc.units.m))
+        var.fields.y,
+        sc.array(dims=['x'], values=np.array([2., 5.]), unit=sc.units.m))
     assert sc.identical(
-        var.x3, sc.array(dims=['x'],
-                         values=np.array([3., 6.]),
-                         unit=sc.units.m))
+        var.fields.z,
+        sc.array(dims=['x'], values=np.array([3., 6.]), unit=sc.units.m))
 
 
 def test_vector_elements_setter():
@@ -87,20 +84,26 @@ def test_vector_elements_setter():
                      values=np.array([[1, 2, 3], [4, 5, 6]]),
                      unit=sc.units.m)
 
-    var.x1 = sc.array(dims=['x'], values=np.array([7., 8.]), unit=sc.units.m)
+    var.fields.x = sc.array(dims=['x'],
+                            values=np.array([7., 8.]),
+                            unit=sc.units.m)
     expected = sc.vectors(dims=['x'],
                           values=np.array([[7, 2, 3], [8, 5, 6]]),
                           unit=sc.units.m)
     assert sc.identical(var, expected)
 
-    var.x2 = sc.array(dims=['x'], values=np.array([7., 8.]), unit=sc.units.m)
+    var.fields.y = sc.array(dims=['x'],
+                            values=np.array([7., 8.]),
+                            unit=sc.units.m)
     assert not sc.identical(var, expected)
     expected = sc.vectors(dims=['x'],
                           values=np.array([[7, 7, 3], [8, 8, 6]]),
                           unit=sc.units.m)
     assert sc.identical(var, expected)
 
-    var.x3 = sc.array(dims=['x'], values=np.array([7., 8.]), unit=sc.units.m)
+    var.fields.z = sc.array(dims=['x'],
+                            values=np.array([7., 8.]),
+                            unit=sc.units.m)
     assert not sc.identical(var, expected)
     expected = sc.vectors(dims=['x'],
                           values=np.array([[7, 7, 7], [8, 8, 8]]),
@@ -114,9 +117,9 @@ def test_vector_readonly_elements():
     with pytest.raises(sc.VariableError):
         var['x', 0] = vec + vec
     with pytest.raises(sc.VariableError):
-        var.x1 = 1.1 * sc.units.m
+        var.fields.x = 1.1 * sc.units.m
     assert not var.values.flags['WRITEABLE']
-    assert not var.x1.values.flags['WRITEABLE']
+    assert not var.fields.x.values.flags['WRITEABLE']
 
 
 def test_matrix_from_quat_coeffs_list():
@@ -200,14 +203,18 @@ def test_matrix_elements_setter():
     values = np.arange(18).reshape(2, 3, 3)
     m = sc.matrices(dims=['x'], values=values, unit=sc.units.m)
 
-    m.x11 = sc.array(dims=['x'], values=np.array([1., 1.]), unit=sc.units.m)
+    m.fields.xx = sc.array(dims=['x'],
+                           values=np.array([1., 1.]),
+                           unit=sc.units.m)
     expected = sc.matrices(dims=['x'], values=values, unit=sc.units.m)
     assert not sc.identical(m, expected)
     values[:, 0, 0] = 1
     expected = sc.matrices(dims=['x'], values=values, unit=sc.units.m)
     assert sc.identical(m, expected)
 
-    m.x23 = sc.array(dims=['x'], values=np.array([1., 1.]), unit=sc.units.m)
+    m.fields.yz = sc.array(dims=['x'],
+                           values=np.array([1., 1.]),
+                           unit=sc.units.m)
     assert not sc.identical(m, expected)
     values[:, 1, 2] = 1
     expected = sc.matrices(dims=['x'], values=values, unit=sc.units.m)

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -142,19 +142,13 @@ namespace {
 template <class T>
 std::unordered_map<std::string, scipp::index> element_offsets;
 template <>
-std::unordered_map<std::string, scipp::index>
-    element_offsets<Eigen::Vector3d>({{"x", 0}, {"y", 1}, {"z", 2}});
+std::unordered_map<std::string, scipp::index> element_offsets<Eigen::Vector3d> =
+    std::unordered_map<std::string, scipp::index>{{"x", 0}, {"y", 1}, {"z", 2}};
 template <>
-std::unordered_map<std::string, scipp::index>
-    element_offsets<Eigen::Matrix3d>({{"xx", 0},
-                                      {"xy", 3},
-                                      {"xz", 6},
-                                      {"yx", 1},
-                                      {"yy", 4},
-                                      {"yz", 7},
-                                      {"zx", 2},
-                                      {"zy", 5},
-                                      {"zz", 8}});
+std::unordered_map<std::string, scipp::index> element_offsets<Eigen::Matrix3d> =
+    std::unordered_map<std::string, scipp::index>{
+        {"xx", 0}, {"xy", 3}, {"xz", 6}, {"yx", 1}, {"yy", 4},
+        {"yz", 7}, {"zx", 2}, {"zy", 5}, {"zz", 8}};
 } // namespace
 
 template <class T> struct ElementKeys {

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -172,7 +172,15 @@ std::unordered_map<std::string, scipp::index>
     element_offsets<Eigen::Vector3d>({{"x", 0}, {"y", 1}, {"z", 2}});
 template <>
 std::unordered_map<std::string, scipp::index>
-    element_offsets<Eigen::Matrix3d>({{"x", 0}, {"y", 1}, {"z", 2}});
+    element_offsets<Eigen::Matrix3d>({{"xx", 0},
+                                      {"xy", 1},
+                                      {"xz", 2},
+                                      {"yx", 3},
+                                      {"yy", 4},
+                                      {"yz", 5},
+                                      {"zx", 6},
+                                      {"zy", 7},
+                                      {"zz", 8}});
 } // namespace
 
 template <class T> struct ElementKeys {

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -173,13 +173,13 @@ std::unordered_map<std::string, scipp::index>
 template <>
 std::unordered_map<std::string, scipp::index>
     element_offsets<Eigen::Matrix3d>({{"xx", 0},
-                                      {"xy", 1},
-                                      {"xz", 2},
-                                      {"yx", 3},
+                                      {"xy", 3},
+                                      {"xz", 6},
+                                      {"yx", 1},
                                       {"yy", 4},
-                                      {"yz", 5},
-                                      {"zx", 6},
-                                      {"zy", 7},
+                                      {"yz", 7},
+                                      {"zx", 2},
+                                      {"zy", 5},
                                       {"zz", 8}});
 } // namespace
 

--- a/variable/include/scipp/variable/structure_array_variable.tcc
+++ b/variable/include/scipp/variable/structure_array_variable.tcc
@@ -12,7 +12,8 @@ template <class T>
 constexpr auto structure_element_offset{
     T::missing_specialization_of_structure_element_offset};
 
-template <class T, class... Is> Variable Variable::elements(Is... index) const {
+template <class T, class... Is>
+Variable Variable::elements_impl(Is... index) const {
   if (dtype() == core::dtype<core::bin<Variable>>) {
     const auto &[idx, dim, buf] = constituents<Variable>();
     return make_bins_no_validate(idx, dim, buf.template elements<T>(index...));
@@ -37,6 +38,14 @@ template <class T, class... Is> Variable Variable::elements(Is... index) const {
     elements.m_offset += offset;
   }
   return elements;
+}
+
+template <class T> Variable Variable::elements() const {
+  return elements_impl<T>();
+}
+
+template <class T> Variable Variable::elements(const std::string &key) const {
+  return elements_impl<T>(key);
 }
 
 template <class T, class Elem>

--- a/variable/include/scipp/variable/structures.h
+++ b/variable/include/scipp/variable/structures.h
@@ -21,4 +21,7 @@ make_vectors(const Dimensions &dims, const units::Unit &unit,
 make_matrices(const Dimensions &dims, const units::Unit &unit,
               element_array<double> &&values);
 
+[[nodiscard]] SCIPP_VARIABLE_EXPORT std::vector<std::string>
+element_keys(const Variable &var);
+
 } // namespace scipp::variable

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -95,7 +95,8 @@ public:
   void validateSlice(const Slice &s, const Variable &data) const;
   [[maybe_unused]] Variable &setSlice(Slice params, const Variable &data);
 
-  template <class T, class... Index> Variable elements(Index... index) const;
+  template <class T> Variable elements() const;
+  template <class T> Variable elements(const std::string &key) const;
 
   void rename(Dim from, Dim to);
 
@@ -141,6 +142,8 @@ private:
                                                         const Variable &);
   template <class... Ts, class... Args>
   static Variable construct(const DType &type, Args &&... args);
+  template <class T, class... Index>
+  Variable elements_impl(Index... index) const;
 
   void expectWritable() const;
 

--- a/variable/test/linalg_test.cpp
+++ b/variable/test/linalg_test.cpp
@@ -28,12 +28,14 @@ TEST_F(LinalgVectorTest, elem_access) {
     EXPECT_EQ(vectors.elements<Eigen::Vector3d>().slice(
                   {Dim::InternalStructureComponent, i}),
               elems.slice({Dim::X, i}));
-    EXPECT_EQ(vectors.elements<Eigen::Vector3d>(scipp::index(i)),
-              elems.slice({Dim::X, i}));
   }
-  EXPECT_THROW_DISCARD(vectors.elements<Eigen::Vector3d>(scipp::index(-1)),
-                       std::out_of_range);
-  EXPECT_THROW_DISCARD(vectors.elements<Eigen::Vector3d>(scipp::index(3)),
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("x")),
+            elems.slice({Dim::X, 0}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("y")),
+            elems.slice({Dim::X, 1}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("z")),
+            elems.slice({Dim::X, 2}));
+  EXPECT_THROW_DISCARD(vectors.elements<Eigen::Vector3d>(std::string("X")),
                        std::out_of_range);
 }
 
@@ -45,11 +47,10 @@ protected:
 };
 
 TEST_F(LinalgMatrixTest, range_check) {
-  for (scipp::index i : {-1, 0, 1, 2, 3})
-    for (scipp::index j : {-1, 0, 1, 2, 3})
-      if (i < 0 || i > 2 || j < 0 || j > 2)
-        EXPECT_THROW_DISCARD(matrices.elements<Eigen::Matrix3d>(i, j),
-                             std::out_of_range);
-      else
-        EXPECT_NO_THROW_DISCARD(matrices.elements<Eigen::Matrix3d>(i, j));
+  for (const std::string &key :
+       {"xx", "xy", "xz", "yx", "yy", "yz", "zx", "zy", "zz"})
+    EXPECT_NO_THROW_DISCARD(matrices.elements<Eigen::Matrix3d>(key));
+  for (const std::string &key : {"x", "y", "z", "XX"})
+    EXPECT_THROW_DISCARD(matrices.elements<Eigen::Matrix3d>(key),
+                         std::out_of_range);
 }

--- a/variable/test/linalg_test.cpp
+++ b/variable/test/linalg_test.cpp
@@ -29,13 +29,10 @@ TEST_F(LinalgVectorTest, elem_access) {
                   {Dim::InternalStructureComponent, i}),
               elems.slice({Dim::X, i}));
   }
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("x")),
-            elems.slice({Dim::X, 0}));
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("y")),
-            elems.slice({Dim::X, 1}));
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("z")),
-            elems.slice({Dim::X, 2}));
-  EXPECT_THROW_DISCARD(vectors.elements<Eigen::Vector3d>(std::string("X")),
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("x"), elems.slice({Dim::X, 0}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("y"), elems.slice({Dim::X, 1}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("z"), elems.slice({Dim::X, 2}));
+  EXPECT_THROW_DISCARD(vectors.elements<Eigen::Vector3d>("X"),
                        std::out_of_range);
 }
 

--- a/variable/test/variable_structure_test.cpp
+++ b/variable/test/variable_structure_test.cpp
@@ -31,21 +31,18 @@ TEST_F(VariableStructureTest, elem_access) {
                   {Dim::InternalStructureComponent, i}),
               elems.slice({Dim::X, i}));
   }
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("x")),
-            elems.slice({Dim::X, 0}));
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("y")),
-            elems.slice({Dim::X, 1}));
-  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("z")),
-            elems.slice({Dim::X, 2}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("x"), elems.slice({Dim::X, 0}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("y"), elems.slice({Dim::X, 1}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>("z"), elems.slice({Dim::X, 2}));
 }
 
 TEST_F(VariableStructureTest, matrices_elem_access) {
   // storage order is column-major
   EXPECT_EQ(
-      matrices.elements<Eigen::Matrix3d>(std::string("xy")),
+      matrices.elements<Eigen::Matrix3d>("xy"),
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{4, 14}));
   EXPECT_EQ(
-      matrices.elements<Eigen::Matrix3d>(std::string("yx")),
+      matrices.elements<Eigen::Matrix3d>("yx"),
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{2, 12}));
 }
 
@@ -79,14 +76,14 @@ TEST_F(VariableStructureTest, binned) {
                     .slice({Dim::InternalStructureComponent, i}),
                 elems.slice({Dim::X, i}).slice({Dim::Y, x, x + 1}));
     }
-    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("x"))
-                  .values<core::bin<Variable>>()[x],
-              elems.slice({Dim::X, 0}).slice({Dim::Y, x, x + 1}));
-    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("y"))
-                  .values<core::bin<Variable>>()[x],
-              elems.slice({Dim::X, 1}).slice({Dim::Y, x, x + 1}));
-    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("z"))
-                  .values<core::bin<Variable>>()[x],
-              elems.slice({Dim::X, 2}).slice({Dim::Y, x, x + 1}));
+    EXPECT_EQ(
+        var.elements<Eigen::Vector3d>("x").values<core::bin<Variable>>()[x],
+        elems.slice({Dim::X, 0}).slice({Dim::Y, x, x + 1}));
+    EXPECT_EQ(
+        var.elements<Eigen::Vector3d>("y").values<core::bin<Variable>>()[x],
+        elems.slice({Dim::X, 1}).slice({Dim::Y, x, x + 1}));
+    EXPECT_EQ(
+        var.elements<Eigen::Vector3d>("z").values<core::bin<Variable>>()[x],
+        elems.slice({Dim::X, 2}).slice({Dim::Y, x, x + 1}));
   }
 }

--- a/variable/test/variable_structure_test.cpp
+++ b/variable/test/variable_structure_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "scipp/core/eigen.h"
+#include "scipp/variable/bins.h"
 #include "scipp/variable/structures.h"
 
 using namespace scipp;
@@ -29,18 +30,22 @@ TEST_F(VariableStructureTest, elem_access) {
     EXPECT_EQ(vectors.elements<Eigen::Vector3d>().slice(
                   {Dim::InternalStructureComponent, i}),
               elems.slice({Dim::X, i}));
-    EXPECT_EQ(vectors.elements<Eigen::Vector3d>(scipp::index(i)),
-              elems.slice({Dim::X, i}));
   }
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("x")),
+            elems.slice({Dim::X, 0}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("y")),
+            elems.slice({Dim::X, 1}));
+  EXPECT_EQ(vectors.elements<Eigen::Vector3d>(std::string("z")),
+            elems.slice({Dim::X, 2}));
 }
 
 TEST_F(VariableStructureTest, matrices_elem_access) {
   // storage order is column-major
   EXPECT_EQ(
-      matrices.elements<Eigen::Matrix3d>(scipp::index(0), scipp::index(1)),
+      matrices.elements<Eigen::Matrix3d>(std::string("xy")),
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{4, 14}));
   EXPECT_EQ(
-      matrices.elements<Eigen::Matrix3d>(scipp::index(1), scipp::index(0)),
+      matrices.elements<Eigen::Matrix3d>(std::string("yx")),
       makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{2, 12}));
 }
 
@@ -59,4 +64,29 @@ TEST_F(VariableStructureTest, elem_access_unit_overwrite) {
 TEST_F(VariableStructureTest, readonly) {
   EXPECT_FALSE(vectors.elements<Eigen::Vector3d>().is_readonly());
   EXPECT_TRUE(vectors.as_const().elements<Eigen::Vector3d>().is_readonly());
+}
+
+TEST_F(VariableStructureTest, binned) {
+  Variable indices = makeVariable<scipp::index_pair>(
+      Dimensions(Dim::X, 2), Values{std::pair{0, 1}, std::pair{1, 2}});
+  Variable var = make_bins(indices, Dim::Y, vectors);
+  Variable elems = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
+                                        units::m, Values{1, 2, 3, 4, 5, 6});
+  for (auto x : {0, 1}) {
+    for (auto i : {0, 1, 2}) {
+      EXPECT_EQ(var.elements<Eigen::Vector3d>()
+                    .values<core::bin<Variable>>()[x]
+                    .slice({Dim::InternalStructureComponent, i}),
+                elems.slice({Dim::X, i}).slice({Dim::Y, x, x + 1}));
+    }
+    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("x"))
+                  .values<core::bin<Variable>>()[x],
+              elems.slice({Dim::X, 0}).slice({Dim::Y, x, x + 1}));
+    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("y"))
+                  .values<core::bin<Variable>>()[x],
+              elems.slice({Dim::X, 1}).slice({Dim::Y, x, x + 1}));
+    EXPECT_EQ(var.elements<Eigen::Vector3d>(std::string("z"))
+                  .values<core::bin<Variable>>()[x],
+              elems.slice({Dim::X, 2}).slice({Dim::Y, x, x + 1}));
+  }
 }

--- a/variable/variable_instantiate_linalg.cpp
+++ b/variable/variable_instantiate_linalg.cpp
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include "scipp/core/eigen.h"
 #include "scipp/variable/structure_array_variable.tcc"
+#include "scipp/variable/structures.h"
 #include "scipp/variable/variable.h"
 
 namespace scipp::variable {

--- a/variable/variable_instantiate_linalg.cpp
+++ b/variable/variable_instantiate_linalg.cpp
@@ -8,27 +8,28 @@
 
 namespace scipp::variable {
 
+// TODO For now we use hard-coded field names and offsets. The intention is to
+// generalize StructureArrayModel to support more general structures. Field
+// names and sizes/offsets would then be stored as part of the model, and would
+// be initialized dynamically at runtime.
 template <>
-constexpr auto structure_element_offset<Eigen::Vector3d> = [](scipp::index i) {
-  if (i < 0 || i > 2)
-    throw std::out_of_range("out of range index (" + std::to_string(i) +
-                            ") for element access of vector of length 3.");
-  return i;
-};
+constexpr auto structure_element_offset<Eigen::Vector3d> =
+    [](const std::string &key) {
+      static std::map<std::string, scipp::index> offsets{
+          {"x", 0}, {"y", 1}, {"z", 2}};
+      return offsets.at(key);
+    };
 
 template <>
 constexpr auto structure_element_offset<Eigen::Matrix3d> =
-    [](scipp::index i, scipp::index j) {
-      if (i < 0 || i > 2 || j < 0 || j > 2)
-        throw std::out_of_range("out of range indices (" + std::to_string(i) +
-                                "," + std::to_string(j) +
-                                ") for element access of 3x3 matrix.");
-      return 3 * j + i;
+    [](const std::string &key) {
+      static std::map<std::string, scipp::index> offsets{
+          {"xx", 0}, {"xy", 3}, {"xz", 6}, {"yx", 1}, {"yy", 4},
+          {"yz", 7}, {"zx", 2}, {"zy", 5}, {"zz", 8}};
+      return offsets.at(key);
     };
 
-INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(vector_3_float64, Eigen::Vector3d, double,
-                                     scipp::index)
-INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(matrix_3_float64, Eigen::Matrix3d, double,
-                                     scipp::index, scipp::index)
+INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(vector_3_float64, Eigen::Vector3d, double)
+INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(matrix_3_float64, Eigen::Matrix3d, double)
 
 } // namespace scipp::variable

--- a/variable/variable_instantiate_linalg.cpp
+++ b/variable/variable_instantiate_linalg.cpp
@@ -29,6 +29,14 @@ constexpr auto structure_element_offset<Eigen::Matrix3d> =
       return offsets.at(key);
     };
 
+std::vector<std::string> element_keys(const Variable &var) {
+  if (variableFactory().elem_dtype(var) == dtype<Eigen::Vector3d>)
+    return {"x", "y", "z"};
+  if (variableFactory().elem_dtype(var) == dtype<Eigen::Matrix3d>)
+    return {"xx", "xy", "xz", "yx", "yy", "yz", "zx", "zy", "zz"};
+  throw except::TypeError("dtype is not structured");
+}
+
 INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(vector_3_float64, Eigen::Vector3d, double)
 INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(matrix_3_float64, Eigen::Matrix3d, double)
 


### PR DESCRIPTION
- Add `fields` property.
- For now names are hard-coded, should be possible to generalize later without breaking the Python interface.
- Had considered adding `__iter__`, `__getitem__` and `__setitem__` to `Fields`, but kept it simple for now.