### PR TITLE
Plot: check for ill-formed inputs with multi-dimensional coords

### DIFF
--- a/python/src/scipp/plotting/objects.py
+++ b/python/src/scipp/plotting/objects.py
@@ -3,6 +3,7 @@
 # @author Neil Vaytet
 
 from .tools import parse_params
+from .._scipp.core import DimensionError
 import ipywidgets as ipw
 
 
@@ -359,17 +360,35 @@ class Plot:
         """
         Validation checks before plotting.
         """
+        multid_coord = self.model.get_multid_coord()
 
         # Protect against having a multi-dimensional coord along a slider axis
         for ax, dim in self.axes.items():
-            if isinstance(ax, int) and (dim == self.model.get_multid_coord()):
-                raise RuntimeError("A ragged coordinate cannot lie along "
-                                   "a slider dimension, it must be one of "
-                                   "the displayed dimensions.")
+            if isinstance(ax, int) and (dim == multid_coord):
+                raise DimensionError("A ragged coordinate cannot lie along "
+                                     "a slider dimension, it must be one of "
+                                     "the displayed dimensions.")
 
         # Protect against duplicate entries in axes
         if len(self.axes.values()) != len(set(self.axes.values())):
-            raise RuntimeError("Duplicate entry in axes: {}".format(self.axes))
+            raise DimensionError("Duplicate entry in axes: {}".format(
+                self.axes))
+
+        # Protect against ill-formed data where multi-dimensional coord does
+        # not apply to inner dimension
+        if multid_coord is not None:
+            multid_coord_dims = self.model.get_data_coord(
+                self.name, multid_coord)[0].dims
+            if (multid_coord in multid_coord_dims) and (multid_coord !=
+                                                        multid_coord_dims[-1]):
+                raise DimensionError(
+                    "Plot input is ill-constructed. "
+                    "When using multi-dimensional coordinates, the named "
+                    "dimension of the coordinate must be the same as the "
+                    "inner/last dim. "
+                    "Here the named dimension is {}, "
+                    "while the inner dim is {}.".format(
+                        multid_coord, multid_coord_dims[-1]))
 
     def savefig(self, filename=None):
         """

--- a/python/tests/plotting/test_plot_2d.py
+++ b/python/tests/plotting/test_plot_2d.py
@@ -367,44 +367,27 @@ def test_plot_redraw_binned():
 
 
 def test_plot_bad_2d_coord():
+    def make_data_array(dims, coord_name):
+        return sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
+            dims[0]: 10,
+            dims[1]: 2
+        }),
+                            coords={
+                                coord_name:
+                                sc.fold(0.1 * sc.arange('x', 20), 'x', {
+                                    dims[0]: 10,
+                                    dims[1]: 2
+                                })
+                            })
+
     # Ill-formed
-    a = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
-        'x': 10,
-        'y': 2
-    }),
-                     coords={
-                         'x':
-                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
-                             'x': 10,
-                             'y': 2
-                         })
-                     })
+    a = make_data_array(['x', 'y'], 'x')
     with pytest.raises(sc.DimensionError):
         plot(a)
     # Good dim order
-    b = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
-        'y': 10,
-        'x': 2
-    }),
-                     coords={
-                         'x':
-                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
-                             'y': 10,
-                             'x': 2
-                         })
-                     })
+    b = make_data_array(['y', 'x'], 'x')
     plot(b)
     # Non-dim coord
-    c = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
-        'x': 10,
-        'y': 2
-    }),
-                     coords={
-                         'z':
-                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
-                             'x': 10,
-                             'y': 2
-                         })
-                     })
+    c = make_data_array(['x', 'y'], 'z')
     plot(c)
     plot(c, axes={'x': 'z'})

--- a/python/tests/plotting/test_plot_2d.py
+++ b/python/tests/plotting/test_plot_2d.py
@@ -5,7 +5,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
+import pytest
 import numpy as np
 import scipp as sc
 from plot_helper import make_dense_dataset, make_binned_data_array, plot
@@ -364,3 +364,47 @@ def test_plot_redraw_binned():
                       asum + bsum)
     pa.close()
     pb.close()
+
+
+def test_plot_bad_2d_coord():
+    # Ill-formed
+    a = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
+        'x': 10,
+        'y': 2
+    }),
+                     coords={
+                         'x':
+                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
+                             'x': 10,
+                             'y': 2
+                         })
+                     })
+    with pytest.raises(sc.DimensionError):
+        plot(a)
+    # Good dim order
+    b = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
+        'y': 10,
+        'x': 2
+    }),
+                     coords={
+                         'x':
+                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
+                             'y': 10,
+                             'x': 2
+                         })
+                     })
+    plot(b)
+    # Non-dim coord
+    c = sc.DataArray(data=sc.fold(sc.arange('x', 2 * 10), 'x', {
+        'x': 10,
+        'y': 2
+    }),
+                     coords={
+                         'z':
+                         sc.fold(0.1 * sc.arange('x', 20), 'x', {
+                             'x': 10,
+                             'y': 2
+                         })
+                     })
+    plot(c)
+    plot(c, axes={'x': 'z'})


### PR DESCRIPTION
Add a new check on the multi-d coordinate in the input to verify that the dimension it applies to is the inner dim.