### PR TITLE
Temporarily disable windows builds

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -32,8 +32,8 @@ extends:
       osx:
         py_versions: ['3.7']
         conda_env: 'scipp-developer-minimal.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scipp-developer-minimal.yml'
+      # windows:
+      #   py_versions: ['3.7']
+      #   conda_env: 'scipp-developer-minimal.yml'
     deploy: true
     conda_label: 'dev'

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -38,6 +38,6 @@ extends:
       osx:
         py_versions: ['3.7']
         conda_env: 'scipp-developer-minimal.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scipp-developer-minimal.yml'
+      # windows:
+      #   py_versions: ['3.7']
+      #   conda_env: 'scipp-developer-minimal.yml'

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -34,9 +34,9 @@ extends:
       osx:
         py_versions: ['3.7', '3.8']
         conda_env: 'scipp-developer-minimal.yml'
-      windows:
-        py_versions: ['3.7', '3.8']
-        conda_env: 'scipp-developer-minimal.yml'
+      # windows:
+      #   py_versions: ['3.7', '3.8']
+      #   conda_env: 'scipp-developer-minimal.yml'
     deploy: true
     conda_label: 'main'
     release: true


### PR DESCRIPTION
Temporarily disable windows builds because of compilation failure after compiler update on azure from MSVC-19.28.29915.0 to MSVC-19.29.30037.0