### PR TITLE
Add support for slicing with ellipsis

### DIFF
--- a/core/except.cpp
+++ b/core/except.cpp
@@ -65,6 +65,8 @@ void dimensionMatches(const Dimensions &dims, const Dim dim,
 }
 
 void validSlice(const Sizes &dims, const Slice &slice) {
+  if (slice == Slice{})
+    return;
   const auto end = slice.end() < 0 ? slice.begin() + 1 : slice.end();
   if (!dims.contains(slice.dim()) || end > dims[slice.dim()])
     throw except::SliceError("Expected " + to_string(slice) + " to be in " +

--- a/core/include/scipp/core/slice.h
+++ b/core/include/scipp/core/slice.h
@@ -14,6 +14,7 @@ namespace scipp::core {
 /// range
 class SCIPP_CORE_EXPORT Slice {
 public:
+  Slice() : m_dim(Dim::None), m_begin(-1), m_end(-1) {}
   Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_);
   Slice(const Dim dim_, const scipp::index begin_);
   Slice &operator=(const Slice &) = default;

--- a/core/sizes.cpp
+++ b/core/sizes.cpp
@@ -166,6 +166,8 @@ bool Sizes::includes(const Sizes &sizes) const {
 Sizes Sizes::slice(const Slice &params) const {
   core::expect::validSlice(*this, params);
   Sizes sliced(*this);
+  if (params == Slice{})
+    return sliced;
   if (params.isRange())
     sliced.resize(params.dim(), params.end() - params.begin());
   else

--- a/core/test/sizes_test.cpp
+++ b/core/test/sizes_test.cpp
@@ -108,3 +108,11 @@ TEST_F(SizesTest, clear) {
   EXPECT_TRUE(sizes.empty());
   EXPECT_EQ(sizes.begin(), sizes.end());
 }
+
+TEST_F(SizesTest, slice_none) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  EXPECT_EQ(sizes.slice({}), sizes);
+}

--- a/core/test/slice_test.cpp
+++ b/core/test/slice_test.cpp
@@ -7,6 +7,11 @@
 
 using namespace scipp;
 
+TEST(SliceTest, test_default_construct) {
+  Slice slice;
+  EXPECT_EQ(slice.dim(), Dim::None);
+}
+
 TEST(SliceTest, test_construction) {
   Slice point(Dim::X, 0);
   EXPECT_EQ(point.dim(), Dim::X);

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -70,6 +70,8 @@ auto slice_map(const Sizes &sizes, const T &map, const Slice &params) {
                                                   : params.end() + 1;
         out[key] = value.slice(Slice{params.dim(), params.begin(), end});
       }
+    } else if (params == Slice{}) {
+      out[key] = value;
     } else {
       out[key] = value.as_const();
     }

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -154,7 +154,7 @@ Dict<Key, Value> Dict<Key, Value>::slice(const Slice &params) const {
 namespace {
 constexpr auto unaligned_by_dim_slice = [](const auto &item,
                                            const Slice &params) {
-  if (params.end() != -1)
+  if (params == Slice{} || params.end() != -1)
     return false;
   const Dim dim = params.dim();
   const auto &[key, var] = item;

--- a/dataset/test/data_array_test.cpp
+++ b/dataset/test/data_array_test.cpp
@@ -128,3 +128,12 @@ TEST_F(DataArrayTest, as_const) {
   EXPECT_TRUE(b.attrs()[Dim("attr")].is_readonly());
   EXPECT_EQ(a.name(), b.name());
 }
+
+TEST_F(DataArrayTest, full_slice) {
+  DataArray a(data, {{Dim::X, coord}}, {{"mask", mask}}, {{Dim("attr"), attr}});
+  const auto slice = a.slice({});
+  EXPECT_TRUE(slice.data().is_same(a.data()));
+  EXPECT_TRUE(slice.coords()[Dim::X].is_same(a.coords()[Dim::X]));
+  EXPECT_TRUE(slice.masks()["mask"].is_same(a.masks()["mask"]));
+  EXPECT_TRUE(slice.attrs()[Dim("attr")].is_same(a.attrs()[Dim("attr")]));
+}

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -11,11 +11,14 @@ Contributors
 
 Owen Arnold,
 Simon Heybrock,
+Greg Tucker,
 Neil Vaytet,
 and Jan-Lukas Wynen
 
 Features
 ~~~~~~~~
+
+* Slicing syntax now supports ellipsis, e.g., ``da.data[...] = var`` `#1960 <https://github.com/scipp/scipp/pull/1960>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -167,36 +167,19 @@ template <class T> struct slicer {
   // in the Python bindings directly.
   template <class IndexOrRange>
   static void set(T &self, const IndexOrRange &index, const py::object &data) {
-    if constexpr (std::is_same_v<T, Dataset>) {
-      if (py::isinstance<Dataset>(data)) {
-        set_from_view(self, index, py::cast<Dataset>(data));
-        return;
-      } else if (py::isinstance<Dataset>(data)) {
-        set_from_view(self, index, py::cast<Dataset>(data));
-        return;
-      }
-    } else if constexpr (std::is_same_v<T, DataArray>) {
-      if (py::isinstance<DataArray>(data)) {
-        set_from_view(self, index, py::cast<DataArray>(data));
-        return;
-      } else if (py::isinstance<DataArray>(data)) {
-        set_from_view(self, index, py::cast<DataArray>(data));
-        return;
-      }
-    }
+    if constexpr (std::is_same_v<T, Dataset>)
+      if (py::isinstance<Dataset>(data))
+        return set_from_view(self, index, py::cast<Dataset>(data));
 
-    if constexpr (!std::is_same_v<T, Dataset>) {
-      if (py::isinstance<Variable>(data)) {
-        set_from_view(self, index, py::cast<Variable>(data));
-        return;
-      } else if (py::isinstance<Variable>(data)) {
-        set_from_view(self, index, py::cast<Variable>(data));
-        return;
-      } else {
-        set_from_numpy(getitem(self, index), data);
-        return;
-      }
-    }
+    if constexpr (!std::is_same_v<T, Variable>)
+      if (py::isinstance<DataArray>(data))
+        return set_from_view(self, index, py::cast<DataArray>(data));
+
+    if (py::isinstance<Variable>(data))
+      return set_from_view(self, index, py::cast<Variable>(data));
+
+    if constexpr (!std::is_same_v<T, Dataset>)
+      return set_from_numpy(getitem(self, index), data);
 
     std::ostringstream oss;
     oss << "Cannot to assign a " << py::str(data.get_type())

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -127,8 +127,7 @@ template <class T> struct slicer {
   }
 
   static auto get_ellipsis(T &self, const py::ellipsis &) {
-    // TODO return DataArray::view()
-    return self;
+    return self.slice({});
   }
 
   static void set_from_numpy(T &self,
@@ -149,9 +148,9 @@ template <class T> struct slicer {
 
   static void set_from_numpy(T &self, const py::ellipsis &,
                              const py::object &obj) {
-    core::CallDType<double, float, int64_t, int32_t,
-                    bool>::apply<SetData<T>::template Impl>(self.dtype(), self,
-                                                            obj);
+    auto slice = self.slice({});
+    core::CallDType<double, float, int64_t, int32_t, bool>::apply<
+        SetData<decltype(slice)>::template Impl>(slice.dtype(), slice, obj);
   }
 
   template <class Other>
@@ -169,10 +168,7 @@ template <class T> struct slicer {
 
   template <class Other>
   static void set_from_view(T &self, const py::ellipsis &, const Other &data) {
-    if constexpr (std::is_same_v<T, Other>)
-      copy(data, self);
-    else
-      copy(data, self.data());
+    self.setSlice(Slice{}, data);
   }
 
   template <class Other>

--- a/python/bind_slice_methods.h
+++ b/python/bind_slice_methods.h
@@ -201,7 +201,7 @@ void bind_slice_methods(pybind11::class_<T, Ignored...> &c) {
   });
   c.def("__setitem__", &slicer<T>::template set<std::tuple<Dim, scipp::index>>);
   c.def("__setitem__", &slicer<T>::template set<std::tuple<Dim, py::slice>>);
-    c.def("__setitem__", &slicer<T>::template set<py::ellipsis>);
+  c.def("__setitem__", &slicer<T>::template set<py::ellipsis>);
   if constexpr (std::is_same_v<T, DataArray>) {
     c.def("__getitem__", &slicer<T>::get_by_value);
     c.def("__setitem__", &slicer<T>::template set_by_value<Variable>);

--- a/python/tests/slice_test.py
+++ b/python/tests/slice_test.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Simon Heybrock
+import scipp as sc
+
+
+def test_setitem_ellipsis_variable():
+    var = sc.ones(dims=['x'], shape=[2])
+    ref = var
+    ref[...] = 1.2 * sc.units.one
+    assert sc.identical(var, sc.array(dims=['x'], values=[1.2, 1.2]))
+
+
+def test_setitem_ellipsis_data_array():
+    var = sc.ones(dims=['x'], shape=[2])
+    da = sc.DataArray(data=var)
+    expected = da + 0.2 * sc.units.one
+    da[...] = 1.2 * sc.units.one
+    assert sc.identical(da, expected)
+    assert sc.identical(var, da.data)
+    da.data[...] = 2.3 * sc.units.one
+    assert sc.identical(var, da.data)
+
+
+def test_setitem_ellipsis_dataset():
+    var = sc.ones(dims=['x'], shape=[2])
+    da = sc.DataArray(data=var)
+    ds = sc.Dataset({'a': da})
+    expected = ds + 0.2 * sc.units.one
+    ds[...] = 1.2 * sc.units.one
+    assert sc.identical(ds, expected)
+    assert sc.identical(var, ds['a'].data)
+    ds['a'][...] = 2.3 * sc.units.one
+    assert sc.identical(var, ds['a'].data)
+    ds['a'].data[...] = 2.3 * sc.units.one
+    assert sc.identical(var, ds['a'].data)

--- a/units/dim.cpp
+++ b/units/dim.cpp
@@ -16,6 +16,7 @@ namespace {
 const auto &builtin_ids() {
   static std::unordered_map<std::string, Dim::Id> ids{
       {"<invalid>", Dim::Invalid},
+      {"<none>", Dim::None},
       {"<internal_structure_component>", Dim::InternalStructureComponent},
       {"<internal_structure_row>", Dim::InternalStructureRow},
       {"<internal_structure_column>", Dim::InternalStructureColumn},

--- a/units/include/scipp/units/dim.h
+++ b/units/include/scipp/units/dim.h
@@ -15,6 +15,7 @@ class SCIPP_UNITS_EXPORT Dim {
 public:
   enum class Id : uint16_t {
     Invalid,
+    None,
     InternalStructureComponent,
     InternalStructureRow,
     InternalStructureColumn,
@@ -35,6 +36,7 @@ public:
   };
 
   constexpr static auto Invalid = Id::Invalid;
+  constexpr static auto None = Id::None;
   constexpr static auto InternalStructureComponent =
       Id::InternalStructureComponent;
   constexpr static auto InternalStructureRow = Id::InternalStructureRow;

--- a/variable/test/variable_test.cpp
+++ b/variable/test/variable_test.cpp
@@ -164,6 +164,11 @@ TEST(VariableTest, copy_and_move) {
   EXPECT_EQ(moved, reference);
 }
 
+TEST(Variable, full_slice) {
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2});
+  EXPECT_TRUE(var.is_same(var.slice({})));
+}
+
 TEST(Variable, copy_slice) {
   const auto parent = makeVariable<double>(
       Dims{Dim::X, Dim::Y, Dim::Z}, Shape{4, 2, 3},

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -105,6 +105,8 @@ core::ElementArrayViewParams Variable::array_params() const noexcept {
 Variable Variable::slice(const Slice params) const {
   core::expect::validSlice(dims(), params);
   Variable out(*this);
+  if (params == Slice{})
+    return out;
   const auto dim = params.dim();
   const auto begin = params.begin();
   const auto end = params.end();


### PR DESCRIPTION
Related to #1815. The main motivation for adding this now is to be able to replace data without re-pointing the underlying reference to the object given on the RHS:

```python
da.data = var  # replace data variable
da.data[...] = var  # assign to slice, copy into existing data variable
```
Note that `[:]` would not work/make sense for 0-D variables, so I believe `[...]` is better here?