### PR TITLE
Add transpose for DataArray and Dataset

### DIFF
--- a/core/except.cpp
+++ b/core/except.cpp
@@ -27,13 +27,20 @@ DimensionError::DimensionError(scipp::index expectedDim, scipp::index userDim)
                      " Requested size: " + std::to_string(userDim)) {}
 
 namespace {
-std::string format_dims(const core::Dimensions &dims) {
+template <class T> std::string format_dims(const T &dims) {
   if (dims.empty()) {
     return "a scalar";
   }
   return "dimensions " + to_string(dims);
 }
 } // namespace
+
+template <>
+void throw_mismatch_error(const core::Sizes &expected,
+                          const core::Sizes &actual) {
+  throw DimensionError("Expected " + format_dims(expected) + ", got " +
+                       format_dims(actual) + '.');
+}
 
 template <>
 void throw_mismatch_error(const core::Dimensions &expected,

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -45,6 +45,10 @@ struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
 
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
+throw_mismatch_error(const core::Sizes &expected, const core::Sizes &actual);
+
+template <>
+[[noreturn]] SCIPP_CORE_EXPORT void
 throw_mismatch_error(const core::Dimensions &expected,
                      const core::Dimensions &actual);
 

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -61,7 +61,8 @@ void DataArray::setData(const Variable &data) {
   if (m_data->is_same(data))
     return;
   expectWritable(*this);
-  core::expect::equals(static_cast<Sizes>(dims()), data.dims());
+  core::expect::equals(static_cast<Sizes>(dims()),
+                       static_cast<Sizes>(data.dims()));
   *m_data = data;
 }
 

--- a/dataset/data_array.cpp
+++ b/dataset/data_array.cpp
@@ -61,7 +61,7 @@ void DataArray::setData(const Variable &data) {
   if (m_data->is_same(data))
     return;
   expectWritable(*this);
-  core::expect::equals(dims(), data.dims());
+  core::expect::equals(static_cast<Sizes>(dims()), data.dims());
   *m_data = data;
 }
 

--- a/dataset/include/scipp/dataset/shape.h
+++ b/dataset/include/scipp/dataset/shape.h
@@ -37,4 +37,9 @@ resize(const Dataset &d, const Dim dim, const scipp::index size,
 flatten(const DataArray &a, const scipp::span<const Dim> &from_labels,
         const Dim to_dim);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT DataArray
+transpose(const DataArray &a, const std::vector<Dim> &dims = {});
+[[nodiscard]] SCIPP_DATASET_EXPORT Dataset
+transpose(const Dataset &d, const std::vector<Dim> &dims = {});
+
 } // namespace scipp::dataset

--- a/dataset/shape.cpp
+++ b/dataset/shape.cpp
@@ -254,4 +254,14 @@ DataArray flatten(const DataArray &a, const scipp::span<const Dim> &from_labels,
   });
 }
 
+DataArray transpose(const DataArray &a, const std::vector<Dim> &dims) {
+  return {transpose(a.data(), dims), a.coords(), a.masks(), a.attrs(),
+          a.name()};
+}
+
+Dataset transpose(const Dataset &d, const std::vector<Dim> &dims) {
+  return apply_to_items(
+      d, [](auto &&... _) { return transpose(_...); }, dims);
+}
+
 } // namespace scipp::dataset

--- a/dataset/test/shape_test.cpp
+++ b/dataset/test/shape_test.cpp
@@ -477,6 +477,23 @@ TEST_F(TransposeTest, data_array_2d) {
   EXPECT_EQ(transpose(a, {Dim::Y, Dim::X}), a);
 }
 
+TEST_F(TransposeTest, data_array_2d_meta_data) {
+  Variable edges = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3},
+                                        Values{1, 2, 3, 4, 5, 6, 7, 8, 9});
+  // Note: The 2-d coord must not be transposed, since this would break the
+  // association with its dimension. Mask may in principle be transposed but is
+  // not right now.
+  a.coords().set(Dim("edges"), edges);
+  a.masks().set("mask", xy);
+  a.attrs().set(Dim("attr"), xy);
+  auto transposed = transpose(a);
+  EXPECT_EQ(transposed.data(), transpose(a.data()));
+  transposed.setData(a.data());
+  EXPECT_EQ(transposed, a);
+  EXPECT_EQ(transpose(a, {Dim::X, Dim::Y}), transpose(a));
+  EXPECT_EQ(transpose(a, {Dim::Y, Dim::X}), a);
+}
+
 TEST_F(TransposeTest, dataset_no_order) {
   Dataset d;
   d.setData("a", a);

--- a/dataset/test/shape_test.cpp
+++ b/dataset/test/shape_test.cpp
@@ -451,3 +451,51 @@ TEST(ReshapeTest, round_trip_with_all) {
   EXPECT_EQ(flatten(reshaped, std::vector<Dim>{Dim::Row, Dim::Time}, Dim::X),
             a);
 }
+
+class TransposeTest : public ::testing::Test {
+protected:
+  TransposeTest() : a(xy) {
+    a.coords().set(Dim::X, x);
+    a.coords().set(Dim::Y, y);
+    a.masks().set("mask-x", x);
+    a.masks().set("mask-y", y);
+    a.masks().set("mask-xy", xy);
+  }
+  Variable xy = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 2},
+                                     Values{1, 2, 3, 4, 5, 6});
+  Variable x = xy.slice({Dim::Y, 0});
+  Variable y = xy.slice({Dim::X, 0});
+  DataArray a;
+};
+
+TEST_F(TransposeTest, data_array_2d) {
+  auto transposed = transpose(a);
+  EXPECT_EQ(transposed.data(), transpose(a.data()));
+  transposed.setData(a.data());
+  EXPECT_EQ(transposed, a);
+  EXPECT_EQ(transpose(a, {Dim::X, Dim::Y}), transpose(a));
+  EXPECT_EQ(transpose(a, {Dim::Y, Dim::X}), a);
+}
+
+TEST_F(TransposeTest, dataset_no_order) {
+  Dataset d;
+  d.setData("a", a);
+  d.setData("b", transpose(a));
+  d.setData("c", a.slice({Dim::X, 0}));
+  // Slightly unusual but "simple" behavior if no dim order given
+  auto transposed = transpose(d);
+  EXPECT_EQ(transposed["a"], d["b"]);
+  EXPECT_EQ(transposed["b"], d["a"]);
+  EXPECT_EQ(transposed["c"], d["c"]);
+}
+
+TEST_F(TransposeTest, dataset_2d) {
+  Dataset d;
+  d.setData("a", a);
+  d.setData("b", transpose(a));
+  auto transposed = transpose(d, {Dim::X, Dim::Y});
+  EXPECT_EQ(transposed["a"], d["b"]);
+  EXPECT_EQ(transposed["b"], d["b"]);
+  d.setData("c", a.slice({Dim::X, 0}));
+  EXPECT_THROW_DISCARD(transpose(d, {Dim::X, Dim::Y}), except::DimensionError);
+}

--- a/python/shape.cpp
+++ b/python/shape.cpp
@@ -84,4 +84,6 @@ void init_shape(py::module &m) {
   bind_flatten<Variable>(m);
   bind_flatten<DataArray>(m);
   bind_transpose<Variable>(m);
+  bind_transpose<DataArray>(m);
+  bind_transpose<Dataset>(m);
 }

--- a/python/src/scipp/_shape.py
+++ b/python/src/scipp/_shape.py
@@ -115,13 +115,13 @@ def flatten(x, dims=None, to=None):
     return _call_cpp_func(_cpp.flatten, x, dims, to)
 
 
-def transpose(x, dims: _Sequence[str]):
-    """Transpose dimensions of a variable.
+def transpose(x, dims: _Sequence[str] = []):
+    """Transpose dimensions of a variable, an data array, or a dataset.
 
-    :param x: Variable to transpose.
+    :param x: Object to transpose.
     :param dims: List of dimensions in desired order. If default,
                         reverses existing order.
-    :type x: Variable
+    :type x: Variable, DataArray, or Dataset
     :type dims: list[str]
     :raises: If the dtype or unit does not match, or if the
              dimensions and shapes are incompatible.

--- a/templates/dataset_unary.cpp.in
+++ b/templates/dataset_unary.cpp.in
@@ -11,7 +11,7 @@ namespace scipp::variable {
 namespace scipp::dataset {
 
 DataArray @NAME@(const DataArray &a) {
-  return DataArray(@NAME@(a.data()), a.coords(), copy(a.masks()), a.attrs());
+  return DataArray(@NAME@(a.data()), a.coords(), copy(a.masks()), a.attrs(), a.name());
 }
 
 } // namespace scipp::dataset


### PR DESCRIPTION
This will be useful for refactoring/simplifying some plotting code.

- Fixes #847.
- Preserve name in data array unary operations.
- Actually support default dims in transpose in Python bindings, which did not work despite documentation.