### PR TITLE
Add bound methods for some free functions

### DIFF
--- a/docs/_templates/scipp-class-template.rst
+++ b/docs/_templates/scipp-class-template.rst
@@ -1,0 +1,30 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -11,6 +11,7 @@ Features
 
 * Added ``sizes`` argument to ``zeros``, ``ones``, and ``empty`` variable creation functions `#1951 <https://github.com/scipp/scipp/pull/1951>`_.
 * Slicing syntax now supports ellipsis, e.g., ``da.data[...] = var`` `#1960 <https://github.com/scipp/scipp/pull/1960>`_.
+* Added bound method equivalents to many free functions which take a single Variable or DataArray `#1969 <https://github.com/scipp/scipp/pull/1969>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -5,6 +5,8 @@ Classes
 
 .. autosummary::
    :toctree: ../generated
+   :template: scipp-class-template.rst
+   :recursive:
 
    Bins
    DataArray

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -120,10 +120,10 @@ _binding.bind_get()
 for _cls in (Variable, DataArray):
     _binding.bind_functions_as_methods(
         _cls, globals(), ('broadcast', 'flatten', 'fold', 'transpose', 'all',
-                          'any', 'mean', 'sum'))
+                          'any', 'mean', 'sum', 'nanmean', 'nansum'))
 del _cls
 _binding.bind_functions_as_methods(Variable, globals(),
-                                   ('cumsum', 'max', 'min'))
+                                   ('cumsum', 'max', 'min', 'nanmax', 'nanmin'))
 _binding.bind_functions_as_methods(DataArray, globals(), ('groupby', ))
 _binding.bind_functions_as_methods(Dataset, globals(), ('groupby', ))
 del _binding

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -124,4 +124,6 @@ for _cls in (Variable, DataArray):
 del _cls
 _binding.bind_functions_as_methods(Variable, globals(),
                                    ('cumsum', 'max', 'min'))
+_binding.bind_functions_as_methods(DataArray, globals(), ('groupby', ))
+_binding.bind_functions_as_methods(Dataset, globals(), ('groupby', ))
 del _binding

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -122,8 +122,8 @@ for _cls in (Variable, DataArray):
         _cls, globals(), ('broadcast', 'flatten', 'fold', 'transpose', 'all',
                           'any', 'mean', 'sum', 'nanmean', 'nansum'))
 del _cls
-_binding.bind_functions_as_methods(Variable, globals(),
-                                   ('cumsum', 'max', 'min', 'nanmax', 'nanmin'))
+_binding.bind_functions_as_methods(
+    Variable, globals(), ('cumsum', 'max', 'min', 'nanmax', 'nanmin'))
 _binding.bind_functions_as_methods(DataArray, globals(), ('groupby', ))
 _binding.bind_functions_as_methods(Dataset, globals(), ('groupby', ))
 del _binding

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -112,12 +112,10 @@ setattr(Dataset, 'plot', plot)
 # functions.
 for _obj in [Variable, DataArray, Dataset]:
     setattr(_obj, '__array_ufunc__', None)
+del _obj
 
-from ._scipp import core as tmp_core
-from .utils import get as tmp_get
-
-for cls in [Dataset, tmp_core.Coords, tmp_core.Masks]:
-    setattr(cls, 'get', tmp_get)
-
-del tmp_get
-del tmp_core
+from . import _binding
+_binding.bind_get()
+_binding.bind_functions_as_methods(Variable, globals(),
+                                   ['abs', 'sin'])
+del _binding

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -110,12 +110,18 @@ setattr(Dataset, 'plot', plot)
 # __array_ufunc__ should be possible by converting non-scipp arguments to
 # variables. The most difficult part is probably mapping the ufunc to scipp
 # functions.
-for _obj in [Variable, DataArray, Dataset]:
-    setattr(_obj, '__array_ufunc__', None)
-del _obj
+for _cls in (Variable, DataArray, Dataset):
+    setattr(_cls, '__array_ufunc__', None)
+del _cls
 
 from . import _binding
+
 _binding.bind_get()
+for _cls in (Variable, DataArray):
+    _binding.bind_functions_as_methods(
+        _cls, globals(), ('broadcast', 'flatten', 'fold', 'transpose', 'all',
+                          'any', 'mean', 'sum'))
+del _cls
 _binding.bind_functions_as_methods(Variable, globals(),
-                                   ['abs', 'sin'])
+                                   ('cumsum', 'max', 'min'))
 del _binding

--- a/python/src/scipp/_binding.py
+++ b/python/src/scipp/_binding.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Jan-Lukas Wynen
+
+from ._scipp import core
+from .utils import get
+
+
+def bind_get():
+    for cls in [core.Dataset, core.Coords, core.Masks]:
+        setattr(cls, 'get', get)
+
+
+def bind_functions_as_methods(cls, namespace, func_names):
+    for func_name, func in map(lambda n: (n, namespace[n]), func_names):
+        method = func.__get__(None, cls)
+        # Extract the summary from the docstring.
+        # This relies on check W293 in flake8 to avoid implementing a more
+        # sophisticate / expensive parser that running during import of scipp.
+        method.__doc__ = (
+            func.__doc__.split('\n\n', 1)[0] +
+            f'\n\n:seealso: Details in :py:meth:`scipp.{func_name}`')
+        setattr(cls, func_name, method)

--- a/python/src/scipp/_binding.py
+++ b/python/src/scipp/_binding.py
@@ -17,7 +17,9 @@ def bind_functions_as_methods(cls, namespace, func_names):
         # Extract the summary from the docstring.
         # This relies on check W293 in flake8 to avoid implementing a more
         # sophisticate / expensive parser that running during import of scipp.
+        # Line feeds are replaced because they mess with the
+        # reST parser of autosummary.
         method.__doc__ = (
-            func.__doc__.split('\n\n', 1)[0] +
+            func.__doc__.split('\n\n', 1)[0].replace('\n', ' ') +
             f'\n\n:seealso: Details in :py:meth:`scipp.{func_name}`')
         setattr(cls, func_name, method)

--- a/python/src/scipp/_binding.py
+++ b/python/src/scipp/_binding.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Jan-Lukas Wynen
 
+import types
+
 from ._scipp import core
 from .utils import get
 
@@ -13,7 +15,8 @@ def bind_get():
 
 def bind_functions_as_methods(cls, namespace, func_names):
     for func_name, func in map(lambda n: (n, namespace[n]), func_names):
-        method = func.__get__(None, cls)
+        method = types.FunctionType(func.__code__, func.__globals__, func_name,
+                                    func.__defaults__, func.__closure__)
         # Extract the summary from the docstring.
         # This relies on check W293 in flake8 to avoid implementing a more
         # sophisticate / expensive parser that running during import of scipp.

--- a/python/tests/dynamic_binding_test.py
+++ b/python/tests/dynamic_binding_test.py
@@ -20,7 +20,7 @@ def make_containers():
     return var, da
 
 
-@pytest.mark.parametrize('func_name', ('cumsum', 'max', 'mean', 'min', 'sum'))
+@pytest.mark.parametrize('func_name', ('cumsum', 'max', 'mean', 'min', 'nanmax', 'nanmean', 'nanmin', 'nansum', 'sum'))
 def test_bound_methods_reduction_variable(func_name):
     var, _ = make_containers()
     func = getattr(sc, func_name)
@@ -35,7 +35,7 @@ def test_bound_methods_reduction_variable_bool(func_name):
     assert sc.identical(getattr(var, func_name)(), func(var))
 
 
-@pytest.mark.parametrize('func_name', ('mean', 'sum'))
+@pytest.mark.parametrize('func_name', ('mean', 'nanmean', 'nansum', 'sum'))
 def test_bound_methods_reduction_dataarray(func_name):
     _, da = make_containers()
     func = getattr(sc, func_name)

--- a/python/tests/dynamic_binding_test.py
+++ b/python/tests/dynamic_binding_test.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Jan-Lukas Wynen
+
+import pytest
+
+import numpy as np
+import scipp as sc
+
+
+def make_containers():
+    rng = np.random.default_rng(87325)
+    var = sc.array(dims=['x', 'y'], values=rng.uniform(-5, 5, (4, 3)))
+    da = sc.DataArray(var.copy(),
+                      coords={
+                          'x': sc.arange('x', 4),
+                          'y': 0.1 * sc.arange('y', 3)
+                      })
+    return var, da
+
+
+@pytest.mark.parametrize('func_name', ('cumsum', 'max', 'mean', 'min', 'sum'))
+def test_bound_methods_reduction_variable(func_name):
+    var, _ = make_containers()
+    func = getattr(sc, func_name)
+    assert sc.identical(getattr(var, func_name)(), func(var))
+
+
+@pytest.mark.parametrize('func_name', ('any', 'all'))
+def test_bound_methods_reduction_variable_bool(func_name):
+    rng = np.random.default_rng(87415)
+    var = sc.array(dims=['x', 'y'], values=rng.choice([True, False], (4, 3)))
+    func = getattr(sc, func_name)
+    assert sc.identical(getattr(var, func_name)(), func(var))
+
+
+@pytest.mark.parametrize('func_name', ('mean', 'sum'))
+def test_bound_methods_reduction_dataarray(func_name):
+    _, da = make_containers()
+    func = getattr(sc, func_name)
+    assert sc.identical(getattr(da, func_name)(), func(da))
+
+
+def test_bound_methods_shape():
+    var, da = make_containers()
+    assert sc.identical(var.broadcast(['x', 'y', 'z'], [4, 3, 2]),
+                        sc.broadcast(var, ['x', 'y', 'z'], [4, 3, 2]))
+    assert sc.identical(var.transpose(['y', 'x']),
+                        sc.transpose(var, ['y', 'x']))
+    for obj in (var, da):
+        assert sc.identical(obj.flatten(dims=['x', 'y'], to='z'),
+                            sc.flatten(obj, dims=['x', 'y'], to='z'))
+        assert sc.identical(obj.fold(dim='x', sizes={
+            'a': 2,
+            'b': 2
+        }), sc.fold(obj, dim='x', sizes={
+            'a': 2,
+            'b': 2
+        }))

--- a/python/tests/dynamic_binding_test.py
+++ b/python/tests/dynamic_binding_test.py
@@ -20,7 +20,9 @@ def make_containers():
     return var, da
 
 
-@pytest.mark.parametrize('func_name', ('cumsum', 'max', 'mean', 'min', 'nanmax', 'nanmean', 'nanmin', 'nansum', 'sum'))
+@pytest.mark.parametrize('func_name',
+                         ('cumsum', 'max', 'mean', 'min', 'nanmax', 'nanmean',
+                          'nanmin', 'nansum', 'sum'))
 def test_bound_methods_reduction_variable(func_name):
     var, _ = make_containers()
     func = getattr(sc, func_name)

--- a/python/tests/dynamic_binding_test.py
+++ b/python/tests/dynamic_binding_test.py
@@ -58,3 +58,14 @@ def test_bound_methods_shape():
             'a': 2,
             'b': 2
         }))
+
+
+def test_bound_methods_groupby():
+    rng = np.random.default_rng(1491)
+    _, da = make_containers()
+    da.coords['x'] = sc.array(dims=['x'],
+                              values=rng.choice([0, 1], da.coords['x'].shape))
+    assert sc.identical(da.groupby('x').sum('x'), sc.groupby(da, 'x').sum('x'))
+
+    ds = sc.Dataset({'item': da})
+    assert sc.identical(ds.groupby('x').sum('x'), sc.groupby(ds, 'x').sum('x'))


### PR DESCRIPTION
Part of #1302 

This only adds methods that numpy has as well. E.g. maths functions like `abs`, `exp`, etc. are not included but they would be trivial to add.