### PR TITLE
Handle type mismatch explicitly

### DIFF
--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -51,6 +51,13 @@ def scalar(value: _Any,
     :returns: A scalar (zero-dimensional) Variable.
     :rtype: Variable
     """
+    if value is not None and variance is not None \
+            and not isinstance(variance, type(value)):
+        # This case would make pybind11's overload resolution fail.
+        # We cna provide a better error message here.
+        raise TypeError('Cannot construct scalar from value and '
+                        f'variance of different types. Got {type(value)} '
+                        f'and {type(variance)}.') from None
     if dtype is None:
         return _cpp.Variable(value=value, variance=variance, unit=unit)
     else:


### PR DESCRIPTION
Problem: 
```.py
sc.scalar(1, variance=0.1)
```
raises `scipp._scipp.core.VariancesError: Variances for dtype=PyObject not supported.` because only the PyObject overload matches this call. Also 
```.py
sc.scalar(1, variance=0.1, dtype=float)
```
complains that `TypeError: Cannot convert 1 to <class 'float'>. Try omitting the 'dtype=' parameter.`. This time because there is no matching overload.

This PR is just a workaround. A proper solution would likely require handling type conversions and bypassing pybind11's overload handling.