### PR TITLE
Check if arguments share a buffer in sort

### DIFF
--- a/dataset/sort.cpp
+++ b/dataset/sort.cpp
@@ -6,6 +6,25 @@
 #include "scipp/dataset/groupby.h"
 
 namespace scipp::dataset {
+namespace {
+template <class T> void ensure_distinct_buffers(const T &to_sort, const Variable &key) {
+  if constexpr (std::is_same_v<std::decay_t<T>, DataArray>) {
+    if (&to_sort.data().data() == &key.data()) {
+      throw std::invalid_argument("The groupby key is equal to the data. "
+                                  "Consider copying the key variable first.");
+    }
+  } else {
+    for (auto it = to_sort.items_begin(); it != to_sort.items_end(); ++it) {
+      const auto &[name, item] = *it;
+      if (&item.data().data() == &key.data()) {
+        throw std::invalid_argument(
+            "The groupby key is equal to dataset entry '" + name +
+            "'. Consider copying the key variable first.");
+      }
+    }
+  }
+}
+} // namespace
 
 /// Return a Variable sorted based on key.
 Variable sort(const Variable &var, const Variable &key, const SortOrder order) {
@@ -15,6 +34,7 @@ Variable sort(const Variable &var, const Variable &key, const SortOrder order) {
 /// Return a DataArray sorted based on key.
 DataArray sort(const DataArray &array, const Variable &key,
                const SortOrder order) {
+  ensure_distinct_buffers(array, key);
   auto helper = array;
   const Dim dummy = Dim::InternalSort;
   helper.coords().set(dummy, key);
@@ -31,6 +51,7 @@ DataArray sort(const DataArray &array, const Dim &key, const SortOrder order) {
 /// Return a Dataset sorted based on key.
 Dataset sort(const Dataset &dataset, const Variable &key,
              const SortOrder order) {
+  ensure_distinct_buffers(dataset, key);
   auto helper = dataset;
   const Dim dummy = Dim::InternalSort;
   helper.coords().set(dummy, key);

--- a/dataset/test/sort_test.cpp
+++ b/dataset/test/sort_test.cpp
@@ -95,6 +95,17 @@ TEST(SortTest, data_array_1d_descending) {
   EXPECT_EQ(sort(table, Dim::X, SortOrder::Descending), sorted_table);
 }
 
+TEST(SortTest, data_array_key_overlap) {
+  Variable data =
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4});
+  DataArray table =
+      DataArray(data.slice({Dim::Event, 0, 2}),
+                {{Dim::X, makeVariable<double>(Dims{Dim::Event}, Shape{2},
+                                               Values{4, 1})}});
+  EXPECT_THROW_DISCARD(sort(table, data.slice({Dim::Event, 2, 4})),
+                       std::invalid_argument);
+}
+
 TEST(SortTest, dataset_1d) {
   Dataset d;
   d.setData("a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
@@ -145,4 +156,17 @@ TEST(SortTest, dataset_1d_descending) {
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
 
   EXPECT_EQ(sort(d, key, SortOrder::Descending), expected);
+}
+
+TEST(SortTest, dataset_key_overlap) {
+  Dataset d;
+  Variable data =
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4});
+  DataArray array =
+      DataArray(data.slice({Dim::Event, 0, 2}),
+                {{Dim::X, makeVariable<double>(Dims{Dim::Event}, Shape{2},
+                                               Values{4, 1})}});
+  d.setData("a", array);
+  EXPECT_THROW_DISCARD(sort(d, data.slice({Dim::Event, 2, 4})),
+                       std::invalid_argument);
 }


### PR DESCRIPTION
Calling sort with a key that matches the data or at least partially overlaps it can cause an infinite loop.

The check added here is pretty crude, one could check  for an actual overlap. See the added tests, they pass even though those particular cases would be fine in practice.