### PR TITLE
Manual broadcast from bin to event

### DIFF
--- a/docs/user-guide/binned-data/binned-data.ipynb
+++ b/docs/user-guide/binned-data/binned-data.ipynb
@@ -352,6 +352,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Arithmetic operations\n",
+    "\n",
+    "A number of [arithmetic operations and other operations](computation.ipynb) for binned data arrays are supported."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manipulating bin-based and event-based metadata\n",
+    "\n",
+    "#### Convert bin-based coordinate into event-based coordinate\n",
+    "\n",
+    "Consider binned data as above, but with a coordinate that has no corresponding event-coord.\n",
+    "This could be the case, e.g., with a `time` dimension that corresponds to groups rather than bins:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da = binned.copy()\n",
+    "del da.coords['y']\n",
+    "del da.bins.coords['y']\n",
+    "da.rename_dims({'y':'time'})\n",
+    "da.coords['time'] = sc.array(dims=['time'], unit='s', values=np.arange(4))\n",
+    "da"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we, e.g., intend to erase the grouping dimension, we may nevertheless want to preserve the `time` information.\n",
+    "This can be achieve in 2 simple steps, (1) creating an empty event-coord and (2) using the `[...]` syntax to call `__setitem__` from the bin-coord:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da.events.coords['time'] = sc.empty(sizes=da.events.sizes, dtype='int64', unit='s')\n",
+    "da.bins.coords['time'][...] = da.coords['time']\n",
+    "sc.table(binned.events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plotting higher dimensions\n",
     "\n",
     "On-the-fly histogramming is also supported for plotting binned data with more than 2 dimensions:"
@@ -375,15 +429,6 @@
     "zbins = sc.Variable(dims=['z'], unit=sc.units.m, values=np.linspace(0.1, 0.9, 20))\n",
     "binned = sc.bin(data3d, [zbins, ybins, xbins])\n",
     "sc.plot(binned, resolution=10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Arithmetic operations\n",
-    "\n",
-    "A number of [arithmetic operations and other operations](computation.ipynb) for binned data arrays are supported."
    ]
   }
  ],

--- a/variable/test/variable_bin_test.cpp
+++ b/variable/test/variable_bin_test.cpp
@@ -178,3 +178,17 @@ TEST_F(VariableBinsTest, to_constituents) {
   EXPECT_EQ(dim1, Dim::X);
   EXPECT_EQ(buf1, buffer);
 }
+
+TEST_F(VariableBinsTest, setSlice) {
+  const auto dense = makeVariable<double>(indices.dims(), Values{1.1, 2.2});
+  var.setSlice({}, dense);
+  auto expected = make_bins(
+      indices, Dim::X,
+      makeVariable<double>(buffer.dims(), Values{1.1, 1.1, 2.2, 2.2}));
+  EXPECT_EQ(var, expected);
+  var.setSlice({Dim::Y, 1}, dense.slice({Dim::Y, 0}));
+  expected = make_bins(
+      indices, Dim::X,
+      makeVariable<double>(buffer.dims(), Values{1.1, 1.1, 1.1, 1.1}));
+  EXPECT_EQ(var, expected);
+}

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -10,6 +10,7 @@
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/except.h"
 #include "scipp/variable/variable_concept.h"
+#include "scipp/variable/variable_factory.h"
 
 namespace scipp::variable {
 
@@ -153,23 +154,28 @@ Variable Variable::slice(const Slice params) const {
 
 void Variable::validateSlice(const Slice &s, const Variable &data) const {
   core::expect::validSlice(this->dims(), s);
-  if (data.hasVariances() != this->hasVariances()) {
+  if (variableFactory().hasVariances(data) !=
+      variableFactory().hasVariances(*this)) {
     auto variances_message = [](const auto &variable) {
-      return "does" + std::string(variable.hasVariances() ? "" : " NOT") +
+      return "does" +
+             std::string(variableFactory().hasVariances(variable) ? ""
+                                                                  : " NOT") +
              " have variances.";
     };
     throw except::VariancesError("Invalid slice operation. Slice " +
                                  variances_message(data) + "Variable " +
                                  variances_message(*this));
   }
-  if (data.unit() != this->unit())
+  if (variableFactory().elem_unit(data) != variableFactory().elem_unit(*this))
     throw except::UnitError(
-        "Invalid slice operation. Slice has unit: " + to_string(data.unit()) +
-        " Variable has unit: " + to_string(this->unit()));
-  if (data.dtype() != this->dtype())
+        "Invalid slice operation. Slice has unit: " +
+        to_string(variableFactory().elem_unit(data)) +
+        " Variable has unit: " + to_string(variableFactory().elem_unit(*this)));
+  if (variableFactory().elem_dtype(data) != variableFactory().elem_dtype(*this))
     throw except::TypeError("Invalid slice operation. Slice has dtype " +
-                            to_string(data.dtype()) + ". Variable has dtype " +
-                            to_string(this->dtype()));
+                            to_string(variableFactory().elem_dtype(data)) +
+                            ". Variable has dtype " +
+                            to_string(variableFactory().elem_dtype(*this)));
 }
 
 Variable &Variable::setSlice(const Slice params, const Variable &data) {


### PR DESCRIPTION
Fixes #1966.

I decided to not add suppor for coord broadcast in `bin`, since there are frequent cases where this behavior is *not* desired. This would have required providing additional keyword args, further complicating `bin` (usage). I hope this solution is a good middle-ground. In the future we may still consider supporting this in `bin`, e.g., by distinguising the `erase` argument from, e.g., `flatten` (where the latter would broadcast the bin coord to a new event coord, while the formater would not).

Example:
```python
da.events.coords['time'] = sc.empty(sizes=da.events.sizes, dtype='int64', unit='s')
da.bins.coords['time'][...] = da.coords['time']
```