### PR TITLE
Allow construction of Variables from multi dimensional lists and tuples

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,6 +12,7 @@ Features
 * Added ``sizes`` argument to ``zeros``, ``ones``, and ``empty`` variable creation functions `#1951 <https://github.com/scipp/scipp/pull/1951>`_.
 * Slicing syntax now supports ellipsis, e.g., ``da.data[...] = var`` `#1960 <https://github.com/scipp/scipp/pull/1960>`_.
 * Added bound method equivalents to many free functions which take a single Variable or DataArray `#1969 <https://github.com/scipp/scipp/pull/1969>`_.
+* Variables can now be constructed directly from multi dimensional lists and tuples `#1977 <https://github.com/scipp/scipp/pull/1977>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -307,11 +307,21 @@ def array(*,
     :param dtype: Optional, type of underlying data. Default=None,
       in which case type is inferred from value input.
     """
-    return _cpp.Variable(dims=dims,
-                         values=values,
-                         variances=variances,
-                         unit=unit,
-                         dtype=dtype)
+    try:
+        return _cpp.Variable(dims=dims,
+                             values=values,
+                             variances=variances,
+                             unit=unit,
+                             dtype=dtype)
+    except RuntimeError as exc:
+        if 'Unable to cast' in exc.args[0]:
+            raise TypeError(
+                'Cannot convert data to an array. '
+                'Did you forget to wrap it in a list or numpy array?\n'
+                f'Got values = {type(values)}' +
+                (f'\n    variances = {type(variances)}'
+                 if variances is not None else '')) from None
+        raise
 
 
 def linspace(dim: str,

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -3,8 +3,10 @@
 # @author Matthew Andrew
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from typing import Any as _Any, Sequence as _Sequence, Union as _Union
+from typing import Any as _Any, Sequence as _Sequence, Union as _Union,\
+    Optional as _Optional
 import numpy as _np
+from numpy.typing import ArrayLike as _ArrayLike
 
 
 def _parse_dims_shape_sizes(dims, shape, sizes):
@@ -286,8 +288,8 @@ def vectors(*,
 
 def array(*,
           dims: _Sequence[str],
-          values: _Union[_np.ndarray, list],
-          variances: _Union[_np.ndarray, list] = None,
+          values: _ArrayLike,
+          variances: _Optional[_ArrayLike] = None,
           unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
           dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given

--- a/python/tests/variable_test.py
+++ b/python/tests/variable_test.py
@@ -3,6 +3,8 @@
 # @file
 # @author Simon Heybrock
 
+import itertools
+
 import numpy as np
 import pytest
 
@@ -154,6 +156,49 @@ def test_create_via_unit():
     expected = sc.Variable(1.2, unit=sc.units.m)
     var = 1.2 * sc.units.m
     assert sc.identical(var, expected)
+
+
+@pytest.mark.parametrize("types",
+                         itertools.product(*[(tuple, list, np.array)] * 2))
+def test_create_1d_array_like(types):
+    values_type, variances_type = types
+
+    values = np.arange(5.0)
+    expected = sc.Variable(dims=('x', ), values=values)
+    assert sc.identical(sc.Variable(dims=['x'], values=values_type(values)),
+                        expected)
+
+    variances = np.arange(5.0) * 0.1
+    expected = sc.Variable(dims=('x', ), values=values, variances=variances)
+    assert sc.identical(
+        sc.Variable(dims=['x'],
+                    values=values_type(values),
+                    variances=variances_type(variances)), expected)
+
+
+@pytest.mark.parametrize("types",
+                         itertools.product(*[(tuple, list, np.array)] * 4))
+def test_create_2d_array_like(types):
+    inner_values_type, outer_values_type, \
+      inner_variances_type, outer_variances_type = types
+
+    values = np.arange(15.0).reshape(3, 5)
+    expected = sc.Variable(dims=('x', 'y'), values=values)
+
+    assert sc.identical(
+        sc.Variable(dims=['x', 'y'],
+                    values=outer_values_type(
+                        [inner_values_type(val) for val in values])), expected)
+
+    variances = np.arange(15.0).reshape(3, 5) * 0.1
+    expected = sc.Variable(dims=('x', 'y'), values=values, variances=variances)
+    assert sc.identical(
+        sc.Variable(dims=['x', 'y'],
+                    values=outer_values_type(
+                        [inner_values_type(val) for val in values]),
+                    variances=outer_values_type(
+                        [inner_values_type(var) for var in variances])),
+        expected)
 
 
 def test_create_1D_string():

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -94,20 +94,6 @@ void bind_init_0D_numpy_types(py::class_<Variable> &c) {
       py::arg("unit") = units::one, py::arg("dtype") = py::none());
 }
 
-void bind_init_list(py::class_<Variable> &c) {
-  c.def(py::init([](const std::array<Dim, 1> &label, const py::list &values,
-                    const std::optional<py::list> &variances,
-                    const units::Unit &unit, py::object &dtype) {
-          auto arr = py::array(values);
-          auto varr =
-              variances ? std::optional(py::array(*variances)) : std::nullopt;
-          auto dims = std::vector<Dim>{label[0]};
-          return do_make_variable(dims, arr, varr, unit, dtype);
-        }),
-        py::arg("dims"), py::arg("values"), py::arg("variances") = std::nullopt,
-        py::arg("unit") = units::one, py::arg("dtype") = py::none());
-}
-
 template <class T, class Elem, int... N>
 void bind_structured_creation(py::module &m, const std::string &name) {
   m.def(
@@ -211,7 +197,6 @@ of variances.)");
         return size_of(self, SizeofTag::Underlying);
       });
 
-  bind_init_list(variable);
   // Order matters for pybind11's overload resolution. Do not change.
   bind_init_0D_numpy_types(variable);
   bind_init_0D_native_python_types<bool>(variable);


### PR DESCRIPTION
Also fixes the only outstanding point of https://github.com/scipp/scipp/issues/1541

Example:
 ```.py
var1 = sc.array(dims=['x', 'y'], values=[[1, 2], [3, 4]])
var2 = sc.array(dims=['x', 'y'], values=[(1, 2), (3, 4)])
```