### PR TITLE
NaNs in groupby

### DIFF
--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -4,6 +4,8 @@
 /// @author Simon Heybrock
 #include <numeric>
 
+#include "scipp/common/numeric.h"
+
 #include "scipp/core/bucket.h"
 #include "scipp/core/histogram.h"
 #include "scipp/core/parallel.h"
@@ -241,7 +243,8 @@ template <class T> struct MakeGroups {
       // handling in follow-up "apply" steps.
       const auto begin = i;
       const auto &value = *it;
-      while (it != end && *it == value) {
+      while (it != end && (*it == value || (scipp::numeric::isnan(value) &&
+                                            scipp::numeric::isnan(*it)))) {
         ++it;
         ++i;
       }

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -4,8 +4,6 @@
 /// @author Simon Heybrock
 #include <numeric>
 
-#include <iostream>
-
 #include "scipp/common/numeric.h"
 
 #include "scipp/core/bucket.h"
@@ -18,10 +16,8 @@
 
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/choose.h"
-#include "scipp/dataset/dataset_util.h"
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/groupby.h"
-#include "scipp/dataset/reduction.h"
 #include "scipp/dataset/shape.h"
 
 #include "../variable/operations_common.h"

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -241,7 +241,7 @@ template <class T> struct NanSensitiveLess {
     return a < b;
   }
 };
-}
+} // namespace
 
 template <class T> struct MakeGroups {
   static auto apply(const Variable &key, const Dim targetDim) {

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -4,6 +4,8 @@
 /// @author Simon Heybrock
 #include <numeric>
 
+#include <iostream>
+
 #include "scipp/common/numeric.h"
 
 #include "scipp/core/bucket.h"
@@ -243,8 +245,13 @@ template <class T> struct MakeGroups {
       // handling in follow-up "apply" steps.
       const auto begin = i;
       const auto &value = *it;
-      while (it != end && (*it == value || (scipp::numeric::isnan(value) &&
-                                            scipp::numeric::isnan(*it)))) {
+      if (scipp::numeric::isnan(value)) {
+        // NaN's cannot be used as keys in std::map -> drop those elements.
+        ++it;
+        ++i;
+        continue;
+      }
+      while (it != end && *it == value) {
         ++it;
         ++i;
       }

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -108,13 +108,15 @@ TEST_F(GroupbyTest, copy_nan) {
                                        Values{0.0, nan, 1.0, 0.0, 3.0, 3.0}));
 
   auto by_dim = groupby(da, Dim("labels"));
-  EXPECT_EQ(by_dim.size(), 3);
+  EXPECT_EQ(by_dim.size(), 4);
   EXPECT_EQ(by_dim.copy(0).data(),
             makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 3}));
   EXPECT_EQ(by_dim.copy(1).data(),
             makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{2}));
   EXPECT_EQ(by_dim.copy(2).data(),
             makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{4, 5}));
+  EXPECT_EQ(by_dim.copy(3).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1}));
 
   auto by_bins = groupby(
       da, Dim("labels"),

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -25,7 +25,7 @@ struct GroupbyTest : public ::testing::Test {
                                         units::s, Values{1, 2, 3, 4, 5, 6}));
     d["a"].attrs().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
     d.setCoord(Dim("labels1"), makeVariable<double>(Dimensions{Dim::X, 3},
-                                                    units::m, Values{1, 3, 2}));
+                                                    units::m, Values{1, 2, 3}));
     d.setCoord(Dim("labels2"), makeVariable<double>(Dimensions{Dim::X, 3},
                                                     units::m, Values{1, 1, 3}));
   }

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -102,18 +102,28 @@ TEST_F(GroupbyTest, copy_multiple_subgroups) {
 TEST_F(GroupbyTest, copy_nan) {
   constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
   DataArray da{
-      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{0, 1, 2, 3})};
-  da.coords().set(
-      Dim("labels"),
-      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{0.0, nan, 1.0, 3.0}));
-  auto one_group = groupby(
+      makeVariable<double>(Dims{Dim::X}, Shape{6}, Values{0, 1, 2, 3, 4, 5})};
+  da.coords().set(Dim("labels"),
+                  makeVariable<double>(Dims{Dim::X}, Shape{6},
+                                       Values{0.0, nan, 1.0, 0.0, 3.0, 3.0}));
+
+  auto by_dim = groupby(da, Dim("labels"));
+  EXPECT_EQ(by_dim.size(), 3);
+  EXPECT_EQ(by_dim.copy(0).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 3}));
+  EXPECT_EQ(by_dim.copy(1).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{2}));
+  EXPECT_EQ(by_dim.copy(2).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{4, 5}));
+
+  auto by_bins = groupby(
       da, Dim("labels"),
-      makeVariable<double>(Dims{Dim("labels")}, Shape{3}, Values{0, 2, 4}));
-  EXPECT_EQ(one_group.size(), 2);
-  EXPECT_EQ(one_group.copy(0).data(),
-            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 2}));
-  EXPECT_EQ(one_group.copy(1).data(),
-            makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{3}));
+      makeVariable<double>(Dims{Dim("labels")}, Shape{3}, Values{0, 2, 5}));
+  EXPECT_EQ(by_bins.size(), 2);
+  EXPECT_EQ(by_bins.copy(0).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{0, 2, 3}));
+  EXPECT_EQ(by_bins.copy(1).data(),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{4, 5}));
 }
 
 TEST_F(GroupbyTest, fail_2d_coord) {

--- a/dataset/test/sort_test.cpp
+++ b/dataset/test/sort_test.cpp
@@ -47,6 +47,34 @@ TEST(SortTest, variable_2d) {
   EXPECT_EQ(sort(var, keyY), expectedY);
 }
 
+TEST(SortTest, variable_1d_nan) {
+  // The position of NaN's after sorting is undefined. So we check if the result
+  // is ascending / descending instead of comparing to a reference.
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+  for (const auto &values : {std::vector<double>{4.0, nan, 1.0, 3.0},
+                             std::vector<double>{4.0, nan, 1.0, nan},
+                             std::vector<double>{4.0, nan, nan, 3.0}}) {
+    const auto var =
+        makeVariable<double>(Dims{Dim::X}, Shape{4}, Values(values));
+    const auto ascending = sort(var, var, SortOrder::Ascending);
+    for (scipp::index i = 1; i < ascending.dims().volume(); ++i) {
+      if (!std::isnan(ascending.values<double>()[i - 1]) &&
+          !std::isnan(ascending.values<double>()[i])) {
+        ASSERT_LE(ascending.values<double>()[i - 1],
+                  ascending.values<double>()[i]);
+      }
+    }
+    const auto descending = sort(var, var, SortOrder::Descending);
+    for (scipp::index i = 1; i < descending.dims().volume(); ++i) {
+      if (!std::isnan(descending.values<double>()[i - 1]) &&
+          !std::isnan(descending.values<double>()[i])) {
+        ASSERT_GE(descending.values<double>()[i - 1],
+                  descending.values<double>()[i]);
+      }
+    }
+  }
+}
+
 TEST(SortTest, data_array_1d) {
   Variable data = makeVariable<double>(
       Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 3, 2, 4});

--- a/dataset/test/sort_test.cpp
+++ b/dataset/test/sort_test.cpp
@@ -48,29 +48,38 @@ TEST(SortTest, variable_2d) {
 }
 
 TEST(SortTest, variable_1d_nan) {
-  // The position of NaN's after sorting is undefined. So we check if the result
-  // is ascending / descending instead of comparing to a reference.
+  // We cannot compare the sorted results to reference variables because
+  // NaN != Nan. So make sure the non-NaN values are sorted and NaN's are
+  // at the beginning / end depending on the sorting order.
   constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
-  for (const auto &values : {std::vector<double>{4.0, nan, 1.0, 3.0},
-                             std::vector<double>{4.0, nan, 1.0, nan},
-                             std::vector<double>{4.0, nan, nan, 3.0}}) {
+  std::vector test_values{std::vector<double>{4.0, nan, 1.0, 3.0},
+                          std::vector<double>{4.0, nan, 1.0, nan},
+                          std::vector<double>{4.0, nan, nan, 3.0}};
+  std::vector<scipp::index> n_nan{1, 2, 2};
+  for (scipp::index i_test = 0; i_test < scipp::size(test_values); ++i_test) {
+    const auto &values = test_values.at(i_test);
+    const auto n = n_nan.at(i_test);
     const auto var =
         makeVariable<double>(Dims{Dim::X}, Shape{4}, Values(values));
+
     const auto ascending = sort(var, var, SortOrder::Ascending);
-    for (scipp::index i = 1; i < ascending.dims().volume(); ++i) {
-      if (!std::isnan(ascending.values<double>()[i - 1]) &&
-          !std::isnan(ascending.values<double>()[i])) {
-        ASSERT_LE(ascending.values<double>()[i - 1],
-                  ascending.values<double>()[i]);
-      }
+    scipp::index i = 1;
+    for (; i < ascending.dims().volume() - n; ++i) {
+      ASSERT_LE(ascending.values<double>()[i - 1],
+                ascending.values<double>()[i]);
     }
+    for (; i < ascending.dims().volume(); ++i) {
+      ASSERT_TRUE(std::isnan(ascending.values<double>()[i]));
+    }
+
     const auto descending = sort(var, var, SortOrder::Descending);
-    for (scipp::index i = 1; i < descending.dims().volume(); ++i) {
-      if (!std::isnan(descending.values<double>()[i - 1]) &&
-          !std::isnan(descending.values<double>()[i])) {
-        ASSERT_GE(descending.values<double>()[i - 1],
-                  descending.values<double>()[i]);
-      }
+    for (i = 0; i < n; ++i) {
+      ASSERT_TRUE(std::isnan(descending.values<double>()[i]));
+    }
+    ++i; // move i - 1 past the last NaN
+    for (; i < descending.dims().volume(); ++i) {
+      ASSERT_GE(descending.values<double>()[i - 1],
+                descending.values<double>()[i]);
     }
   }
 }


### PR DESCRIPTION
Handle NaNs in the key in groupby.

There are two problems in `MakeGroups::apply`:
- `nan == nan` is `false` which is a problem in the while loop
- `nan < x` and `nan > x` are both always false which means that NaN cannot be used as the key to `std::map`

EDIT
The previous solution dropped elements with NaN keys from groupby. The current solution keeps them and combines them all into a single group.
When sorting, NaNs are guaranteed to be at the end (order ascending) or at the beginning (order descending).