### PR TITLE
Return unit of dividend in modulo

### DIFF
--- a/core/test/element_arithmetic_test.cpp
+++ b/core/test/element_arithmetic_test.cpp
@@ -189,7 +189,7 @@ TYPED_TEST(ElementArithmeticDivisionTest, remainder) {
 TEST(ElementArithmeticDivisionTest, units) {
   EXPECT_EQ(divide(units::m, units::s), units::m / units::s);
   EXPECT_EQ(floor_divide(units::m, units::s), units::m / units::s);
-  EXPECT_EQ(mod(units::m, units::s), units::m / units::s);
+  EXPECT_EQ(mod(units::m, units::s), units::m);
 }
 
 class ElementNanArithmeticTest : public ::testing::Test {

--- a/units/test/unit_test.cpp
+++ b/units/test/unit_test.cpp
@@ -39,7 +39,6 @@ TEST(UnitTest, overflows) {
   EXPECT_THROW(m64 * m64, except::UnitError);
   EXPECT_THROW(units::one / inv_m128, except::UnitError);
   EXPECT_THROW(inv_m128 / units::m, except::UnitError);
-  EXPECT_THROW(inv_m128 % units::m, except::UnitError);
   EXPECT_THROW(pow(units::m, 128), except::UnitError);
 }
 
@@ -108,6 +107,16 @@ TEST(UnitTest, divide) {
 TEST(UnitTest, divide_counts) {
   Unit counts{units::counts};
   EXPECT_EQ(counts / counts, units::dimensionless);
+}
+
+TEST(UnitTest, modulo) {
+  Unit one{units::dimensionless};
+  Unit l{units::m};
+  Unit t{units::s};
+  EXPECT_EQ(l % one, l);
+  EXPECT_EQ(t % one, t);
+  EXPECT_EQ(l % l, l);
+  EXPECT_EQ(l % t, l);
 }
 
 TEST(UnitTest, pow) {

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -71,7 +71,7 @@ Unit &Unit::operator*=(const Unit &other) { return *this = *this * other; }
 
 Unit &Unit::operator/=(const Unit &other) { return *this = *this / other; }
 
-Unit &Unit::operator%=(const Unit &other) { return operator/=(other); }
+Unit &Unit::operator%=([[maybe_unused]] const Unit &other) { return *this; }
 
 Unit operator+(const Unit &a, const Unit &b) {
   if (a == b)
@@ -100,7 +100,7 @@ Unit operator/(const Unit &a, const Unit &b) {
   return Unit{a.underlying() / b.underlying()};
 }
 
-Unit operator%(const Unit &a, const Unit &b) { return a / b; }
+Unit operator%(const Unit &a, [[maybe_unused]] const Unit &b) { return a; }
 
 Unit operator-(const Unit &a) { return a; }
 


### PR DESCRIPTION
Following the definition of modulo
```
a % b = a - a//b * b
```
the unit should be
```
[a % b] = [a]
```