### PR TITLE
Add typehints in the public Python API

### DIFF
--- a/docs/_templates/scipp-class-template.rst
+++ b/docs/_templates/scipp-class-template.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,11 @@ extensions = [
 
 autodoc_typehints = 'description'
 
+autodoc_type_aliases = {
+    'DataArrayLike': 'DataArrayLike',
+    'DatasetLike': 'DatasetLike',
+}
+
 rst_epilog = f"""
 .. |SCIPP_RELEASE_MONTH| replace:: {os.popen("git show -s --format=%cd --date=format:'%B %Y'").read()}
 .. |SCIPP_VERSION| replace:: {os.popen("git describe --tags --abbrev=0").read()}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ rst_epilog = f"""
 """  # noqa: E501
 
 intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -241,3 +241,25 @@ Compatibility
 
    to_dict
    from_dict
+
+
+Typing
+======
+
+.. autosummary::
+   :toctree: ../generated
+
+   is_variable
+   is_dataset
+   is_data_array
+   is_dataset_or_array
+   typing.is_scalar
+
+Type aliases
+~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../generated
+
+   typing.DataArrayLike
+   typing.DatasetLike

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -249,17 +249,5 @@ Typing
 .. autosummary::
    :toctree: ../generated
 
-   is_variable
-   is_dataset
-   is_data_array
-   is_dataset_or_array
-   typing.is_scalar
-
-Type aliases
-~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: ../generated
-
    typing.DataArrayLike
    typing.DatasetLike

--- a/python/operations.cpp
+++ b/python/operations.cpp
@@ -63,26 +63,15 @@ void bind_issorted(py::module &m) {
       py::call_guard<py::gil_scoped_release>());
 }
 
-template <typename T> void bind_sort_variable(py::module &m) {
-  m.def(
-      "sort",
-      [](const T &x, const Dim dim, const std::string &order) {
-        return sort(x, dim, get_sort_order(order));
-      },
-      py::arg("x"), py::arg("key"), py::arg("order") = "ascending",
-      py::call_guard<py::gil_scoped_release>());
-}
-
 void init_operations(py::module &m) {
   bind_dot<Variable>(m);
 
   bind_sort<Variable>(m);
   bind_sort<DataArray>(m);
   bind_sort<Dataset>(m);
+  bind_sort_dim<Variable>(m);
   bind_sort_dim<DataArray>(m);
   bind_sort_dim<Dataset>(m);
-
-  bind_sort_variable<Variable>(m);
   bind_issorted(m);
 
   m.def("get_slice_params", [](const Variable &var, const Variable &coord,

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -46,7 +46,7 @@ from .extend_units import *
 from .html import to_html, make_html
 from .object_list import _repr_html_
 from .utils import collapse, slices
-from .utils.typing import is_variable, is_dataset, is_data_array, \
+from .typing import is_variable, is_dataset, is_data_array, \
                           is_dataset_or_array
 from .compat.dict import to_dict, from_dict
 from .sizes import _make_sizes

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -46,8 +46,6 @@ from .extend_units import *
 from .html import to_html, make_html
 from .object_list import _repr_html_
 from .utils import collapse, slices
-from .typing import is_variable, is_dataset, is_data_array, \
-                          is_dataset_or_array
 from .compat.dict import to_dict, from_dict
 from .sizes import _make_sizes
 

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+# flake8: noqa: E501
 
 from __future__ import annotations
 
@@ -125,7 +126,9 @@ def isclose(x: _cpp.Variable,
     """Compares values (x, y) element by element against absolute
     and relative tolerances (non-symmetric).
 
-    abs(x - y) <= atol + rtol * abs(y)
+    .. code-block:: python
+
+        abs(x - y) <= atol + rtol * abs(y)
 
     If both x and y have variances, the variances are also compared
     between elements. In this case, both values and variances must
@@ -133,9 +136,8 @@ def isclose(x: _cpp.Variable,
 
     .. code-block:: python
 
-        abs(x.value - y.value) <= atol + rtol * abs(y.value) and abs(
-            sqrt(x.variance) - sqrt(y.variance)) \
-                <= atol + rtol * abs(sqrt(y.variance))
+        abs(x.value - y.value) <= atol + rtol * abs(y.value) and
+          abs(sqrt(x.variance) - sqrt(y.variance)) <= atol + rtol * abs(sqrt(y.variance))
 
     :param x: Left input.
     :param y: Right input.

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DataArrayLike, DatasetLike
+from .typing import DataArrayLike, DatasetLike
 
 
 def less(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -204,4 +204,6 @@ def allclose(x, y, rtol=None, atol=None, equal_nan=False):
     --------
     :py:func:`scipp.isclose` : comparing element-wise with specified tolerances
     """
-    return _call_cpp_func(_cpp.all, isclose(x, y, rtol, atol, equal_nan)).value
+    return _call_cpp_func(
+        _cpp.all, isclose(x, y, rtol=rtol, atol=atol,
+                          equal_nan=equal_nan)).value

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+
+from __future__ import annotations
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .utils.typing import DataArrayLike, DatasetLike
 
 
-def less(x, y):
+def less(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '<' (less).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -21,11 +25,11 @@ def less(x, y):
     return _call_cpp_func(_cpp.less, x, y)
 
 
-def greater(x, y):
+def greater(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '>' (greater).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -37,11 +41,11 @@ def greater(x, y):
     return _call_cpp_func(_cpp.greater, x, y)
 
 
-def less_equal(x, y):
+def less_equal(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '<=' (less_equal).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -53,11 +57,11 @@ def less_equal(x, y):
     return _call_cpp_func(_cpp.less_equal, x, y)
 
 
-def greater_equal(x, y):
+def greater_equal(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '>=' (greater_equal).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -69,11 +73,11 @@ def greater_equal(x, y):
     return _call_cpp_func(_cpp.greater_equal, x, y)
 
 
-def equal(x, y):
+def equal(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '==' (equal).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -85,11 +89,11 @@ def equal(x, y):
     return _call_cpp_func(_cpp.equal, x, y)
 
 
-def not_equal(x, y):
+def not_equal(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise '!=' (not_equal).
 
     Warning: If one or both of the operators have variances (uncertainties)
-    there are ignored silently, i.e., comparison is based exclusively on
+    they are ignored silently, i.e., comparison is based exclusively on
     the values.
 
     :param x: Left input.
@@ -101,7 +105,7 @@ def not_equal(x, y):
     return _call_cpp_func(_cpp.not_equal, x, y)
 
 
-def identical(x, y):
+def identical(x: DatasetLike, y: DatasetLike) -> DatasetLike:
     """Full comparison of x and y.
 
     :param x: Left input.
@@ -112,8 +116,12 @@ def identical(x, y):
     return _call_cpp_func(_cpp.identical, x, y)
 
 
-def isclose(x, y, rtol=None, atol=None, equal_nan=False):
-    """Compares values (x, y) element by element against tolerance absolute
+def isclose(x: _cpp.Variable,
+            y: _cpp.Variable,
+            rtol: _cpp.Variable = None,
+            atol: _cpp.Variable = None,
+            equal_nan: bool = False) -> _cpp.Variable:
+    """Compares values (x, y) element by element against absolute
     and relative tolerances (non-symmetric).
 
     abs(x - y) <= atol + rtol * abs(y)
@@ -138,13 +146,6 @@ def isclose(x, y, rtol=None, atol=None, equal_nan=False):
     :param equal_nan: if true, non-finite values at the same index in (x, y)
                       are treated as equal.
                       Signbit must match for infs.
-    :type x: Variable
-    :type y: Variable
-    :type rtol: Variable. May be a scalar or an array variable.
-                Cannot have variances.
-    :type atol: Variable. May be a scalar or an array variable.
-                Cannot have variances.
-    :type equal_nan: bool
     :return: Variable same size as input.
              Element True if absolute diff of value <= atol + rtol * abs(y),
              otherwise False.

--- a/python/src/scipp/_comparison.py
+++ b/python/src/scipp/_comparison.py
@@ -118,6 +118,7 @@ def identical(x: DatasetLike, y: DatasetLike) -> DatasetLike:
 
 def isclose(x: _cpp.Variable,
             y: _cpp.Variable,
+            *,
             rtol: _cpp.Variable = None,
             atol: _cpp.Variable = None,
             equal_nan: bool = False) -> _cpp.Variable:

--- a/python/src/scipp/_counts.py
+++ b/python/src/scipp/_counts.py
@@ -1,31 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+
+from typing import Union
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
-def counts_to_density(x, dim):
+def counts_to_density(x: Union[_cpp.DataArray, _cpp.Dataset],
+                      dim: str) -> Union[_cpp.DataArray, _cpp.Dataset]:
     """Converts counts to count density on a given dimension.
 
     :param x: Data as counts.
     :param dim: Dimension on which to convert.
-    :type x: Dataset or DataArray
-    :type dim: str
-    :rtype: Dataset or DataArray
     :return: Data as count density.
     """
     return _call_cpp_func(_cpp.counts_to_density, x, dim)
 
 
-def density_to_counts(x, dim):
+def density_to_counts(x: Union[_cpp.DataArray, _cpp.Dataset],
+                      dim: str) -> Union[_cpp.DataArray, _cpp.Dataset]:
     """Converts counts to count density on a given dimension.
 
     :param x: Data as count density.
     :param dim: Dimension on which to convert.
-    :type x: Dataset or DataArray
-    :type dim: str
-    :rtype: Dataset or DataArray
     :return: Data as counts.
     """
     return _call_cpp_func(_cpp.density_to_counts, x, dim)

--- a/python/src/scipp/_cumulative.py
+++ b/python/src/scipp/_cumulative.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+
+from typing import Optional
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
-def cumsum(a, dim=None, mode='inclusive'):
+def cumsum(a: _cpp.Variable,
+           dim: Optional[str] = None,
+           mode: Optional[str] = 'inclusive') -> _cpp.Variable:
     """Return the cumulative sum along the specified dimension.
 
     :param a: Input data.

--- a/python/src/scipp/_dataset.py
+++ b/python/src/scipp/_dataset.py
@@ -27,16 +27,13 @@ def combine_masks(masks, labels, shape):
     return _call_cpp_func(_cpp.combine_masks, labels, shape)
 
 
-def merge(lhs, rhs):
+def merge(lhs: _cpp.Dataset, rhs: _cpp.Dataset) -> _cpp.Dataset:
     """Merge two datasets into one.
 
     :param lhs: First dataset.
     :param rhs: Second dataset.
-    :type lhs: Dataset
-    :type rhs: Dataset
     :raises: If there are conflicting items with different content.
     :return: A new dataset that contains the union of all data items,
              coords, masks and attributes.
-    :rtype: Dataset
     """
     return _call_cpp_func(_cpp.merge, lhs, rhs)

--- a/python/src/scipp/_groupby.py
+++ b/python/src/scipp/_groupby.py
@@ -1,20 +1,24 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+
+from typing import Optional, Union
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
-def groupby(data, group, bins=None):
+def groupby(
+    data: Union[_cpp.DataArray, _cpp.Dataset],
+    group: Union[_cpp.Variable, str],
+    bins: Optional[_cpp.Variable] = None
+) -> Union[_cpp.GroupByDataArray, _cpp.GroupByDataset]:
     """Group dataset or data array based on values of specified labels.
 
     :param data: Input data to reduce.
     :param group: Name of labels to use for grouping
       or Variable to use for grouping
     :param bins: Optional Bins for grouping label values.
-    :type data: Dataset or DataArray
-    :type group: str or Variable
-    :type bins: Variable
     :return: GroupBy helper object.
     """
     if bins is None:

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -76,28 +76,31 @@ def sqrt(x, out=None):
     return _call_cpp_func(_cpp.sqrt, x, out=out)
 
 
-def exp(x):
+def exp(x, out=None):
     """Element-wise exponentiation.
 
     :param x: Input data.
+    :param out: Optional output buffer.
     :returns: e raised to the power of the input.
     """
-    return _call_cpp_func(_cpp.exp, x)
+    return _call_cpp_func(_cpp.exp, x, out=out)
 
 
-def log(x):
+def log(x, out=None):
     """Element-wise natural logarithm.
 
     :param x: Input data.
+    :param out: Optional output buffer.
     :returns: Base e logiarithm of the input.
     """
-    return _call_cpp_func(_cpp.log, x)
+    return _call_cpp_func(_cpp.log, x, out=out)
 
 
-def log10(x):
+def log10(x, out=None):
     """Element-wise base 10 logarithm.
 
     :param x: Input data.
+    :param out: Optional output buffer.
     :returns: Base 10 logarithm of the input.
     """
-    return _call_cpp_func(_cpp.log10, x)
+    return _call_cpp_func(_cpp.log10, x, out=out)

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
 from typing import Optional
 
 from ._scipp import core as _cpp

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from typing import Optional
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .utils.typing import DataArrayLike
 
 
-def abs(x, out=None):
+def abs(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
     """Element-wise absolute value.
 
     :param x: Input data.
@@ -17,21 +21,20 @@ def abs(x, out=None):
     return _call_cpp_func(_cpp.abs, x, out=out)
 
 
-def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
+def nan_to_num(x: _cpp.Variable,
+               *,
+               nan: _cpp.Variable = None,
+               posinf: _cpp.Variable = None,
+               neginf: _cpp.Variable = None,
+               out: _cpp.Variable = None) -> _cpp.Variable:
     """Element-wise special value replacement.
 
     All elements in the output are identical to input except in the presence
     of a NaN, Inf or -Inf.
-    The function allows replacements to be separately specified for nan, inf
-    or -inf values.
+    The function allows replacements to be separately specified for NaN, Inf
+    or -Inf values.
     You can choose to replace a subset of those special values by providing
     just the required keyword arguments.
-    If the replacement is value-only and the input has variances, the variance
-    at the element(s) undergoing replacement are also replaced with the
-    replacement value.
-    If the replacement has a variance and the input has variances, the
-    variance at the element(s) undergoing replacement are also replaced with
-    the replacement variance.
 
     :param x: Input data.
     :param nan: Replacement values for NaN in the input.
@@ -39,12 +42,12 @@ def nan_to_num(x, nan=None, posinf=None, neginf=None, out=None):
     :param neginf: Replacement values for -Inf in the input.
     :param out: Optional output buffer.
     :raises: If the types of input and replacement do not match.
-    :return: Input elements are replaced in output with specified subsitutions.
+    :return: Input with specified substitutions.
     """
     return _call_cpp_func(_cpp.nan_to_num, x, nan, posinf, neginf, out=out)
 
 
-def norm(x):
+def norm(x: DataArrayLike) -> DataArrayLike:
     """Element-wise norm.
 
     :param x: Input data.
@@ -54,7 +57,8 @@ def norm(x):
     return _call_cpp_func(_cpp.norm, x, out=None)
 
 
-def reciprocal(x, out=None):
+def reciprocal(x: DataArrayLike,
+               out: Optional[DataArrayLike] = None) -> DataArrayLike:
     """Element-wise reciprocal.
 
     :param x: Input data.
@@ -65,7 +69,8 @@ def reciprocal(x, out=None):
     return _call_cpp_func(_cpp.reciprocal, x, out=out)
 
 
-def sqrt(x, out=None):
+def sqrt(x: DataArrayLike,
+         out: Optional[DataArrayLike] = None) -> DataArrayLike:
     """Element-wise square-root.
 
     :param x: Input data.
@@ -76,8 +81,9 @@ def sqrt(x, out=None):
     return _call_cpp_func(_cpp.sqrt, x, out=out)
 
 
-def exp(x, out=None):
-    """Element-wise exponentiation.
+def exp(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise exponential.
 
     :param x: Input data.
     :param out: Optional output buffer.
@@ -86,7 +92,8 @@ def exp(x, out=None):
     return _call_cpp_func(_cpp.exp, x, out=out)
 
 
-def log(x, out=None):
+def log(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
     """Element-wise natural logarithm.
 
     :param x: Input data.
@@ -96,7 +103,8 @@ def log(x, out=None):
     return _call_cpp_func(_cpp.log, x, out=out)
 
 
-def log10(x, out=None):
+def log10(x: DataArrayLike,
+          out: Optional[DataArrayLike] = None) -> DataArrayLike:
     """Element-wise base 10 logarithm.
 
     :param x: Input data.

--- a/python/src/scipp/_math.py
+++ b/python/src/scipp/_math.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DataArrayLike
+from .typing import DataArrayLike
 
 
 def abs(x: DataArrayLike,

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -1,54 +1,59 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+from typing import Optional, Union
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .utils.typing import DataArrayLike, DatasetLike
 
 
-def dot(x, y):
+def dot(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:
     """Element-wise dot product.
 
     :param x: Left hand side operand.
     :param y: Right hand side operand.
-    :type x: Variable
-    :type y: Variable
     :raises: If the dtype of the input is not vector_3_float64.
     :return: The dot product of the input vectors.
-    :rtype: Variable
     """
     return _call_cpp_func(_cpp.dot, x, y)
 
 
-def issorted(x, dim, order='ascending'):
+def issorted(x: _cpp.Variable,
+             dim: str,
+             order: Optional[str] = 'ascending') -> bool:
     """
-    Check if the values of a variable are sorted in.
-    If `order` is `ascending`, check if values are non-decreasing along `dim`.
-    If `order` is `descending`, check if values are non-increasing along 'dim'.
+    Check if the values of a variable are sorted.
+
+    - If ``order`` is 'ascending',
+      check if values are non-decreasing along ``dim``.
+    - If ``order`` is 'descending',
+      check if values are non-increasing along ``dim``.
 
     :param x: Variable to check.
     :param dim: Dimension along which order is checked.
-    :param order: Optional Sorted order. Valid options are 'ascending' and
+    :param order: Sorting order. Valid options are 'ascending' and
       'descending'. Default is 'ascending'.
-    :type x: Variable
-    :type dim: str
-    :type order: str
     :return: True if the variable values are monotonously ascending or
       descending (depending on the requested order), False otherwise.
-    :rtype: bool
     """
     return _call_cpp_func(_cpp.issorted, x, dim, order)
 
 
-def sort(x, key, order='ascending'):
+def sort(x: DatasetLike,
+         key: Union[str, _cpp.Variable],
+         order: Optional[str] = 'ascending') -> DatasetLike:
     """Sort variable along a dimension by a sort key or dimension label
+
+    - If ``order`` is 'ascending',
+      sort such that values are non-decreasing according to ``key``.
+    - If ``order`` is 'descending',
+      sort such that values are non-increasing according to ``key``.
 
     :param x: Data to be sorted.
     :param key: Either a 1D variable sort key or a dimension label.
-    :param order: Optional Sorted order. Valid options are 'ascending' and
+    :param order: Sorting order. Valid options are 'ascending' and
       'descending'. Default is 'ascending'.
-    :type x: Dataset, DataArray, Variable
-    :type key: Variable, str
-    :type order: str
     :raises: If the key is invalid, e.g., if it does not have
       exactly one dimension, or if its dtype is not sortable.
     :return: The sorted equivalent of the input.
@@ -56,7 +61,7 @@ def sort(x, key, order='ascending'):
     return _call_cpp_func(_cpp.sort, x, key, order)
 
 
-def values(x):
+def values(x: DataArrayLike) -> DataArrayLike:
     """Return the object without variances.
 
     :param x: Variable or DataArray
@@ -65,7 +70,7 @@ def values(x):
     return _call_cpp_func(_cpp.values, x)
 
 
-def variances(x):
+def variances(x: DataArrayLike) -> DataArrayLike:
     """Return object containing the variances of the input as values.
 
     :param x: Variable or DataArray
@@ -74,7 +79,7 @@ def variances(x):
     return _call_cpp_func(_cpp.variances, x)
 
 
-def stddevs(x):
+def stddevs(x: DataArrayLike) -> DataArrayLike:
     """Return object containing the stddevs of the input as values.
 
     This is essentially `sqrt(variances(x))`
@@ -85,7 +90,10 @@ def stddevs(x):
     return _call_cpp_func(_cpp.stddevs, x)
 
 
-def rebin(x, dim, bins, old=None):
+def rebin(x: DataArrayLike,
+          dim: str,
+          bins: _cpp.Variable,
+          old: Optional[_cpp.Variable] = None) -> DataArrayLike:
     """
     Rebin a dimension of a variable or a data array.
 
@@ -98,15 +106,10 @@ def rebin(x, dim, bins, old=None):
     :param dim: Dimension to rebin over.
     :param bins: New bin edges.
     :param old: Old bin edges.
-    :type x: Variable or DataArray
-    :type dim: str
-    :type bins: Variable
-    :type old: Variable, optional
     :raises: If data cannot be rebinned, e.g., if the unit is not
              counts, or the existing coordinate is not a bin-edge
              coordinate.
     :return: Data rebinned according to the new bin edges.
-    :rtype: Variable or DataArray
     """
     if old is None:
         return _call_cpp_func(_cpp.rebin, x, dim, bins)

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+from __future__ import annotations
 from typing import Optional, Union
 
 from ._scipp import core as _cpp

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DataArrayLike, DatasetLike
+from .typing import DataArrayLike, DatasetLike
 
 
 def dot(x: DataArrayLike, y: DataArrayLike) -> DataArrayLike:

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -1,19 +1,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from typing import Optional
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .utils.typing import DatasetLike
 
 
-def mean(x, dim=None, out=None):
-    """Element-wise mean over the specified dimension, if variances are
-    present, the new variance is computed as standard-deviation of the mean.
+def mean(x: DatasetLike,
+         dim: Optional[str] = None,
+         out: Optional[DatasetLike] = None) -> DatasetLike:
+    """Element-wise mean over the specified dimension.
 
-    If the input has variances, the variances stored in the ouput are based on
+    If the input has variances, the variances stored in the output are based on
     the "standard deviation of the mean", i.e.,
     :math:`\\sigma_{mean} = \\sigma / \\sqrt{N}`.
     :math:`N` is the length of the input dimension.
-    :math:`sigma` is estimated as the average of the standard deviations of
+    :math:`\\sigma` is estimated as the average of the standard deviations of
     the input elements along that dimension.
 
     :param x: Input data.
@@ -23,6 +27,7 @@ def mean(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The mean of the input values.
+    :seealso: :py:func:`scipp.nanmean`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.mean, x, out=out)
@@ -30,16 +35,16 @@ def mean(x, dim=None, out=None):
         return _call_cpp_func(_cpp.mean, x, dim=dim, out=out)
 
 
-def nanmean(x, dim=None, out=None):
-    """Element-wise mean over the specified dimension, if variances are
-    present, the new variance is computed as standard-deviation of the mean.
-    NaNs are ignored.
+def nanmean(x: DatasetLike,
+            dim: Optional[str] = None,
+            out: Optional[DatasetLike] = None) -> DatasetLike:
+    """Element-wise mean over the specified dimension ignoring NaNs.
 
     If the input has variances, the variances stored in the ouput are based on
     the "standard deviation of the mean", i.e.,
     :math:`\\sigma_{mean} = \\sigma / \\sqrt{N}`.
     :math:`N` is the length of the input dimension.
-    :math:`sigma` is estimated as the average of the standard deviations of
+    :math:`\\sigma` is estimated as the average of the standard deviations of
     the input elements along that dimension.
 
     :param x: Input data.
@@ -49,6 +54,7 @@ def nanmean(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The mean of the input values.
+    :seealso: :py:func:`scipp.mean`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.nanmean, x, out=out)
@@ -56,7 +62,9 @@ def nanmean(x, dim=None, out=None):
         return _call_cpp_func(_cpp.nanmean, x, dim=dim, out=out)
 
 
-def sum(x, dim=None, out=None):
+def sum(x: DatasetLike,
+        dim: Optional[str] = None,
+        out: Optional[DatasetLike] = None) -> DatasetLike:
     """Element-wise sum over the specified dimension.
 
     :param x: Input data.
@@ -66,6 +74,7 @@ def sum(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The sum of the input values.
+    :seealso: :py:func:`scipp.nansum`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.sum, x, out=out)
@@ -73,8 +82,10 @@ def sum(x, dim=None, out=None):
         return _call_cpp_func(_cpp.sum, x, dim=dim, out=out)
 
 
-def nansum(x, dim=None, out=None):
-    """Element-wise sum over the specified dimension. NaNs are treated as zero.
+def nansum(x: DatasetLike,
+           dim: Optional[str] = None,
+           out: Optional[DatasetLike] = None) -> DatasetLike:
+    """Element-wise sum over the specified dimension; NaNs are treated as zero.
 
     :param x: Input data.
     :param dim: Optional dimension along which to calculate the sum. If not
@@ -83,6 +94,7 @@ def nansum(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The sum of the input values with NaNs set to zero.
+    :seealso: :py:func:`scipp.sum`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.nansum, x, out=out)
@@ -101,6 +113,7 @@ def min(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The min of the input values.
+    :seealso: :py:func:`scipp.nanmin`, :py:func:`scipp.nanmax`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.min, x, out=out)
@@ -119,6 +132,7 @@ def max(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The max of the input values.
+    :seealso: :py:func:`scipp.nanmax`, :py:func:`scipp.min`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.max, x, out=out)
@@ -137,6 +151,7 @@ def nanmin(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The min of the input values.
+    :seealso: :py:func:`scipp.min`, :py:func:`scipp.nanmax`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.nanmin, x, out=out)
@@ -155,6 +170,7 @@ def nanmax(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The max of the input values.
+    :seealso: :py:func:`scipp.max`, :py:func:`scipp.nanmin`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.nanmax, x, out=out)
@@ -173,6 +189,7 @@ def all(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The AND of the input values.
+    :seealso: :py:func:`scipp.any`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.all, x, out=out)
@@ -191,6 +208,7 @@ def any(x, dim=None, out=None):
     :raises: If the dimension does not exist, or the dtype cannot be summed,
              e.g., if it is a string.
     :return: The OR of the input values.
+    :seealso: :py:func:`scipp.all`.
     """
     if dim is None:
         return _call_cpp_func(_cpp.any, x, out=out)

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
+
 from typing import Optional
 
 from ._scipp import core as _cpp
@@ -102,7 +104,9 @@ def nansum(x: DatasetLike,
         return _call_cpp_func(_cpp.nansum, x, dim=dim, out=out)
 
 
-def min(x, dim=None, out=None):
+def min(x: _cpp.Variable,
+        dim: Optional[str] = None,
+        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise min over the specified dimension or all dimensions if not
     provided.
 
@@ -121,7 +125,9 @@ def min(x, dim=None, out=None):
         return _call_cpp_func(_cpp.min, x, dim=dim, out=out)
 
 
-def max(x, dim=None, out=None):
+def max(x: _cpp.Variable,
+        dim: Optional[str] = None,
+        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise max over the specified dimension or all dimensions if not
     provided.
 
@@ -140,7 +146,9 @@ def max(x, dim=None, out=None):
         return _call_cpp_func(_cpp.max, x, dim=dim, out=out)
 
 
-def nanmin(x, dim=None, out=None):
+def nanmin(x: _cpp.Variable,
+           dim: Optional[str] = None,
+           out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise min ignoring not at number values over the specified
     dimension or all dimensions if not provided.
 
@@ -159,7 +167,9 @@ def nanmin(x, dim=None, out=None):
         return _call_cpp_func(_cpp.nanmin, x, dim=dim, out=out)
 
 
-def nanmax(x, dim=None, out=None):
+def nanmax(x: _cpp.Variable,
+           dim: Optional[str] = None,
+           out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise max ignoring not a number values over the specified
     dimension or all dimensions if not provided.
 
@@ -178,7 +188,9 @@ def nanmax(x, dim=None, out=None):
         return _call_cpp_func(_cpp.nanmax, x, dim=dim, out=out)
 
 
-def all(x, dim=None, out=None):
+def all(x: _cpp.Variable,
+        dim: Optional[str] = None,
+        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise AND over the specified dimension or all dimensions if not
     provided.
 
@@ -197,7 +209,9 @@ def all(x, dim=None, out=None):
         return _call_cpp_func(_cpp.all, x, dim=dim, out=out)
 
 
-def any(x, dim=None, out=None):
+def any(x: _cpp.Variable,
+        dim: Optional[str] = None,
+        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise OR over the specified dimension or all dimensions if not
     provided.
 

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from __future__ import annotations
 
+from __future__ import annotations
 from typing import Optional
 
 from ._scipp import core as _cpp

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DatasetLike
+from .typing import DatasetLike
 
 
 def mean(x: DatasetLike,

--- a/python/src/scipp/_shape.py
+++ b/python/src/scipp/_shape.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DataArrayLike, DatasetLike
+from .typing import DataArrayLike, DatasetLike
 
 
 def broadcast(x: _cpp.Variable, dims: Union[List[str], Tuple[str]],

--- a/python/src/scipp/_shape.py
+++ b/python/src/scipp/_shape.py
@@ -3,12 +3,16 @@
 # @author Matthew Andrew
 # flake8: noqa: E501
 
+from __future__ import annotations
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from typing import Sequence as _Sequence
+from .utils.typing import DataArrayLike, DatasetLike
 
 
-def broadcast(x, dims, shape):
+def broadcast(x: _cpp.Variable, dims: Union[List[str], Tuple[str]],
+              shape: Sequence[int]) -> _cpp.Variable:
     """Broadcast a variable.
 
     Note that scipp operations broadcast automatically, so using this function
@@ -17,15 +21,12 @@ def broadcast(x, dims, shape):
     :param x: Variable to broadcast.
     :param dims: List of new dimensions.
     :param shape: New extents in each dimension.
-    :type x: Variable
-    :type dims: list[str]
-    :type shape: list[int]
     :return: New variable with requested dimension labels and shape.
     """
     return _call_cpp_func(_cpp.broadcast, x, dims, shape)
 
 
-def concatenate(x, y, dim):
+def concatenate(x: DatasetLike, y: DatasetLike, dim: str) -> DatasetLike:
     """Concatenate input arrays along the given dimension.
 
     Concatenation can happen in two ways:
@@ -43,9 +44,6 @@ def concatenate(x, y, dim):
     :param x: Left hand side input.
     :param y: Right hand side input.
     :param dim: Dimension along which to concatenate.
-    :type x: Dataset, DataArray or Variable. Must be same type as y
-    :type y: Dataset, DataArray or Variable. Must be same type as x
-    :type dim: str
     :raises: If the dtype or unit does not match, or if the
              dimensions and shapes are incompatible.
     :return: The absolute values of the input.
@@ -83,7 +81,11 @@ def concatenate(x, y, dim):
     return _call_cpp_func(_cpp.concatenate, x, y, dim)
 
 
-def fold(x, dim, sizes=None, dims=None, shape=None):
+def fold(x: DataArrayLike,
+         dim: str,
+         sizes: Optional[Dict[str, int]] = None,
+         dims: Optional[Union[List[str], Tuple[str]]] = None,
+         shape: Optional[Sequence[int]] = None) -> DataArrayLike:
     """Fold a single dimension of a variable or data array into multiple dims.
 
     :param x: Variable or DataArray to fold.
@@ -91,11 +93,6 @@ def fold(x, dim, sizes=None, dims=None, shape=None):
     :param sizes: A dict mapping new dims to new shapes.
     :param dims: A list of new dims labels.
     :param shape: A list of new dim shapes.
-    :type x: Variable or DataArray
-    :type dim: str
-    :type sizes: dict
-    :type dims: list[str]
-    :type shape: list[int]
     :raises: If the volume of the old shape is not equal to the
              volume of the new shape.
     :return: Variable or DataArray with requested dimension labels and shape.
@@ -143,7 +140,9 @@ def fold(x, dim, sizes=None, dims=None, shape=None):
         return _call_cpp_func(_cpp.fold, x, dim, dict(zip(dims, shape)))
 
 
-def flatten(x, dims=None, to=None):
+def flatten(x: DataArrayLike,
+            dims: Optional[Union[List[str], Tuple[str]]] = None,
+            to: Optional[str] = None) -> DataArrayLike:
     """Flatten multiple dimensions of a variable or data array into a single
     dimension. If dims is omitted, then we flatten all of the inputs dimensions
     into a single dim.
@@ -151,9 +150,6 @@ def flatten(x, dims=None, to=None):
     :param x: Variable or DataArray to flatten.
     :param dims: A list of dim labels that will be flattened.
     :param to: A single dim label for the resulting flattened dim.
-    :type x: Variable or DataArray
-    :type dims: list[str]
-    :type to: str
     :raises: If the bin edge coordinates cannot be stitched back together.
     :return: Variable or DataArray with requested dimension labels and shape.
 
@@ -179,7 +175,7 @@ def flatten(x, dims=None, to=None):
 
       >>> a = sc.DataArray(0.1 * sc.array(dims=['x', 'y'], values=np.arange(6).reshape(2, 3)),
       ...        coords={'x': sc.arange('x', 2),
-      ...               'y': sc.arange('y', 3),
+      ...                'y': sc.arange('y', 3),
       ...                'xy': sc.array(dims=['x', 'y'],
       ...                               values=np.arange(6).reshape(2, 3))})
       >>> a
@@ -213,16 +209,16 @@ def flatten(x, dims=None, to=None):
     return _call_cpp_func(_cpp.flatten, x, dims, to)
 
 
-def transpose(x, dims: _Sequence[str] = []):
+def transpose(
+        x: DatasetLike,
+        dims: Optional[Union[List[str], Tuple[str]]] = None) -> DatasetLike:
     """Transpose dimensions of a variable, an data array, or a dataset.
 
     :param x: Object to transpose.
     :param dims: List of dimensions in desired order. If default,
-                        reverses existing order.
-    :type x: Variable, DataArray, or Dataset
-    :type dims: list[str]
+                 reverses existing order.
     :raises: If the dtype or unit does not match, or if the
              dimensions and shapes are incompatible.
     :return: The absolute values of the input.
     """
-    return _call_cpp_func(_cpp.transpose, x, dims)
+    return _call_cpp_func(_cpp.transpose, x, dims if dims is not None else [])

--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .utils.typing import DataArrayLike
+from .typing import DataArrayLike
 
 
 def sin(x: DataArrayLike,

--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -85,7 +85,8 @@ def atan(x: DataArrayLike,
     return _call_cpp_func(_cpp.atan, x, out=out)
 
 
-def atan2(y: _cpp.Variable,
+def atan2(*,
+          y: _cpp.Variable,
           x: _cpp.Variable,
           out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise inverse tangent of y/x determining the correct quadrant.

--- a/python/src/scipp/_trigonometry.py
+++ b/python/src/scipp/_trigonometry.py
@@ -1,85 +1,101 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+
+from __future__ import annotations
+from typing import Optional
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .utils.typing import DataArrayLike
 
 
-def sin(x, out=None):
-    """Element-wise sin.
+def sin(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise sine.
 
     :param x: Input data.
     :param out: Optional output buffer.
-    :raises: If the unit is not a plane-angle unit, or if the sin cannot be
+    :raises: If the unit is not a plane-angle unit, or if the sine cannot be
              computed on the dtype, e.g., if it is an integer.
-    :return: The sin values of the input.
+    :return: The sine values of the input.
     """
     return _call_cpp_func(_cpp.sin, x, out=out)
 
 
-def cos(x, out=None):
-    """Element-wise cos.
+def cos(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise cosine.
 
     :param x: Input data.
     :param out: Optional output buffer.
-    :raises: If the unit is not a plane-angle unit, or if the cos cannot be
+    :raises: If the unit is not a plane-angle unit, or if the cosine cannot be
              computed on the dtype, e.g., if it is an integer.
-    :return: The cos values of the input.
+    :return: The cosine values of the input.
     """
     return _call_cpp_func(_cpp.cos, x, out=out)
 
 
-def tan(x, out=None):
-    """Element-wise tan.
+def tan(x: DataArrayLike,
+        out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise tangent.
 
     :param x: Input data.
     :param out: Optional output buffer.
-    :raises: If the unit is not a plane-angle unit, or if the tan cannot be
+    :raises: If the unit is not a plane-angle unit, or if the tangent cannot be
              computed on the dtype, e.g., if it is an integer.
-    :return: The tan values of the input.
+    :return: The tangent values of the input.
     """
     return _call_cpp_func(_cpp.tan, x, out=out)
 
 
-def asin(x, out=None):
-    """Element-wise inverse sin.
+def asin(x: DataArrayLike,
+         out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise inverse sine.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The inverse sin values of the input.
+    :return: The inverse sine values of the input.
     """
     return _call_cpp_func(_cpp.asin, x, out=out)
 
 
-def acos(x, out=None):
-    """Element-wise inverse cos.
+def acos(x: DataArrayLike,
+         out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise inverse cosine.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The inverse cos values of the input.
+    :return: The inverse cosine values of the input.
     """
     return _call_cpp_func(_cpp.acos, x, out=out)
 
 
-def atan(x, out=None):
-    """Element-wise inverse tan.
+def atan(x: DataArrayLike,
+         out: Optional[DataArrayLike] = None) -> DataArrayLike:
+    """Element-wise inverse tangent.
 
     :param x: Input data.
     :param out: Optional output buffer.
     :raises: If the unit is not dimensionless.
-    :return: The inverse tan values of the input.
+    :return: The inverse tangent values of the input.
     """
     return _call_cpp_func(_cpp.atan, x, out=out)
 
 
-def atan2(y, x, out=None):
-    """Element-wise inverse tan providing signed angle.
+def atan2(y: _cpp.Variable,
+          x: _cpp.Variable,
+          out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+    """Element-wise inverse tangent of y/x determining the correct quadrant.
 
     :param y: Input y values.
     :param x: Input x values.
     :param out: Optional output buffer.
-    :return: The signed inverse tan values of the inputs.
+    :return: The signed inverse tangent values of y/x in the range [-π, π].
+    :seealso: All edge cases are documented
+              `here <https://en.cppreference.com/w/c/numeric/math/atan2>`_.
+              Note that domain errors are *not* propagated to Python.
     """
     return _call_cpp_func(_cpp.atan2, y, x, out=out)

--- a/python/src/scipp/_unary.py
+++ b/python/src/scipp/_unary.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+from typing import Union as _Union
+
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from typing import Union as _Union
 
 
 def isnan(x: _cpp.Variable) -> _cpp.Variable:

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -20,15 +20,13 @@ def _parse_dims_shape_sizes(dims, shape, sizes):
     return {"dims": dims, "shape": shape}
 
 
-def islinspace(x):
+def islinspace(x: _cpp.Variable) -> bool:
     """
     Check if the values of a variable are evenly spaced.
 
     :param x: Variable to check.
-    :type x: Variable
     :returns: True if the variable contains regularly spaced values,
       False otherwise.
-    :rtype: bool
     """
     return _call_cpp_func(_cpp.islinspace, x)
 

--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
-from ._scipp import core as _cpp
-from ._cpp_wrapper_util import call_func as _call_cpp_func
+
 from typing import Any as _Any, Sequence as _Sequence, Union as _Union,\
     Optional as _Optional
+
 import numpy as _np
 from numpy.typing import ArrayLike as _ArrayLike
+
+from ._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
 def _parse_dims_shape_sizes(dims, shape, sizes):

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -2,24 +2,25 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Neil Vaytet
 
+from __future__ import annotations
+
 from .._variable import vector, vectors, matrix, matrices
 from .. import utils as su
+from ..utils.typing import DatasetLike
 from .._scipp import core as sc
 
 import numpy as np
 from collections import defaultdict
 
 
-def to_dict(scipp_obj):
+def to_dict(scipp_obj: DatasetLike) -> dict:
     """
     Convert a scipp object (Variable, DataArray or Dataset) to a python dict.
 
     :param scipp_obj: A Variable, DataArray or Dataset to be converted to a
                       python dict.
-    :type scipp_obj: Variable, DataArray, or Dataset
     :return: A dict containing all the information necessary to fully define
              the supplied scipp object.
-    :rtype: dict
     """
     if su.is_variable(scipp_obj):
         return _variable_to_dict(scipp_obj)
@@ -97,7 +98,7 @@ def _dims_to_strings(dims):
     return [str(dim) for dim in dims]
 
 
-def from_dict(dict_obj):
+def from_dict(dict_obj: dict) -> DatasetLike:
     """
     Convert a python dict to a scipp Variable, DataArray or Dataset.
     If the input keys contain both `'coords'` and `'data'`, then a DataArray is
@@ -107,9 +108,7 @@ def from_dict(dict_obj):
     Otherwise, a Dataset is returned.
 
     :param dict_obj: A python dict to be converted to a scipp object.
-    :type dict_obj: dict
     :return: A scipp Variable, DataArray or Dataset.
-    :rtype: Variable, DataArray, or Dataset
     """
     keys_as_set = set(dict_obj.keys())
     if {"coords", "data"}.issubset(keys_as_set):

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 from .._variable import vector, vectors, matrix, matrices
-from .. import utils as su
-from ..utils.typing import DatasetLike
+from ..typing import is_variable, is_data_array, is_dataset
+from ..typing import DatasetLike
 from .._scipp import core as sc
 
 import numpy as np
@@ -22,11 +22,11 @@ def to_dict(scipp_obj: DatasetLike) -> dict:
     :return: A dict containing all the information necessary to fully define
              the supplied scipp object.
     """
-    if su.is_variable(scipp_obj):
+    if is_variable(scipp_obj):
         return _variable_to_dict(scipp_obj)
-    elif su.is_data_array(scipp_obj):
+    elif is_data_array(scipp_obj):
         return _data_array_to_dict(scipp_obj)
-    elif su.is_dataset(scipp_obj):
+    elif is_dataset(scipp_obj):
         # TODO: This currently duplicates all coordinates that would otherwise
         # be at the Dataset level onto the individual DataArrays. We are also
         # manually duplicating all attributes, since these are not carried when

--- a/python/src/scipp/compat/dict.py
+++ b/python/src/scipp/compat/dict.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from .._variable import vector, vectors, matrix, matrices
-from ..typing import is_variable, is_data_array, is_dataset
 from ..typing import DatasetLike
 from .._scipp import core as sc
 
@@ -22,11 +21,11 @@ def to_dict(scipp_obj: DatasetLike) -> dict:
     :return: A dict containing all the information necessary to fully define
              the supplied scipp object.
     """
-    if is_variable(scipp_obj):
+    if isinstance(scipp_obj, sc.Variable):
         return _variable_to_dict(scipp_obj)
-    elif is_data_array(scipp_obj):
+    elif isinstance(scipp_obj, sc.DataArray):
         return _data_array_to_dict(scipp_obj)
-    elif is_dataset(scipp_obj):
+    elif isinstance(scipp_obj, sc.Dataset):
         # TODO: This currently duplicates all coordinates that would otherwise
         # be at the Dataset level onto the individual DataArrays. We are also
         # manually duplicating all attributes, since these are not carried when

--- a/python/src/scipp/html/__init__.py
+++ b/python/src/scipp/html/__init__.py
@@ -5,13 +5,14 @@
 
 from __future__ import annotations
 
-from ..typing import is_variable, DatasetLike
+from ..typing import DatasetLike
+from .._scipp import core as sc
 from .formatting_html import dataset_repr, inject_style, variable_repr
 
 
 def make_html(container: DatasetLike) -> str:
     inject_style()
-    if is_variable(container):
+    if isinstance(container, sc.Variable):
         return variable_repr(container)
     else:
         return dataset_repr(container)

--- a/python/src/scipp/html/__init__.py
+++ b/python/src/scipp/html/__init__.py
@@ -2,11 +2,14 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Dimitar Tasev
-from ..utils.typing import is_variable
+
+from __future__ import annotations
+
+from ..typing import is_variable, DatasetLike
 from .formatting_html import dataset_repr, inject_style, variable_repr
 
 
-def make_html(container):
+def make_html(container: DatasetLike) -> str:
     inject_style()
     if is_variable(container):
         return variable_repr(container)
@@ -14,6 +17,6 @@ def make_html(container):
         return dataset_repr(container)
 
 
-def to_html(container):
+def to_html(container: DatasetLike):
     from IPython.display import display, HTML
     display(HTML(make_html(container)))

--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -8,7 +8,7 @@ from functools import partial, reduce
 from html import escape
 
 from .._scipp import core as sc
-from ..utils import is_data_array, is_dataset
+from ..typing import is_data_array, is_dataset
 from .resources import load_icons
 
 BIN_EDGE_LABEL = "[bin-edge]"

--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -8,7 +8,6 @@ from functools import partial, reduce
 from html import escape
 
 from .._scipp import core as sc
-from ..typing import is_data_array, is_dataset
 from .resources import load_icons
 
 BIN_EDGE_LABEL = "[bin-edge]"
@@ -27,7 +26,7 @@ def _format_array(data, size, ellipsis_after, do_ellide=True):
         if hasattr(elem, "__round__"):
             if not hasattr(data, "dtype") or data.dtype != bool:
                 elem = round(elem, 2)
-        if is_data_array(elem):
+        if isinstance(elem, sc.DataArray):
             dims = ', '.join(f'{dim}: {s}' for dim, s in elem.sizes.items())
             coords = ', '.join(elem.coords)
             if elem.unit == sc.units.one:
@@ -73,7 +72,7 @@ def _get_events(var, variances, ellipsis_after, summary=False):
     dims = var.bins.constituents['data'].dims
     bin_dim = dict(zip(dims, range(len(dims))))[dim]
     s = []
-    if not is_data_array(var.values):
+    if not isinstance(var.values, sc.DataArray):
         size = len(var.values)
         i = 0
 
@@ -114,7 +113,7 @@ def _ordered_dict(data):
 
 def inline_variable_repr(var, has_variances=False):
     if var.bins is None:
-        if is_data_array(var):
+        if isinstance(var, sc.DataArray):
             return _format_non_events(var.data, has_variances)
         else:
             return _format_non_events(var, has_variances)
@@ -342,7 +341,7 @@ def summarize_variable(name,
 
 
 def summarize_data(dataset):
-    has_attrs = is_dataset(dataset)
+    has_attrs = isinstance(dataset, sc.Dataset)
     vars_li = "".join("<li class='sc-var-item'>{}</li>".format(
         summarize_variable(name,
                            var,
@@ -381,7 +380,7 @@ def _mapping_section(mapping,
                      details_func=None,
                      max_items_collapse=None,
                      enabled=True):
-    n_items = 1 if is_data_array(mapping) else len(mapping)
+    n_items = 1 if isinstance(mapping, sc.DataArray) else len(mapping)
     collapsed = n_items >= max_items_collapse
 
     return collapsible_section(
@@ -478,9 +477,10 @@ def dataset_repr(ds):
     if len(ds.coords) > 0:
         sections.append(coord_section(ds.coords, ds))
 
-    sections.append(data_section(ds if is_dataset(ds) else {'': ds}))
+    sections.append(
+        data_section(ds if isinstance(ds, sc.Dataset) else {'': ds}))
 
-    if not is_dataset(ds):
+    if not isinstance(ds, sc.Dataset):
         if len(ds.masks) > 0:
             sections.append(mask_section(ds.masks, ds))
         if len(ds.attrs) > 0:

--- a/python/src/scipp/io/hdf5.py
+++ b/python/src/scipp/io/hdf5.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 
-from ..utils.typing import DatasetLike
+from ..typing import DatasetLike
 
 
 def _dtype_lut():

--- a/python/src/scipp/io/hdf5.py
+++ b/python/src/scipp/io/hdf5.py
@@ -3,6 +3,12 @@
 # @file
 # @author Simon Heybrock
 
+from __future__ import annotations
+from pathlib import Path
+from typing import Union
+
+from ..utils.typing import DatasetLike
+
 
 def _dtype_lut():
     from .._scipp.core import dtype as d
@@ -269,7 +275,7 @@ class HDF5IO:
         return cls._handlers[group.attrs['scipp-type']].read(group)
 
 
-def to_hdf5(obj, filename):
+def to_hdf5(obj: DatasetLike, filename: Union[str, Path]):
     """
     Writes object out to file in hdf5 format.
     """
@@ -278,7 +284,7 @@ def to_hdf5(obj, filename):
         HDF5IO.write(f, obj)
 
 
-def open_hdf5(filename):
+def open_hdf5(filename: Union[str, Path]) -> DatasetLike:
     import h5py
     with h5py.File(filename, 'r') as f:
         return HDF5IO.read(f)

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -6,7 +6,7 @@ from .formatters import VectorFormatter, StringFormatter, \
                         DateFormatter, LabelFormatter
 from .tools import to_bin_edges, to_bin_centers, make_fake_coord, \
                    vars_to_err, find_limits, to_dict
-from ..utils import name_with_unit, vector_type, string_type, datetime_type
+from ..utils import name_with_unit, has_vector_type, has_string_type, has_datetime_type
 from .._scipp import core as sc
 import numpy as np
 import enum
@@ -130,11 +130,11 @@ class PlotModel:
             keys.append(dim_label_map[dim])
 
         for key in keys:
-            if vector_type(data_array.meta[key]):
+            if has_vector_type(data_array.meta[key]):
                 kind[key] = Kind.vector
-            elif string_type(data_array.meta[key]):
+            elif has_string_type(data_array.meta[key]):
                 kind[key] = Kind.string
-            elif datetime_type(data_array.meta[key]):
+            elif has_datetime_type(data_array.meta[key]):
                 kind[key] = Kind.datetime
             else:
                 kind[key] = Kind.other

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -6,7 +6,8 @@ from .formatters import VectorFormatter, StringFormatter, \
                         DateFormatter, LabelFormatter
 from .tools import to_bin_edges, to_bin_centers, make_fake_coord, \
                    vars_to_err, find_limits, to_dict
-from ..utils import name_with_unit, has_vector_type, has_string_type, has_datetime_type
+from ..utils import name_with_unit
+from ..typing import has_vector_type, has_string_type, has_datetime_type
 from .._scipp import core as sc
 import numpy as np
 import enum

--- a/python/src/scipp/plotting/plot.py
+++ b/python/src/scipp/plotting/plot.py
@@ -51,18 +51,18 @@ def _input_to_data_array(item, all_keys, key=None):
     DataArrays.
     """
     to_plot = {}
-    if st.is_dataset(item):
+    if isinstance(item, sc.Dataset):
         for name in sorted(item.keys()):
             if st.has_numeric_type(item[name]):
                 proto_plt_key = f'{key}_{name}' if key else name
                 to_plot[_make_plot_key(proto_plt_key, all_keys)] = item[name]
-    elif st.is_variable(item):
+    elif isinstance(item, sc.Variable):
         if st.has_numeric_type(item):
             if key is None:
                 key = _brief_str(item)
             to_plot[_make_plot_key(key,
                                    all_keys)] = _variable_to_data_array(item)
-    elif st.is_data_array(item):
+    elif isinstance(item, sc.DataArray):
         if st.has_numeric_type(item):
             if key is None:
                 key = item.name

--- a/python/src/scipp/plotting/plot.py
+++ b/python/src/scipp/plotting/plot.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 from .._scipp import core as sc
-from .. import utils as su
+from .. import typing as st
 from ..compat.dict import from_dict
 from .dispatch import dispatch
 from .objects import PlotDict
@@ -51,19 +51,19 @@ def _input_to_data_array(item, all_keys, key=None):
     DataArrays.
     """
     to_plot = {}
-    if su.is_dataset(item):
+    if st.is_dataset(item):
         for name in sorted(item.keys()):
-            if su.has_numeric_type(item[name]):
+            if st.has_numeric_type(item[name]):
                 proto_plt_key = f'{key}_{name}' if key else name
                 to_plot[_make_plot_key(proto_plt_key, all_keys)] = item[name]
-    elif su.is_variable(item):
-        if su.has_numeric_type(item):
+    elif st.is_variable(item):
+        if st.has_numeric_type(item):
             if key is None:
                 key = _brief_str(item)
             to_plot[_make_plot_key(key,
                                    all_keys)] = _variable_to_data_array(item)
-    elif su.is_data_array(item):
-        if su.has_numeric_type(item):
+    elif st.is_data_array(item):
+        if st.has_numeric_type(item):
             if key is None:
                 key = item.name
             to_plot[_make_plot_key(key, all_keys)] = item

--- a/python/src/scipp/plotting/plot.py
+++ b/python/src/scipp/plotting/plot.py
@@ -53,17 +53,17 @@ def _input_to_data_array(item, all_keys, key=None):
     to_plot = {}
     if su.is_dataset(item):
         for name in sorted(item.keys()):
-            if su.numeric_type(item[name]):
+            if su.has_numeric_type(item[name]):
                 proto_plt_key = f'{key}_{name}' if key else name
                 to_plot[_make_plot_key(proto_plt_key, all_keys)] = item[name]
     elif su.is_variable(item):
-        if su.numeric_type(item):
+        if su.has_numeric_type(item):
             if key is None:
                 key = _brief_str(item)
             to_plot[_make_plot_key(key,
                                    all_keys)] = _variable_to_data_array(item)
     elif su.is_data_array(item):
-        if su.numeric_type(item):
+        if su.has_numeric_type(item):
             if key is None:
                 key = item.name
             to_plot[_make_plot_key(key, all_keys)] = item

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -11,7 +11,7 @@ from ._scipp import core as sc
 from . import config
 from .html import inject_style
 from .utils import hex_to_rgb, rgb_to_hex
-from .typing import is_data_array, DatasetLike
+from .typing import DatasetLike
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.
@@ -324,7 +324,7 @@ class DatasetDrawer:
 
     def _dims(self):
         dims = self._dataset.dims
-        if is_data_array(self._dataset):
+        if isinstance(self._dataset, sc.DataArray):
             # Handle, e.g., bin edges of a slice, where data lacks the edge dim
             for item in self._dataset.meta.values():
                 for dim in item.dims:
@@ -366,7 +366,7 @@ class DatasetDrawer:
         area_z = []
         area_xy = []
         area_0d = []
-        if is_data_array(self._dataset):
+        if isinstance(self._dataset, sc.DataArray):
             area_xy.append(DrawerItem('', self._dataset,
                                       config.colors['data']))
         else:
@@ -390,7 +390,7 @@ class DatasetDrawer:
                     area_xy.append(item)
 
         ds = self._dataset
-        if is_data_array(ds):
+        if isinstance(ds, sc.DataArray):
             categories = zip(['coords', 'masks', 'attrs'],
                              [ds.coords, ds.masks, ds.attrs])
         else:

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -10,8 +10,8 @@ import numpy as np
 from ._scipp import core as sc
 from . import config
 from .html import inject_style
-from .utils import is_data_array, hex_to_rgb, rgb_to_hex
-from .utils.typing import DatasetLike
+from .utils import hex_to_rgb, rgb_to_hex
+from .typing import is_data_array, DatasetLike
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.

--- a/python/src/scipp/show.py
+++ b/python/src/scipp/show.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
 from html import escape
+from typing import Optional
+
 import numpy as np
+
 from ._scipp import core as sc
 from . import config
-from .utils import is_data_array, hex_to_rgb, rgb_to_hex
 from .html import inject_style
+from .utils import is_data_array, hex_to_rgb, rgb_to_hex
+from .utils.typing import DatasetLike
 
 # Unit is `em`. This particular value is chosen to avoid a horizontal scroll
 # bar with the readthedocs theme.
@@ -453,7 +458,8 @@ class DatasetDrawer:
                           height)
 
 
-def make_svg(container, content_only=False):
+def make_svg(container: DatasetLike,
+             content_only: Optional[bool] = False) -> str:
     """
     Return a svg representation of a variable or dataset.
     """
@@ -464,7 +470,7 @@ def make_svg(container, content_only=False):
     return draw.make_svg(content_only=content_only)
 
 
-def show(container):
+def show(container: DatasetLike):
     """
     Show a graphical representation of a variable or dataset.
     """

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -11,7 +11,8 @@ from . import config
 from . import utils as su
 from ._scipp import core as sc
 from .html.formatting_html import inject_style
-from .utils.typing import DatasetLike
+from .typing import is_dataset, is_dataset_or_array, is_variable,\
+    is_scalar, DatasetLike
 
 
 def _make_table_sections(dict_of_variables):
@@ -202,8 +203,8 @@ class TableViewer:
         self.headers = 0
         self.trigger_update = True
 
-        if su.is_dataset_or_array(scipp_obj):
-            if su.is_dataset(scipp_obj):
+        if is_dataset_or_array(scipp_obj):
+            if is_dataset(scipp_obj):
                 iterlist = scipp_obj
                 tag_names = ['coords', 'data']
                 tag_keys = [scipp_obj.coords, iterlist]
@@ -238,9 +239,9 @@ class TableViewer:
             ndims = len(scipp_obj.shape)
             if ndims < 2:
                 group = "{}D Variables".format(ndims)
-                if su.is_variable(scipp_obj):
+                if is_variable(scipp_obj):
                     self.headers = 1
-                    key = '' if su.is_scalar(scipp_obj) else str(
+                    key = '' if is_scalar(scipp_obj) else str(
                         scipp_obj.dims[0])
                     var = scipp_obj
                 else:

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -11,8 +11,7 @@ from . import config
 from . import utils as su
 from ._scipp import core as sc
 from .html.formatting_html import inject_style
-from .typing import is_dataset, is_dataset_or_array, is_variable,\
-    is_scalar, DatasetLike
+from .typing import is_scalar, DatasetLike
 
 
 def _make_table_sections(dict_of_variables):
@@ -203,8 +202,8 @@ class TableViewer:
         self.headers = 0
         self.trigger_update = True
 
-        if is_dataset_or_array(scipp_obj):
-            if is_dataset(scipp_obj):
+        if isinstance(scipp_obj, (sc.DataArray, sc.Dataset)):
+            if isinstance(scipp_obj, sc.Dataset):
                 iterlist = scipp_obj
                 tag_names = ['coords', 'data']
                 tag_keys = [scipp_obj.coords, iterlist]
@@ -239,7 +238,7 @@ class TableViewer:
             ndims = len(scipp_obj.shape)
             if ndims < 2:
                 group = "{}D Variables".format(ndims)
-                if is_variable(scipp_obj):
+                if isinstance(scipp_obj, sc.Variable):
                     self.headers = 1
                     key = '' if is_scalar(scipp_obj) else str(
                         scipp_obj.dims[0])

--- a/python/src/scipp/table.py
+++ b/python/src/scipp/table.py
@@ -3,6 +3,7 @@
 # @file
 # @author Igor Gudich & Neil Vaytet
 
+from __future__ import annotations
 from html import escape
 
 # Scipp imports
@@ -10,6 +11,7 @@ from . import config
 from . import utils as su
 from ._scipp import core as sc
 from .html.formatting_html import inject_style
+from .utils.typing import DatasetLike
 
 
 def _make_table_sections(dict_of_variables):
@@ -171,7 +173,7 @@ def _is_bin_centers(container, var, dim):
     return max(largest) == var.shape[0] + 1 if len(largest) > 0 else False
 
 
-def table(scipp_obj):
+def table(scipp_obj: DatasetLike):
     """
     Create a html table from the contents of a Dataset (0D and 1D Variables
     only), DataArray, Variable or raw numpy array.

--- a/python/src/scipp/typing.py
+++ b/python/src/scipp/typing.py
@@ -8,39 +8,11 @@ import typing as _std_typing
 from ._scipp import core as sc
 
 
-def is_variable(obj: _std_typing.Any) -> bool:
-    """
-    Return True if the input is of type scipp.Variable.
-    """
-    return isinstance(obj, sc.Variable)
-
-
 def is_scalar(obj: _std_typing.Any) -> bool:
     """
     Return True if the input is a scalar.
     """
     return obj.dims == []
-
-
-def is_dataset(obj: _std_typing.Any) -> bool:
-    """
-    Return True if the input is of type scipp.Dataset.
-    """
-    return isinstance(obj, sc.Dataset)
-
-
-def is_data_array(obj: _std_typing.Any) -> bool:
-    """
-    Return True if the input is of type scipp.DataArray.
-    """
-    return isinstance(obj, sc.DataArray)
-
-
-def is_dataset_or_array(obj: _std_typing.Any) -> bool:
-    """
-    Return True if the input object is either a scipp.Dataset or DataArray.
-    """
-    return is_dataset(obj) or is_data_array(obj)
 
 
 def has_vector_type(obj: _std_typing.Any) -> bool:

--- a/python/src/scipp/typing.py
+++ b/python/src/scipp/typing.py
@@ -5,7 +5,7 @@
 
 import typing as _std_typing
 
-from .._scipp import core as sc
+from ._scipp import core as sc
 
 
 def is_variable(obj: _std_typing.Any) -> bool:

--- a/python/src/scipp/utils/__init__.py
+++ b/python/src/scipp/utils/__init__.py
@@ -7,7 +7,6 @@
 
 from .collapse_and_slices import *
 from .colors import *
-from .typing import *
 from .to_string import *
 from .comparison import *
 from .get import *

--- a/python/src/scipp/utils/typing.py
+++ b/python/src/scipp/utils/typing.py
@@ -3,6 +3,8 @@
 # @file
 # @author Neil Vaytet
 
+import typing as _std_typing
+
 from .._scipp import core as sc
 
 
@@ -67,3 +69,6 @@ def numeric_type(obj):
     Return False if the dtype is either vector or string.
     """
     return (not vector_type(obj)) and (not string_type(obj))
+
+
+DataArrayLike = _std_typing.Union[sc.Variable, sc.DataArray]

--- a/python/src/scipp/utils/typing.py
+++ b/python/src/scipp/utils/typing.py
@@ -72,3 +72,4 @@ def numeric_type(obj):
 
 
 DataArrayLike = _std_typing.Union[sc.Variable, sc.DataArray]
+DatasetLike = _std_typing.Union[DataArrayLike, sc.Dataset]

--- a/python/src/scipp/utils/typing.py
+++ b/python/src/scipp/utils/typing.py
@@ -8,68 +8,72 @@ import typing as _std_typing
 from .._scipp import core as sc
 
 
-def is_variable(obj):
+def is_variable(obj: _std_typing.Any) -> bool:
     """
-    Return True if the input is of type scipp.core.Variable.
+    Return True if the input is of type scipp.Variable.
     """
     return isinstance(obj, sc.Variable)
 
 
-def is_scalar(obj):
+def is_scalar(obj: _std_typing.Any) -> bool:
     """
-    Return True if the input is a scalar
+    Return True if the input is a scalar.
     """
     return obj.dims == []
 
 
-def is_dataset(obj):
+def is_dataset(obj: _std_typing.Any) -> bool:
     """
-    Return True if the input is of type scipp.core.Variable.
+    Return True if the input is of type scipp.Dataset.
     """
     return isinstance(obj, sc.Dataset)
 
 
-def is_data_array(obj):
+def is_data_array(obj: _std_typing.Any) -> bool:
     """
-    Return True if the input is of type scipp.core.Variable.
+    Return True if the input is of type scipp.DataArray.
     """
     return isinstance(obj, sc.DataArray)
 
 
-def is_dataset_or_array(obj):
+def is_dataset_or_array(obj: _std_typing.Any) -> bool:
     """
-    Return True if the input object is either a Dataset or DataArray.
+    Return True if the input object is either a scipp.Dataset or DataArray.
     """
     return is_dataset(obj) or is_data_array(obj)
 
 
-def vector_type(obj):
+def has_vector_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is vector_3_float64.
     """
     return obj.dtype == sc.dtype.vector_3_float64
 
 
-def string_type(obj):
+def has_string_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is string.
     """
     return obj.dtype == sc.dtype.string
 
 
-def datetime_type(obj):
+def has_datetime_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is datetime64.
     """
     return obj.dtype == sc.dtype.datetime64
 
 
-def numeric_type(obj):
+def has_numeric_type(obj: _std_typing.Any) -> bool:
     """
     Return False if the dtype is either vector or string.
     """
-    return (not vector_type(obj)) and (not string_type(obj))
+    return (not has_vector_type(obj)) and (not has_string_type(obj))
 
 
+#: Any object that behaves like a scipp.DataArray in most operations.
+#: This explicitly excludes Datasets.
 DataArrayLike = _std_typing.Union[sc.Variable, sc.DataArray]
+
+#: Any object that behaves like a scipp.Dataset in most operations.
 DatasetLike = _std_typing.Union[DataArrayLike, sc.Dataset]

--- a/python/tests/lifetime_test.py
+++ b/python/tests/lifetime_test.py
@@ -159,7 +159,7 @@ def test_lifetime_inverse_trigonometry_out_arg(func):
 
 def test_lifetime_atan2_out_arg():
     var = 1.0 * sc.units.one
-    var = sc.atan2(var, var, out=var)
+    var = sc.atan2(y=var, x=var, out=var)
     var *= 1.0  # var would be an invalid view is keep_alive not correct
 
 

--- a/python/tests/variable_comparison_test.py
+++ b/python/tests/variable_comparison_test.py
@@ -25,7 +25,7 @@ def test_comparison_op_exports_for_variable():
 def test_isclose():
     unit = sc.units.one
     a = sc.Variable(['x'], values=np.array([1, 2, 3]), unit=unit)
-    assert sc.all(sc.isclose(a, a, 0 * unit, 0 * unit)).value
+    assert sc.all(sc.isclose(a, a, rtol=0 * unit, atol=0 * unit)).value
 
 
 def test_isclose_atol_defaults():

--- a/python/tests/variable_test.py
+++ b/python/tests/variable_test.py
@@ -994,7 +994,7 @@ def test_isneginf():
 def test_nan_to_num():
     a = sc.Variable(dims=['x'], values=np.array([1, np.nan]))
     replace = sc.Variable(value=0.0)
-    b = sc.nan_to_num(a, replace)
+    b = sc.nan_to_num(a, nan=replace)
     expected = sc.Variable(dims=['x'], values=np.array([1, replace.value]))
     assert sc.identical(b, expected)
 


### PR DESCRIPTION
Did I miss anything?

I am not too happy with 'DataArrayLike' and 'DatasetLike' but I could not think of a better name to capture the difference between the two.