### PR TITLE
Add constructors from scalar numpy arrays

### DIFF
--- a/python/numpy.h
+++ b/python/numpy.h
@@ -66,6 +66,13 @@ auto cast_to_array_like(const py::object &obj, const units::Unit unit) {
     // solution for other types.
     // TODO Related to #290, we should properly support
     //  multi-dimensional input, and ignore bad shapes.
+    if (obj.attr("ndim").cast<int>() > 1) {
+      const auto &array = obj.cast<py::array>();
+      std::ostringstream oss;
+      oss << "Support for numpy arrays of dtype " << py::str(array.dtype())
+          << " of more than one dimension is not implemented.";
+      throw std::invalid_argument(oss.str());
+    }
     try {
       return obj.cast<const std::vector<PyType>>();
     } catch (std::runtime_error &) {

--- a/python/tests/variable_test.py
+++ b/python/tests/variable_test.py
@@ -87,6 +87,32 @@ def test_create_with_variances_from_numpy_1d():
     np.testing.assert_array_equal(var.variances, np.arange(4, 8))
 
 
+def test_create_from_numpy_0d():
+    var = sc.Variable(value=np.array(1.0))
+    assert var.dtype == sc.dtype.float64
+    assert var.value == 1.0
+
+
+def test_create_with_variance_from_numpy_0d():
+    var = sc.Variable(value=np.array(1.0), variance=np.array(0.1))
+    assert var.dtype == sc.dtype.float64
+    assert var.value == 1.0
+    assert var.variance == 0.1
+
+
+def test_create_from_numpy_0d_string():
+    var = sc.Variable(value=np.array('a string'))
+    assert var.dtype == sc.dtype.string
+    assert var.value == 'a string'
+
+
+def test_create_from_numpy_0d_datetime():
+    var = sc.Variable(value=np.array(np.datetime64(0, 's')))
+    assert var.dtype == sc.dtype.datetime64
+    assert var.unit == sc.units.s
+    assert var.value == np.datetime64(0, 's')
+
+
 @pytest.mark.parametrize(
     "value",
     [1.2, np.float64(1.2), sc.Variable(1.2).value])

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -37,6 +37,9 @@ namespace py = pybind11;
 
 namespace {
 template <class T> void check_dtype_matches(const py::object &dtype) {
+  if (dtype.is_none()) {
+    return;
+  }
   const auto requested_dtype = scipp_dtype(dtype);
   const auto data_dtype =
       scipp::dtype<std::conditional_t<std::is_same_v<T, py::object>,


### PR DESCRIPTION
Fixes #1974

Note that higher dimensional arrays still don't work:
```.py
sc.Variable(values=np.array([["1", "2"]]), dims=["x", "y"])
```
This would require a more complicated change away from `std::vector`.