### PR TITLE
Better error for isclose and allclose

### DIFF
--- a/common/include/scipp/common/except.h
+++ b/common/include/scipp/common/except.h
@@ -6,6 +6,7 @@
 
 #include <initializer_list>
 #include <stdexcept>
+#include <string>
 
 namespace scipp::except {
 
@@ -18,10 +19,11 @@ template <class T> struct Error : public std::runtime_error {
 
 template <class Expected, class Actual>
 [[noreturn]] void throw_mismatch_error(const Expected &expected,
-                                       const Actual &actual) {
+                                       const Actual &actual,
+                                       std::string optional_message) {
   throw Error<std::decay_t<Expected>>("Expected  " + to_string(expected) +
                                       " to be equal to " + to_string(actual) +
-                                      '.');
+                                      '.' + optional_message);
 }
 
 template <class Expected, class Actual>

--- a/common/include/scipp/common/except.h
+++ b/common/include/scipp/common/except.h
@@ -20,7 +20,7 @@ template <class T> struct Error : public std::runtime_error {
 template <class Expected, class Actual>
 [[noreturn]] void throw_mismatch_error(const Expected &expected,
                                        const Actual &actual,
-                                       std::string optional_message) {
+                                       const std::string &optional_message) {
   throw Error<std::decay_t<Expected>>("Expected  " + to_string(expected) +
                                       " to be equal to " + to_string(actual) +
                                       '.' + optional_message);

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -13,9 +13,10 @@ TypeError::TypeError(const std::string &msg) : Error{msg} {}
 
 template <>
 void throw_mismatch_error(const core::DType &expected,
-                          const core::DType &actual) {
+                          const core::DType &actual,
+                          std::string optional_message) {
   throw TypeError("Expected dtype " + to_string(expected) + ", got " +
-                  to_string(actual) + '.');
+                  to_string(actual) + '.' + optional_message);
 }
 
 DimensionError::DimensionError(const std::string &msg)
@@ -37,16 +38,18 @@ template <class T> std::string format_dims(const T &dims) {
 
 template <>
 void throw_mismatch_error(const core::Sizes &expected,
-                          const core::Sizes &actual) {
+                          const core::Sizes &actual,
+                          std::string optional_message) {
   throw DimensionError("Expected " + format_dims(expected) + ", got " +
-                       format_dims(actual) + '.');
+                       format_dims(actual) + '.' + optional_message);
 }
 
 template <>
 void throw_mismatch_error(const core::Dimensions &expected,
-                          const core::Dimensions &actual) {
+                          const core::Dimensions &actual,
+                          std::string optional_message) {
   throw DimensionError("Expected " + format_dims(expected) + ", got " +
-                       format_dims(actual) + '.');
+                       format_dims(actual) + '.' + optional_message);
 }
 
 void throw_dimension_length_error(const core::Dimensions &expected, Dim actual,

--- a/core/except.cpp
+++ b/core/except.cpp
@@ -14,7 +14,7 @@ TypeError::TypeError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const core::DType &expected,
                           const core::DType &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw TypeError("Expected dtype " + to_string(expected) + ", got " +
                   to_string(actual) + '.' + optional_message);
 }
@@ -39,7 +39,7 @@ template <class T> std::string format_dims(const T &dims) {
 template <>
 void throw_mismatch_error(const core::Sizes &expected,
                           const core::Sizes &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw DimensionError("Expected " + format_dims(expected) + ", got " +
                        format_dims(actual) + '.' + optional_message);
 }
@@ -47,7 +47,7 @@ void throw_mismatch_error(const core::Sizes &expected,
 template <>
 void throw_mismatch_error(const core::Dimensions &expected,
                           const core::Dimensions &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw DimensionError("Expected " + format_dims(expected) + ", got " +
                        format_dims(actual) + '.' + optional_message);
 }

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -37,7 +37,7 @@ struct SCIPP_CORE_EXPORT TypeError : public Error<core::DType> {
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_mismatch_error(const core::DType &expected, const core::DType &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
   explicit DimensionError(const std::string &msg);
@@ -47,13 +47,13 @@ struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_mismatch_error(const core::Sizes &expected, const core::Sizes &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_mismatch_error(const core::Dimensions &expected,
                      const core::Dimensions &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_dimension_length_error(const core::Dimensions &expected, Dim actual,

--- a/core/include/scipp/core/except.h
+++ b/core/include/scipp/core/except.h
@@ -36,7 +36,8 @@ struct SCIPP_CORE_EXPORT TypeError : public Error<core::DType> {
 
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
-throw_mismatch_error(const core::DType &expected, const core::DType &actual);
+throw_mismatch_error(const core::DType &expected, const core::DType &actual,
+                     std::string optional_message);
 
 struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
   explicit DimensionError(const std::string &msg);
@@ -45,12 +46,14 @@ struct SCIPP_CORE_EXPORT DimensionError : public Error<core::Dimensions> {
 
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
-throw_mismatch_error(const core::Sizes &expected, const core::Sizes &actual);
+throw_mismatch_error(const core::Sizes &expected, const core::Sizes &actual,
+                     std::string optional_message);
 
 template <>
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_mismatch_error(const core::Dimensions &expected,
-                     const core::Dimensions &actual);
+                     const core::Dimensions &actual,
+                     std::string optional_message);
 
 [[noreturn]] SCIPP_CORE_EXPORT void
 throw_dimension_length_error(const core::Dimensions &expected, Dim actual,
@@ -101,9 +104,10 @@ template <class A, class B> void includes(const A &a, const B &b) {
 } // namespace scipp::expect
 
 namespace scipp::core::expect {
-template <class A, class B> void equals(const A &a, const B &b) {
+template <class A, class B>
+void equals(const A &a, const B &b, std::string optional_message = "") {
   if (a != b)
-    scipp::except::throw_mismatch_error(a, b);
+    scipp::except::throw_mismatch_error(a, b, optional_message);
 }
 
 template <class A, class B>
@@ -123,8 +127,10 @@ void sizeMatches(const T &range, const Ts &... other) {
 
 inline auto to_string(const std::string &s) { return s; }
 
-template <class T> void unit(const T &object, const units::Unit &unit) {
-  expect::equals(object.unit(), unit);
+template <class T>
+void unit(const T &object, const units::Unit &unit,
+          std::string optional_message = "") {
+  expect::equals(object.unit(), unit, optional_message);
 }
 
 template <class T>

--- a/dataset/except.cpp
+++ b/dataset/except.cpp
@@ -12,7 +12,7 @@ DataArrayError::DataArrayError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const dataset::DataArray &expected,
                           const dataset::DataArray &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw DataArrayError("Expected DataArray " + to_string(expected) + ", got " +
                        to_string(actual) + '.' + optional_message);
 }
@@ -22,7 +22,7 @@ DatasetError::DatasetError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const dataset::Dataset &expected,
                           const dataset::Dataset &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw DatasetError("Expected Dataset " + to_string(expected) + ", got " +
                      to_string(actual) + '.' + optional_message);
 }

--- a/dataset/except.cpp
+++ b/dataset/except.cpp
@@ -11,18 +11,20 @@ DataArrayError::DataArrayError(const std::string &msg) : Error{msg} {}
 
 template <>
 void throw_mismatch_error(const dataset::DataArray &expected,
-                          const dataset::DataArray &actual) {
+                          const dataset::DataArray &actual,
+                          std::string optional_message) {
   throw DataArrayError("Expected DataArray " + to_string(expected) + ", got " +
-                       to_string(actual) + '.');
+                       to_string(actual) + '.' + optional_message);
 }
 
 DatasetError::DatasetError(const std::string &msg) : Error{msg} {}
 
 template <>
 void throw_mismatch_error(const dataset::Dataset &expected,
-                          const dataset::Dataset &actual) {
+                          const dataset::Dataset &actual,
+                          std::string optional_message) {
   throw DatasetError("Expected Dataset " + to_string(expected) + ", got " +
-                     to_string(actual) + '.');
+                     to_string(actual) + '.' + optional_message);
 }
 
 CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,

--- a/dataset/include/scipp/dataset/except.h
+++ b/dataset/include/scipp/dataset/except.h
@@ -31,7 +31,7 @@ template <>
 [[noreturn]] SCIPP_DATASET_EXPORT void
 throw_mismatch_error(const dataset::DataArray &expected,
                      const dataset::DataArray &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 struct SCIPP_DATASET_EXPORT DatasetError : public Error<dataset::Dataset> {
   explicit DatasetError(const std::string &msg);
@@ -41,7 +41,7 @@ template <>
 [[noreturn]] SCIPP_DATASET_EXPORT void
 throw_mismatch_error(const dataset::Dataset &expected,
                      const dataset::Dataset &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
   CoordMismatchError(const Dim dim, const Variable &expected,

--- a/dataset/include/scipp/dataset/except.h
+++ b/dataset/include/scipp/dataset/except.h
@@ -30,7 +30,8 @@ struct SCIPP_DATASET_EXPORT DataArrayError : public Error<dataset::DataArray> {
 template <>
 [[noreturn]] SCIPP_DATASET_EXPORT void
 throw_mismatch_error(const dataset::DataArray &expected,
-                     const dataset::DataArray &actual);
+                     const dataset::DataArray &actual,
+                     std::string optional_message);
 
 struct SCIPP_DATASET_EXPORT DatasetError : public Error<dataset::Dataset> {
   explicit DatasetError(const std::string &msg);
@@ -39,7 +40,8 @@ struct SCIPP_DATASET_EXPORT DatasetError : public Error<dataset::Dataset> {
 template <>
 [[noreturn]] SCIPP_DATASET_EXPORT void
 throw_mismatch_error(const dataset::Dataset &expected,
-                     const dataset::Dataset &actual);
+                     const dataset::Dataset &actual,
+                     std::string optional_message);
 
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
   CoordMismatchError(const Dim dim, const Variable &expected,

--- a/units/except.cpp
+++ b/units/except.cpp
@@ -10,7 +10,7 @@ UnitError::UnitError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const units::Unit &expected,
                           const units::Unit &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw UnitError("Expected unit " + to_string(expected) + ", got " +
                   to_string(actual) + '.' + optional_message);
 }

--- a/units/except.cpp
+++ b/units/except.cpp
@@ -9,8 +9,9 @@ UnitError::UnitError(const std::string &msg) : Error{msg} {}
 
 template <>
 void throw_mismatch_error(const units::Unit &expected,
-                          const units::Unit &actual) {
+                          const units::Unit &actual,
+                          std::string optional_message) {
   throw UnitError("Expected unit " + to_string(expected) + ", got " +
-                  to_string(actual) + '.');
+                  to_string(actual) + '.' + optional_message);
 }
 } // namespace scipp::except

--- a/units/include/scipp/units/except.h
+++ b/units/include/scipp/units/except.h
@@ -18,6 +18,6 @@ struct SCIPP_UNITS_EXPORT UnitError : public Error<units::Unit> {
 template <>
 [[noreturn]] SCIPP_UNITS_EXPORT void
 throw_mismatch_error(const units::Unit &expected, const units::Unit &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 } // namespace scipp::except

--- a/units/include/scipp/units/except.h
+++ b/units/include/scipp/units/except.h
@@ -17,6 +17,7 @@ struct SCIPP_UNITS_EXPORT UnitError : public Error<units::Unit> {
 
 template <>
 [[noreturn]] SCIPP_UNITS_EXPORT void
-throw_mismatch_error(const units::Unit &expected, const units::Unit &actual);
+throw_mismatch_error(const units::Unit &expected, const units::Unit &actual,
+                     std::string optional_message);
 
 } // namespace scipp::except

--- a/variable/comparison.cpp
+++ b/variable/comparison.cpp
@@ -22,9 +22,7 @@ Variable _values(Variable &&in) { return in.hasVariances() ? values(in) : in; }
 
 Variable isclose(const Variable &a, const Variable &b, const Variable &rtol,
                  const Variable &atol, const NanComparisons equal_nans) {
-  if (rtol.unit() != scipp::units::dimensionless)
-    throw except::UnitError("rtol arg must be dimensionless, but has unit " +
-                            to_string(rtol.unit()));
+  core::expect::unit(rtol, scipp::units::dimensionless, " For rtol arg");
   // Element expansion comparison for vectors
   if (a.dtype() == dtype<Eigen::Vector3d>)
     return all(isclose(a.elements<Eigen::Vector3d>(),

--- a/variable/comparison.cpp
+++ b/variable/comparison.cpp
@@ -4,6 +4,7 @@
 /// @author Piotr Rozyczko
 #include "scipp/core/element/comparison.h"
 #include "scipp/core/eigen.h"
+#include "scipp/units/string.h"
 #include "scipp/variable/comparison.h"
 #include "scipp/variable/math.h"
 #include "scipp/variable/reduction.h"
@@ -21,6 +22,9 @@ Variable _values(Variable &&in) { return in.hasVariances() ? values(in) : in; }
 
 Variable isclose(const Variable &a, const Variable &b, const Variable &rtol,
                  const Variable &atol, const NanComparisons equal_nans) {
+  if (rtol.unit() != scipp::units::dimensionless)
+    throw except::UnitError("rtol arg must be dimensionless, but has unit " +
+                            to_string(rtol.unit()));
   // Element expansion comparison for vectors
   if (a.dtype() == dtype<Eigen::Vector3d>)
     return all(isclose(a.elements<Eigen::Vector3d>(),

--- a/variable/except.cpp
+++ b/variable/except.cpp
@@ -10,9 +10,10 @@ VariableError::VariableError(const std::string &msg) : Error{msg} {}
 
 template <>
 void throw_mismatch_error(const variable::Variable &expected,
-                          const variable::Variable &actual) {
+                          const variable::Variable &actual,
+                          std::string optional_message) {
   throw VariableError("Expected\n" + to_string(expected) + ", got\n" +
-                      to_string(actual) + '.');
+                      to_string(actual) + '.' + optional_message);
 }
 } // namespace scipp::except
 

--- a/variable/except.cpp
+++ b/variable/except.cpp
@@ -11,7 +11,7 @@ VariableError::VariableError(const std::string &msg) : Error{msg} {}
 template <>
 void throw_mismatch_error(const variable::Variable &expected,
                           const variable::Variable &actual,
-                          std::string optional_message) {
+                          const std::string &optional_message) {
   throw VariableError("Expected\n" + to_string(expected) + ", got\n" +
                       to_string(actual) + '.' + optional_message);
 }

--- a/variable/include/scipp/variable/except.h
+++ b/variable/include/scipp/variable/except.h
@@ -20,7 +20,8 @@ struct SCIPP_VARIABLE_EXPORT VariableError : public Error<variable::Variable> {
 template <>
 [[noreturn]] SCIPP_VARIABLE_EXPORT void
 throw_mismatch_error(const variable::Variable &expected,
-                     const variable::Variable &actual);
+                     const variable::Variable &actual,
+                     std::string optional_message);
 
 } // namespace scipp::except
 

--- a/variable/include/scipp/variable/except.h
+++ b/variable/include/scipp/variable/except.h
@@ -21,7 +21,7 @@ template <>
 [[noreturn]] SCIPP_VARIABLE_EXPORT void
 throw_mismatch_error(const variable::Variable &expected,
                      const variable::Variable &actual,
-                     std::string optional_message);
+                     const std::string &optional_message);
 
 } // namespace scipp::except
 

--- a/variable/test/comparison_test.cpp
+++ b/variable/test/comparison_test.cpp
@@ -46,6 +46,7 @@ TYPED_TEST(IsCloseTest, rtol_when_variables_within_tolerance) {
   const auto atol = makeVariable<TypeParam>(Values{0});
   EXPECT_EQ(isclose(a, b, rtol, atol), true * units::one);
 }
+
 TYPED_TEST(IsCloseTest, rtol_when_variables_outside_tolerance) {
   const auto a = makeVariable<TypeParam>(Values{7});
   const auto b = makeVariable<TypeParam>(Values{9});
@@ -54,6 +55,7 @@ TYPED_TEST(IsCloseTest, rtol_when_variables_outside_tolerance) {
   const auto atol = makeVariable<TypeParam>(Values{0});
   EXPECT_EQ(isclose(a, b, rtol, atol), false * units::one);
 }
+
 TEST(IsCloseTest, with_vectors) {
   const auto u =
       makeVariable<Eigen::Vector3d>(Values{Eigen::Vector3d{0, 0, 0}});
@@ -119,6 +121,18 @@ TEST(IsCloseTest, compare_values_and_variances) {
                     makeVariable<double>(Values{1.0})),
             true * units::one);
 }
+
+TEST(IsCloseTest, rtol_units) {
+  auto unit = scipp::units::m;
+  const auto a = makeVariable<double>(Values{1.0}, Variances{1.0}, unit);
+  // This is fine
+  EXPECT_EQ(isclose(a, a, 1.0 * scipp::units::one, 1.0 * unit),
+            true * scipp::units::one);
+  // Now rtol has units m
+  EXPECT_THROW_DISCARD(isclose(a, a, 1.0 * unit, 1.0 * unit),
+                       except::UnitError);
+}
+
 TEST(ComparisonTest, variances_test) {
   const auto a = makeVariable<float>(Values{1.0}, Variances{1.0});
   const auto b = makeVariable<float>(Values{2.0}, Variances{2.0});


### PR DESCRIPTION
Avoid confusing errors for users if rtol is not dimensionless. Otherwise they get an error relating to internals of operations, namely the error from 

`rtol * abs(b) + atol` which in the case of K, would be ```Cannot add K and K^2```, they now get a clearer error: ```rtol arg must be dimensionless, but has unit K```