### PR TITLE
Sponsors for license

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This is also the place to ask new questions that have not been answered yet, by 
 
 If you are interested in developing Scipp, please see the [developer getting started guide](https://scipp.github.io/developer/getting-started.html).
 
-## Sponsors
+## Contributing Organizations
 
-The following organisations have made major contributions to the development of scipp, and other developments in the [scipp ecosystem](../../../):
+The following organizations have made major contributions to the development of scipp, and other developments in the [scipp ecosystem](../../../):
 
 * [European Spallation Source ERIC](https://europeanspallationsource.se/), Sweden
 * [Science and Technology Funding Council](https://stfc.ukri.org/councils/stfc), UK

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ If you are interested in developing Scipp, please see the [developer getting sta
 
 ## Sponsors
 
-The following organisations have contributed development effort into the production of scipp and other developments in the [scipp ecosystem](../../../):
+The following organisations have made major contributions to the development of scipp, and other developments in the [scipp ecosystem](../../../):
 
 * [European Spallation Source ERIC](https://europeanspallationsource.se/), Sweden
 * [Science and Technology Funding Council](https://stfc.ukri.org/councils/stfc), UK
-* [Institut Laue-Langevin, France](https://www.ill.eu/), France
 
 See individual [release notes](https://scipp.github.io/about/release-notes.html) for the individual contributors to each release 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If you are interested in developing Scipp, please see the [developer getting sta
 
 The following organisations have contributed development effort into the production of scipp and other developments in the [scipp ecosystem](../../../):
 
-* [European Spallation Source](https://europeanspallationsource.se/) 
-* [ISIS Neutron and Muon Source](https://stfc.ukri.org/research/our-science-facilities/isis-neutron-and-muon-source/)
-* [Institut Laue-Langevin](https://www.ill.eu/)
+* [Data Management and Software Centre, European Spallation Source, Sweden](https://europeanspallationsource.se/) 
+* [UKRI, UK](https://stfc.ukri.org/research/our-science-facilities/isis-neutron-and-muon-source/)
+* [Institut Laue-Langevin, France](https://www.ill.eu/)
 
 See individual [release notes](https://scipp.github.io/about/release-notes.html) for the individual contributors to each release 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ See [here](https://github.com/scipp/scipp/issues?utf8=%E2%9C%93&q=label%3Aquesti
 This is also the place to ask new questions that have not been answered yet, by [opening](https://github.com/scipp/scipp/issues/new?assignees=&labels=question&template=question.md&title=) a new **Question** issue.
 
 If you are interested in developing Scipp, please see the [developer getting started guide](https://scipp.github.io/developer/getting-started.html).
+
+## Sponsors
+
+The following organisations have contributed development effort into the production of scipp and other developments in the [scipp ecosystem](../../../):
+
+* [European Spallation Source](https://europeanspallationsource.se/) 
+* [ISIS Neutron and Muon Source](https://stfc.ukri.org/research/our-science-facilities/isis-neutron-and-muon-source/)
+* [Institut Laue-Langevin](https://www.ill.eu/)
+
+See individual [release notes](https://scipp.github.io/about/release-notes.html) for the individual contributors to each release 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If you are interested in developing Scipp, please see the [developer getting sta
 
 The following organisations have contributed development effort into the production of scipp and other developments in the [scipp ecosystem](../../../):
 
-* [Data Management and Software Centre, European Spallation Source, Sweden](https://europeanspallationsource.se/) 
-* [UKRI, UK](https://stfc.ukri.org/research/our-science-facilities/isis-neutron-and-muon-source/)
-* [Institut Laue-Langevin, France](https://www.ill.eu/)
+* [European Spallation Source ERIC](https://europeanspallationsource.se/), Sweden
+* [Science and Technology Funding Council](https://stfc.ukri.org/councils/stfc), UK
+* [Institut Laue-Langevin, France](https://www.ill.eu/), France
 
 See individual [release notes](https://scipp.github.io/about/release-notes.html) for the individual contributors to each release 

--- a/docs/about/about.rst
+++ b/docs/about/about.rst
@@ -7,7 +7,7 @@ Development
 -----------
 
 Scipp is a open source project by the `European Spallation Source ERIC <https://europeanspallationsource.se/>`_ (ESS).
-Other major contributions were provided by the `Science and Technology Facilities Council <https://www.ukri.org/councils/stfc/>`_ (STFC).
+Other major contributions were provided by the `Science and Technology Facilities Council <https://www.ukri.org/councils/stfc/>`_ (UKRI-STFC).
 
 References and citations
 ------------------------

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -73,11 +73,11 @@ Breaking changes
 Contributors
 ~~~~~~~~~~~~
 
-Owen Arnold,
-Simon Heybrock,
-Matthew D. Jones,
-Neil Vaytet,
-and Jan-Lukas Wynen
+* Owen Arnold @UKRI,
+* Simon Heybrock @ESS,
+* Matthew D. Jones @UKRI,
+* Neil Vaytet @ESS,
+* and Jan-Lukas Wynen @ESS
 
 v0.6.1 (April 2021)
 -------------------

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -323,7 +323,7 @@ Limitations:
 * Numerous "edge cases" not supported yet.
 * While tested, probably far from bug-free.
 
-Contributing Organisations
+Contributing Organizations
 --------------------------
 * <sup>a</sup> `European Spallation Source ERIC <https://europeanspallationsource.se/>`_ Sweden
 * <sup>b</sup> `Science and Technology Facilities Council <https://www.ukri.org/councils/stfc/>`_ UK

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -23,11 +23,11 @@ Bugfixes
 Contributors
 ~~~~~~~~~~~~
 
-Owen Arnold,
-Simon Heybrock,
-Greg Tucker,
-Neil Vaytet,
-and Jan-Lukas Wynen
+Owen Arnold<sup>b, c</sup>,
+Simon Heybrock<sup>a</sup>,
+Greg Tucker<sup>a</sup>,
+Neil Vaytet<sup>a</sup>,
+and Jan-Lukas Wynen<sup>a</sup>
 
 v0.7.0 (June 2021)
 ------------------
@@ -322,3 +322,10 @@ Limitations:
 * Limited performance and no parallelization.
 * Numerous "edge cases" not supported yet.
 * While tested, probably far from bug-free.
+
+Contributing Facilities
+-----------------------
+* <sup>a</sup> **Data Management and Software Centre, European Spallation Source, Sweden**
+* <sup>b</sup> **UK Research and Innovation, UK**
+* <sup>c</sup> **Tessella, UK**
+* <sup>d</sup> **Institut Laue-Langevin, France**

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -75,7 +75,7 @@ Contributors
 
 Owen Arnold<sup>b, c</sup>,
 Simon Heybrock<sup>a</sup>,
-Matthew D. Jonesr<sup>b, c</sup>,
+Matthew D. Jones<sup>b, c</sup>,
 Neil Vaytet<sup>a</sup>,
 and Jan-Lukas Wynen<sup>a</sup>
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -325,7 +325,7 @@ Limitations:
 
 Contributing Organisations
 --------------------------
-* <sup>a</sup> **Data Management and Software Centre, European Spallation Source, Sweden**
-* <sup>b</sup> **UK Research and Innovation, UK**
-* <sup>c</sup> **Tessella, UK**
-* <sup>d</sup> **Institut Laue-Langevin, France**
+* <sup>a</sup> `European Spallation Source ERIC <https://europeanspallationsource.se/>`_ Sweden
+* <sup>b</sup> `Science and Technology Facilities Council <https://www.ukri.org/councils/stfc/>`_ UK
+* <sup>c</sup> `Tessella <https://www.tessella.com/>`_ UK
+* <sup>d</sup> `Institut Laue-Langevin <https://www.ill.eu/>`_ France

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -323,8 +323,8 @@ Limitations:
 * Numerous "edge cases" not supported yet.
 * While tested, probably far from bug-free.
 
-Contributing Facilities
------------------------
+Contributing Organisations
+--------------------------
 * <sup>a</sup> **Data Management and Software Centre, European Spallation Source, Sweden**
 * <sup>b</sup> **UK Research and Innovation, UK**
 * <sup>c</sup> **Tessella, UK**

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -328,4 +328,3 @@ Contributing Organisations
 * <sup>a</sup> `European Spallation Source ERIC <https://europeanspallationsource.se/>`_ Sweden
 * <sup>b</sup> `Science and Technology Facilities Council <https://www.ukri.org/councils/stfc/>`_ UK
 * <sup>c</sup> `Tessella <https://www.tessella.com/>`_ UK
-* <sup>d</sup> `Institut Laue-Langevin <https://www.ill.eu/>`_ France

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -73,11 +73,11 @@ Breaking changes
 Contributors
 ~~~~~~~~~~~~
 
-* Owen Arnold @UKRI,
-* Simon Heybrock @ESS,
-* Matthew D. Jones @UKRI,
-* Neil Vaytet @ESS,
-* and Jan-Lukas Wynen @ESS
+Owen Arnold<sup>b, c</sup>,
+Simon Heybrock<sup>a</sup>,
+Matthew D. Jonesr<sup>b, c</sup>,
+Neil Vaytet<sup>a</sup>,
+and Jan-Lukas Wynen<sup>a</sup>
 
 v0.6.1 (April 2021)
 -------------------


### PR DESCRIPTION
* UKRI want's to be able to link contributing facility with the software.
* We don't want to add contributing facilities to license file since this would require more frequent license changes than we would like (whole approval mechanism possibly)

Proposed solution.
* Mention all facilities sponsoring developers in README though we already list major contributors in the about. This is better or the argument of making the contributing organisations visible.
* Link developers against their respective facilities in the release notes