### PR TITLE
Fix images on docs front page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,3 +238,10 @@ import scipp as sc
 doctest_default_flags = doctest.ELLIPSIS | doctest.IGNORE_EXCEPTION_DETAIL | \
                         doctest.DONT_ACCEPT_TRUE_FOR_1 | \
                         doctest.NORMALIZE_WHITESPACE
+
+# -- Options for linkcheck ------------------------------------------------
+
+linkcheck_ignore = [
+    # Specific lines in Github blobs cannot be found by linkcheck.
+    r'https?://github\.com/.*?/blob/[a-f0-9]+/.+?#'
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,19 +3,19 @@
 
 .. |data-structures| image:: _static/title-repr-html.png
    :width: 33%
-   :target: user-guide/data-structures.rst
+   :target: user-guide/data-structures.html
 
 .. |binning| image:: _static/title-binning.png
    :width: 33%
-   :target: user-guide/binned-data/binned-data.rst
+   :target: user-guide/binned-data/binned-data.html
 
 .. |masking| image:: _static/title-masking.png
    :width: 33%
-   :target: user-guide/masking.rst
+   :target: user-guide/masking.html
 
 .. |plotting| image:: _static/title-plotting.png
    :width: 33%
-   :target: visualization/plotting-overview.rst
+   :target: visualization/plotting-overview.html
 
 .. |scipp-neutron| image:: _static/title-instrument-view.png
    :width: 33%
@@ -23,7 +23,7 @@
 
 .. |slicing| image:: _static/title-show.png
    :width: 33%
-   :target: user-guide/slicing.rst
+   :target: user-guide/slicing.html
 
 scipp - Multi-dimensional data arrays with labeled dimensions
 =============================================================


### PR DESCRIPTION
Currently, only the image in the link to scippneutron is shown in the docs.

For some reason, sphinx does not like the links to the rst files here. I tried with different paths and apparently broken links show the image. But correct links do not unless we link to the HTML page.
The downside is that linkcheck flags the HTML links as broken even though they work in practice.