### PR TITLE
Use internal linkage for iterator functions

### DIFF
--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -21,7 +21,7 @@ namespace detail {
 using slice_list =
     boost::container::small_vector<std::pair<Slice, scipp::index>, 2>;
 
-static constexpr auto make_key_value = [](auto &&view) {
+inline constexpr auto make_key_value = [](auto &&view) {
   using In = decltype(view);
   using View =
       std::conditional_t<std::is_rvalue_reference_v<In>, std::decay_t<In>, In>;
@@ -29,11 +29,11 @@ static constexpr auto make_key_value = [](auto &&view) {
                                       std::forward<decltype(view)>(view));
 };
 
-static constexpr auto make_key = [](auto &&view) -> decltype(auto) {
+inline constexpr auto make_key = [](auto &&view) -> decltype(auto) {
   return view.first;
 };
 
-static constexpr auto make_value = [](auto &&view) -> decltype(auto) {
+inline constexpr auto make_value = [](auto &&view) -> decltype(auto) {
   return view.second;
 };
 


### PR DESCRIPTION
Fixes #1584

The way i understand it, using external linkage for `make_key` and `make_value` with `boost::transform_iterator` which has internal linkage can cause the compiler to not merge the different copies of `make_key` and `make_values` from different translation units.
I don't think that this caused any bugs because all copies of those functions were identical.

As a side not, I looked at this again because scipp fails to link on my local Windows with 'undefined external symbol' errors in `values_begin` and `keys_begin`. But the change in the PR did not fix it.