### PR TITLE
Fix `subspan_view` for slices and other shape/stride related ops and other bug in `histogram`

### DIFF
--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -39,13 +39,12 @@ DataArray histogram(const DataArray &events, const Variable &binEdges) {
     const auto data_dim = events.dims().inner();
     result = apply_and_drop_dim(
         events,
-        [](const DataArray &events_, const Dim data_dim_,
-           const Variable &binEdges_) {
-          const auto dim_ = binEdges_.dims().inner();
-          const auto data = masked_data(events_, dim_);
+        [dim](const DataArray &events_, const Dim data_dim_,
+              const Variable &binEdges_) {
+          const auto data = masked_data(events_, data_dim_);
           return transform_subspan(
-              events_.dtype(), dim_, binEdges_.dims()[dim_] - 1,
-              subspan_view(events_.coords()[dim_], data_dim_),
+              events_.dtype(), dim, binEdges_.dims()[dim] - 1,
+              subspan_view(events_.coords()[dim], data_dim_),
               subspan_view(data, data_dim_), binEdges_, element::histogram,
               "histogram");
         },

--- a/variable/test/subspan_view_test.cpp
+++ b/variable/test/subspan_view_test.cpp
@@ -87,3 +87,67 @@ TEST_F(SubspanViewTest, broadcast_mutable_fails) {
   EXPECT_THROW_DISCARD(subspan_view(broadcasted, Dim::X),
                        except::VariableError);
 }
+
+class SubspanViewOfSliceTest : public ::testing::Test {
+protected:
+  Variable var{makeVariable<double>(
+      Dims{Dim::Z, Dim::Y, Dim::X}, Shape{3, 3, 3}, units::m,
+      Values{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+             15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27})};
+};
+
+TEST_F(SubspanViewOfSliceTest, inner_slice_left) {
+  var = var.slice({Dim::X, 0, 2});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {1, 2}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {4, 5}));
+}
+
+TEST_F(SubspanViewOfSliceTest, inner_slice_right) {
+  var = var.slice({Dim::X, 1, 3});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {2, 3}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {5, 6}));
+}
+
+TEST_F(SubspanViewOfSliceTest, middle_slice) {
+  var = var.slice({Dim::Y, 1, 3});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {4, 5, 6}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {7, 8, 9}));
+}
+
+TEST_F(SubspanViewOfSliceTest, outer_slice) {
+  var = var.slice({Dim::Z, 1, 3});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {10, 11, 12}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {13, 14, 15}));
+}
+
+TEST_F(SubspanViewOfSliceTest, broadcast) {
+  const auto var2 =
+      broadcast(var.slice({Dim::Y, 0}), var.dims()).slice({Dim::X, 1, 3});
+  auto view = subspan_view(var2, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<const double>>()[0], {2, 3}));
+  EXPECT_TRUE(equals(view.values<span<const double>>()[1], {2, 3}));
+  EXPECT_TRUE(equals(view.values<span<const double>>()[2], {2, 3}));
+  EXPECT_TRUE(equals(view.values<span<const double>>()[3], {11, 12}));
+}
+
+TEST_F(SubspanViewOfSliceTest, tranpose) {
+  var = var.transpose({Dim::Y, Dim::Z, Dim::X});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {1, 2, 3}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {10, 11, 12}));
+}
+
+TEST_F(SubspanViewOfSliceTest, slice_tranpose) {
+  var = var.transpose({Dim::Y, Dim::Z, Dim::X});
+  for (auto dim : {Dim::X, Dim::Y, Dim::Z})
+    var = var.slice({dim, 1, 3});
+  auto view = subspan_view(var, Dim::X);
+  EXPECT_TRUE(equals(view.values<span<double>>()[0], {14, 15}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[1], {23, 24}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[2], {17, 18}));
+  EXPECT_TRUE(equals(view.values<span<double>>()[3], {26, 27}));
+}


### PR DESCRIPTION
Fixes #2029.

The bug was the assumption that shape defines offsets/strides, which was correct prior to the shared-buffer rewrite. Now we have to consider strides directly. I fear we may have other instances of code that make similar wrong assumptions, not sure if there is a way to locate those.

Fixes  #2033.