### PR TITLE
Fix MSVC warnings

### DIFF
--- a/benchmark/bin_benchmark.cpp
+++ b/benchmark/bin_benchmark.cpp
@@ -40,7 +40,9 @@ static void BM_bin_table(benchmark::State &state) {
   state.counters["ybins"] = edges_y.dims().volume() - 1;
   state.counters["events"] = nEvent;
 }
-BENCHMARK(BM_bin_table)->RangeMultiplier(10)->Ranges({{10, 1e6}, {1e5, 1e8}});
+BENCHMARK(BM_bin_table)
+    ->RangeMultiplier(10)
+    ->Ranges({{10, 2ul << 19ul}, {2ul << 16ul, 2ul << 15ul}});
 
 static void BM_rebin_outer(benchmark::State &state) {
   const scipp::index nx = state.range(0);
@@ -59,6 +61,9 @@ static void BM_rebin_outer(benchmark::State &state) {
   state.counters["ybins"] = edges_y.dims().volume() - 1;
   state.counters["events"] = nEvent;
 }
-BENCHMARK(BM_rebin_outer)->RangeMultiplier(10)->Ranges({{10, 1e6}, {1e5, 1e8}});
+BENCHMARK(BM_rebin_outer)
+    ->RangeMultiplier(10)
+    ->Ranges({{10, static_cast<int64_t>(1e6)},
+              {static_cast<int64_t>(1e5), static_cast<int64_t>(1e8)}});
 
 BENCHMARK_MAIN();

--- a/benchmark/buckets_benchmark.cpp
+++ b/benchmark/buckets_benchmark.cpp
@@ -48,7 +48,7 @@ static void BM_buckets_concatenate(benchmark::State &state) {
 }
 BENCHMARK(BM_buckets_concatenate)
     ->RangeMultiplier(4)
-    ->Ranges({{64, 1e6}, {2 << 20, 1e9}});
+    ->Ranges({{64, 2ul << 19ul}, {2ul << 20ul, 2ul << 29ul}});
 
 auto make_table(const scipp::index size) {
   Dimensions dims(Dim::Event, size);
@@ -73,6 +73,6 @@ static void BM_bucketby(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations() * nEvent);
   state.counters["events"] = nEvent;
 }
-BENCHMARK(BM_bucketby)->RangeMultiplier(4)->Ranges({{64, 1e7}});
+BENCHMARK(BM_bucketby)->RangeMultiplier(4)->Ranges({{64, 2ul << 23ul}});
 
 BENCHMARK_MAIN();

--- a/common/test/islinspace_test.cpp
+++ b/common/test/islinspace_test.cpp
@@ -63,7 +63,7 @@ TEST(IsLinspaceTest, std_iota) {
 TEST(IsLinspaceTest, generate_addition) {
   std::vector<double> range;
   double current = 345.4564675;
-  std::generate_n(std::back_inserter(range), 1e5, [&current]() {
+  std::generate_n(std::back_inserter(range), 2ul << 16ul, [&current]() {
     const double step = 0.0034674;
     current += step;
     return current;

--- a/core/test/element_comparison_test.cpp
+++ b/core/test/element_comparison_test.cpp
@@ -203,10 +203,12 @@ constexpr auto check_inplace = [](auto op, auto a, auto b, auto expected) {
 };
 
 TEST(ComparisonTest, min_max_support_time_point) {
-  std::get<core::time_point>(decltype(max_equals)::types{});
-  std::get<core::time_point>(decltype(min_equals)::types{});
-  std::get<core::time_point>(decltype(nanmax_equals)::types{});
-  std::get<core::time_point>(decltype(nanmin_equals)::types{});
+  static_cast<void>(std::get<core::time_point>(decltype(max_equals)::types{}));
+  static_cast<void>(std::get<core::time_point>(decltype(min_equals)::types{}));
+  static_cast<void>(
+      std::get<core::time_point>(decltype(nanmax_equals)::types{}));
+  static_cast<void>(
+      std::get<core::time_point>(decltype(nanmin_equals)::types{}));
 }
 
 TEST(ComparisonTest, max_equals) {

--- a/core/test/element_math_test.cpp
+++ b/core/test/element_math_test.cpp
@@ -26,8 +26,8 @@ TEST(ElementAbsTest, value_and_variance) {
 
 TEST(ElementAbsTest, supported_types) {
   auto supported = decltype(element::abs)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementNormTest, unit) {
@@ -63,8 +63,8 @@ TEST(ElementSqrtTest, value_and_variance) {
 
 TEST(ElementSqrtTest, supported_types) {
   auto supported = decltype(element::sqrt)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementDotTest, unit) {

--- a/core/test/element_trigonometry_test.cpp
+++ b/core/test/element_trigonometry_test.cpp
@@ -28,8 +28,8 @@ TEST(ElementSinOutArgTest, value_float) {
 
 TEST(ElementSinOutArgTest, supported_types) {
   auto supported = decltype(element::sin)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementCosOutArgTest, unit_rad) {
@@ -48,8 +48,8 @@ TEST(ElementCosOutArgTest, value_float) {
 
 TEST(ElementCosOutArgTest, supported_types) {
   auto supported = decltype(element::cos)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementTanOutArgTest, unit_rad) {
@@ -68,8 +68,8 @@ TEST(ElementTanOutArgTest, value_float) {
 
 TEST(ElementTanOutArgTest, supported_types) {
   auto supported = decltype(element::tan)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementAsinTest, unit) {
@@ -101,8 +101,8 @@ TEST(ElementAsinOutArgTest, value_float) {
 
 TEST(ElementAsinOutArgTest, supported_types) {
   auto supported = decltype(element::asin)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementAcosTest, unit) {
@@ -134,8 +134,8 @@ TEST(ElementAcosOutArgTest, value_float) {
 
 TEST(ElementAcosOutArgTest, supported_types) {
   auto supported = decltype(element::acos)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 TEST(ElementAtanTest, unit) {
@@ -165,8 +165,8 @@ TEST(ElementAtanOutArgTest, value_float) {
 
 TEST(ElementAtanOutArgTest, supported_types) {
   auto supported = decltype(element::atan)::types{};
-  std::get<double>(supported);
-  std::get<float>(supported);
+  static_cast<void>(std::get<double>(supported));
+  static_cast<void>(std::get<float>(supported));
 }
 
 template <typename T> class ElementAtan2Test : public ::testing::Test {};

--- a/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/variable/test/variable_keyword_args_constructor_test.cpp
@@ -134,14 +134,15 @@ TEST(VariableUniversalConstructorTest, no_copy_on_matched_types) {
 TEST(VariableUniversalConstructorTest, convertable_types) {
   using namespace scipp::variable::detail;
   auto data = std::vector<double>{1.0, 4.5, 2.7, 5.0, 7.0, 6.7};
+  std::vector<float> float_data(data.size());
+  std::transform(data.begin(), data.end(), float_data.begin(),
+                 [](const double x) { return static_cast<float>(x); });
   auto variable = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3},
                            Values(data), units::kg, Variances(data));
 
   EXPECT_EQ(variable.dtype(), dtype<float>);
-  EXPECT_TRUE(equals(variable.values<float>(),
-                     std::vector<float>(data.begin(), data.end())));
-  EXPECT_TRUE(equals(variable.variances<float>(),
-                     std::vector<float>(data.begin(), data.end())));
+  EXPECT_TRUE(equals(variable.values<float>(), float_data));
+  EXPECT_TRUE(equals(variable.variances<float>(), float_data));
 }
 
 TEST(VariableUniversalConstructorTest, unconvertable_types) {


### PR DESCRIPTION
No bugs, just some warnings about using types cleanly. Some warnings remain, namely
> D:\a\1\s\variable\test\transform_test.cpp(779): warning C4700: uninitialized local variable 'op_arg_0_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(791): warning C4700: uninitialized local variable 'op_arg_1_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(804): warning C4700: uninitialized local variable 'all_args_with_flag' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(950): warning C4700: uninitialized local variable 'op_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(819): warning C4700: uninitialized local variable 'op_arg_0_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(826): warning C4700: uninitialized local variable 'op_arg_1_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(840): warning C4700: uninitialized local variable 'op_arg_0_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(852): warning C4700: uninitialized local variable 'op_arg_1_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(865): warning C4700: uninitialized local variable 'all_args_with_flag' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(889): warning C4700: uninitialized local variable 'op_arg_0_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(897): warning C4700: uninitialized local variable 'op_arg_1_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]
D:\a\1\s\variable\test\transform_test.cpp(930): warning C4700: uninitialized local variable 'op_has_flags' used [D:\a\1\s\build\variable\test\scipp-variable-test.vcxproj]

But those look like false positives to me.