### PR TITLE
Support histogramming of dense data with stride != 1

### DIFF
--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include <algorithm>
+
 #include "scipp/dataset/histogram.h"
 #include "scipp/core/element/histogram.h"
 #include "scipp/dataset/bins.h"
@@ -9,6 +11,7 @@
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/groupby.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/shape.h"
 #include "scipp/variable/transform_subspan.h"
 
 #include "dataset_operations_common.h"
@@ -17,6 +20,19 @@ using namespace scipp::core;
 using namespace scipp::variable;
 
 namespace scipp::dataset {
+
+namespace {
+/// Return `var` unchanged if stride along `dim` is 1, else move `dim` to inner
+/// dim and return copy such that stride is 1.
+auto as_contiguous(const Variable &var, const Dim dim) {
+  if (var.strides()[var.dims().index(dim)] == 1)
+    return var;
+  std::vector<Dim> dims(var.dims().begin(), var.dims().end());
+  const auto it = std::find(dims.begin(), dims.end(), dim);
+  std::rotate(it, it + 1, dims.end());
+  return copy(transpose(var, dims));
+}
+} // namespace
 
 DataArray histogram(const DataArray &events, const Variable &binEdges) {
   using namespace scipp::core;
@@ -36,19 +52,25 @@ DataArray histogram(const DataArray &events, const Variable &binEdges) {
         },
         dim, binEdges);
   } else if (!is_histogram(events, dim)) {
-    const auto data_dim = events.dims().inner();
+    const auto event_dim = dim_of_coord(events.coords()[dim], dim);
     result = apply_and_drop_dim(
         events,
-        [dim](const DataArray &events_, const Dim data_dim_,
+        [dim](const DataArray &events_, const Dim event_dim_,
               const Variable &binEdges_) {
-          const auto data = masked_data(events_, data_dim_);
+          const auto data = masked_data(events_, event_dim_);
+          // Warning: Don't try to move the `as_contiguous` into `subspan_view`
+          // without special care: It may return a new variable which will go
+          // out of scope, leading to subtle bugs. Here on the other hand the
+          // returned temporary is kept alive until the end of the
+          // full-expression.
           return transform_subspan(
               events_.dtype(), dim, binEdges_.dims()[dim] - 1,
-              subspan_view(events_.coords()[dim], data_dim_),
-              subspan_view(data, data_dim_), binEdges_, element::histogram,
-              "histogram");
+              subspan_view(as_contiguous(events_.coords()[dim], event_dim_),
+                           event_dim_),
+              subspan_view(as_contiguous(data, event_dim_), event_dim_),
+              binEdges_, element::histogram, "histogram");
         },
-        data_dim, binEdges);
+        event_dim, binEdges);
   } else {
     throw except::BinEdgeError(
         "Data is already histogrammed. Expected event data or dense point "

--- a/dataset/histogram.cpp
+++ b/dataset/histogram.cpp
@@ -4,12 +4,12 @@
 /// @author Simon Heybrock
 #include <algorithm>
 
-#include "scipp/dataset/histogram.h"
 #include "scipp/core/element/histogram.h"
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/dataset/except.h"
 #include "scipp/dataset/groupby.h"
+#include "scipp/dataset/histogram.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/transform_subspan.h"


### PR DESCRIPTION
Previously this failed with an obscure error (something like `DimensionError: Expected dimension to be in [pixel:500, ], got event.`). Instead of a better error, we now support this by simply copying the input to a contiguous layout in that case.

This approach may not be optimal in terms of memory use and performance (the latter is actually less clear, since it has to be balanced against non-linear memory lookup during the histogramming step), but this is better than nothing and can be improved if required later.