### PR TITLE
Consistent fold and flatten keywords

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -19,6 +19,7 @@ Breaking changes
 
 .. include:: <isonum.txt>
 
+* Keyword arg ``to`` of ``flatten`` function renamed to ``dim``, far consistency with ``fold``.
 * Changed names of arithmetic functions to match numpy's names: ``plus`` |rarr| :func:`scipp.add`, ``minus`` |rarr| :func:`scipp.subtract`, ``times`` |rarr| :func:`scipp.multiply` `#1999 <https://github.com/scipp/scipp/pull/1999>`_.
 * Changed Variable init method, all arguments are keyword-only, special overloads which default-initialize data were removed `#1994 <https://github.com/scipp/scipp/pull/1994>`_.
 * Made arguments of many functions keyword-only, e.g. constructors of ``DataArray`` and ``Dataset``, ``bin``, and ``atan2`` `#1983 <https://github.com/scipp/scipp/pull/1983>`_, `#2008 <https://github.com/scipp/scipp/pull/2008>`_, `#2012 <https://github.com/scipp/scipp/pull/2012>`_.

--- a/python/src/scipp/_shape.py
+++ b/python/src/scipp/_shape.py
@@ -82,6 +82,7 @@ def concatenate(x: VariableLike, y: VariableLike, dim: str) -> VariableLike:
 
 
 def fold(x: VariableLike,
+         *,
          dim: str,
          sizes: Optional[Dict[str, int]] = None,
          dims: Optional[Union[List[str], Tuple[str]]] = None,
@@ -140,16 +141,19 @@ def fold(x: VariableLike,
         return _call_cpp_func(_cpp.fold, x, dim, dict(zip(dims, shape)))
 
 
-def flatten(x: VariableLike,
-            dims: Optional[Union[List[str], Tuple[str]]] = None,
-            to: Optional[str] = None) -> VariableLike:
+def flatten(
+    x: VariableLike,
+    *,
+    dim: str,
+    dims: Optional[Union[List[str], Tuple[str]]] = None,
+) -> VariableLike:
     """Flatten multiple dimensions of a variable or data array into a single
     dimension. If dims is omitted, then we flatten all of the inputs dimensions
     into a single dim.
 
     :param x: Variable or DataArray to flatten.
     :param dims: A list of dim labels that will be flattened.
-    :param to: A single dim label for the resulting flattened dim.
+    :param dim: A single dim label for the resulting flattened dim.
     :raises: If the bin edge coordinates cannot be stitched back together.
     :return: Variable or DataArray with requested dimension labels and shape.
 
@@ -158,19 +162,19 @@ def flatten(x: VariableLike,
       >>> v = sc.array(dims=['x', 'y'], values=np.arange(6).reshape(2, 3))
       >>> v
       <scipp.Variable> (x: 2, y: 3)      int64  [dimensionless]  [0, 1, ..., 4, 5]
-      >>> sc.flatten(v, to='u')
+      >>> sc.flatten(v, dim='u')
       <scipp.Variable> (u: 6)      int64  [dimensionless]  [0, 1, ..., 4, 5]
-      >>> sc.flatten(v, dims=['x', 'y'], to='u')
+      >>> sc.flatten(v, dims=['x', 'y'], dim='u')
       <scipp.Variable> (u: 6)      int64  [dimensionless]  [0, 1, ..., 4, 5]
 
       >>> v = sc.array(dims=['x', 'y', 'z'], values=np.arange(24).reshape(2, 3, 4))
       >>> v
       <scipp.Variable> (x: 2, y: 3, z: 4)      int64  [dimensionless]  [0, 1, ..., 22, 23]
-      >>> sc.flatten(v, to='u')
+      >>> sc.flatten(v, dim='u')
       <scipp.Variable> (u: 24)      int64  [dimensionless]  [0, 1, ..., 22, 23]
-      >>> sc.flatten(v, dims=['x', 'y'], to='u')
+      >>> sc.flatten(v, dims=['x', 'y'], dim='u')
       <scipp.Variable> (u: 6, z: 4)      int64  [dimensionless]  [0, 1, ..., 22, 23]
-      >>> sc.flatten(v, dims=['y', 'z'], to='u')
+      >>> sc.flatten(v, dims=['y', 'z'], dim='u')
       <scipp.Variable> (x: 2, u: 12)      int64  [dimensionless]  [0, 1, ..., 22, 23]
 
       >>> a = sc.DataArray(0.1 * sc.array(dims=['x', 'y'], values=np.arange(6).reshape(2, 3)),
@@ -187,7 +191,7 @@ def flatten(x: VariableLike,
         y                           int64  [dimensionless]  (y)  [0, 1, 2]
       Data:
                                   float64  [dimensionless]  (x, y)  [0.000000, 0.100000, ..., 0.400000, 0.500000]
-      >>> sc.flatten(a, to='u')
+      >>> sc.flatten(a, dim='u')
       <scipp.DataArray>
       Dimensions: Sizes[u:6, ]
       Coordinates:
@@ -198,15 +202,9 @@ def flatten(x: VariableLike,
                                   float64  [dimensionless]  (u)  [0.000000, 0.100000, ..., 0.400000, 0.500000]
 
     """
-    if to is None:
-        # Note that this is a result of the fact that we want to support
-        # calling flatten without kwargs, and that in this case it semantically
-        # makes more sense for the dims that we want to flatten to come first
-        # in the argument list.
-        raise RuntimeError("The final flattened dimension is required.")
     if dims is None:
         dims = x.dims
-    return _call_cpp_func(_cpp.flatten, x, dims, to)
+    return _call_cpp_func(_cpp.flatten, x, dims, dim)
 
 
 def transpose(

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -131,7 +131,7 @@ def find_log_limits(x):
     """
     from .. import flatten, ones
     volume = np.product(x.shape)
-    pixel = flatten(sc.values(x), to='pixel')
+    pixel = flatten(sc.values(x), dim='pixel')
     weights = ones(dims=['pixel'], shape=[volume])
     hist = sc.histogram(sc.DataArray(data=weights, coords={'order': pixel}),
                         bins=sc.Variable(dims=['order'],

--- a/python/tests/dynamic_binding_test.py
+++ b/python/tests/dynamic_binding_test.py
@@ -51,8 +51,8 @@ def test_bound_methods_shape():
     assert sc.identical(var.transpose(['y', 'x']),
                         sc.transpose(var, ['y', 'x']))
     for obj in (var, da):
-        assert sc.identical(obj.flatten(dims=['x', 'y'], to='z'),
-                            sc.flatten(obj, dims=['x', 'y'], to='z'))
+        assert sc.identical(obj.flatten(dims=['x', 'y'], dim='z'),
+                            sc.flatten(obj, dims=['x', 'y'], dim='z'))
         assert sc.identical(obj.fold(dim='x', sizes={
             'a': 2,
             'b': 2


### PR DESCRIPTION
- Rename `to` to `dim` in `flatten`, to match naming in `fold`.
- Require keyword args for dim, avoiding need for hacky error message.