### PR TITLE
Pin sphinx version to avoid logo bug in 4.10.

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -229,5 +229,5 @@ Typing
 .. autosummary::
    :toctree: ../generated
 
-   typing.LabeledArray
    typing.MetaDataMap
+   typing.VariableLike

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -36,7 +36,7 @@ dependencies:
 
   # Docs
   - pandoc
-  - sphinx
+  - sphinx=4.0.2 # see https://github.com/sphinx-doc/sphinx/issues/9438
   - sphinx_rtd_theme
   - nbsphinx
   - docutils=0.16 # see https://github.com/spatialaudio/nbsphinx/issues/549


### PR DESCRIPTION
Sphinx 4.1.0 introduced a bug around logos and favicons: https://github.com/sphinx-doc/sphinx/issues/9438

This is hopefully a temporary solution.