### PR TITLE
Remove inline-unit-growth limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,11 +134,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 include(IPO)
 
-# Optimization flags
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --param inline-unit-growth=50")
-endif()
-
 # Get version from git-describe
 execute_process(
   COMMAND git describe --tag


### PR DESCRIPTION
I do not see a run time difference with or without this flag.

_Without_ the flag, the dynamic libraries are consistently smaller. Most notably, `libscipp-variable.so` was reduced from 9.1MB to 8.7MB. 

Tested with gcc 10.2.0 on Linux.