### PR TITLE
Change case to Python_EXECUTABLE in docs

### DIFF
--- a/docs/reference/developer/getting-started.rst
+++ b/docs/reference/developer/getting-started.rst
@@ -49,7 +49,7 @@ To build a debug version of the library:
   cmake \
     -GNinja \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DPYTHON_EXECUTABLE=$(command -v python3) \
+    -DPython_EXECUTABLE=$(command -v python3) \
     -DCMAKE_INSTALL_PREFIX=../install \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
     -DDYNAMIC_LIB=ON \
@@ -70,7 +70,7 @@ Alternatively, to build a release version with all optimizations enabled:
 
   cmake \
     -GNinja \
-    -DPYTHON_EXECUTABLE=$(command -v python3) \
+    -DPython_EXECUTABLE=$(command -v python3) \
     -DCMAKE_INSTALL_PREFIX=../install \
     -DCMAKE_BUILD_TYPE=Release \
     ..

--- a/tools/benchmark_build.py
+++ b/tools/benchmark_build.py
@@ -92,7 +92,7 @@ def configure(case, build_dir, install_dir):
     ]
     cmake_args.extend([
         f'-DCMAKE_INSTALL_PREFIX={install_dir}',
-        f'-DPYTHON_EXECUTABLE={sys.executable}',
+        f'-DPython_EXECUTABLE={sys.executable}',
         str(SRCDIR)
     ])
 

--- a/tools/build_cpp.py
+++ b/tools/build_cpp.py
@@ -47,7 +47,7 @@ def main(prefix='install', build_dir='build', source_dir='.'):
     # Default cmake flags
     cmake_flags = {
         '-G': 'Ninja',
-        '-DPYTHON_EXECUTABLE': shutil.which("python"),
+        '-DPython_EXECUTABLE': shutil.which("python"),
         '-DCMAKE_INSTALL_PREFIX': prefix,
         '-DWITH_CTEST': 'OFF',
         '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION': 'ON'


### PR DESCRIPTION
b1f3afd152d6802a2e7e105dba4599717a70655e changed the case of the CMake argument for the Python executable but did not update the docs.