### PR TITLE
Use base LLNL units repo

### DIFF
--- a/cmake/LLNL-units.in
+++ b/cmake/LLNL-units.in
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 externalproject_add(
   llnl-units
-  GIT_REPOSITORY https://github.com/SimonHeybrock/units.git
+  GIT_REPOSITORY https://github.com/LLNL/units.git
   GIT_TAG origin/master
   SOURCE_DIR "${CMAKE_BINARY_DIR}/llnl-units-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/llnl-units-build"


### PR DESCRIPTION
The base repo has caught up to the fork we have been using (https://github.com/SimonHeybrock/units).