### PR TITLE
Disable --parallel flag for windows builds

### DIFF
--- a/tools/build_cpp.py
+++ b/tools/build_cpp.py
@@ -71,8 +71,14 @@ def main(prefix='install', build_dir='build', source_dir='.'):
         shell = True
         build_config = 'Release'
 
+        # cmake --build --parallel is detrimental to build performance on windows
+        # see https://github.com/scipp/scipp/issues/2078 for details
+        build_flags = []
+    else:
+        # For other platforms we do want to add the parallel build flag.
+        build_flags = [parallel_flag]
+
     # Additional flags for --build commands
-    build_flags = [parallel_flag]
     if len(build_config) > 0:
         build_flags += ['--config', build_config]
 


### PR DESCRIPTION
Closes https://github.com/scipp/scipp/issues/2078 - see comment on the ticket for a more detailed explanation of the issue this solves.

Using `tools\build_cpp.py` on my local machine gives a significant speedup. This speedup seems to also be present on the CI servers, although the build times do fluctuate a bit (I guess based on how much load there is on azure devops)

Measured on my local machine:
On branch: `time python tools\build_cpp.py`: 20:25.45
On main: `time python tools\build_cpp.py`: 26:34.31