### PR TITLE
Add pop method to coords, masks, attrs

### DIFF
--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -160,8 +160,8 @@ public:
   void rebuildSizes();
   void set(const key_type &key, mapped_type coord);
   void erase(const key_type &key);
-  mapped_type extract(const key_type &key,
-                      const mapped_type *default_value = nullptr);
+  mapped_type extract(const key_type &key);
+  mapped_type extract(const key_type &key, const mapped_type &default_value);
 
   Dict slice(const Slice &params) const;
   std::tuple<Dict, Dict> slice_coords(const Slice &params) const;

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -160,7 +160,8 @@ public:
   void rebuildSizes();
   void set(const key_type &key, mapped_type coord);
   void erase(const key_type &key);
-  mapped_type extract(const key_type &key);
+  mapped_type extract(const key_type &key,
+                      const mapped_type *default_value = nullptr);
 
   Dict slice(const Slice &params) const;
   std::tuple<Dict, Dict> slice_coords(const Slice &params) const;

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -139,7 +139,11 @@ void Dict<Key, Value>::erase(const key_type &key) {
 }
 
 template <class Key, class Value>
-Value Dict<Key, Value>::extract(const key_type &key) {
+Value Dict<Key, Value>::extract(const key_type &key,
+                                const mapped_type *const default_value) {
+  if (default_value != nullptr && !contains(key)) {
+    return *default_value;
+  }
   auto extracted = at(key);
   erase(key);
   return extracted;

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -139,14 +139,19 @@ void Dict<Key, Value>::erase(const key_type &key) {
 }
 
 template <class Key, class Value>
-Value Dict<Key, Value>::extract(const key_type &key,
-                                const mapped_type *const default_value) {
-  if (default_value != nullptr && !contains(key)) {
-    return *default_value;
-  }
+Value Dict<Key, Value>::extract(const key_type &key) {
   auto extracted = at(key);
   erase(key);
   return extracted;
+}
+
+template <class Key, class Value>
+Value Dict<Key, Value>::extract(const key_type &key,
+                                const mapped_type &default_value) {
+  if (contains(key)) {
+    return extract(key);
+  }
+  return default_value;
 }
 
 template <class Key, class Value>

--- a/python/bind_data_array.h
+++ b/python/bind_data_array.h
@@ -72,7 +72,7 @@ void bind_mutable_view(py::module &m, const std::string &name) {
           "items", [](T &self) { return items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
           R"(view on self's items)")
-      .def("pop", &T::extract);
+      .def("pop", &T::extract, py::arg("k"), py::arg("d") = nullptr);
 }
 
 template <class T>
@@ -95,7 +95,7 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name) {
           "items", [](T &self) { return str_items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
           R"(view on self's items)")
-      .def("pop", &T::extract);
+      .def("pop", &T::extract, py::arg("k"), py::arg("d") = nullptr);
 }
 
 template <class T, class... Ignored>

--- a/python/bind_data_array.h
+++ b/python/bind_data_array.h
@@ -53,11 +53,26 @@ void bind_common_mutable_view_operators(pybind11::class_<T, Ignored...> &view) {
       .def("__contains__", &T::contains);
 }
 
+template <class T, class... Ignored>
+void bind_pop(pybind11::class_<T, Ignored...> &view) {
+  view.def(
+      "pop",
+      [](T &self, const typename T::key_type &key,
+         const typename T::mapped_type *const default_value) {
+        if (default_value == nullptr) {
+          return self.extract(key);
+        }
+        return self.extract(key, *default_value);
+      },
+      py::arg("k"), py::arg("d") = nullptr);
+}
+
 template <class T>
 void bind_mutable_view(py::module &m, const std::string &name) {
   py::class_<T> view(m, name.c_str());
   bind_common_mutable_view_operators<T>(view);
   bind_inequality_to_operator<T>(view);
+  bind_pop(view);
   view.def(
           "__iter__",
           [](T &self) {
@@ -71,8 +86,7 @@ void bind_mutable_view(py::module &m, const std::string &name) {
       .def(
           "items", [](T &self) { return items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
-          R"(view on self's items)")
-      .def("pop", &T::extract, py::arg("k"), py::arg("d") = nullptr);
+          R"(view on self's items)");
 }
 
 template <class T>
@@ -80,6 +94,7 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name) {
   py::class_<T> view(m, name.c_str());
   bind_common_mutable_view_operators<T>(view);
   bind_inequality_to_operator<T>(view);
+  bind_pop(view);
   view.def(
           "__iter__",
           [](T &self) {
@@ -94,8 +109,7 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name) {
       .def(
           "items", [](T &self) { return str_items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
-          R"(view on self's items)")
-      .def("pop", &T::extract, py::arg("k"), py::arg("d") = nullptr);
+          R"(view on self's items)");
 }
 
 template <class T, class... Ignored>

--- a/python/bind_data_array.h
+++ b/python/bind_data_array.h
@@ -71,7 +71,8 @@ void bind_mutable_view(py::module &m, const std::string &name) {
       .def(
           "items", [](T &self) { return items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
-          R"(view on self's items)");
+          R"(view on self's items)")
+      .def("pop", &T::extract);
 }
 
 template <class T>
@@ -93,7 +94,8 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name) {
       .def(
           "items", [](T &self) { return str_items_view(self); },
           py::return_value_policy::move, py::keep_alive<0, 1>(),
-          R"(view on self's items)");
+          R"(view on self's items)")
+      .def("pop", &T::extract);
 }
 
 template <class T, class... Ignored>

--- a/python/tests/data_array_test.py
+++ b/python/tests/data_array_test.py
@@ -107,10 +107,12 @@ def test_coords():
 
 def test_masks():
     da = make_dataarray()
-    da.masks['mask1'] = sc.Variable(dims=['x'],
-                                    values=np.array([False, True], dtype=bool))
+    mask = sc.Variable(dims=['x'], values=np.array([False, True], dtype=bool))
+    da.masks['mask1'] = mask
     assert len(dict(da.masks)) == 1
     assert 'mask1' in da.masks
+    assert sc.identical(da.masks.pop('mask1'), mask)
+    assert (len(dict(da.masks))) == 0
 
 
 def test_name():

--- a/python/tests/dataset_test.py
+++ b/python/tests/dataset_test.py
@@ -158,6 +158,16 @@ def test_coords_get():
     assert d.coords.get('z') is None
 
 
+def test_coords_pop():
+    d = sc.Dataset()
+    d.coords['x'] = sc.scalar(1.0)
+    d.coords['y'] = sc.scalar(2.0)
+    assert sc.identical(d.coords.pop('x'), sc.scalar(1.0))
+    assert list(d.coords.keys()) == ['y']
+    assert sc.identical(d.coords.pop('y'), sc.scalar(2.0))
+    assert len(list(d.coords.keys())) == 0
+
+
 def test_slice_item():
     d = sc.Dataset(coords={'x': sc.Variable(dims=['x'], values=np.arange(4, 8))})
     d['a'] = sc.Variable(dims=['x'], values=np.arange(4))

--- a/python/tests/dataset_test.py
+++ b/python/tests/dataset_test.py
@@ -164,6 +164,8 @@ def test_coords_pop():
     d.coords['y'] = sc.scalar(2.0)
     assert sc.identical(d.coords.pop('x'), sc.scalar(1.0))
     assert list(d.coords.keys()) == ['y']
+    assert sc.identical(d.coords.pop('z', sc.scalar(3.0)), sc.scalar(3.0))
+    assert list(d.coords.keys()) == ['y']
     assert sc.identical(d.coords.pop('y'), sc.scalar(2.0))
     assert len(list(d.coords.keys())) == 0
 


### PR DESCRIPTION
Behaves like `dict.pop` in Python.

Question: The corresponding C++ function is called `extract`. Do we want to rename one of them to have consistent names or do we keep both as they are? I am in favour of naming things as in Python, i.e. `pop`.