### PR TITLE
Move bin-edge dims of coords into innermost dim in coordinate transform

### DIFF
--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -68,6 +68,24 @@ def _produce_coord(obj, name):
     return obj.coords[name]
 
 
+def _move_to_back(lis, val):
+    lis.remove(val)
+    lis.append(val)
+    return lis
+
+
+def _store_coord(obj, name, coord):
+    edges = find_bin_edges(coord, obj)
+    if not edges:
+        obj.coords[name] = coord
+    elif len(edges) == 1:
+        obj.coords[name] = coord.transpose(_move_to_back(coord.dims, edges[0]))
+    else:
+        raise NotImplementedError(
+            'Coordinates with more than one bin-edge dimension are not supported. '
+            f'Got coord {coord} with bin edges {edges}.')
+
+
 class CoordTransform:
     Graph = Dict[Union[str, Tuple[str, ...]], Union[str, Callable]]
 
@@ -129,7 +147,7 @@ class CoordTransform:
             out = {name: out}
         self._rename.setdefault(dim, []).extend(out.keys())
         for key, coord in out.items():
-            self.obj.coords[key] = coord
+            _store_coord(self.obj, key, coord)
         if self.obj.bins is not None:
             if isinstance(out_bins, Variable):
                 out_bins = {name: out_bins}

--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -6,6 +6,7 @@ import inspect
 import warnings
 from typing import Union, List, Dict, Tuple, Callable
 from . import Variable, DataArray, Dataset, bins, VariableError
+from .utils.dimensions import find_bin_edges
 
 
 def _argnames(func):

--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -75,12 +75,16 @@ def _move_to_back(lis, val):
     return lis
 
 
+def _move_bin_edge_to_innermost(var, edge_dim):
+    return var.transpose(_move_to_back(var.dims, edge_dim))
+
+
 def _store_coord(obj, name, coord):
     edges = find_bin_edges(coord, obj)
     if not edges:
         obj.coords[name] = coord
     elif len(edges) == 1:
-        obj.coords[name] = coord.transpose(_move_to_back(coord.dims, edges[0]))
+        obj.coords[name] = _move_bin_edge_to_innermost(coord, edges[0])
     else:
         raise NotImplementedError(
             'Coordinates with more than one bin-edge dimension are not supported. '

--- a/python/src/scipp/html/formatting_html.py
+++ b/python/src/scipp/html/formatting_html.py
@@ -9,6 +9,7 @@ from html import escape
 
 from .._scipp import core as sc
 from .resources import load_icons
+from ..utils.dimensions import find_bin_edges
 
 BIN_EDGE_LABEL = "[bin-edge]"
 VARIANCE_PREFIX = "σ² = "
@@ -168,23 +169,6 @@ def summarize_coord(dim, var, ds=None):
 
 def summarize_mask(dim, var, ds=None):
     return summarize_variable(str(dim), var, is_index=False, embedded_in=ds)
-
-
-def find_bin_edges(var, ds):
-    """
-    Checks if the coordinate contains bin-edges.
-    """
-    bin_edges = []
-    for idx, dim in enumerate(var.dims):
-        length = var.shape[idx]
-        if not ds.dims:
-            # Have a scalar slice.
-            # Cannot match dims, just assume length 2 attributes are bin-edge
-            if length == 2:
-                bin_edges.append(dim)
-        elif dim in ds.dims and ds.shape[ds.dims.index(dim)] + 1 == length:
-            bin_edges.append(dim)
-    return bin_edges
 
 
 def summarize_coords(coords, ds=None):

--- a/python/src/scipp/utils/dimensions.py
+++ b/python/src/scipp/utils/dimensions.py
@@ -9,8 +9,7 @@ def find_bin_edges(var, ds):
     var is a coord or attr of ds.
     """
     bin_edges = []
-    for idx, dim in enumerate(var.dims):
-        length = var.shape[idx]
+    for dim, length in var.sizes.items():
         if not ds.dims:
             # Have a scalar slice.
             # Cannot match dims, just assume length 2 attributes are bin-edge

--- a/python/src/scipp/utils/dimensions.py
+++ b/python/src/scipp/utils/dimensions.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Jan-Lukas Wynen
+
+
+def find_bin_edges(var, ds):
+    """
+    Returns a list of bin-edge dimension labels assuming that
+    var is a coord or attr of ds.
+    """
+    bin_edges = []
+    for idx, dim in enumerate(var.dims):
+        length = var.shape[idx]
+        if not ds.dims:
+            # Have a scalar slice.
+            # Cannot match dims, just assume length 2 attributes are bin-edge
+            if length == 2:
+                bin_edges.append(dim)
+        elif dim in ds.dims and ds.shape[ds.dims.index(dim)] + 1 == length:
+            bin_edges.append(dim)
+    return bin_edges

--- a/python/tests/transform_coords_test.py
+++ b/python/tests/transform_coords_test.py
@@ -51,6 +51,10 @@ def ab(*, a, b):
     return a + b
 
 
+def ba(b, a):
+    return b + a
+
+
 def bc(*, b, c):
     return b * c
 
@@ -146,6 +150,26 @@ def test_dim_rename_multi_level_merge_multi_output():
     # Similar to test_dim_rename_multi_level_merge above, but now an implicit
     # intermediate result prevents conversion of a to c
     assert da.dims == ['a', 'bc']
+
+
+def test_dim_merge_two_transposed():
+    # *a   *b
+    #   \  /
+    #    ab
+    # without bin-edge
+    original = sc.DataArray(data=a + b, coords={'a': a, 'b': b})
+    # ab depends on two dimension coords => no rename of a
+    da = original.transform_coords(['ba'], graph={'ba': ba})
+    assert da.dims == ['a', 'b']
+    assert sc.identical(da.coords['ba'], sc.transpose(b + a, ['b', 'a']))
+
+    # without bin-edge
+    bin_edge = sc.arange('b', 0, b.shape[0] + 1)
+    original = sc.DataArray(data=a + b, coords={'a': a, 'b': bin_edge})
+    # ab depends on two dimension coords => no rename of a
+    da = original.transform_coords(['ba'], graph={'ba': ba})
+    assert da.dims == ['a', 'b']
+    assert sc.identical(da.coords['ba'], sc.transpose(bin_edge + a, ['a', 'b']))
 
 
 def test_rename_dims_param():


### PR DESCRIPTION
Addresses https://github.com/scipp/scipp/issues/2057#issuecomment-892646978
We may still want to reconsider the limitation that bin-edge dims must be innermost in multi-dimensional coords.