### PR TITLE
Add simplified option to `show_graph`

### DIFF
--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -299,7 +299,7 @@ def show_graph(graph, size: str = None, simplified: bool = False):
     :param size: Size forwarded to graphviz, must be a string, "width,height"
                  or "size". In the latter case, the same value is used for
                  both width and height.
-    :param simplified: If ``True``, do not show the conversion functions but
+    :param simplified: If ``True``, do not show the conversion functions,
                        only the potential input and output coordinates.
     """
     return Graph(graph).show(size=size, simplified=simplified)

--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -33,7 +33,7 @@ class Graph:
     def __contains__(self, name):
         return name in self._graph
 
-    def show(self, size=None):
+    def show(self, size=None, simplified=False):
         try:
             from graphviz import Digraph
         except ImportError:
@@ -46,9 +46,12 @@ class Graph:
             if isinstance(producer, str):  # rename
                 dot.edge(producer, output)
             else:
-                name = f'{producer.__name__}(...)'
-                dot.node(name, shape='ellipse', style='filled', color='lightgrey')
-                dot.edge(name, output)
+                if not simplified:
+                    name = f'{producer.__name__}(...)'
+                    dot.node(name, shape='ellipse', style='filled', color='lightgrey')
+                    dot.edge(name, output)
+                else:
+                    name = output
                 argnames = _argnames(producer)
                 for arg in argnames:
                     dot.edge(arg, name)
@@ -286,7 +289,7 @@ def transform_coords(x: Union[DataArray, Dataset],
         return _transform_dataset(x, coords=coords, graph=graph, kwargs=kwargs)
 
 
-def show_graph(graph, size: str = None):
+def show_graph(graph, size: str = None, simplified: bool = False):
     """
     Show graphical representation of a graph as required by
     :py:func:`transform_coords`
@@ -296,5 +299,7 @@ def show_graph(graph, size: str = None):
     :param size: Size forwarded to graphviz, must be a string, "width,height"
                  or "size". In the latter case, the same value is used for
                  both width and height.
+    :param simplified: If ``True``, do not show the conversion functions but
+                       only the potential input and output coordinates.
     """
-    return Graph(graph).show(size=size)
+    return Graph(graph).show(size=size, simplified=simplified)


### PR DESCRIPTION
Graphs can become quite large and the names of the conversion functions are not necessarily meaningful to a user if those functions are defined internally in some package (e.g. scippneutron). This option allows omitting them from the graph.