### PR TITLE
Bump gcc version in tooling docs to 9.3

### DIFF
--- a/docs/reference/developer/tooling.rst
+++ b/docs/reference/developer/tooling.rst
@@ -14,7 +14,7 @@ Note: Ubuntu users can use the `Kitware Repo <https://apt.kitware.com/>`_ to obt
 Compilers
 ~~~~~~~~~
 
-- GCC >= 7
+- GCC >= 9
 - LLVM Clang >= 7
 - XCode >= 10.2
 


### PR DESCRIPTION
Whilst trying to compile with GCC 7.3 there were multiple warnings and an error that stopped compiling, so this will bump our min version in our tooling documentation.