### PR TITLE
Add test for transform_coord with coord attr clash

### DIFF
--- a/python/tests/transform_coords_test.py
+++ b/python/tests/transform_coords_test.py
@@ -333,3 +333,10 @@ def test_duplicate_output_keys():
     with pytest.raises(ValueError):
         graph = {('b', 'd'): to_bd, ('b', 'c'): to_bc}
         original.transform_coords(['b'], graph=graph)
+
+
+def test_prioritize_coords_attrs_conflict():
+    original = sc.DataArray(data=a, coords={'a': a}, attrs={'a': -1 * a})
+
+    with pytest.raises(sc.DataArrayError):
+        original.transform_coords(['b'], graph={'b': 'a'})


### PR DESCRIPTION
This is to ensure that this behaviour is not accidentally changed. Automatically picking using either a coord or an attribute when both are present could quickly lead to surprises.