### PR TITLE
Make compat a package

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -225,8 +225,8 @@ Compatibility
 
    to_dict
    from_dict
-   from_pandas
-   from_xarray
+   compat.from_pandas
+   compat.from_xarray
 
 
 Typing

--- a/python/src/scipp/compat/__init__.py
+++ b/python/src/scipp/compat/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @file
+# @author Jan-Lukas Wynen
+
+from .pandas_compat import from_pandas
+from .xarray_compat import from_xarray
+
+__all__ = ['from_pandas', 'from_xarray']

--- a/python/src/scipp/compat/pandas_compat.py
+++ b/python/src/scipp/compat/pandas_compat.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Union, TYPE_CHECKING
 
-from .. import Dataset, DataArray, Variable, VariableLike
+from .._scipp.core import Dataset, DataArray, Variable
+from ..typing import VariableLike
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/python/src/scipp/compat/pandas_compat.py
+++ b/python/src/scipp/compat/pandas_compat.py
@@ -42,8 +42,8 @@ def from_pandas(pd_obj: Union[pd.DataFrame, pd.Series]) -> VariableLike:
     Converts a pandas.DataFrame or pandas.Series object into a
     scipp Dataset or DataArray respectively.
 
-    :param pd_obj: the Dataframe or Series to convert
-    :return: the converted scipp object.
+    :param pd_obj: The Dataframe or Series to convert
+    :return: The converted scipp object.
     """
     import pandas as pd
     if isinstance(pd_obj, pd.DataFrame):

--- a/python/src/scipp/compat/xarray_compat.py
+++ b/python/src/scipp/compat/xarray_compat.py
@@ -18,9 +18,9 @@ def from_xarray(obj: Union[xr.DataArray, xr.Dataset]) -> VariableLike:
     If you know in advance what type of object you need to convert, you can
     also call from_xarray_dataarray or from_xarray_dataset directly.
 
-    :param obj: the xarray object to convert; must be either an xarray
+    :param obj: The xarray object to convert; must be either an xarray
         DataArray or Dataset object.
-    :return: the converted scipp object.
+    :return: The converted scipp object.
     """
     import xarray as xr
 
@@ -41,8 +41,8 @@ def from_xarray_dataarray(da: xr.DataArray) -> DataArray:
     """
     Converts an xarray.DataArray object to a scipp.DataArray object.
 
-    :param da: an xarray.DataArray object to be converted.
-    :return: the converted scipp DataArray object.
+    :param da: An xarray.DataArray object to be converted.
+    :return: The converted scipp DataArray object.
     """
     coords = {}
     attrs = {attr: scalar(da.attrs[attr]) for attr in da.attrs if attr != "units"}
@@ -63,8 +63,8 @@ def from_xarray_dataset(ds: xr.Dataset) -> Dataset:
     """
     Converts an xarray.Dataset object to a scipp.Dataset object.
 
-    :param ds: an xarray.Dataset object to be converted.
-    :return: the converted scipp dataset object.
+    :param ds: An xarray.Dataset object to be converted.
+    :return: The converted scipp dataset object.
     """
     sc_data = {k: from_xarray(v) for k, v in ds.items()}
     return Dataset(data=sc_data)

--- a/python/src/scipp/compat/xarray_compat.py
+++ b/python/src/scipp/compat/xarray_compat.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Union, TYPE_CHECKING
 
-from .. import Dataset, DataArray, Variable, scalar, VariableLike, Unit
+from .._scipp.core import Dataset, DataArray, Unit, Variable
+from ..typing import VariableLike
+from .._variable import scalar
 
 if TYPE_CHECKING:
     import xarray as xr

--- a/python/tests/compat/pandas_compat_test.py
+++ b/python/tests/compat/pandas_compat_test.py
@@ -1,6 +1,6 @@
 import pandas
 import scipp as sc
-from scipp.compat.pandas_compat import from_pandas
+from scipp.compat import from_pandas
 
 
 def _make_reference_da(row_name, row_coords, values, dtype="int64"):

--- a/python/tests/compat/xarray_compat_test.py
+++ b/python/tests/compat/xarray_compat_test.py
@@ -1,7 +1,7 @@
 import numpy
 import xarray
 import scipp as sc
-from scipp.compat.xarray_compat import from_xarray
+from scipp.compat import from_xarray
 
 
 def test_empty_attrs_dataarray():


### PR DESCRIPTION
Simplifies import of `from_pandas` and `from_xarray`.

Also fixes the corresponding links in the documentation.