### PR TITLE
Allow pass through in `coord_transform`

### DIFF
--- a/python/src/scipp/coords.py
+++ b/python/src/scipp/coords.py
@@ -78,20 +78,25 @@ def _move_to_back(lis, val):
     return lis
 
 
-def _move_bin_edge_to_innermost(var, edge_dim):
-    return var.transpose(_move_to_back(var.dims, edge_dim))
-
-
-def _store_coord(obj, name, coord):
+def _move_bin_edge_to_innermost(obj, coord):
     edges = find_bin_edges(coord, obj)
     if not edges:
-        obj.coords[name] = coord
+        return coord
     elif len(edges) == 1:
-        obj.coords[name] = _move_bin_edge_to_innermost(coord, edges[0])
+        return coord.transpose(_move_to_back(coord.dims, edges[0]))
     else:
         raise NotImplementedError(
             'Coordinates with more than one bin-edge dimension are not supported. '
             f'Got coord {coord} with bin edges {edges}.')
+
+
+def _store_coord(obj, name, coord):
+    obj.coords[name] = _move_bin_edge_to_innermost(obj, coord)
+    if name in obj.attrs:
+        # If name is both an input and output to a function,
+        # the input handling made it an attr, but since it is
+        # an output, we want to store it as a coord (and only as a coord).
+        del obj.attrs[name]
 
 
 class CoordTransform:

--- a/python/tests/transform_coords_test.py
+++ b/python/tests/transform_coords_test.py
@@ -359,6 +359,35 @@ def test_duplicate_output_keys():
         original.transform_coords(['b'], graph=graph)
 
 
+def test_pass_through_unary():
+    original = sc.DataArray(data=a + b, coords={'a': a, 'b': b})
+    expected = original.copy()
+    assert sc.identical(original.transform_coords(['a'], graph={'a': 'a'}), expected)
+
+    with_a_as_attr = original.copy()
+    with_a_as_attr.attrs['a'] = with_a_as_attr.coords.pop('a')
+    assert sc.identical(with_a_as_attr.transform_coords(['a'], graph={'a': 'a'}),
+                        expected)
+
+
+def test_pass_through_binary():
+    def ac(a, b):
+        return {'a': a, 'c': b, 'd': a}
+
+    graph = {('a', 'c', 'd'): ac}
+
+    original = sc.DataArray(data=a + b, coords={'a': a, 'b': b})
+    expected = sc.DataArray(data=a + b, coords={'a': a, 'c': b, 'd': a}, attrs={'b': b})
+    assert sc.identical(original.transform_coords(['a'], graph=graph), original)
+    assert sc.identical(original.transform_coords(['c'], graph=graph), expected)
+
+    with_a_as_attr = original.copy()
+    with_a_as_attr.attrs['a'] = with_a_as_attr.coords.pop('a')
+    assert sc.identical(with_a_as_attr.transform_coords(['a'], graph=graph), original)
+    assert sc.identical(with_a_as_attr.transform_coords(['c'], graph=graph), expected)
+    assert sc.identical(with_a_as_attr.transform_coords(['d'], graph=graph), expected)
+
+
 def test_prioritize_coords_attrs_conflict():
     original = sc.DataArray(data=a, coords={'a': a}, attrs={'a': -1 * a})
 


### PR DESCRIPTION
Needed in to promote certain attributes to coords, e.g. converting from wavelength to time-of-flight needs `Ltotal` as input but it should also be stored as a coord. This ensures that the conversion is a proper inversion of time-of-flight -> wavelength.