### PR TITLE
Add clang-format to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
         - id: yapf
           args: ["-i", "-r"]
           files: "python"
+  - repo: https://github.com/mantidproject/pre-commit-hooks.git
+    rev: ebd7eb9cc07498e58a8af5688104ab1e98f25b04
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
Mantid has a repository for pre-commit framework hooks including clang-format.
I made a branch on this repo called scipp: https://github.com/mantidproject/pre-commit-hooks/tree/scipp, and ran through the workflow to create the hook for clang-format version 10, the branch is independent of master and can easily be edited to be kept up to date/updated more generally with a new PR.

This would make it harder to move forward with clang-format versions but it will help developers with clang-format by doing it for them, before even committing and sending to the CI.

Clang-format in this case works on Windows, MacOS, and Linux OSs that support the compiled glibc version.