### PR TITLE
Add `scipp.constants`

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,6 +34,7 @@ test:
     - python-graphviz
     - xarray
     - pandas
+    - scipy
   source_files:
     - python/tests
   commands:

--- a/docs/_templates/scipp-module-template.rst
+++ b/docs/_templates/scipp-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: scipp-class-template.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: scipp-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -18,6 +18,7 @@ Features
 * Add ``from_pandas`` and ``from_xarray`` for conversion of pandas dataframes, xarray data arrays and dataset to scipp objects `#2054 <https://github.com/scipp/scipp/pull/2054>`_.
 * Added ``full`` and ``full_like`` variable creation functions `#2069 <https://github.com/scipp/scipp/pull/2069>`_.
 * Added a power function and support for the ``**`` operator `#2083 <https://github.com/scipp/scipp/pull/2083>`_.
+* Add ``scipp.constants`` module for physical constants `#2101 <https://github.com/scipp/scipp/pull/2101>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -40,6 +40,7 @@ Bugfixes
 ~~~~~~~~
 
 * Various fixes in ``plot``, see  `#2018 <https://github.com/scipp/scipp/pull/2018>`_ for details.
+* Operations with Python floats to long interpret the float as 32-bit float `#2101 <https://github.com/scipp/scipp/pull/2101>`_.
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -228,6 +228,16 @@ Compatibility
    compat.from_pandas
    compat.from_xarray
 
+Modules
+=======
+
+.. autosummary::
+   :toctree: ../generated/modules
+   :template: scipp-module-template.rst
+   :recursive:
+
+   constants
+
 
 Typing
 ======

--- a/python/bind_operators.h
+++ b/python/bind_operators.h
@@ -228,17 +228,13 @@ static void bind_binary(pybind11::class_<T, Ignored...> &c) {
 
 template <class T, class... Ignored>
 void bind_in_place_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::in_place_binary<float>(c);
   OpBinder<ScalarToVariable>::in_place_binary<double>(c);
-  OpBinder<ScalarToVariable>::in_place_binary<int32_t>(c);
   OpBinder<ScalarToVariable>::in_place_binary<int64_t>(c);
 }
 
 template <class T, class... Ignored>
 void bind_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::binary<float>(c);
   OpBinder<ScalarToVariable>::binary<double>(c);
-  OpBinder<ScalarToVariable>::binary<int32_t>(c);
   OpBinder<ScalarToVariable>::binary<int64_t>(c);
 }
 

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -51,7 +51,7 @@ from ._scipp.core import BinEdgeError, BinnedDataError, CoordError, \
 from ._scipp.core import units, dtype, buckets
 from . import geometry
 # Import functions
-from ._scipp.core import choose, logical_and, logical_or, logical_xor, where
+from ._scipp.core import as_const, choose, logical_and, logical_or, logical_xor, where
 # Import python functions
 from .show import show, make_svg
 from .table import table

--- a/python/src/scipp/constants/__init__.py
+++ b/python/src/scipp/constants/__init__.py
@@ -1,7 +1,8 @@
 # flake8: noqa: E501
 r"""
 Physical and mathematical constants with units.
-This is a wrapper around `scipy.constants <https://docs.scipy.org/doc/scipy/reference/constants.html>`_.
+This module a wrapper around `scipy.constants <https://docs.scipy.org/doc/scipy/reference/constants.html>`_
+and requires the ``scipy`` package to be installed.
 
 Mathematical constants:
 

--- a/python/src/scipp/constants/__init__.py
+++ b/python/src/scipp/constants/__init__.py
@@ -1,0 +1,117 @@
+# flake8: noqa: E501
+r"""
+==================================
+Constants (:mod:`scipp.constants`)
+==================================
+
+.. currentmodule:: scipp.constants
+
+Physical and mathematical constants and units.
+This is a wrapper around ``scipy.constants``.
+
+Mathematical constants
+======================
+
+================  =================================================================
+``pi``            Pi
+``golden``        Golden ratio
+``golden_ratio``  Golden ratio
+================  =================================================================
+
+Physical constants
+==================
+
+===========================  =============================================
+``c``                        speed of light in vacuum
+``speed_of_light``           speed of light in vacuum
+``mu_0``                     the magnetic constant :math:`\mu_0`
+``epsilon_0``                the electric constant (vacuum permittivity),
+                             :math:`\epsilon_0`
+``h``                        the Planck constant :math:`h`
+``Planck``                   the Planck constant :math:`h`
+``hbar``                     :math:`\hbar = h/(2\pi)`
+``G``                        Newtonian constant of gravitation
+``gravitational_constant``   Newtonian constant of gravitation
+``g``                        standard acceleration of gravity
+``e``                        elementary charge
+``elementary_charge``        elementary charge
+``R``                        molar gas constant
+``gas_constant``             molar gas constant
+``alpha``                    fine-structure constant
+``fine_structure``           fine-structure constant
+``N_A``                      Avogadro constant
+``Avogadro``                 Avogadro constant
+``k``                        Boltzmann constant
+``Boltzmann``                Boltzmann constant
+``sigma``                    Stefan-Boltzmann constant :math:`\sigma`
+``Stefan_Boltzmann``         Stefan-Boltzmann constant :math:`\sigma`
+``Wien``                     Wien displacement law constant
+``Rydberg``                  Rydberg constant
+``m_e``                      electron mass
+``electron_mass``            electron mass
+``m_p``                      proton mass
+``proton_mass``              proton mass
+``m_n``                      neutron mass
+``neutron_mass``             neutron mass
+===========================  =============================================
+
+Constants database
+------------------
+
+In addition to the above variables, :mod:`scipp.constants` also contains the
+2018 CODATA recommended values [CODATA2018]_ database containing more physical
+constants.
+The database is accessed using :py:func:`scipp.constants.physical_constants`.
+
+References
+==========
+.. [CODATA2018] CODATA Recommended Values of the Fundamental
+   Physical Constants 2018.
+   https://physics.nist.gov/cuu/Constants/
+"""
+import math as _math
+from .. import scalar, Variable
+
+
+def physical_constants(key: str, with_variance: bool = False) -> Variable:
+    """
+    Returns the CODATA recommended value of the requested physical constant.
+
+    :param key: Key of the requested constant. See `scipy.constants.physical_constants <https://docs.scipy.org/doc/scipy/reference/constants.html#scipy.constants.physical_constants>`_ for an overview.
+    :param with_variance: Optional, if True, the uncertainty if the constant is
+                          included as the variance. Default is False.
+    """
+    from scipy.constants import physical_constants as _cd
+    value, unit, uncertainty = _cd[key]
+    args = {'value': value, 'unit': unit.replace(' ', '*')}
+    if with_variance:
+        stddev = uncertainty
+        args['variance'] = stddev * stddev
+    return scalar(**args)
+
+
+# mathematical constants
+pi = _math.pi
+golden = golden_ratio = (1 + _math.sqrt(5)) / 2
+
+# physical constants
+c = speed_of_light = physical_constants('speed of light in vacuum')
+mu_0 = physical_constants('vacuum mag. permeability')
+epsilon_0 = physical_constants('vacuum electric permittivity')
+h = Planck = physical_constants('Planck constant')
+hbar = h / (2 * pi)
+G = gravitational_constant = physical_constants('Newtonian constant of gravitation')
+g = physical_constants('standard acceleration of gravity')
+e = elementary_charge = physical_constants('elementary charge')
+R = gas_constant = physical_constants('molar gas constant')
+alpha = fine_structure = physical_constants('fine-structure constant')
+N_A = Avogadro = physical_constants('Avogadro constant')
+k = Boltzmann = physical_constants('Boltzmann constant')
+sigma = Stefan_Boltzmann = physical_constants('Stefan-Boltzmann constant')
+Wien = physical_constants('Wien wavelength displacement law constant')
+Rydberg = physical_constants('Rydberg constant')
+
+m_e = electron_mass = physical_constants('electron mass')
+m_p = proton_mass = physical_constants('proton mass')
+m_n = neutron_mass = physical_constants('neutron mass')
+m_u = u = atomic_mass = physical_constants('atomic mass constant')

--- a/python/src/scipp/constants/__init__.py
+++ b/python/src/scipp/constants/__init__.py
@@ -58,7 +58,7 @@ The database is accessed using :py:func:`scipp.constants.physical_constants`.
    https://physics.nist.gov/cuu/Constants/
 """
 import math as _math
-from .. import scalar, Variable
+from .. import as_const, scalar, Variable
 
 
 def physical_constants(key: str, with_variance: bool = False) -> Variable:
@@ -77,7 +77,7 @@ def physical_constants(key: str, with_variance: bool = False) -> Variable:
     if with_variance:
         stddev = uncertainty
         args['variance'] = stddev * stddev
-    return scalar(**args)
+    return as_const(scalar(**args))
 
 
 # mathematical constants

--- a/python/src/scipp/constants/__init__.py
+++ b/python/src/scipp/constants/__init__.py
@@ -1,16 +1,9 @@
 # flake8: noqa: E501
 r"""
-==================================
-Constants (:mod:`scipp.constants`)
-==================================
+Physical and mathematical constants with units.
+This is a wrapper around `scipy.constants <https://docs.scipy.org/doc/scipy/reference/constants.html>`_.
 
-.. currentmodule:: scipp.constants
-
-Physical and mathematical constants and units.
-This is a wrapper around ``scipy.constants``.
-
-Mathematical constants
-======================
+Mathematical constants:
 
 ================  =================================================================
 ``pi``            Pi
@@ -18,8 +11,7 @@ Mathematical constants
 ``golden_ratio``  Golden ratio
 ================  =================================================================
 
-Physical constants
-==================
+Physical constants:
 
 ===========================  =============================================
 ``c``                        speed of light in vacuum
@@ -55,16 +47,11 @@ Physical constants
 ``neutron_mass``             neutron mass
 ===========================  =============================================
 
-Constants database
-------------------
-
 In addition to the above variables, :mod:`scipp.constants` also contains the
 2018 CODATA recommended values [CODATA2018]_ database containing more physical
 constants.
 The database is accessed using :py:func:`scipp.constants.physical_constants`.
 
-References
-==========
 .. [CODATA2018] CODATA Recommended Values of the Fundamental
    Physical Constants 2018.
    https://physics.nist.gov/cuu/Constants/
@@ -75,11 +62,13 @@ from .. import scalar, Variable
 
 def physical_constants(key: str, with_variance: bool = False) -> Variable:
     """
-    Returns the CODATA recommended value of the requested physical constant.
+    Returns the CODATA recommended value with unit of the requested physical constant.
 
     :param key: Key of the requested constant. See `scipy.constants.physical_constants <https://docs.scipy.org/doc/scipy/reference/constants.html#scipy.constants.physical_constants>`_ for an overview.
     :param with_variance: Optional, if True, the uncertainty if the constant is
                           included as the variance. Default is False.
+    :returns: Scalar variable with unit and optional variance.
+    :rtype: Variable
     """
     from scipy.constants import physical_constants as _cd
     value, unit, uncertainty = _cd[key]

--- a/python/src/scipp/constants/__init__.py
+++ b/python/src/scipp/constants/__init__.py
@@ -80,8 +80,8 @@ def physical_constants(key: str, with_variance: bool = False) -> Variable:
 
 
 # mathematical constants
-pi = _math.pi
-golden = golden_ratio = (1 + _math.sqrt(5)) / 2
+pi = scalar(_math.pi)
+golden = golden_ratio = scalar((1 + _math.sqrt(5)) / 2)
 
 # physical constants
 c = speed_of_light = physical_constants('speed of light in vacuum')

--- a/python/tests/constants/constants_test.py
+++ b/python/tests/constants/constants_test.py
@@ -23,3 +23,12 @@ def test_physical_constants():
     assert var.variance is None
     var = ours.physical_constants('speed of light in vacuum', with_variance=True)
     assert var.variance == e * e
+
+
+@pytest.mark.parametrize(
+    "var", [ours.m_e, ours.physical_constants('speed of light in vacuum')])
+def test_constants_cannot_be_modified(var):
+    original = var.copy()
+    with pytest.raises(sc.VariableError):
+        var *= 2.0
+    assert sc.identical(var, original)

--- a/python/tests/constants/constants_test.py
+++ b/python/tests/constants/constants_test.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+import scipp as sc
+import scipy.constants as theirs
+import scipp.constants as ours
+
+import pytest
+
+
+@pytest.mark.parametrize("name", dir(ours))
+def test_constant(name):
+    var = getattr(ours, name)
+    if not isinstance(var, sc.Variable):
+        pytest.skip()
+    assert var.value == getattr(theirs, name)
+
+
+def test_physical_constants():
+    v, u, e = theirs.physical_constants['speed of light in vacuum']
+    var = ours.physical_constants('speed of light in vacuum')
+    assert var.value == v
+    assert var.unit == u
+    assert var.variance is None
+    var = ours.physical_constants('speed of light in vacuum', with_variance=True)
+    assert var.variance == e * e

--- a/python/tests/python_scalar_operations_test.py
+++ b/python/tests/python_scalar_operations_test.py
@@ -23,6 +23,15 @@ def test_operation_with_python_int32():
     assert sc.identical(a + b, a + sc.scalar(b))
 
 
+def test_reverse_operation_with_python_int32():
+    a = sc.scalar(3, dtype='int32')
+    b = 2
+    assert sc.identical(b + a, sc.scalar(b) + a)
+    assert sc.identical(b - a, sc.scalar(b) - a)
+    assert sc.identical(b * a, sc.scalar(b) * a)
+    assert sc.identical(b / a, sc.scalar(b) / a)
+
+
 def test_inplace_operation_with_python_int32():
     a = sc.scalar(3, dtype='int32')
     b = 2

--- a/python/tests/python_scalar_operations_test.py
+++ b/python/tests/python_scalar_operations_test.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+import scipp as sc
+
+
+def test_operation_with_python_float():
+    a = sc.scalar(1.23456789)
+    b = 9.87654321
+    assert (a / b).value == (a / sc.scalar(b)).value
+
+
+def test_inplace_operation_with_python_float():
+    a = sc.scalar(1.23456789)
+    b = 9.87654321
+    expected = a.value / b
+    a /= b
+    assert a.value == expected
+
+
+def test_operation_with_python_int32():
+    a = sc.scalar(3, dtype='int32')
+    b = 2
+    assert sc.identical(a + b, a + sc.scalar(b))
+
+
+def test_inplace_operation_with_python_int32():
+    a = sc.scalar(3, dtype='int32')
+    b = 2
+    expected = a.value + b
+    a += b
+    assert a.value == expected

--- a/python/tests/variable_test.py
+++ b/python/tests/variable_test.py
@@ -889,20 +889,20 @@ def test_comparison():
 
 def test_radd_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var + 1).dtype == var.dtype
-    assert (1 + var).dtype == var.dtype
+    assert (var + 1).dtype == sc.dtype.int64
+    assert (1 + var).dtype == sc.dtype.int64
 
 
 def test_rsub_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var - 1).dtype == var.dtype
-    assert (1 - var).dtype == var.dtype
+    assert (var - 1).dtype == sc.dtype.int64
+    assert (1 - var).dtype == sc.dtype.int64
 
 
 def test_rmul_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var * 1).dtype == var.dtype
-    assert (1 * var).dtype == var.dtype
+    assert (var * 1).dtype == sc.dtype.int64
+    assert (1 * var).dtype == sc.dtype.int64
 
 
 def test_rtruediv_int():

--- a/python/unary.cpp
+++ b/python/unary.cpp
@@ -71,6 +71,11 @@ template <class T> void bind_to_unit(py::module &m) {
       py::arg("x"), py::arg("unit"), py::arg("copy") = true,
       py::call_guard<py::gil_scoped_release>());
 }
+
+template <class T> void bind_as_const(py::module &m) {
+  m.def(
+      "as_const", [](const T &x) { return x.as_const(); }, py::arg("x"));
+}
 } // namespace
 
 void init_unary(py::module &m) {
@@ -78,4 +83,6 @@ void init_unary(py::module &m) {
   bind_nan_to_num<Variable>(m);
   bind_to_unit<Variable>(m);
   bind_to_unit<DataArray>(m);
+  bind_as_const<Variable>(m);
+  bind_as_const<DataArray>(m);
 }

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -93,20 +93,23 @@ of variances.)");
           "__radd__", [](Variable &a, double &b) { return a + b * units::one; },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
-          "__radd__", [](Variable &a, int &b) { return a + b * units::one; },
+          "__radd__",
+          [](Variable &a, int64_t &b) { return a + b * units::one; },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
           "__rsub__", [](Variable &a, double &b) { return b * units::one - a; },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
-          "__rsub__", [](Variable &a, int &b) { return b * units::one - a; },
+          "__rsub__",
+          [](Variable &a, int64_t &b) { return b * units::one - a; },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
           "__rmul__",
           [](Variable &a, double &b) { return a * (b * units::one); },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
-          "__rmul__", [](Variable &a, int &b) { return a * (b * units::one); },
+          "__rmul__",
+          [](Variable &a, int64_t &b) { return a * (b * units::one); },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
           "__rtruediv__",
@@ -114,7 +117,7 @@ of variances.)");
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
           "__rtruediv__",
-          [](Variable &a, int &b) { return (b * units::one) / a; },
+          [](Variable &a, int64_t &b) { return (b * units::one) / a; },
           py::is_operator(), py::call_guard<py::gil_scoped_release>())
       .def(
           "__rpow__",

--- a/scipp-developer-minimal.yml
+++ b/scipp-developer-minimal.yml
@@ -33,3 +33,4 @@ dependencies:
   - python-graphviz
   - xarray  # For testing xarray <-> scipp conversion
   - pandas  # For testing pandas <-> scipp conversion
+  - scipy

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -33,6 +33,7 @@ dependencies:
   - python-graphviz
   - xarray  # For testing xarray <-> scipp conversion
   - pandas  # For testing pandas <-> scipp conversion
+  - scipy
 
   # Formatting & static analysis
   - pre-commit


### PR DESCRIPTION
Fixes #2064.

Based on `scipy.constants`. Just like there the following is not supported:
```python
import scipp as sc
sc.constants
```
since we do not import `constants` in the top level `__init__.py`. Not sure this is what we want ultimately, but it avoids setup cost and avoids making `scipy` a mandatory dependency.

`scipp.constants.physical_constants` is implemented as a function (it is a dict in `scipy`). Two reasons:
- Avoid creation of many variables on import.
- Not all unit strings appear to be parseable right now. 

Also fixes #2082, in particular a bad bug in operations with Python floats.