### PR TITLE
Explicitly disable static build of LLNL/Units

### DIFF
--- a/cmake/LLNL-units.cmake
+++ b/cmake/LLNL-units.cmake
@@ -31,6 +31,7 @@ set(UNITS_NAMESPACE
     CACHE STRING "" FORCE
 )
 set(UNITS_BUILD_SHARED_LIBRARY ON)
+set(UNITS_BUILD_STATIC_LIBRARY OFF)
 set(UNITS_BASE_TYPE uint64_t)
 add_subdirectory(
   ${CMAKE_BINARY_DIR}/llnl-units-src ${CMAKE_BINARY_DIR}/llnl-units-build


### PR DESCRIPTION
Fixes a warning emitted by LLNL/Unit's Cmake:
```
CMake Warning at build/llnl-units-src/CMakeLists.txt:159 (message):
  Both UNITS_BUILD_SHARED_LIBRARY and UNITS_BUILD_STATIC_LIBRARY are set to
  ON, only the shared library will be built
```