### PR TITLE
Bins data fixes and API cleanup

### DIFF
--- a/cmake/scipp-functions.cmake
+++ b/cmake/scipp-functions.cmake
@@ -13,54 +13,54 @@ decltype(auto) preprocess(const scipp::variable::Variable &var) {
 }"
 )
 
-scipp_unary(math abs)
-scipp_unary(math exp)
-scipp_unary(math log)
-scipp_unary(math log10)
-scipp_unary(math reciprocal)
-scipp_unary(math sqrt)
-scipp_unary(math norm NO_OUT)
-scipp_binary(math pow SKIP_VARIABLE)
-scipp_binary(math dot NO_OUT)
-scipp_binary(math cross NO_OUT)
+scipp_unary(math abs OUT)
+scipp_unary(math exp OUT)
+scipp_unary(math log OUT)
+scipp_unary(math log10 OUT)
+scipp_unary(math reciprocal OUT)
+scipp_unary(math sqrt OUT)
+scipp_unary(math norm)
+scipp_binary(math pow SKIP_VARIABLE OUT)
+scipp_binary(math dot)
+scipp_binary(math cross)
 setup_scipp_category(math)
 
-scipp_unary(util values NO_OUT)
-scipp_unary(util variances NO_OUT)
-scipp_unary(util stddevs NO_OUT)
+scipp_unary(util values)
+scipp_unary(util variances)
+scipp_unary(util stddevs)
 setup_scipp_category(util)
 
-scipp_unary(trigonometry sin PREPROCESS_VARIABLE "${convert_to_rad}")
-scipp_unary(trigonometry cos PREPROCESS_VARIABLE "${convert_to_rad}")
-scipp_unary(trigonometry tan PREPROCESS_VARIABLE "${convert_to_rad}")
-scipp_unary(trigonometry asin)
-scipp_unary(trigonometry acos)
-scipp_unary(trigonometry atan)
-scipp_binary(trigonometry atan2)
-setup_scipp_category(trigonometry)
+scipp_unary(trigonometry sin PREPROCESS_VARIABLE "${convert_to_rad}" OUT)
+scipp_unary(trigonometry cos PREPROCESS_VARIABLE "${convert_to_rad}" OUT)
+scipp_unary(trigonometry tan PREPROCESS_VARIABLE "${convert_to_rad}" OUT)
+scipp_unary(trigonometry asin OUT)
+scipp_unary(trigonometry acos OUT)
+scipp_unary(trigonometry atan OUT)
+scipp_binary(trigonometry atan2 OUT)
+setup_scipp_category(trigonometry OUT)
 
-scipp_unary(special_values isnan NO_OUT)
-scipp_unary(special_values isinf NO_OUT)
-scipp_unary(special_values isfinite NO_OUT)
-scipp_unary(special_values isposinf NO_OUT)
-scipp_unary(special_values isneginf NO_OUT)
+scipp_unary(special_values isnan)
+scipp_unary(special_values isinf)
+scipp_unary(special_values isfinite)
+scipp_unary(special_values isposinf)
+scipp_unary(special_values isneginf)
 setup_scipp_category(special_values)
 
-scipp_binary(comparison equal NO_OUT)
-scipp_binary(comparison greater NO_OUT)
-scipp_binary(comparison greater_equal NO_OUT)
-scipp_binary(comparison less NO_OUT)
-scipp_binary(comparison less_equal NO_OUT)
-scipp_binary(comparison not_equal NO_OUT)
+scipp_binary(comparison equal)
+scipp_binary(comparison greater)
+scipp_binary(comparison greater_equal)
+scipp_binary(comparison less)
+scipp_binary(comparison less_equal)
+scipp_binary(comparison not_equal)
 setup_scipp_category(comparison)
 
-scipp_function("unary" arithmetic operator- OP unary_minus NO_OUT)
-scipp_function("binary" arithmetic operator+ OP add NO_OUT)
-scipp_function("binary" arithmetic operator- OP subtract NO_OUT)
-scipp_function("binary" arithmetic operator* OP multiply NO_OUT)
-scipp_function("binary" arithmetic operator/ OP divide NO_OUT)
-scipp_function("binary" arithmetic floor_divide NO_OUT)
-scipp_function("binary" arithmetic operator% OP mod NO_OUT)
+scipp_function("unary" arithmetic operator- OP unary_minus)
+scipp_function("binary" arithmetic operator+ OP add)
+scipp_function("binary" arithmetic operator- OP subtract)
+scipp_function("binary" arithmetic operator* OP multiply)
+scipp_function("binary" arithmetic operator/ OP divide)
+scipp_function("binary" arithmetic floor_divide)
+scipp_function("binary" arithmetic operator% OP mod)
 scipp_function("inplace" arithmetic operator+= OP add_equals)
 scipp_function("inplace" arithmetic operator-= OP subtract_equals)
 scipp_function("inplace" arithmetic operator*= OP multiply_equals)
@@ -68,40 +68,16 @@ scipp_function("inplace" arithmetic operator/= OP divide_equals)
 scipp_function("inplace" arithmetic operator%= OP mod_equals)
 setup_scipp_category(arithmetic)
 
-scipp_function("unary" logical operator~ OP logical_not NO_OUT)
-scipp_function("binary" logical operator| OP logical_or NO_OUT)
-scipp_function("binary" logical operator& OP logical_and NO_OUT)
-scipp_function("binary" logical operator^ OP logical_xor NO_OUT)
+scipp_function("unary" logical operator~ OP logical_not)
+scipp_function("binary" logical operator| OP logical_or)
+scipp_function("binary" logical operator& OP logical_and)
+scipp_function("binary" logical operator^ OP logical_xor)
 scipp_function("inplace" logical operator|= OP logical_or_equals)
 scipp_function("inplace" logical operator&= OP logical_and_equals)
 scipp_function("inplace" logical operator^= OP logical_xor_equals)
 setup_scipp_category(logical)
 
-scipp_function(
-  "unary"
-  bins
-  bin_sizes
-  SKIP_VARIABLE
-  NO_OUT
-  BASE_INCLUDE
-  dataset/bins.h
-)
-scipp_function(
-  "unary"
-  bins
-  bins_sum
-  SKIP_VARIABLE
-  NO_OUT
-  BASE_INCLUDE
-  dataset/bins.h
-)
-scipp_function(
-  "unary"
-  bins
-  bins_mean
-  SKIP_VARIABLE
-  NO_OUT
-  BASE_INCLUDE
-  dataset/bins.h
-)
+scipp_function("unary" bins bin_sizes SKIP_VARIABLE BASE_INCLUDE dataset/bins.h)
+scipp_function("unary" bins bins_sum SKIP_VARIABLE BASE_INCLUDE dataset/bins.h)
+scipp_function("unary" bins bins_mean SKIP_VARIABLE BASE_INCLUDE dataset/bins.h)
 setup_scipp_category(bins)

--- a/cmake/scipp-functions.cmake
+++ b/cmake/scipp-functions.cmake
@@ -77,7 +77,31 @@ scipp_function("inplace" logical operator&= OP logical_and_equals)
 scipp_function("inplace" logical operator^= OP logical_xor_equals)
 setup_scipp_category(logical)
 
-scipp_function("unary" bins bin_sizes SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
-scipp_function("unary" bins bins_sum SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
-scipp_function("unary" bins bins_mean SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
+scipp_function(
+  "unary"
+  bins
+  bin_sizes
+  SKIP_VARIABLE
+  NO_OUT
+  BASE_INCLUDE
+  dataset/bins.h
+)
+scipp_function(
+  "unary"
+  bins
+  bins_sum
+  SKIP_VARIABLE
+  NO_OUT
+  BASE_INCLUDE
+  dataset/bins.h
+)
+scipp_function(
+  "unary"
+  bins
+  bins_mean
+  SKIP_VARIABLE
+  NO_OUT
+  BASE_INCLUDE
+  dataset/bins.h
+)
 setup_scipp_category(bins)

--- a/cmake/scipp-functions.cmake
+++ b/cmake/scipp-functions.cmake
@@ -76,3 +76,8 @@ scipp_function("inplace" logical operator|= OP logical_or_equals)
 scipp_function("inplace" logical operator&= OP logical_and_equals)
 scipp_function("inplace" logical operator^= OP logical_xor_equals)
 setup_scipp_category(logical)
+
+scipp_function("unary" bins bin_sizes SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
+scipp_function("unary" bins bins_sum SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
+scipp_function("unary" bins bins_mean SKIP_VARIABLE NO_OUT BASE_INCLUDE dataset/bins.h)
+setup_scipp_category(bins)

--- a/cmake/scipp-util.cmake
+++ b/cmake/scipp-util.cmake
@@ -4,7 +4,7 @@
 # ~~~
 function(scipp_function template category function_name)
   set(options SKIP_VARIABLE NO_OUT)
-  set(oneValueArgs OP PREPROCESS_VARIABLE)
+  set(oneValueArgs OP PREPROCESS_VARIABLE, BASE_INCLUDE)
   cmake_parse_arguments(
     PARSE_ARGV 3 SCIPP_FUNCTION "${options}" "${oneValueArgs}" ""
   )
@@ -21,6 +21,11 @@ function(scipp_function template category function_name)
     set(OPNAME ${SCIPP_FUNCTION_OP})
   else()
     set(OPNAME ${NAME})
+  endif()
+  if(DEFINED SCIPP_FUNCTION_BASE_INCLUDE)
+    set(BASE_INCLUDE ${SCIPP_FUNCTION_BASE_INCLUDE})
+  else()
+    set(BASE_INCLUDE variable/${OPNAME}.h)
   endif()
   if(DEFINED SCIPP_FUNCTION_PREPROCESS_VARIABLE)
     set(PREPROCESS_VARIABLE ${SCIPP_FUNCTION_PREPROCESS_VARIABLE})

--- a/cmake/scipp-util.cmake
+++ b/cmake/scipp-util.cmake
@@ -4,7 +4,7 @@
 # ~~~
 function(scipp_function template category function_name)
   set(options SKIP_VARIABLE NO_OUT)
-  set(oneValueArgs OP PREPROCESS_VARIABLE, BASE_INCLUDE)
+  set(oneValueArgs OP PREPROCESS_VARIABLE BASE_INCLUDE)
   cmake_parse_arguments(
     PARSE_ARGV 3 SCIPP_FUNCTION "${options}" "${oneValueArgs}" ""
   )

--- a/cmake/scipp-util.cmake
+++ b/cmake/scipp-util.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # ~~~
 function(scipp_function template category function_name)
-  set(options SKIP_VARIABLE NO_OUT)
+  set(options SKIP_VARIABLE OUT)
   set(oneValueArgs OP PREPROCESS_VARIABLE BASE_INCLUDE)
   cmake_parse_arguments(
     PARSE_ARGV 3 SCIPP_FUNCTION "${options}" "${oneValueArgs}" ""
@@ -12,10 +12,10 @@ function(scipp_function template category function_name)
   message("Generating files for ${function_name}")
   set(NAME ${function_name})
   set(ELEMENT_INCLUDE ${category})
-  if(SCIPP_FUNCTION_NO_OUT)
-    set(GENERATE_OUT "false")
-  else()
+  if(SCIPP_FUNCTION_OUT)
     set(GENERATE_OUT "true")
+  else()
+    set(GENERATE_OUT "false")
   endif()
   if(DEFINED SCIPP_FUNCTION_OP)
     set(OPNAME ${SCIPP_FUNCTION_OP})

--- a/dataset/bins.cpp
+++ b/dataset/bins.cpp
@@ -296,17 +296,16 @@ Variable histogram(const Variable &data, const Variable &binEdges) {
 Variable map(const DataArray &function, const Variable &x, Dim dim) {
   if (dim == Dim::Invalid)
     dim = edge_dimension(function);
-  const auto &coord = bins_view<DataArray>(x).meta()[dim];
   const auto &edges = function.meta()[dim];
   const auto data = masked_data(function, dim);
   const auto weights = subspan_view(data, dim);
   if (all(islinspace(edges, dim)).value<bool>()) {
-    return variable::transform(coord, subspan_view(edges, dim), weights,
+    return variable::transform(x, subspan_view(edges, dim), weights,
                                core::element::event::map_linspace, "map");
   } else {
     if (!allsorted(edges, dim))
       throw except::BinEdgeError("Bin edges of histogram must be sorted.");
-    return variable::transform(coord, subspan_view(edges, dim), weights,
+    return variable::transform(x, subspan_view(edges, dim), weights,
                                core::element::event::map_sorted_edges, "map");
   }
 }

--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -80,7 +80,7 @@ T GroupBy<T>::makeReductionOutput(const Dim reductionDim,
   T out;
   if (is_bins(m_data)) {
     const auto out_sizes =
-        GroupBy(bucket_sizes(m_data), {key(), groups()}).sum(reductionDim);
+        GroupBy(bin_sizes(m_data), {key(), groups()}).sum(reductionDim);
     out = resize(m_data, reductionDim, out_sizes);
   } else {
     out = resize(m_data, reductionDim, size(), fill);

--- a/dataset/include/scipp/dataset/bins.h
+++ b/dataset/include/scipp/dataset/bins.h
@@ -66,7 +66,7 @@ SCIPP_DATASET_EXPORT void scale(DataArray &data, const DataArray &histogram,
 } // namespace scipp::dataset::buckets
 
 // These functions are placed in scipp::variable for ADL but cannot be easily
-// moved into thatcompilation module since the implementation requires
+// moved into that compilation module since the implementation requires
 // DataArray.
 namespace scipp::variable {
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable bin_sizes(const Variable &var);

--- a/dataset/include/scipp/dataset/bins.h
+++ b/dataset/include/scipp/dataset/bins.h
@@ -65,6 +65,9 @@ SCIPP_DATASET_EXPORT void scale(DataArray &data, const DataArray &histogram,
 
 } // namespace scipp::dataset::buckets
 
+// These functions are placed in scipp::variable for ADL but cannot be easily
+// moved into thatcompilation module since the implementation requires
+// DataArray.
 namespace scipp::variable {
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable bin_sizes(const Variable &var);
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable bins_sum(const Variable &data);

--- a/dataset/include/scipp/dataset/bins.h
+++ b/dataset/include/scipp/dataset/bins.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "scipp/dataset/dataset.h"
+#include "scipp/dataset/generated_bins.h"
 #include "scipp/variable/bins.h"
 
 namespace scipp::dataset {
@@ -31,11 +32,6 @@ make_bins_no_validate(Variable indices, const Dim dim, DataArray buffer);
                                                       Dataset buffer);
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable
 make_bins_no_validate(Variable indices, const Dim dim, Dataset buffer);
-
-[[nodiscard]] SCIPP_DATASET_EXPORT Variable bucket_sizes(const Variable &var);
-[[nodiscard]] SCIPP_DATASET_EXPORT DataArray
-bucket_sizes(const DataArray &array);
-[[nodiscard]] SCIPP_DATASET_EXPORT Dataset bucket_sizes(const Dataset &dataset);
 
 [[nodiscard]] SCIPP_DATASET_EXPORT bool is_bins(const DataArray &array);
 [[nodiscard]] SCIPP_DATASET_EXPORT bool is_bins(const Dataset &dataset);
@@ -67,12 +63,10 @@ SCIPP_DATASET_EXPORT void append(DataArray &a, const DataArray &b);
 SCIPP_DATASET_EXPORT void scale(DataArray &data, const DataArray &histogram,
                                 Dim dim = Dim::Invalid);
 
-[[nodiscard]] SCIPP_DATASET_EXPORT Variable sum(const Variable &data);
-[[nodiscard]] SCIPP_DATASET_EXPORT DataArray sum(const DataArray &data);
-[[nodiscard]] SCIPP_DATASET_EXPORT Dataset sum(const Dataset &data);
-
-[[nodiscard]] SCIPP_DATASET_EXPORT Variable mean(const Variable &data);
-[[nodiscard]] SCIPP_DATASET_EXPORT DataArray mean(const DataArray &data);
-[[nodiscard]] SCIPP_DATASET_EXPORT Dataset mean(const Dataset &data);
-
 } // namespace scipp::dataset::buckets
+
+namespace scipp::variable {
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable bin_sizes(const Variable &var);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable bins_sum(const Variable &data);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable bins_mean(const Variable &data);
+} // namespace scipp::variable

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -135,11 +135,11 @@ protected:
 
   void expect_near(const DataArray &a, const DataArray &b) {
     const auto tolerance =
-        values(max(buckets::sum(a.data())) * (1e-14 * units::one));
-    EXPECT_TRUE(all(isclose(values(buckets::sum(a.data())),
-                            values(buckets::sum(b.data())), 0.0 * units::one,
-                            tolerance))
-                    .value<bool>());
+        values(max(bins_sum(a.data())) * (1e-14 * units::one));
+    EXPECT_TRUE(
+        all(isclose(values(bins_sum(a.data())), values(bins_sum(b.data())),
+                    0.0 * units::one, tolerance))
+            .value<bool>());
     EXPECT_EQ(a.masks(), b.masks());
     EXPECT_EQ(a.coords(), b.coords());
     EXPECT_EQ(a.attrs(), b.attrs());
@@ -300,13 +300,13 @@ TEST_P(BinTest, rebin_masked) {
   auto binned = bin(table, {edges_x_coarse});
   binned.masks().set("x-mask", makeVariable<bool>(Dims{Dim::X}, Shape{2},
                                                   Values{false, true}));
-  EXPECT_EQ(buckets::sum(bin(binned, {edges_x})), histogram(binned, edges_x));
+  EXPECT_EQ(bins_sum(bin(binned, {edges_x})), histogram(binned, edges_x));
   if (table.dims().volume() > 0) {
     EXPECT_NE(bin(binned, {edges_x}), bin(table, {edges_x}));
-    EXPECT_NE(buckets::sum(bin(binned, {edges_x})), histogram(table, edges_x));
+    EXPECT_NE(bins_sum(bin(binned, {edges_x})), histogram(table, edges_x));
     binned.masks().erase("x-mask");
     EXPECT_EQ(bin(binned, {edges_x}), bin(table, {edges_x}));
-    EXPECT_EQ(buckets::sum(bin(binned, {edges_x})), histogram(table, edges_x));
+    EXPECT_EQ(bins_sum(bin(binned, {edges_x})), histogram(table, edges_x));
   }
 }
 

--- a/dataset/test/bins_test.cpp
+++ b/dataset/test/bins_test.cpp
@@ -71,10 +71,9 @@ TEST(DataArrayBins2dTest, concatenate_dim_2d) {
 
   EXPECT_EQ(buckets::concatenate(zy, Dim::Y), z);
   EXPECT_EQ(buckets::concatenate(zy, Dim::Z), y);
-  EXPECT_EQ(buckets::sum(
-                buckets::concatenate(buckets::concatenate(zy, Dim::Y), Dim::Z)),
-            buckets::sum(buckets::concatenate(buckets::concatenate(zy, Dim::Z),
-                                              Dim::Y)));
+  EXPECT_EQ(
+      bins_sum(buckets::concatenate(buckets::concatenate(zy, Dim::Y), Dim::Z)),
+      bins_sum(buckets::concatenate(buckets::concatenate(zy, Dim::Z), Dim::Y)));
 }
 
 TEST_F(DataArrayBinsTest, concatenate) {
@@ -172,8 +171,7 @@ TEST_F(DataArrayBinsTest, histogram_existing_dim) {
 }
 
 TEST_F(DataArrayBinsTest, sum) {
-  EXPECT_EQ(buckets::sum(var),
-            makeVariable<double>(indices.dims(), Values{3, 7}));
+  EXPECT_EQ(bins_sum(var), makeVariable<double>(indices.dims(), Values{3, 7}));
 }
 
 TEST_F(DataArrayBinsTest, operations_on_empty) {
@@ -378,16 +376,14 @@ protected:
 };
 
 TEST_F(DataArrayBinsPlusMinusTest, plus) {
-  using buckets::sum;
-  EXPECT_EQ(sum(buckets::concatenate(a, b)), sum(a) + sum(b));
+  EXPECT_EQ(bins_sum(buckets::concatenate(a, b)), bins_sum(a) + bins_sum(b));
 }
 
 TEST_F(DataArrayBinsPlusMinusTest, minus) {
-  using buckets::sum;
   auto tmp = -b;
   EXPECT_EQ(b.unit(), units::one);
   EXPECT_EQ(tmp.unit(), units::one);
-  EXPECT_EQ(sum(buckets::concatenate(a, -b)), sum(a) - sum(b));
+  EXPECT_EQ(bins_sum(buckets::concatenate(a, -b)), bins_sum(a) - bins_sum(b));
 }
 
 TEST_F(DataArrayBinsPlusMinusTest, plus_equals) {
@@ -396,7 +392,7 @@ TEST_F(DataArrayBinsPlusMinusTest, plus_equals) {
   EXPECT_EQ(out, buckets::concatenate(a, b));
   buckets::append(out, -b);
   EXPECT_NE(out, a); // events not removed by "undo" of addition
-  EXPECT_NE(buckets::sum(out), buckets::sum(a)); // mismatching variances
+  EXPECT_NE(bins_sum(out), bins_sum(a)); // mismatching variances
   EXPECT_EQ(out, buckets::concatenate(buckets::concatenate(a, b), -b));
 }
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -17,12 +17,13 @@ Features
 * Add ``transform_coords`` for (multi-step) transformations based on existing coords, with support of event coords `#2058 <https://github.com/scipp/scipp/pull/2058>`_.
 * Add ``from_pandas`` and ``from_xarray`` for conversion of pandas dataframes, xarray data arrays and dataset to scipp objects `#2054 <https://github.com/scipp/scipp/pull/2054>`_.
 * Added ``full`` and ``full_like`` variable creation functions `#2069 <https://github.com/scipp/scipp/pull/2069>`_.
-* ``islinspace`` can now take multi-dimensional variables aslong as you pass the dimension to be checked `#2094 https://github.com/scipp/scipp/pull/2094`
+* ``islinspace`` can now take multi-dimensional variables aslong as you pass the dimension to be checked `#2094 https://github.com/scipp/scipp/pull/2094`_.
 * Added a power function and support for the ``**`` operator `#2083 <https://github.com/scipp/scipp/pull/2083>`_.
 * Binned data now has a ``mean`` method as well as ``sum``, which returns the mean of each element within a bin.
 * Add ``scipp.constants`` module for physical constants `#2101 <https://github.com/scipp/scipp/pull/2101>`_.
 * Add ``scipp.spatial.transform`` module providing ``from_rotvec`` and ``as_rotvec`` `#2102 <https://github.com/scipp/scipp/pull/2102>`_.
 * Add ``cross`` function to complementing existing ``dot`` function `#2109 <https://github.com/scipp/scipp/pull/2109>`_.
+* Unary operations such as ``sin`` are now available for datasets as well `#2112 https://github.com/scipp/scipp/pull/2112`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -39,9 +40,10 @@ Breaking changes
 * ``astype`` and ``to_unit`` now copy the input by default even when no transformation is required, use the new ``copy`` argument to avoid `#2016 <https://github.com/scipp/scipp/pull/2016>`_.
 * ``rename_dims`` does not rename dimension-coords any more, only dims will be renamed `#2058 <https://github.com/scipp/scipp/pull/2058>`_.
 * ``rename_dims`` does not modify the input anymore but returns a new object with renamed dims `#2058 <https://github.com/scipp/scipp/pull/2058>`_.
-* ``issorted`` and ``islinspace`` return a variable of type boolean instead of a boolean `#2094 https://github.com/scipp/scipp/pull/2094
+* ``issorted`` and ``islinspace`` return a variable of type boolean instead of a boolean `#2094 https://github.com/scipp/scipp/pull/2094`_.
 * Multi-dimensional coordinates are no longer associated with their inner dimension, which affects the behavior when slicing:
   Such coords will no longer be turned into attributes during a slice operation on the inner dimension `#2098 <https://github.com/scipp/scipp/pull/2098>`_.
+* ``buckets.map(histogram, da.data, 'time')`` has been replaced by ``lookup(histogram, 'time')[da.bins.coords['time']]`` `#2112 https://github.com/scipp/scipp/pull/2112`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -67,6 +67,7 @@ General
    transform_coords
    values
    variances
+   where
 
 Math
 ~~~~

--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -218,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "event_temp = sc.buckets.map(temperature, events.data, 'time')\n",
+    "event_temp = sc.lookup(temperature, 'time')[events.bins.coords['time']]\n",
     "events.bins.coords['temperature'] = event_temp"
    ]
   },
@@ -341,7 +341,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -355,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/python/bins.cpp
+++ b/python/bins.cpp
@@ -69,12 +69,6 @@ template <class T> void bind_bins(pybind11::module &m) {
                                         // implicit conversions in functor
 }
 
-template <class T> void bind_bin_size(pybind11::module &m) {
-  m.def(
-      "bin_size", [](const T &x) { return dataset::bucket_sizes(x); },
-      py::call_guard<py::gil_scoped_release>());
-}
-
 template <class T> auto bin_begin_end(const Variable &var) {
   auto &&[indices, dim, buffer] = var.constituents<T>();
   static_cast<void>(dim);
@@ -116,10 +110,6 @@ void init_buckets(py::module &m) {
   bind_bins<Variable>(m);
   bind_bins<DataArray>(m);
   bind_bins<Dataset>(m);
-
-  bind_bin_size<Variable>(m);
-  bind_bin_size<DataArray>(m);
-  bind_bin_size<Dataset>(m);
 
   m.def("is_bins", variable::is_bins);
   m.def("is_bins",
@@ -200,24 +190,6 @@ void init_buckets(py::module &m) {
               py::call_guard<py::gil_scoped_release>());
   buckets.def("scale", dataset::buckets::scale,
               py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "sum", [](const Variable &x) { return dataset::buckets::sum(x); },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "mean", [](const Variable &x) { return dataset::buckets::mean(x); },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "sum", [](const DataArray &x) { return dataset::buckets::sum(x); },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "mean", [](const DataArray &x) { return dataset::buckets::mean(x); },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "sum", [](const Dataset &x) { return dataset::buckets::sum(x); },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "mean", [](const Dataset &x) { return dataset::buckets::mean(x); },
-      py::call_guard<py::gil_scoped_release>());
 
   m.def(
       "bin",

--- a/python/scipp.cpp
+++ b/python/scipp.cpp
@@ -28,6 +28,7 @@ void init_units(py::module &);
 void init_variable(py::module &);
 
 void init_generated_arithmetic(py::module &);
+void init_generated_bins(py::module &);
 void init_generated_comparison(py::module &);
 void init_generated_logical(py::module &);
 void init_generated_math(py::module &);
@@ -59,6 +60,7 @@ void init_core(py::module &m) {
   init_element_array_view(core);
 
   init_generated_arithmetic(core);
+  init_generated_bins(core);
   init_generated_comparison(core);
   init_generated_logical(core);
   init_generated_math(core);

--- a/python/src/scipp/__init__.py
+++ b/python/src/scipp/__init__.py
@@ -48,7 +48,7 @@ from ._scipp.core import BinEdgeError, BinnedDataError, CoordError, \
                          DTypeError, NotFoundError, SizeError, SliceError, \
                          UnitError, VariableError, VariancesError
 # Import submodules
-from ._scipp.core import units, dtype, buckets
+from ._scipp.core import units, dtype
 from . import geometry
 # Import functions
 from ._scipp.core import as_const, choose, logical_and, logical_or, logical_xor, where

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -13,6 +13,9 @@ class lookup:
         self.func = func
         self.dim = dim
 
+    def __getitem__(self, var):
+        return _cpp.buckets.map(self.func, var, self.dim)
+
 
 class Bins:
     """

--- a/python/src/scipp/_bins.py
+++ b/python/src/scipp/_bins.py
@@ -95,7 +95,7 @@ class Bins:
         :return: The sum of each of the input bins.
         :seealso: :py:func:`scipp.sum` for summing non-bin data
         """
-        return _call_cpp_func(_cpp.buckets.sum, self._obj)
+        return _call_cpp_func(_cpp.bins_sum, self._obj)
 
     def mean(self) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Mean of each bin.
@@ -103,14 +103,14 @@ class Bins:
         :return: The mean of each of the input bins.
         :seealso: :py:func:`scipp.mean` for calculating the mean of non-bin data
         """
-        return _call_cpp_func(_cpp.buckets.mean, self._obj)
+        return _call_cpp_func(_cpp.bins_mean, self._obj)
 
     def size(self) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Number of events or elements in a bin.
 
         :return: The number of elements in each of the input bins.
         """
-        return _call_cpp_func(_cpp.bin_size, self._obj)
+        return _call_cpp_func(_cpp.bin_sizes, self._obj)
 
     def concatenate(
             self,

--- a/python/src/scipp/_operations.py
+++ b/python/src/scipp/_operations.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 from ._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from .typing import VariableLike
+from . import Variable
 
 
 def dot(x: VariableLike, y: VariableLike) -> VariableLike:
@@ -148,3 +149,16 @@ def rebin(x: VariableLike,
         return _call_cpp_func(_cpp.rebin, x, dim, bins)
     else:
         return _call_cpp_func(_cpp.rebin, x, dim, old, bins)
+
+
+def where(condition: Variable, x: Variable, y: Variable) -> Variable:
+    """Return elements chosen from x or y depending on condition.
+
+    :param condition: Variable with dtype=bool. Where True, yield x, otherwise yield y.
+    :param x: Variable with values from which to choose.
+    :param y: Variable with values from which to choose.
+    :return: Variable with elements from x where condition is True, and elements from y
+             elsewhere.
+    :seealso: :py:func:`scipp.choose`
+    """
+    return _call_cpp_func(_cpp.where, condition, x, y)

--- a/templates/dataset_unary.cpp.in
+++ b/templates/dataset_unary.cpp.in
@@ -2,13 +2,19 @@
 // Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
-#include "scipp/variable/@OPNAME@.h"
+#include "scipp/@BASE_INCLUDE@"
 #include "scipp/dataset/@OPNAME@.h"
+
+#include "dataset_operations_common.h"
 
 namespace scipp::dataset {
 
 DataArray @NAME@(const DataArray &a) {
   return DataArray(@NAME@(a.data()), a.coords(), copy(a.masks()), a.attrs(), a.name());
+}
+
+Dataset @NAME@(const Dataset &ds) {
+  return apply_to_items(ds, [](auto &&_) { return @NAME@(_); });
 }
 
 } // namespace scipp::dataset

--- a/templates/dataset_unary.h.in
+++ b/templates/dataset_unary.h.in
@@ -11,4 +11,7 @@ namespace scipp::dataset {
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 @NAME@(const DataArray &a);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT Dataset
+@NAME@(const Dataset &ds);
+
 } // namespace scipp::dataset

--- a/templates/python_unary.cpp.in
+++ b/templates/python_unary.cpp.in
@@ -25,4 +25,5 @@ template <typename T> void bind_@OPNAME@(py::module &m) {
 void init_@OPNAME@(py::module &m) {
   bind_@OPNAME@<Variable>(m);
   bind_@OPNAME@<DataArray>(m);
+  bind_@OPNAME@<Dataset>(m);
 }


### PR DESCRIPTION
- Fix issue in `bins.sum()` and `bins.mean()` where (after the shallow-copy refactor) we missed to copy masks, i.e., mask were unintentionally shared. The fix is to generate these functions instead using the usual cmake functions.
- As a "side effect", we are now generating unary operations for `Dataset`. Note that binary operations are more tricky, so I am leaving those for now.
- `sc.buckets.map` replaced by `__getitem__` of `sc.lookup`.
  - Argument is now a variable, not a data array with matching event-coord, so this becomes more flexible and can be used on standalone event variables.