### PR TITLE
Avoid near-empty colorbar range and disable cbar offset

### DIFF
--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -79,9 +79,8 @@ static constexpr auto histogram = overloaded{
       if (events_unit != edge_unit)
         throw except::UnitError(
             "Bin edges must have same unit as the input coordinate.");
-      if (weights_unit != units::counts && weights_unit != units::dimensionless)
-        throw except::UnitError(
-            "Data to histogram must have unit `counts` or `dimensionless`.");
+      if (weights_unit != units::counts)
+        throw except::UnitError("Data to histogram must have unit `counts`.");
       return weights_unit;
     },
     transform_flags::expect_in_variance_if_out_variance,

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -67,9 +67,9 @@ static constexpr auto rebin = overloaded{
       if (target_edges != edges)
         throw except::UnitError(
             "Input and output bin edges must have the same unit.");
-      if (data != units::counts && data != units::one)
-        throw except::UnitError("Only count-data (units::counts or "
-                                "units::dimensionless) can be rebinned.");
+      // TODO No check of data unit until we have separate rebin and resample.
+      // As it is now we resample bool but rebin counts, so we cannot have a
+      // sensbiel check here.
       return data;
     },
     transform_flags::expect_in_variance_if_out_variance,

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -69,7 +69,7 @@ static constexpr auto rebin = overloaded{
             "Input and output bin edges must have the same unit.");
       // TODO No check of data unit until we have separate rebin and resample.
       // As it is now we resample bool but rebin counts, so we cannot have a
-      // sensbiel check here.
+      // sensible check here.
       return data;
     },
     transform_flags::expect_in_variance_if_out_variance,

--- a/core/test/element_histogram_test.cpp
+++ b/core/test/element_histogram_test.cpp
@@ -22,8 +22,8 @@ TEST(ElementHistogramTest, variance_flags) {
 TEST(ElementHistogramTest, unit) {
   // Note that this is an operator for `transform_subspan`, so the overload for
   // units has one argument fewer than the one for data.
-  for (const auto unit : {units::counts, units::one})
-    EXPECT_EQ(element::histogram(units::m, unit, units::m), unit);
+  EXPECT_EQ(element::histogram(units::m, units::counts, units::m),
+            units::counts);
 }
 
 TEST(ElementHistogramTest, event_and_edge_unit_must_match) {
@@ -35,9 +35,10 @@ TEST(ElementHistogramTest, event_and_edge_unit_must_match) {
                except::UnitError);
 }
 
-TEST(ElementHistogramTest, weight_unit_must_be_counts_or_one) {
+TEST(ElementHistogramTest, weight_unit_must_be_counts) {
   EXPECT_NO_THROW(element::histogram(units::m, units::counts, units::m));
-  EXPECT_NO_THROW(element::histogram(units::m, units::one, units::m));
+  EXPECT_THROW(element::histogram(units::m, units::one, units::m),
+               except::UnitError);
   EXPECT_THROW(element::histogram(units::m, units::s, units::m),
                except::UnitError);
   EXPECT_THROW(element::histogram(units::m, units::m, units::m),

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -296,7 +296,8 @@ TEST_P(BinTest, group_and_bin) {
 }
 
 TEST_P(BinTest, rebin_masked) {
-  const auto table = GetParam();
+  auto table = GetParam();
+  table.setUnit(units::counts); // we want to use `histogram` for comparison
   auto binned = bin(table, {edges_x_coarse});
   binned.masks().set("x-mask", makeVariable<bool>(Dims{Dim::X}, Shape{2},
                                                   Values{false, true}));

--- a/dataset/test/bins_test.cpp
+++ b/dataset/test/bins_test.cpp
@@ -117,8 +117,9 @@ TEST_F(DataArrayBinsTest, concatenate_with_broadcast) {
 }
 
 TEST_F(DataArrayBinsTest, histogram) {
-  Variable weights = makeVariable<double>(
-      Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
+  Variable weights =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, units::counts,
+                           Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
   DataArray events = DataArray(weights, {{Dim::Z, data}});
   Variable buckets = make_bins(indices, Dim::X, events);
   // `buckets` *does not* depend on the histogramming dimension
@@ -126,13 +127,14 @@ TEST_F(DataArrayBinsTest, histogram) {
       makeVariable<double>(Dims{Dim::Z}, Shape{4}, Values{0, 1, 2, 4});
   EXPECT_EQ(buckets::histogram(buckets, bin_edges),
             makeVariable<double>(Dims{Dim::Y, Dim::Z}, Shape{2, 3},
-                                 Values{0, 1, 2, 0, 0, 3},
+                                 units::counts, Values{0, 1, 2, 0, 0, 3},
                                  Variances{0, 1, 2, 0, 0, 3}));
 }
 
 TEST_F(DataArrayBinsTest, histogram_masked) {
-  Variable weights = makeVariable<double>(
-      Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
+  Variable weights =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, units::counts,
+                           Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
   Variable mask = makeVariable<bool>(Dims{Dim::X}, Shape{4},
                                      Values{false, false, true, false});
   DataArray events = DataArray(weights, {{Dim::Z, data}}, {{"mask", mask}});
@@ -142,20 +144,22 @@ TEST_F(DataArrayBinsTest, histogram_masked) {
       makeVariable<double>(Dims{Dim::Z}, Shape{4}, Values{0, 1, 2, 4});
   EXPECT_EQ(buckets::histogram(buckets, bin_edges),
             makeVariable<double>(Dims{Dim::Y, Dim::Z}, Shape{2, 3},
-                                 Values{0, 1, 2, 0, 0, 0},
+                                 units::counts, Values{0, 1, 2, 0, 0, 0},
                                  Variances{0, 1, 2, 0, 0, 0}));
 }
 
 TEST_F(DataArrayBinsTest, histogram_existing_dim) {
-  Variable weights = makeVariable<double>(
-      Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
+  Variable weights =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, units::counts,
+                           Values{1, 2, 3, 4}, Variances{1, 2, 3, 4});
   DataArray events = DataArray(weights, {{Dim::Y, data}});
   Variable buckets = make_bins(indices, Dim::X, events);
   // `buckets` *does* depend on the histogramming dimension
   const auto bin_edges =
       makeVariable<double>(Dims{Dim::Y}, Shape{4}, Values{0, 1, 2, 4});
-  const auto expected = makeVariable<double>(
-      Dims{Dim::Y}, Shape{3}, Values{0, 1, 5}, Variances{0, 1, 5});
+  const auto expected =
+      makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::counts,
+                           Values{0, 1, 5}, Variances{0, 1, 5});
   EXPECT_EQ(buckets::histogram(buckets, bin_edges), expected);
 
   // Histogram data array containing binned variable
@@ -165,10 +169,11 @@ TEST_F(DataArrayBinsTest, histogram_existing_dim) {
   // Masked data array
   a.masks().set(
       "mask", makeVariable<bool>(Dims{Dim::Y}, Shape{2}, Values{false, true}));
-  EXPECT_EQ(histogram(a, bin_edges),
-            DataArray(makeVariable<double>(Dims{Dim::Y}, Shape{3},
-                                           Values{0, 1, 2}, Variances{0, 1, 2}),
-                      {{Dim::Y, bin_edges}}));
+  EXPECT_EQ(
+      histogram(a, bin_edges),
+      DataArray(makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::counts,
+                                     Values{0, 1, 2}, Variances{0, 1, 2}),
+                {{Dim::Y, bin_edges}}));
 }
 
 TEST_F(DataArrayBinsTest, sum) {

--- a/dataset/test/histogram_test.cpp
+++ b/dataset/test/histogram_test.cpp
@@ -240,8 +240,9 @@ TEST(HistogramTest, dense_vs_binned) {
   using testdata::make_table;
   auto table_no_variance = make_table(100);
   table_no_variance.data().setVariances(Variable{});
-  for (const auto &table :
+  for (auto table :
        {make_table(0), make_table(100), make_table(1000), table_no_variance}) {
+    table.setUnit(units::counts);
     const auto binned_x =
         bin(table, {makeVariable<double>(Dims{Dim::X}, Shape{5},
                                          Values{-2, -1, 0, 1, 2})});
@@ -260,11 +261,11 @@ TEST(HistogramTest, dense_vs_binned) {
 struct Histogram1DTest : public ::testing::Test {
 protected:
   Histogram1DTest() {
-    data = makeVariable<double>(Dims{Dim::X}, Shape{10},
+    data = makeVariable<double>(Dims{Dim::X}, Shape{10}, units::counts,
                                 Values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
     coord = makeVariable<double>(Dims{Dim::X}, Shape{10},
                                  Values{1, 2, 1, 2, 3, 4, 3, 2, 1, 1});
-    mask = less(data, 4.0 * units::one);
+    mask = less(data, 4.0 * units::counts);
   }
   Variable data;
   Variable coord;
@@ -276,7 +277,8 @@ TEST_F(Histogram1DTest, coord_name_matches_dim) {
   const auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
   EXPECT_EQ(histogram(da, edges).data(),
-            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{19, 12, 12}));
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, units::counts,
+                                 Values{19, 12, 12}));
 }
 
 TEST_F(Histogram1DTest, coord_name_differs_dim) {
@@ -285,14 +287,15 @@ TEST_F(Histogram1DTest, coord_name_differs_dim) {
   const auto edges =
       makeVariable<double>(Dims{Dim::Y}, Shape{4}, Values{1, 2, 3, 4});
   EXPECT_EQ(histogram(da, edges).data(),
-            makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{19, 12, 12}));
+            makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::counts,
+                                 Values{19, 12, 12}));
 }
 
 struct Histogram2DTest : public ::testing::Test {
 protected:
   Histogram2DTest() {
     data = makeVariable<double>(
-        Dims{Dim::Y, Dim::X}, Shape{3, 4},
+        Dims{Dim::Y, Dim::X}, Shape{3, 4}, units::counts,
         Values{11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34});
     coord = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
                                  Values{1, 2, 1, 2, 3, 4, 3, 2, 1, 1, 2, 3});
@@ -312,6 +315,7 @@ TEST_F(Histogram2DTest, outer_1d_coord) {
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1.0, 2.5, 5.0});
   EXPECT_EQ(histogram(da, edges).data(),
             makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2},
+                                 units::counts,
                                  Values{42, 21, 44, 22, 46, 23, 48, 24}));
 }
 
@@ -329,6 +333,7 @@ TEST_F(Histogram2DTest, outer_2d_coord) {
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1.0, 2.5, 5.0});
   EXPECT_EQ(histogram(da, edges).data(),
             makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2},
+                                 units::counts,
                                  Values{42, 21, 44, 22, 46, 23, 38, 34}));
 }
 

--- a/dataset/test/rebin_test.cpp
+++ b/dataset/test/rebin_test.cpp
@@ -148,6 +148,7 @@ TEST_F(RebinTest, rebin_with_ragged_coord) {
 TEST(RebinWithMaskTest, preserves_unrelated_mask) {
   Dataset ds;
   ds.setData("data_xy", broadcast(makeVariable<double>(Dimensions{Dim::X, 5},
+                                                       units::counts,
                                                        Values{1, 2, 3, 4, 5}),
                                   Dimensions({Dim::Y, Dim::X}, {5, 5})));
   ds.setCoord(Dim::X, makeVariable<double>(Dimensions{Dim::X, 6},
@@ -165,7 +166,8 @@ TEST(RebinWithMaskTest, preserves_unrelated_mask) {
   const Dataset result = rebin(ds, Dim::X, edges);
 
   ASSERT_EQ(result["data_xy"].data(),
-            broadcast(makeVariable<double>(Dimensions{Dim::X, 2}, Values{3, 7}),
+            broadcast(makeVariable<double>(Dimensions{Dim::X, 2}, units::counts,
+                                           Values{3, 7}),
                       Dimensions({Dim::Y, Dim::X}, {5, 2})));
   ASSERT_EQ(result["data_xy"].masks()["mask_x"],
             makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true}));

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -46,6 +46,7 @@ Breaking changes
 * Multi-dimensional coordinates are no longer associated with their inner dimension, which affects the behavior when slicing:
   Such coords will no longer be turned into attributes during a slice operation on the inner dimension `#2098 <https://github.com/scipp/scipp/pull/2098>`_.
 * ``buckets.map(histogram, da.data, 'time')`` has been replaced by ``lookup(histogram, 'time')[da.bins.coords['time']]`` `#2112 <https://github.com/scipp/scipp/pull/2112>`_.
+* ``rebin`` and ``histogram`` do not support dimensionless units any more, only "counts" is supported `#2141 <https://github.com/scipp/scipp/pull/2141>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
+++ b/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
@@ -12,6 +12,8 @@ Repeatedly there is doubt over how dimensionless quantities should be handled in
 This is primarily ``rebin`` and ``histogram``, but the effect is most visible in ``plot`` which internally rebins or resamples data.
 
 There is no "counts" unit in the SI base unit system but we have included "counts" in the scipp unit system from early on, since distinguishing dimensionless quantities from (neutron) counts is often essential.
+For example, an explicit unit for "counts" prevents addition of "counts" with a ratio of counts.
+
 Should "dimensionless" be handled similar to counts?
 Let us consider which quantities may be dimensionless, or how they arise:
 

--- a/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
+++ b/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
@@ -1,0 +1,38 @@
+ADR 0009: Handle dimensionless as non-counts
+============================================
+
+- Status: proposed
+- Deciders: Jan-Lukas, Neil, Owen, Simon
+- Date: 2021-09-01
+
+Context
+-------
+
+Repeatedly there is doubt over how dimensionless quantities should be handled in operations that deal with counts.
+This is primarily ``rebin`` and ``histogram``, but the effect is most visible in ``plot`` which internally rebins or resamples data.
+
+There is no "counts" unit in the SI base unit system but we have included "counts" in the scipp unit system from early on, since distinguishing dimensionless quantities from (neutron) counts is often essential.
+Should "dimensionless" be handled similar to counts?
+Let us consider which quantities may be dimensionless, or how they arise:
+
+- `Wikipedia's list of dimensionless quantities <https://en.wikipedia.org/wiki/List_of_dimensionless_quantities>`_ is long and none of them appears to be "count-like".
+- Dimensionless quantities naturally arise when we compute the ration of to quantities with identical units.
+  Treating ratios as counts in, e.g., ``rebin`` is obviously incorrect.
+
+Decision
+--------
+
+Dimensionless should never by handled as if it was a counts-unit.
+
+Consequences
+------------
+
+Positive:
+~~~~~~~~~
+
+- Fixes misleading and dangerous behavior.
+
+Negative:
+~~~~~~~~~
+
+- User intervention is required when ingesting data into scipp from a source that does not support a "counts" unit but uses dimensionless instead.

--- a/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
+++ b/docs/reference/developer/adr/0009-handle-dimensionless-as-non-counts.rst
@@ -1,7 +1,7 @@
 ADR 0009: Handle dimensionless as non-counts
 ============================================
 
-- Status: proposed
+- Status: accepted
 - Deciders: Jan-Lukas, Neil, Owen, Simon
 - Date: 2021-09-01
 
@@ -16,7 +16,7 @@ Should "dimensionless" be handled similar to counts?
 Let us consider which quantities may be dimensionless, or how they arise:
 
 - `Wikipedia's list of dimensionless quantities <https://en.wikipedia.org/wiki/List_of_dimensionless_quantities>`_ is long and none of them appears to be "count-like".
-- Dimensionless quantities naturally arise when we compute the ration of to quantities with identical units.
+- Dimensionless quantities naturally arise when we compute the ratio of two quantities with identical units.
   Treating ratios as counts in, e.g., ``rebin`` is obviously incorrect.
 
 Decision

--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -60,6 +60,7 @@
     "sizes = 4*np.array([7000, 3333, 3000, 5000])\n",
     "size = np.sum(sizes)\n",
     "data = sc.Variable(dims=['event'],\n",
+    "                   unit='counts',\n",
     "                   values=np.ones(size),\n",
     "                   variances=np.ones(size))\n",
     "time = sc.Variable(dims=['event'], unit=sc.units.s, dtype=sc.dtype.datetime64, values=np.zeros(size, dtype=int))\n",

--- a/python/src/scipp/plotting/figure2d.py
+++ b/python/src/scipp/plotting/figure2d.py
@@ -85,7 +85,7 @@ class PlotFigure2d(PlotFigure):
 
     def _make_limits(self, vmin, vmax):
         if math.isclose(vmin, vmax):
-            offset = 0.1 * max(abs(vmin), abs(vmax))
+            offset = 0.001 * max(abs(vmin), abs(vmax))
             vmin -= offset
             vmax += offset
         return vmin, vmax

--- a/python/src/scipp/plotting/figure2d.py
+++ b/python/src/scipp/plotting/figure2d.py
@@ -8,6 +8,7 @@ from .toolbar import PlotToolbar2d
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize, LogNorm
+import math
 import warnings
 
 
@@ -73,6 +74,7 @@ class PlotFigure2d(PlotFigure):
                                      ax=self.ax,
                                      cax=self.cax,
                                      extend=extend)
+            self.cbar.formatter.set_useOffset(False)
         if self.cax is None:
             self.cbar.ax.yaxis.set_label_coords(-1.1, 0.5)
         self.mask_image = {}
@@ -81,6 +83,10 @@ class PlotFigure2d(PlotFigure):
         """
         Rescale the colorbar limits according to the supplied values.
         """
+        if math.isclose(vmin, vmax):
+            offset = 0.1 * max(abs(vmin), abs(vmax))
+            vmin -= offset
+            vmax += offset
         self.norm.vmin = vmin
         self.norm.vmax = vmax
         self.image_values.set_clim(vmin, vmax)

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -8,17 +8,10 @@ from .tools import to_bin_edges
 
 
 def _unit_requires_mean(obj):
-    return obj.unit != sc.units.counts and obj.unit != sc.units.dimensionless
+    return obj.unit != sc.units.counts
 
 
 def _resample(array, dim, edges):
-    # TODO Note that there are some inconsistencies here and in `rebin`. Should
-    # dimensionless be handled like counts? `rebin` does, but at some point we
-    # had decided that the plotting code should not. Furthermore, `rebin`
-    # handling `bool` as "non-counts", i.e., it does not sum but "average"
-    # (using `or`). What we need here works currently, since masks are
-    # dimensionless and we want `bool` as output, but this needs to be
-    # revisited.
     if not _unit_requires_mean(array):
         return sc.rebin(array, dim, edges)
     if array.dtype == sc.dtype.float64:
@@ -27,6 +20,7 @@ def _resample(array, dim, edges):
         array = array.astype(sc.dtype.float64)
     # Scale by bin widths, so `rebin` is effectively performing a "mean"
     # operation instead of "sum".
+    # TODO
     # Note that it is inefficient to do this repeatedly. Rather than working
     # around that here we should look into supporting an alternative to
     # `rebin` that works on non-counts data

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -4,6 +4,7 @@
 
 from .. import config
 from .._scipp import core as sc
+from .._variable import scalar
 import numpy as np
 from copy import copy
 import io
@@ -127,10 +128,10 @@ def find_log_limits(x):
     # limits are negative.
     if len(ar) == 0:
         [vmin, vmax] = find_linear_limits(x)
-        if vmin <= 0.0:
-            if vmax <= 0.0:
-                vmin = 0.1
-                vmax = 1.0
+        if vmin.value <= 0.0:
+            if vmax.value <= 0.0:
+                vmin = scalar(0.1)
+                vmax = scalar(1.0)
             else:
                 vmin = 1.0e-3 * vmax
     else:

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -115,13 +115,13 @@ def find_log_limits(x):
     from .. import flatten, ones
     volume = np.product(x.shape)
     pixel = flatten(sc.values(x.astype(sc.dtype.float64)), to='pixel')
-    weights = ones(dims=['pixel'], shape=[volume])
+    weights = ones(dims=['pixel'], shape=[volume], unit='counts')
     hist = sc.histogram(sc.DataArray(data=weights, coords={'order': pixel}),
                         bins=sc.Variable(dims=['order'],
                                          values=np.geomspace(1e-30, 1e30, num=61),
                                          unit=x.unit))
     # Find the first and the last non-zero bins
-    inds = np.nonzero((hist.data > 0.0 * sc.units.one).values)
+    inds = np.nonzero((hist.data > 0.0 * sc.units.counts).values)
     ar = np.arange(hist.data.shape[0])[inds]
     # Safety check in case there are no values in range 1.0e-30:1.0e+30:
     # fall back to the linear method and replace with arbitrary values if the

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -95,10 +95,14 @@ struct Less {
 
 Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
                const Variable &newCoord) {
+  // TODO Note that this currently rebins counts but resamples bool
   // Rebin could also implemented for count-densities. However, it may be better
   // to avoid this since it increases complexity. Instead, densities could
   // always be computed on-the-fly for visualization, if required.
-  core::expect::unit_any_of(var, {units::counts, units::one});
+  if (var.dtype() == dtype<bool>)
+    core::expect::unit_any_of(var, {units::one});
+  else
+    core::expect::unit_any_of(var, {units::counts});
   if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -100,9 +100,9 @@ Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
   // to avoid this since it increases complexity. Instead, densities could
   // always be computed on-the-fly for visualization, if required.
   if (var.dtype() == dtype<bool>)
-    core::expect::unit_any_of(var, {units::one});
+    core::expect::equals(var.unit(), units::one);
   else
-    core::expect::unit_any_of(var, {units::counts});
+    core::expect::equals(var.unit(), units::counts);
   if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -225,7 +225,10 @@ TEST(Variable, rebin_mask_outer_single) {
 
   ASSERT_EQ(result, expected);
 }
-TEST(Variable, check_rebin_cannot_be_used_on_bin_data) {
+
+// TODO Enable this once we have `resample`. Right now this fails with
+// UnitError, not the "desired" TypeError.
+TEST(Variable, DISABLED_check_rebin_cannot_be_used_on_bin_data) {
   Dimensions dims{Dim::Y, 1};
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});


### PR DESCRIPTION
As we discovered previously, having sane defaults for axis tics and ranges for extreme cases of inputs is difficult. This fixes another example of this.

- Fixes #2139.
  - Avoid near-empty range by extending `vmin` and `vmax`.
  - Disable the offset feature that matplotlib has enabled by default. We keep getting question about this, so I presume it may just be too confusing (and I wonder why it is matplotlib's default?)?
- Fix #2090.
- Do not support histogramming or rebinning dimensionless (see added ADR).
- Plots now handle dimensionless as non-counts.

Aside from this, there is still the confusing nature of resampled data: In the linked issue the user may expect to see "1" everywhere, but does not due to resampling. I am beginning to reconsider whether resampling by default is the best approach? Could there be solutions where we do not resample data with "normal" resolution, and only do so for extreme cases such as the "pixel" axis?