### PR TITLE
Allow scalar array creation

### DIFF
--- a/python/src/scipp/_variable.py
+++ b/python/src/scipp/_variable.py
@@ -339,7 +339,7 @@ def array(*,
     :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
               :py:func:`scipp.empty` :py:func:`scipp.scalar`
 
-    :param dims: Dimension labels, nonempty.
+    :param dims: Dimension labels
     :param values: Initial values.
     :param variances: Optional, initial variances, must be same shape
       and size as values. Default=None
@@ -347,9 +347,6 @@ def array(*,
     :param dtype: Optional, type of underlying data. Default=None,
       in which case type is inferred from value input.
     """
-    if not dims:
-        raise ValueError("The dims of an array must not be empty. "
-                         "Use sc.scalar to construct a scalar variable.")
     return _cpp.Variable(dims=dims,
                          values=values,
                          variances=variances,

--- a/python/tests/variable_creation_test.py
+++ b/python/tests/variable_creation_test.py
@@ -231,10 +231,13 @@ def test_array_creates_correct_variable():
 
 
 def test_array_empty_dims():
-    assert sc.identical(sc.array(dims=[], values=[1]), sc.scalar([1]))
+    assert sc.identical(sc.array(dims=[], values=[1]),
+                        sc.scalar([1], dtype=sc.dtype.PyObject))
     a = np.asarray(1.1)
     assert sc.identical(sc.array(dims=None, values=a), sc.scalar(1.1))
     assert sc.identical(sc.array(dims=[], values=a), sc.scalar(1.1))
+    assert sc.identical(sc.array(dims=[], values=a, variances=a),
+                        sc.scalar(1.1, variance=1.1))
 
 
 def test_zeros_like():

--- a/python/tests/variable_creation_test.py
+++ b/python/tests/variable_creation_test.py
@@ -230,11 +230,11 @@ def test_array_creates_correct_variable():
     assert sc.identical(var, expected)
 
 
-def test_array_needs_nonempty_dims():
-    with pytest.raises(ValueError):
-        sc.array(dims=[], values=[])
-    with pytest.raises(ValueError):
-        sc.array(dims=None, values=[])
+def test_array_empty_dims():
+    assert sc.identical(sc.array(dims=[], values=[1]), sc.scalar([1]))
+    a = np.asarray(1.1)
+    assert sc.identical(sc.array(dims=None, values=a), sc.scalar(1.1))
+    assert sc.identical(sc.array(dims=[], values=a), sc.scalar(1.1))
 
 
 def test_zeros_like():


### PR DESCRIPTION
There does not seem to be a good reason for forbidding this. Scalar
arrays exist, and disallowing this breaks generic code (scippneutron in
this example).