### PR TITLE
Fix 3d scatter plot with log norm

### DIFF
--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -370,7 +370,8 @@ void main() {
                          cmap=self.scalar_map.get_cmap(),
                          norm=self.scalar_map.norm,
                          extend=self.extend)
-        _.formatter.set_useOffset(False)
+        if not isinstance(self.scalar_map.norm, LogNorm):
+            _.formatter.set_useOffset(False)
         cbar_ax.set_ylabel(self._unit)
         # TODO If we set this position it is clipped somewhere. For now we
         # leave the default, which places unit to the right of the colorbar.

--- a/python/tests/plotting/plot_3d_test.py
+++ b/python/tests/plotting/plot_3d_test.py
@@ -43,6 +43,10 @@ def test_plot_projection_3d():
     plot(_with_fake_pos(ndim=3), positions='pos', projection="3d")
 
 
+def test_plot_projection_3d_log_norm():
+    plot(_with_fake_pos(ndim=3), positions='pos', projection="3d", norm='log')
+
+
 def test_plot_projection_3d_dataset():
     plot(_with_fake_pos(ndim=3), positions='pos', projection="3d")
 


### PR DESCRIPTION
Broken recently by disabled offset. Test with log norm was missing.