### PR TITLE
Rename min and max to amin and amax respectively

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -47,6 +47,7 @@ Breaking changes
   Such coords will no longer be turned into attributes during a slice operation on the inner dimension `#2098 <https://github.com/scipp/scipp/pull/2098>`_.
 * ``buckets.map(histogram, da.data, 'time')`` has been replaced by ``lookup(histogram, 'time')[da.bins.coords['time']]`` `#2112 <https://github.com/scipp/scipp/pull/2112>`_.
 * ``rebin`` and ``histogram`` do not support dimensionless units any more, only "counts" is supported `#2141 <https://github.com/scipp/scipp/pull/2141>`_.
+* ``min`` and ``max`` free functions renamed to ``amin`` and ``amax`` respectively to better reflect other python libraries `#2155 <https://github.com/scipp/scipp/pull/2155>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/python/src/scipp/_reduction.py
+++ b/python/src/scipp/_reduction.py
@@ -108,10 +108,10 @@ def nansum(x: VariableLike,
         return _call_cpp_func(_cpp.nansum, x, dim=dim, out=out)
 
 
-def min(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def amin(x: _cpp.Variable,
+         dim: Optional[str] = None,
+         *,
+         out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise min over the specified dimension or all dimensions if not
     provided.
 
@@ -130,10 +130,10 @@ def min(x: _cpp.Variable,
         return _call_cpp_func(_cpp.min, x, dim=dim, out=out)
 
 
-def max(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def amax(x: _cpp.Variable,
+         dim: Optional[str] = None,
+         *,
+         out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
     """Element-wise max over the specified dimension or all dimensions if not
     provided.
 

--- a/python/src/scipp/plotting/controller3d.py
+++ b/python/src/scipp/plotting/controller3d.py
@@ -19,7 +19,7 @@ class PlotController3d(PlotController):
         self.view.set_position_params(self.model)
         for key in self.panel.options[:-1]:
             value = self._get_cut(key)
-            self.panel.set_range(key, sc.min(value), sc.max(value))
+            self.panel.set_range(key, sc.amin(value), sc.amax(value))
 
     def _get_cut(self, key):
         # PlotPanel3d currently uses hard-coded keys/labels for cut buttons

--- a/python/src/scipp/plotting/formatters.py
+++ b/python/src/scipp/plotting/formatters.py
@@ -227,7 +227,7 @@ def make_formatter(array, key):
             formatter["custom_locator"] = True
         elif kind == Kind.datetime:
             coord = _get_or_make_coord(array, dim)
-            form = DateFormatter(offset=sc.min(coord), dim=key).formatter
+            form = DateFormatter(offset=sc.amin(coord), dim=key).formatter
             formatter["need_callbacks"] = True
         elif dim is not key:
             coord = _get_or_make_coord(array, dim)

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -92,7 +92,7 @@ class PlotModel:
             if typing.has_vector_type(coord) or typing.has_string_type(coord):
                 coord = arange(dim=dim, start=0, stop=array.sizes[dim])
             elif typing.has_datetime_type(coord):
-                coord = coord - sc.min(coord)
+                coord = coord - sc.amin(coord)
         else:
             coord = arange(dim=dim, start=0, stop=array.sizes[dim])
         return coord

--- a/python/src/scipp/plotting/model1d.py
+++ b/python/src/scipp/plotting/model1d.py
@@ -91,8 +91,8 @@ class PlotModel1d(PlotModel):
                 for array in self.dslice.values()
             ]
             return [
-                sc.min(reduce(partial(sc.concatenate, dim='dummy'), low)),
-                sc.max(reduce(partial(sc.concatenate, dim='dummy'), high))
+                sc.amin(reduce(partial(sc.concatenate, dim='dummy'), low)),
+                sc.amax(reduce(partial(sc.concatenate, dim='dummy'), high))
             ]
         else:
             return [None, None]

--- a/python/src/scipp/plotting/model3d.py
+++ b/python/src/scipp/plotting/model3d.py
@@ -60,8 +60,8 @@ class ScatterPointModel:
         """
         extents = {}
         for dim, x in self.components.items():
-            xmin = sc.min(x).value
-            xmax = sc.max(x).value
+            xmin = sc.amin(x).value
+            xmax = sc.amax(x).value
             extents[dim] = np.array([xmin, xmax])
         return extents
 

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -127,8 +127,8 @@ class ResamplingModel():
             if s is None:
                 coord = self._array.meta[dim]
                 # TODO handle flipped coord
-                low = sc.min(coord[dim, 0]).value
-                high = sc.max(coord[dim, -1]).value
+                low = sc.amin(coord[dim, 0]).value
+                high = sc.amax(coord[dim, -1]).value
                 params[dim] = (low, high, coord.unit, self.resolution[dim])
             elif isinstance(s, int):
                 out = out[dim, s]

--- a/python/tests/variable_reduction_test.py
+++ b/python/tests/variable_reduction_test.py
@@ -35,12 +35,12 @@ def test_any_with_dim():
 
 def test_min():
     var = sc.Variable(dims=['x'], values=[1.0, 2.0, 3.0])
-    assert sc.identical(sc.min(var, 'x'), sc.scalar(1.0))
+    assert sc.identical(sc.amin(var, 'x'), sc.scalar(1.0))
 
 
 def test_max():
     var = sc.Variable(dims=['x'], values=[1.0, 2.0, 3.0])
-    assert sc.identical(sc.max(var, 'x'), sc.scalar(3.0))
+    assert sc.identical(sc.amax(var, 'x'), sc.scalar(3.0))
 
 
 def test_nanmin():


### PR DESCRIPTION
This was borne out of a discussion about `round`, `around`, and `round_`. In numpy free floating functions do not shadow standard library functions in python, this renaming will stop min and max shadowing the standard functions. It will also bring us in line with what will occur in the creation of `floor`, `ceil`, and `around` free floating functions.