### PR TITLE
Handle units of binned data in pow

### DIFF
--- a/variable/pow.cpp
+++ b/variable/pow.cpp
@@ -51,12 +51,13 @@ template <class T> struct PowUnit {
 template <class V>
 Variable pow_handle_unit(V &&base, const Variable &exponent,
                          const bool in_place) {
-  if (exponent.unit() != units::one) {
+  if (const auto exp_unit = variableFactory().elem_unit(exponent);
+      exp_unit != units::one) {
     throw except::UnitError("Powers must be dimensionless, got exponent.unit=" +
-                            to_string(exponent.unit()) + ".");
+                            to_string(exp_unit) + ".");
   }
 
-  const auto base_unit = base.unit();
+  const auto base_unit = variableFactory().elem_unit(base);
   if (base_unit == units::one) {
     return pow_do_transform(std::forward<V>(base), exponent, in_place);
   }
@@ -68,10 +69,11 @@ Variable pow_handle_unit(V &&base, const Variable &exponent,
   }
 
   Variable res = in_place ? std::forward<V>(base) : copy(std::forward<V>(base));
-  res.setUnit(units::one);
+  variableFactory().set_elem_unit(res, units::one);
   pow_do_transform(res, exponent, true);
-  res.setUnit(core::CallDType<double, float, int64_t, int32_t>::apply<PowUnit>(
-      exponent.dtype(), base_unit, exponent));
+  variableFactory().set_elem_unit(
+      res, core::CallDType<double, float, int64_t, int32_t>::apply<PowUnit>(
+               exponent.dtype(), base_unit, exponent));
   return res;
 }
 

--- a/variable/pow.cpp
+++ b/variable/pow.cpp
@@ -85,6 +85,9 @@ bool has_negative_value(const Variable &var) {
 template <class V>
 Variable pow_handle_dtype(V &&base, const Variable &exponent,
                           const bool in_place) {
+  if (is_bins(exponent)) {
+    throw std::invalid_argument("Binned exponents are not supported by pow.");
+  }
   if (!is_int(base.dtype())) {
     return pow_handle_unit(std::forward<V>(base), exponent, in_place);
   }

--- a/variable/test/math_test.cpp
+++ b/variable/test/math_test.cpp
@@ -293,6 +293,16 @@ TEST(Variable, pow_binned_variable) {
   EXPECT_EQ(result, expected);
 }
 
+TEST(Variable, pow_binned_variable_exp) {
+  const auto buffer = makeVariable<double>(
+      Dims{Dim::Event}, Shape{5}, Values{1.0, 2.0, 3.0, 4.0, 5.0}, units::m);
+  const auto indices = makeVariable<index_pair>(
+      Dims{Dim::X}, Shape{2}, Values{index_pair{0, 2}, index_pair{2, 5}});
+  const auto exponent = make_bins(indices, Dim::Event, buffer);
+  EXPECT_THROW_DISCARD(pow(int64_t{2} * units::one, exponent),
+                       std::invalid_argument);
+}
+
 TYPED_TEST(VariableMathTest, sqrt) {
   for (TypeParam x : {0.0, 1.23, 1.23456789, 3.45}) {
     for (auto [uin, uout] :


### PR DESCRIPTION
Previously, `pow` would only look at the unit of the bins, not the events. Now it uses the same solution as `transform`.