### PR TITLE
Fix plotting of binned data with float32 coords

### DIFF
--- a/core/include/scipp/core/element/bin.h
+++ b/core/include/scipp/core/element/bin.h
@@ -38,6 +38,8 @@ static constexpr auto update_indices_by_binning = overloaded{
                       update_indices_by_binning_arg<int32_t, int64_t, double>,
                       update_indices_by_binning_arg<int64_t, int32_t, double>,
                       update_indices_by_binning_arg<int32_t, int32_t, double>,
+                      update_indices_by_binning_arg<int64_t, float, double>,
+                      update_indices_by_binning_arg<int32_t, float, double>,
                       update_indices_by_binning_arg<int64_t, int32_t, int64_t>,
                       update_indices_by_binning_arg<int32_t, int32_t, int64_t>>,
     [](units::Unit &indices, const units::Unit &coord,

--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -37,6 +37,7 @@ using args = std::tuple<span<Out>, span<const Coord>, span<const Weight>,
 static constexpr auto histogram = overloaded{
     element::arg_list<
         histogram_detail::args<float, double, float, double>,
+        histogram_detail::args<float, float, float, double>,
         histogram_detail::args<float, int64_t, float, double>,
         histogram_detail::args<float, int32_t, float, double>,
         histogram_detail::args<double, double, double, double>,

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -256,6 +256,15 @@ def test_plot_2d_binned_data_non_counts():
     plot(da)
 
 
+def test_plot_2d_binned_data_float32_coord():
+    da = make_binned_data_array(ndim=2)
+    da.events.coords['xx'] = da.events.coords['xx'].astype('float32')
+    plot(da)
+    # Try without event-coord so implementation cannot use `histogram`
+    del da.bins.coords['yy']
+    da.coords['yy'] = da.coords['yy']['yy', 1:]
+
+
 def test_plot_3d_binned_data_where_outer_dimension_has_no_event_coord():
     data = make_binned_data_array(ndim=2)
     data = sc.concatenate(data, data * sc.scalar(2.0), 'run')


### PR DESCRIPTION
There were a couple of missing dtype combinations in `bin` and `histogram` that made this fail.