### PR TITLE
Delete coord used for grouping by `bin`

### DIFF
--- a/dataset/bin.cpp
+++ b/dataset/bin.cpp
@@ -477,6 +477,9 @@ DataArray groupby_concat_bins(const DataArray &array, const Variable &edges,
       hide_masked(array.data(), array.masks(), builder.dims().labels());
   TargetBins<DataArray> target_bins(masked, builder.dims());
   builder.build(*target_bins, array.coords());
+  // Note: Unlike in the other cases below we do not call
+  // `drop_grouped_event_coords` here. Grouping is based on a bin-coord rather
+  // than event-coord so we do not touch the latter.
   return add_metadata(bin<DataArray>(masked, *target_bins, builder),
                       array.coords(), array.masks(), array.attrs(),
                       builder.edges(), builder.groups(), {reductionDim});

--- a/dataset/test/bin_test.cpp
+++ b/dataset/test/bin_test.cpp
@@ -109,13 +109,15 @@ TEST(BinGroupTest, 1d) {
   Variable groups =
       makeVariable<std::string>(Dims{Dim("label")}, Shape{2}, Values{"a", "c"});
   const auto binned = bin(table, {}, {groups});
+  auto expected = copy(table);
+  expected.coords().erase(Dim("label"));
   EXPECT_EQ(binned.dims(), groups.dims());
   EXPECT_EQ(binned.values<core::bin<DataArray>>()[1],
-            table.slice({Dim::Row, 2, 3}));
+            expected.slice({Dim::Row, 2, 3}));
   EXPECT_EQ(binned.values<core::bin<DataArray>>()[0].slice({Dim::Row, 0}),
-            table.slice({Dim::Row, 0}));
+            expected.slice({Dim::Row, 0}));
   EXPECT_EQ(binned.values<core::bin<DataArray>>()[0].slice({Dim::Row, 1}),
-            table.slice({Dim::Row, 4}));
+            expected.slice({Dim::Row, 4}));
 }
 
 class BinTest : public ::testing::TestWithParam<DataArray> {
@@ -343,10 +345,6 @@ TEST_P(BinTest, rebinned_meta_data_dropped) {
 TEST_P(BinTest, bin_by_group) {
   const auto table = GetParam();
   auto binned = bin(table, {}, {groups});
-  // Currently `bin` is not removing coords used for grouping, see TODO.
-  std::get<2>(binned.data().constituents<DataArray>())
-      .coords()
-      .erase(Dim("group"));
   // Using bin coord (instead of event coord) for binning.
   // Edges giving same grouping as existing => data matches
   auto edges = makeVariable<double>(Dims{Dim("group")}, Shape{6},


### PR DESCRIPTION
This event coord is unnecessary since the bin-coord contains the full
information (unlike when *edges* are used, where the event coord is
necessary). If we preserve it there are a number of "issues":

- Wastes memory.
- Has to be processed in follow-up operations (including calling `bin`
another time), which can be costly.
- Inconsistent with `groupby`, where the grouping labels are dropped in
the grouping operation.

Note that this showed up in practice in `scippneutron.load_nexus`, which used `sc.bin` to group by `detector_id`, but preserved the IDs for every event.