### PR TITLE
Change strategy on handling of counts and non-counts units

### DIFF
--- a/core/include/scipp/core/element/histogram.h
+++ b/core/include/scipp/core/element/histogram.h
@@ -80,8 +80,6 @@ static constexpr auto histogram = overloaded{
       if (events_unit != edge_unit)
         throw except::UnitError(
             "Bin edges must have same unit as the input coordinate.");
-      if (weights_unit != units::counts)
-        throw except::UnitError("Data to histogram must have unit `counts`.");
       return weights_unit;
     },
     transform_flags::expect_in_variance_if_out_variance,

--- a/core/include/scipp/core/element/rebin.h
+++ b/core/include/scipp/core/element/rebin.h
@@ -21,6 +21,7 @@ template <class Less>
 static constexpr auto rebin = overloaded{
     [](const auto &data_new, const auto &xnew, const auto &data_old,
        const auto &xold) {
+      using T = decltype(xold[0] + (xold[0] - xnew[0]));
       constexpr Less less;
       zero(data_new);
       const auto oldSize = scipp::size(xold) - 1;
@@ -28,18 +29,20 @@ static constexpr auto rebin = overloaded{
       scipp::index iold = 0;
       scipp::index inew = 0;
       while ((iold < oldSize) && (inew < newSize)) {
-        const auto xo_low = xold[iold];
-        const auto xo_high = xold[iold + 1];
-        const auto xn_low = xnew[inew];
-        const auto xn_high = xnew[inew + 1];
+        const T xo_low = xold[iold];
+        const T xo_high = xold[iold + 1];
+        const T xn_low = xnew[inew];
+        const T xn_high = xnew[inew + 1];
         if (!less(xo_low, xn_high))
           inew++; // old and new bins do not overlap
         else if (!less(xn_low, xo_high))
           iold++; // old and new bins do not overlap
         else {
           // delta is the overlap of the bins on the x axis
-          const auto delta = std::abs(std::min<double>(xn_high, xo_high, less) -
-                                      std::max<double>(xn_low, xo_low, less));
+          using std::min;
+          using std::max;
+          const auto delta =
+              std::abs(min(xn_high, xo_high, less) - max(xn_low, xo_low, less));
           const auto owidth = std::abs(xo_high - xo_low);
           const auto scale = delta / owidth;
           if constexpr (is_ValueAndVariance_v<
@@ -67,9 +70,6 @@ static constexpr auto rebin = overloaded{
       if (target_edges != edges)
         throw except::UnitError(
             "Input and output bin edges must have the same unit.");
-      // TODO No check of data unit until we have separate rebin and resample.
-      // As it is now we resample bool but rebin counts, so we cannot have a
-      // sensible check here.
       return data;
     },
     transform_flags::expect_in_variance_if_out_variance,

--- a/core/test/element_histogram_test.cpp
+++ b/core/test/element_histogram_test.cpp
@@ -35,14 +35,9 @@ TEST(ElementHistogramTest, event_and_edge_unit_must_match) {
                except::UnitError);
 }
 
-TEST(ElementHistogramTest, weight_unit_must_be_counts) {
-  EXPECT_NO_THROW(element::histogram(units::m, units::counts, units::m));
-  EXPECT_THROW(element::histogram(units::m, units::one, units::m),
-               except::UnitError);
-  EXPECT_THROW(element::histogram(units::m, units::s, units::m),
-               except::UnitError);
-  EXPECT_THROW(element::histogram(units::m, units::m, units::m),
-               except::UnitError);
+TEST(ElementHistogramTest, weight_unit_propagates) {
+  for (const auto &unit : {units::m, units::counts, units::one})
+    EXPECT_EQ(element::histogram(units::m, unit, units::m), unit);
 }
 
 TEST(ElementHistogramTest, values) {

--- a/python/src/scipp/plotting/__init__.py
+++ b/python/src/scipp/plotting/__init__.py
@@ -142,11 +142,6 @@ def plot(*args, **kwargs):
         `"log"`. Defaults to `"linear"`.
     :type norm: str, optional
 
-    :param resampling_mode: Resampling mode. Possible choices are `"sum"` and
-        `"mean"`. This applies only to binned event data and non-1d data.
-        Defaults to `"mean"` unless the unit is 'counts' or 'dimensionless'.
-    :type resampling_mode: str, optional
-
     :param pax: Attach profile plot to supplied Matplotlib axes.
         Defaults to `None`.
     :type pax: matplotlib.axes.Axes, optional
@@ -164,6 +159,11 @@ def plot(*args, **kwargs):
         `"1d"`, `"2d"`, or `"3d"`. Defaults to `"2d"` if the number of
         dimensions of the input is >= 2.
     :type projection: str, optional
+
+    :param resampling_mode: Resampling mode. Possible choices are `"sum"` and
+        `"mean"`. This applies only to binned event data and non-1d data.
+        Defaults to `"mean"` unless the unit is 'counts' or 'dimensionless'.
+    :type resampling_mode: str, optional
 
     :param scale: Specify the scale (`"linear"` or `"log"`) for a displayed
         dimension axis. E.g. `scale={"tof": "log"}`. Defaults to None.

--- a/python/src/scipp/plotting/__init__.py
+++ b/python/src/scipp/plotting/__init__.py
@@ -142,6 +142,11 @@ def plot(*args, **kwargs):
         `"log"`. Defaults to `"linear"`.
     :type norm: str, optional
 
+    :param resampling_mode: Resampling mode. Possible choices are `"sum"` and
+        `"mean"`. This applies only to binned event data and non-1d data.
+        Defaults to `"mean"` unless the unit is 'counts' or 'dimensionless'.
+    :type resampling_mode: str, optional
+
     :param pax: Attach profile plot to supplied Matplotlib axes.
         Defaults to `None`.
     :type pax: matplotlib.axes.Axes, optional

--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -63,6 +63,7 @@ class PlotController:
         self.panel = panel
         mode = _guess_resampling_mode(self.model.data_arrays)
         self.model.mode = mode
+        view.figure.toolbar.set_resampling_mode_display(self.model.is_resampling)
         self.profile = profile
         if profile is not None:
             self._profile_view = PlotView1d(figure=profile, formatters=view.formatters)
@@ -172,8 +173,9 @@ class PlotController:
         self.model.mode = mode
         if self._profile_model:
             self._profile_model.mode = mode
-        self.update_data()
-        self.rescale_to_data()
+        # Call update_axes to update data and rescale. Also turns profile view off,
+        # since updating it would be complicated if there are saved lines.
+        self.update_axes()
 
     def swap_dimensions(self, index, old_dim, new_dim):
         """

--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -163,6 +163,18 @@ class PlotController:
         self.view.toggle_norm(self.norm, vmin, vmax)
         self.refresh()
 
+    def toggle_resampling_mode(self, change):
+        """
+        Toggle data resampling mode from toolbar button signal.
+        """
+        value = change['owner'].value
+        mode = ResamplingMode.mean if value else ResamplingMode.sum
+        self.model.mode = mode
+        if self._profile_model:
+            self._profile_model.mode = mode
+        self.update_data()
+        self.rescale_to_data()
+
     def swap_dimensions(self, index, old_dim, new_dim):
         """
         Swap one dimension for another in the displayed axes.

--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 from .view1d import PlotView1d
 from .resampling_model import ResamplingMode
-from ..core import units
 
 
 class MarkerModel:
@@ -19,12 +18,6 @@ class MarkerModel:
 
     def __delitem__(self, key):
         del self._markers[key]
-
-
-def _guess_resampling_mode(array):
-    if array.unit in [units.counts, units.one]:
-        return ResamplingMode.sum
-    return ResamplingMode.mean
 
 
 class PlotController:
@@ -46,6 +39,7 @@ class PlotController:
                  vmin=None,
                  vmax=None,
                  norm=None,
+                 resampling_mode=None,
                  scale=None,
                  widgets=None,
                  model=None,
@@ -61,14 +55,14 @@ class PlotController:
         self._profile_model = profile_model
         self._profile_markers = MarkerModel()
         self.panel = panel
-        mode = _guess_resampling_mode(self.model.data_arrays)
-        self.model.mode = mode
-        view.figure.toolbar.set_resampling_mode_display(self.model.is_resampling)
+        self.model.mode = resampling_mode
+        if view.figure.toolbar is not None:
+            view.figure.toolbar.set_resampling_mode_display(self.model.is_resampling)
         self.profile = profile
         if profile is not None:
             self._profile_view = PlotView1d(figure=profile, formatters=view.formatters)
             self._profile_model.dims = self._dims[:-len(self.model.dims)]
-            self._profile_model.mode = mode
+            self._profile_model.mode = resampling_mode
         self.view = view
 
         self.vmin = vmin

--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 from .view1d import PlotView1d
+from .resampling_model import ResamplingMode
+from ..core import units
 
 
 class MarkerModel:
@@ -17,6 +19,12 @@ class MarkerModel:
 
     def __delitem__(self, key):
         del self._markers[key]
+
+
+def _guess_resampling_mode(array):
+    if array.unit in [units.counts, units.one]:
+        return ResamplingMode.sum
+    return ResamplingMode.mean
 
 
 class PlotController:
@@ -53,10 +61,13 @@ class PlotController:
         self._profile_model = profile_model
         self._profile_markers = MarkerModel()
         self.panel = panel
+        mode = _guess_resampling_mode(self.model.data_arrays)
+        self.model.mode = mode
         self.profile = profile
         if profile is not None:
             self._profile_view = PlotView1d(figure=profile, formatters=view.formatters)
             self._profile_model.dims = self._dims[:-len(self.model.dims)]
+            self._profile_model.mode = mode
         self.view = view
 
         self.vmin = vmin

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -71,6 +71,10 @@ class PlotModel:
         pass
 
     @property
+    def unit(self):
+        return self.data_arrays.unit
+
+    @property
     def dims(self):
         return self._dims
 

--- a/python/src/scipp/plotting/model.py
+++ b/python/src/scipp/plotting/model.py
@@ -6,6 +6,7 @@ from .tools import find_limits, to_dict, to_bin_centers
 from .. import typing
 from ..core import DataArray
 from ..core import arange, bins
+from .resampling_model import ResamplingMode
 
 
 class DataArrayDict(dict):
@@ -23,7 +24,8 @@ class DataArrayDict(dict):
 
     @property
     def unit(self):
-        return next(iter(self.values())).unit
+        array = next(iter(self.values()))
+        return array.unit if array.events is None else array.events.unit
 
     @property
     def meta(self):
@@ -32,14 +34,10 @@ class DataArrayDict(dict):
 
 class PlotModel:
     """
-    Base class for `model`.
+    Base class for plot models.
 
     Upon creation, it:
     - makes a copy of the input data array (including masks)
-    - units of the original data are saved, and units of the copy are set to
-        counts, because `rebin` is used for resampling and only accepts counts.
-    - it replaces all coordinates with corresponding bin-edges, which allows
-        for much more generic plotting code
     - coordinates that contain strings or vectors are converted to fake
         integer coordinates, and axes formatters are updated with lambda
         function formatters.
@@ -49,6 +47,7 @@ class PlotModel:
     """
     def __init__(self, scipp_obj_dict=None):
         self._dims = None
+        self._mode = None
         self.data_arrays = {}
 
         # Create dict of DataArrays using information from controller
@@ -79,6 +78,18 @@ class PlotModel:
     def dims(self, dims):
         self._dims = dims
         self._dims_updated()
+
+    def _mode_updated(self):
+        pass
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, m: ResamplingMode):
+        self._mode = m
+        self._mode_updated()
 
     def _setup_coords(self, array):
         data = array.data

--- a/python/src/scipp/plotting/model1d.py
+++ b/python/src/scipp/plotting/model1d.py
@@ -22,6 +22,7 @@ class PlotModel1d(PlotModel):
 
     def _make_1d_resampling_model(self, array):
         model = resampling_model(array)
+        model.mode = self.mode
         if self.resolution is not None:
             model.resolution[self.dims[0]] = self.resolution
             model.bounds[self.dims[0]] = None

--- a/python/src/scipp/plotting/model1d.py
+++ b/python/src/scipp/plotting/model1d.py
@@ -51,6 +51,12 @@ class PlotModel1d(PlotModel):
 
     @property
     def is_resampling(self):
+        # Two relevant cases where ndim != 1 leads to resampling:
+        # - Profile plot of higher-dimensional data.
+        # - projection='1d', with non-trivial thickness (set via slider).
+        # In the latter case there is strictly speaking no resampling if thickness is 1
+        # but in that case sum==mean and we avoid hiding/showing the toolbar button
+        # depending on selected thickness.
         return self._resolution is not None or len(self.data_arrays.dims) != 1
 
     @property

--- a/python/src/scipp/plotting/model1d.py
+++ b/python/src/scipp/plotting/model1d.py
@@ -49,6 +49,10 @@ class PlotModel1d(PlotModel):
         return model.data
 
     @property
+    def is_resampling(self):
+        return self._resolution is not None or len(self.data_arrays.dims) != 1
+
+    @property
     def resolution(self):
         return self._resolution
 

--- a/python/src/scipp/plotting/model2d.py
+++ b/python/src/scipp/plotting/model2d.py
@@ -31,6 +31,9 @@ class PlotModel2d(PlotModel):
             self._model.resolution[dim] = resolution
             self._model.bounds[dim] = None
 
+    def _mode_updated(self):
+        self._model.mode = self.mode
+
     def update(self):
         """
         Create or update the internal resampling model.

--- a/python/src/scipp/plotting/model2d.py
+++ b/python/src/scipp/plotting/model2d.py
@@ -34,6 +34,10 @@ class PlotModel2d(PlotModel):
     def _mode_updated(self):
         self._model.mode = self.mode
 
+    @property
+    def is_resampling(self):
+        return True
+
     def update(self):
         """
         Create or update the internal resampling model.

--- a/python/src/scipp/plotting/model3d.py
+++ b/python/src/scipp/plotting/model3d.py
@@ -12,10 +12,11 @@ def _planar_norm(a, b):
     return sqrt(a * a + b * b)
 
 
-def _flatten(da, *, mode: ResamplingMode, dims):
+def _flatten(da, *, dims, mode=None):
     flat = flatten(da, dims=dims, to='_'.join(dims))
     if flat.bins is None:
         return flat
+    mode = ResamplingMode(mode)
     if mode == ResamplingMode.mean:
         return flat.bins.mean()
     else:
@@ -27,13 +28,10 @@ class ScatterPointModel:
     Model representing scattered data.
     """
     def __init__(self, *, positions, scipp_obj_dict, resolution):
-        scipp_obj_dict = {
-            key: _flatten(array, dims=positions.dims)
-            for key, array in scipp_obj_dict.items()
-        }
-        self._data_model = PlotModel1d(scipp_obj_dict=scipp_obj_dict,
-                                       resolution=resolution)
-        self._positions = _flatten(positions, dims=positions.dims)
+        self._scipp_obj_dict = scipp_obj_dict
+        self._positions_dims = positions.dims
+        self._resolution = resolution
+        self._positions = _flatten(positions, dims=self._positions_dims)
         # TODO Get dim labels from field names
         self._scatter_dims = ['x', 'y', 'z']
         fields = self._positions.fields
@@ -43,12 +41,34 @@ class ScatterPointModel:
         self._data_model.mode = self.mode
 
     @property
+    def is_resampling(self):
+        return next(iter(self._scipp_obj_dict.values())).bins is not None
+
+    def _initialize(self):
+        scipp_obj_dict = {
+            key: _flatten(array, dims=self._positions_dims, mode=self.mode)
+            for key, array in self._scipp_obj_dict.items()
+        }
+        self._data_model = PlotModel1d(scipp_obj_dict=scipp_obj_dict,
+                                       resolution=self._resolution)
+        self._data_model.mode = self._mode
+
+    @property
     def dims(self):
         return self._scatter_dims
 
     @property
     def positions(self):
         return self._positions
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, m: ResamplingMode):
+        self._mode = m
+        self._initialize()
 
     @property
     def unit(self):

--- a/python/src/scipp/plotting/model3d.py
+++ b/python/src/scipp/plotting/model3d.py
@@ -4,7 +4,7 @@
 from functools import lru_cache
 from ..core import flatten, sqrt, norm
 from .model1d import PlotModel1d
-from .resampling_model import _unit_requires_mean
+from .resampling_model import ResamplingMode
 import numpy as np
 
 
@@ -12,11 +12,11 @@ def _planar_norm(a, b):
     return sqrt(a * a + b * b)
 
 
-def _flatten(da, dims):
+def _flatten(da, *, mode: ResamplingMode, dims):
     flat = flatten(da, dims=dims, to='_'.join(dims))
     if flat.bins is None:
         return flat
-    if _unit_requires_mean(flat.events):
+    if mode == ResamplingMode.mean:
         return flat.bins.mean()
     else:
         return flat.bins.sum()
@@ -38,6 +38,9 @@ class ScatterPointModel:
         self._scatter_dims = ['x', 'y', 'z']
         fields = self._positions.fields
         self._components = dict(zip(self.dims, [fields.x, fields.y, fields.z]))
+
+    def _mode_updated(self):
+        self._data_model.mode = self.mode
 
     @property
     def dims(self):

--- a/python/src/scipp/plotting/objects.py
+++ b/python/src/scipp/plotting/objects.py
@@ -8,6 +8,7 @@ from .tools import parse_params
 from .._scipp.core import DimensionError
 from .model1d import PlotModel1d
 from .widgets import PlotWidgets
+from .resampling_model import ResamplingMode
 
 
 def make_params(*, cmap=None, norm=None, vmin=None, vmax=None, masks=None, color=None):
@@ -272,6 +273,8 @@ class Plot:
                                      view=self.view,
                                      panel=self.panel,
                                      profile=self.profile)
+        self._tool_button_states[
+            'resampling_mode'] = self.model.mode == ResamplingMode.mean
         self._render()
 
     def _ipython_display_(self):

--- a/python/src/scipp/plotting/objects.py
+++ b/python/src/scipp/plotting/objects.py
@@ -384,6 +384,7 @@ def make_plot(builder,
               labels=None,
               errorbars=None,
               norm=None,
+              resampling_mode=None,
               scale=None,
               resolution=None,
               **kwargs):
@@ -394,6 +395,7 @@ def make_plot(builder,
               labels=labels,
               resolution=resolution,
               norm=norm,
+              resampling_mode=resampling_mode,
               scale=scale)
     if filename is not None:
         sp.savefig(filename)

--- a/python/src/scipp/plotting/objects.py
+++ b/python/src/scipp/plotting/objects.py
@@ -8,7 +8,6 @@ from .tools import parse_params
 from .._scipp.core import DimensionError
 from .model1d import PlotModel1d
 from .widgets import PlotWidgets
-from .resampling_model import ResamplingMode
 
 
 def make_params(*, cmap=None, norm=None, vmin=None, vmax=None, masks=None, color=None):
@@ -273,8 +272,7 @@ class Plot:
                                      view=self.view,
                                      panel=self.panel,
                                      profile=self.profile)
-        self._tool_button_states[
-            'resampling_mode'] = self.model.mode == ResamplingMode.mean
+        self._tool_button_states['resampling_mode'] = self.model.mode
         self._render()
 
     def _ipython_display_(self):

--- a/python/src/scipp/plotting/profile.py
+++ b/python/src/scipp/plotting/profile.py
@@ -105,7 +105,7 @@ class PlotProfile(PlotFigure1d):
         the scale on the matplotlib axes.
         """
         if self.toolbar is not None:
-            self.toolbar.hide_resampling_mode()
+            self.toolbar.set_resampling_mode_display(False)
             self.toolbar.connect(controller=self)
 
     def toggle_dim_scale(self, dim):

--- a/python/src/scipp/plotting/profile.py
+++ b/python/src/scipp/plotting/profile.py
@@ -105,6 +105,7 @@ class PlotProfile(PlotFigure1d):
         the scale on the matplotlib axes.
         """
         if self.toolbar is not None:
+            self.toolbar.hide_resampling_mode()
             self.toolbar.connect(controller=self)
 
     def toggle_dim_scale(self, dim):

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -65,6 +65,7 @@ class ResamplingModel():
     @mode.setter
     def mode(self, m: ResamplingMode):
         self._mode = ResamplingMode(m)
+        self.reset()
 
     @property
     def resolution(self):

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
+from enum import Enum
+
 from ..core import bin as bin_
 from ..core import dtype, units
 from ..core import linspace, rebin, get_slice_params, concatenate, histogram
@@ -9,12 +11,13 @@ from ..core import DataArray, DimensionError
 from .tools import to_bin_edges
 
 
-def _unit_requires_mean(obj):
-    return obj.unit != units.counts
+class ResamplingMode(Enum):
+    sum = 0
+    mean = 1
 
 
-def _resample(array, dim, edges):
-    if not _unit_requires_mean(array):
+def _resample(array, mode: ResamplingMode, dim, edges):
+    if mode == ResamplingMode.sum:
         return rebin(array, dim, edges)
     if array.dtype == dtype.float64:
         array = array.copy()
@@ -32,7 +35,7 @@ def _resample(array, dim, edges):
     array.data *= width
     unit = array.unit
     array.unit = units.counts
-    array = _resample(array, dim, edges)
+    array = rebin(array, dim, edges)
     width = edges[dim, 1:] - edges[dim, :-1]
     width.unit = units.one
     array /= width
@@ -41,7 +44,11 @@ def _resample(array, dim, edges):
 
 
 class ResamplingModel():
-    def __init__(self, array, resolution=None, bounds=None):
+    def __init__(self, array, *, resolution=None, bounds=None):
+        """
+        Model over a data array providing unified resampling functionality.
+        """
+        self._mode = None
         self._resolution = {} if resolution is None else resolution
         self._bounds = {} if bounds is None else bounds
         self._resampled = None
@@ -50,6 +57,14 @@ class ResamplingModel():
         self._home = None
         self._home_params = None
         self.update_array(array)
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, m: ResamplingMode):
+        self._mode = ResamplingMode(m)
 
     @property
     def resolution(self):
@@ -99,9 +114,9 @@ class ResamplingModel():
                 plan.insert(0, edge)
         for edge in plan:
             try:
-                array = _resample(array, dim, edge)
+                array = _resample(array, self.mode, dim, edge)
             except RuntimeError:  # Limitation of rebin for slice of inner dim
-                array = _resample(array.copy(), edge.dims[-1], edge)
+                array = _resample(array.copy(), self.mode, edge.dims[-1], edge)
         return array
 
     def _make_edges(self, params):
@@ -208,11 +223,11 @@ class ResamplingBinnedModel(ResamplingModel):
             bounds = concatenate(edges[dim, 0], edges[dim, -1], dim)
             binned = bin_(array, edges=self.edges[:-1] + [bounds])
             # TODO Use histogramming with "mean" mode once implemented
-            if _unit_requires_mean(binned.events):
+            if self.mode == ResamplingMode.mean:
                 return bin_(binned, edges=[edges]).bins.mean()
             else:
                 return histogram(binned, bins=edges)
-        elif _unit_requires_mean(array.events):
+        elif self.mode == ResamplingMode.mean:
             return bin_(array, edges=self.edges).bins.mean()
         else:
             return bin_(array, edges=self.edges).bins.sum()

--- a/python/src/scipp/plotting/toolbar.py
+++ b/python/src/scipp/plotting/toolbar.py
@@ -274,7 +274,7 @@ class PlotToolbar3d(PlotToolbar):
         self.add_togglebutton(name="toggle_norm",
                               description="log",
                               tooltip="log(data)")
-        self.members['toggle_resampling_mode'] = None
+        self.members['resampling_mode'] = None
 
     def home_view(self, button):
         self.mpl_toolbar.reset_camera()

--- a/python/src/scipp/plotting/toolbar.py
+++ b/python/src/scipp/plotting/toolbar.py
@@ -46,7 +46,9 @@ class PlotToolbar:
         self._resampling_mode = _make_toggle_button(
             description='',
             tooltip="Switch current resampling mode. Options are 'sum' and 'mean'."
-            "The correct mode depends on the interpretation of data")
+            " The correct mode depends on the interpretation of data."
+            " The default value is guessed based on the data unit but in practice"
+            " the automatic selection cannot always be relied on.")
 
     def initialize(self, log_axis_buttons, button_states):
         self.members['resampling_mode'] = self._resampling_mode

--- a/python/tests/plotting/plot_1d_test.py
+++ b/python/tests/plotting/plot_1d_test.py
@@ -14,7 +14,10 @@ from .plot_helper import plot
 
 
 def test_plot_1d():
-    plot(make_dense_data_array(ndim=1))
+    da = make_dense_data_array(ndim=1)
+    plot(da)
+    plot(da, resampling_mode='sum')
+    plot(da, resampling_mode='mean')
 
 
 def test_plot_1d_with_variances():
@@ -22,7 +25,10 @@ def test_plot_1d_with_variances():
 
 
 def test_plot_1d_bin_edges():
-    plot(make_dense_data_array(ndim=1, binedges=True))
+    da = make_dense_data_array(ndim=1, binedges=True)
+    plot(da)
+    plot(da, resampling_mode='sum')
+    plot(da, resampling_mode='mean')
 
 
 def test_plot_1d_with_labels():
@@ -39,6 +45,8 @@ def test_plot_1d_log_axes():
     plot(da, scale={'x': 'log'})
     plot(da, norm='log')
     plot(da, norm='log', scale={'x': 'log'})
+    plot(da, norm='log', scale={'x': 'log'}, resampling_mode='sum')
+    plot(da, norm='log', scale={'x': 'log'}, resampling_mode='mean')
 
 
 def test_plot_1d_bin_edges_with_variances():
@@ -81,7 +89,10 @@ def test_plot_collapse():
 
 
 def test_plot_sliceviewer_with_1d_projection():
-    plot(make_dense_data_array(ndim=3), projection="1d")
+    da = make_dense_data_array(ndim=3)
+    plot(da, projection="1d")
+    plot(da, projection="1d", resampling_mode='sum')
+    plot(da, projection="1d", resampling_mode='mean')
 
 
 def test_plot_sliceviewer_with_1d_projection_with_nans():

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -13,7 +13,10 @@ from .plot_helper import plot
 
 
 def test_plot_2d():
-    plot(make_dense_data_array(ndim=2))
+    da = make_dense_data_array(ndim=2)
+    plot(da)
+    plot(da, resampling_mode='sum')
+    plot(da, resampling_mode='mean')
 
 
 def test_plot_2d_dataset():
@@ -25,11 +28,17 @@ def test_plot_2d_with_variances():
 
 
 def test_plot_2d_with_log():
-    plot(make_dense_data_array(ndim=2), norm='log')
+    da = make_dense_data_array(ndim=2)
+    plot(da, norm='log')
+    plot(da, norm='log', resampling_mode='sum')
+    plot(da, norm='log', resampling_mode='mean')
 
 
 def test_plot_2d_with_log_and_variances():
-    plot(make_dense_data_array(ndim=2, with_variance=True), norm='log')
+    da = make_dense_data_array(ndim=2, with_variance=True)
+    plot(da, norm='log')
+    plot(da, norm='log', resampling_mode='sum')
+    plot(da, norm='log', resampling_mode='mean')
 
 
 def test_plot_2d_with_vmin_vmax():
@@ -241,6 +250,8 @@ def test_plot_2d_with_decreasing_edges():
 def test_plot_2d_binned_data():
     da = make_binned_data_array(ndim=2)
     plot(da)
+    plot(da, resampling_mode='sum')
+    plot(da, resampling_mode='mean')
     # Try without event-coord so implementation cannot use `histogram`
     for dim in ['xx', 'yy']:
         copy = da.copy()

--- a/python/tests/plotting/plot_3d_test.py
+++ b/python/tests/plotting/plot_3d_test.py
@@ -40,7 +40,10 @@ def make_data_array_with_position_vectors():
 
 
 def test_plot_projection_3d():
-    plot(_with_fake_pos(ndim=3), positions='pos', projection="3d")
+    da = _with_fake_pos(ndim=3)
+    plot(da, positions='pos', projection="3d")
+    plot(da, positions='pos', projection="3d", resampling_mode='sum')
+    plot(da, positions='pos', projection="3d", resampling_mode='mean')
 
 
 def test_plot_projection_3d_log_norm():
@@ -129,6 +132,8 @@ def test_plot_3d_binned_data():
     da = make_binned_data_array(ndim=1)
     pos = sc.vectors(dims=da.dims, values=np.random.rand(da.sizes[da.dims[0]], 3))
     plot(da, projection='3d', positions=pos)
+    plot(da, projection='3d', positions=pos, resampling_mode='sum')
+    plot(da, projection='3d', positions=pos, resampling_mode='mean')
 
 
 def test_plot_redraw():

--- a/tools/manual_testing/plot.ipynb
+++ b/tools/manual_testing/plot.ipynb
@@ -159,7 +159,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.plot(labels={'xx':'xx2'}, errorbars=False)"
+    "da.plot(labels={'xx':'xx2'}, errorbars=False, resolution=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7ef29ec-c530-4a88-ab21-cd0d1176c1ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da.plot(labels={'xx':'xx2'}, errorbars=False, resolution=3, resampling_mode='sum')"
    ]
   },
   {

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -101,8 +101,6 @@ Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
   // always be computed on-the-fly for visualization, if required.
   if (var.dtype() == dtype<bool>)
     core::expect::equals(var.unit(), units::one);
-  else
-    core::expect::equals(var.unit(), units::counts);
   if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");

--- a/variable/rebin.cpp
+++ b/variable/rebin.cpp
@@ -114,6 +114,11 @@ Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
   using transform_args = std::tuple<
       args<double, double, int64_t, double>,
       args<double, double, int32_t, double>,
+      args<double, core::time_point, double, core::time_point>,
+      args<float, core::time_point, float, core::time_point>,
+      args<double, core::time_point, int64_t, core::time_point>,
+      args<double, core::time_point, int32_t, core::time_point>,
+      args<bool, core::time_point, bool, core::time_point>,
       args<double, double, double, double>, args<float, float, float, float>,
       args<float, double, float, double>, args<float, float, float, double>,
       args<bool, double, bool, double>>;
@@ -129,11 +134,11 @@ Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
     if (ascending) {
       return transform_subspan<transform_args>(
           out_type, dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
-          core::element::rebin<Less>);
+          core::element::rebin<Less>, "rebin");
     } else {
       return transform_subspan<transform_args>(
           out_type, dim, newCoord.dims()[dim] - 1, newCoord, var, oldCoord,
-          core::element::rebin<Greater>);
+          core::element::rebin<Greater>, "rebin");
     }
   } else {
     auto dims = var.dims();

--- a/variable/test/rebin_test.cpp
+++ b/variable/test/rebin_test.cpp
@@ -7,6 +7,8 @@
 #include "scipp/variable/rebin.h"
 #include "scipp/variable/variable.h"
 
+#include "test_macros.h"
+
 using namespace scipp;
 
 TEST(RebinTest, inner) {
@@ -226,9 +228,7 @@ TEST(Variable, rebin_mask_outer_single) {
   ASSERT_EQ(result, expected);
 }
 
-// TODO Enable this once we have `resample`. Right now this fails with
-// UnitError, not the "desired" TypeError.
-TEST(Variable, DISABLED_check_rebin_cannot_be_used_on_bin_data) {
+TEST(Variable, check_rebin_cannot_be_used_on_bin_data) {
   Dimensions dims{Dim::Y, 1};
   Variable buffer =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
@@ -239,6 +239,5 @@ TEST(Variable, DISABLED_check_rebin_cannot_be_used_on_bin_data) {
       makeVariable<double>(Dimensions{Dim::Y, 2}, Values{1, 4});
   const auto newEdge =
       makeVariable<double>(Dimensions{Dim::Y, 4}, Values{0, 1, 2, 3});
-  EXPECT_THROW([[maybe_unused]] auto res = rebin(var, Dim::Y, oldEdge, newEdge),
-               except::TypeError);
+  EXPECT_THROW_DISCARD(rebin(var, Dim::Y, oldEdge, newEdge), except::TypeError);
 }


### PR DESCRIPTION
In discussions over the past days it has become clear that:
- It is not possible to decide based on the unit of data whether it has to be summed or averaged during "resampling" operations. This appears to be dependent on the interpretation of the data and can apparently not be encoded in dtype or unit.
- We need to decide what to display when plotting (see also #2167), without running into too many problems from *hidden* bad defaults.

Therefore, we have the following changes here:
- `rebin` and `histogram` to not restrict data units any more.
- `plot` supports a `resampling_mode` option.
- For users convenience we determine a default mode based on the unit.
- In practice the default mode *may be wrong*, therefor we add a toolbar button as a *visual indicator* to highlight the current mode.
  - Unsolved: How can this be handled when plotting non-interactively, e.g., to a file? This may be a bigger issue and is out of the scope of this PR. It is probably a sub-aspect of the entire resampling discussion, see #2167 again. 

Other changes:
- `rebin` now also works with `datetime64` edges