### PR TITLE
Remove low-level overload of rebin

### DIFF
--- a/python/src/scipp/core/operations.py
+++ b/python/src/scipp/core/operations.py
@@ -138,31 +138,20 @@ def stddevs(x: VariableLike) -> VariableLike:
     return _call_cpp_func(_cpp.stddevs, x)
 
 
-def rebin(x: VariableLike,
-          dim: str,
-          bins: _cpp.Variable,
-          old: Optional[_cpp.Variable] = None) -> VariableLike:
+def rebin(x: VariableLike, dim: str, bins: _cpp.Variable) -> VariableLike:
     """
-    Rebin a dimension of a variable or a data array.
+    Rebin a dimension of a data array or dataset.
 
-    In the case of a Variable, both the old and the new bin edges have to be
-    supplied.
-    In the case of a DataArray, only the new edges are needed, as the
-    coordinate associated with dim will be used as the old bin edges.
+    The input must contain bin edges for the given dimension `dim`.
 
     :param x: Data to rebin.
     :param dim: Dimension to rebin over.
     :param bins: New bin edges.
-    :param old: Old bin edges.
-    :raises: If data cannot be rebinned, e.g., if the unit is not
-             counts, or the existing coordinate is not a bin-edge
-             coordinate.
+    :raises: If data cannot be rebinned, e.g., if the existing coordinate is not a
+             bin-edge coordinate.
     :return: Data rebinned according to the new bin edges.
     """
-    if old is None:
-        return _call_cpp_func(_cpp.rebin, x, dim, bins)
-    else:
-        return _call_cpp_func(_cpp.rebin, x, dim, old, bins)
+    return _call_cpp_func(_cpp.rebin, x, dim, bins)
 
 
 def where(condition: _cpp.Variable, x: _cpp.Variable,

--- a/python/variable.cpp
+++ b/python/variable.cpp
@@ -12,7 +12,6 @@
 #include "scipp/core/time_point.h"
 
 #include "scipp/variable/operations.h"
-#include "scipp/variable/rebin.h"
 #include "scipp/variable/structures.h"
 #include "scipp/variable/util.h"
 #include "scipp/variable/variable.h"
@@ -180,12 +179,6 @@ of variances.)");
       },
       py::arg("x"), py::arg("dim") = py::none(),
       py::call_guard<py::gil_scoped_release>());
-
-  m.def("rebin",
-        py::overload_cast<const Variable &, const Dim, const Variable &,
-                          const Variable &>(&rebin),
-        py::arg("x"), py::arg("dim"), py::arg("old"), py::arg("new"),
-        py::call_guard<py::gil_scoped_release>());
 
   bind_structured_creation<Eigen::Vector3d, double, 3>(m, "vectors");
   bind_structured_creation<Eigen::Matrix3d, double, 3, 3>(m, "matrices");


### PR DESCRIPTION
Fixes #2179.

The Python wrapper unified the overloads for DataArray and Variable. This is confusing and not a good interface.

Since creating data arrays from variables is cheap after the shared-ownership refactor we remove the variable-based overload entirely.