### PR TITLE
Events property readonly flag

### DIFF
--- a/dataset/dataset.cpp
+++ b/dataset/dataset.cpp
@@ -7,6 +7,8 @@
 #include "scipp/dataset/dataset_util.h"
 #include "scipp/dataset/except.h"
 
+#include "dataset_operations_common.h"
+
 namespace scipp::dataset {
 
 namespace {
@@ -250,6 +252,21 @@ const Sizes &Dataset::sizes() const { return m_coords.sizes(); }
 const Sizes &Dataset::dims() const { return sizes(); }
 
 bool Dataset::is_readonly() const noexcept { return m_readonly; }
+
+Dataset Dataset::as_const() const {
+  Dataset out;
+  out.m_coords = m_coords.as_const();
+  for (const auto &[k, v] : m_data)
+    out.m_data[k] = v.as_const();
+  out.m_readonly = true;
+  return out;
+}
+
+Dataset Dataset::view() const {
+  // TODO Cannot return view right now, would require wrapping fields of Dataset
+  // in shared_ptr. We return as_const for now to avoid breakage.
+  return as_const();
+}
 
 typename Masks::holder_type union_or(const Masks &currentMasks,
                                      const Masks &otherMasks) {

--- a/dataset/include/scipp/dataset/dataset.h
+++ b/dataset/include/scipp/dataset/dataset.h
@@ -195,6 +195,9 @@ public:
 
   bool is_readonly() const noexcept;
 
+  [[nodiscard]] Dataset as_const() const;
+  [[nodiscard]] Dataset view() const;
+
 private:
   // Declared friend so gtest recognizes it
   friend SCIPP_DATASET_EXPORT std::ostream &operator<<(std::ostream &,

--- a/dataset/test/CMakeLists.txt
+++ b/dataset/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
   binned_arithmetic_test.cpp
   binned_creation_test.cpp
   bins_test.cpp
+  bins_view_test.cpp
   bin_test.cpp
   choose_test.cpp
   concatenate_test.cpp

--- a/dataset/test/bins_view_test.cpp
+++ b/dataset/test/bins_view_test.cpp
@@ -43,13 +43,17 @@ TEST_F(BinsViewTest, slice_readonly) {
   auto slice = var.slice({Dim::Y, 0});
   auto view = bins_view<DataArray>(slice);
   ASSERT_THROW(view.coords().erase(Dim::X), except::DataArrayError);
-  auto buffer = slice.bin_buffer<DataArray>();
-  ASSERT_THROW(buffer.coords().erase(Dim::X), except::DataArrayError);
-  EXPECT_TRUE(buffer.is_readonly());
-  EXPECT_TRUE(buffer.coords().is_readonly());
-  EXPECT_TRUE(buffer.masks().is_readonly());
-  EXPECT_TRUE(buffer.attrs().is_readonly());
-  EXPECT_TRUE(buffer.meta().is_readonly());
+  auto buf = slice.bin_buffer<DataArray>();
+  ASSERT_THROW(buf.coords().erase(Dim::X), except::DataArrayError);
+  EXPECT_TRUE(buf.is_readonly());
+  EXPECT_TRUE(buf.coords().is_readonly());
+  EXPECT_TRUE(buf.masks().is_readonly());
+  EXPECT_TRUE(buf.attrs().is_readonly());
+  EXPECT_TRUE(buf.meta().is_readonly());
+  auto copied(buf); // Shallow copy clears flags, as usual
+  EXPECT_FALSE(copied.is_readonly());
+  EXPECT_FALSE(copied.coords().is_readonly());
+  EXPECT_TRUE(copied.coords()[Dim::X].is_readonly());
 }
 
 TEST_F(BinsViewTest, constituents_erase) {

--- a/dataset/test/bins_view_test.cpp
+++ b/dataset/test/bins_view_test.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+
+#include "scipp/dataset/bins.h"
+#include "scipp/dataset/bins_view.h"
+#include "scipp/dataset/dataset.h"
+
+using namespace scipp;
+using namespace scipp::dataset;
+
+class BinsViewTest : public ::testing::Test {
+protected:
+  Dimensions dims{Dim::Y, 2};
+  Variable indices = makeVariable<scipp::index_pair>(
+      dims, Values{std::pair{0, 2}, std::pair{2, 4}});
+  Variable data =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  DataArray buffer = DataArray(data, {{Dim::X, data + data}});
+  Variable var = make_bins(indices, Dim::X, buffer);
+};
+
+TEST_F(BinsViewTest, erase) {
+  auto view = bins_view<DataArray>(var);
+  auto da = var.bin_buffer<DataArray>();
+  EXPECT_TRUE(da.coords().contains(Dim::X));
+  view.coords().erase(Dim::X);
+  EXPECT_FALSE(da.coords().contains(Dim::X));
+}
+
+TEST_F(BinsViewTest, insert) {
+  auto view = bins_view<DataArray>(var);
+  const auto &da = var.bin_buffer<DataArray>();
+  EXPECT_FALSE(da.coords().contains(Dim::Y));
+  view.coords().set(Dim::Y, view.coords()[Dim::X]);
+  EXPECT_TRUE(da.coords().contains(Dim::Y));
+}
+
+TEST_F(BinsViewTest, constituents_erase) {
+  auto &&[i, dim, buf] = var.constituents<DataArray>();
+  auto da = var.bin_buffer<DataArray>();
+  EXPECT_TRUE(da.coords().contains(Dim::X));
+  buf.coords().erase(Dim::X);
+  // Constituents returns (shallow) copy, not modified.
+  EXPECT_TRUE(da.coords().contains(Dim::X));
+  EXPECT_TRUE(
+      std::get<2>(var.constituents<DataArray>()).coords().contains(Dim::X));
+}
+
+TEST_F(BinsViewTest, constituents_insert) {
+  auto &&[i, dim, buf] = var.constituents<DataArray>();
+  auto da = var.bin_buffer<DataArray>();
+  EXPECT_FALSE(da.coords().contains(Dim::Y));
+  buf.coords().set(Dim::Y, buf.coords()[Dim::X]);
+  // Constituents returns (shallow) copy, not modified.
+  EXPECT_FALSE(da.coords().contains(Dim::Y));
+  EXPECT_FALSE(
+      std::get<2>(var.constituents<DataArray>()).coords().contains(Dim::Y));
+}

--- a/dataset/test/bins_view_test.cpp
+++ b/dataset/test/bins_view_test.cpp
@@ -7,6 +7,7 @@
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/bins_view.h"
 #include "scipp/dataset/dataset.h"
+#include "scipp/dataset/except.h"
 
 using namespace scipp;
 using namespace scipp::dataset;
@@ -36,6 +37,19 @@ TEST_F(BinsViewTest, insert) {
   EXPECT_FALSE(da.coords().contains(Dim::Y));
   view.coords().set(Dim::Y, view.coords()[Dim::X]);
   EXPECT_TRUE(da.coords().contains(Dim::Y));
+}
+
+TEST_F(BinsViewTest, slice_readonly) {
+  auto slice = var.slice({Dim::Y, 0});
+  auto view = bins_view<DataArray>(slice);
+  ASSERT_THROW(view.coords().erase(Dim::X), except::DataArrayError);
+  auto buffer = slice.bin_buffer<DataArray>();
+  ASSERT_THROW(buffer.coords().erase(Dim::X), except::DataArrayError);
+  EXPECT_TRUE(buffer.is_readonly());
+  EXPECT_TRUE(buffer.coords().is_readonly());
+  EXPECT_TRUE(buffer.masks().is_readonly());
+  EXPECT_TRUE(buffer.attrs().is_readonly());
+  EXPECT_TRUE(buffer.meta().is_readonly());
 }
 
 TEST_F(BinsViewTest, constituents_erase) {

--- a/python/tests/bins_test.py
+++ b/python/tests/bins_test.py
@@ -69,6 +69,12 @@ def test_events_property():
     assert 'coord' in binned.events.coords
     assert 'mask' in binned.events.masks
     assert 'attr' in binned.events.attrs
+    with pytest.raises(sc.DataArrayError):
+        # readonly because slice
+        del binned['y', 0].events.coords['coord']
+    # not readonly if not a slice
+    del binned['y', :].events.coords['coord']
+    assert 'coord' not in binned.events.coords
 
 
 def test_bins():

--- a/variable/include/scipp/variable/bin_array_variable.tcc
+++ b/variable/include/scipp/variable/bin_array_variable.tcc
@@ -45,14 +45,9 @@ template <class T> std::tuple<Variable, Dim, T> Variable::constituents() {
   return {bin_indices(), model.bin_dim(), model.buffer()};
 }
 
-template <class T> const T &Variable::bin_buffer() const {
+template <class T> T Variable::bin_buffer() const {
   auto &model = requireT<const BinArrayModel<T>>(data());
-  return model.buffer();
-}
-
-template <class T> T &Variable::bin_buffer() {
-  auto &model = requireT<BinArrayModel<T>>(data());
-  return model.buffer();
+  return is_slice() ? model.buffer().as_const() : model.buffer().view();
 }
 
 template <class T> class BinVariableMakerCommon : public AbstractVariableMaker {
@@ -238,9 +233,7 @@ Variable make_bins_impl(Variable indices, const Dim dim, T &&buffer) {
   INSTANTIATE_VARIABLE_BASE(name, core::bin<__VA_ARGS__>)                      \
   template SCIPP_EXPORT std::tuple<Variable, Dim, __VA_ARGS__>                 \
   Variable::constituents<__VA_ARGS__>() const;                                 \
-  template SCIPP_EXPORT const __VA_ARGS__ &Variable::bin_buffer<__VA_ARGS__>() \
-      const;                                                                   \
-  template SCIPP_EXPORT __VA_ARGS__ &Variable::bin_buffer<__VA_ARGS__>();      \
+  template SCIPP_EXPORT __VA_ARGS__ Variable::bin_buffer<__VA_ARGS__>() const; \
   template SCIPP_EXPORT std::tuple<Variable, Dim, __VA_ARGS__>                 \
   Variable::constituents<__VA_ARGS__>();                                       \
   template SCIPP_EXPORT std::tuple<Variable, Dim, __VA_ARGS__>                 \

--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -123,8 +123,7 @@ public:
   [[nodiscard]] core::ElementArrayViewParams array_params() const noexcept;
 
   [[nodiscard]] Variable bin_indices() const;
-  template <class T> const T &bin_buffer() const;
-  template <class T> T &bin_buffer();
+  template <class T> T bin_buffer() const;
 
   template <class T> std::tuple<Variable, Dim, T> constituents() const;
   template <class T> std::tuple<Variable, Dim, T> constituents();
@@ -140,6 +139,7 @@ public:
   [[nodiscard]] bool is_same(const Variable &other) const noexcept;
 
   [[nodiscard]] Variable as_const() const;
+  [[nodiscard]] Variable view() const;
 
   auto &unchecked_dims() { return m_dims; }
   auto &unchecked_strides() { return m_strides; }

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -272,6 +272,8 @@ Variable Variable::as_const() const {
   return out;
 }
 
+Variable Variable::view() const { return *this; }
+
 void Variable::expectWritable() const {
   if (m_readonly)
     throw except::VariableError("Read-only flag is set, cannot mutate data.");


### PR DESCRIPTION
Reduce risk for breaking binned data by setting readonly flag for the `events` property of a slice.