### PR TITLE
Do not apply bin masks when plotting event data

### DIFF
--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -207,6 +207,12 @@ class ResamplingBinnedModel(ResamplingModel):
     def _make_array(self, array):
         return array
 
+    def _strip_masks(self, array):
+        array = array.copy(deep=False)
+        for name in list(array.masks.keys()):
+            del array.masks[name]
+        return array
+
     def _resample(self, array):
         # We could bin with all edges and then use `bins.sum()` but especially
         # for inputs with many bins handling the final edges using `histogram`
@@ -217,11 +223,7 @@ class ResamplingBinnedModel(ResamplingModel):
         # inconsistent with how dense data is handled, where data is preserved
         # even if masked, but masks grow. Therefore, we remove masks here. They
         # get handled in _call_resample.
-        array = DataArray(data=array.data,
-                          coords={k: v
-                                  for k, v in array.coords.items()},
-                          attrs={k: v
-                                 for k, v in array.attrs.items()})
+        array = self._strip_masks(array)
         if dim in array.bins.coords:
             # Must specify bounds for final dim despite handling by `histogram`
             # below: If coord is ragged binning would throw otherwise.

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -213,11 +213,15 @@ class ResamplingBinnedModel(ResamplingModel):
         # is faster with the current implementation of `sc.bin`.
         edges = self.edges[-1]
         dim = edges.dims[-1]
-        # TODO `bin` applies masks, but later we add rebinned masks. This is
+        # `bin` applies masks, but later we add rebinned masks. This would be
         # inconsistent with how dense data is handled, where data is preserved
-        # even if masked, but masks grow. Note that manual masks handling for
-        # dense data in _call_resample is thus redundant, if it could be
-        # handled consistently here.
+        # even if masked, but masks grow. Therefore, we remove masks here. They
+        # get handled in _call_resample.
+        array = DataArray(data=array.data,
+                          coords={k: v
+                                  for k, v in array.coords.items()},
+                          attrs={k: v
+                                 for k, v in array.attrs.items()})
         if dim in array.bins.coords:
             # Must specify bounds for final dim despite handling by `histogram`
             # below: If coord is ragged binning would throw otherwise.

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -333,7 +333,14 @@ def test_plot_2d_binned_data_with_variances_resolution():
 
 
 def test_plot_2d_binned_data_with_masks():
-    plot(make_binned_data_array(ndim=2, masks=True))
+    da = make_binned_data_array(ndim=2, masks=True)
+    p = da.plot()
+    unmasked = p.view.figure.image_values.get_array()
+    da.masks['all'] = da.data.bins.sum() == da.data.bins.sum()
+    p = da.plot()
+    # Bin masks are *not* applied
+    assert np.allclose(p.view.figure.image_values.get_array(), unmasked)
+    assert not np.isclose(p.view.figure.image_values.get_array().sum(), 0.0)
 
 
 def test_plot_customized_mpl_axes():
@@ -417,10 +424,10 @@ def test_plot_redraw_counts():
 def test_plot_redraw_binned():
     da = make_binned_data_array(ndim=2)
     p = sc.plot(da, resolution=64)
-    before = p.view.figure.image_values.get_array().sum()
+    before = p.view.figure.image_values.get_array()
     da *= 5.0
     p.redraw()
-    assert np.isclose(p.view.figure.image_values.get_array().sum(), 5.0 * before)
+    assert np.allclose(p.view.figure.image_values.get_array(), 5.0 * before)
     p.close()
 
 


### PR DESCRIPTION
This resolves an open to-do in `ResamplingModel`. The masks were applied when resampling binned data, which was confusing and inconsistent.

Before:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/12912489/133367372-391e8e7c-a533-4669-8c2d-9646875b0325.png">

After:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/12912489/133367330-c84ee08f-1398-4363-9ea7-d7faef1e9b4a.png">
