### PR TITLE
Fix optional plotting import required to import scipp

### DIFF
--- a/python/src/scipp/plotting/widgets.py
+++ b/python/src/scipp/plotting/widgets.py
@@ -4,7 +4,6 @@
 from functools import partial
 from html import escape
 from ..utils import value_to_string
-import ipywidgets as ipw
 
 
 class PlotWidgets:
@@ -15,6 +14,7 @@ class PlotWidgets:
     """
     def __init__(self, *, dims, formatters, ndim, dim_label_map, masks, sizes):
 
+        import ipywidgets as ipw
         self._dims = dims
         self._labels = dim_label_map
         self._controller = None
@@ -119,6 +119,7 @@ class PlotWidgets:
         """
         Gather all widgets in a single container box.
         """
+        import ipywidgets as ipw
         return ipw.VBox(self.container)
 
     def _add_masks_controls(self, masks):
@@ -126,6 +127,7 @@ class PlotWidgets:
         Add checkboxes for individual masks, as well as a global hide/show all
         toggle button.
         """
+        import ipywidgets as ipw
         masks_found = False
         self.mask_checkboxes = {}
         for name in masks:


### PR DESCRIPTION
`conda create -n scipp-08-testing python=3.7`
`conda install scipp -c scipp --yes` (installs 0.8.1 scipp)

```python
>>> import scipp as sc
sTraceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/spu92482/miniconda3/envs/scipp-08-testing/lib/python3.7/scipp/__init__.py", line 46, in <module>
    from .plotting import plot
  File "/Users/spu92482/miniconda3/envs/scipp-08-testing/lib/python3.7/scipp/plotting/__init__.py", line 6, in <module>
    from .plot import plot as _plot
  File "/Users/spu92482/miniconda3/envs/scipp-08-testing/lib/python3.7/scipp/plotting/plot.py", line 9, in <module>
    from .objects import PlotDict
  File "/Users/spu92482/miniconda3/envs/scipp-08-testing/lib/python3.7/scipp/plotting/objects.py", line 10, in <module>
    from .widgets import PlotWidgets
  File "/Users/spu92482/miniconda3/envs/scipp-08-testing/lib/python3.7/scipp/plotting/widgets.py", line 7, in <module>
    import ipywidgets as ipw
ModuleNotFoundError: No module named 'ipywidgets'
```