### PR TITLE
isnear should not throw when returning is preferable

### DIFF
--- a/python/src/scipp/utils/comparison.py
+++ b/python/src/scipp/utils/comparison.py
@@ -42,8 +42,7 @@ def isnear(x,
     same_len = len(x.meta) == len(y.meta) if include_attrs else len(x.coords) == len(
         y.coords)
     if not same_len:
-        raise RuntimeError('Different number of items'
-                           f' in meta {len(x.meta)} {len(y.meta)}')
+        return False
     for key, val in x.meta.items() if include_attrs else x.coords.items():
         a = x.meta[key] if include_attrs else x.coords[key]
         b = y.meta[key] if include_attrs else y.coords[key]

--- a/python/tests/utils/comparision_test.py
+++ b/python/tests/utils/comparision_test.py
@@ -8,10 +8,13 @@ def test_wont_match_when_meta_size_unequal():
     point = sc.scalar(value=1.0)
     a = sc.DataArray(data=point, attrs={'x': point})
     b = sc.DataArray(data=point)
-    with pytest.raises(RuntimeError):
-        su.isnear(a, b, rtol=0 * sc.units.one, atol=1.0 * sc.units.one)
-    # Raise nothing if we are ignoring differing parts
-    su.isnear(a, b, rtol=0 * sc.units.one, atol=1.0 * sc.units.one, include_attrs=False)
+    assert not su.isnear(a, b, rtol=0 * sc.units.one, atol=1.0 * sc.units.one)
+    # ingore attributes, should give the same result
+    assert su.isnear(a,
+                     b,
+                     rtol=0 * sc.units.one,
+                     atol=1.0 * sc.units.one,
+                     include_attrs=False)
 
 
 def test_wont_match_when_meta_keys_unequal():


### PR DESCRIPTION
Specifically it should return False when the number of attributes does not match rather than throw