### PR TITLE
Fix plotting of binned data with masks and memory issues

### DIFF
--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -134,7 +134,7 @@ class ResamplingModel():
 
     def _make_edges(self, params):
         edges = []
-        for i, (dim, par) in enumerate(params.items()):
+        for dim, par in params.items():
             if isinstance(par, int):
                 continue
             low, high, unit, res = par
@@ -179,6 +179,11 @@ class ResamplingModel():
                         out = out[get_slice_params(out.data, out.meta[dim], low, high)]
                 params[dim] = (low.value, high.value, low.unit,
                                self.resolution.get(dim, None))
+        # Order params as in original data. This is particularely important for binned
+        # data since ResamplingBinnedModel uses some optimization to avoid many bins
+        # for the inner dimension. If params (and thus edges) were out of order we can
+        # run into big memory and/or performance issues.
+        params = {dim: params[dim] for dim in self._array.dims if dim in self.bounds}
         if params == self._home_params:
             # This is a crude caching mechanism for past views. Currently we
             # have the "back" buttons disabled in the matplotlib toolbar, so

--- a/python/src/scipp/plotting/resampling_model.py
+++ b/python/src/scipp/plotting/resampling_model.py
@@ -263,6 +263,8 @@ def _with_edges(array):
     new_array = array.copy(deep=False)
     prefix = ''.join(array.dims)
     for dim, var in array.coords.items():
+        if dim not in array.dims:
+            continue
         new_array.coords[f'{prefix}_{dim}'] = var
         if var.sizes[dim] == array.sizes[dim]:
             new_array.coords[dim] = to_bin_edges(var, dim)

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -315,7 +315,7 @@ def test_plot_2d_binned_data_datetime64():
 
 
 def test_plot_3d_binned_data_where_outer_dimension_has_no_event_coord():
-    data = make_binned_data_array(ndim=2)
+    data = make_binned_data_array(ndim=2, masks=True)
     data = sc.concatenate(data, data * sc.scalar(2.0), 'run')
     plot_obj = sc.plot(data)
     plot_obj.widgets._controls['run']['slider'].value = 1

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -268,7 +268,7 @@ def test_plot_2d_binned_data():
 
 def test_plot_2d_binned_data_non_counts():
     da = make_binned_data_array(ndim=2)
-    da.events.unit = 'K'
+    da.bins.unit = 'K'
     plot(da)
     # Try without event-coord so implementation cannot use `histogram`
     for dim in ['xx', 'yy']:
@@ -282,7 +282,7 @@ def test_plot_2d_binned_data_non_counts():
 
 def test_plot_2d_binned_data_float32_coord():
     da = make_binned_data_array(ndim=2)
-    da.events.coords['xx'] = da.events.coords['xx'].astype('float32')
+    da.bins.coords['xx'] = da.bins.coords['xx'].astype('float32')
     plot(da)
     # Try without event-coord so implementation cannot use `histogram`
     for dim in ['xx', 'yy']:
@@ -300,9 +300,8 @@ def test_plot_2d_binned_data_datetime64():
     offset = (1000 * da.coords['xx']).astype('int64')
     offset.unit = 's'
     da.coords['xx'] = start + offset
-    offset = (1000 * da.events.coords['xx']).astype('int64')
-    offset.unit = 's'
-    da.events.coords['xx'] = start + offset
+    offset = (1000 * da.bins.coords['xx']).astype('int64') * sc.scalar(1, unit='s/m')
+    da.bins.coords['xx'] = start + offset
     plot(da)
     # Try without event-coord so implementation cannot use `histogram`
     for dim in ['xx', 'yy']:

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -295,7 +295,7 @@ def test_plot_2d_binned_data_float32_coord():
 
 
 def test_plot_2d_binned_data_datetime64():
-    da = make_binned_data_array(ndim=2)
+    da = make_binned_data_array(ndim=2, masks=True)
     start = sc.scalar(np.datetime64('now'))
     offset = (1000 * da.coords['xx']).astype('int64')
     offset.unit = 's'

--- a/variable/include/scipp/variable/bin_array_model.h
+++ b/variable/include/scipp/variable/bin_array_model.h
@@ -28,7 +28,7 @@ public:
     if (unit != units::one)
       throw except::UnitError(
           "Bins cannot have a unit. Did you mean to set the unit of the bin "
-          "elements? This can be set, e.g., with `array.events.unit = 'm'`.");
+          "elements? This can be set, e.g., with `array.bins.unit = 'm'`.");
   }
 
   bool hasVariances() const noexcept override { return false; }


### PR DESCRIPTION
Plotting with masks did not work in two cases:
- Non edge coord
- Non-float coord

Also fix a memory issue which was consuming 10s of GByte when plotting binned data with a large dimension. This only happened when the slice viewer requested an "unusual" dimension order. The new solution tries to find the optimal way to avoid this.