### PR TITLE
Fix accumulate for non-idempotent initial values

### DIFF
--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -8,6 +8,7 @@
 #include "scipp/dataset/reduction.h"
 #include "scipp/dataset/shape.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/shape.h"
 
 #include "test_macros.h"
 
@@ -754,8 +755,8 @@ TEST_F(GroupbyMinMaxTest, max_empty_bin) {
 
 TEST(GroupbyLargeTest, sum) {
   const scipp::index large = 114688;
-  auto data = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{large, 100}) +
-              makeVariable<double>(Values{100});
+  auto data = broadcast(makeVariable<double>(Values{1}),
+                        {{Dim::X, Dim::Y}, {large, 10}});
   auto z = makeVariable<int32_t>(Dims{Dim::X}, Shape{large});
   for (scipp::index i = 0; i < large; ++i)
     z.values<int32_t>()[i] = (i / 6000) % 13;

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -751,3 +751,16 @@ TEST_F(GroupbyMinMaxTest, max_empty_bin) {
   expected.setCoord(Dim("labels2"), edges);
   EXPECT_EQ(groupby(d, Dim("labels2"), edges).max(Dim::X), expected);
 }
+
+TEST(GroupbyLargeTest, sum) {
+  const scipp::index large = 114688;
+  auto data = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{large, 100}) +
+              makeVariable<double>(Values{100});
+  auto z = makeVariable<int32_t>(Dims{Dim::X}, Shape{large});
+  for (scipp::index i = 0; i < large; ++i)
+    z.values<int32_t>()[i] = (i / 6000) % 13;
+  DataArray da(data);
+  da.coords().set(Dim::Z, z);
+  auto grouped = groupby(da, Dim::Z).sum(Dim::X);
+  EXPECT_EQ(sum(grouped), sum(da));
+}

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -25,6 +25,14 @@ Simon Heybrock :sup:`a`\ ,
 Neil Vaytet :sup:`a`\ ,
 and Jan-Lukas Wynen :sup:`a`\
 
+v0.8.3 (September 2021)
+-----------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix serious correctness bug in ``groupby.sum`` and ``groupby.mean`` `#2200 <https://github.com/scipp/scipp/pull/2200>`_.
+
 v0.8.0 (September 2021)
 -----------------------
 
@@ -94,6 +102,15 @@ Neil Vaytet :sup:`a`\ ,
 Tom Willemsen :sup:`b, c`\ ,
 and Jan-Lukas Wynen :sup:`a`\
 
+v0.7.2 (September 2021)
+-----------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix serious correctness bug in ``groupby.sum`` and ``groupby.mean`` `#2200 <https://github.com/scipp/scipp/pull/2200>`_.
+
+>>>>>>> f83b3b7ed... 0.7.2 release notes
 v0.7.0 (June 2021)
 ------------------
 

--- a/variable/test/accumulate_test.cpp
+++ b/variable/test/accumulate_test.cpp
@@ -157,3 +157,16 @@ TEST_F(AccumulateTest, 3d_outer_middle) {
   accumulate_in_place<pair_self_t<int64_t>>(result, var, op, name);
   EXPECT_EQ(result, expected);
 }
+
+TEST_F(AccumulateTest, 1d_to_scalar_non_idempotent_init) {
+  for (scipp::index i : {1, 7, 13, 31, 73, 99, 327, 1037, 7341, 8192, 45327}) {
+    const auto var =
+        broadcast(make_variable({{Dim::X}, 24}), {{Dim::X, Dim::Y}, {24, i}});
+    const auto expected = makeVariable<int64_t>(Values{300 * i});
+    auto result = makeVariable<int64_t>(Values{0});
+    accumulate_in_place<pair_self_t<int64_t>>(result, var, op, name);
+    EXPECT_EQ(result, expected) << i;
+    accumulate_in_place<pair_self_t<int64_t>>(result, var, op, name);
+    EXPECT_EQ(result, 2 * units::one * expected) << i;
+  }
+}


### PR DESCRIPTION
This fixes a bug that was introduced when implementing multi-threading for reduction operations (after 0.6, the bug is thus in the 0.7 and 0.8 releases). As far as I can tell this "only" affected `groupby.sum` (and `groupby.mean`, by extension). Normal `sum` and `mean` operations (not using `groupby`) are not affected.

This might have affected users, but unless they were quite unlucky they would have noticed since typically the result is of by a large factor, often by orders of magnitude.

I will make bug fix releases based on this.