### PR TITLE
Update llnl/units and build conan recipe in cmake configure stage

### DIFF
--- a/.conan-recipes/llnl-units/conanfile.py
+++ b/.conan-recipes/llnl-units/conanfile.py
@@ -1,0 +1,80 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+CMAKE_PROJECT_STR = """project(
+    UNITS
+    LANGUAGES CXX
+    VERSION 0.5.0
+)"""
+
+
+class UnitsConan(ConanFile):
+    name = "LLNL-Units"
+    version = "0.5.0"
+    license = "BSD-3"
+    url = "https://github.com/scipp/conan-llnl-units"
+    homepage = "https://units.readthedocs.io"
+    description = ("A run-time C++ library for working with units "
+                   "of measurement and conversions between them "
+                   "and with string representations of units "
+                   "and measurements")
+    topics = ("units", "dimensions", "quantities", "physical-units",
+              "dimensional-analysis", "run-time")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "base_type": ["uint32_t", "uint64_t"],
+               "namespace": "ANY"}
+    default_options = {"shared": False,
+                       "fPIC": True,
+                       "base_type": "uint32_t",
+                       "namespace": None}
+    generators = "cmake"
+
+    def source(self):
+        git = tools.Git("units")
+        git.clone("https://github.com/SimonHeybrock/units.git")
+
+        cmake_project_str = (CMAKE_PROJECT_STR.replace("\n", os.linesep)
+                             if self.settings.os == "Windows" else
+                             CMAKE_PROJECT_STR)
+
+        tools.replace_in_file("units/CMakeLists.txt",
+                              cmake_project_str,
+                              cmake_project_str + """
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()""")
+
+    def build(self):
+        cmake = CMake(self)
+        units_namespace = self.options.get_safe("namespace")
+        cmake.definitions["UNITS_ENABLE_TESTS"] = "OFF"
+        cmake.definitions["UNITS_BASE_TYPE"] = self.options.base_type
+        if units_namespace:
+            cmake.definitions["UNITS_NAMESPACE"] = units_namespace
+        if self.options["shared"]:
+            cmake.definitions["UNITS_BUILD_SHARED_LIBRARY"] = "ON"
+            cmake.definitions["UNITS_BUILD_STATIC_LIBRARY"] = "OFF"
+        # The library uses C++14, but we want to set the namespace
+        # to llnl::units which requires C++17.
+        cmake.definitions["CMAKE_CXX_STANDARD"] = "17"
+        cmake.configure(source_folder="units")
+        cmake.build(target="units")
+
+    def package(self):
+        self.copy("*.hpp", dst="include/units", src="units/units")
+        self.copy("*units.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["units"]
+        units_namespace = self.options.get_safe("namespace")
+        self.cpp_info.defines = [
+            f"UNITS_BASE_TYPE={self.options.base_type}"
+        ]
+        if units_namespace:
+            self.cpp_info.defines.append(f"UNITS_NAMESPACE={units_namespace}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,12 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
+execute_process(
+  COMMAND conan create . scipp/stable
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/.conan-recipes/llnl-units"
+                    COMMAND_ECHO STDOUT
+)
+
 # Conan dependencies
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
   message(
@@ -82,9 +88,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 
 conan_cmake_autodetect(conan_settings)
-conan_add_remote(
-  NAME scipp URL https://artifactoryconan.esss.dk/artifactory/api/conan/scipp
-)
 conan_cmake_install(
   PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR} SETTINGS ${conan_settings} BUILD
   outdated

--- a/units/unit.cpp
+++ b/units/unit.cpp
@@ -29,7 +29,8 @@ std::string map_unit_string(const std::string &unit) {
 } // namespace
 
 Unit::Unit(const std::string &unit)
-    : Unit(llnl::units::unit_from_string(map_unit_string(unit))) {
+    : Unit(llnl::units::unit_from_string(map_unit_string(unit),
+                                         llnl::units::strict_si)) {
   if (!is_valid(m_unit))
     throw except::UnitError("Failed to convert string `" + unit +
                             "` to valid unit.");


### PR DESCRIPTION
Updating llnl/units for a number of recent improvements and fixes.

To facility updating and simplify process, I include the recipe from https://github.com/scipp/conan-llnl-units directly and `conan create` it in the cmake configure stage. This seems to work, but are there downsides? This rebuilds the recipe when cmake is called but it appears to detect if it is not changed?