### PR TITLE
Require numpy>=1.20 and scipy>=1.7

### DIFF
--- a/scipp-developer-minimal.yml
+++ b/scipp-developer-minimal.yml
@@ -21,7 +21,7 @@ dependencies:
   - ipympl
   - ipywidgets
   - matplotlib-base
-  - numpy >=1.15.3
+  - numpy>=1.20.0
   - python
   - python-configuration
   - pythreejs
@@ -34,4 +34,4 @@ dependencies:
   - python-graphviz
   - xarray  # For testing xarray <-> scipp conversion
   - pandas  # For testing pandas <-> scipp conversion
-  - scipy
+  - scipy>=1.7.0

--- a/scipp-developer.yml
+++ b/scipp-developer.yml
@@ -22,7 +22,7 @@ dependencies:
   - ipympl
   - ipywidgets
   - matplotlib-base
-  - numpy >=1.15.3
+  - numpy>=1.20.0
   - python
   - python-configuration
   - pythreejs
@@ -35,7 +35,7 @@ dependencies:
   - python-graphviz
   - xarray  # For testing xarray <-> scipp conversion
   - pandas  # For testing pandas <-> scipp conversion
-  - scipy
+  - scipy>=1.7.0
 
   # Formatting & static analysis
   - pre-commit


### PR DESCRIPTION
- `numpy>=1.20` is required by https://github.com/scipp/scipp/blob/main/python/src/scipp/core/variable.py#L11
- `scipy>=1.7` is required by https://github.com/scipp/scipp/blob/main/python/src/scipp/spatial/transform.py#L21