### PR TITLE
Connect mouse hover events only when profile is being shown

### DIFF
--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -291,6 +291,7 @@ class PlotController:
 
         self.profile.toggle_view(visible=visible)
         self.profile.toggle_hover_visibility(False)
+        self.view.toggle_profile_connection(visible=visible)
 
     def hover(self, slices):
         if self.profile is not None and self.profile.is_visible():

--- a/python/src/scipp/plotting/controller.py
+++ b/python/src/scipp/plotting/controller.py
@@ -291,7 +291,7 @@ class PlotController:
 
         self.profile.toggle_view(visible=visible)
         self.profile.toggle_hover_visibility(False)
-        self.view.toggle_profile_connection(visible=visible)
+        self.view.toggle_mouse_events(active=visible)
 
     def hover(self, slices):
         if self.profile is not None and self.profile.is_visible():

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -155,8 +155,8 @@ class PlotFigure:
         if self.toolbar is not None:
             self.toolbar.connect(controller=controller)
 
-    def toggle_profile_connection(self, visible, event_handler):
-        if visible:
+    def toggle_mouse_events(self, active, event_handler):
+        if active:
             self.event_connections['button_press_event'] = self.fig.canvas.mpl_connect(
                 'button_press_event', event_handler.handle_button_press)
             self.event_connections['pick_event'] = self.fig.canvas.mpl_connect(

--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -55,6 +55,7 @@ class PlotFigure:
         self.xlabel = xlabel
         self.ylabel = ylabel
         self.draw_no_delay = False
+        self.event_connections = {}
 
     def initialize_toolbar(self, **kwargs):
         if self.toolbar is not None:
@@ -145,7 +146,7 @@ class PlotFigure:
                 ticker.LogLocator()
             }
 
-    def connect(self, controller, event_handler):
+    def connect(self, controller):
         """
         Connect the toolbar to callback from the controller. This includes
         rescaling the data norm, and change the scale (log or linear) on the
@@ -153,11 +154,19 @@ class PlotFigure:
         """
         if self.toolbar is not None:
             self.toolbar.connect(controller=controller)
-        self.fig.canvas.mpl_connect('button_press_event',
-                                    event_handler.handle_button_press)
-        self.fig.canvas.mpl_connect('pick_event', event_handler.handle_pick)
-        self.fig.canvas.mpl_connect('motion_notify_event',
-                                    event_handler.handle_motion_notify)
+
+    def toggle_profile_connection(self, visible, event_handler):
+        if visible:
+            self.event_connections['button_press_event'] = self.fig.canvas.mpl_connect(
+                'button_press_event', event_handler.handle_button_press)
+            self.event_connections['pick_event'] = self.fig.canvas.mpl_connect(
+                'pick_event', event_handler.handle_pick)
+            self.event_connections['motion_notify_event'] = self.fig.canvas.mpl_connect(
+                'motion_notify_event', event_handler.handle_motion_notify)
+        else:
+            for cid in self.event_connections.values():
+                self.fig.canvas.mpl_disconnect(cid)
+            self.event_connections.clear()
 
     def draw(self):
         """

--- a/python/src/scipp/plotting/figure3d.py
+++ b/python/src/scipp/plotting/figure3d.py
@@ -116,7 +116,7 @@ class PlotFigure3d:
         """
         return
 
-    def connect(self, controller, event_handler):
+    def connect(self, controller):
         """
         Connect the toolbar Home button to reset the camera position.
         """

--- a/python/src/scipp/plotting/view.py
+++ b/python/src/scipp/plotting/view.py
@@ -94,7 +94,7 @@ class PlotView:
         `controller`.
         """
         self.controller = controller
-        self.figure.connect(controller=controller, event_handler=self)
+        self.figure.connect(controller=controller)
 
     def _slices_from_event(self, event):
         slices = {}
@@ -107,6 +107,9 @@ class PlotView:
                     return {}
                 slices[dim] = params
         return slices
+
+    def toggle_profile_connection(self, visible):
+        self.figure.toggle_profile_connection(visible=visible, event_handler=self)
 
     def handle_motion_notify(self, event):
         self.controller.hover(self._slices_from_event(event))

--- a/python/src/scipp/plotting/view.py
+++ b/python/src/scipp/plotting/view.py
@@ -108,8 +108,8 @@ class PlotView:
                 slices[dim] = params
         return slices
 
-    def toggle_profile_connection(self, visible):
-        self.figure.toggle_profile_connection(visible=visible, event_handler=self)
+    def toggle_mouse_events(self, active):
+        self.figure.toggle_mouse_events(active=active, event_handler=self)
 
     def handle_motion_notify(self, event):
         self.controller.hover(self._slices_from_event(event))


### PR DESCRIPTION
This is to help with performance, as the mouse hover events were triggering slice computations when not needed
The slow down became evident when trying to draw a zoom box on JupyterHub