### PR TITLE
Use pipelines tags to avoid breaking ability for patch releases

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -14,7 +14,7 @@ resources:
     name: scipp/pipelines
     type: github
     endpoint: scipp
-    ref: main
+    ref: refs/tags/1.0.0
 
 trigger:
   - main

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -14,7 +14,7 @@ resources:
     name: scipp/pipelines
     type: github
     endpoint: scipp
-    ref: main
+    ref: refs/tags/1.0.0
 
 trigger:
   branches:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -14,7 +14,7 @@ resources:
     name: scipp/pipelines
     type: github
     endpoint: scipp
-    ref: main
+    ref: refs/tags/1.0.0
 
 trigger:
   tags:


### PR DESCRIPTION
Over the past half year or so I multiple times ran into problems when attempting to make a patch release, since `pipelines/main` had moved on, so patch builds failed. We fix this as follows:

- Tag releases in the pipelines repo.
- Do not refer to `pipelines/main` from our Azure config, but rather `pipelines/tag`.
- Also fixes the chicken-egg problem of merging changes into `pipelines` that require updates in downstream repos such as scipp.