### PR TITLE
Fix gcc11 and some clang-tidy warnings

### DIFF
--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -19,7 +19,7 @@ namespace scipp::core {
 /// dimension is inner dimension.
 class SCIPP_CORE_EXPORT Dimensions : public Sizes {
 public:
-  constexpr Dimensions() noexcept {}
+  constexpr Dimensions() noexcept = default;
   Dimensions(const Dim dim, const scipp::index size)
       : Dimensions({{dim, size}}) {}
   Dimensions(const std::vector<Dim> &labels,

--- a/core/include/scipp/core/dimensions.h
+++ b/core/include/scipp/core/dimensions.h
@@ -45,12 +45,13 @@ public:
   }
 
   /// Return the shape of the space defined by *this.
-  constexpr scipp::span<const scipp::index> shape() const &noexcept {
+  [[nodiscard]] constexpr scipp::span<const scipp::index>
+  shape() const &noexcept {
     return sizes();
   }
 
   /// Return the volume of the space defined by *this.
-  constexpr scipp::index volume() const noexcept {
+  [[nodiscard]] constexpr scipp::index volume() const noexcept {
     scipp::index volume{1};
     for (const auto &length : shape())
       volume *= length;
@@ -58,13 +59,15 @@ public:
   }
 
   /// Return number of dims
-  constexpr scipp::index ndim() const noexcept { return Sizes::size(); }
+  [[nodiscard]] constexpr scipp::index ndim() const noexcept {
+    return Sizes::size();
+  }
 
-  Dim inner() const noexcept;
+  [[nodiscard]] Dim inner() const noexcept;
 
-  Dim label(const scipp::index i) const;
-  scipp::index size(const scipp::index i) const;
-  scipp::index offset(const Dim label) const;
+  [[nodiscard]] Dim label(const scipp::index i) const;
+  [[nodiscard]] scipp::index size(const scipp::index i) const;
+  [[nodiscard]] scipp::index offset(const Dim label) const;
 
   // TODO Better names required.
   void add(const Dim label, const scipp::index size);

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -72,7 +72,7 @@ protected:
   using base::insert_right;
 
 public:
-  Sizes() = default;
+  constexpr Sizes() noexcept = default;
 
   void set(const Dim dim, const scipp::index size);
   void resize(const Dim dim, const scipp::index size);

--- a/core/include/scipp/core/sizes.h
+++ b/core/include/scipp/core/sizes.h
@@ -27,27 +27,30 @@ public:
   bool operator==(const small_stable_map &other) const noexcept;
   bool operator!=(const small_stable_map &other) const noexcept;
 
-  auto begin() const noexcept { return m_keys.begin(); }
-  auto end() const noexcept { return m_keys.begin() + size(); }
-  auto rbegin() const noexcept { return m_keys.rbegin() - size() + NDIM_MAX; }
-  auto rend() const noexcept { return m_keys.rend(); }
-  typename std::array<Key, Capacity>::const_iterator find(const Key &key) const;
+  [[nodiscard]] auto begin() const noexcept { return m_keys.begin(); }
+  [[nodiscard]] auto end() const noexcept { return m_keys.begin() + size(); }
+  [[nodiscard]] auto rbegin() const noexcept {
+    return m_keys.rbegin() - size() + NDIM_MAX;
+  }
+  [[nodiscard]] auto rend() const noexcept { return m_keys.rend(); }
+  [[nodiscard]] typename std::array<Key, Capacity>::const_iterator
+  find(const Key &key) const;
   [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
-  constexpr scipp::index size() const noexcept { return m_size; }
-  bool contains(const Key &key) const;
-  scipp::index index(const Key &key) const;
-  const Value &operator[](const Key &key) const;
-  const Value &at(const Key &key) const;
+  [[nodiscard]] constexpr scipp::index size() const noexcept { return m_size; }
+  [[nodiscard]] bool contains(const Key &key) const;
+  [[nodiscard]] scipp::index index(const Key &key) const;
+  [[nodiscard]] const Value &operator[](const Key &key) const;
+  [[nodiscard]] const Value &at(const Key &key) const;
   void assign(const Key &key, const Value &value);
   void insert_left(const Key &key, const Value &value);
   void insert_right(const Key &key, const Value &value);
   void erase(const Key &key);
   void clear() noexcept;
   void replace_key(const Key &from, const Key &to);
-  constexpr scipp::span<const Key> keys() const &noexcept {
+  [[nodiscard]] constexpr scipp::span<const Key> keys() const &noexcept {
     return {m_keys.data(), static_cast<size_t>(size())};
   }
-  constexpr scipp::span<const Value> values() const &noexcept {
+  [[nodiscard]] constexpr scipp::span<const Value> values() const &noexcept {
     return {m_values.data(), static_cast<size_t>(size())};
   }
 
@@ -73,13 +76,13 @@ public:
 
   void set(const Dim dim, const scipp::index size);
   void resize(const Dim dim, const scipp::index size);
-  bool includes(const Sizes &sizes) const;
-  Sizes slice(const Slice &params) const;
+  [[nodiscard]] bool includes(const Sizes &sizes) const;
+  [[nodiscard]] Sizes slice(const Slice &params) const;
 
   /// Return the labels of the space defined by *this.
-  constexpr auto labels() const &noexcept { return keys(); }
+  [[nodiscard]] constexpr auto labels() const &noexcept { return keys(); }
   /// Return the shape of the space defined by *this.
-  constexpr auto sizes() const &noexcept { return values(); }
+  [[nodiscard]] constexpr auto sizes() const &noexcept { return values(); }
 };
 
 [[nodiscard]] SCIPP_CORE_EXPORT Sizes concatenate(const Sizes &a,

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -18,9 +18,6 @@
 namespace scipp::dataset {
 
 namespace detail {
-using slice_list =
-    boost::container::small_vector<std::pair<Slice, scipp::index>, 2>;
-
 struct make_key_value {
   template <class T> auto operator()(T &&view) const {
     using View =

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -181,7 +181,4 @@ template <class Masks>
 SCIPP_DATASET_EXPORT Variable masks_merge_if_contained(const Masks &masks,
                                                        const Dimensions &dims);
 
-[[nodiscard]] SCIPP_DATASET_EXPORT Coords copy(const Coords &coords);
-[[nodiscard]] SCIPP_DATASET_EXPORT Masks copy(const Masks &masks);
-
 } // namespace scipp::dataset

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -77,7 +77,7 @@ public:
   Dict &operator=(Dict &&other) noexcept;
 
   /// Return the number of coordinates in the view.
-  index size() const noexcept { return scipp::size(m_items); }
+  [[nodiscard]] index size() const noexcept { return scipp::size(m_items); }
   /// Return true if there are 0 coordinates in the view.
   [[nodiscard]] bool empty() const noexcept { return size() == 0; }
 
@@ -134,8 +134,8 @@ public:
   bool operator==(const Dict &other) const;
   bool operator!=(const Dict &other) const;
 
-  const Sizes &sizes() const noexcept { return m_sizes; }
-  const auto &items() const noexcept { return m_items; }
+  [[nodiscard]] const Sizes &sizes() const noexcept { return m_sizes; }
+  [[nodiscard]] const auto &items() const noexcept { return m_items; }
 
   void setSizes(const Sizes &sizes);
   void rebuildSizes();
@@ -152,7 +152,7 @@ public:
   void rename(const Dim from, const Dim to);
 
   void set_readonly() noexcept;
-  bool is_readonly() const noexcept;
+  [[nodiscard]] bool is_readonly() const noexcept;
   [[nodiscard]] Dict as_const() const;
   [[nodiscard]] Dict merge_from(const Dict &other) const;
 

--- a/dataset/include/scipp/dataset/map_view.h
+++ b/dataset/include/scipp/dataset/map_view.h
@@ -75,9 +75,9 @@ public:
        const bool readonly = false);
   Dict(const Sizes &sizes, holder_type items, const bool readonly = false);
   Dict(const Dict &other);
-  Dict(Dict &&other);
+  Dict(Dict &&other) noexcept;
   Dict &operator=(const Dict &other);
-  Dict &operator=(Dict &&other);
+  Dict &operator=(Dict &&other) noexcept;
 
   /// Return the number of coordinates in the view.
   index size() const noexcept { return scipp::size(m_items); }

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -26,10 +26,9 @@ Dict<Key, Value>::Dict(const Sizes &sizes,
 template <class Key, class Value>
 Dict<Key, Value>::Dict(const Sizes &sizes, holder_type items,
                        const bool readonly)
-    : m_sizes(sizes) {
+    : m_sizes(sizes), m_readonly(readonly) {
   for (auto &&[key, value] : items)
     set(key, std::move(value));
-  m_readonly = readonly;
 }
 
 template <class Key, class Value>

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -51,10 +51,10 @@ template <class Key, class Value>
 bool Dict<Key, Value>::operator==(const Dict &other) const {
   if (size() != other.size())
     return false;
-  for (const auto [name, data] : *this)
-    if (!other.contains(name) || data != other[name])
-      return false;
-  return true;
+  return std::all_of(this->begin(), this->end(), [&other](const auto &item) {
+    const auto &[name, data] = item;
+    return other.contains(name) && data == other[name];
+  });
 }
 
 template <class Key, class Value>

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -26,9 +26,11 @@ Dict<Key, Value>::Dict(const Sizes &sizes,
 template <class Key, class Value>
 Dict<Key, Value>::Dict(const Sizes &sizes, holder_type items,
                        const bool readonly)
-    : m_sizes(sizes), m_readonly(readonly) {
+    : m_sizes(sizes) {
   for (auto &&[key, value] : items)
     set(key, std::move(value));
+  // `set` requires Dict to be writable, set readonly flag at the end.
+  m_readonly = readonly; // NOLINT(cppcoreguidelines-prefer-member-initializer)
 }
 
 template <class Key, class Value>

--- a/dataset/map_view.cpp
+++ b/dataset/map_view.cpp
@@ -37,7 +37,7 @@ Dict<Key, Value>::Dict(const Dict &other)
     : Dict(other.m_sizes, other.m_items, false) {}
 
 template <class Key, class Value>
-Dict<Key, Value>::Dict(Dict &&other)
+Dict<Key, Value>::Dict(Dict &&other) noexcept
     : Dict(std::move(other.m_sizes), std::move(other.m_items),
            other.m_readonly) {}
 
@@ -45,7 +45,7 @@ template <class Key, class Value>
 Dict<Key, Value> &Dict<Key, Value>::operator=(const Dict &other) = default;
 
 template <class Key, class Value>
-Dict<Key, Value> &Dict<Key, Value>::operator=(Dict &&other) = default;
+Dict<Key, Value> &Dict<Key, Value>::operator=(Dict &&other) noexcept = default;
 
 template <class Key, class Value>
 bool Dict<Key, Value>::operator==(const Dict &other) const {


### PR DESCRIPTION
Fixes a longer standing gcc11 warning about copying iteration variables. While I was at it, I fixed or silenced a number of clang-tidy warnings in related files.