### PR TITLE
Remove const from return value of variable::ndim

### DIFF
--- a/variable/include/scipp/variable/variable.h
+++ b/variable/include/scipp/variable/variable.h
@@ -70,7 +70,7 @@ public:
   void expectCanSetUnit(const units::Unit &) const;
 
   [[nodiscard]] const Dimensions &dims() const;
-  [[nodiscard]] const scipp::index ndim() const;
+  [[nodiscard]] scipp::index ndim() const;
 
   [[nodiscard]] DType dtype() const;
 

--- a/variable/variable.cpp
+++ b/variable/variable.cpp
@@ -73,7 +73,7 @@ const Dimensions &Variable::dims() const {
   return m_dims;
 }
 
-const scipp::index Variable::ndim() const {
+scipp::index Variable::ndim() const {
   if (!is_valid())
     throw std::runtime_error("invalid variable");
   return m_dims.ndim();


### PR DESCRIPTION
`const` is obsolete here and causes many compiler warnings.