### PR TITLE
Consider coords and attrs in groupby instead of just coords

### DIFF
--- a/dataset/groupby.cpp
+++ b/dataset/groupby.cpp
@@ -328,7 +328,7 @@ GroupBy<T> call_groupby(const T &array, const Variable &key, const Dim &dim) {
 /// Grouping will create a new coordinate for the dimension of the grouping
 /// coord in a later apply/combine step.
 GroupBy<DataArray> groupby(const DataArray &array, const Dim dim) {
-  const auto &key = array.coords()[dim];
+  const auto &key = array.meta()[dim];
   return call_groupby(array, key, dim);
 }
 
@@ -339,7 +339,7 @@ GroupBy<DataArray> groupby(const DataArray &array, const Dim dim) {
 /// new coordinate to the output in a later apply/combine step.
 GroupBy<DataArray> groupby(const DataArray &array, const Dim dim,
                            const Variable &bins) {
-  const auto &key = array.coords()[dim];
+  const auto &key = array.meta()[dim];
   return groupby(array, key, bins);
 }
 
@@ -362,7 +362,7 @@ GroupBy<DataArray> groupby(const DataArray &array, const Variable &key,
 /// Grouping will create a new coordinate for the dimension of the grouping
 /// coord in a later apply/combine step.
 GroupBy<Dataset> groupby(const Dataset &dataset, const Dim dim) {
-  const auto &key = dataset.coords()[dim];
+  const auto &key = dataset.meta()[dim];
   return call_groupby(dataset, key, dim);
 }
 
@@ -373,7 +373,7 @@ GroupBy<Dataset> groupby(const Dataset &dataset, const Dim dim) {
 /// new coordinate to the output in a later apply/combine step.
 GroupBy<Dataset> groupby(const Dataset &dataset, const Dim dim,
                          const Variable &bins) {
-  const auto &key = dataset.coords()[dim];
+  const auto &key = dataset.meta()[dim];
   return groupby(dataset, key, bins);
 }
 
@@ -400,7 +400,7 @@ template class GroupBy<Dataset>;
 constexpr auto slice_by_value = [](const auto &x, const Dim dim,
                                    const auto &key) {
   const auto size = x.dims()[dim];
-  const auto &coord = x.coords()[dim];
+  const auto &coord = x.meta()[dim];
   for (scipp::index i = 0; i < size; ++i)
     if (coord.slice({dim, i}) == key)
       return x.slice({dim, i});

--- a/dataset/test/groupby_test.cpp
+++ b/dataset/test/groupby_test.cpp
@@ -184,6 +184,15 @@ TEST_F(GroupbyTest, array_variable) {
   EXPECT_THROW(groupby(arr, var_bad, bins), except::DimensionError);
 }
 
+TEST_F(GroupbyTest, by_attr) {
+  auto da = copy(d["a"]);
+  const auto key = Dim("labels1");
+  const auto grouped_coord = groupby(da, key).sum(Dim::X);
+  da.attrs().set(key, da.coords().extract(key));
+  const auto grouped_attr = groupby(da, key).sum(Dim::X);
+  EXPECT_EQ(grouped_coord, grouped_attr);
+}
+
 struct GroupbyMaskedTest : public GroupbyTest {
   GroupbyMaskedTest() : GroupbyTest() {
     for (const auto &item : {"a", "b", "c"})

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -10,6 +10,7 @@ Features
 ~~~~~~~~
 
 * Add ``erf`` and ``erfc`` functions `#2195 <https://github.com/scipp/scipp/pull/2195>`_.
+* ``groupby`` now also supports grouping by attributes instead of just by coordinates `#2227 <https://github.com/scipp/scipp/pull/2227>`_.
 * Reduction operations such as ``sum``, ``nansum``, and ``cumsum`` of single precision (float32) data now use double precision (float64) internally to reduce rounding errors `#2218 <https://github.com/scipp/scipp/pull/2218>`_.
 
 Breaking changes


### PR DESCRIPTION
This is something `scippneutron` ran into after switching to use `transform_coords`. There is no harm considering aligned as well as unaligned coords (attrs).