### PR TITLE
Use matplotlib Agg backend in python tests

### DIFF
--- a/python/tests/plotting/plot_0d_test.py
+++ b/python/tests/plotting/plot_0d_test.py
@@ -6,6 +6,8 @@
 import scipp as sc
 import pytest
 from .plot_helper import plot
+import matplotlib
+matplotlib.use('Agg')
 
 
 def test_plot_0d_variable():

--- a/python/tests/plotting/plot_1d_test.py
+++ b/python/tests/plotting/plot_1d_test.py
@@ -7,6 +7,8 @@ import numpy as np
 import scipp as sc
 from ..factory import make_dense_data_array, make_dense_dataset
 from .plot_helper import plot
+import matplotlib
+matplotlib.use('Agg')
 
 # TODO: For now we are just checking that the plot does not throw any errors.
 # In the future it would be nice to check the output by either comparing

--- a/python/tests/plotting/plot_2d_test.py
+++ b/python/tests/plotting/plot_2d_test.py
@@ -10,6 +10,8 @@ import scipp as sc
 from ..factory import make_dense_data_array, make_dense_dataset, \
                       make_binned_data_array
 from .plot_helper import plot
+import matplotlib
+matplotlib.use('Agg')
 
 
 def test_plot_2d():

--- a/python/tests/plotting/plot_3d_test.py
+++ b/python/tests/plotting/plot_3d_test.py
@@ -7,6 +7,8 @@ import numpy as np
 import scipp as sc
 from ..factory import make_dense_data_array, make_binned_data_array
 from .plot_helper import plot
+import matplotlib
+matplotlib.use('Agg')
 
 
 def _with_fake_pos(*args, **kwargs):

--- a/python/tests/plotting/plot_methods_test.py
+++ b/python/tests/plotting/plot_methods_test.py
@@ -5,6 +5,8 @@
 
 import numpy as np
 import scipp as sc
+import matplotlib
+matplotlib.use('Agg')
 
 
 def test_plot_variable():

--- a/python/tests/plotting/plot_nd_test.py
+++ b/python/tests/plotting/plot_nd_test.py
@@ -8,6 +8,8 @@ import pytest
 import scipp as sc
 from ..factory import make_dense_data_array, make_dense_dataset
 from .plot_helper import plot
+import matplotlib
+matplotlib.use('Agg')
 
 # TODO: For now we are just checking that the plot does not throw any errors.
 # In the future it would be nice to check the output by either comparing


### PR DESCRIPTION
This is an attempt to fix the intermittent TK related errors on Windows build.
The `Agg` backend doesn't support showing figures in graphical windows.

I hoped that this would also speed up the tests, but the results are not convincing on my local machine.