### PR TITLE
Fix figure size/resolution in docs

### DIFF
--- a/python/src/scipp/plotting/figure.py
+++ b/python/src/scipp/plotting/figure.py
@@ -102,9 +102,11 @@ class PlotFigure:
         """
         Convert the Matplotlib figure to a static image.
         """
+        width, height = self.fig.get_size_inches()
+        dpi = self.fig.get_dpi()
         return ipw.Image(value=fig_to_pngbytes(self.fig),
-                         width=config.plot.width,
-                         height=config.plot.height)
+                         width=width * dpi,
+                         height=height * dpi)
 
     def close(self):
         """

--- a/python/src/scipp/plotting/tools.py
+++ b/python/src/scipp/plotting/tools.py
@@ -192,7 +192,7 @@ def fig_to_pngbytes(fig):
     """
     import matplotlib.pyplot as plt
     buf = io.BytesIO()
-    fig.savefig(buf, format='png', bbox_inches='tight')
+    fig.savefig(buf, format='png')
     plt.close(fig)
     buf.seek(0)
     return buf.getvalue()

--- a/python/src/scipp/runtime_config.py
+++ b/python/src/scipp/runtime_config.py
@@ -38,10 +38,10 @@ defaults = {
         },
         # The default image height (in pixels)
         "height":
-        467,
+        400,
         # The default image width (in pixels)
         "width":
-        700,
+        600,
         # Resolution
         "dpi":
         96,


### PR DESCRIPTION
By getting the actual width of the figure when saving to a static image, instead of assuming the size is the default in the config.

Before:
![Screenshot at 2021-10-18 13-05-31](https://user-images.githubusercontent.com/39047984/137719743-a103ec52-b5d1-4185-aafa-178b6c496f51.png)

After:
![Screenshot at 2021-10-18 13-07-27](https://user-images.githubusercontent.com/39047984/137719749-ba1dc505-a0b1-469d-a3f9-98fb6034d082.png)
