### PR TITLE
Perform shallow copy instead of assignment in shallow_copy bench

### DIFF
--- a/benchmarks/variable.py
+++ b/benchmarks/variable.py
@@ -10,7 +10,7 @@ class Variable:
         self.var2 = sc.array(dims=['x'], values=[1, 2, 3, 4, 5])
 
     def time_shallow_copy(self):
-        self.var1 = self.var2
+        self.var1.copy(deep=False)
 
     def time_deep_copy(self):
         self.var1.copy()


### PR DESCRIPTION
I was informed by Jan-Lukas that the benchmark wasn't properly benchmarking a shallow copy, hence this change, after this PR is merged I will remove previous shallow copy results.