### PR TITLE
Optimize and fix mapping operations using `sc.lookup()`.

### DIFF
--- a/docs/reference/free-functions.rst
+++ b/docs/reference/free-functions.rst
@@ -18,6 +18,7 @@ General
    logical_and
    logical_or
    logical_xor
+   lookup
    merge
    rebin
    slices

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -297,6 +297,9 @@ Variable map(const DataArray &function, const Variable &x, Dim dim) {
   if (dim == Dim::Invalid)
     dim = edge_dimension(function);
   const auto &edges = function.meta()[dim];
+  if (!is_edges(function.dims(), edges.dims(), dim))
+    throw except::BinEdgeError(
+        "Function used as lookup table in map operation must be a histogram");
   const auto data = masked_data(function, dim);
   const auto weights = subspan_view(data, dim);
   if (all(islinspace(edges, dim)).value<bool>()) {

--- a/lib/dataset/test/bins_test.cpp
+++ b/lib/dataset/test/bins_test.cpp
@@ -234,6 +234,13 @@ TEST_F(DataArrayBinsMapTest, map) {
   EXPECT_EQ(partial, expected);
 }
 
+TEST_F(DataArrayBinsMapTest, fail_no_bin_edges) {
+  const auto &coord = bins_view<DataArray>(buckets).meta()[Dim::Z];
+  histogram.coords().set(Dim::Z, bin_edges.slice({Dim::Z, 1, 4}));
+  EXPECT_THROW_DISCARD(buckets::map(histogram, coord, Dim::Z),
+                       except::BinEdgeError);
+}
+
 TEST_F(DataArrayBinsMapTest, map_masked) {
   const auto &coord = bins_view<DataArray>(buckets).meta()[Dim::Z];
   histogram.masks().set(

--- a/lib/variable/rebin.cpp
+++ b/lib/variable/rebin.cpp
@@ -17,10 +17,6 @@ using namespace scipp::core::element;
 
 namespace scipp::variable {
 
-bool isBinEdge(const Dim dim, Dimensions edges, const Dimensions &toMatch) {
-  return edges[dim] - 1 == toMatch[dim];
-}
-
 // Workaround VS C7526 (undefined inline variable) with dtype<> in template.
 bool is_dtype_bool(const Variable &var) { return var.dtype() == dtype<bool>; }
 
@@ -122,7 +118,7 @@ Variable rebin(const Variable &var, const Dim dim, const Variable &oldCoord,
   // always be computed on-the-fly for visualization, if required.
   if (var.dtype() == dtype<bool>)
     core::expect::equals(var.unit(), units::one);
-  if (!isBinEdge(dim, oldCoord.dims(), var.dims()))
+  if (!is_edges(var.dims(), oldCoord.dims(), dim))
     throw except::BinEdgeError(
         "The input does not have coordinates with bin-edges.");
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -14,7 +14,7 @@ from .operations import islinspace
 class Lookup:
     def __init__(self, func: _cpp.DataArray, dim: str):
         if func.ndim == 1 and func.dtype in [
-                _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64, _cpp.dtype.string
+                _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64
         ] and not islinspace(func.coords[dim], dim).value:
             # Significant speedup if `func` is large but mostly constant.
             func = merge_equal_adjacent(func)

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -11,7 +11,7 @@ from .domains import merge_equal_adjacent
 from .operations import islinspace
 
 
-class lookup:
+class Lookup:
     def __init__(self, func: _cpp.DataArray, dim: str):
         if func.ndim == 1 and func.dtype in [
                 _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64, _cpp.dtype.string
@@ -23,6 +23,27 @@ class lookup:
 
     def __getitem__(self, var):
         return _cpp.buckets.map(self.func, var, self.dim)
+
+
+def lookup(func: _cpp.DataArray, dim: str):
+    """
+    Create a "lookup table" from a histogram (data array with bin-edge coord).
+
+    The lookup table can be used to map, e.g., time-stamps to corresponding values
+    given by a time-series log.
+
+    :param func: Histogram defining the lookup table.
+    :param dim: Dimension along which the lookup occurs.
+
+    Examples:
+
+      >>> x = sc.linspace(dim='x', start=0.0, stop=1.0, num=4)
+      >>> vals = sc.array(dims=['x'], values=[3, 2, 1])
+      >>> hist = sc.DataArray(data=vals, coords={'x': x})
+      >>> sc.lookup(hist, 'x')[sc.array(dims=['event'], values=[0.1,0.4,0.1,0.6,0.9])]
+      <scipp.Variable> (event: 5)      int64  [dimensionless]  [3, 2, ..., 2, 1]
+    """
+    return Lookup(func, dim)
 
 
 class Bins:
@@ -138,10 +159,10 @@ class Bins:
         raise RuntimeError("Reduction along all dims not supported yet.")
 
     def concatenate(
-            self,
-            other: Union[_cpp.Variable, _cpp.DataArray],
-            *,
-            out: Optional[_cpp.DataArray] = None
+        self,
+        other: Union[_cpp.Variable, _cpp.DataArray],
+        *,
+        out: Optional[_cpp.DataArray] = None
     ) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Concatenate bins element-wise by concatenating bin contents along
         their internal bin dimension.

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -137,10 +137,10 @@ class Bins:
         raise RuntimeError("Reduction along all dims not supported yet.")
 
     def concatenate(
-        self,
-        other: Union[_cpp.Variable, _cpp.DataArray],
-        *,
-        out: Optional[_cpp.DataArray] = None
+            self,
+            other: Union[_cpp.Variable, _cpp.DataArray],
+            *,
+            out: Optional[_cpp.DataArray] = None
     ) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Concatenate bins element-wise by concatenating bin contents along
         their internal bin dimension.

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -7,7 +7,7 @@ import warnings
 from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLike, MetaDataMap
-from .domains import find_domains
+from .domains import merge_equal_adjacent
 from .operations import islinspace
 
 
@@ -16,7 +16,8 @@ class lookup:
         if func.ndim == 1 and func.dtype in [
                 _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64, _cpp.dtype.string
         ] and not islinspace(func.coords[dim], dim).value:
-            func = find_domains(func)
+            # Significant speedup if `func` is large but mostly constant.
+            func = merge_equal_adjacent(func)
         self.func = func
         self.dim = dim
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -7,10 +7,15 @@ import warnings
 from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLike, MetaDataMap
+from .domains import find_domains
 
 
 class lookup:
     def __init__(self, func: _cpp.DataArray, dim: str):
+        if func.ndim == 1 and func.dtype in [
+                _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64, _cpp.dtype.string
+        ]:
+            func = find_domains(func)
         self.func = func
         self.dim = dim
 
@@ -131,10 +136,10 @@ class Bins:
         raise RuntimeError("Reduction along all dims not supported yet.")
 
     def concatenate(
-            self,
-            other: Union[_cpp.Variable, _cpp.DataArray],
-            *,
-            out: Optional[_cpp.DataArray] = None
+        self,
+        other: Union[_cpp.Variable, _cpp.DataArray],
+        *,
+        out: Optional[_cpp.DataArray] = None
     ) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Concatenate bins element-wise by concatenating bin contents along
         their internal bin dimension.

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -8,13 +8,14 @@ from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLike, MetaDataMap
 from .domains import find_domains
+from .operations import islinspace
 
 
 class lookup:
     def __init__(self, func: _cpp.DataArray, dim: str):
         if func.ndim == 1 and func.dtype in [
                 _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64, _cpp.dtype.string
-        ]:
+        ] and not islinspace(func.coords[dim], dim).value:
             func = find_domains(func)
         self.func = func
         self.dim = dim

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -159,10 +159,10 @@ class Bins:
         raise RuntimeError("Reduction along all dims not supported yet.")
 
     def concatenate(
-        self,
-        other: Union[_cpp.Variable, _cpp.DataArray],
-        *,
-        out: Optional[_cpp.DataArray] = None
+            self,
+            other: Union[_cpp.Variable, _cpp.DataArray],
+            *,
+            out: Optional[_cpp.DataArray] = None
     ) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Concatenate bins element-wise by concatenating bin contents along
         their internal bin dimension.

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -17,7 +17,7 @@ def find_domains(da: DataArray) -> DataArray:
     """
     dim = da.dim
     condition = da.data != da.data
-    condition['x', :-1] = da.data['x', 1:] == da.data['x', :-1]
+    condition[dim, :-1] = da.data[dim, 1:] == da.data[dim, :-1]
     condition
     group = f'{dim}_'
     tmp = DataArray(da.data, coords={dim: da.coords[dim][dim, 1:], group: condition})

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from __future__ import annotations
+from typing import Optional
+
+from . import DataArray, concat
+
+
+def find_domains(da: DataArray, dim: Optional[str] = None) -> DataArray:
+    """Find domains of constant values in a histogram.
+
+    This effectively merges adjacent bins that have identical values.
+
+    :param da: Input data array.
+    :param dim: Optional dimension label. If not provided, ``da`` must be 1-D.
+    :return: Data array with bins spanning domains of input.
+    """
+    if dim is None:
+        dim = da.dim
+    condition = da.data == da.data
+    condition['x', :-1] = da.data['x', 1:] != da.data['x', :-1]
+    condition
+    group = f'{dim}_'
+    tmp = DataArray(da.data, coords={dim: da.coords[dim][dim, 1:], group: condition})
+    out = tmp.groupby(group).copy(1)
+    del out.coords[group]
+    out.coords[dim] = concat([da.coords[dim][dim, 0:1], out.coords[dim]], dim)
+    return out

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -3,7 +3,7 @@
 # @author Simon Heybrock
 from __future__ import annotations
 
-from .._scipp.core import DataArray
+from .._scipp.core import DataArray, DimensionError
 from .shape import concat
 from .variable import empty
 
@@ -14,7 +14,11 @@ def merge_equal_adjacent(da: DataArray) -> DataArray:
     :param da: Input data array, must be a 1-D histogram.
     :return: Data array with bins spanning domains of input.
     """
-    dim = da.dim
+    try:
+        dim = da.dim
+    except DimensionError as e:
+        raise DimensionError(
+            "Cannot merge equal adjacent bins non-1-D data array") from e
     condition = empty(dims=da.dims, shape=da.shape, dtype='bool')
     condition[dim, -1] = False
     condition[dim, :-1] = da.data[dim, 1:] == da.data[dim, :-1]

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -2,22 +2,19 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from __future__ import annotations
-from typing import Optional
 
 from . import DataArray, concat
 
 
-def find_domains(da: DataArray, dim: Optional[str] = None) -> DataArray:
-    """Find domains of constant values in a histogram.
+def find_domains(da: DataArray) -> DataArray:
+    """Find domains of constant values in a 1-D histogram.
 
     This effectively merges adjacent bins that have identical values.
 
     :param da: Input data array.
-    :param dim: Optional dimension label. If not provided, ``da`` must be 1-D.
     :return: Data array with bins spanning domains of input.
     """
-    if dim is None:
-        dim = da.dim
+    dim = da.dim
     condition = da.data == da.data
     condition['x', :-1] = da.data['x', 1:] != da.data['x', :-1]
     condition

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 
 from .._scipp.core import DataArray
 from .shape import concat
+from .variable import empty
 
 
-def find_domains(da: DataArray) -> DataArray:
-    """Find domains of constant values in a 1-D histogram.
+def merge_equal_adjacent(da: DataArray) -> DataArray:
+    """Merges adjacent bins that have identical values.
 
-    This effectively merges adjacent bins that have identical values.
-
-    :param da: Input data array.
+    :param da: Input data array, must be a 1-D histogram.
     :return: Data array with bins spanning domains of input.
     """
     dim = da.dim
-    condition = da.data != da.data
+    condition = empty(dims=da.dims, shape=da.shape, dtype='bool')
+    condition[dim, -1] = False
     condition[dim, :-1] = da.data[dim, 1:] == da.data[dim, :-1]
     group = f'{dim}_'
     tmp = DataArray(da.data, coords={dim: da.coords[dim][dim, 1:], group: condition})

--- a/src/scipp/core/domains.py
+++ b/src/scipp/core/domains.py
@@ -18,7 +18,6 @@ def find_domains(da: DataArray) -> DataArray:
     dim = da.dim
     condition = da.data != da.data
     condition[dim, :-1] = da.data[dim, 1:] == da.data[dim, :-1]
-    condition
     group = f'{dim}_'
     tmp = DataArray(da.data, coords={dim: da.coords[dim][dim, 1:], group: condition})
     # Note the flipped condition: In case we do not merge any bins we may have only a

--- a/src/scipp/core/sizes.py
+++ b/src/scipp/core/sizes.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+
 def _make_sizes(obj):
     """
     Makes a dictionary of dimensions labels to dimension sizes

--- a/src/scipp/core/sizes.py
+++ b/src/scipp/core/sizes.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
+
 def _make_sizes(obj):
     """
     Makes a dictionary of dimensions labels to dimension sizes

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -130,6 +130,22 @@ def test_bins_arithmetic():
                         sc.Variable(dims=['event'], values=[1.0, 2.0, 6.0, 8.0]))
 
 
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_lookup_getitem(dtype):
+    x_lin = sc.linspace(dim='xx', start=0, stop=1, num=4)
+    x = x_lin.copy()
+    x.values[0] -= 0.01
+    data = sc.array(dims=['xx'], values=[0, 1, 0], dtype=dtype)
+    hist_lin = sc.DataArray(data=data, coords={'xx': x_lin})
+    hist = sc.DataArray(data=data, coords={'xx': x})
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 0.2])
+    lut = sc.lookup(hist, 'xx')
+    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 0], dtype=dtype)
+    assert sc.identical(lut[var], expected)
+    lut = sc.lookup(hist_lin, 'xx')
+    assert sc.identical(lut[var], expected)
+
+
 def test_load_events_bins():
     with in_memory_nexus_file_with_event_data() as nexus_file:
         event_data_groups = find_by_nx_class("NXevent_data", nexus_file)

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -1,119 +1,119 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 import scipp as sc
-from scipp.core.domains import find_domains
+from scipp.core.domains import merge_equal_adjacent
 import pytest
 
 x = sc.arange(dim='x', start=0, stop=10)
 
 
-def test_find_domains_fail_not_1d():
+def test_merge_equal_adjacent_fail_not_1d():
     data = sc.ones(dims=['y', 'x'], shape=[2, 9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': sc.concat([x, x], 'y')})
     with pytest.raises(sc.DimensionError):
-        find_domains(da)
+        merge_equal_adjacent(da)
 
 
-def test_find_domains_fail_no_edges():
+def test_merge_equal_adjacent_fail_no_edges():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x['x', 1:]})
     with pytest.raises(sc.DimensionError):
-        find_domains(da)
+        merge_equal_adjacent(da)
 
 
-def test_find_domains_length_1():
+def test_merge_equal_adjacent_length_1():
     data = sc.ones(dims=['x'], shape=[1], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 2])})
-    assert sc.identical(find_domains(da), da)
+    assert sc.identical(merge_equal_adjacent(da), da)
 
 
-def test_find_domains_length_2():
+def test_merge_equal_adjacent_length_2():
     data = sc.ones(dims=['x'], shape=[2], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 1, 2])})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[1], dtype='int64'),
                             coords={'x': sc.array(dims=['x'], values=[0, 2])})
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
 
-def test_find_domains_2_domains_length_2():
+def test_merge_equal_adjacent_2_domains_length_2():
     data = sc.array(dims=['x'], values=[1, 0])
     da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 1, 2])})
-    assert sc.identical(find_domains(da), da)
+    assert sc.identical(merge_equal_adjacent(da), da)
 
 
-def test_find_domains_constant():
+def test_merge_equal_adjacent_constant():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
 
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[1], dtype='int64'),
                             coords={'x': sc.array(dims=['x'], values=[0, 9])})
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
 
-def test_find_domains_2_domains():
+def test_merge_equal_adjacent_2_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 0, 0, 0, 0, 0, 0, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 8, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
 
-def test_find_domains_3_domains():
+def test_merge_equal_adjacent_3_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 0, 0, 0, 0, 0, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 8, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 8, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
 
-def test_find_domains_4_domains():
+def test_merge_equal_adjacent_4_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 8, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 0, 0, 0, 0, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 3, 7, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
 
-def test_find_domains_multicolor():
+def test_merge_equal_adjacent_multicolor():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 2, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 2, 2, 2, 2, 2, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 8, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 2, 2, 2, 2, 2, 0, 2, 2])
     expected.data = sc.array(dims=['x'], values=[0, 2, 0, 2])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 6, 7, 9])
-    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(merge_equal_adjacent(da), expected)

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -21,6 +21,26 @@ def test_find_domains_fail_no_edges():
         find_domains(da)
 
 
+def test_find_domains_length_1():
+    data = sc.ones(dims=['x'], shape=[1], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 2])})
+    assert sc.identical(find_domains(da), da)
+
+
+def test_find_domains_length_2():
+    data = sc.ones(dims=['x'], shape=[2], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 1, 2])})
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
+                            coords={'x': sc.array(dims=['x'], values=[0, 2])})
+    assert sc.identical(find_domains(da), expected)
+
+
+def test_find_domains_2_domains_length_2():
+    data = sc.array(dims=['x'], values=[1, 0])
+    da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 1, 2])})
+    assert sc.identical(find_domains(da), da)
+
+
 def test_find_domains_constant():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -30,7 +30,7 @@ def test_find_domains_length_1():
 def test_find_domains_length_2():
     data = sc.ones(dims=['x'], shape=[2], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': sc.array(dims=['x'], values=[0, 1, 2])})
-    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1], dtype='int64'),
                             coords={'x': sc.array(dims=['x'], values=[0, 2])})
     assert sc.identical(find_domains(da), expected)
 
@@ -45,7 +45,7 @@ def test_find_domains_constant():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
 
-    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1], dtype='int64'),
                             coords={'x': sc.array(dims=['x'], values=[0, 9])})
     assert sc.identical(find_domains(da), expected)
 

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -7,96 +7,93 @@ import pytest
 x = sc.arange(dim='x', start=0, stop=10)
 
 
+def test_find_domains_fail_not_1d():
+    data = sc.ones(dims=['y', 'x'], shape=[2, 9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': sc.concat([x, x], 'y')})
+    with pytest.raises(sc.DimensionError):
+        find_domains(da)
+
+
 def test_find_domains_fail_no_edges():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x['x', 1:]})
-
     with pytest.raises(sc.DimensionError):
         find_domains(da)
-    with pytest.raises(sc.DimensionError):
-        find_domains(da, 'x')
 
 
-def check_1d(da, expected):
-    assert sc.identical(find_domains(da), expected)
-    assert sc.identical(find_domains(da, 'x'), expected)
-    with pytest.raises(sc.NotFoundError):
-        find_domains(da, 'y')
-
-
-def test_find_domains_1d_constant():
+def test_find_domains_constant():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
 
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
                             coords={'x': sc.array(dims=['x'], values=[0, 9])})
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
 
-def test_find_domains_1d_2_domains():
+def test_find_domains_2_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 0, 0, 0, 0, 0, 0, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 8, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
 
-def test_find_domains_1d_3_domains():
+def test_find_domains_3_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 0, 0, 0, 0, 0, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 8, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 0])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 8, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
 
-def test_find_domains_1d_4_domains():
+def test_find_domains_4_domains():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 8, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 0, 1, 0, 0, 0, 0, 1, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 3, 7, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
 
-def test_find_domains_1d_multicolor():
+def test_find_domains_multicolor():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 2, 1]))
 
     da.data = sc.array(dims=['x'], values=[0, 1, 1, 2, 2, 2, 2, 2, 1])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 8, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)
 
     da.data = sc.array(dims=['x'], values=[0, 2, 2, 2, 2, 2, 0, 2, 2])
     expected.data = sc.array(dims=['x'], values=[0, 2, 0, 2])
     expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 6, 7, 9])
-    check_1d(da, expected)
+    assert sc.identical(find_domains(da), expected)

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -7,13 +7,96 @@ import pytest
 x = sc.arange(dim='x', start=0, stop=10)
 
 
-def test_find_domains():
+def test_find_domains_fail_no_edges():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x['x', 1:]})
+
+    with pytest.raises(sc.DimensionError):
+        find_domains(da)
+    with pytest.raises(sc.DimensionError):
+        find_domains(da, 'x')
+
+
+def check_1d(da, expected):
+    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(find_domains(da, 'x'), expected)
+    with pytest.raises(sc.NotFoundError):
+        find_domains(da, 'y')
+
+
+def test_find_domains_1d_constant():
     data = sc.ones(dims=['x'], shape=[9], dtype='int64')
     da = sc.DataArray(data=data, coords={'x': x})
 
     expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
                             coords={'x': sc.array(dims=['x'], values=[0, 9])})
-    assert sc.identical(find_domains(da), expected)
-    assert sc.identical(find_domains(da, 'x'), expected)
-    with pytest.raises(sc.NotFoundError):
-        find_domains(da, 'y')
+    check_1d(da, expected)
+
+
+def test_find_domains_1d_2_domains():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x})
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1]))
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 0, 0, 0, 0, 0, 0, 0, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 8, 9])
+    check_1d(da, expected)
+
+
+def test_find_domains_1d_3_domains():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x})
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0]))
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 0])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 1, 0, 0, 0, 0, 0, 0])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 1, 1, 1, 1, 1, 1, 0])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 8, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 0, 1, 1, 1, 1, 1, 1, 0])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 8, 9])
+    check_1d(da, expected)
+
+
+def test_find_domains_1d_4_domains():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x})
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 0, 1]))
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 0, 0, 0, 0, 0, 0, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 2, 8, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 0, 1, 0, 0, 0, 0, 1, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 2, 3, 7, 9])
+    check_1d(da, expected)
+
+
+def test_find_domains_1d_multicolor():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x})
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[0, 1, 2, 1]))
+
+    da.data = sc.array(dims=['x'], values=[0, 1, 1, 2, 2, 2, 2, 2, 1])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 3, 8, 9])
+    check_1d(da, expected)
+
+    da.data = sc.array(dims=['x'], values=[0, 2, 2, 2, 2, 2, 0, 2, 2])
+    expected.data = sc.array(dims=['x'], values=[0, 2, 0, 2])
+    expected.coords['x'] = sc.array(dims=['x'], values=[0, 1, 6, 7, 9])
+    check_1d(da, expected)

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+import scipp as sc
+from scipp.core.domains import find_domains
+import pytest
+
+x = sc.arange(dim='x', start=0, stop=10)
+
+
+def test_find_domains():
+    data = sc.ones(dims=['x'], shape=[9], dtype='int64')
+    da = sc.DataArray(data=data, coords={'x': x})
+
+    expected = sc.DataArray(data=sc.array(dims=['x'], values=[1]),
+                            coords={'x': sc.array(dims=['x'], values=[0, 9])})
+    assert sc.identical(find_domains(da), expected)
+    assert sc.identical(find_domains(da, 'x'), expected)
+    with pytest.raises(sc.NotFoundError):
+        find_domains(da, 'y')


### PR DESCRIPTION
- Fixes #2263.
- Find constant domains in lookup table for significant speedup with long time series. This happens in practice and can yield a 2x or more speedup. See also https://github.com/scipp/ess/pull/57.