### PR TITLE
Fix regression in `transform_coords` causing dense counterparts of event coords to be not computed

### DIFF
--- a/src/scipp/coords.py
+++ b/src/scipp/coords.py
@@ -196,6 +196,13 @@ class _ComputeRule(_Rule):
             outputs = self._compute_pure_dense(inputs)
         else:
             outputs = self._compute_with_events(inputs)
+        # Compute missing dense outputs, provided that all inputs have dense components.
+        # Checking presence in outputs first to avoid multiple calls to _func.
+        missing_dense = not all(coord.has_dense for coord in outputs.values())
+        if missing_dense and all(coord.has_dense for coord in inputs.values()):
+            dense_outputs = self._compute_pure_dense(inputs)
+            for name, coord in dense_outputs.items():
+                outputs[name].dense = coord.dense
         return self._without_unrequested(outputs)
 
     def _compute_pure_dense(self, inputs):

--- a/tests/transform_coords_test.py
+++ b/tests/transform_coords_test.py
@@ -279,6 +279,8 @@ def test_binned():
     graph = {('xy', 'yy'): convert, 'x2': 'x'}
     da = binned.transform_coords(['xy', 'yy'], graph=graph)
     check_binned(da, binned)
+    assert sc.identical(da.coords['xy'], (binned.coords['x'] *
+                                          binned.coords['y']).rename_dims({'x': 'x2'}))
     # If input is sliced, transform_coords has to copy the buffer
     da = binned['y', 0:1].transform_coords(['xy', 'yy'], graph=graph)
     check_binned(da, binned['y', 0:1])


### PR DESCRIPTION
Caused by #2266.