### PR TITLE
Remove `events` property

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,11 +15,21 @@ Breaking changes
 Bugfixes
 ~~~~~~~~
 
+Deprecations
+~~~~~~~~~~~~
+
+* The deprecated ``events`` property has been removed.
+
 Stability, Maintainability, and Testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Contributors
 ~~~~~~~~~~~~
+
+Simon Heybrock:sup:`a`\ ,
+Neil Vaytet:sup:`a`\ ,
+Tom Willemsen:sup:`b, c`\ ,
+and Jan-Lukas Wynen:sup:`a`
 
 v0.9.0 (November 2021)
 ----------------------

--- a/docs/user-guide/binned-data/binned-data.ipynb
+++ b/docs/user-guide/binned-data/binned-data.ipynb
@@ -196,7 +196,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "buffer = binned.events\n",
+    "buffer = binned.bins.constituents['data']\n",
     "scatter = ax.scatter(\n",
     "    x=buffer.coords['x'].values,\n",
     "    y=buffer.coords['y'].values,\n",

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -34,13 +34,11 @@ setattr(Variable, 'sizes', property(_make_sizes))
 setattr(DataArray, 'sizes', property(_make_sizes))
 setattr(Dataset, 'sizes', property(_make_sizes))
 
-from .bins import _bins, _set_bins, _events
+from .bins import _bins, _set_bins
 
 setattr(Variable, 'bins', property(_bins, _set_bins))
 setattr(DataArray, 'bins', property(_bins, _set_bins))
 setattr(Dataset, 'bins', property(_bins, _set_bins))
-setattr(Variable, 'events', property(_events))
-setattr(DataArray, 'events', property(_events))
 
 from .structured import _fields
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -199,22 +199,6 @@ class GroupbyBins:
         return self._obj.concat(dim)
 
 
-def _events(obj):
-    """
-    Returns the data underlying the bins stored in the object, or None if the
-    object stores dense data.
-    """
-    warnings.warn("The 'events' property is deprecated; use 'bins'.",
-                  DeprecationWarning)
-    if _cpp.is_bins(obj):
-        if isinstance(obj, _cpp.Variable):
-            return _cpp.bins_data(obj)
-        else:
-            return _cpp.bins_data(obj.data)
-    else:
-        return None
-
-
 def _bins(obj):
     """
     Returns helper :py:class:`scipp.Bins` allowing bin-wise operations


### PR DESCRIPTION
Closes #2192.

Note that features required to replace the use of the property are part of the 0.9. This just removes the property for the next (0.10) release.