### PR TITLE
Avoid non-linear scaling contribution in bins.concat

### DIFF
--- a/lib/core/include/scipp/core/array_to_string.h
+++ b/lib/core/include/scipp/core/array_to_string.h
@@ -51,9 +51,10 @@ std::string array_to_string(const T &arr,
     return std::string("[]");
   std::string s = "[";
   for (scipp::index i = 0; i < scipp::size(arr); ++i) {
-    if (i == 2 && size > 4) {
+    scipp::index n = 4;
+    if (i == n && size > 2 * n) {
       s += "..., ";
-      i = size - 2;
+      i = size - n;
     }
     s += element_to_string(arr[i], unit);
   }

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -304,8 +304,8 @@ public:
         // kept unchanged there is a 1:1 mapping from input to output dims. We
         // can thus avoid storing and processing a lot of length-0 contributions
         // to bins.
-        if (m_offsets.dims().empty() && m_dims[dim] != 0) {
-          m_nbin = (m_dims.volume() / m_dims[dim]) * units::one;
+        if (m_offsets.dims().empty() && m_dims[dim] == m_dims.volume()) {
+          m_nbin = scipp::index{1} * units::one;
           m_offsets = make_range(0, m_dims[dim], 1, dim);
         } else {
           update_indices_from_existing(indices, dim);

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -304,10 +304,14 @@ public:
         // kept unchanged there is a 1:1 mapping from input to output dims. We
         // can thus avoid storing and processing a lot of length-0 contributions
         // to bins.
+        // Note that this is only possible (in this simple manner) if there are
+        // no other actions affecting output dimensions.
         if (m_offsets.dims().empty() && m_dims[dim] == m_dims.volume()) {
+          // Offset to output bin tracked using base offset for input bins
           m_nbin = scipp::index{1} * units::one;
           m_offsets = make_range(0, m_dims[dim], 1, dim);
         } else {
+          // Offset to output bin tracked in indices for individual events
           update_indices_from_existing(indices, dim);
         }
       } else if (action == AxisAction::Join) {

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -299,9 +299,18 @@ public:
         } else {
           update_indices_by_binning(indices, get_coord(dim), key, linspace);
         }
-      } else if (action == AxisAction::Existing)
-        update_indices_from_existing(indices, dim);
-      else if (action == AxisAction::Join) {
+      } else if (action == AxisAction::Existing) {
+        // Similar to binning along an existing dim, if a dimension is simply
+        // kept unchanged there is a 1:1 mapping from input to output dims. We
+        // can thus avoid storing and processing a lot of length-0 contributions
+        // to bins.
+        if (m_offsets.dims().empty() && m_dims[dim] != 0) {
+          m_nbin = (m_dims.volume() / m_dims[dim]) * units::one;
+          m_offsets = make_range(0, m_dims[dim], 1, dim);
+        } else {
+          update_indices_from_existing(indices, dim);
+        }
+      } else if (action == AxisAction::Join) {
         ; // target bin 0 for all
       }
     }

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -282,6 +282,14 @@ TEST_P(BinTest, rebin_coarse_to_fine_2d_outer) {
   expect_near(bin(xy_coarse, {edges_x}), xy);
 }
 
+TEST_P(BinTest, rebin_coarse_to_fine_2d_outer_no_coord) {
+  const auto table = GetParam();
+  auto xy_coarse = bin(table, {edges_x_coarse, edges_y});
+  auto xy = bin(table, {edges_x, edges_y});
+  xy_coarse.coords().erase(Dim::X);
+  expect_near(bin(xy_coarse, {edges_x}), xy);
+}
+
 TEST_P(BinTest, rebin_empty_dim) {
   const auto table = GetParam();
   const auto xy = bin(table, {edges_x, edges_y});


### PR DESCRIPTION
Addresses parts of #1846. The approach is the same as when *rebinning* an existing dim, avoiding allocating and handling a ton of length-0 contributions to output bins.

<img width="660" alt="image" src="https://user-images.githubusercontent.com/12912489/141248809-7e81bccd-617f-4499-a37b-bf479f9ab9a5.png">

Same on log-log scale:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/12912489/141248767-7cbc7123-54d1-4a8d-ad04-f027d6bfe680.png">

Code to try:
```python
import scipp as sc
nx = 100000
binned = sc.data.binned_x(nevent=2*nx, nbin=nx)
ny = 40
y = sc.linspace(dim='y', start=0, stop=1, num=ny+1, unit='m')
binned = sc.bin(binned, edges=[y])
```
```python
%%time
binned.bins.concat('x')
```