### PR TITLE
Fix kernel crash from quadratic memory use in `sc.bin`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,6 +15,8 @@ Breaking changes
 Bugfixes
 ~~~~~~~~
 
+* Fix kernel crash or poor performance when using ``bin`` or ``da.bins.concat`` along an inner dimension in the presence of a long outer dimension `#2278 <https://github.com/scipp/scipp/pull/2278>`_.
+
 Stability, Maintainability, and Testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/core/subbin_sizes.cpp
+++ b/lib/core/subbin_sizes.cpp
@@ -29,6 +29,16 @@ void SubbinSizes::operator=(const scipp::index value) {
 SubbinSizes &SubbinSizes::operator+=(const SubbinSizes &other) {
   if (other.offset() < offset()) // avoid realloc if possible
     return *this = *this + other;
+  // This case is crucial to avoid an N*N term in memory use after call to
+  // 'sum' in the setup of output bin sizes in 'bin' (in certain cases). The
+  // problem comes from the initialization of the output in 'sum', which is set
+  // to "0" (defined as offset 0 and one 0 entry in SubbinSizes), rather than
+  // using the actual offset of an input element.
+  if (sizes().size() == 1 && sizes()[0] == 0) {
+    m_offset = other.m_offset;
+    m_sizes = other.sizes();
+    return *this;
+  }
   scipp::index current = other.offset() - offset();
   const auto length = current + scipp::size(other.sizes());
   if (length > scipp::size(sizes()))

--- a/lib/variable/bin_detail.cpp
+++ b/lib/variable/bin_detail.cpp
@@ -64,11 +64,11 @@ Variable sum_subbin_sizes(const Variable &var) {
 
 std::vector<scipp::index> flatten_subbin_sizes(const Variable &var,
                                                const scipp::index length) {
-  std::vector<scipp::index> flat;
-  for (const auto &val : var.values<core::SubbinSizes>()) {
-    flat.insert(flat.end(), val.sizes().begin(), val.sizes().end());
-    for (scipp::index i = 0; i < length - scipp::size(val.sizes()); ++i)
-      flat.push_back(0);
+  std::vector<scipp::index> flat(length * var.dims().volume());
+  auto it = flat.begin();
+  for (const auto &sub : var.values<core::SubbinSizes>()) {
+    std::copy_n(sub.sizes().begin(), sub.sizes().size(), it + sub.offset());
+    it += length;
   }
   return flat;
 }


### PR DESCRIPTION
Addresses part of #1846.

This happens, e.g., when concatenating the inner dim of 2d binned data
when the outer dim is long.