### PR TITLE
Fix clang 13 warnings

### DIFF
--- a/lib/benchmark/slice_benchmark.cpp
+++ b/lib/benchmark/slice_benchmark.cpp
@@ -20,7 +20,7 @@ auto make_table() {
 static void BM_dataset_create_view(benchmark::State &state) {
   auto d = make_table();
   for (auto _ : state) {
-    Dataset view(d);
+    [[maybe_unused]] Dataset view(d);
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -28,7 +28,7 @@ static void BM_dataset_create_view(benchmark::State &state) {
 static void BM_dataset_slice(benchmark::State &state) {
   auto d = make_table();
   for (auto _ : state) {
-    d.slice({Dim::X, 1});
+    benchmark::DoNotOptimize(d.slice({Dim::X, 1}));
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -36,7 +36,7 @@ static void BM_dataset_slice(benchmark::State &state) {
 static void BM_dataset_slice_item(benchmark::State &state) {
   auto d = make_table();
   for (auto _ : state) {
-    d.slice({Dim::X, 1})["b"];
+    benchmark::DoNotOptimize(d.slice({Dim::X, 1})["b"]);
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -44,7 +44,7 @@ static void BM_dataset_slice_item(benchmark::State &state) {
 static void BM_dataset_slice_item_dims(benchmark::State &state) {
   auto d = make_table();
   for (auto _ : state) {
-    d.slice({Dim::X, 1})["b"].dims();
+    benchmark::DoNotOptimize(d.slice({Dim::X, 1})["b"].dims());
   }
   state.SetItemsProcessed(state.iterations());
 }

--- a/lib/core/include/scipp/core/slice.h
+++ b/lib/core/include/scipp/core/slice.h
@@ -17,6 +17,7 @@ public:
   Slice() : m_dim(Dim::None), m_begin(-1), m_end(-1) {}
   Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_);
   Slice(const Dim dim_, const scipp::index begin_);
+  Slice(const Slice &) = default;
   Slice &operator=(const Slice &) = default;
   bool operator==(const Slice &other) const noexcept;
   bool operator!=(const Slice &other) const noexcept;

--- a/lib/dataset/test/concatenate_test.cpp
+++ b/lib/dataset/test/concatenate_test.cpp
@@ -311,8 +311,10 @@ protected:
 };
 
 TEST_F(ConcatTest, empty) {
-  EXPECT_THROW(concat(std::vector<DataArray>{}, Dim::X), std::invalid_argument);
-  EXPECT_THROW(concat(std::vector<Dataset>{}, Dim::X), std::invalid_argument);
+  EXPECT_THROW_DISCARD(concat(std::vector<DataArray>{}, Dim::X),
+                       std::invalid_argument);
+  EXPECT_THROW_DISCARD(concat(std::vector<Dataset>{}, Dim::X),
+                       std::invalid_argument);
 }
 
 TEST_F(ConcatTest, single_existing_dim) {
@@ -402,7 +404,7 @@ TEST_F(ConcatHistogramTest, fail_mixing_point_data_and_histogram) {
                        except::BinEdgeError);
   EXPECT_THROW_DISCARD(concat(std::vector{a, no_edges(b), no_edges(c)}, Dim::X),
                        except::BinEdgeError);
-  EXPECT_NO_THROW(
+  EXPECT_NO_THROW_DISCARD(
       concat(std::vector{no_edges(a), no_edges(b), no_edges(c)}, Dim::X));
 }
 


### PR DESCRIPTION
There was only 1 warning. Implicitly defaulted copy constructors are deprecated when the copy assignment operator is defined (or defaulted) explicitly.