### PR TITLE
Fix kernel crash from quadratic memory use in `sc.bin`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -15,6 +15,8 @@ Breaking changes
 Bugfixes
 ~~~~~~~~
 
+* Fix kernel crash or poor performance when using ``bin`` or ``da.bins.concat`` along an inner dimension in the presence of a long outer dimension `#2278 <https://github.com/scipp/scipp/pull/2278>`_.
+
 Stability, Maintainability, and Testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -5,8 +5,6 @@
 #include <numeric>
 #include <set>
 
-#include "scipp/common/ranges.h"
-
 #include "scipp/core/element/bin.h"
 #include "scipp/core/element/cumulative.h"
 
@@ -120,7 +118,7 @@ auto bin(const Variable &data, const Variable &indices,
   // Not using cumsum along *all* dims, since some outer dims may be left
   // untouched (no rebin).
   std::vector<std::pair<Dim, scipp::index>> strategy;
-  for (const auto dim : views::reverse(data.dims()))
+  for (const auto dim : data.dims())
     if (dims.contains(dim) && dims[dim] > 0)
       strategy.emplace_back(dim, data.dims()[dim]);
   // To avoid excessive memory consumption in intermediate results for

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -135,12 +135,13 @@ protected:
   Variable edges_y_coarse =
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{-2, -1, 2});
 
-  void expect_near(const DataArray &a, const DataArray &b) {
+  void expect_near(const DataArray &a, const DataArray &b, double rtol = 1e-14,
+                   double atol = 0.0) {
     const auto tolerance =
-        values(max(bins_sum(a.data())) * (1e-14 * units::one));
+        values(max(bins_sum(a.data())) * (rtol * units::one));
     EXPECT_TRUE(
         all(isclose(values(bins_sum(a.data())), values(bins_sum(b.data())),
-                    0.0 * units::one, tolerance))
+                    atol * units::one, tolerance))
             .value<bool>());
     EXPECT_EQ(a.masks(), b.masks());
     EXPECT_EQ(a.coords(), b.coords());
@@ -410,7 +411,7 @@ TEST_P(BinTest, erase_binning_and_bin_along_different_dimension) {
   expect_near(test_output, binned_along_y);
 }
 
-TEST_P(BinTest, erase_binning_and_rebin_along_different_dimension) {
+TEST_P(BinTest, erase_binning_and_rebin_trivial_along_different_dimension) {
   const auto table = GetParam();
   const auto binned_along_x = bin(table, {edges_x, edges_y});
   const auto binned_along_y = bin(table, {edges_y});
@@ -421,6 +422,34 @@ TEST_P(BinTest, erase_binning_and_rebin_along_different_dimension) {
   // Expect result of clearing x binning and adding y binning to be the same
   // as binning the original data along y
   expect_near(test_output, binned_along_y);
+}
+
+TEST_P(BinTest,
+       erase_binning_and_rebin_coarse_to_fine_along_different_dimension) {
+  const auto table = GetParam();
+  const auto binned_along_x = bin(table, {edges_x, edges_y_coarse});
+  const auto binned_along_y = bin(table, {edges_y});
+
+  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
+  const auto test_output =
+      bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension);
+  // Expect result of clearing x binning and adding y binning to be the same
+  // as binning the original data along y
+  expect_near(test_output, binned_along_y);
+}
+
+TEST_P(BinTest,
+       erase_binning_and_rebin_fine_to_coarse_along_different_dimension) {
+  const auto table = GetParam();
+  const auto binned_along_x = bin(table, {edges_x, edges_y});
+  const auto binned_along_y = bin(table, {edges_y_coarse});
+
+  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
+  const auto test_output =
+      bin(binned_along_x, {edges_y_coarse}, {}, clear_binning_from_dimension);
+  // Expect result of clearing x binning and adding y binning to be the same
+  // as binning the original data along y
+  expect_near(test_output, binned_along_y, 1e-14, 1e-13);
 }
 
 TEST_P(BinTest, error_if_erase_binning_and_try_rebin_along_same_dimension) {

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -410,6 +410,19 @@ TEST_P(BinTest, erase_binning_and_bin_along_different_dimension) {
   expect_near(test_output, binned_along_y);
 }
 
+TEST_P(BinTest, erase_binning_and_rebin_along_different_dimension) {
+  const auto table = GetParam();
+  const auto binned_along_x = bin(table, {edges_x, edges_y});
+  const auto binned_along_y = bin(table, {edges_y});
+
+  const std::vector<Dim> clear_binning_from_dimension = {Dim::X};
+  const auto test_output =
+      bin(binned_along_x, {edges_y}, {}, clear_binning_from_dimension);
+  // Expect result of clearing x binning and adding y binning to be the same
+  // as binning the original data along y
+  expect_near(test_output, binned_along_y);
+}
+
 TEST_P(BinTest, error_if_erase_binning_and_try_rebin_along_same_dimension) {
   const auto table = GetParam();
   const auto binned_along_x = bin(table, {edges_x_coarse});

--- a/lib/variable/bin_detail.cpp
+++ b/lib/variable/bin_detail.cpp
@@ -64,11 +64,11 @@ Variable sum_subbin_sizes(const Variable &var) {
 
 std::vector<scipp::index> flatten_subbin_sizes(const Variable &var,
                                                const scipp::index length) {
-  std::vector<scipp::index> flat;
-  for (const auto &val : var.values<core::SubbinSizes>()) {
-    flat.insert(flat.end(), val.sizes().begin(), val.sizes().end());
-    for (scipp::index i = 0; i < length - scipp::size(val.sizes()); ++i)
-      flat.push_back(0);
+  std::vector<scipp::index> flat(length * var.dims().volume());
+  auto it = flat.begin();
+  for (const auto &sub : var.values<core::SubbinSizes>()) {
+    std::copy_n(sub.sizes().begin(), sub.sizes().size(), it + sub.offset());
+    it += length;
   }
   return flat;
 }


### PR DESCRIPTION
Addresses part of #1846.

This happens, e.g., when concatenating the inner dim of 2d binned data when the outer dim is long.

Prior solution in #2278 was broken, since it trimmed too much in `SubbinSizes`.

- Added a unit test.
- New solution simply ensures that we reduce the longest dimension first when setting up sub-bin offsets.
 
As a possibly unwanted side effect this solution will not guarantee event order in the output. We have never made such a promise, but this should be kept in mind.

The effect of reordering the sub-bin-offset computation is that writes to a particular output may be less ordered. So far I have not been able to see an effect of this. My initial feeling was that the effect may be negative, but on the other hand it could make writes by different threads less "adjacent".