### PR TITLE
Fix `dim` property to return a string in Python

### DIFF
--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -414,7 +414,7 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
       "Dimension labels of the data (read-only).",
       py::return_value_policy::move);
   c.def_property_readonly(
-      "dim", &T::dim,
+      "dim", [](const T &self) { return self.dim().name(); },
       "The only dimension label for 1-dimensional data, raising an exception "
       "if the data is not 1-dimensional.");
   c.def_property_readonly(

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -73,6 +73,8 @@ def test_operation_with_scalar_quantity():
 def test_single_dim_access():
     var = sc.Variable(dims=['x'], values=[0.0])
     assert var.dim == 'x'
+    assert isinstance(var.dim, str)
+    assert var.sizes[var.dim] == 1
 
 
 def test_0D_scalar_access():


### PR DESCRIPTION
In #2251 the `dim` property was added. However, it did not return a string in Python, so things such as `da.sizes[da.dim]` did not work.