### PR TITLE
Better error messsages

### DIFF
--- a/docs/images/variable_classes.dia
+++ b/docs/images/variable_classes.dia
@@ -285,7 +285,7 @@
         </dia:composite>
         <dia:composite type="umloperation">
           <dia:attribute name="name">
-            <dia:string>#hasVariances#</dia:string>
+            <dia:string>#has_variances#</dia:string>
           </dia:attribute>
           <dia:attribute name="stereotype">
             <dia:string>##</dia:string>
@@ -571,7 +571,7 @@
         </dia:composite>
         <dia:composite type="umloperation">
           <dia:attribute name="name">
-            <dia:string>#hasVariances#</dia:string>
+            <dia:string>#has_variances#</dia:string>
           </dia:attribute>
           <dia:attribute name="stereotype">
             <dia:string>##</dia:string>

--- a/docs/images/variable_classes.svg
+++ b/docs/images/variable_classes.svg
@@ -10,7 +10,7 @@
       <rect style="fill: #ffffff; fill-opacity: 1; stroke-opacity: 1; stroke-width: 2; stroke: #000000" x="550" y="168" width="440" height="68"/>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:700" x="553" y="181.881">+clone(): unique_ptr&lt;VariableConcept&gt;</text>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:700" x="553" y="197.881">+dtype(): DType</text>
-      <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:700" x="553" y="213.881">+hasVariances(): bool</text>
+      <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:700" x="553" y="213.881">+has_variances(): bool</text>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:700" x="553" y="229.881">+equals(a:VariableConstView,b:VariableConstView): bool</text>
     </g>
     <g>
@@ -21,7 +21,7 @@
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:normal;font-weight:normal" x="523" y="347.881">-m_variances: optional&lt;element_array&lt;T&gt;&gt;</text>
       <rect style="fill: #ffffff; fill-opacity: 1; stroke-opacity: 1; stroke-width: 2; stroke: #000000" x="520" y="354" width="500" height="100"/>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:normal" x="523" y="367.881">+clone(): VariableConceptHandle</text>
-      <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:normal" x="523" y="383.881">+hasVariances(): bool</text>
+      <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:normal" x="523" y="383.881">+has_variances(): bool</text>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:normal" x="523" y="399.881">+dtype(): DType</text>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:italic;font-weight:normal" x="523" y="415.881">+equals(a:VariableConstView,b:VariableConstView): bool</text>
       <text font-size="12.8" style="fill: #000000; fill-opacity: 1; stroke: none;text-anchor:start;font-family:monospace;font-style:normal;font-weight:normal" x="523" y="431.881">+values(params:ElementArrayViewParams): ElementArrayView&lt;T&gt;</text>

--- a/lib/core/dimensions.cpp
+++ b/lib/core/dimensions.cpp
@@ -71,7 +71,8 @@ Dimensions merge(const Dimensions &a, const Dimensions &b) {
     if (b.contains(dim)) {
       if (a[dim] != b[dim])
         throw except::DimensionError(
-            "Cannot merge subspaces with mismatching extent");
+            "Cannot merge dimensions with mismatching extent in '" +
+            to_string(dim) + "': " + to_string(a) + " and " + to_string(b));
       while (it != end && *it != dim) {
         if (!a.contains(*it))
           out.addInner(*it, b[*it]);

--- a/lib/core/include/scipp/core/except.h
+++ b/lib/core/include/scipp/core/except.h
@@ -31,7 +31,7 @@ struct SCIPP_CORE_EXPORT TypeError : public Error<core::DType> {
 
   template <class... Vars>
   explicit TypeError(const std::string &msg, Vars &&... vars)
-      : TypeError{msg + ((pretty_dtype(vars) + ", ") + ...)} {}
+      : TypeError{msg + (('\'' + pretty_dtype(vars) + "', ") + ...)} {}
 };
 
 template <>

--- a/lib/core/include/scipp/core/except.h
+++ b/lib/core/include/scipp/core/except.h
@@ -31,7 +31,7 @@ struct SCIPP_CORE_EXPORT TypeError : public Error<core::DType> {
 
   template <class... Vars>
   explicit TypeError(const std::string &msg, Vars &&... vars)
-      : TypeError{msg + ((pretty_dtype(vars) + ' ') + ...)} {}
+      : TypeError{msg + ((pretty_dtype(vars) + ", ") + ...)} {}
 };
 
 template <>

--- a/lib/core/include/scipp/core/sizes.h
+++ b/lib/core/include/scipp/core/sizes.h
@@ -97,8 +97,6 @@ public:
 SCIPP_CORE_EXPORT bool is_edges(const Sizes &sizes, const Sizes &dataSizes,
                                 const Dim dim);
 
-SCIPP_CORE_EXPORT std::string to_string(const Sizes &sizes);
-
 } // namespace scipp::core
 
 namespace scipp {

--- a/lib/core/include/scipp/core/string.h
+++ b/lib/core/include/scipp/core/string.h
@@ -29,6 +29,7 @@ SCIPP_CORE_EXPORT std::string to_string(const char *s);
 SCIPP_CORE_EXPORT std::string to_string(const bool b);
 SCIPP_CORE_EXPORT std::string to_string(const DType dtype);
 SCIPP_CORE_EXPORT std::string to_string(const Dimensions &dims);
+SCIPP_CORE_EXPORT std::string to_string(const Sizes &sizes);
 SCIPP_CORE_EXPORT std::string to_string(const Slice &slice);
 SCIPP_CORE_EXPORT std::string to_string(const scipp::index_pair &index);
 

--- a/lib/core/sizes.cpp
+++ b/lib/core/sizes.cpp
@@ -207,12 +207,4 @@ bool is_edges(const Sizes &sizes, const Sizes &dataSizes, const Dim dim) {
   return size == (sizes.contains(dim) ? sizes[dim] + 1 : 2);
 }
 
-std::string to_string(const Sizes &sizes) {
-  std::string repr("Sizes[");
-  for (const auto &dim : sizes)
-    repr += to_string(dim) + ":" + std::to_string(sizes[dim]) + ", ";
-  repr += "]";
-  return repr;
-}
-
 } // namespace scipp::core

--- a/lib/core/string.cpp
+++ b/lib/core/string.cpp
@@ -33,6 +33,14 @@ std::string to_string(const Dimensions &dims) {
   return s;
 }
 
+std::string to_string(const Sizes &sizes) {
+  std::string repr("Sizes[");
+  for (const auto &dim : sizes)
+    repr += to_string(dim) + ":" + std::to_string(sizes[dim]) + ", ";
+  repr += "]";
+  return repr;
+}
+
 const std::string &to_string(const std::string &s) { return s; }
 std::string_view to_string(const std::string_view s) { return s; }
 std::string to_string(const char *s) { return std::string(s); }

--- a/lib/dataset/arithmetic.cpp
+++ b/lib/dataset/arithmetic.cpp
@@ -26,7 +26,7 @@ template <class T, class Op> void dry_run_op(T &&a, const Variable &b, Op op) {
 }
 
 template <class T, class Op> void dry_run_op(T &&a, const DataArray &b, Op op) {
-  expect::coordsAreSuperset(a, b);
+  expect::coords_are_superset(a, b);
   dry_run_op(a, b.data(), op);
 }
 

--- a/lib/dataset/arithmetic.cpp
+++ b/lib/dataset/arithmetic.cpp
@@ -26,7 +26,7 @@ template <class T, class Op> void dry_run_op(T &&a, const Variable &b, Op op) {
 }
 
 template <class T, class Op> void dry_run_op(T &&a, const DataArray &b, Op op) {
-  expect::coords_are_superset(a, b);
+  expect::coords_are_superset(a, b, "");
   dry_run_op(a, b.data(), op);
 }
 

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -227,9 +227,10 @@ Variable concatenate(const Variable &var0, const Variable &var1) {
 }
 
 DataArray concatenate(const DataArray &a, const DataArray &b) {
-  return DataArray{
-      buckets::concatenate(a.data(), b.data()), union_(a.coords(), b.coords()),
-      union_or(a.masks(), b.masks()), intersection(a.attrs(), b.attrs())};
+  return DataArray{buckets::concatenate(a.data(), b.data()),
+                   union_(a.coords(), b.coords(), "concatenate"),
+                   union_or(a.masks(), b.masks()),
+                   intersection(a.attrs(), b.attrs())};
 }
 
 /// Reduce a dimension by concatenating all elements along the dimension.

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -261,7 +261,7 @@ void append(Variable &var0, const Variable &var1) {
 void append(Variable &&var0, const Variable &var1) { append(var0, var1); }
 
 void append(DataArray &a, const DataArray &b) {
-  expect::coordsAreSuperset(a, b);
+  expect::coords_are_superset(a, b);
   union_or_in_place(a.masks(), b.masks());
   auto data = a.data();
   append(data, b.data());
@@ -317,7 +317,7 @@ void scale(DataArray &array, const DataArray &histogram, Dim dim) {
   if (dim == Dim::Invalid)
     dim = edge_dimension(histogram);
   // Coords along dim are ignored since "binning" is dynamic for buckets.
-  expect::coordsAreSuperset(array, histogram.slice({dim, 0}));
+  expect::coords_are_superset(array, histogram.slice({dim, 0}));
   // scale applies masks along dim but others are kept
   union_or_in_place(array.masks(), histogram.slice({dim, 0}).masks());
   auto data = bins_view<DataArray>(array.data()).data();

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -262,7 +262,7 @@ void append(Variable &var0, const Variable &var1) {
 void append(Variable &&var0, const Variable &var1) { append(var0, var1); }
 
 void append(DataArray &a, const DataArray &b) {
-  expect::coords_are_superset(a, b);
+  expect::coords_are_superset(a, b, "bins.append");
   union_or_in_place(a.masks(), b.masks());
   auto data = a.data();
   append(data, b.data());
@@ -318,7 +318,7 @@ void scale(DataArray &array, const DataArray &histogram, Dim dim) {
   if (dim == Dim::Invalid)
     dim = edge_dimension(histogram);
   // Coords along dim are ignored since "binning" is dynamic for buckets.
-  expect::coords_are_superset(array, histogram.slice({dim, 0}));
+  expect::coords_are_superset(array, histogram.slice({dim, 0}), "bins.scale");
   // scale applies masks along dim but others are kept
   union_or_in_place(array.masks(), histogram.slice({dim, 0}).masks());
   auto data = bins_view<DataArray>(array.data()).data();

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -104,7 +104,7 @@ constexpr auto copy_or_resize = [](const auto &var, const Dim dim,
   // _uninitialized_ variable.
   return var.dims().contains(dim)
              ? variable::variableFactory().create(var.dtype(), dims, var.unit(),
-                                                  var.hasVariances())
+                                                  var.has_variances())
              : copy(var);
 };
 }
@@ -356,7 +356,7 @@ Variable bins_sum(const Variable &data) {
   type = type == dtype<bool> ? dtype<int64_t> : type;
   const auto unit = variable::variableFactory().elem_unit(data);
   Variable summed;
-  if (variable::variableFactory().hasVariances(data))
+  if (variable::variableFactory().has_variances(data))
     summed = Variable(type, data.dims(), unit, Values{}, Variances{});
   else
     summed = Variable(type, data.dims(), unit, Values{});

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -11,7 +11,7 @@
 namespace scipp::dataset {
 
 namespace {
-template <class T> void expectWritable(const T &dict) {
+template <class T> void expect_writable(const T &dict) {
   if (dict.is_readonly())
     throw except::DataArrayError("Read-only flag is set, cannot set new data.");
 }
@@ -79,7 +79,7 @@ void DataArray::setData(const Variable &data) {
   // Return early on self assign to avoid exceptions from Python inplace ops
   if (m_data->is_same(data))
     return;
-  expectWritable(*this);
+  expect_writable(*this);
   core::expect::equals(static_cast<Sizes>(dims()),
                        static_cast<Sizes>(data.dims()));
   *m_data = data;

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -87,7 +87,7 @@ void DataArray::setData(const Variable &data) {
 
 /// Return true if the dataset proxies have identical content.
 bool operator==(const DataArray &a, const DataArray &b) {
-  if (a.hasVariances() != b.hasVariances())
+  if (a.has_variances() != b.has_variances())
     return false;
   if (a.coords() != b.coords())
     return false;

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -125,14 +125,14 @@ DataArray DataArray::slice(const Slice &s) const {
 }
 
 void DataArray::validateSlice(const Slice &s, const DataArray &array) const {
-  expect::coords_are_superset(slice(s), array);
+  expect::coords_are_superset(slice(s), array, "");
   data().validateSlice(s, array.data());
   masks().validateSlice(s, array.masks());
 }
 
 DataArray &DataArray::setSlice(const Slice &s, const DataArray &array) {
   // validateSlice, but not masks as otherwise repeated
-  expect::coords_are_superset(slice(s), array);
+  expect::coords_are_superset(slice(s), array, "");
   data().validateSlice(s, array.data());
   // Apply changes
   masks().setSlice(s, array.masks());

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -125,14 +125,14 @@ DataArray DataArray::slice(const Slice &s) const {
 }
 
 void DataArray::validateSlice(const Slice &s, const DataArray &array) const {
-  expect::coordsAreSuperset(slice(s), array);
+  expect::coords_are_superset(slice(s), array);
   data().validateSlice(s, array.data());
   masks().validateSlice(s, array.masks());
 }
 
 DataArray &DataArray::setSlice(const Slice &s, const DataArray &array) {
   // validateSlice, but not masks as otherwise repeated
-  expect::coordsAreSuperset(slice(s), array);
+  expect::coords_are_superset(slice(s), array);
   data().validateSlice(s, array.data());
   // Apply changes
   masks().setSlice(s, array.masks());

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -6,7 +6,7 @@
 #include "scipp/core/except.h"
 #include "scipp/dataset/dataset_util.h"
 #include "scipp/dataset/except.h"
-#include<iostream>
+
 namespace scipp::dataset {
 
 namespace {

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -193,7 +193,7 @@ Dataset Dataset::slice(const Slice s) const {
 
 Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
   // Validate slice on all items as a dry-run
-  expect::coords_are_superset(slice(s).coords(), data.coords());
+  expect::coords_are_superset(slice(s).coords(), data.coords(), "");
   for (const auto &[name, item] : m_data)
     item.validateSlice(s, data.m_data.at(name));
   // Only if all items checked for dry-run does modification go-ahead
@@ -204,7 +204,7 @@ Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
 
 Dataset &Dataset::setSlice(const Slice s, const DataArray &data) {
   // Validate slice on all items as a dry-run
-  expect::coords_are_superset(slice(s).coords(), data.coords());
+  expect::coords_are_superset(slice(s).coords(), data.coords(), "");
   for (const auto &item : m_data)
     item.second.validateSlice(s, data);
   // Only if all items checked for dry-run does modification go-ahead

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -157,7 +157,7 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
   setSizes(data.dims());
   for (auto &&[dim, coord] : data.coords()) {
     if (const auto it = m_coords.find(dim); it != m_coords.end())
-      expect::matchingCoord(dim, coord, it->second);
+      expect::matching_coord(dim, coord, it->second);
     else
       setCoord(dim, std::move(coord));
   }

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -157,7 +157,7 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
   setSizes(data.dims());
   for (auto &&[dim, coord] : data.coords()) {
     if (const auto it = m_coords.find(dim); it != m_coords.end())
-      expect::matching_coord(dim, coord, it->second);
+      expect::matching_coord(dim, coord, it->second, "set coord");
     else
       setCoord(dim, std::move(coord));
   }

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -6,7 +6,7 @@
 #include "scipp/core/except.h"
 #include "scipp/dataset/dataset_util.h"
 #include "scipp/dataset/except.h"
-
+#include<iostream>
 namespace scipp::dataset {
 
 namespace {
@@ -157,7 +157,7 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
   setSizes(data.dims());
   for (auto &&[dim, coord] : data.coords()) {
     if (const auto it = m_coords.find(dim); it != m_coords.end())
-      core::expect::equals(coord, it->second);
+      expect::matchingCoord(dim, coord, it->second);
     else
       setCoord(dim, std::move(coord));
   }

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -193,7 +193,7 @@ Dataset Dataset::slice(const Slice s) const {
 
 Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
   // Validate slice on all items as a dry-run
-  expect::coordsAreSuperset(slice(s).coords(), data.coords());
+  expect::coords_are_superset(slice(s).coords(), data.coords());
   for (const auto &[name, item] : m_data)
     item.validateSlice(s, data.m_data.at(name));
   // Only if all items checked for dry-run does modification go-ahead
@@ -204,7 +204,7 @@ Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
 
 Dataset &Dataset::setSlice(const Slice s, const DataArray &data) {
   // Validate slice on all items as a dry-run
-  expect::coordsAreSuperset(slice(s).coords(), data.coords());
+  expect::coords_are_superset(slice(s).coords(), data.coords());
   for (const auto &item : m_data)
     item.second.validateSlice(s, data);
   // Only if all items checked for dry-run does modification go-ahead

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -10,7 +10,7 @@
 namespace scipp::dataset {
 
 namespace {
-template <class T> void expectWritable(const T &dict) {
+template <class T> void expect_writable(const T &dict) {
   if (dict.is_readonly())
     throw except::DatasetError(
         "Read-only flag is set, cannot insert new or erase existing items.");
@@ -41,7 +41,7 @@ Dataset &Dataset::operator=(Dataset &&other) {
 ///
 /// Coordinates are not modified.
 void Dataset::clear() {
-  expectWritable(*this);
+  expect_writable(*this);
   m_data.clear();
   rebuildDims();
 }
@@ -69,7 +69,7 @@ bool Dataset::contains(const std::string &name) const noexcept {
 ///
 /// Coordinates are not modified.
 void Dataset::erase(const std::string &name) {
-  expectWritable(*this);
+  expect_writable(*this);
   scipp::expect::contains(*this, name);
   m_data.erase(std::string(name));
   rebuildDims();
@@ -111,7 +111,7 @@ void Dataset::rebuildDims() {
 
 /// Set (insert or replace) the coordinate for the given dimension.
 void Dataset::setCoord(const Dim dim, Variable coord) {
-  expectWritable(*this);
+  expect_writable(*this);
   bool set_sizes = true;
   for (const auto &coord_dim : coord.dims())
     if (is_edges(m_coords.sizes(), coord.dims(), coord_dim))
@@ -128,7 +128,7 @@ void Dataset::setCoord(const Dim dim, Variable coord) {
 /// AttrPolicy::Keep is specified.
 void Dataset::setData(const std::string &name, Variable data,
                       const AttrPolicy attrPolicy) {
-  expectWritable(*this);
+  expect_writable(*this);
   setSizes(data.dims());
   const auto replace = contains(name);
   if (replace && attrPolicy == AttrPolicy::Keep)
@@ -153,7 +153,7 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
         it->attrs() == data.attrs() && it->coords() == data.coords())
       return;
   }
-  expectWritable(*this);
+  expect_writable(*this);
   setSizes(data.dims());
   for (auto &&[dim, coord] : data.coords()) {
     if (const auto it = m_coords.find(dim); it != m_coords.end())

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -12,7 +12,8 @@
 
 namespace scipp::dataset {
 
-template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
+template <class T1, class T2>
+auto union_(const T1 &a, const T2 &b, const std::string_view opname) {
   std::unordered_map<typename T1::key_type, typename T1::mapped_type> out;
 
   for (const auto &[key, item] : a)
@@ -20,7 +21,7 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
 
   for (const auto &item : b) {
     if (const auto it = a.find(item.first); it != a.end()) {
-      expect::matching_coord(it->first, it->second, item.second);
+      expect::matching_coord(it->first, it->second, item.second, opname);
     } else
       out.emplace(item.first, item.second);
   }

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -20,7 +20,7 @@ template <class T1, class T2> auto union_(const T1 &a, const T2 &b) {
 
   for (const auto &item : b) {
     if (const auto it = a.find(item.first); it != a.end()) {
-      expect::matchingCoord(it->first, it->second, item.second);
+      expect::matching_coord(it->first, it->second, item.second);
     } else
       out.emplace(item.first, item.second);
   }

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -57,7 +57,7 @@ void isKey(const Variable &key) {
   if (key.dims().ndim() != 1)
     throw except::DimensionError(
         "Coord for binning or grouping must be 1-dimensional");
-  if (key.hasVariances())
+  if (key.has_variances())
     throw except::VariancesError(
         "Coord for binning or grouping cannot have variances");
 }

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -53,7 +53,7 @@ void matching_coord(const Dim dim, const Variable &a, const Variable &b) {
     throw except::CoordMismatchError(dim, a, b);
 }
 
-void isKey(const Variable &key) {
+void is_key(const Variable &key) {
   if (key.dims().ndim() != 1)
     throw except::DimensionError(
         "Coord for binning or grouping must be 1-dimensional");

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -33,6 +33,14 @@ CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
                    "', expected\n" + format_variable(expected) + ", got\n" +
                    format_variable(actual)} {}
 
+CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
+                                       const Variable &actual,
+                                       const std::string_view opname)
+    : DatasetError{"Mismatch in coordinate '" + to_string(dim) +
+                   "' in operation '" + std::string(opname) + "':\n" +
+                   format_variable(expected) + "\nvs\n" +
+                   format_variable(actual)} {}
+
 } // namespace scipp::except
 
 namespace scipp::dataset::expect {
@@ -48,9 +56,10 @@ void coords_are_superset(const DataArray &a, const DataArray &b) {
   coords_are_superset(a.coords(), b.coords());
 }
 
-void matching_coord(const Dim dim, const Variable &a, const Variable &b) {
+void matching_coord(const Dim dim, const Variable &a, const Variable &b,
+                    const std::string_view opname) {
   if (a != b)
-    throw except::CoordMismatchError(dim, a, b);
+    throw except::CoordMismatchError(dim, a, b, opname);
 }
 
 void is_key(const Variable &key) {

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -36,7 +36,7 @@ CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
 } // namespace scipp::except
 
 namespace scipp::dataset::expect {
-void coordsAreSuperset(const Coords &a_coords, const Coords &b_coords) {
+void coords_are_superset(const Coords &a_coords, const Coords &b_coords) {
   for (const auto &b_coord : b_coords) {
     if (a_coords[b_coord.first] != b_coord.second)
       throw except::CoordMismatchError(b_coord.first, a_coords[b_coord.first],
@@ -44,8 +44,8 @@ void coordsAreSuperset(const Coords &a_coords, const Coords &b_coords) {
   }
 }
 
-void coordsAreSuperset(const DataArray &a, const DataArray &b) {
-  coordsAreSuperset(a.coords(), b.coords());
+void coords_are_superset(const DataArray &a, const DataArray &b) {
+  coords_are_superset(a.coords(), b.coords());
 }
 
 void matchingCoord(const Dim dim, const Variable &a, const Variable &b) {

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -48,7 +48,7 @@ void coords_are_superset(const DataArray &a, const DataArray &b) {
   coords_are_superset(a.coords(), b.coords());
 }
 
-void matchingCoord(const Dim dim, const Variable &a, const Variable &b) {
+void matching_coord(const Dim dim, const Variable &a, const Variable &b) {
   if (a != b)
     throw except::CoordMismatchError(dim, a, b);
 }

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -27,33 +27,38 @@ void throw_mismatch_error(const dataset::Dataset &expected,
                      to_string(actual) + '.' + optional_message);
 }
 
-CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
-                                       const Variable &actual)
-    : DatasetError{"Mismatch in coordinate '" + to_string(dim) +
-                   "', expected\n" + format_variable(expected) + ", got\n" +
-                   format_variable(actual)} {}
+namespace {
+auto format_coord_mismatch_message(const Dim dim, const Variable &a,
+                                   const Variable &b,
+                                   const std::string_view opname) {
+  std::string message = "Mismatch in coordinate '" + to_string(dim);
+  if (!opname.empty())
+    message += "' in operation '" + std::string(opname);
+  message += "':\n" + format_variable(a) + "\nvs\n" + format_variable(b);
+  return message;
+}
+} // namespace
 
-CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &expected,
-                                       const Variable &actual,
+CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &a,
+                                       const Variable &b,
                                        const std::string_view opname)
-    : DatasetError{"Mismatch in coordinate '" + to_string(dim) +
-                   "' in operation '" + std::string(opname) + "':\n" +
-                   format_variable(expected) + "\nvs\n" +
-                   format_variable(actual)} {}
+    : DatasetError{format_coord_mismatch_message(dim, a, b, opname)} {}
 
 } // namespace scipp::except
 
 namespace scipp::dataset::expect {
-void coords_are_superset(const Coords &a_coords, const Coords &b_coords) {
+void coords_are_superset(const Coords &a_coords, const Coords &b_coords,
+                         const std::string_view opname) {
   for (const auto &b_coord : b_coords) {
     if (a_coords[b_coord.first] != b_coord.second)
       throw except::CoordMismatchError(b_coord.first, a_coords[b_coord.first],
-                                       b_coord.second);
+                                       b_coord.second, opname);
   }
 }
 
-void coords_are_superset(const DataArray &a, const DataArray &b) {
-  coords_are_superset(a.coords(), b.coords());
+void coords_are_superset(const DataArray &a, const DataArray &b,
+                         const std::string_view opname) {
+  coords_are_superset(a.coords(), b.coords(), opname);
 }
 
 void matching_coord(const Dim dim, const Variable &a, const Variable &b,

--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -266,7 +266,7 @@ template <class T> struct NanSensitiveLess {
 
 template <class T> struct MakeGroups {
   static auto apply(const Variable &key, const Dim targetDim) {
-    expect::isKey(key);
+    expect::is_key(key);
     const auto &values = key.values<T>();
 
     const auto dim = key.dims().inner();
@@ -301,7 +301,7 @@ template <class T> struct MakeGroups {
 
 template <class T> struct MakeBinGroups {
   static auto apply(const Variable &key, const Variable &bins) {
-    expect::isKey(key);
+    expect::is_key(key);
     if (bins.dims().ndim() != 1)
       throw except::DimensionError("Group-by bins must be 1-dimensional");
     if (key.unit() != bins.unit())

--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -83,7 +83,7 @@ auto resize_array(const DataArray &da, const Dim reductionDim,
   DataArray dense_dummy(da);
   dense_dummy.setData(empty(da.dims(), variableFactory().elem_unit(da.data()),
                             variableFactory().elem_dtype(da.data()),
-                            variableFactory().hasVariances(da.data())));
+                            variableFactory().has_variances(da.data())));
   return resize_array(dense_dummy, reductionDim, size, fill);
 }
 } // namespace

--- a/lib/dataset/include/scipp/dataset/data_array.h
+++ b/lib/dataset/include/scipp/dataset/data_array.h
@@ -64,7 +64,7 @@ public:
   void setUnit(const units::Unit unit) { m_data->setUnit(unit); }
 
   /// Return true if the data array contains data variances.
-  bool hasVariances() const { return m_data->hasVariances(); }
+  bool has_variances() const { return m_data->has_variances(); }
 
   /// Return untyped const view for data (values and optional variances).
   const Variable &data() const { return *m_data; }

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -53,9 +53,9 @@ struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
 
 namespace scipp::dataset::expect {
 
-SCIPP_DATASET_EXPORT void coordsAreSuperset(const DataArray &a,
-                                            const DataArray &b);
-SCIPP_DATASET_EXPORT void coordsAreSuperset(const Coords &a, const Coords &b);
+SCIPP_DATASET_EXPORT void coords_are_superset(const DataArray &a,
+                                              const DataArray &b);
+SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b);
 SCIPP_DATASET_EXPORT void matchingCoord(const Dim dim, const Variable &a,
                                         const Variable &b);
 

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -56,8 +56,8 @@ namespace scipp::dataset::expect {
 SCIPP_DATASET_EXPORT void coords_are_superset(const DataArray &a,
                                               const DataArray &b);
 SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b);
-SCIPP_DATASET_EXPORT void matchingCoord(const Dim dim, const Variable &a,
-                                        const Variable &b);
+SCIPP_DATASET_EXPORT void matching_coord(const Dim dim, const Variable &a,
+                                         const Variable &b);
 
 SCIPP_DATASET_EXPORT void isKey(const Variable &key);
 

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -46,6 +46,8 @@ throw_mismatch_error(const dataset::Dataset &expected,
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
   CoordMismatchError(const Dim dim, const Variable &expected,
                      const Variable &actual);
+  CoordMismatchError(const Dim dim, const Variable &expected,
+                     const Variable &actual, std::string_view opname);
   using DatasetError::DatasetError;
 };
 
@@ -57,7 +59,8 @@ SCIPP_DATASET_EXPORT void coords_are_superset(const DataArray &a,
                                               const DataArray &b);
 SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b);
 SCIPP_DATASET_EXPORT void matching_coord(const Dim dim, const Variable &a,
-                                         const Variable &b);
+                                         const Variable &b,
+                                         std::string_view opname);
 
 SCIPP_DATASET_EXPORT void is_key(const Variable &key);
 

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -46,6 +46,7 @@ throw_mismatch_error(const dataset::Dataset &expected,
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
   CoordMismatchError(const Dim dim, const Variable &expected,
                      const Variable &actual);
+  using DatasetError::DatasetError;
 };
 
 } // namespace scipp::except

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -44,10 +44,8 @@ throw_mismatch_error(const dataset::Dataset &expected,
                      const std::string &optional_message);
 
 struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
-  CoordMismatchError(const Dim dim, const Variable &expected,
-                     const Variable &actual);
-  CoordMismatchError(const Dim dim, const Variable &expected,
-                     const Variable &actual, std::string_view opname);
+  CoordMismatchError(const Dim dim, const Variable &a, const Variable &b,
+                     std::string_view opname = "");
   using DatasetError::DatasetError;
 };
 
@@ -56,8 +54,10 @@ struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
 namespace scipp::dataset::expect {
 
 SCIPP_DATASET_EXPORT void coords_are_superset(const DataArray &a,
-                                              const DataArray &b);
-SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b);
+                                              const DataArray &b,
+                                              std::string_view opname);
+SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b,
+                                              std::string_view opname);
 SCIPP_DATASET_EXPORT void matching_coord(const Dim dim, const Variable &a,
                                          const Variable &b,
                                          std::string_view opname);

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -59,6 +59,6 @@ SCIPP_DATASET_EXPORT void coords_are_superset(const Coords &a, const Coords &b);
 SCIPP_DATASET_EXPORT void matching_coord(const Dim dim, const Variable &a,
                                          const Variable &b);
 
-SCIPP_DATASET_EXPORT void isKey(const Variable &key);
+SCIPP_DATASET_EXPORT void is_key(const Variable &key);
 
 } // namespace scipp::dataset::expect

--- a/lib/dataset/include/scipp/dataset/slice.h
+++ b/lib/dataset/include/scipp/dataset/slice.h
@@ -8,6 +8,20 @@
 
 namespace scipp::dataset {
 
+[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Dim, scipp::index>
+get_slice_params(const DataArray &data, const Dim dim, const Variable &value);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Dim, scipp::index, scipp::index>
+get_slice_params(const DataArray &data, const Dim dim, const Variable &begin,
+                 const Variable &end);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Dim, scipp::index>
+get_slice_params(const Dataset &data, const Dim dim, const Variable &value);
+
+[[nodiscard]] SCIPP_DATASET_EXPORT std::tuple<Dim, scipp::index, scipp::index>
+get_slice_params(const Dataset &data, const Dim dim, const Variable &begin,
+                 const Variable &end);
+
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray slice(const DataArray &data,
                                                    const Dim dim,
                                                    const Variable &value);

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -151,6 +151,19 @@ template <class Key, class Value> void Dict<Key, Value>::rebuildSizes() {
   m_sizes = std::move(new_sizes);
 }
 
+namespace {
+template <class Key>
+void expect_valid_coord_dims(const Key &key, const Dimensions &coord_dims,
+                             const Sizes &da_sizes) {
+  using core::to_string;
+  if (!da_sizes.includes(coord_dims))
+    throw except::DimensionError(
+        "Cannot add coord '" + to_string(key) + "' of dims " +
+        to_string(coord_dims) + " to DataArray with dims " +
+        to_string(Dimensions{da_sizes.labels(), da_sizes.sizes()}));
+}
+} // namespace
+
 template <class Key, class Value>
 void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
   if (contains(key) && at(key).is_same(coord))
@@ -168,8 +181,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
       break;
     }
   }
-  if (!m_sizes.includes(dims))
-    throw except::DimensionError("Cannot add coord exceeding DataArray dims");
+  expect_valid_coord_dims(key, dims, m_sizes);
   m_items.insert_or_assign(key, std::move(coord));
 }
 

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -9,6 +9,9 @@
 
 namespace scipp::dataset {
 
+template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
+template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
+
 namespace {
 template <class T> void expectWritable(const T &dict) {
   if (dict.is_readonly())
@@ -314,8 +317,5 @@ bool Dict<Key, Value>::item_applies_to(const Key &key,
   return std::all_of(val.dims().begin(), val.dims().end(),
                      [&dims](const Dim dim) { return dims.contains(dim); });
 }
-
-template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
-template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
 
 } // namespace scipp::dataset

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -13,7 +13,7 @@ template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
 
 namespace {
-template <class T> void expectWritable(const T &dict) {
+template <class T> void expect_writable(const T &dict) {
   if (dict.is_readonly())
     throw except::DataArrayError(
         "Read-only flag is set, cannot mutate metadata dict.");
@@ -168,7 +168,7 @@ template <class Key, class Value>
 void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
   if (contains(key) && at(key).is_same(coord))
     return;
-  expectWritable(*this);
+  expect_writable(*this);
   // Is a good definition for things that are allowed: "would be possible to
   // concat along existing dim or extra dim"?
   auto dims = coord.dims();
@@ -187,7 +187,7 @@ void Dict<Key, Value>::set(const key_type &key, mapped_type coord) {
 
 template <class Key, class Value>
 void Dict<Key, Value>::erase(const key_type &key) {
-  expectWritable(*this);
+  expect_writable(*this);
   scipp::expect::contains(*this, key);
   m_items.erase(key);
 }

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -9,9 +9,6 @@
 
 namespace scipp::dataset {
 
-template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
-template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
-
 namespace {
 template <class T> void expect_writable(const T &dict) {
   if (dict.is_readonly())
@@ -329,5 +326,8 @@ bool Dict<Key, Value>::item_applies_to(const Key &key,
   return std::all_of(val.dims().begin(), val.dims().end(),
                      [&dims](const Dim dim) { return dims.contains(dim); });
 }
+
+template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
+template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
 
 } // namespace scipp::dataset

--- a/lib/dataset/operations.cpp
+++ b/lib/dataset/operations.cpp
@@ -33,7 +33,7 @@ auto union_(const Dataset &a, const Dataset &b) {
 }
 
 Dataset merge(const Dataset &a, const Dataset &b) {
-  return Dataset(union_(a, b), union_(a.coords(), b.coords()));
+  return Dataset(union_(a, b), union_(a.coords(), b.coords(), "merge"));
 }
 
 Coords copy(const Coords &coords) { return {coords.sizes(), copy_map(coords)}; }

--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -246,7 +246,7 @@ Variable flatten_bin_edge(const Variable &var,
   auto out_dims = bulk.dims();
   // To make the container of the right size, we increase to_dim by 1
   out_dims.resize(to_dim, out_dims[to_dim] + 1);
-  auto out = empty(out_dims, var.unit(), var.dtype(), var.hasVariances());
+  auto out = empty(out_dims, var.unit(), var.dtype(), var.has_variances());
   copy(bulk, out.slice({to_dim, 0, out_dims[to_dim] - 1}));
   copy(back_flat.slice({to_dim, back.dims().volume() - 1}),
        out.slice({to_dim, out_dims[to_dim] - 1}));

--- a/lib/dataset/test/data_view_test.cpp
+++ b/lib/dataset/test/data_view_test.cpp
@@ -134,13 +134,13 @@ TYPED_TEST(DataArrayViewTest, coords_contains_only_relevant_2d) {
   ASSERT_FALSE(coords.contains(Dim::X));
 }
 
-TYPED_TEST(DataArrayViewTest, hasVariances) {
+TYPED_TEST(DataArrayViewTest, has_variances) {
   Dataset d;
   typename TestFixture::dataset_type &d_ref(d);
   d.setData("a", makeVariable<double>(Values{double{}}));
   d.setData("b", makeVariable<double>(Values{1}, Variances{1}));
-  ASSERT_FALSE(d_ref["a"].hasVariances());
-  ASSERT_TRUE(d_ref["b"].hasVariances());
+  ASSERT_FALSE(d_ref["a"].has_variances());
+  ASSERT_TRUE(d_ref["b"].has_variances());
 }
 
 TYPED_TEST(DataArrayViewTest, values_variances) {

--- a/lib/dataset/test/dataset_arithmetic_test.cpp
+++ b/lib/dataset/test/dataset_arithmetic_test.cpp
@@ -144,7 +144,7 @@ TYPED_TEST(DataArrayViewBinaryEqualsOpTest, lhs_without_variance) {
     auto target = copy(dataset_a["data_xyz"]);
     auto data_array = copy(target);
 
-    if (item.hasVariances()) {
+    if (item.has_variances()) {
       ASSERT_ANY_THROW(TestFixture::op(target, item));
     } else {
       auto reference = copy(target.data());
@@ -152,7 +152,7 @@ TYPED_TEST(DataArrayViewBinaryEqualsOpTest, lhs_without_variance) {
 
       ASSERT_NO_THROW(target = TestFixture::op(target, item));
       EXPECT_EQ(target.data(), reference);
-      EXPECT_FALSE(target.hasVariances());
+      EXPECT_FALSE(target.has_variances());
       EXPECT_EQ(TestFixture::op(data_array, item), target);
     }
   }

--- a/lib/dataset/test/slice_by_value_test.cpp
+++ b/lib/dataset/test/slice_by_value_test.cpp
@@ -29,7 +29,7 @@ constexpr auto make_histogram = make_array_common<1>;
 TEST(SliceByValueTest, test_dimension_not_found) {
   auto test = [](const auto &sliceable) {
     EXPECT_THROW(auto s = slice(sliceable, Dim::Y, {}, {}),
-                 except::NotFoundError);
+                 except::DimensionError);
   };
 
   auto var =

--- a/lib/dataset/util.cpp
+++ b/lib/dataset/util.cpp
@@ -38,7 +38,7 @@ scipp::index size_of(const Variable &view, const SizeofTag tag) {
   }
 
   const auto value_size = view.data().dtype_size();
-  const auto variance_scale = view.hasVariances() ? 2 : 1;
+  const auto variance_scale = view.has_variances() ? 2 : 1;
   const auto data_size =
       tag == SizeofTag::Underlying ? view.data().size() : view.dims().volume();
   return data_size * value_size * variance_scale;

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -68,7 +68,7 @@ class BinVariableMakerDataset
   void set_elem_unit(Variable &, const units::Unit &) const override {
     throw std::runtime_error("undefined");
   }
-  bool hasVariances(const Variable &) const override {
+  bool has_variances(const Variable &) const override {
     throw std::runtime_error("undefined");
   }
 };

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -255,7 +255,7 @@ public:
   }
 
   template <class Var> static py::object variances(py::object &object) {
-    if (!object.cast<Var &>().hasVariances())
+    if (!object.cast<Var &>().has_variances())
       return py::none();
     return get_py_array_t<get_variances, Var>(object);
   }
@@ -274,7 +274,7 @@ public:
   static void set_variances(Var &view, const py::object &obj) {
     if (obj.is_none())
       return remove_variances(view);
-    if (!view.hasVariances())
+    if (!view.has_variances())
       init_variances(view);
     set(view.dims(), view.unit(), get<get_variances>(view), obj);
   }
@@ -364,7 +364,7 @@ public:
       return as_ElementArrayViewImpl<const Ts...>::template variance<const Var>(
           obj);
     expect_scalar(view.dims(), "variance");
-    if (!view.hasVariances())
+    if (!view.has_variances())
       return py::none();
     return std::visit(GetScalarVisitor<decltype(view)>{obj, view},
                       get<get_variances>(view));
@@ -383,7 +383,7 @@ public:
     expect_scalar(view.dims(), "variance");
     if (obj.is_none())
       return remove_variances(view);
-    if (!view.hasVariances())
+    if (!view.has_variances())
       init_variances(view);
 
     std::visit(SetScalarVisitor<decltype(view)>{obj, view},

--- a/lib/python/bind_slice_methods.h
+++ b/lib/python/bind_slice_methods.h
@@ -49,7 +49,7 @@ auto from_py_slice(const T &source,
 template <class View> struct SetData {
   template <class T> struct Impl {
     static void apply(View &slice, const py::object &obj) {
-      if (slice.hasVariances())
+      if (slice.has_variances())
         throw std::runtime_error("Data object contains variances, to set data "
                                  "values use the `values` property or provide "
                                  "a tuple of values and variances.");

--- a/lib/python/bind_slice_methods.h
+++ b/lib/python/bind_slice_methods.h
@@ -65,11 +65,11 @@ auto get_slice(T &self, const std::tuple<Dim, scipp::index> &index) {
   auto [dim, i] = index;
   auto sz = dim_extent(self, dim);
   if (i < -sz || i >= sz) // index is out of range
-    throw std::runtime_error(
-        "The requested index " + std::to_string(i) +
-        " is out of range. Dimension size is " + std::to_string(sz) +
-        " and the allowed range is [" + std::to_string(-sz) + ":" +
-        std::to_string(sz - 1) + "].");
+    throw std::out_of_range("The requested index " + std::to_string(i) +
+                            " is out of range. Dimension size is " +
+                            std::to_string(sz) + " and the allowed range is [" +
+                            std::to_string(-sz) + ":" + std::to_string(sz - 1) +
+                            "].");
   if (i < 0)
     i = sz + i;
   return Slice(dim, i);

--- a/lib/python/bind_slice_methods.h
+++ b/lib/python/bind_slice_methods.h
@@ -122,7 +122,7 @@ template <class T> auto getitem(T &self, const py::ellipsis &) {
 template <class T> struct slicer {
   static auto get_slice_by_value(T &self,
                                  const std::tuple<Dim, Variable> &value) {
-    auto [dim, i] = value;
+    auto &[dim, i] = value;
     return std::make_from_tuple<Slice>(
         get_slice_params(self.dims(), self.coords()[dim], i));
   }

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -28,6 +28,7 @@ enum class DTypeKind : char {
   Datetime = 'M',
   Object = 'O',
   String = 'U',
+  RawData = 'V',
 };
 
 constexpr bool operator==(const char a, const DTypeKind b) {
@@ -120,7 +121,14 @@ scipp::core::DType scipp_dtype(const py::object &type) {
   try {
     return type.cast<DType>();
   } catch (const py::cast_error &) {
-    return scipp_dtype(py::dtype::from_args(type));
+    auto np_dtype = py::dtype::from_args(type);
+    if (np_dtype.kind() == DTypeKind::RawData) {
+      throw std::invalid_argument(
+          "Unsupported numpy dtype: raw data. This can happen when you pass a "
+          "Python object instead of a class. Got dtype=`" +
+          py::str(type).cast<std::string>() + '`');
+    }
+    return scipp_dtype(np_dtype);
   }
 }
 

--- a/lib/templates/dataset_binary.cpp.in
+++ b/lib/templates/dataset_binary.cpp.in
@@ -5,23 +5,16 @@
 #include "scipp/variable/@OPNAME@.h"
 #include "scipp/dataset/@OPNAME@.h"
 
-#include "scipp/dataset/except.h"
-
 #include "dataset_operations_common.h"
 
 namespace scipp::dataset {
 
 DataArray @NAME@(const DataArray &a, const DataArray &b) {
-  try {
-    return DataArray(
-        @NAME@(a.data(), b.data()),
-        union_(a.coords(), b.coords()),
-        union_or(a.masks(), b.masks()),
-        intersection(a.attrs(), b.attrs()));
-  } catch(except::CoordMismatchError &err) {
-    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
-                                     + err.what());
-  }
+  return DataArray(
+      @NAME@(a.data(), b.data()),
+      union_(a.coords(), b.coords(), "@OPNAME@"),
+      union_or(a.masks(), b.masks()),
+      intersection(a.attrs(), b.attrs()));
 }
 
 DataArray @NAME@(const DataArray &a, const Variable &b) {

--- a/lib/templates/dataset_binary.cpp.in
+++ b/lib/templates/dataset_binary.cpp.in
@@ -5,16 +5,23 @@
 #include "scipp/variable/@OPNAME@.h"
 #include "scipp/dataset/@OPNAME@.h"
 
+#include "scipp/dataset/except.h"
+
 #include "dataset_operations_common.h"
 
 namespace scipp::dataset {
 
 DataArray @NAME@(const DataArray &a, const DataArray &b) {
-  return DataArray(
-      @NAME@(a.data(), b.data()),
-      union_(a.coords(), b.coords()),
-      union_or(a.masks(), b.masks()),
-      intersection(a.attrs(), b.attrs()));
+  try {
+    return DataArray(
+        @NAME@(a.data(), b.data()),
+        union_(a.coords(), b.coords()),
+        union_or(a.masks(), b.masks()),
+        intersection(a.attrs(), b.attrs()));
+  } catch(except::CoordMismatchError &err) {
+    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
+                                     + err.what());
+  }
 }
 
 DataArray @NAME@(const DataArray &a, const Variable &b) {

--- a/lib/templates/dataset_binary.cpp.in
+++ b/lib/templates/dataset_binary.cpp.in
@@ -10,11 +10,14 @@
 namespace scipp::dataset {
 
 DataArray @NAME@(const DataArray &a, const DataArray &b) {
+  auto coords = union_(a.coords(), b.coords(), "@OPNAME@");
+  auto masks = union_or(a.masks(), b.masks());
+  auto attrs = intersection(a.attrs(), b.attrs());
   return DataArray(
       @NAME@(a.data(), b.data()),
-      union_(a.coords(), b.coords(), "@OPNAME@"),
-      union_or(a.masks(), b.masks()),
-      intersection(a.attrs(), b.attrs()));
+      std::move(coords),
+      std::move(masks),
+      std::move(attrs));
 }
 
 DataArray @NAME@(const DataArray &a, const Variable &b) {

--- a/lib/templates/dataset_inplace.cpp.in
+++ b/lib/templates/dataset_inplace.cpp.in
@@ -15,7 +15,7 @@ DataArray &@NAME@(DataArray &lhs, const Variable &rhs) {
 }
 DataArray &@NAME@(DataArray &lhs, const DataArray &rhs) {
   try {
-    expect::coordsAreSuperset(lhs, rhs);
+    expect::coords_are_superset(lhs, rhs);
     union_or_in_place(lhs.masks(), rhs.masks());
     @NAME@(lhs.data(), rhs.data());
     return lhs;
@@ -30,7 +30,7 @@ DataArray @NAME@(DataArray &&lhs, const Variable &rhs) {
 }
 DataArray @NAME@(DataArray &&lhs, const DataArray &rhs) {
   try {
-    expect::coordsAreSuperset(lhs, rhs);
+    expect::coords_are_superset(lhs, rhs);
     union_or_in_place(lhs.masks(), rhs.masks());
     return @NAME@(std::move(lhs), rhs.data());
   } catch(except::CoordMismatchError &err) {

--- a/lib/templates/dataset_inplace.cpp.in
+++ b/lib/templates/dataset_inplace.cpp.in
@@ -14,19 +14,29 @@ DataArray &@NAME@(DataArray &lhs, const Variable &rhs) {
   return lhs;
 }
 DataArray &@NAME@(DataArray &lhs, const DataArray &rhs) {
-  expect::coordsAreSuperset(lhs, rhs);
-  union_or_in_place(lhs.masks(), rhs.masks());
-  @NAME@(lhs.data(), rhs.data());
-  return lhs;
+  try {
+    expect::coordsAreSuperset(lhs, rhs);
+    union_or_in_place(lhs.masks(), rhs.masks());
+    @NAME@(lhs.data(), rhs.data());
+    return lhs;
+  } catch(except::CoordMismatchError &err) {
+    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
+                                     + err.what());
+  }
 }
 DataArray @NAME@(DataArray &&lhs, const Variable &rhs) {
   @NAME@(lhs.data(), rhs);
   return std::move(lhs);
 }
 DataArray @NAME@(DataArray &&lhs, const DataArray &rhs) {
-  expect::coordsAreSuperset(lhs, rhs);
-  union_or_in_place(lhs.masks(), rhs.masks());
-  return @NAME@(std::move(lhs), rhs.data());
+  try {
+    expect::coordsAreSuperset(lhs, rhs);
+    union_or_in_place(lhs.masks(), rhs.masks());
+    return @NAME@(std::move(lhs), rhs.data());
+  } catch(except::CoordMismatchError &err) {
+    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
+                                     + err.what());
+  }
 }
 
 } // namespace scipp::dataset

--- a/lib/templates/dataset_inplace.cpp.in
+++ b/lib/templates/dataset_inplace.cpp.in
@@ -14,29 +14,19 @@ DataArray &@NAME@(DataArray &lhs, const Variable &rhs) {
   return lhs;
 }
 DataArray &@NAME@(DataArray &lhs, const DataArray &rhs) {
-  try {
-    expect::coords_are_superset(lhs, rhs);
-    union_or_in_place(lhs.masks(), rhs.masks());
-    @NAME@(lhs.data(), rhs.data());
-    return lhs;
-  } catch(except::CoordMismatchError &err) {
-    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
-                                     + err.what());
-  }
+  expect::coords_are_superset(lhs, rhs, "@OPNAME@");
+  union_or_in_place(lhs.masks(), rhs.masks());
+  @NAME@(lhs.data(), rhs.data());
+  return lhs;
 }
 DataArray @NAME@(DataArray &&lhs, const Variable &rhs) {
   @NAME@(lhs.data(), rhs);
   return std::move(lhs);
 }
 DataArray @NAME@(DataArray &&lhs, const DataArray &rhs) {
-  try {
-    expect::coords_are_superset(lhs, rhs);
-    union_or_in_place(lhs.masks(), rhs.masks());
-    return @NAME@(std::move(lhs), rhs.data());
-  } catch(except::CoordMismatchError &err) {
-    throw except::CoordMismatchError(std::string{"In operation '@OPNAME@': "}
-                                     + err.what());
-  }
+  expect::coords_are_superset(lhs, rhs, "@OPNAME@");
+  union_or_in_place(lhs.masks(), rhs.masks());
+  return @NAME@(std::move(lhs), rhs.data());
 }
 
 } // namespace scipp::dataset

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -69,7 +69,7 @@ Variable resize_default_init(const Variable &var, const Dim dim,
   // Using variableFactory instead of variable::resize for creating
   // _uninitialized_ variable.
   return variable::variableFactory().create(var.dtype(), dims, var.unit(),
-                                            var.hasVariances());
+                                            var.has_variances());
 }
 
 /// Construct a bin-variable over a variable.

--- a/lib/variable/comparison.cpp
+++ b/lib/variable/comparison.cpp
@@ -17,7 +17,7 @@ using namespace scipp::core;
 namespace scipp::variable {
 
 namespace {
-Variable _values(Variable &&in) { return in.hasVariances() ? values(in) : in; }
+Variable _values(Variable &&in) { return in.has_variances() ? values(in) : in; }
 } // namespace
 
 Variable isclose(const Variable &a, const Variable &b, const Variable &rtol,
@@ -30,7 +30,7 @@ Variable isclose(const Variable &a, const Variable &b, const Variable &rtol,
                Dim::InternalStructureComponent);
 
   auto tol = atol + rtol * abs(b);
-  if (a.hasVariances() && b.hasVariances()) {
+  if (a.has_variances() && b.has_variances()) {
     return isclose(values(a), values(b), rtol, atol, equal_nans) &
            isclose(stddevs(a), stddevs(b), rtol, atol, equal_nans);
   } else {

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -31,7 +31,7 @@ public:
           "elements? This can be set, e.g., with `array.bins.unit = 'm'`.");
   }
 
-  bool hasVariances() const noexcept override { return false; }
+  bool has_variances() const noexcept override { return false; }
   const Indices &bin_indices() const override { return indices(); }
 
   const auto &indices() const { return m_indices; }

--- a/lib/variable/include/scipp/variable/bin_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/bin_array_variable.tcc
@@ -160,8 +160,8 @@ public:
     else
       return !std::get<2>(var.constituents<T>()).masks().empty();
   }
-  bool hasVariances(const Variable &var) const override {
-    return std::get<2>(var.constituents<T>()).hasVariances();
+  bool has_variances(const Variable &var) const override {
+    return std::get<2>(var.constituents<T>()).has_variances();
   }
   core::ElementArrayViewParams
   array_params(const Variable &var) const override {

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -60,7 +60,7 @@ public:
 
   VariableConceptHandle clone() const override;
 
-  bool hasVariances() const noexcept override {
+  bool has_variances() const noexcept override {
     return m_variances.has_value();
   }
 
@@ -94,7 +94,7 @@ public:
 
 private:
   void expectHasVariances() const {
-    if (!hasVariances())
+    if (!has_variances())
       throw except::VariancesError("Variable does not have variances.");
   }
   element_array<T> m_values;

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -71,11 +71,11 @@ public:
     return ElementArrayView(base, m_values.data());
   }
   auto variances(const core::ElementArrayViewParams &base) const {
-    expectHasVariances();
+    expect_has_variances();
     return ElementArrayView(base, m_variances->data());
   }
   auto variances(const core::ElementArrayViewParams &base) {
-    expectHasVariances();
+    expect_has_variances();
     return ElementArrayView(base, m_variances->data());
   }
 
@@ -93,7 +93,7 @@ public:
   }
 
 private:
-  void expectHasVariances() const {
+  void expect_has_variances() const {
     if (!has_variances())
       throw except::VariancesError("Variable does not have variances.");
   }

--- a/lib/variable/include/scipp/variable/element_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/element_array_variable.tcc
@@ -104,7 +104,8 @@ ElementArrayModel<T>::makeDefaultFromParent(const scipp::index size) const {
 template <class T>
 bool ElementArrayModel<T>::equals(const Variable &a, const Variable &b) const {
   return equals_impl(a.values<T>(), b.values<T>()) &&
-         (!a.has_variances() || equals_impl(a.variances<T>(), b.variances<T>()));
+         (!a.has_variances() ||
+          equals_impl(a.variances<T>(), b.variances<T>()));
 }
 
 template <class T>

--- a/lib/variable/include/scipp/variable/element_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/element_array_variable.tcc
@@ -51,8 +51,8 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   void set_elem_unit(Variable &var, const units::Unit &u) const override {
     var.setUnit(u);
   }
-  bool hasVariances(const Variable &var) const override {
-    return var.hasVariances();
+  bool has_variances(const Variable &var) const override {
+    return var.has_variances();
   }
   Variable empty_like(const Variable &prototype,
                       const std::optional<Dimensions> &shape,
@@ -61,7 +61,7 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
       throw except::TypeError(
           "Cannot specify sizes in `empty_like` for non-bin prototype.");
     return create(prototype.dtype(), shape ? *shape : prototype.dims(),
-                  prototype.unit(), prototype.hasVariances(), {});
+                  prototype.unit(), prototype.has_variances(), {});
   }
 };
 
@@ -89,7 +89,7 @@ template <class T> VariableConceptHandle ElementArrayModel<T>::clone() const {
 template <class T>
 VariableConceptHandle
 ElementArrayModel<T>::makeDefaultFromParent(const scipp::index size) const {
-  if (hasVariances())
+  if (has_variances())
     return std::make_shared<ElementArrayModel<T>>(
         size, unit(), element_array<T>(size), element_array<T>(size));
   else
@@ -104,7 +104,7 @@ ElementArrayModel<T>::makeDefaultFromParent(const scipp::index size) const {
 template <class T>
 bool ElementArrayModel<T>::equals(const Variable &a, const Variable &b) const {
   return equals_impl(a.values<T>(), b.values<T>()) &&
-         (!a.hasVariances() || equals_impl(a.variances<T>(), b.variances<T>()));
+         (!a.has_variances() || equals_impl(a.variances<T>(), b.variances<T>()));
 }
 
 template <class T>
@@ -119,7 +119,7 @@ void ElementArrayModel<T>::setVariances(const Variable &variances) {
   if (!variances.is_valid())
     return m_variances.reset();
   // TODO Could move if refcount is 1?
-  if (variances.hasVariances())
+  if (variances.has_variances())
     throw except::VariancesError(
         "Cannot set variances from variable with variances.");
   m_variances.emplace(

--- a/lib/variable/include/scipp/variable/element_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/element_array_variable.tcc
@@ -46,7 +46,7 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
   }
   void expect_can_set_elem_unit(const Variable &var,
                                 const units::Unit &u) const override {
-    var.expectCanSetUnit(u);
+    var.expect_can_set_unit(u);
   }
   void set_elem_unit(Variable &var, const units::Unit &u) const override {
     var.setUnit(u);

--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -56,7 +56,7 @@ public:
   void copy(const Variable &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;
 
-  bool hasVariances() const noexcept override { return false; }
+  bool has_variances() const noexcept override { return false; }
   void setVariances(const Variable &) override {
     except::throw_cannot_have_variances(core::dtype<T>);
   }

--- a/lib/variable/include/scipp/variable/transform.h
+++ b/lib/variable/include/scipp/variable/transform.h
@@ -316,7 +316,7 @@ template <class Op, class Out, class Tuple, class Arg, class... Args>
 static void do_transform(Op op, Out &&out, Tuple &&processed, const Arg &arg,
                          const Args &... args) {
   auto vals = arg.values();
-  if (arg.hasVariances()) {
+  if (arg.has_variances()) {
     if constexpr (std::is_base_of_v<
                       core::transform_flags::expect_no_variance_arg_t<
                           std::tuple_size_v<Tuple>>,
@@ -340,10 +340,10 @@ static void do_transform(Op op, Out &&out, Tuple &&processed, const Arg &arg,
           std::tuple_cat(processed, std::tuple(ValuesAndVariances{vals, vars})),
           args...);
     }
-    // else {}  // Cannot happen because args.hasVariances()
+    // else {}  // Cannot happen because args.has_variances()
     //             implies canHaveVariances<value_type>.
     //             The 2nd test is needed to avoid compilation errors
-    //             (hasVariances is a runtime check).
+    //             (has_variances is a runtime check).
   } else {
     if constexpr (std::is_base_of_v<
                       core::transform_flags::expect_variance_arg_t<
@@ -359,7 +359,7 @@ static void do_transform(Op op, Out &&out, Tuple &&processed, const Arg &arg,
 
 template <class T> struct as_view {
   using value_type = typename T::value_type;
-  [[nodiscard]] bool hasVariances() const { return data.hasVariances(); }
+  [[nodiscard]] bool has_variances() const { return data.has_variances(); }
   auto values() const { return decltype(data.values())(data.values(), dims); }
   auto variances() const {
     return decltype(data.variances())(data.variances(), dims);
@@ -376,7 +376,7 @@ template <class Op> struct Transform {
     using Out = decltype(maybe_eval(op(handles.values()[0]...)));
     const bool variances =
         !std::is_base_of_v<core::transform_flags::no_out_variance_t, Op> &&
-        core::canHaveVariances<Out>() && (handles.hasVariances() || ...);
+        core::canHaveVariances<Out>() && (handles.has_variances() || ...);
     auto unit = op.base_op()(variableFactory().elem_unit(*handles.m_var)...);
     auto out = variableFactory().create(dtype<Out>, dims, unit, variances,
                                         *handles.m_var...);
@@ -523,7 +523,7 @@ template <bool dry_run> struct in_place {
                                     const Args &... args) {
     using namespace detail;
     auto vals = arg.values();
-    if (arg.hasVariances()) {
+    if (arg.has_variances()) {
       if constexpr (std::is_base_of_v<
                         core::transform_flags::expect_no_variance_arg_t<
                             std::tuple_size_v<Tuple>>,

--- a/lib/variable/include/scipp/variable/transform_subspan.h
+++ b/lib/variable/include/scipp/variable/transform_subspan.h
@@ -37,7 +37,7 @@ transform_subspan_impl(const DType type, const Dim dim, const scipp::index size,
       std::is_base_of_v<core::transform_flags::expect_variance_arg_t<0>, Op> ||
       (std::is_base_of_v<
            core::transform_flags::expect_in_variance_if_out_variance_t, Op> &&
-       (var.hasVariances() || ...));
+       (var.has_variances() || ...));
   Variable out =
       variableFactory().create(type, dims, op(var.unit()...), variance);
 

--- a/lib/variable/include/scipp/variable/variable.h
+++ b/lib/variable/include/scipp/variable/variable.h
@@ -63,7 +63,7 @@ public:
 
   [[nodiscard]] const units::Unit &unit() const;
   void setUnit(const units::Unit &unit);
-  void expectCanSetUnit(const units::Unit &) const;
+  void expect_can_set_unit(const units::Unit &unit) const;
 
   [[nodiscard]] const Dimensions &dims() const;
   [[nodiscard]] Dim dim() const;

--- a/lib/variable/include/scipp/variable/variable.h
+++ b/lib/variable/include/scipp/variable/variable.h
@@ -152,7 +152,7 @@ private:
   template <class T, class... Index>
   Variable elements_impl(Index... index) const;
 
-  void expectWritable() const;
+  void expect_writable() const;
 
   Dimensions m_dims;
   Strides m_strides;

--- a/lib/variable/include/scipp/variable/variable.h
+++ b/lib/variable/include/scipp/variable/variable.h
@@ -75,7 +75,7 @@ public:
   [[nodiscard]] scipp::index stride(const Dim dim) const;
   [[nodiscard]] scipp::index offset() const;
 
-  [[nodiscard]] bool hasVariances() const;
+  [[nodiscard]] bool has_variances() const;
 
   template <class T> ElementArrayView<const T> values() const;
   template <class T> ElementArrayView<T> values();

--- a/lib/variable/include/scipp/variable/variable_concept.h
+++ b/lib/variable/include/scipp/variable/variable_concept.h
@@ -47,7 +47,7 @@ public:
 
   virtual void setUnit(const units::Unit &unit) { m_unit = unit; }
 
-  virtual bool hasVariances() const noexcept = 0;
+  virtual bool has_variances() const noexcept = 0;
   virtual void setVariances(const Variable &variances) = 0;
 
   virtual bool equals(const Variable &a, const Variable &b) const = 0;

--- a/lib/variable/include/scipp/variable/variable_factory.h
+++ b/lib/variable/include/scipp/variable/variable_factory.h
@@ -33,7 +33,7 @@ public:
                                         const units::Unit &u) const = 0;
   virtual void set_elem_unit(Variable &var, const units::Unit &u) const = 0;
   virtual bool has_masks(const Variable &) const { return false; }
-  virtual bool hasVariances(const Variable &var) const = 0;
+  virtual bool has_variances(const Variable &var) const = 0;
   virtual const Variable &data(const Variable &) const { throw unreachable(); }
   virtual Variable data(Variable &) const { throw unreachable(); }
   virtual core::ElementArrayViewParams array_params(const Variable &) const {
@@ -50,7 +50,7 @@ SCIPP_VARIABLE_EXPORT bool is_bins(const Variable &var);
 ///
 /// The factory can be used for creating variables with a dtype that is not
 /// known in the current module, e.g., dtype<bucket<Dataset>> can be used in
-/// scipp::variable. The main prupose of this is the implementation of
+/// scipp::variable. The main purpose of this is the implementation of
 /// `transform`.
 class SCIPP_VARIABLE_EXPORT VariableFactory {
 private:
@@ -80,7 +80,7 @@ public:
                                 const units::Unit &u) const;
   void set_elem_unit(Variable &var, const units::Unit &u) const;
   bool has_masks(const Variable &var) const;
-  bool hasVariances(const Variable &var) const;
+  bool has_variances(const Variable &var) const;
   template <class T, class Var> auto values(Var &&var) const {
     if (!is_bins(var))
       return var.template values<T>();

--- a/lib/variable/include/scipp/variable/visit.h
+++ b/lib/variable/include/scipp/variable/visit.h
@@ -25,7 +25,7 @@ template <class T, class Var> struct VariableAccess {
   Dimensions dims() const { return m_var->dims(); }
   auto values() const { return variableFactory().values<T>(*m_var); }
   auto variances() const { return variableFactory().variances<T>(*m_var); }
-  bool hasVariances() const { return variableFactory().hasVariances(*m_var); }
+  bool has_variances() const { return variableFactory().has_variances(*m_var); }
   Variable clone() const { return copy(*m_var); }
   Var *m_var{nullptr};
 };

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -39,7 +39,7 @@ Variable make_accumulant(const Variable &var, const Dim dim,
   dims.erase(dim);
   auto prototype = empty(dims, variableFactory().elem_unit(var),
                          variableFactory().elem_dtype(var),
-                         variableFactory().hasVariances(var));
+                         variableFactory().has_variances(var));
   return special_like(prototype, init);
 }
 

--- a/lib/variable/slice.cpp
+++ b/lib/variable/slice.cpp
@@ -53,7 +53,7 @@ auto get_coord(const Variable &coord, const Dim dim) {
 std::tuple<Dim, scipp::index> get_slice_params(const Sizes &dims,
                                                const Variable &coord_,
                                                const Variable &value) {
-  core::expect::equals(value.dims(), Dimensions{});
+  core::expect::equals(Dimensions{}, value.dims());
   const auto dim = coord_.dims().inner();
   if (dims[dim] + 1 == coord_.dims()[dim]) {
     const auto &[coord, ascending] = get_coord(coord_, dim);
@@ -74,9 +74,9 @@ std::tuple<Dim, scipp::index, scipp::index>
 get_slice_params(const Sizes &dims, const Variable &coord_,
                  const Variable &begin, const Variable &end) {
   if (begin.is_valid())
-    core::expect::equals(begin.dims(), Dimensions{});
+    core::expect::equals(Dimensions{}, begin.dims());
   if (end.is_valid())
-    core::expect::equals(end.dims(), Dimensions{});
+    core::expect::equals(Dimensions{}, end.dims());
   const auto dim = coord_.dims().inner();
   const auto &[coord, ascending] = get_coord(coord_, dim);
   scipp::index first = 0;

--- a/lib/variable/string.cpp
+++ b/lib/variable/string.cpp
@@ -85,7 +85,7 @@ std::string format_variable(const Variable &variable,
     s << colSep << make_dims_labels(variable, datasetSizes);
   s << colSep;
   s << apply<ValuesToString>(variable.dtype(), variable);
-  if (variable.hasVariances())
+  if (variable.has_variances())
     s << colSep << apply<VariancesToString>(variable.dtype(), variable);
   return s.str();
 }

--- a/lib/variable/subspan_view.cpp
+++ b/lib/variable/subspan_view.cpp
@@ -39,7 +39,7 @@ template <class T, class Var>
 Variable subspan_view(Var &var, const Dim dim, const Variable &indices) {
   auto subspans =
       make_subspans(var.template values<T>().data(), indices, var.stride(dim));
-  if (var.hasVariances())
+  if (var.has_variances())
     subspans.setVariances(make_subspans(var.template variances<T>().data(),
                                         indices, var.stride(dim)));
   subspans.setUnit(var.unit());

--- a/lib/variable/test/bin_array_model_test.cpp
+++ b/lib/variable/test/bin_array_model_test.cpp
@@ -77,9 +77,9 @@ TEST_F(BucketModelTest, dtype) {
 
 TEST_F(BucketModelTest, variances) {
   Model model(indices.data_handle(), Dim::X, buffer);
-  EXPECT_FALSE(model.hasVariances());
+  EXPECT_FALSE(model.has_variances());
   EXPECT_THROW(model.setVariances(Variable(buffer)), except::VariancesError);
-  EXPECT_FALSE(model.hasVariances());
+  EXPECT_FALSE(model.has_variances());
 }
 
 TEST_F(BucketModelTest, comparison) {

--- a/lib/variable/test/copy_test.cpp
+++ b/lib/variable/test/copy_test.cpp
@@ -20,7 +20,7 @@ protected:
     EXPECT_NE(&a.dims(), &b.dims());
     EXPECT_NE(&a.unit(), &b.unit());
     EXPECT_NE(a.values<double>().data(), b.values<double>().data());
-    if (a.hasVariances()) {
+    if (a.has_variances()) {
       EXPECT_NE(a.variances<double>().data(), b.variances<double>().data());
     }
   }

--- a/lib/variable/test/creation_test.cpp
+++ b/lib/variable/test/creation_test.cpp
@@ -15,12 +15,12 @@ TEST(CreationTest, empty) {
   EXPECT_EQ(var1.dims(), dims);
   EXPECT_EQ(var1.unit(), units::m);
   EXPECT_EQ(var1.dtype(), dtype<double>);
-  EXPECT_EQ(var1.hasVariances(), true);
+  EXPECT_EQ(var1.has_variances(), true);
   const auto var2 = variable::empty(dims, units::s, dtype<int32_t>);
   EXPECT_EQ(var2.dims(), dims);
   EXPECT_EQ(var2.unit(), units::s);
   EXPECT_EQ(var2.dtype(), dtype<int32_t>);
-  EXPECT_EQ(var2.hasVariances(), false);
+  EXPECT_EQ(var2.has_variances(), false);
 }
 
 TEST(CreationTest, ones) {
@@ -48,7 +48,7 @@ TEST_P(DenseVariablesTest, empty_like_default_shape) {
   EXPECT_EQ(empty.dtype(), var.dtype());
   EXPECT_EQ(empty.dims(), var.dims());
   EXPECT_EQ(empty.unit(), var.unit());
-  EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+  EXPECT_EQ(empty.has_variances(), var.has_variances());
 }
 
 TEST_P(DenseVariablesTest, empty_like_slice_default_shape) {
@@ -58,7 +58,7 @@ TEST_P(DenseVariablesTest, empty_like_slice_default_shape) {
     EXPECT_EQ(empty.dtype(), var.dtype());
     EXPECT_EQ(empty.dims(), var.slice({Dim::X, 0}).dims());
     EXPECT_EQ(empty.unit(), var.unit());
-    EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+    EXPECT_EQ(empty.has_variances(), var.has_variances());
   }
 }
 
@@ -69,7 +69,7 @@ TEST_P(DenseVariablesTest, empty_like) {
   EXPECT_EQ(empty.dtype(), var.dtype());
   EXPECT_EQ(empty.dims(), dims);
   EXPECT_EQ(empty.unit(), var.unit());
-  EXPECT_EQ(empty.hasVariances(), var.hasVariances());
+  EXPECT_EQ(empty.has_variances(), var.has_variances());
 }
 
 TEST(CreationTest, special_like_double) {

--- a/lib/variable/test/operations_test.cpp
+++ b/lib/variable/test/operations_test.cpp
@@ -693,7 +693,7 @@ TEST(VariableTest, binary_op_with_variance) {
       Dims{Dim::X, Dim::Y}, Shape{2, 3}, Values{2.0, 4.0, 6.0, 8.0, 10.0, 12.0},
       Variances{0.2, 0.4, 0.6, 0.8, 1.0, 1.2});
   auto tmp = var + var;
-  EXPECT_TRUE(tmp.hasVariances());
+  EXPECT_TRUE(tmp.has_variances());
   EXPECT_EQ(tmp.variances<double>()[0], 0.2);
   EXPECT_EQ(var + var, sum);
 

--- a/lib/variable/test/special_values_test.cpp
+++ b/lib/variable/test/special_values_test.cpp
@@ -70,7 +70,7 @@ template <typename Op> void check_no_out_variances(Op op) {
   const auto var = makeVariable<double>(Dimensions{Dim::Z, 2}, units::m,
                                         Values{1.0, 2.0}, Variances{1.0, 2.0});
   const Variable applied = op(var);
-  EXPECT_FALSE(applied.hasVariances());
+  EXPECT_FALSE(applied.has_variances());
   const Variable applied_on_values = op(values(var));
   EXPECT_EQ(applied, applied_on_values);
 }

--- a/lib/variable/test/subspan_view_test.cpp
+++ b/lib/variable/test/subspan_view_test.cpp
@@ -30,7 +30,7 @@ TEST_F(SubspanViewTest, values) {
   EXPECT_EQ(view.unit(), units::m);
   EXPECT_TRUE(equals(view.values<std::span<double>>()[0], {1, 2, 3}));
   EXPECT_TRUE(equals(view.values<std::span<double>>()[1], {4, 5, 6}));
-  EXPECT_FALSE(view.hasVariances());
+  EXPECT_FALSE(view.has_variances());
 }
 
 TEST_F(SubspanViewTest, values_length_0) {
@@ -41,7 +41,7 @@ TEST_F(SubspanViewTest, values_length_0) {
   // &` overload.
   EXPECT_TRUE(view.values<std::span<const double>>()[0].empty());
   EXPECT_TRUE(view.values<std::span<const double>>()[1].empty());
-  EXPECT_FALSE(view.hasVariances());
+  EXPECT_FALSE(view.has_variances());
 }
 
 TEST_F(SubspanViewTest, values_and_errors) {

--- a/lib/variable/test/transform_binary_test.cpp
+++ b/lib/variable/test/transform_binary_test.cpp
@@ -342,7 +342,7 @@ Variable compute_on_bin_buffer(const Variable &a, const Variable &b,
 
 Variable element_as_scalar(const Variable &var, const scipp::index i) {
   const auto val = var.values<double>()[i];
-  if (var.hasVariances())
+  if (var.has_variances())
     return makeVariable<double>(Shape{}, Values{val},
                                 Variances{var.variances<double>()[i]});
   return makeVariable<double>(Shape{}, Values{val});

--- a/lib/variable/test/transform_unary_test.cpp
+++ b/lib/variable/test/transform_unary_test.cpp
@@ -76,7 +76,7 @@ protected:
     const auto result_return = transform<double>(var, op, name);
     EXPECT_TRUE(equals(result_return.values<double>(),
                        op_manual_values(var.values<double>())));
-    if (var.hasVariances()) {
+    if (var.has_variances()) {
       EXPECT_TRUE(equals(
           result_return.variances<double>(),
           op_manual_variances(var.values<double>(), var.variances<double>())));

--- a/lib/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/lib/variable/test/variable_keyword_args_constructor_test.cpp
@@ -48,9 +48,9 @@ TEST(CreateVariableTest, default_init) {
   auto withVariance =
       makeVariable<float>(Dims{Dim::X}, Shape{3}, Values{}, Variances{});
 
-  EXPECT_FALSE(noVariance.hasVariances());
-  EXPECT_FALSE(stillNoVariance.hasVariances());
-  EXPECT_TRUE(withVariance.hasVariances());
+  EXPECT_FALSE(noVariance.has_variances());
+  EXPECT_FALSE(stillNoVariance.has_variances());
+  EXPECT_TRUE(withVariance.has_variances());
   EXPECT_EQ(noVariance.values<float>().size(), 3);
   EXPECT_EQ(stillNoVariance.values<float>().size(), 3);
   EXPECT_EQ(withVariance.values<float>().size(), 3);
@@ -80,7 +80,7 @@ TEST(VariableUniversalConstructorTest, dimensions_unit_basic) {
   EXPECT_EQ(variable.dims(), (Dimensions{{Dim::X, Dim::Y}, {2, 3}}));
   EXPECT_EQ(variable.unit(), units::kg);
   EXPECT_EQ(variable.values<float>().size(), 6);
-  EXPECT_FALSE(variable.hasVariances());
+  EXPECT_FALSE(variable.has_variances());
 
   auto otherVariable =
       Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3});

--- a/lib/variable/test/variable_test.cpp
+++ b/lib/variable/test/variable_test.cpp
@@ -645,13 +645,14 @@ TEST(VariableTest, create_with_variance) {
                                        Variances{0.1}));
 }
 
-TEST(VariableTest, hasVariances) {
-  ASSERT_FALSE(makeVariable<double>(Values{double{}}).hasVariances());
-  ASSERT_FALSE(makeVariable<double>(Values{1.0}).hasVariances());
-  ASSERT_TRUE(makeVariable<double>(Values{1.0}, Variances{0.1}).hasVariances());
+TEST(VariableTest, has_variances) {
+  ASSERT_FALSE(makeVariable<double>(Values{double{}}).has_variances());
+  ASSERT_FALSE(makeVariable<double>(Values{1.0}).has_variances());
+  ASSERT_TRUE(
+      makeVariable<double>(Values{1.0}, Variances{0.1}).has_variances());
   ASSERT_TRUE(makeVariable<double>(Dims(), Shape(), units::m, Values{1.0},
                                    Variances{0.1})
-                  .hasVariances());
+                  .has_variances());
 }
 
 TEST(VariableTest, values_variances) {
@@ -692,9 +693,9 @@ TEST(VariableTest, set_variances) {
 TEST(VariableTest, set_variances_remove) {
   Variable var =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{}, Variances{});
-  EXPECT_TRUE(var.hasVariances());
+  EXPECT_TRUE(var.has_variances());
   EXPECT_NO_THROW(var.setVariances(Variable()));
-  EXPECT_FALSE(var.hasVariances());
+  EXPECT_FALSE(var.has_variances());
 }
 
 TEST(VariableViewTest, set_variances) {
@@ -717,7 +718,7 @@ TEST(VariableViewTest, create_with_variance) {
                                         Values{1.0, 2.0}, Variances{0.1, 0.2});
   ASSERT_NO_THROW_DISCARD(var.slice({Dim::X, 1, 2}));
   const auto slice = var.slice({Dim::X, 1, 2});
-  ASSERT_TRUE(slice.hasVariances());
+  ASSERT_TRUE(slice.has_variances());
   ASSERT_EQ(slice.variances<double>().size(), 1);
   ASSERT_EQ(slice.variances<double>()[0], 0.2);
   const auto reference =

--- a/lib/variable/util.cpp
+++ b/lib/variable/util.cpp
@@ -27,7 +27,7 @@ Variable linspace(const Variable &start, const Variable &stop, const Dim dim,
   if (start.dtype() != dtype<double> && start.dtype() != dtype<float>)
     throw except::TypeError(
         "Cannot create linspace with non-floating-point start and/or stop.");
-  if (start.hasVariances() || stop.hasVariances())
+  if (start.has_variances() || stop.has_variances())
     throw except::VariancesError(
         "Cannot create linspace with start and/or stop containing variances.");
   auto dims = start.dims();

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -83,7 +83,7 @@ DType Variable::dtype() const { return data().dtype(); }
 
 bool Variable::hasVariances() const { return data().hasVariances(); }
 
-void Variable::expectCanSetUnit(const units::Unit &unit) const {
+void Variable::expect_can_set_unit(const units::Unit &unit) const {
   if (this->unit() != unit && is_slice())
     throw except::UnitError("Partial view on data of variable cannot be used "
                             "to change the unit.");
@@ -93,7 +93,7 @@ const units::Unit &Variable::unit() const { return m_object->unit(); }
 
 void Variable::setUnit(const units::Unit &unit) {
   expect_writable();
-  expectCanSetUnit(unit);
+  expect_can_set_unit(unit);
   m_object->setUnit(unit);
 }
 

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -14,7 +14,7 @@
 
 namespace scipp::variable {
 
-/// Construct from parent with same dtype, unit, and hasVariances but new dims.
+/// Construct from parent with same dtype, unit, and has_variances but new dims.
 ///
 /// In the case of bucket variables the buffer size is set to zero.
 Variable::Variable(const Variable &parent, const Dimensions &dims)
@@ -81,7 +81,7 @@ scipp::index Variable::ndim() const {
 
 DType Variable::dtype() const { return data().dtype(); }
 
-bool Variable::hasVariances() const { return data().hasVariances(); }
+bool Variable::has_variances() const { return data().has_variances(); }
 
 void Variable::expect_can_set_unit(const units::Unit &unit) const {
   if (this->unit() != unit && is_slice())
@@ -114,7 +114,7 @@ bool Variable::operator==(const Variable &other) const {
     return false;
   if (dtype() != other.dtype())
     return false;
-  if (hasVariances() != other.hasVariances())
+  if (has_variances() != other.has_variances())
     return false;
   if (dims().volume() == 0 && dims() == other.dims())
     return true;
@@ -169,12 +169,12 @@ Variable Variable::slice(const Slice params) const {
 
 void Variable::validateSlice(const Slice &s, const Variable &data) const {
   core::expect::validSlice(this->dims(), s);
-  if (variableFactory().hasVariances(data) !=
-      variableFactory().hasVariances(*this)) {
+  if (variableFactory().has_variances(data) !=
+      variableFactory().has_variances(*this)) {
     auto variances_message = [](const auto &variable) {
       return "does" +
-             std::string(variableFactory().hasVariances(variable) ? ""
-                                                                  : " NOT") +
+             std::string(variableFactory().has_variances(variable) ? ""
+                                                                   : " NOT") +
              " have variances.";
     };
     throw except::VariancesError("Invalid slice operation. Slice " +

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -92,7 +92,7 @@ void Variable::expectCanSetUnit(const units::Unit &unit) const {
 const units::Unit &Variable::unit() const { return m_object->unit(); }
 
 void Variable::setUnit(const units::Unit &unit) {
-  expectWritable();
+  expect_writable();
   expectCanSetUnit(unit);
   m_object->setUnit(unit);
 }
@@ -128,7 +128,7 @@ bool Variable::operator!=(const Variable &other) const {
 const VariableConcept &Variable::data() const & { return *m_object; }
 
 VariableConcept &Variable::data() & {
-  expectWritable();
+  expect_writable();
   return *m_object;
 }
 
@@ -251,7 +251,7 @@ bool Variable::is_same(const Variable &other) const noexcept {
 }
 
 void Variable::setVariances(const Variable &v) {
-  expectWritable();
+  expect_writable();
   if (is_slice())
     throw except::VariancesError(
         "Cannot add variances via sliced view of Variable.");
@@ -282,7 +282,7 @@ Variable Variable::as_const() const {
   return out;
 }
 
-void Variable::expectWritable() const {
+void Variable::expect_writable() const {
   if (m_readonly)
     throw except::VariableError("Read-only flag is set, cannot mutate data.");
 }

--- a/lib/variable/variable_factory.cpp
+++ b/lib/variable/variable_factory.cpp
@@ -66,8 +66,8 @@ bool VariableFactory::has_masks(const Variable &var) const {
   return m_makers.at(var.dtype())->has_masks(var);
 }
 
-bool VariableFactory::hasVariances(const Variable &var) const {
-  return m_makers.at(var.dtype())->hasVariances(var);
+bool VariableFactory::has_variances(const Variable &var) const {
+  return m_makers.at(var.dtype())->has_variances(var);
 }
 
 Variable VariableFactory::empty_like(const Variable &prototype,

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -186,9 +186,9 @@ def test_2D_access_variances():
 def test_getitem_element():
     var = sc.arange('a', 0, 8).fold('a', {'x': 2, 'y': 4})
     for i in range(var.sizes['x']):
-        assert sc.identical(var['x', i], sc.arange('y', 0, 4) + i * 4)
+        assert sc.identical(var['x', i], sc.arange('y', 0 + i * 4, 4 + i * 4))
     for j in range(var.sizes['y']):
-        assert sc.identical(var['y', j], sc.arange('x', 0, 8, 4) + j)
+        assert sc.identical(var['y', j], sc.arange('x', 0 + j, 8 + j, 4))
 
 
 def test_getitem_element_out_of_range():

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -183,8 +183,24 @@ def test_2D_access_variances():
     assert np.array_equal(var.variances, np.ones(shape=shape))
 
 
-def test_getitem():
-    var = sc.Variable(dims=['x', 'y'], values=np.arange(0, 8).reshape(2, 4))
+def test_getitem_element():
+    var = sc.arange('a', 0, 8).fold('a', {'x': 2, 'y': 4})
+    for i in range(var.sizes['x']):
+        assert sc.identical(var['x', i], sc.arange('y', 0, 4) + i * 4)
+    for j in range(var.sizes['y']):
+        assert sc.identical(var['y', j], sc.arange('x', 0, 8, 4) + j)
+
+
+def test_getitem_element_out_of_range():
+    var = sc.arange('a', 0, 8).fold('a', {'x': 2, 'y': 4})
+    with pytest.raises(IndexError):
+        _ = var['x', 4]
+    with pytest.raises(IndexError):
+        _ = var['y', 5]
+
+
+def test_getitem_range():
+    var = sc.arange('a', 0, 8).fold('a', {'x': 2, 'y': 4})
     var_slice = var['x', 1:2]
     assert sc.identical(
         var_slice, sc.Variable(dims=['x', 'y'], values=np.arange(4, 8).reshape(1, 4)))


### PR DESCRIPTION
Part of #1183

```.py
>>> # coord size mismatch
>>> var = sc.array(dims=['event'], values=[1, 2, 3], dtype=float)
>>> sc.DataArray(data=var, coords={'a': sc.array(dims=['event'], values=[1, 2, 3, 4, 5])})
scipp._scipp.core.DimensionError: Cannot add coord 'a' of dims (event: 5) to DataArray with dims (event: 3)

>>> # Dataset coord mismatch
>>> da1 = sc.DataArray(data=var, coords={'a': sc.array(dims=['event'], values=[1, 2, 3])},
                   masks={'m': sc.array(dims=['event'], values=[True, False, True])})
>>> da2 = sc.DataArray(data=var, coords={'a': sc.array(dims=['event'], values=[1, -2, 3])})
>>> sc.Dataset(data={'1': da1, '2': da2})
scipp._scipp.core.CoordError: Mismatch in coordinate 'a' in operation 'set coord':
(event: 3)      int64  [dimensionless]  [1, -2, 3]
vs
(event: 3)      int64  [dimensionless]  [1, 2, 3]

>>> # operation coord mismatch
>>> da1 + da2
scipp._scipp.core.CoordError: Mismatch in coordinate 'a' in operation 'add':
(event: 3)      int64  [dimensionless]  [1, 2, 3]
vs
(event: 3)      int64  [dimensionless]  [1, -2, 3]

>>> # size mismatch in mask
>>> da3 = sc.DataArray(data=var, coords={'a': sc.array(dims=['event'], values=[1, 2, 3])},
                   masks={'m': sc.array(dims=['event'], values=[True, False, False, True])})
>>> da1 + da3
scipp._scipp.core.DimensionError: Cannot merge dimensions with mismatching extent in 'event': (event: 3) and (event: 4)

>>> # guarantee that coords are handled before data (should usually be cheaper)
>>> da4 = sc.DataArray(data=sc.array(dims=['event'], values=['a', 'b', 'c']),
                   coords={'a': sc.array(dims=['event'], values=[1, -2, 3])})
>>> da1 + da4
scipp._scipp.core.CoordError: Mismatch in coordinate 'a' in operation 'add':
(event: 3)      int64  [dimensionless]  [1, 2, 3]
vs
(event: 3)      int64  [dimensionless]  [1, -2, 3]

>>> # more concrete message when passing objects as dtypes
>>> sc.scalar(dict(), dtype=dict())
ValueError: Unsupported numpy dtype: raw data. This can happen when you pass a Python object instead of a class. Got dtype=`{}`

>>> # invalid slice dimension (slice by value)
>>> da1['b', 2*sc.units.one]
scipp._scipp.core.DimensionError: Invalid slice dimension: 'b': no coordinate for that dimension. Coordinates are (a, )
```

Also includes renames to snake_case for several functions.