### PR TITLE
Use a second point cloud for cut surfaces in 3d plots

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fix kernel crash or poor performance when using ``bin`` or ``da.bins.concat`` along an inner dimension in the presence of a long outer dimension `#2278 <https://github.com/scipp/scipp/pull/2278>`_.
+* Improved the rendering of cut slices in 3d plots where some strange artifacts could appear depending on the order in which the pixels were being drawn `#2287 <https://github.com/scipp/scipp/pull/2287>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/src/scipp/plotting/controller3d.py
+++ b/src/scipp/plotting/controller3d.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Neil Vaytet
-
+import numpy as np
 from ..core import scalar, where
 from ..core import abs as abs_
 from .controller import PlotController
@@ -36,14 +36,15 @@ class PlotController3d(PlotController):
         When the opacity slider in the panel is changed, ask the view to update
         the opacity.
         """
-        self.view.update_opacity(alpha=scalar(alpha))
+        # self.view.update_opacity(alpha=scalar(alpha))
+        self.view.update_opacity(alpha=alpha)
         # There is a strange effect with point clouds and opacities.
         # Results are best when depthTest is False, at low opacities.
         # But when opacities are high, the points appear in the order
         # they were drawn, and not in the order they are with respect
         # to the camera position. So for high opacities, we switch to
         # depthTest = True.
-        self.view.update_depth_test(alpha > 0.9)
+        self.view.update_depth_test(alpha > 0.5)
 
     def update_depth_test(self, value):
         """
@@ -51,7 +52,10 @@ class PlotController3d(PlotController):
         """
         self.view.update_depth_test(value)
 
-    def update_cut_surface(self, *, key, center, delta, active, inactive):
+    def remove_cut_surface(self):
+        self.view.remove_cut_surface()
+
+    def add_cut_surface(self, *, key, center, delta, active, inactive):
         """
         When the position or thickness of the cut surface is changed via the
         widgets in the `PlotPanel3d`, get new alpha values from the
@@ -63,10 +67,12 @@ class PlotController3d(PlotController):
         else:
             value = self._get_cut(key)
         u = value.unit
-        alpha = where(
-            abs_(value - center * u) < 0.5 * delta * u, scalar(active),
-            scalar(inactive))
-        self.view.update_opacity(alpha=alpha)
+        # alpha = where(
+        #     abs_(value - center * u) < 0.5 * delta * u, scalar(active),
+        #     scalar(inactive))
+        # self.view.update_opacity(alpha=alpha)
+        indices = np.where((abs_(value - center * u) < 0.5 * delta * u).values)
+        self.view.add_cut_surface(indices)
 
     def get_pixel_size(self):
         """

--- a/src/scipp/plotting/controller3d.py
+++ b/src/scipp/plotting/controller3d.py
@@ -44,13 +44,13 @@ class PlotController3d(PlotController):
         # they were drawn, and not in the order they are with respect
         # to the camera position. So for high opacities, we switch to
         # depthTest = True.
-        self.view.update_depth_test(alpha > 0.5)
+        # self.view.update_depth_test(alpha > 0.5)
 
-    def update_depth_test(self, value):
-        """
-        Update the state of depth test in the view (see `update_opacity`).
-        """
-        self.view.update_depth_test(value)
+    # def update_depth_test(self, value):
+    #     """
+    #     Update the state of depth test in the view (see `update_opacity`).
+    #     """
+    #     self.view.update_depth_test(value)
 
     def remove_cut_surface(self):
         self.view.remove_cut_surface()

--- a/src/scipp/plotting/controller3d.py
+++ b/src/scipp/plotting/controller3d.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Neil Vaytet
-import numpy as np
-from ..core import scalar, where
 from ..core import abs as abs_
 from .controller import PlotController
 
@@ -36,23 +34,12 @@ class PlotController3d(PlotController):
         When the opacity slider in the panel is changed, ask the view to update
         the opacity.
         """
-        # self.view.update_opacity(alpha=scalar(alpha))
         self.view.update_opacity(alpha=alpha)
-        # There is a strange effect with point clouds and opacities.
-        # Results are best when depthTest is False, at low opacities.
-        # But when opacities are high, the points appear in the order
-        # they were drawn, and not in the order they are with respect
-        # to the camera position. So for high opacities, we switch to
-        # depthTest = True.
-        # self.view.update_depth_test(alpha > 0.5)
-
-    # def update_depth_test(self, value):
-    #     """
-    #     Update the state of depth test in the view (see `update_opacity`).
-    #     """
-    #     self.view.update_depth_test(value)
 
     def remove_cut_surface(self):
+        """
+        When panel requests to remove the cut surface, ask the view to remove it.
+        """
         self.view.remove_cut_surface()
 
     def add_cut_surface(self, *, key, center, delta, active, inactive):
@@ -67,11 +54,7 @@ class PlotController3d(PlotController):
         else:
             value = self._get_cut(key)
         u = value.unit
-        # alpha = where(
-        #     abs_(value - center * u) < 0.5 * delta * u, scalar(active),
-        #     scalar(inactive))
-        # self.view.update_opacity(alpha=alpha)
-        indices = np.where((abs_(value - center * u) < 0.5 * delta * u).values)
+        indices = (abs_(value - center * u) < 0.5 * delta * u).values
         self.view.add_cut_surface(indices)
 
     def get_pixel_size(self):

--- a/src/scipp/plotting/figure3d.py
+++ b/src/scipp/plotting/figure3d.py
@@ -200,8 +200,9 @@ class PlotFigure3d:
                     array=np.ones([positions.shape[0], 3], dtype='float32'))
             })
 
+        pixel_ratio = config.plot.get("pixel_ratio", 1.0)
         self.points_material = p3.PointsMaterial(vertexColors='VertexColors',
-                                                 size=self._pixel_size,
+                                                 size=self._pixel_size * pixel_ratio,
                                                  transparent=True)
         return p3.Points(geometry=self.points_geometry, material=self.points_material)
 

--- a/src/scipp/plotting/panel3d.py
+++ b/src/scipp/plotting/panel3d.py
@@ -48,23 +48,11 @@ class PlotPanel3d(PlotPanel):
                                      continuous_update=False,
                                      layout={"width": "350px"})
         cut_unit = ipw.Label(value=str(low.unit))
-        # cut_checkbox = ipw.Checkbox(value=True,
-        #                             description="Continuous update",
-        #                             indent=False,
-        #                             layout={"width": "20px"})
-        # ipw.jslink((cut_checkbox, 'value'), (cut_slider, 'continuous_update'))
         cut_slider.observe(self._update_cut_surface, names="value")
 
         self._cut_sliders[key] = cut_slider
         self._cut_surface_thicknesses[key] = cut_surface_thickness
-        controls = ipw.HBox([
-            ipw.HBox([
-                cut_slider,
-                cut_unit,
-                # cut_checkbox
-            ]),
-            cut_surface_thickness
-        ])
+        controls = ipw.HBox([ipw.HBox([cut_slider, cut_unit]), cut_surface_thickness])
         controls.layout.display = 'none'
         return controls
 
@@ -87,17 +75,9 @@ class PlotPanel3d(PlotPanel):
             "and the lower value has no effect. When a cut surface is "
             "present, the max value is the opacity of the slice, while the "
             "min value is the opacity of the background.",
-            continuous_update=True,
+            continuous_update=False,
             style={'description_width': '60px'})
         self.opacity_slider.observe(self._update_opacity, names="value")
-        self.opacity_checkbox = ipw.Checkbox(
-            value=self.opacity_slider.continuous_update,
-            description="Continuous update",
-            indent=False,
-            layout={"width": "20px"})
-        self.opacity_checkbox_link = ipw.jslink(
-            (self.opacity_checkbox, 'value'),
-            (self.opacity_slider, 'continuous_update'))
 
         # Add buttons to provide a choice of different cut surfaces:
         # - Cartesian X, Y, Z
@@ -129,8 +109,7 @@ class PlotPanel3d(PlotPanel):
 
         self._cut_controls = []
         self._cut_controls_box = ipw.VBox([self.cut_surface_buttons])
-        self.container.children = (ipw.HBox(
-            [self.opacity_slider, self.opacity_checkbox]), self._cut_controls_box)
+        self.container.children = (self.opacity_slider, self._cut_controls_box)
 
     def set_range(self, key, low, high):
         # TODO scaling? See old impl:
@@ -158,9 +137,6 @@ class PlotPanel3d(PlotPanel):
                 "main": change["new"][0],
                 "cut": change["new"][1]
             })
-            # if change["new"][1] != change["old"][1]:
-            # self.controller.update_opacity(alpha=change["new"][0])
-            # # self._update_cut_surface()
 
     def _check_if_reset_needed(self, owner, content, buffers):
         """
@@ -175,17 +151,13 @@ class PlotPanel3d(PlotPanel):
         """
         Handle button update when the type of cut surface is changed.
         """
-        # self._update_opacity({"new": self.opacity_slider.value})
         if change['old'] is not None:
             self._cut_controls[change['old']].layout.display = 'none'
-            # self._update_opacity({"new": self.opacity_slider.value})
         if change["new"] is None:
             self._current_cut = None
-            # self._update_opacity({"new": self.opacity_slider.value})
         else:
             self._current_cut = self.options[change['new']]
             self._cut_controls[change['new']].layout.display = ''
-            # self.controller.update_depth_test(False)
         self._update_cut_surface()
         self._update_opacity({"new": self.opacity_slider.value})
 
@@ -204,7 +176,6 @@ class PlotPanel3d(PlotPanel):
             delta=delta,
             inactive=self.opacity_slider.lower,
             active=self.opacity_slider.upper)
-        # self.controller.set_opacity()
 
     def update_data(self, axparams=None):
         """

--- a/src/scipp/plotting/panel3d.py
+++ b/src/scipp/plotting/panel3d.py
@@ -152,11 +152,15 @@ class PlotPanel3d(PlotPanel):
         Take cut surface into account if present.
         """
         if self.cut_surface_buttons.value is None:
-            self.controller.update_opacity(alpha=change["new"][1])
+            self.controller.update_opacity(alpha={"main": change["new"][1]})
         else:
-            print('_update_opacity', change["new"][0])
-            self.controller.update_opacity(alpha=change["new"][0])
-            # self._update_cut_surface()
+            self.controller.update_opacity(alpha={
+                "main": change["new"][0],
+                "cut": change["new"][1]
+            })
+            # if change["new"][1] != change["old"][1]:
+            # self.controller.update_opacity(alpha=change["new"][0])
+            # # self._update_cut_surface()
 
     def _check_if_reset_needed(self, owner, content, buffers):
         """
@@ -171,18 +175,19 @@ class PlotPanel3d(PlotPanel):
         """
         Handle button update when the type of cut surface is changed.
         """
-        self._update_opacity({"new": self.opacity_slider.value})
+        # self._update_opacity({"new": self.opacity_slider.value})
         if change['old'] is not None:
             self._cut_controls[change['old']].layout.display = 'none'
-            self._update_opacity({"new": self.opacity_slider.value})
+            # self._update_opacity({"new": self.opacity_slider.value})
         if change["new"] is None:
             self._current_cut = None
-            self._update_opacity({"new": self.opacity_slider.value})
+            # self._update_opacity({"new": self.opacity_slider.value})
         else:
             self._current_cut = self.options[change['new']]
             self._cut_controls[change['new']].layout.display = ''
-            self.controller.update_depth_test(False)
-            self._update_cut_surface()
+            # self.controller.update_depth_test(False)
+        self._update_cut_surface()
+        self._update_opacity({"new": self.opacity_slider.value})
 
     def _update_cut_surface(self, change=None):
         """

--- a/src/scipp/plotting/view3d.py
+++ b/src/scipp/plotting/view3d.py
@@ -20,7 +20,6 @@ class PlotView3d(PlotView):
         self._axes = ['z', 'y', 'x']
 
     def update_opacity(self, *args, **kwargs):
-        # self.figure.update_opacity(alpha.values)
         self.figure.update_opacity(*args, **kwargs)
 
     def update_depth_test(self, *args, **kwargs):

--- a/src/scipp/plotting/view3d.py
+++ b/src/scipp/plotting/view3d.py
@@ -19,9 +19,9 @@ class PlotView3d(PlotView):
         super().__init__(figure=figure, formatters=formatters)
         self._axes = ['z', 'y', 'x']
 
-    def update_opacity(self, alpha):
+    def update_opacity(self, *args, **kwargs):
         # self.figure.update_opacity(alpha.values)
-        self.figure.update_opacity(alpha)
+        self.figure.update_opacity(*args, **kwargs)
 
     def update_depth_test(self, *args, **kwargs):
         self.figure.update_depth_test(*args, **kwargs)

--- a/src/scipp/plotting/view3d.py
+++ b/src/scipp/plotting/view3d.py
@@ -20,7 +20,8 @@ class PlotView3d(PlotView):
         self._axes = ['z', 'y', 'x']
 
     def update_opacity(self, alpha):
-        self.figure.update_opacity(alpha.values)
+        # self.figure.update_opacity(alpha.values)
+        self.figure.update_opacity(alpha)
 
     def update_depth_test(self, *args, **kwargs):
         self.figure.update_depth_test(*args, **kwargs)
@@ -57,3 +58,9 @@ class PlotView3d(PlotView):
 
     def set_position_params(self, params):
         self.figure.set_position_params(params)
+
+    def remove_cut_surface(self):
+        self.figure.remove_cut_surface()
+
+    def add_cut_surface(self, *args, **kwargs):
+        self.figure.add_cut_surface(*args, **kwargs)

--- a/tests/plotting/plot_3d_test.py
+++ b/tests/plotting/plot_3d_test.py
@@ -8,6 +8,7 @@ import scipp as sc
 from ..factory import make_dense_data_array, make_binned_data_array
 from .plot_helper import plot
 import matplotlib
+
 matplotlib.use('Agg')
 
 
@@ -141,8 +142,8 @@ def test_plot_3d_binned_data():
 def test_plot_redraw():
     da = _with_fake_pos(ndim=3, unit='K')
     p = sc.plot(da, positions='pos', projection="3d")
-    before = p.view.figure.points_geometry.attributes["rgba_color"].array
+    before = p.view.figure.points_geometry.attributes["color"].array
     da *= 5.0
     p.redraw()
-    after = p.view.figure.points_geometry.attributes["rgba_color"].array
+    after = p.view.figure.points_geometry.attributes["color"].array
     assert np.any(before != after)


### PR DESCRIPTION
This is an attempt to alleviate some issues when rendering semi-transparent points in the 3d plots.
This most commonly arises when we use the cut-surface buttons.

In `threejs`, when objects are rendered, a `depthTest` is performed by default on the object, and any object that would be hidden by another along the camera line of sign is not drawn in the scene, to save on computational cost.
However, this depth test does not consider transparency.
So we can end up with some very transparent pixels in the foreground causing opaque pixels in the background (that should be visible to the eye through the transparent pixels) to not be drawn.

To mitigate this problem, we simply turned `depthTest` off whenever a cut slice was made.
However, this has its own disadvantages. The points are now drawn in the order they are stored in the array, and this means that depending on the camera angle (when we rotate around the scene), we can see some point that should in principle be at the back of the scene coming to the front, because they have been drawn after the points in the foreground.

In this PR, we take a new approach whereby instead of having different opacities for different points in the cloud, we create a new point cloud for the cut slice, make that opaque, and set the opacity to something low for the original point cloud. This seems to work much better with regards to the issue above. This is also nice because we no longer have to write our custom shader that handles rgba colors, we just set the opacity for the entire point cloud material with a single float value.

Example:
```Py
import scipp as sc
import numpy as np
x = np.arange(50.) / 50.
x, y, z = np.meshgrid(x, x, x)
# Purposefully split the points in two halves to reveal the split at the center of the x axis
positions1 = np.array([x.flatten(), y.flatten(), z.flatten()]).astype('float32').T
positions2 = np.array([-x.flatten(), y.flatten(), z.flatten()]).astype('float32').T
positions = np.concatenate([positions1, positions2])
da = sc.DataArray(
    data=sc.array(dims=['xyz'], values=np.sin(positions[:, 1])),
    coords={
        'xyz':sc.vectors(dims=['xyz'], unit='m', values=positions),
})
da.plot(projection='3d', positions='xyz')
```

Before: (notice the rift in the middle because of how we are storing the points: first half positive `x`, second half negative `x`)
![Screenshot at 2021-11-15 21-16-35](https://user-images.githubusercontent.com/39047984/141849389-e86b5031-ebaf-4146-8f55-de5ef6ba0f13.png)

After:
![Screenshot at 2021-11-15 21-17-07](https://user-images.githubusercontent.com/39047984/141849735-b7f51355-648a-4324-838d-87a1a1d61394.png)

**Cons of this approach**
When we want to move a cut slice with the cut slice position slider, we have to remove the point cloud from the scene, and add a new one in after that. This is because the new slice most often contains a different number of points, and in `pythreejs` we cannot change the number of points in an existing point cloud.
This causes the cut slice to flicker as we are moving it along.
As a workaround, we have disabled `continuous_update` on the cut slice position slider (and removed the checkbox that toggles `continuous_update`), so that the flickering is no longer visible.
I think that continuous updates were making things quite slow anyway when a large number of pixes was present, and is it probably a better default.