### PR TITLE
Replace old CSS when injecting

### DIFF
--- a/src/scipp/_styling.py
+++ b/src/scipp/_styling.py
@@ -14,8 +14,6 @@ def inject_style():
     if not inject_style._has_been_injected:
         from IPython.display import display, Javascript
         from .html.resources import load_style
-        # `display` claims that its parameter should be a tuple, but
-        # that does not seem to work in the case of Javascript.
         display(
             Javascript(f"""
             const style = document.createElement('style');

--- a/src/scipp/_styling.py
+++ b/src/scipp/_styling.py
@@ -8,7 +8,8 @@ def inject_style():
     HTML and SVG output without duplicating it in every cell.
     This also preserves the style when the output in Jupyter is cleared.
 
-    The style is only injected once per session.
+    The style is only injected once per session but if the kernel is restarted,
+    the old style (if present in the HTML) is replaced.
     """
     if not inject_style._has_been_injected:
         from IPython.display import display, Javascript
@@ -18,8 +19,14 @@ def inject_style():
         display(
             Javascript(f"""
             const style = document.createElement('style');
+            style.setAttribute('id', 'scipp-style-sheet');
             style.textContent = String.raw`{load_style()}`;
-            document.head.append(style);
+            const oldStyle = document.getElementById('scipp-style-sheet');
+            if (oldStyle === null) {{
+                document.head.append(style);
+            }} else {{
+                oldStyle.replaceWith(style);
+            }}
             """))
     inject_style._has_been_injected = True
 

--- a/src/scipp/html/resources.py
+++ b/src/scipp/html/resources.py
@@ -4,6 +4,7 @@
 # @author Jan-Lukas Wynen
 
 import importlib.resources as pkg_resources
+from functools import lru_cache
 from string import Template
 
 
@@ -28,29 +29,20 @@ def _preprocess_style(template: str) -> str:
     return css
 
 
+@lru_cache(maxsize=1)
 def load_style() -> str:
     """
     Load the bundled CSS style and return it as a string.
     The string is cached upon first call.
     """
-    if load_style.style is None:
-        load_style.style = _preprocess_style(
-            pkg_resources.read_text('scipp.html', 'style.css.template'))
-    return load_style.style
+    return _preprocess_style(pkg_resources.read_text('scipp.html',
+                                                     'style.css.template'))
 
 
-load_style.style = None
-
-
+@lru_cache(maxsize=1)
 def load_icons() -> str:
     """
     Load the bundled icons and return them as an HTML string.
     The string is cached upon first call.
     """
-    if load_icons.icons is None:
-        load_icons.icons = pkg_resources.read_text('scipp.html',
-                                                   'icons-svg-inline.html')
-    return load_icons.icons
-
-
-load_icons.icons = None
+    return pkg_resources.read_text('scipp.html', 'icons-svg-inline.html')


### PR DESCRIPTION
Alternative to #2285

- Fixes #2284 by replacing an old style sheet if found.
- Add `lru_cache` for loaded CSS and icons.
- Preserves the existing mechanism that appends the style to the document head.