### PR TITLE
Preserve size of log widget

### DIFF
--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -443,17 +443,19 @@ label.sc-hide-icon svg{
   stroke-dasharray: 0.2, 0.2;
 }
 
-div.sc-log {
-  line-height: 2.5ex;
+.sc-log-wrap {
   height: 25ex;
   resize: vertical;
   overflow-y: scroll;
   display: flex;
   flex-direction: column-reverse;
-  border: solid;
-  border-width: 1px;
+  border: 1px solid;
   border-color: var(--jp-border-color2);
   background-color: var(--sc-background-color1);
+}
+
+div.sc-log {
+  line-height: 2.5ex;
 }
 
 table.sc-log {

--- a/src/scipp/logging.py
+++ b/src/scipp/logging.py
@@ -140,8 +140,9 @@ def display_logs() -> None:
             'Cannot display log widgets because no widget handler is installed.')
 
     from IPython.display import display
+    from ipywidgets import VBox
     inject_style()
-    display(widget)
+    display(VBox([widget]).add_class('sc-log-wrap'))
 
 
 def clear_log_widget() -> None:


### PR DESCRIPTION
Fixes #2288

Sizing and scrolling is now controlled by an outer box around the log widget. So replacing the contents of the widget does not affect these states.