### PR TITLE
Avoid line break in time stamp in log widget in Chrome

### DIFF
--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -473,7 +473,7 @@ tr.sc-log > td {
 }
 
 .sc-log-time-stamp {
-  min-width: 21ch;
+  min-width: 22ch;
   padding-right: 1em;
   font-family: var(--jp-code-font-family);
   color: var(--sc-font-color2);

--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -443,17 +443,19 @@ label.sc-hide-icon svg{
   stroke-dasharray: 0.2, 0.2;
 }
 
-div.sc-log {
-  line-height: 2.5ex;
+.sc-log-wrap {
   height: 25ex;
   resize: vertical;
   overflow-y: scroll;
   display: flex;
   flex-direction: column-reverse;
-  border: solid;
-  border-width: 1px;
+  border: 1px solid;
   border-color: var(--jp-border-color2);
   background-color: var(--sc-background-color1);
+}
+
+div.sc-log {
+  line-height: 2.5ex;
 }
 
 table.sc-log {

--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -474,9 +474,12 @@ tr.sc-log > td {
 
 .sc-log-time-stamp {
   min-width: 22ch;
-  padding-right: 1em;
   font-family: var(--jp-code-font-family);
   color: var(--sc-font-color2);
+}
+
+.sc-log-level {
+  min-width: 10ch;
 }
 
 tr.sc-log-debug td.sc-log-level {
@@ -503,7 +506,6 @@ tr.sc-log-critical td.sc-log-level {
 }
 
 .sc-log-message {
-  padding-left: 1em;
   white-space: pre-wrap;
   width: 100%;
 }
@@ -513,7 +515,6 @@ tr.sc-log-critical td.sc-log-level {
 }
 
 .sc-log-name {
-  padding-left: 1em;
   padding-right: 0.5em;
   text-align: right;
   white-space: pre-wrap;

--- a/src/scipp/logging.py
+++ b/src/scipp/logging.py
@@ -140,8 +140,9 @@ def display_logs() -> None:
             'Cannot display log widgets because no widget handler is installed.')
 
     from IPython.display import display
+    from ipywidgets import VBox
     inject_style()
-    display(widget)
+    display(VBox([widget]).add_class('sc-log-wrap'))
 
 
 def clear_log_widget() -> None:


### PR DESCRIPTION
Depends on #2295
Time stamps in logging widgets should now always be shown on a single line. Tested in Chromium and Firefox in docs and 
Jupyter lab.