### PR TITLE
Fix linkcheck errors

### DIFF
--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -267,7 +267,7 @@
     "\n",
     "**New in 0.6**\n",
     "\n",
-    "Conversions between different unit scales (not to be confused with [conversions provided by scippneutron](https://scipp.github.io/scippneutron/user-guide/unit-conversions.html)) are now supported.\n",
+    "Conversions between different unit scales are now supported.\n",
     "`to_unit` provides conversion of variables between, e.g., `mm` and `m`.\n",
     "\n",
     "</div>\n",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,5 +221,12 @@ doctest_default_flags = doctest.ELLIPSIS | doctest.IGNORE_EXCEPTION_DETAIL | \
 
 linkcheck_ignore = [
     # Specific lines in Github blobs cannot be found by linkcheck.
-    r'https?://github\.com/.*?/blob/[a-f0-9]+/.+?#'
+    r'https?://github\.com/.*?/blob/[a-f0-9]+/.+?#',
+    # Links with images on index page have to point to html files
+    # which linkcheck cannot find.
+    'user-guide/data-structures.html',
+    'user-guide/binned-data/binned-data.html',
+    'user-guide/masking.html',
+    'visualization/plotting-overview.html',
+    'user-guide/slicing.html'
 ]

--- a/docs/reference/developer/customizing.rst
+++ b/docs/reference/developer/customizing.rst
@@ -25,7 +25,7 @@ Note that this ``tcc`` file should *never* be included in a header.
 - The second macro argument is the C++ type.
 
 To support formatting of variables with the new ``dtype`` it should be registered in ``scipp::variable::formatterRegistry()``.
-`variable_instantiate_py_object.cpp <https://github.com/scipp/scipp/blob/main/python/variable_instantiate_py_object.cpp>`_ can be used as a reference.
+`variable_instantiate_py_object.cpp <https://github.com/scipp/scipp/blob/main/lib/python/variable_instantiate_py_object.cpp>`_ can be used as a reference.
 
 In addition to these steps, it is currently required to manually add Python bindings in several places.
 TODO: Improve or document this process.

--- a/docs/reference/developer/dependencies.rst
+++ b/docs/reference/developer/dependencies.rst
@@ -5,7 +5,7 @@ Places where dependencies are specified:
 
   - Conda package build (`conda/meta.yml <https://github.com/scipp/scipp/blob/main/conda/meta.yaml>`_)
   - Developer environment (`scipp-developer.yml <https://github.com/scipp/scipp/blob/main/scipp-developer.yml>`_)
-  - Conan file (`condafile.txt <https://github.com/scipp/scipp/blob/main/conanfile.txt>`_) 
+  - Conan file (`condafile.txt <https://github.com/scipp/scipp/blob/main/lib/conanfile.txt>`_)
 
 Conda packages
 ##############

--- a/docs/reference/developer/dependencies.rst
+++ b/docs/reference/developer/dependencies.rst
@@ -5,7 +5,7 @@ Places where dependencies are specified:
 
   - Conda package build (`conda/meta.yml <https://github.com/scipp/scipp/blob/main/conda/meta.yaml>`_)
   - Developer environment (`scipp-developer.yml <https://github.com/scipp/scipp/blob/main/scipp-developer.yml>`_)
-  - Conan file (`condafile.txt <https://github.com/scipp/scipp/blob/main/lib/conanfile.txt>`_)
+  - Conan file (`conanfile.txt <https://github.com/scipp/scipp/blob/main/lib/conanfile.txt>`_)
 
 Conda packages
 ##############
@@ -16,6 +16,6 @@ These include runtime dependencies for scipp
 Conan
 #####
 
-Required conan dependencies are fully specified in `condafile.txt <https://github.com/scipp/scipp/blob/main/conanfile.txt>`_
+Required conan dependencies are fully specified in `conanfile.txt <https://github.com/scipp/scipp/blob/main/lib/conanfile.txt>`_
 Note that these are brought into the project at cmake-time for the purposes of building and testing scipp.
 

--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -262,7 +262,7 @@ if you want to preallocate memory to fill later, use :py:func:`scipp.empty`.
 :type unit: scipp.Unit
 :type dtype: Any
 
-:seealso: Specialized `creation functions <../reference/api.rst#creation-functions>`_,
+:seealso: Specialized `creation functions <../../reference/creation-functions.rst>`_,
  in particular :py:func:`scipp.array` and :py:func:`scipp.scalar`.
 )raw");
 }

--- a/src/scipp/core/arithmetic.py
+++ b/src/scipp/core/arithmetic.py
@@ -22,7 +22,7 @@ def add(a: VariableLike, b: VariableLike) -> VariableLike:
     :param b: Second summand.
     :return: Sum of ``a`` and ``b``.
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.add, a, b)
@@ -53,7 +53,7 @@ def divide(dividend: VariableLike, divisor: VariableLike) -> VariableLike:
     >>> (sc.arange('x', -2.0, 3.0) / sc.scalar(2.0)).values
     array([-1. , -0.5,  0. ,  0.5,  1. ])
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.divide, dividend, divisor)
@@ -83,7 +83,7 @@ def floor_divide(dividend: VariableLike, divisor: VariableLike) -> VariableLike:
     >>> (sc.arange('x', -2.0, 3.0) // sc.scalar(2.0)).values
     array([-1., -1.,  0.,  0.,  1.])
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.floor_divide, dividend, divisor)
@@ -127,7 +127,7 @@ def mod(dividend: VariableLike, divisor: VariableLike) -> VariableLike:
     >>> (sc.arange('x', -3, 5) % sc.scalar(3)).values
     array([0, 1, 2, 0, 1, 2, 0, 1])
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.mod, dividend, divisor)
@@ -149,7 +149,7 @@ def multiply(a: VariableLike, b: VariableLike) -> VariableLike:
     :param b: Right factor.
     :return: Product of ``a`` and ``b``.
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.multiply, a, b)
@@ -168,7 +168,7 @@ def subtract(minuend: VariableLike, subtrahend: VariableLike) -> VariableLike:
     :param subtrahend: Subtrahend.
     :return: ``subtrahend`` subtracted from ``minuend``.
 
-    See the guide on `computation <../user-guide/computation.rst>`_ for
+    See the guide on `computation <../../user-guide/computation.rst>`_ for
     general concepts and broadcasting behavior.
     """
     return _call_cpp_func(_cpp.subtract, minuend, subtrahend)


### PR DESCRIPTION
Prepare the scipp repo for running linkcheck ( #2290). The actual setup needs to be done in `pipelines`.