### PR TITLE
Fix broken `sc.bins` if indices are not ordered

### DIFF
--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -144,7 +144,7 @@ Dataset resize_default_init(const Dataset &parent, const Dim dim,
 /// Each bin is represented by a Variable slice. `indices` defines the array of
 /// bins as slices of `buffer` along `dim`.
 Variable make_bins(Variable indices, const Dim dim, DataArray buffer) {
-  expect_valid_bin_indices(indices.data_handle(), dim, buffer.dims());
+  expect_valid_bin_indices(indices, dim, buffer.dims());
   return make_bins_no_validate(std::move(indices), dim, std::move(buffer));
 }
 
@@ -162,7 +162,7 @@ Variable make_bins_no_validate(Variable indices, const Dim dim,
 /// Each bin is represented by a Variable slice. `indices` defines the array of
 /// bins as slices of `buffer` along `dim`.
 Variable make_bins(Variable indices, const Dim dim, Dataset buffer) {
-  expect_valid_bin_indices(indices.data_handle(), dim, buffer.sizes());
+  expect_valid_bin_indices(indices, dim, buffer.sizes());
   return make_bins_no_validate(std::move(indices), dim, std::move(buffer));
 }
 

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -77,7 +77,7 @@ Variable resize_default_init(const Variable &var, const Dim dim,
 /// Each bin is represented by a VariableView. `indices` defines the array of
 /// bins as slices of `buffer` along `dim`.
 Variable make_bins(Variable indices, const Dim dim, Variable buffer) {
-  expect_valid_bin_indices(indices.data_handle(), dim, buffer.dims());
+  expect_valid_bin_indices(indices, dim, buffer.dims());
   return make_bins_no_validate(std::move(indices), dim, buffer);
 }
 

--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -34,6 +34,10 @@ public:
         m_elements(std::make_shared<ElementArrayModel<Elem>>(
             size * element_count, unit, std::move(model))) {}
 
+  StructureArrayModel(VariableConceptHandle &&elements)
+      : VariableConcept(units::one), // unit ignored
+        m_elements(std::move(elements)) {}
+
   static DType static_dtype() noexcept { return scipp::dtype<T>; }
   DType dtype() const noexcept override { return scipp::dtype<T>; }
   scipp::index size() const override {
@@ -62,7 +66,7 @@ public:
   }
 
   VariableConceptHandle clone() const override {
-    return std::make_shared<StructureArrayModel<T, Elem>>(*this);
+    return std::make_shared<StructureArrayModel<T, Elem>>(m_elements->clone());
   }
 
   auto values(const core::ElementArrayViewParams &base) const {

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -37,9 +37,9 @@ template <class T> T normalize_impl(const T &nominator, const T &denominator) {
          reciprocal(astype(denominator, type, CopyPolicy::TryAvoid));
 }
 
-SCIPP_VARIABLE_EXPORT void
-expect_valid_bin_indices(const VariableConceptHandle &indices, const Dim dim,
-                         const Sizes &buffer_sizes);
+SCIPP_VARIABLE_EXPORT void expect_valid_bin_indices(const Variable &indices,
+                                                    const Dim dim,
+                                                    const Sizes &buffer_sizes);
 
 template <class T>
 Variable make_bins_impl(Variable indices, const Dim dim, T &&buffer);

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -4,6 +4,7 @@
 
 #include "scipp/variable/bins.h"
 #include "scipp/variable/operations.h"
+#include "scipp/variable/shape.h"
 
 using namespace scipp;
 
@@ -21,6 +22,15 @@ TEST_F(VariableBinsTest, make_bins_from_slice) {
   // Sharing indices or not yields equivalent results.
   EXPECT_EQ(make_bins(indices.slice({Dim::Y, 1}), Dim::X, buffer),
             make_bins(copy(indices.slice({Dim::Y, 1})), Dim::X, buffer));
+}
+
+TEST_F(VariableBinsTest,
+       make_bins_from_unordered_index_validation_does_not_mutate) {
+  indices = makeVariable<scipp::index_pair>(
+      dims, Values{std::pair{2, 4}, std::pair{0, 2}});
+  auto original = copy(indices);
+  var = make_bins(indices, Dim::X, buffer);
+  EXPECT_EQ(var.bin_indices(), original);
 }
 
 TEST_F(VariableBinsTest, make_bins_shares_indices_and_buffer) {

--- a/lib/variable/test/variable_structure_test.cpp
+++ b/lib/variable/test/variable_structure_test.cpp
@@ -23,6 +23,13 @@ TEST_F(VariableStructureTest, basics) {
   EXPECT_EQ(vectors.values<Eigen::Vector3d>()[1], Eigen::Vector3d(4, 5, 6));
 }
 
+TEST_F(VariableStructureTest, copy) {
+  // StructureArrayModel holds a VariableConceptHandle, copy should not share
+  auto copied = copy(vectors);
+  copied += copied;
+  EXPECT_NE(copied, vectors);
+}
+
 TEST_F(VariableStructureTest, elem_access) {
   Variable elems = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
                                         units::m, Values{1, 2, 3, 4, 5, 6});

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -28,12 +28,10 @@ private:
   Variable data(Variable &var) const override { return this->buffer(var); }
 };
 
-void expect_valid_bin_indices(const VariableConceptHandle &indices,
-                              const Dim dim, const Sizes &buffer_sizes) {
-  auto copy =
-      requireT<const StructureArrayModel<scipp::index_pair, scipp::index>>(
-          *indices->clone());
-  const auto vals = copy.values();
+void expect_valid_bin_indices(const Variable &indices, const Dim dim,
+                              const Sizes &buffer_sizes) {
+  auto var = copy(indices);
+  const auto vals = var.values<scipp::index_pair>().as_span();
   std::sort(vals.begin(), vals.end());
   if ((!vals.empty() && (vals.begin()->first < 0)) ||
       (!vals.empty() && ((vals.end() - 1)->second > buffer_sizes[dim])))

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -32,7 +32,7 @@ void expect_valid_bin_indices(const VariableConceptHandle &indices,
                               const Dim dim, const Sizes &buffer_sizes) {
   auto copy =
       requireT<const StructureArrayModel<scipp::index_pair, scipp::index>>(
-          *indices);
+          *indices->clone());
   const auto vals = copy.values();
   std::sort(vals.begin(), vals.end());
   if ((!vals.empty() && (vals.begin()->first < 0)) ||

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -82,6 +82,14 @@ def test_bins():
     assert sc.identical(var['y', 1].value, data['x', 2:4])
 
 
+def test_bins_of_transpose():
+    data = sc.Variable(dims=['row'], values=[1, 2, 3, 4])
+    begin = sc.Variable(dims=['x', 'y'], values=[[0, 1], [2, 3]], dtype=sc.dtype.int64)
+    end = begin + 1
+    var = sc.bins(begin=begin, end=end, dim='row', data=data)
+    assert sc.identical(sc.bins(**var.transpose().bins.constituents), var.transpose())
+
+
 def test_bins_view():
     col = sc.Variable(dims=['event'], values=[1, 2, 3, 4])
     table = sc.DataArray(data=col,


### PR DESCRIPTION
This was introduced by #2243.