### PR TITLE
Reduce 3d visualization docs page size from 5.2 to 1.6 MByte

### DIFF
--- a/docs/visualization/plotting/plotting-nd-data.ipynb
+++ b/docs/visualization/plotting/plotting-nd-data.ipynb
@@ -34,10 +34,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "N = 50\n",
-    "M = 40\n",
-    "L = 30\n",
-    "K = 20\n",
+    "N = 20\n",
+    "M = 30\n",
+    "L = 20\n",
+    "K = 10\n",
     "xx = np.arange(N, dtype=np.float64)\n",
     "yy = np.arange(M, dtype=np.float64)\n",
     "zz = np.arange(L, dtype=np.float64)\n",
@@ -191,8 +191,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.coords['dummy-pos'] = sc.geometry.position(*[d.coords[dim] for dim in ['x', 'y', 'z']])\n",
-    "sc.plot(d, projection='3d', positions='dummy-pos')"
+    "d2 = d['y', :10].copy()\n",
+    "d2.coords['dummy-pos'] = sc.geometry.position(*[d2.coords[dim] for dim in ['x', 'y', 'z']])\n",
+    "sc.plot(d2, projection='3d', positions='dummy-pos')"
    ]
   },
   {
@@ -213,9 +214,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ranges = [sc.arange(dim=dim, start=0.0, stop=d.sizes[dim]) for dim in ['x', 'y', 'z']]\n",
-    "d.coords['dummy-pos'] = sc.geometry.position(*ranges)\n",
-    "sc.plot(d, projection='3d', positions='dummy-pos')"
+    "ranges = [sc.arange(dim=dim, start=0.0, stop=d2.sizes[dim]) for dim in ['x', 'y', 'z']]\n",
+    "d2.coords['dummy-pos'] = sc.geometry.position(*ranges)\n",
+    "sc.plot(d2, projection='3d', positions='dummy-pos')"
    ]
   },
   {
@@ -238,7 +239,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -252,7 +253,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Should improve load times, and reduce overall github pages size. There are some more pages that may benefit from optimization, but possibly most are just related to the plot resolutions, i.e., not clear if we want to change that.