### PR TITLE
Add `bins.unit` property

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -10,6 +10,7 @@ Features
 ~~~~~~~~
 
 * Added support for slicing without specifying a dimension (only for 1-D objects) `#2321 <https://github.com/scipp/scipp/pull/2321>`_.
+* Added ``unit`` property to ``obj.bins`` for getting and setting unit of bin elements `#2330 <https://github.com/scipp/scipp/pull/2330>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -28,7 +28,7 @@ public:
     if (unit != units::one)
       throw except::UnitError(
           "Bins cannot have a unit. Did you mean to set the unit of the bin "
-          "elements? This can be set, e.g., with `array.bins.unit = 'm'`.");
+          "elements? This can be set with `array.bins.unit = 'm'`.");
   }
 
   bool has_variances() const noexcept override { return false; }

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -111,6 +111,16 @@ class Bins:
         _cpp._bins_view(self._data()).data = data
 
     @property
+    def unit(self) -> _cpp.Unit:
+        """Unit of the bin elements"""
+        return self.constituents['data'].unit
+
+    @unit.setter
+    def unit(self, unit: Union[_cpp.Unit, str]):
+        """Set unit of the bin elements"""
+        self.constituents['data'].unit = unit
+
+    @property
     def constituents(self) -> Dict[str, Union[str, _cpp.Variable, _cpp.DataArray]]:
         """Constituents of binned data, as supported by :py:func:`sc.bins`."""
         return _call_cpp_func(_cpp.bins_constituents, self._data())

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -90,7 +90,7 @@ def test_bins_of_transpose():
     assert sc.identical(sc.bins(**var.transpose().bins.constituents), var.transpose())
 
 
-def test_bins_view():
+def make_binned():
     col = sc.Variable(dims=['event'], values=[1, 2, 3, 4])
     table = sc.DataArray(data=col,
                          coords={'time': col * 2.2},
@@ -98,12 +98,17 @@ def test_bins_view():
                          masks={'mask': col == col})
     begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
     end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
-    var = sc.bins(begin=begin, end=end, dim='event', data=table)
+    return sc.bins(begin=begin, end=end, dim='event', data=table)
+
+
+def test_bins_view():
+    var = make_binned()
     assert 'time' in var.bins.coords
     assert 'time' in var.bins.meta
     assert 'attr' in var.bins.meta
     assert 'attr' in var.bins.attrs
     assert 'mask' in var.bins.masks
+    col = sc.Variable(dims=['event'], values=[1, 2, 3, 4])
     with pytest.raises(sc.DTypeError):
         var.bins.coords['time2'] = col  # col is not binned
 
@@ -125,6 +130,33 @@ def test_bins_view():
     var.bins.data = var.bins.data * 2.0
     del var.bins.coords['time3']
     assert 'time3' not in var.bins.coords
+
+
+def test_bins_view_data_array_unit():
+    var = make_binned()
+    with pytest.raises(sc.UnitError):
+        var.unit = 'K'
+    assert var.bins.unit == ''
+    var.bins.unit = 'K'
+    assert var.bins.unit == 'K'
+
+
+def test_bins_view_coord_unit():
+    var = make_binned()
+    with pytest.raises(sc.UnitError):
+        var.bins.coords['time'].unit = 'K'
+    assert var.bins.coords['time'].bins.unit == ''
+    var.bins.coords['time'].bins.unit = 'K'
+    assert var.bins.coords['time'].bins.unit == 'K'
+
+
+def test_bins_view_data_unit():
+    var = make_binned()
+    with pytest.raises(sc.UnitError):
+        var.bins.data.unit = 'K'
+    assert var.bins.data.bins.unit == ''
+    var.bins.data.bins.unit = 'K'
+    assert var.bins.data.bins.unit == 'K'
 
 
 def test_bins_arithmetic():


### PR DESCRIPTION
While the error message of `binned.unit = myunit` referred to using `binned.bins.unit = myunit`, it didn't actually exist. Likely an oversight when refactoring away from `binned.events.unit = myunit`.