### PR TITLE
NaN-aware coord compare

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -24,6 +24,8 @@ Breaking changes
 Bugfixes
 ~~~~~~~~
 
+* Fix coordinate and attribute comparisons to treat NaN (not-a-number) values as equal, which previously prevented most operations with data arrays or datasets that contained NaN values in their coordinates or attributes `#2331 <https://github.com/scipp/scipp/pull/2331>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -102,6 +102,16 @@ bool operator!=(const DataArray &a, const DataArray &b) {
   return !operator==(a, b);
 }
 
+bool equals_nan(const DataArray &a, const DataArray &b) {
+  if (!equals_nan(a.coords(), b.coords()))
+    return false;
+  if (!equals_nan(a.masks(), b.masks()))
+    return false;
+  if (!equals_nan(a.attrs(), b.attrs()))
+    return false;
+  return equals_nan(a.data(), b.data());
+}
+
 /// Return the name of the data array.
 ///
 /// If part of a dataset, the name of the array is equal to the key of this item

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -246,6 +246,17 @@ bool Dataset::operator!=(const Dataset &other) const {
   return !operator==(other);
 }
 
+bool equals_nan(const Dataset &a, const Dataset &b) {
+  if (a.size() != b.size())
+    return false;
+  if (!equals_nan(a.coords(), b.coords()))
+    return false;
+  for (const auto &data : a)
+    if (!b.contains(data.name()) || !equals_nan(data, b[data.name()]))
+      return false;
+  return true;
+}
+
 const Sizes &Dataset::sizes() const { return m_coords.sizes(); }
 const Sizes &Dataset::dims() const { return sizes(); }
 Dim Dataset::dim() const {

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -33,7 +33,8 @@ auto union_(const T1 &a, const T2 &b, const std::string_view opname) {
 template <class Map> auto intersection(const Map &a, const Map &b) {
   std::unordered_map<typename Map::key_type, Variable> out;
   for (const auto &[key, item] : a)
-    if (const auto it = b.find(key); it != b.end() && it->second == item)
+    if (const auto it = b.find(key);
+        it != b.end() && equals_nan(it->second, item))
       out.emplace(key, item);
   return out;
 }

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -63,7 +63,7 @@ void coords_are_superset(const DataArray &a, const DataArray &b,
 
 void matching_coord(const Dim dim, const Variable &a, const Variable &b,
                     const std::string_view opname) {
-  if (a != b)
+  if (!equals_nan(a, b))
     throw except::CoordMismatchError(dim, a, b, opname);
 }
 

--- a/lib/dataset/include/scipp/dataset/data_array.h
+++ b/lib/dataset/include/scipp/dataset/data_array.h
@@ -120,6 +120,9 @@ SCIPP_DATASET_EXPORT bool operator!=(const DataArray &a, const DataArray &b);
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
 copy(const DataArray &array, AttrPolicy attrPolicy = AttrPolicy::Keep);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT bool equals_nan(const DataArray &a,
+                                                   const DataArray &b);
+
 } // namespace scipp::dataset
 
 namespace scipp {

--- a/lib/dataset/include/scipp/dataset/dataset.h
+++ b/lib/dataset/include/scipp/dataset/dataset.h
@@ -269,6 +269,9 @@ SCIPP_DATASET_EXPORT void union_or_in_place(Masks &masks,
 
 SCIPP_DATASET_EXPORT Dataset merge(const Dataset &a, const Dataset &b);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT bool equals_nan(const Dataset &a,
+                                                   const Dataset &b);
+
 } // namespace scipp::dataset
 
 namespace scipp::core {

--- a/lib/dataset/include/scipp/dataset/map_view.h
+++ b/lib/dataset/include/scipp/dataset/map_view.h
@@ -181,4 +181,7 @@ template <class Masks>
 SCIPP_DATASET_EXPORT Variable masks_merge_if_contained(const Masks &masks,
                                                        const Dimensions &dims);
 
+template <class Key, class Value>
+bool equals_nan(const Dict<Key, Value> &a, const Dict<Key, Value> &b);
+
 } // namespace scipp::dataset

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -59,6 +59,16 @@ bool Dict<Key, Value>::operator==(const Dict &other) const {
 }
 
 template <class Key, class Value>
+bool equals_nan(const Dict<Key, Value> &a, const Dict<Key, Value> &b) {
+  if (a.size() != b.size())
+    return false;
+  return std::all_of(a.begin(), a.end(), [&b](const auto &item) {
+    const auto &[name, data] = item;
+    return b.contains(name) && equals_nan(data, b[name]);
+  });
+}
+
+template <class Key, class Value>
 bool Dict<Key, Value>::operator!=(const Dict &other) const {
   return !operator==(other);
 }
@@ -329,5 +339,10 @@ bool Dict<Key, Value>::item_applies_to(const Key &key,
 
 template class SCIPP_DATASET_EXPORT Dict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT Dict<std::string, Variable>;
+template SCIPP_DATASET_EXPORT bool equals_nan(const Dict<Dim, Variable> &a,
+                                              const Dict<Dim, Variable> &b);
+template SCIPP_DATASET_EXPORT bool
+equals_nan(const Dict<std::string, Variable> &a,
+           const Dict<std::string, Variable> &b);
 
 } // namespace scipp::dataset

--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -149,7 +149,7 @@ Dataset concat(const scipp::span<const Dataset> dss, const Dim dim) {
                     [&first](auto &ds) { return ds.contains(first.name()); })) {
       auto das = map(dss, [&first](auto &&ds) { return ds[first.name()]; });
       if (std::any_of(das.begin(), das.end(), [dim, &first](auto &da) {
-            return da.dims().contains(dim) || da != first;
+            return da.dims().contains(dim) || !equals_nan(da, first);
           }))
         result.setData(first.name(), concat(das, dim));
       else

--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -98,7 +98,7 @@ template <class Maps> auto concat_maps(const Maps &maps, const Dim dim) {
     } else {
       // 1D coord is kept only if all inputs have matching 1D coords.
       if (std::any_of(vars.begin(), vars.end(), [dim, &vars](auto &var) {
-            return var.dims().contains(dim) || var != vars.front();
+            return var.dims().contains(dim) || !equals_nan(var, vars.front());
           })) {
         // Mismatching 1D coords must be broadcast to ensure new coord shape
         // matches new data shape.

--- a/lib/dataset/test/CMakeLists.txt
+++ b/lib/dataset/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   dataset_test.cpp
   dataset_view_test.cpp
   data_view_test.cpp
+  equals_nan_test.cpp
   event_data_operations_consistency_test.cpp
   except_test.cpp
   generated_test.cpp

--- a/lib/dataset/test/data_array_comparison_test.cpp
+++ b/lib/dataset/test/data_array_comparison_test.cpp
@@ -22,12 +22,16 @@ void expect_eq(const DataArray &a, const DataArray &b) {
   EXPECT_TRUE(b == a);
   EXPECT_FALSE(a != b);
   EXPECT_FALSE(b != a);
+  EXPECT_TRUE(equals_nan(a, b));
+  EXPECT_TRUE(equals_nan(b, a));
 }
 void expect_ne(const DataArray &a, const DataArray &b) {
   EXPECT_TRUE(a != b);
   EXPECT_TRUE(b != a);
   EXPECT_FALSE(a == b);
   EXPECT_FALSE(b == a);
+  EXPECT_FALSE(equals_nan(a, b));
+  EXPECT_FALSE(equals_nan(b, a));
 }
 } // namespace
 

--- a/lib/dataset/test/dataset_comparison_test.cpp
+++ b/lib/dataset/test/dataset_comparison_test.cpp
@@ -24,6 +24,8 @@ private:
     EXPECT_TRUE(b == a);
     EXPECT_FALSE(a != b);
     EXPECT_FALSE(b != a);
+    EXPECT_TRUE(equals_nan(a, b));
+    EXPECT_TRUE(equals_nan(b, a));
   }
   template <class A, class B>
   void expect_ne_impl(const A &a, const B &b) const {
@@ -31,6 +33,8 @@ private:
     EXPECT_TRUE(b != a);
     EXPECT_FALSE(a == b);
     EXPECT_FALSE(b == a);
+    EXPECT_FALSE(equals_nan(a, b));
+    EXPECT_FALSE(equals_nan(b, a));
   }
 
 protected:

--- a/lib/dataset/test/equals_nan_test.cpp
+++ b/lib/dataset/test/equals_nan_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "scipp/dataset/bins.h"
+#include "scipp/dataset/shape.h"
 
 using namespace scipp;
 
@@ -72,6 +73,18 @@ TEST_F(EqualsNanTest, concat_nan_coord) {
   da.coords()[Dim::X] += nan;
   const auto out = dataset::concat(std::vector{da, copy(da)}, Dim::Y);
   ASSERT_TRUE(equals_nan(out.coords()[Dim::X], da.coords()[Dim::X]));
+}
+
+TEST_F(EqualsNanTest, concat_nan_mask) {
+  da.masks()["mask"] += nan;
+  const auto out = dataset::concat(std::vector{da, copy(da)}, Dim::Y);
+  ASSERT_TRUE(equals_nan(out.masks()["mask"], da.masks()["mask"]));
+}
+
+TEST_F(EqualsNanTest, concat_nan_attr) {
+  da.attrs()[Dim("attr")] += nan;
+  const auto out = dataset::concat(std::vector{da, copy(da)}, Dim::Y);
+  ASSERT_TRUE(equals_nan(out.attrs()[Dim("attr")], da.attrs()[Dim("attr")]));
 }
 
 TEST_F(EqualsNanTest, dataset_item_self_assign) {

--- a/lib/dataset/test/equals_nan_test.cpp
+++ b/lib/dataset/test/equals_nan_test.cpp
@@ -87,6 +87,18 @@ TEST_F(EqualsNanTest, concat_nan_attr) {
   ASSERT_TRUE(equals_nan(out.attrs()[Dim("attr")], da.attrs()[Dim("attr")]));
 }
 
+TEST_F(EqualsNanTest, concat_nan_item) {
+  da.masks().erase("mask");
+  ds["a"].masks().erase("mask");
+  ds.setData("b", copy(da));
+  ds["a"] += nan;
+  auto ds2 = copy(ds);
+  ds2["b"] += da;
+  const auto out = dataset::concat(std::vector{ds, ds2}, Dim::Y);
+  // concat will avoid broadcasting "a" since it is equal, need to accepts NAN
+  ASSERT_TRUE(equals_nan(out["a"], da));
+}
+
 TEST_F(EqualsNanTest, dataset_item_self_assign) {
   // This is relevant for d['x', 1:]['a'] *= 1.5. We should accept NaNs. Current
   // implementation in Dataset.setData does not, because pointer comparison

--- a/lib/dataset/test/equals_nan_test.cpp
+++ b/lib/dataset/test/equals_nan_test.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause Copyright (c) 2021 Scipp contributors
+// (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/dataset/bins.h"
+
+using namespace scipp;
+
+template <class T> void check_equal(const T &var) {
+  EXPECT_TRUE(equals_nan(var, var));
+  EXPECT_TRUE(equals_nan(var, copy(var)));
+  EXPECT_NE(var, var);
+  EXPECT_NE(var, copy(var));
+}
+
+class EqualsNanTest : public ::testing::Test {
+protected:
+  EqualsNanTest() { ds.setData("a", da); }
+  Dimensions dims{Dim::Y, 2};
+  Variable indices = makeVariable<scipp::index_pair>(
+      dims, Values{std::pair{0, 2}, std::pair{2, 4}});
+  Variable data =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
+  DataArray da =
+      DataArray(data, {{Dim::X, data + data}}, {{"mask", data + data}},
+                {{Dim("attr"), data + data}});
+  Variable nan = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                      Values{1.0f, 2.0f, NAN, 4.0f});
+  Dataset ds;
+
+  void check() {
+    check_equal(da);
+    check_equal(ds);
+    check_equal(makeVariable<DataArray>(Values{da}));
+    check_equal(makeVariable<Dataset>(Values{ds}));
+    check_equal(make_bins(indices, Dim::X, da));
+    check_equal(make_bins(indices, Dim::X, ds));
+  }
+};
+
+TEST_F(EqualsNanTest, nan_data) {
+  da += nan;
+  check();
+}
+
+TEST_F(EqualsNanTest, nan_coord) {
+  da.coords()[Dim::X] += nan;
+  check();
+}
+
+TEST_F(EqualsNanTest, nan_mask) {
+  da.masks()["mask"] += nan;
+  check();
+}
+
+TEST_F(EqualsNanTest, nan_attr) {
+  da.attrs()[Dim("attr")] += nan;
+  check();
+}

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -78,6 +78,8 @@ public:
 
   [[nodiscard]] bool equals(const Variable &a,
                             const Variable &b) const override;
+  [[nodiscard]] bool equals_nan(const Variable &a,
+                                const Variable &b) const override;
   void copy(const Variable &src, Variable &dest) const override;
   void copy(const Variable &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;
@@ -116,6 +118,14 @@ bool BinArrayModel<T>::equals(const Variable &a, const Variable &b) const {
   // TODO This implementation is slow since it creates a view for every bucket.
   return a.dtype() == dtype() && b.dtype() == dtype() &&
          equals_impl(a.values<bucket<T>>(), b.values<bucket<T>>());
+}
+
+template <class T>
+bool BinArrayModel<T>::equals_nan(const Variable &a, const Variable &b) const {
+  fprintf(stderr, "BinArrayModel<T>::equals_nan\n");
+  // TODO This implementation is slow since it creates a view for every bucket.
+  return a.dtype() == dtype() && b.dtype() == dtype() &&
+         equals_nan_impl(a.values<bucket<T>>(), b.values<bucket<T>>());
 }
 
 template <class T>

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -122,7 +122,6 @@ bool BinArrayModel<T>::equals(const Variable &a, const Variable &b) const {
 
 template <class T>
 bool BinArrayModel<T>::equals_nan(const Variable &a, const Variable &b) const {
-  fprintf(stderr, "BinArrayModel<T>::equals_nan\n");
   // TODO This implementation is slow since it creates a view for every bucket.
   return a.dtype() == dtype() && b.dtype() == dtype() &&
          equals_nan_impl(a.values<bucket<T>>(), b.values<bucket<T>>());

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #pragma once
 #include "scipp/common/initialization.h"
+#include "scipp/common/numeric.h"
 #include "scipp/core/dimensions.h"
 #include "scipp/core/element_array_view.h"
 #include "scipp/core/except.h"
@@ -31,6 +32,29 @@ bool equals_impl(const T1 &view1, const T2 &view2) {
     return std::equal(view1.begin(), view1.end(), view2.begin(), view2.end());
 }
 
+template <class T> bool equals_nan(const T &a, const T &b) { return a == b; }
+
+template <class T1, class T2>
+bool equals_nan_impl(const T1 &view1, const T2 &view2) {
+  // TODO Use optimizations in case of contigous views (instead of slower
+  // ElementArrayView iteration). Add multi threading?
+  if constexpr (is_span_v<typename T1::value_type>)
+    return std::equal(
+        view1.begin(), view1.end(), view2.begin(), view2.end(),
+        [](const auto &a, const auto &b) { return equals_nan_impl(a, b); });
+  else
+    return std::equal(
+        view1.begin(), view1.end(), view2.begin(), view2.end(),
+        [](const auto &x, const auto &y) {
+          if constexpr (std::is_floating_point_v<std::decay_t<decltype(x)>>) {
+            using numeric::isnan;
+            if (isnan(x) && isnan(y))
+              return true;
+          }
+          return equals_nan(x, y);
+        });
+}
+
 /// Implementation of VariableConcept that holds an array with element type T.
 template <class T> class ElementArrayModel : public VariableConcept {
 public:
@@ -53,6 +77,7 @@ public:
   }
 
   bool equals(const Variable &a, const Variable &b) const override;
+  bool equals_nan(const Variable &a, const Variable &b) const override;
   void copy(const Variable &src, Variable &dest) const override;
   void copy(const Variable &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -32,7 +32,14 @@ bool equals_impl(const T1 &view1, const T2 &view2) {
     return std::equal(view1.begin(), view1.end(), view2.begin(), view2.end());
 }
 
-template <class T> bool equals_nan(const T &a, const T &b) { return a == b; }
+template <class T> bool equals_nan(const T &a, const T &b) {
+  if constexpr (std::is_floating_point_v<T>) {
+    using numeric::isnan;
+    if (isnan(a) && isnan(b))
+      return true;
+  }
+  return a == b;
+}
 
 template <class T1, class T2>
 bool equals_nan_impl(const T1 &view1, const T2 &view2) {
@@ -45,14 +52,7 @@ bool equals_nan_impl(const T1 &view1, const T2 &view2) {
   else
     return std::equal(
         view1.begin(), view1.end(), view2.begin(), view2.end(),
-        [](const auto &x, const auto &y) {
-          if constexpr (std::is_floating_point_v<std::decay_t<decltype(x)>>) {
-            using numeric::isnan;
-            if (isnan(x) && isnan(y))
-              return true;
-          }
-          return equals_nan(x, y);
-        });
+        [](const auto &x, const auto &y) { return equals_nan(x, y); });
 }
 
 /// Implementation of VariableConcept that holds an array with element type T.

--- a/lib/variable/include/scipp/variable/element_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/element_array_variable.tcc
@@ -97,7 +97,7 @@ ElementArrayModel<T>::makeDefaultFromParent(const scipp::index size) const {
                                                   element_array<T>(size));
 }
 
-/// Helper for implementing Variable(View)::operator==.
+/// Helper for implementing Variable::operator==.
 ///
 /// This method is using virtual dispatch as a trick to obtain T, such that
 /// values<T> and variances<T> can be compared.
@@ -106,6 +106,18 @@ bool ElementArrayModel<T>::equals(const Variable &a, const Variable &b) const {
   return equals_impl(a.values<T>(), b.values<T>()) &&
          (!a.has_variances() ||
           equals_impl(a.variances<T>(), b.variances<T>()));
+}
+
+/// Helper for implementing Variable::operator==.
+///
+/// This method is using virtual dispatch as a trick to obtain T, such that
+/// values<T> and variances<T> can be compared.
+template <class T>
+bool ElementArrayModel<T>::equals_nan(const Variable &a,
+                                      const Variable &b) const {
+  return equals_nan_impl(a.values<T>(), b.values<T>()) &&
+         (!a.has_variances() ||
+          equals_nan_impl(a.variances<T>(), b.variances<T>()));
 }
 
 template <class T>

--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -55,7 +55,10 @@ public:
     return makeDefaultFromParent(shape.dims().volume());
   }
 
-  bool equals(const Variable &a, const Variable &b) const override;
+  [[nodiscard]] bool equals(const Variable &a,
+                            const Variable &b) const override;
+  [[nodiscard]] bool equals_nan(const Variable &a,
+                                const Variable &b) const override;
   void copy(const Variable &src, Variable &dest) const override;
   void copy(const Variable &src, Variable &&dest) const override;
   void assign(const VariableConcept &other) override;
@@ -108,6 +111,13 @@ bool StructureArrayModel<T, Elem>::equals(const Variable &a,
                                           const Variable &b) const {
   return a.dtype() == dtype() && b.dtype() == dtype() &&
          a.elements<T>() == b.elements<T>();
+}
+
+template <class T, class Elem>
+bool StructureArrayModel<T, Elem>::equals_nan(const Variable &a,
+                                              const Variable &b) const {
+  return a.dtype() == dtype() && b.dtype() == dtype() &&
+         variable::equals_nan(a.elements<T>(), b.elements<T>());
 }
 
 template <class T, class Elem>

--- a/lib/variable/include/scipp/variable/variable.h
+++ b/lib/variable/include/scipp/variable/variable.h
@@ -211,6 +211,9 @@ Variable::Variable(const DType &type, Ts &&... args)
                                                       Variable &out);
 [[maybe_unused]] SCIPP_VARIABLE_EXPORT Variable copy(const Variable &var,
                                                      Variable &&out);
+
+[[nodiscard]] SCIPP_VARIABLE_EXPORT bool equals_nan(const Variable &a,
+                                                    const Variable &b);
 } // namespace scipp::variable
 
 namespace scipp::core {

--- a/lib/variable/include/scipp/variable/variable_concept.h
+++ b/lib/variable/include/scipp/variable/variable_concept.h
@@ -51,6 +51,7 @@ public:
   virtual void setVariances(const Variable &variances) = 0;
 
   virtual bool equals(const Variable &a, const Variable &b) const = 0;
+  virtual bool equals_nan(const Variable &a, const Variable &b) const = 0;
   virtual void copy(const Variable &src, Variable &dest) const = 0;
   virtual void copy(const Variable &src, Variable &&dest) const = 0;
   virtual void assign(const VariableConcept &other) = 0;

--- a/lib/variable/test/CMakeLists.txt
+++ b/lib/variable/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   copy_test.cpp
   creation_test.cpp
   cumulative_test.cpp
+  equals_nan_test.cpp
   linalg_test.cpp
   math_test.cpp
   mean_test.cpp

--- a/lib/variable/test/equals_nan_test.cpp
+++ b/lib/variable/test/equals_nan_test.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BSD-3-Clause Copyright (c) 2021 Scipp contributors
+// (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/variable/bins.h"
+#include "scipp/variable/structures.h"
+
+using namespace scipp;
+
+void check_equal(const Variable &a, const Variable &b) {
+  EXPECT_TRUE(equals_nan(a, b));
+  EXPECT_TRUE(equals_nan(a, copy(b)));
+  EXPECT_NE(a, b);
+  EXPECT_NE(a, copy(b));
+}
+
+TEST(EqualsNanTest, values) {
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                  Values{1.0f, 2.0f, NAN, 4.0f});
+  check_equal(var, var);
+}
+
+TEST(EqualsNanTest, variances) {
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                  Values{1.0f, 2.0f, 3.0f, 4.0f},
+                                  Variances{1.0f, 2.0f, NAN, 4.0f});
+  check_equal(var, var);
+}
+
+TEST(EqualsNanTest, structured) {
+  auto var =
+      variable::make_vectors(Dimensions(Dim::X, 1), units::m, {1, 2, NAN});
+  check_equal(var, var);
+}
+
+TEST(EqualsNanTest, binned) {
+  Dimensions dims{Dim::Y, 2};
+  Variable indices = makeVariable<scipp::index_pair>(
+      dims, Values{std::pair{0, 2}, std::pair{2, 4}});
+  Variable buffer = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                         Values{1.0f, 2.0f, NAN, 4.0f});
+  Variable var = make_bins(indices, Dim::X, buffer);
+  check_equal(var, var);
+}

--- a/lib/variable/test/equals_nan_test.cpp
+++ b/lib/variable/test/equals_nan_test.cpp
@@ -27,6 +27,13 @@ TEST(EqualsNanTest, variances) {
   check_equal(var, var);
 }
 
+TEST(EqualsNanTest, nested) {
+  auto inner = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                    Values{1.0f, 2.0f, NAN, 4.0f});
+  auto var = makeVariable<Variable>(Values{inner});
+  check_equal(var, var);
+}
+
 TEST(EqualsNanTest, structured) {
   auto var =
       variable::make_vectors(Dimensions(Dim::X, 1), units::m, {1, 2, NAN});

--- a/lib/variable/test/variable_comparison_test.cpp
+++ b/lib/variable/test/variable_comparison_test.cpp
@@ -23,6 +23,8 @@ private:
     EXPECT_TRUE(b == a);
     EXPECT_FALSE(a != b);
     EXPECT_FALSE(b != a);
+    EXPECT_TRUE(equals_nan(a, b));
+    EXPECT_TRUE(equals_nan(b, a));
   }
   template <class A, class B>
   void expect_ne_impl(const A &a, const B &b) const {
@@ -30,6 +32,8 @@ private:
     EXPECT_TRUE(b != a);
     EXPECT_FALSE(a == b);
     EXPECT_FALSE(b == a);
+    EXPECT_FALSE(equals_nan(a, b));
+    EXPECT_FALSE(equals_nan(b, a));
   }
 
 protected:


### PR DESCRIPTION
Fixes #2327. Changes are:

- Binary operations comparing coords treat NAN values as equal.
- This includes attributes.

The implementation is a bit involved, since we need to handle nested variables, data arrays, and datasets.

I have little confidence that I found *all* cases where coords (or attrs) are compute using `==` (or `!=`) but should actually be changed to `equals_nan`. I suspect we will have to update more operations in the future, as we find issues.