### PR TITLE
Add optimize.curve_fit wrapper

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -13,6 +13,7 @@ Features
 * Added support for slicing without specifying a dimension (only for 1-D objects) `#2321 <https://github.com/scipp/scipp/pull/2321>`_.
 * Added ``sc.interpolate.interp1d``, ``sc.integration.trapezoid``, and ``sc.integration.simpson`` as convenience wrappers of the scipy functions of the same name `#2324 <https://github.com/scipp/scipp/pull/2324>`_.
 * Added ``unit`` property to ``obj.bins`` for getting and setting unit of bin elements `#2330 <https://github.com/scipp/scipp/pull/2330>`_.
+* Added ``sc.optimize.curve_fit`` as convenience wrappers of the scipy function of the same name `#2350 <https://github.com/scipp/scipp/pull/2350>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/reference/classes.rst
+++ b/docs/reference/classes.rst
@@ -3,6 +3,9 @@
 Classes
 =======
 
+General
+-------
+
 .. autosummary::
    :toctree: ../generated/classes
    :template: scipp-class-template.rst
@@ -15,5 +18,28 @@ Classes
    GroupByDataset
    Unit
    Variable
+
+Exceptions
+----------
+
+.. autosummary::
+   :toctree: ../generated/classes
+   :template: scipp-class-template.rst
+   :recursive:
+
+   BinEdgeError
+   CoordError
+   DimensionError
+   DTypeError
+   UnitError
+
+Typing
+------
+
+.. autosummary::
+   :toctree: ../generated/classes
+   :template: scipp-class-template.rst
+   :recursive:
+
    typing.VariableLike
    typing.MetaDataMap

--- a/docs/reference/modules.rst
+++ b/docs/reference/modules.rst
@@ -12,5 +12,6 @@ Modules
    integrate
    interpolate
    logging
+   optimize
    spatial
    units

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -23,6 +23,13 @@ from .._scipp.core import BinEdgeError, BinnedDataError, CoordError, \
                          DataArrayError, DatasetError, DimensionError, \
                          DTypeError, NotFoundError, SizeError, SliceError, \
                          UnitError, VariableError, VariancesError
+
+BinEdgeError.__doc__ = 'Inappropriate bin-edge coordinate.'
+CoordError.__doc__ = 'Inappropriate coordinate values.'
+UnitError.__doc__ = 'Inappropriate unit value.'
+DimensionError.__doc__ = 'Inappropriate dimension labels and/or shape.'
+DTypeError.__doc__ = 'Inappropriate dtype.'
+
 # Import submodules
 from .._scipp.core import dtype
 

--- a/src/scipp/integrate/__init__.py
+++ b/src/scipp/integrate/__init__.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-"""Sub-package for integration."""
+"""Sub-package for integration.
+
+This subpackage provides wrappers for a subset of functions from
+:py:mod:`scipy.integrate`.
+"""
 
 from ..core import array, DataArray
 from ..compat.wrapping import wrap1d

--- a/src/scipp/integrate/__init__.py
+++ b/src/scipp/integrate/__init__.py
@@ -27,7 +27,7 @@ def _integrate(func: Callable, da: DataArray, dim: str, **kwargs) -> DataArray:
 def trapezoid(da: DataArray, dim: str, **kwargs) -> DataArray:
     """Integrate data array along the given dimension with the composite trapezoidal rule.
 
-    This is a wrapper around :py:class:`scipy.integrate.trapezoid`.
+    This is a wrapper around :py:func:`scipy.integrate.trapezoid`.
 
     Examples:
 
@@ -48,7 +48,7 @@ def trapezoid(da: DataArray, dim: str, **kwargs) -> DataArray:
 def simpson(da: DataArray, dim: str, **kwargs) -> DataArray:
     """Integrate data array along the given dimension with the composite Simpson's rule.
 
-    This is a wrapper around :py:class:`scipy.integrate.simpson`.
+    This is a wrapper around :py:func:`scipy.integrate.simpson`.
 
     Examples:
 

--- a/src/scipp/interpolate/__init__.py
+++ b/src/scipp/interpolate/__init__.py
@@ -58,7 +58,8 @@ def interp1d(da: DataArray, dim: str, **kwargs) -> Callable:
     If the input data array contains masks that depend on the interpolation dimension
     the masked points are treated as missing, i.e., they are ignored for the definition
     of the interpolation function. If such a mask also depends on additional dimensions
-    ``DimensionError`` is raised since interpolation requires points to be 1-D.
+    :py:class:`scipp.DimensionError` is raised since interpolation requires points to
+    be 1-D.
 
     Parameters not described above are forwarded to scipy.interpolate.interp1d. The
     most relevant ones are (see :py:class:`scipy.interpolate.interp1d` for details):

--- a/src/scipp/interpolate/__init__.py
+++ b/src/scipp/interpolate/__init__.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-"""Sub-package for objects used in interpolation."""
+"""Sub-package for objects used in interpolation.
+
+This subpackage provides wrappers for a subset of functions from
+:py:mod:`scipy.interpolate`.
+"""
 
 from ..core import array, Variable, DataArray, DimensionError, UnitError
 from ..core import irreducible_mask

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+"""Sub-package for optimization such as curve fitting."""
+
+from ..core import scalar, stddevs, Variable, DataArray
+from ..interpolate import _drop_masked
+
+from typing import Callable, List, Tuple
+from inspect import signature
+
+
+def _as_scalar(obj, unit):
+    if unit is None:
+        return obj
+    return scalar(value=obj, unit=unit)
+
+
+def _wrap_func(f, x_prototype, p_units):
+    x_prototype = x_prototype.copy()
+
+    def func(x, *args):
+        x_prototype.values = x
+        p = [_as_scalar(v, u) for v, u in zip(args, p_units)]
+        return f(x_prototype, *p).values
+
+    return func
+
+
+def curve_fit(f: Callable,
+              da: DataArray,
+              p0: List[Variable] = None,
+              **kwargs) -> Tuple[List[Variable], List[List[Variable]]]:
+    """Use non-linear least squares to fot a function, f, to data."""
+    for arg in ['xdata', 'ydata', 'sigma']:
+        if arg in kwargs:
+            raise TypeError(
+                f"Invalid argument '{arg}', already defined by the input data array.")
+    import scipy.optimize as opt
+    da = _drop_masked(da, da.dim)
+    sigma = stddevs(da) if da.variances is not None else None
+    x = da.coords[da.dim]
+    sig = signature(f)
+    if p0 is None:
+        p0 = [1] * (len(sig.parameters) - 1)
+    p_units = [p.unit if isinstance(p, Variable) else None for p in p0]
+    p0 = [p.value if isinstance(p, Variable) else p for p in p0]
+    popt, pcov = opt.curve_fit(f=_wrap_func(f, x, p_units),
+                               xdata=x.values,
+                               ydata=da.values,
+                               sigma=sigma.values,
+                               p0=p0)
+    # TODO units for pcov
+    return [_as_scalar(v, u) for v, u in zip(popt, p_units)], pcov
+
+
+__all__ = ['curve_fit']

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -76,6 +76,12 @@ def curve_fit(
         values of the data array provide the dependent data. If the data array stores
         variances then the standard deviations (square root of the variances) are taken
         into account when fitting.
+    :param p0: Initial guess for the parameters (length N). If None, then the initial
+        values will all be 1 (if the number of parameters for the function can be
+        determined using introspection, otherwise a ValueError is raised). If the fit
+        function cannot handle initial values of 1, in particular for parameters that
+        are not dimensionless, then typically a UnitError is raised, but details will
+        depend on the function.
 
     Example:
 

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -45,10 +45,10 @@ def _covariance_with_units(pcov, units):
 
 
 def curve_fit(
-    f: Callable,
-    da: DataArray,
-    p0: List[Variable] = None,
-    **kwargs
+        f: Callable,
+        da: DataArray,
+        p0: List[Variable] = None,
+        **kwargs
 ) -> Tuple[List[Union[Variable, Real]], List[List[Union[Variable, Real]]]]:
     """Use non-linear least squares to fit a function, f, to data."""
     for arg in ['xdata', 'ydata', 'sigma']:

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -109,14 +109,12 @@ def curve_fit(
     import scipy.optimize as opt
     da = _drop_masked(da, da.dim)
     sigma = stddevs(da).values if da.variances is not None else None
-    x = da.coords[da.dim]
-    sig = signature(f)
     if p0 is None:
-        p0 = [1.0] * (len(sig.parameters) - 1)
+        p0 = [1.0] * (len(signature(f).parameters) - 1)
     p_units = [p.unit if isinstance(p, Variable) else None for p in p0]
     p0 = [p.value if isinstance(p, Variable) else p for p in p0]
     popt, pcov = opt.curve_fit(f=_wrap_func(f, p_units),
-                               xdata=x,
+                               xdata=da.coords[da.dim],
                                ydata=da.values,
                                sigma=sigma,
                                p0=p0)

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -4,6 +4,7 @@
 """Sub-package for optimization such as curve fitting."""
 
 from ..core import scalar, stddevs, Variable, DataArray
+from ..core import BinEdgeError
 from ..interpolate import _drop_masked
 import numpy as np
 
@@ -55,6 +56,8 @@ def curve_fit(
         if arg in kwargs:
             raise TypeError(
                 f"Invalid argument '{arg}', already defined by the input data array.")
+    if da.sizes[da.dim] != da.coords[da.dim].sizes[da.dim]:
+        raise BinEdgeError("Cannot fit data array with bin-edge coordinate.")
     import scipy.optimize as opt
     da = _drop_masked(da, da.dim)
     sigma = stddevs(da).values if da.variances is not None else None

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -80,8 +80,8 @@ def curve_fit(
         values will all be 1 (if the number of parameters for the function can be
         determined using introspection, otherwise a ValueError is raised). If the fit
         function cannot handle initial values of 1, in particular for parameters that
-        are not dimensionless, then typically a UnitError is raised, but details will
-        depend on the function.
+        are not dimensionless, then typically a :py:class:`scipp.UnitError` is raised,
+        but details will depend on the function.
 
     Example:
 

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -47,11 +47,11 @@ def _covariance_with_units(pcov, units):
 
 
 def curve_fit(
-    f: Callable,
-    da: DataArray,
-    *,
-    p0: List[Variable] = None,
-    **kwargs
+        f: Callable,
+        da: DataArray,
+        *,
+        p0: List[Variable] = None,
+        **kwargs
 ) -> Tuple[List[Union[Variable, Real]], List[List[Union[Variable, Real]]]]:
     """Use non-linear least squares to fit a function, f, to data.
 

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -55,7 +55,7 @@ def curve_fit(
 ) -> Tuple[List[Union[Variable, Real]], List[List[Union[Variable, Real]]]]:
     """Use non-linear least squares to fit a function, f, to data.
 
-    This is a wrapper around :py:class:`scipy.optimize.curve_fit`. See there for a
+    This is a wrapper around :py:func:`scipy.optimize.curve_fit`. See there for a
     complete description of parameters. The differences are:
 
     - Instead of separate xdata, ydata, and sigma arguments, the input data array

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -98,7 +98,7 @@ def curve_fit(
       >>> round(popt[0])
       5
       >>> sc.round(popt[1])
-      <scipp.Variable> ()    float64            [1/m]  [17.000000]
+      <scipp.Variable> ()    float64            [1/m]  [17]
     """
     for arg in ['xdata', 'ydata', 'sigma']:
         if arg in kwargs:

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -65,7 +65,7 @@ def curve_fit(
     x = da.coords[da.dim]
     sig = signature(f)
     if p0 is None:
-        p0 = [1] * (len(sig.parameters) - 1)
+        p0 = [1.0] * (len(sig.parameters) - 1)
     p_units = [p.unit if isinstance(p, Variable) else None for p in p0]
     p0 = [p.value if isinstance(p, Variable) else p for p in p0]
     popt, pcov = opt.curve_fit(f=_wrap_func(f, x, p_units),

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -19,13 +19,10 @@ def _as_scalar(obj, unit):
     return scalar(value=obj, unit=unit)
 
 
-def _wrap_func(f, x_prototype, p_units):
-    x_prototype = x_prototype.copy()
-
+def _wrap_func(f, p_units):
     def func(x, *args):
-        x_prototype.values = x
         p = [_as_scalar(v, u) for v, u in zip(args, p_units)]
-        return f(x_prototype, *p).values
+        return f(x, *p).values
 
     return func
 
@@ -68,8 +65,8 @@ def curve_fit(
         p0 = [1.0] * (len(sig.parameters) - 1)
     p_units = [p.unit if isinstance(p, Variable) else None for p in p0]
     p0 = [p.value if isinstance(p, Variable) else p for p in p0]
-    popt, pcov = opt.curve_fit(f=_wrap_func(f, x, p_units),
-                               xdata=x.values,
+    popt, pcov = opt.curve_fit(f=_wrap_func(f, p_units),
+                               xdata=x,
                                ydata=da.values,
                                sigma=sigma,
                                p0=p0)

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -48,6 +48,7 @@ def _covariance_with_units(pcov, units):
 def curve_fit(
         f: Callable,
         da: DataArray,
+        *,
         p0: List[Variable] = None,
         **kwargs
 ) -> Tuple[List[Union[Variable, Real]], List[List[Union[Variable, Real]]]]:

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -35,8 +35,8 @@ def _covariance_with_units(pcov, units):
         for j, elem in enumerate(row):
             ui = units[i]
             uj = units[j]
-            u = None
-            if ui is None:
+            u = ui
+            if u is None:
                 u = uj
             elif uj is not None:
                 u = ui * uj

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -64,7 +64,7 @@ def test_masks_are_not_ignored():
     da = array1d(size=20)
     unmasked, _ = curve_fit(func, da)
     da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
-    da.masks['mask'][:-5] = sc.scalar(True)
+    da.masks['mask'][-5:] = sc.scalar(True)
     masked, _ = curve_fit(func, da)
     assert all(masked != unmasked)
 

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -54,6 +54,12 @@ def test_should_raise_BinEdgeError_when_data_array_is_histogram():
         curve_fit(func, hist)
 
 
+def test_should_raise_DimensionError_when_data_array_is_not_1d():
+    da = sc.concat([array1d(), array1d()], 'extra_dim')
+    with pytest.raises(sc.DimensionError):
+        curve_fit(func, da)
+
+
 def test_masks_are_not_ignored():
     da = array1d(size=20)
     unmasked, _ = curve_fit(func, da)

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -67,7 +67,7 @@ def test_masks_are_not_ignored():
 @pytest.mark.parametrize("noise_scale", [1e-1, 1e-2, 1e-3, 1e-6, 1e-9])
 def test_optimized_params_approach_real_params_as_data_noise_decreases(noise_scale):
     popt, _ = curve_fit(func, array1d(a=1.7, b=1.5, noise_scale=noise_scale))
-    np.testing.assert_allclose(popt, [1.7, 1.5], rtol=noise_scale)
+    np.testing.assert_allclose(popt, [1.7, 1.5], rtol=2.0 * noise_scale)
 
 
 @pytest.mark.parametrize("mask_pos", [0, 1, -3])

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import numpy as np
+import scipp as sc
+from scipp.optimize import curve_fit
+
+import pytest
+
+
+def func(x, a, b):
+    return a * sc.exp(-(b / x.unit) * x)
+
+
+def array1d():
+    size = 20
+    x = sc.linspace(dim='xx', start=0.5, stop=2.0, num=size, unit='m')
+    y = func(x, 1.2, 1.3)
+    rng = np.random.default_rng()
+    y.values += 0.1 * rng.normal(size)
+    da = sc.DataArray(y, coords={'xx': x})
+    return da
+
+
+def test_should_not_raise_given_function_with_dimensionless_params_and_1d_array():
+    curve_fit(func, array1d())
+
+
+def test_should_raise_TypeError_when_xdata_given_as_param():
+    with pytest.raises(TypeError):
+        curve_fit(func, array1d(), xdata=np.arange(4))
+
+
+def test_should_raise_TypeError_when_ydata_given_as_param():
+    with pytest.raises(TypeError):
+        curve_fit(func, array1d(), ydata=np.arange(4))
+
+
+def test_should_raise_TypeError_when_sigma_given_as_param():
+    with pytest.raises(TypeError):
+        curve_fit(func, array1d(), sigma=np.arange(4))
+
+
+def test_should_raise_NotFoundError_when_data_array_has_no_coord():
+    da = array1d()
+    del da.coords[da.dim]
+    with pytest.raises(sc.NotFoundError):
+        curve_fit(func, da)
+
+
+def test_should_raise_BinEdgeError_when_data_array_is_histogram():
+    da = array1d()
+    hist = da[1:].copy()
+    hist.coords[hist.dim] = da.coords[hist.dim]
+    with pytest.raises(sc.BinEdgeError):
+        curve_fit(func, hist)
+
+
+def test_masks_are_not_ignored():
+    da = array1d()
+    unmasked, _ = curve_fit(func, da)
+    da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
+    da.masks['mask'][0] = True
+    masked, _ = curve_fit(func, da)
+    assert all(masked != unmasked)
+
+
+@pytest.mark.parametrize("mask_pos", [0, 1, -3])
+@pytest.mark.parametrize("mask_size", [1, 2])
+def test_masked_points_are_treated_as_if_they_were_removed(mask_pos, mask_size):
+    da = array1d()
+    da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
+    da.masks['mask'][mask_pos:mask_pos + mask_size] = sc.scalar(True)
+    masked, _ = curve_fit(func, da)
+    removed, _ = curve_fit(
+        func, sc.concat([da[:mask_pos], da[mask_pos + mask_size:]], da.dim))
+    assert all(masked == removed)

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -11,8 +11,7 @@ def func(x, a, b):
     return a * sc.exp(-(b / x.unit) * x)
 
 
-def array1d(*, a=1.2, b=1.3, noise_scale=0.1):
-    size = 50
+def array1d(*, a=1.2, b=1.3, noise_scale=0.1, size=50):
     x = sc.linspace(dim='xx', start=-0.1, stop=4.0, num=size, unit='m')
     y = func(x, a, b)
     rng = np.random.default_rng()
@@ -56,10 +55,10 @@ def test_should_raise_BinEdgeError_when_data_array_is_histogram():
 
 
 def test_masks_are_not_ignored():
-    da = array1d()
+    da = array1d(size=20)
     unmasked, _ = curve_fit(func, da)
     da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
-    da.masks['mask'][0] = True
+    da.masks['mask'][:-5] = sc.scalar(True)
     masked, _ = curve_fit(func, da)
     assert all(masked != unmasked)
 
@@ -73,7 +72,7 @@ def test_optimized_params_approach_real_params_as_data_noise_decreases(noise_sca
 @pytest.mark.parametrize("mask_pos", [0, 1, -3])
 @pytest.mark.parametrize("mask_size", [1, 2])
 def test_masked_points_are_treated_as_if_they_were_removed(mask_pos, mask_size):
-    da = array1d()
+    da = array1d(size=10)
     da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
     da.masks['mask'][mask_pos:mask_pos + mask_size] = sc.scalar(True)
     masked, _ = curve_fit(func, da)


### PR DESCRIPTION
Add `optimize.curve_fit` as wrapper for scipy functionality.

Here is an example to play with:

```python
import scipp as sc
import numpy as np
from scipp.optimize import curve_fit

def f(x, a, b):
    return a*sc.exp(-b*x)

x = sc.linspace(dim='x', start=0, stop=4, num=50, unit='m')
y = f(x, 1.5, 1.3 / sc.Unit('m'))
rng = np.random.default_rng()
y_noise = 0.1 * rng.normal(size=50)
y.values += y_noise
y.variances = 0.1*(y.values + 1)

da = sc.DataArray(data=y, coords={'x':x})
da.masks['mask'] = x < 1.4 * sc.Unit('m')
da.plot()
```

```python
popt, pcov = curve_fit(f, da, p0=[1.4, 1.2 / sc.Unit('m')])
sc.plot({'fit':sc.DataArray(data=f(x, *popt), coords={'x':x}), 'data':da})
```

Note that `p0` can be omitted if and only if `f` takes dimensionless parameters.

Fixes #2325.

