### PR TITLE
Switch to Thursday builds instead of nightly

### DIFF
--- a/.github/workflows/package_nightly_and_release.yml
+++ b/.github/workflows/package_nightly_and_release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 4"  # every Thursday
 
 defaults:
   run:


### PR DESCRIPTION
Avoid redundant builds and partially bypass build fails from failed anaconda uploads.