### PR TITLE
Fix bug in `sc.bin` when rebinning to multi-dim coord

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -29,6 +29,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fix coordinate and attribute comparisons to treat NaN (not-a-number) values as equal, which previously prevented most operations with data arrays or datasets that contained NaN values in their coordinates or attributes `#2331 <https://github.com/scipp/scipp/pull/2331>`_.
+* Fix incorrect result from ``sc.bin`` when rebinning an inner dimension to a multi-dimensional coordinate `#2355 <https://github.com/scipp/scipp/pull/2355>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -282,7 +282,8 @@ public:
         // algorithm, `indices`, containing the index of the target bin for
         // every input event. This is unrelated and varies independently,
         // depending on parameters of the input.
-        if (bin_coords.count(dim) && m_offsets.dims().empty() &&
+        if (key.ndim() == 1 && // index setup not implemented for this case
+            bin_coords.count(dim) && m_offsets.dims().empty() &&
             bin_coords.at(dim).dims().contains(dim) &&
             allsorted(bin_coords.at(dim), dim)) {
           const auto &bin_coord = bin_coords.at(dim);

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -226,6 +226,22 @@ TEST_P(BinTest, 2d_drop_out_of_group) {
             bin(table, {}, {groups1_drop, groups2_drop}));
 }
 
+TEST_P(
+    BinTest,
+    rebin_inner_1d_coord_to_2d_coord_gives_same_result_as_direct_binning_to_2d_coord) {
+  auto table = GetParam();
+  auto xy = bin(table, {edges_x_coarse, edges_y_coarse});
+  Variable edges_y_2d = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                                             Values{-2, 1, 2, -3, 0, 3});
+  // With bin-coord for Y
+  expect_near(bin(xy, {edges_y_2d}),
+              bin(bin(table, {edges_x_coarse}), {edges_y_2d}));
+  // Without bin-coord for Y
+  xy.coords().erase(Dim::Y);
+  expect_near(bin(xy, {edges_y_2d}),
+              bin(bin(table, {edges_x_coarse}), {edges_y_2d}));
+}
+
 TEST_P(BinTest, rebin_2d_with_2d_coord) {
   auto table = GetParam();
   auto xy = bin(table, {edges_x_coarse, edges_y_coarse});


### PR DESCRIPTION
Fixes #2354.