### PR TITLE
Add datetime creation functions

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Features
 * Added ``unit`` property to ``obj.bins`` for getting and setting unit of bin elements `#2330 <https://github.com/scipp/scipp/pull/2330>`_.
 * Added :py:func:`scipp.optimize.curve_fit` as convenience wrappers of the scipy function of the same name `#2350 <https://github.com/scipp/scipp/pull/2350>`_.
 * Added :py:func:`scipp.signal.butter` and :py:func:`scipp.signal.sosfiltfilt` as wrappers of the scipy functions of the same name `#2356 <https://github.com/scipp/scipp/pull/2356>`_.
+* Added :py:func:`scipp.datetime`, :py:func:`scipp.datetimes`, and :py:func:`scipp.epoch` to conveniently construct variables containing datetimes `#2360 <https://github.com/scipp/scipp/pull/2360>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/reference/creation-functions.rst
+++ b/docs/reference/creation-functions.rst
@@ -8,8 +8,11 @@ Creation functions
 
    array
    arange
+   datetime
+   datetimes
    empty
    empty_like
+   epoch
    full
    full_like
    geomspace

--- a/docs/reference/dtype.ipynb
+++ b/docs/reference/dtype.ipynb
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.datetime('2022-01-10T14:31:21').value.astype(int)"
+    "sc.datetime('2022-01-10T14:31:21')"
    ]
   },
   {

--- a/docs/reference/dtype.ipynb
+++ b/docs/reference/dtype.ipynb
@@ -114,7 +114,7 @@
     "## Dates and Times\n",
     "\n",
     "Scipp has a special dtype for time-points, `sc.dtype.datetime64`.\n",
-    "Variables can be constructed from integers which encode the time since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time):"
+    "Variables can be constructed using [scipp.datetime](../generated/functions/scipp.datetime.rst) and [scipp.datetimes](../generated/functions/scipp.datetimes.rst):"
    ]
   },
   {
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.scalar(value=0, unit=sc.units.s, dtype=sc.dtype.datetime64)"
+    "sc.datetime('2022-01-10T14:31:21').value.astype(int)"
    ]
   },
   {
@@ -132,14 +132,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.scalar(value=681794055, unit=sc.units.s, dtype=sc.dtype.datetime64)"
+    "sc.datetimes(dims=['t'], values=['2022-01-10T14:31:21', '2022-01-11T11:09:05'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Datetime variables always need a temporal unit and that unit determines how the integer that is passed to `value=` is interpreted:"
+    "Datetimes can also be constructed from integers which encode the time since the scipp epoch which is equal to the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).\n",
+    "The `unit` argument determines what time scale the integers represent."
    ]
   },
   {
@@ -148,7 +149,58 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var = sc.scalar(value=681794055, unit=sc.units.ns, dtype=sc.dtype.datetime64)\n",
+    "sc.datetime(0, unit='s')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.datetimes(dims=['t'], values=[123456789, 345678912], unit='us')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a shortand, [scipp.epoch](../generated/functions/scipp.epoch.rst) can be used to get a scalar containing scipp's epoch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.epoch(unit='s')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other creation functions also work with datetimes by specifying the `datetime64` dtype explicitly.\n",
+    "However, only integer inputs and Numpy arrays of [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html#basic-datetimes) can be used in those cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.scalar(value=24, unit='h', dtype=sc.dtype.datetime64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var = sc.scalar(value=681794055, unit=sc.units.s, dtype='datetime64')\n",
     "var"
    ]
   },
@@ -156,7 +208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Datetime elements are automatically converted to and from [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html#basic-datetimes) objects:"
+    "Scipp's datetime variables can interoperate with [numpy.datetime64](https://numpy.org/doc/stable/reference/arrays.datetime.html#basic-datetimes) and arrays thereof:"
    ]
   },
   {
@@ -174,15 +226,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "now = sc.scalar(value=np.datetime64('now'))\n",
-    "now"
+    "sc.scalar(value=np.datetime64('now'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that `now` has unit `s` even though we did not specify it.\n",
+    "Or more succinctly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.datetime('now')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `'now'` implies unit `s` even though we did not specify it.\n",
     "The unit was deduced from the `numpy.datetime64` object which encodes a unit of its own."
    ]
   },
@@ -203,21 +270,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = sc.scalar(value=np.datetime64('2021-03-14', 'ms'))\n",
-    "b = sc.scalar(value=np.datetime64('2000-01-01', 'ms'))\n",
+    "a = sc.datetime('2021-03-14T00:00:00', unit='ms')\n",
+    "b = sc.datetime('2000-01-01T00:00:00', unit='ms')\n",
     "a - b"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    a + b\n",
-    "except sc.DTypeError as err:\n",
-    "    print(err)"
+    "a + b"
    ]
   },
   {
@@ -252,7 +320,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -266,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/lib/python/bind_units.cpp
+++ b/lib/python/bind_units.cpp
@@ -59,4 +59,6 @@ void init_units(py::module &m) {
   units.attr("us") = units::us;
   units.attr("ns") = units::ns;
   units.attr("mm") = units::mm;
+
+  m.def("to_numpy_time_string", to_numpy_time_string);
 }

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -82,7 +82,7 @@ from .core import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all, any
 from .core import broadcast, concat, concatenate, fold, flatten, transpose
 from .core import sin, cos, tan, asin, acos, atan, atan2
 from .core import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange
+from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime
 
 from .logging import display_logs, get_logger
 

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -82,7 +82,7 @@ from .core import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all, any
 from .core import broadcast, concat, concatenate, fold, flatten, transpose
 from .core import sin, cos, tan, asin, acos, atan, atan2
 from .core import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime
+from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes
 
 from .logging import display_logs, get_logger
 

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -82,7 +82,7 @@ from .core import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all, any
 from .core import broadcast, concat, concatenate, fold, flatten, transpose
 from .core import sin, cos, tan, asin, acos, atan, atan2
 from .core import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes
+from .core import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes, epoch
 
 from .logging import display_logs, get_logger
 

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -83,4 +83,4 @@ from .reduction import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all
 from .shape import broadcast, concat, concatenate, fold, flatten, transpose
 from .trigonometry import sin, cos, tan, asin, acos, atan, atan2
 from .unary import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange
+from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -83,4 +83,4 @@ from .reduction import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all
 from .shape import broadcast, concat, concatenate, fold, flatten, transpose
 from .trigonometry import sin, cos, tan, asin, acos, atan, atan2
 from .unary import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime
+from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -83,4 +83,4 @@ from .reduction import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all
 from .shape import broadcast, concat, concatenate, fold, flatten, transpose
 from .trigonometry import sin, cos, tan, asin, acos, atan, atan2
 from .unary import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes
+from .variable import scalar, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes, epoch

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -509,11 +509,9 @@ def datetimes(*,
 
     Examples:
 
-      >>> sc.datetimes(dims=['t'],
-                       values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
+      >>> sc.datetimes(dims=['t'], values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
       <scipp.Variable> (t: 2)  datetime64              [s]  [2021-01-10T01:23:45, 2021-01-11T01:23:45]
-      >>> sc.datetimes(dims=['t'], unit='h',
-                       values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
+      >>> sc.datetimes(dims=['t'], values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'], unit='h')
       <scipp.Variable> (t: 2)  datetime64              [h]  [2021-01-10T01:00:00, 2021-01-11T01:00:00]
       >>> sc.datetimes(dims=['t'], values=[0, 1610288175], unit='s')
       <scipp.Variable> (t: 2)  datetime64              [s]  [1970-01-01T00:00:00, 2021-01-10T14:16:15]

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -484,8 +484,6 @@ def datetime(value: _Union[str, int, _np.datetime64],
       <scipp.Variable> ()  datetime64              [s]  [2021-01-10T14:16:15]
       >>> sc.datetime('2021-01-10T14:16:15', unit='ns')
       <scipp.Variable> ()  datetime64             [ns]  [2021-01-10T14:16:14.999999744]
-      >>> sc.datetime('now', unit='s')
-      <scipp.Variable> ()  datetime64              [s]  [2022-01-10T13:16:20]
       >>> sc.datetime(1610288175, unit='s')
       <scipp.Variable> ()  datetime64              [s]  [2021-01-10T14:16:15]
     """

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Matthew Andrew
+# flake8: noqa: E501
 
 from __future__ import annotations
 
@@ -460,17 +461,84 @@ def arange(dim: str,
                  dtype=dtype)
 
 
-def datetime(value, unit=None) -> _cpp.Variable:
+def datetime(value: _Union[str, int, _np.datetime64],
+             *,
+             unit: _Optional[_Union[_cpp.Unit, str]] = None) -> _cpp.Variable:
+    """Constructs a zero dimensional :class:`Variable` with a dtype of datetime64.
+
+    :seealso: :py:func:`scipp.datetimes` :py:func:`scipp.epoch`
+              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+
+    :param value:
+     - `str`: Interpret the string according to the ISO 8601 date time format.
+     - `int`: Number of time units (see argument ``unit``) since scipp's epoch
+              (see :py:func:`scipp.epoch`).
+     - `np.datetime64`: Construct equivalent datetime of scipp.
+    :param unit: Unit of the resulting datetime.
+                 Can be deduced if ``value`` is a str or np.datetime64 but
+                 is required if it is an int.
+
+    Examples:
+
+      >>> sc.datetime('2021-01-10T14:16:15')
+      <scipp.Variable> ()  datetime64              [s]  [2021-01-10T14:16:15]
+      >>> sc.datetime('2021-01-10T14:16:15', unit='ns')
+      <scipp.Variable> ()  datetime64             [ns]  [2021-01-10T14:16:14.999999744]
+      >>> sc.datetime('now', unit='s')
+      <scipp.Variable> ()  datetime64              [s]  [2022-01-10T13:16:20]
+      >>> sc.datetime(1610288175, unit='s')
+      <scipp.Variable> ()  datetime64              [s]  [2021-01-10T14:16:15]
+    """
     if isinstance(value, str):
         return scalar(_np.datetime64(value), unit=unit)
-    return scalar(value, unit=unit, dtype='datetime64')
+    return scalar(value, unit=unit, dtype=_cpp.dtype.datetime64)
 
 
-def datetimes(*, dims, values, unit=None) -> _cpp.Variable:
+def datetimes(*,
+              dims,
+              values: array_like,
+              unit: _Optional[_Union[_cpp.Unit, str]] = None) -> _cpp.Variable:
+    """Constructs an array :class:`Variable` with a dtype of datetime64.
+
+    :seealso: :py:func:`scipp.datetime` :py:func:`scipp.epoch`
+              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+
+    :param dims: Dimension labels
+    :param values: Numpy array or something that can be converted to a
+                   Numpy array of datetimes.
+    :param unit: Unit for the resulting Variable.
+                 Can be deduced if ``values`` contains strings or np.datetime64's.
+
+    Examples:
+
+      >>> sc.datetimes(dims=['t'],
+                       values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
+      <scipp.Variable> (t: 2)  datetime64              [s]  [2021-01-10T01:23:45, 2021-01-11T01:23:45]
+      >>> sc.datetimes(dims=['t'], unit='h',
+                       values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
+      <scipp.Variable> (t: 2)  datetime64              [h]  [2021-01-10T01:00:00, 2021-01-11T01:00:00]
+      >>> sc.datetimes(dims=['t'], values=[0, 1610288175], unit='s')
+      <scipp.Variable> (t: 2)  datetime64              [s]  [1970-01-01T00:00:00, 2021-01-10T14:16:15]
+    """
     np_unit_str = f'[{_cpp.to_numpy_time_string(unit)}]' if unit else ''
     return array(dims=dims,
                  values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))
 
 
-def epoch(*, unit) -> _cpp.Variable:
-    return scalar(0, unit=unit, dtype='datetime64')
+def epoch(*, unit: _Union[_cpp.Unit, str]) -> _cpp.Variable:
+    """Constructs a zero dimensional :class:`Variable` with a dtype of
+    datetime64 that contains scipp's epoch.
+
+    Currently, the epoch of datetimes in scipp is the Unix epoch 1970-01-01T00:00:00.
+
+    :seealso: :py:func:`scipp.datetime` :py:func:`scipp.datetimes`
+              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+
+    :param unit: Unit of the resulting Variable.
+
+    Examples:
+
+      >>> sc.epoch(unit='s')
+      <scipp.Variable> ()  datetime64              [s]  [1970-01-01T00:00:00]
+    """
+    return scalar(0, unit=unit, dtype=_cpp.dtype.datetime64)

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -458,3 +458,11 @@ def arange(dim: str,
                  values=_np.arange(start, stop, step),
                  unit=unit,
                  dtype=dtype)
+
+
+def datetime(value, unit=None) -> _cpp.Variable:
+    if isinstance(value, str):
+        if value == 'epoch':
+            return scalar(0, dtype='datetime64', unit=unit)
+        return scalar(_np.datetime64(value), unit=unit)
+    return scalar(value, unit=unit, dtype='datetime64')

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -462,8 +462,6 @@ def arange(dim: str,
 
 def datetime(value, unit=None) -> _cpp.Variable:
     if isinstance(value, str):
-        if value == 'epoch':
-            return scalar(0, dtype='datetime64', unit=unit)
         return scalar(_np.datetime64(value), unit=unit)
     return scalar(value, unit=unit, dtype='datetime64')
 
@@ -472,3 +470,7 @@ def datetimes(*, dims, values, unit=None) -> _cpp.Variable:
     np_unit_str = f'[{_cpp.to_numpy_time_string(unit)}]' if unit else ''
     return array(dims=dims,
                  values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))
+
+
+def epoch(*, unit) -> _cpp.Variable:
+    return scalar(0, unit=unit, dtype='datetime64')

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -466,3 +466,9 @@ def datetime(value, unit=None) -> _cpp.Variable:
             return scalar(0, dtype='datetime64', unit=unit)
         return scalar(_np.datetime64(value), unit=unit)
     return scalar(value, unit=unit, dtype='datetime64')
+
+
+def datetimes(*, dims, values, unit=None) -> _cpp.Variable:
+    np_unit_str = f'[{_cpp.to_numpy_time_string(unit)}]' if unit else ''
+    return array(dims=dims,
+                 values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -394,13 +394,6 @@ def test_datetime():
                         sc.scalar(-94716, dtype='datetime64', unit='min'))
 
 
-def test_datetime_epoch():
-    assert sc.identical(sc.datetime('epoch', unit='s'),
-                        sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
-    assert sc.identical(sc.datetime(0, unit='s'),
-                        sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
-
-
 def test_datetimes():
     assert sc.identical(
         sc.datetimes(dims=['t'], values=['1970', '2021'], unit='Y'),
@@ -436,3 +429,9 @@ def test_datetimes():
         sc.datetimes(dims=['t'], values=[-723, 2**13, -3**5], unit='min'),
         sc.array(dims=['t'],
                  values=np.array([-723, 2**13, -3**5], dtype='datetime64[m]')))
+
+
+def test_datetime_epoch():
+    assert sc.identical(sc.epoch(unit='s'),
+                        sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
+    assert sc.identical(sc.epoch(unit='D'), sc.scalar(np.datetime64('1970-01-01', 'D')))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -399,3 +399,40 @@ def test_datetime_epoch():
                         sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
     assert sc.identical(sc.datetime(0, unit='s'),
                         sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
+
+
+def test_datetimes():
+    assert sc.identical(
+        sc.datetimes(dims=['t'], values=['1970', '2021'], unit='Y'),
+        sc.array(dims=['t'],
+                 values=[np.datetime64('1970', 'Y'),
+                         np.datetime64('2021', 'Y')],
+                 unit='Y'))
+    assert sc.identical(
+        sc.datetimes(dims=['t'],
+                     values=['2152-11-25T13:13:46', '1111-11-11T11:11:11'],
+                     unit='s'),
+        sc.array(dims=['t'],
+                 values=[
+                     np.datetime64('2152-11-25T13:13:46', 's'),
+                     np.datetime64('1111-11-11T11:11:11', 's')
+                 ],
+                 unit='s'))
+    assert sc.identical(
+        sc.datetimes(dims=['t'],
+                     values=['2152-11-25T13:13:46', '1111-11-11T11:11:11'],
+                     unit='us'),
+        sc.array(dims=['t'],
+                 values=[
+                     np.datetime64('2152-11-25T13:13:46', 'us'),
+                     np.datetime64('1111-11-11T11:11:11', 'us')
+                 ],
+                 unit='us'))
+
+    assert sc.identical(
+        sc.datetimes(dims=['t'], values=[0, 123, 2**10], unit='s'),
+        sc.array(dims=['t'], values=np.array([0, 123, 2**10], dtype='datetime64[s]')))
+    assert sc.identical(
+        sc.datetimes(dims=['t'], values=[-723, 2**13, -3**5], unit='min'),
+        sc.array(dims=['t'],
+                 values=np.array([-723, 2**13, -3**5], dtype='datetime64[m]')))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -372,3 +372,30 @@ def test_empty_sizes():
                         sc.empty(sizes=dict(zip(dims, shape))))
     with pytest.raises(ValueError):
         sc.empty(dims=dims, shape=shape, sizes=dict(zip(dims, shape)))
+
+
+def test_datetime():
+    assert sc.identical(sc.datetime('1970', unit='Y'),
+                        sc.scalar(np.datetime64('1970', 'Y')))
+    assert sc.identical(sc.datetime('2015-06-13'),
+                        sc.scalar(np.datetime64('2015-06-13', 'D')))
+    assert sc.identical(sc.datetime('2152-11-25T13:13:46'),
+                        sc.scalar(np.datetime64('2152-11-25T13:13:46', 's')))
+    assert sc.identical(sc.datetime('2152-11-25T13:13:46', unit='h'),
+                        sc.scalar(np.datetime64('2152-11-25T13', 'h')))
+    assert sc.identical(sc.datetime('2152-11-25T13:13:46', unit='us'),
+                        sc.scalar(np.datetime64('2152-11-25T13:13:46', 'us')))
+
+    assert sc.identical(sc.datetime(626, unit='s'),
+                        sc.scalar(626, dtype='datetime64', unit='s'))
+    assert sc.identical(sc.datetime(2**10, unit='ns'),
+                        sc.scalar(2**10, dtype='datetime64', unit='ns'))
+    assert sc.identical(sc.datetime(-94716, unit='min'),
+                        sc.scalar(-94716, dtype='datetime64', unit='min'))
+
+
+def test_datetime_epoch():
+    assert sc.identical(sc.datetime('epoch', unit='s'),
+                        sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))
+    assert sc.identical(sc.datetime(0, unit='s'),
+                        sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -393,6 +393,11 @@ def test_datetime():
     assert sc.identical(sc.datetime(-94716, unit='min'),
                         sc.scalar(-94716, dtype='datetime64', unit='min'))
 
+    assert sc.identical(sc.datetime(np.datetime64(314, 's'), unit='s'),
+                        sc.scalar(314, dtype='datetime64', unit='s'))
+    assert sc.identical(sc.datetime(np.datetime64(671, 'h')),
+                        sc.scalar(671, dtype='datetime64', unit='h'))
+
 
 def test_datetimes():
     assert sc.identical(


### PR DESCRIPTION
As discussed on Slack.

I did end up adding `sc.epoch` because numpy does not support it and parsing the inputs strings ourselves is fairly complicated.  We would have to check if the input contains any strings and if so, handle `'epoch'` before passing it to numpy to turn it into an array.
I tried supporting conversions from `str` to `datetime64` in Variable's constructor directly but that would have required special cases in several generic functions that otherwise are straight forward.