### PR TITLE
Camera options for 3d plots

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Features
 * Added ``unit`` property to ``obj.bins`` for getting and setting unit of bin elements `#2330 <https://github.com/scipp/scipp/pull/2330>`_.
 * Added :py:func:`scipp.optimize.curve_fit` as convenience wrappers of the scipy function of the same name `#2350 <https://github.com/scipp/scipp/pull/2350>`_.
 * Added :py:func:`scipp.signal.butter` and :py:func:`scipp.signal.sosfiltfilt` as wrappers of the scipy functions of the same name `#2356 <https://github.com/scipp/scipp/pull/2356>`_.
+* Added ``camera`` option for 3-D scatter plots to control camera position and the point the camera is looking at `#2361 <https://github.com/scipp/scipp/pull/2361>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -88,11 +88,12 @@ def plot(*args, **kwargs):
 
     :param camera: Dict configuring the camera. Valid entries are 'position' and
         'look_at'. This option is valid only for 3-D scatter plots.
-        The 'position' entry defined the position of the camera and the 'look_at'
+        The 'position' entry defines the position of the camera and the 'look_at'
         entry defines the point the camera is looking at.
-        Both must be scalar variables with the correct unit, i.e., the unit of the
-        scatter point positions. Defaults to `None`, in which case the camera looks
-        at the center of the cloud of plotted points.
+        Both must be variables containing a single vector with the correct unit,
+        i.e., a unit compatible with the unit of the scatter point positions.
+        Defaults to `None`, in which case the camera looks at the center of the
+        cloud of plotted points.
     :type camera: dict, optional
 
     :param cax: Attach colorbar to supplied Matplotlib axes.

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -86,6 +86,11 @@ def plot(*args, **kwargs):
         is used. `labels={"time": "time-labels"}`. Defaults to `None`.
     :type labels: dict, optional
 
+    :param camera: Define initial camera 'position' and 'look_at' (3d only).
+        Defaults to `None`. When nothing is specified, the camera looks at the
+        mean position of the pixels.
+    :type camera: dict, optional
+
     :param cax: Attach colorbar to supplied Matplotlib axes.
         Defaults to `None`.
     :type cax: matplotlib.axes.Axes, optional

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -86,9 +86,13 @@ def plot(*args, **kwargs):
         is used. `labels={"time": "time-labels"}`. Defaults to `None`.
     :type labels: dict, optional
 
-    :param camera: Define initial camera 'position' and 'look_at' (3d only).
-        Defaults to `None`. When nothing is specified, the camera looks at the
-        mean position of the pixels.
+    :param camera: Dict configuring the camera. Valid entries are 'position' and
+        'look_at'. This option is valid only for 3-D scatter plots.
+        The 'position' entry defined the position of the camera and the 'look_at'
+        entry defines the point the camera is looking at.
+        Both must be scalar variables with the correct unit, i.e., the unit of the
+        scatter point positions. Defaults to `None`, in which case the camera looks
+        at the center of the cloud of plotted points.
     :type camera: dict, optional
 
     :param cax: Attach colorbar to supplied Matplotlib axes.

--- a/src/scipp/plotting/plot3d.py
+++ b/src/scipp/plotting/plot3d.py
@@ -35,7 +35,8 @@ def plot3d(scipp_obj_dict, *, positions, **kwargs):
                 show_outline=True,
                 xlabel=None,
                 ylabel=None,
-                zlabel=None):
+                zlabel=None,
+                camera=None):
         array = next(iter(scipp_obj_dict.values()))
         pos = array.meta[positions] if isinstance(positions, str) else positions
         out = {
@@ -64,7 +65,8 @@ def plot3d(scipp_obj_dict, *, positions, **kwargs):
                                      tick_size=tick_size,
                                      xlabel=xlabel,
                                      ylabel=ylabel,
-                                     zlabel=zlabel)
+                                     zlabel=zlabel,
+                                     camera=camera)
 
         return out
 

--- a/src/scipp/plotting/plot3d.py
+++ b/src/scipp/plotting/plot3d.py
@@ -8,6 +8,7 @@ from .view3d import PlotView3d
 from .figure3d import PlotFigure3d
 from .controller3d import PlotController3d
 from .model3d import ScatterPointModel
+from ..core import UnitError
 
 
 def plot3d(scipp_obj_dict, *, positions, **kwargs):
@@ -39,6 +40,12 @@ def plot3d(scipp_obj_dict, *, positions, **kwargs):
                 camera=None):
         array = next(iter(scipp_obj_dict.values()))
         pos = array.meta[positions] if isinstance(positions, str) else positions
+        if camera is not None:
+            for k, v in camera.items():
+                if v.unit != pos.unit:
+                    raise UnitError(f"Unit of scatter point positions '{pos.unit}' "
+                                    f"does not match unit '{v.unit}' of camera['{k}'].")
+            camera = {k: tuple(v.value) for k, v in camera.items()}
         out = {
             'view_ndims': 0,
             'dims': list(set(array.dims) - set(pos.dims)),

--- a/src/scipp/plotting/plot3d.py
+++ b/src/scipp/plotting/plot3d.py
@@ -8,7 +8,7 @@ from .view3d import PlotView3d
 from .figure3d import PlotFigure3d
 from .controller3d import PlotController3d
 from .model3d import ScatterPointModel
-from ..core import UnitError
+from ..core import UnitError, to_unit
 
 
 def plot3d(scipp_obj_dict, *, positions, **kwargs):
@@ -41,10 +41,14 @@ def plot3d(scipp_obj_dict, *, positions, **kwargs):
         array = next(iter(scipp_obj_dict.values()))
         pos = array.meta[positions] if isinstance(positions, str) else positions
         if camera is not None:
+            camera = dict(camera)
             for k, v in camera.items():
-                if v.unit != pos.unit:
-                    raise UnitError(f"Unit of scatter point positions '{pos.unit}' "
-                                    f"does not match unit '{v.unit}' of camera['{k}'].")
+                try:
+                    camera[k] = to_unit(v, pos.unit)
+                except UnitError:
+                    raise UnitError(
+                        f"Unit  '{v.unit}' of camera['{k}'] not convertible "
+                        f"to unit of scatter point positions '{pos.unit}'.")
             camera = {k: tuple(v.value) for k, v in camera.items()}
         out = {
             'view_ndims': 0,

--- a/tests/plotting/plot_3d_test.py
+++ b/tests/plotting/plot_3d_test.py
@@ -171,6 +171,26 @@ def test_plot_projection_3d_with_camera():
          camera={'look_at': sc.vector(value=[0, 0, 30], unit='m')})
 
 
+def test_plot_projection_3d_with_camera_supports_compatible_units():
+    da = make_data_array_with_position_vectors()
+    da.coords['xyz'].unit = 'm'
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={
+             'position': sc.vector(value=[150, 10, 10], unit='mm'),
+             'look_at': sc.vector(value=[0, 0, 30], unit='mm')
+         })
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={'position': sc.vector(value=[150, 10, 10], unit='mm')})
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={'look_at': sc.vector(value=[0, 0, 30], unit='mm')})
+
+
 def test_plot_projection_3d_with_camera_raises_if_camera_param_units_wrong():
     da = make_data_array_with_position_vectors()
     da.coords['xyz'].unit = 'm'
@@ -178,9 +198,9 @@ def test_plot_projection_3d_with_camera_raises_if_camera_param_units_wrong():
         plot(da,
              projection="3d",
              positions="xyz",
-             camera={'position': sc.vector(value=[150, 10, 10], unit='mm')})
+             camera={'position': sc.vector(value=[150, 10, 10], unit='s')})
     with pytest.raises(sc.UnitError):
         plot(da,
              projection="3d",
              positions="xyz",
-             camera={'look_at': sc.vector(value=[0, 0, 30], unit='mm')})
+             camera={'look_at': sc.vector(value=[0, 0, 30], unit='s')})

--- a/tests/plotting/plot_3d_test.py
+++ b/tests/plotting/plot_3d_test.py
@@ -147,3 +147,17 @@ def test_plot_redraw():
     p.redraw()
     after = p.view.figure.points_geometry.attributes["color"].array
     assert np.any(before != after)
+
+
+def test_plot_projection_3d_with_camera():
+    da = make_data_array_with_position_vectors()
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={
+             'position': [150, 10, 10],
+             'look_at': [0, 0, 30]
+         })
+    plot(da, projection="3d", positions="xyz", camera={
+        'position': [150, 10, 10],
+    })

--- a/tests/plotting/plot_3d_test.py
+++ b/tests/plotting/plot_3d_test.py
@@ -9,6 +9,8 @@ from ..factory import make_dense_data_array, make_binned_data_array
 from .plot_helper import plot
 import matplotlib
 
+import pytest
+
 matplotlib.use('Agg')
 
 
@@ -151,12 +153,34 @@ def test_plot_redraw():
 
 def test_plot_projection_3d_with_camera():
     da = make_data_array_with_position_vectors()
+    da.coords['xyz'].unit = 'm'
     plot(da,
          projection="3d",
          positions="xyz",
          camera={
-             'position': [150, 10, 10],
-             'look_at': [0, 0, 30]
+             'position': sc.vector(value=[150, 10, 10], unit='m'),
+             'look_at': sc.vector(value=[0, 0, 30], unit='m')
          })
-    plot(da, projection="3d", positions="xyz", camera={'position': [150, 10, 10]})
-    plot(da, projection="3d", positions="xyz", camera={'look_at': [0, 0, 30]})
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={'position': sc.vector(value=[150, 10, 10], unit='m')})
+    plot(da,
+         projection="3d",
+         positions="xyz",
+         camera={'look_at': sc.vector(value=[0, 0, 30], unit='m')})
+
+
+def test_plot_projection_3d_with_camera_raises_if_camera_param_units_wrong():
+    da = make_data_array_with_position_vectors()
+    da.coords['xyz'].unit = 'm'
+    with pytest.raises(sc.UnitError):
+        plot(da,
+             projection="3d",
+             positions="xyz",
+             camera={'position': sc.vector(value=[150, 10, 10], unit='mm')})
+    with pytest.raises(sc.UnitError):
+        plot(da,
+             projection="3d",
+             positions="xyz",
+             camera={'look_at': sc.vector(value=[0, 0, 30], unit='mm')})

--- a/tests/plotting/plot_3d_test.py
+++ b/tests/plotting/plot_3d_test.py
@@ -158,6 +158,5 @@ def test_plot_projection_3d_with_camera():
              'position': [150, 10, 10],
              'look_at': [0, 0, 30]
          })
-    plot(da, projection="3d", positions="xyz", camera={
-        'position': [150, 10, 10],
-    })
+    plot(da, projection="3d", positions="xyz", camera={'position': [150, 10, 10]})
+    plot(da, projection="3d", positions="xyz", camera={'look_at': [0, 0, 30]})


### PR DESCRIPTION
Example:

```Py
N = 1000
M = 100
theta = np.random.random(N) * np.pi
phi = np.random.random(N) * 2.0 * np.pi
r = 10.0 + (np.random.random(N) - 0.5)
x = r * np.sin(theta) * np.sin(phi)
y = r * np.sin(theta) * np.cos(phi)
z = r * np.cos(theta)

a = np.arange(M*N).reshape([M, N]) * np.sin(y)
da = sc.DataArray(
    data=sc.array(dims=['time', 'xyz'], values=a),
    coords={
        'xyz':sc.vectors(dims=['xyz'], unit='m', values=np.array([x, y, z]).T),
        'time':sc.array(dims=['time'], unit='s', values=np.arange(M).astype(float))})
da.plot(projection='3d', positions='xyz', camera={'position':[150, 10, 10], 'look_at': [0, 0, 30]})
```