### PR TITLE
Support structured dtypes in interp1d

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/sanitizers-cmake"]
 	path = lib/cmake/sanitizers-cmake
-	url = git://github.com/arsenm/sanitizers-cmake.git
+	url = https://github.com/arsenm/sanitizers-cmake.git

--- a/tests/interpolate/interp1d_test.py
+++ b/tests/interpolate/interp1d_test.py
@@ -168,3 +168,20 @@ def test_options(kind, fill_value):
                         axis=0,
                         kind=kind,
                         fill_value=fill_value)(x.values))
+
+
+def test_structured_dtype_interpolation_interpolates_elements():
+    da = make_array()
+    da.data = sc.vector(value=[1, 2, 3]) * da.data
+    x = sc.array(dims=['x'], values=[1, 3])
+    da = sc.DataArray(data=sc.vectors(dims=['x'],
+                                      values=[[1, 2, 3], [5, 4, 3]],
+                                      unit='m'),
+                      coords={'x': x})
+    xnew = sc.array(dims=['x'], values=[1, 2, 3])
+    out = interp1d(da, 'x')(xnew)
+    expected = sc.DataArray(data=sc.vectors(dims=['x'],
+                                            values=[[1, 2, 3], [3, 3, 3], [5, 4, 3]],
+                                            unit='m'),
+                            coords={'x': xnew})
+    assert sc.identical(out, expected)

--- a/tests/interpolate/interp1d_test.py
+++ b/tests/interpolate/interp1d_test.py
@@ -171,8 +171,6 @@ def test_options(kind, fill_value):
 
 
 def test_structured_dtype_interpolation_interpolates_elements():
-    da = make_array()
-    da.data = sc.vector(value=[1, 2, 3]) * da.data
     x = sc.array(dims=['x'], values=[1, 3])
     da = sc.DataArray(data=sc.vectors(dims=['x'],
                                       values=[[1, 2, 3], [5, 4, 3]],


### PR DESCRIPTION
This worked almost out of the box since `scipy.interpolate.interp1d` can work with extra axis. Only change needed here is creation of the output data variable.