### PR TITLE
Safer interface for `scipp.optimize.curve_fit`

### DIFF
--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -115,10 +115,22 @@ def curve_fit(
 
       >>> from scipp.optimize import curve_fit
       >>> popt, _ = curve_fit(func, da, p0 = {'b': 1.0 / sc.Unit('m')})
-      >>> round(popt['a'])
-      5
-      >>> sc.round(popt['b'])
+      >>> sc.round(sc.values(popt['a']))
+      <scipp.Variable> ()    float64            [dimensionless]  [5]
+      >>> sc.round(sc.values(popt['b']))
       <scipp.Variable> ()    float64            [1/m]  [17]
+
+    Fit-function parameters that have a default value do not participate in the fit
+    unless an initial guess is provided via the p0 parameters:
+
+      >>> from functools import partial
+      >>> func2 = partial(func, a=5)
+      >>> popt, _ = curve_fit(func2, da, p0 = {'b': 1.0 / sc.Unit('m')})
+      >>> 'a' in popt
+      False
+      >>> popt, _ = curve_fit(func2, da, p0 = {'a':2, 'b': 1.0 / sc.Unit('m')})
+      >>> 'a' in popt
+      True
     """
     for arg in ['xdata', 'ydata', 'sigma']:
         if arg in kwargs:

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -75,25 +75,31 @@ def curve_fit(
       if present, i.e., the standard deviations.
     - The fit function f must work with scipp objects. This provides additional safety
       over the underlying scipy function by ensuring units are consistent.
+    - The fit function f must only take a single positional argument, x. All other
+      arguments mapping to fit parameters must be keyword-only arguments.
+    - The inital guess in p0 must be provided as a dict, mapping from fit-function
+      parameter names to initial guesses.
     - The fit parameters may be scalar scipp variables. In that case an initial guess
       p0 with the correct units must be provided.
     - The returned optimal parameter values popt and the coverance matrix pcov will
-      have units provided that the initial parameters have units.
+      have units provided that the initial parameters have units. popt and pcov are
+      a dict and a dic of dict, respectively. The are indexed using the fit parameter
+      names.
 
     :param f: The model function, f(x, ...). It must take the independent variable
         (coordinate of the data array da) as the first argument and the parameters
-        to fit as separate remaining arguments.
+        to fit as keyword arguments.
     :param da: One-dimensional data array. The dimension coordinate for the only
         dimension defines the independent variable where the data is measured. The
         values of the data array provide the dependent data. If the data array stores
         variances then the standard deviations (square root of the variances) are taken
         into account when fitting.
-    :param p0: Initial guess for the parameters (length N). If None, then the initial
-        values will all be 1 (if the number of parameters for the function can be
-        determined using introspection, otherwise a ValueError is raised). If the fit
-        function cannot handle initial values of 1, in particular for parameters that
-        are not dimensionless, then typically a :py:class:`scipp.UnitError` is raised,
-        but details will depend on the function.
+    :param p0: An optional dict of optional initial guesses for the parameters. If None,
+        then the initial values will all be 1 (if the parameter names for the function
+        can be determined using introspection, otherwise a ValueError is raised). If
+        the fit function cannot handle initial values of 1, in particular for parameters
+        that are not dimensionless, then typically a :py:class:`scipp.UnitError` is
+        raised, but details will depend on the function.
 
     Example:
 

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -11,6 +11,7 @@ from ..core import scalar, stddevs, Variable, DataArray
 from ..core import BinEdgeError
 from ..interpolate import _drop_masked
 
+import numpy as np
 from numbers import Real
 from typing import Callable, Dict, Tuple, Union
 from inspect import getfullargspec
@@ -61,7 +62,7 @@ def curve_fit(
     f: Callable,
     da: DataArray,
     *,
-    p0: Dict[str, Union[Variable, Real]] = None,
+    p0: Dict[str, Variable] = None,
     **kwargs
 ) -> Tuple[Dict[str, Union[Variable, Real]], Dict[str, Dict[str, Union[Variable,
                                                                        Real]]]]:
@@ -135,7 +136,10 @@ def curve_fit(
                                ydata=da.values,
                                sigma=sigma,
                                p0=p0)
-    popt = {k: _as_scalar(v, u) for k, v, u in zip(p, popt, p_units)}
+    popt = {
+        name: scalar(value=val, variance=var, unit=u)
+        for name, val, var, u in zip(p, popt, np.diag(pcov), p_units)
+    }
     pcov = _covariance_with_units(list(p.keys()), pcov, p_units)
     return popt, pcov
 

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -97,7 +97,7 @@ def curve_fit(
 
     Example:
 
-      >>> def func(x, a, b):
+      >>> def func(x, *, a, b):
       ...     return a * sc.exp(-b * x)
 
       >>> x = sc.linspace(dim='x', start=0.0, stop=0.4, num=50, unit='m')
@@ -106,10 +106,10 @@ def curve_fit(
       >>> da = sc.DataArray(y, coords={'x': x})
 
       >>> from scipp.optimize import curve_fit
-      >>> popt, _ = curve_fit(func, da, p0 = [1.0, 1.0 / sc.Unit('m')])
-      >>> round(popt[0])
+      >>> popt, _ = curve_fit(func, da, p0 = {'b': 1.0 / sc.Unit('m')})
+      >>> round(popt['a'])
       5
-      >>> sc.round(popt[1])
+      >>> sc.round(popt['b'])
       <scipp.Variable> ()    float64            [1/m]  [17]
     """
     for arg in ['xdata', 'ydata', 'sigma']:

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -85,7 +85,8 @@ def curve_fit(
     - The returned optimal parameter values popt and the coverance matrix pcov will
       have units provided that the initial parameters have units. popt and pcov are
       a dict and a dic of dict, respectively. The are indexed using the fit parameter
-      names.
+      names. The variance of the returned optimal parameter values is set to the
+      corresponding diagonal value of the covariance matrix.
 
     :param f: The model function, f(x, ...). It must take the independent variable
         (coordinate of the data array da) as the first argument and the parameters

--- a/src/scipp/optimize/__init__.py
+++ b/src/scipp/optimize/__init__.py
@@ -84,7 +84,7 @@ def curve_fit(
       p0 with the correct units must be provided.
     - The returned optimal parameter values popt and the coverance matrix pcov will
       have units provided that the initial parameters have units. popt and pcov are
-      a dict and a dic of dict, respectively. The are indexed using the fit parameter
+      a dict and a dict of dict, respectively. They are indexed using the fit parameter
       names. The variance of the returned optimal parameter values is set to the
       corresponding diagonal value of the covariance matrix.
 

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -78,6 +78,12 @@ def test_optimized_params_approach_real_params_as_data_noise_decreases(noise_sca
     assert sc.allclose(popt['b'], sc.scalar(1.5), rtol=sc.scalar(2.0 * noise_scale))
 
 
+def test_optimized_params_variances_are_diag_of_covariance_matrix():
+    popt, pcov = curve_fit(func, array1d(a=1.7, b=1.5))
+    assert popt['a'].variance == pcov['a']['a']
+    assert popt['b'].variance == pcov['b']['b']
+
+
 @pytest.mark.parametrize("mask_pos", [0, 1, -3])
 @pytest.mark.parametrize("mask_size", [1, 2])
 def test_masked_points_are_treated_as_if_they_were_removed(mask_pos, mask_size):

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -66,13 +66,15 @@ def test_masks_are_not_ignored():
     da.masks['mask'] = sc.zeros(sizes=da.sizes, dtype=bool)
     da.masks['mask'][-5:] = sc.scalar(True)
     masked, _ = curve_fit(func, da)
-    assert all(masked != unmasked)
+    assert masked['a'] != unmasked['a']
+    assert masked['b'] != unmasked['b']
 
 
 @pytest.mark.parametrize("noise_scale", [1e-1, 1e-2, 1e-3, 1e-6, 1e-9])
 def test_optimized_params_approach_real_params_as_data_noise_decreases(noise_scale):
     popt, _ = curve_fit(func, array1d(a=1.7, b=1.5, noise_scale=noise_scale))
-    np.testing.assert_allclose(popt, [1.7, 1.5], rtol=2.0 * noise_scale)
+    np.testing.assert_allclose(popt['a'], 1.7, rtol=2.0 * noise_scale)
+    np.testing.assert_allclose(popt['b'], 1.5, rtol=2.0 * noise_scale)
 
 
 @pytest.mark.parametrize("mask_pos", [0, 1, -3])
@@ -84,7 +86,8 @@ def test_masked_points_are_treated_as_if_they_were_removed(mask_pos, mask_size):
     masked, _ = curve_fit(func, da)
     removed, _ = curve_fit(
         func, sc.concat([da[:mask_pos], da[mask_pos + mask_size:]], da.dim))
-    assert all(masked == removed)
+    assert masked['a'] == removed['a']
+    assert masked['b'] == removed['b']
 
 
 @pytest.mark.parametrize("variance,expected", [(1e9, 1.0), (1, 2.0), (1 / 3, 3.0),
@@ -97,7 +100,7 @@ def test_variances_determine_weights(variance, expected):
     da.variances[1] = variance
     # Fit a constant to highlight influence of weights
     popt, _ = curve_fit(lambda x, *, a: sc.scalar(a), da)
-    assert popt[0] == pytest.approx(expected)
+    assert popt['a'] == pytest.approx(expected)
 
 
 def test_fit_function_with_dimensionful_params_raises_UnitError_when_no_p0_given():
@@ -115,9 +118,9 @@ def test_fit_function_with_dimensionful_params_yields_outputs_with_units():
     x = sc.linspace(dim='x', start=0.5, stop=2.0, num=10, unit='m')
     da = sc.DataArray(f(x, a=1.2, b=1.3 / sc.Unit('m')), coords={'x': x})
     popt, pcov = curve_fit(f, da, p0={'a': 1.1, 'b': 1.2 / sc.Unit('m')})
-    assert not isinstance(popt[0], sc.Variable)
-    assert popt[1].unit == sc.Unit('1/m')
-    assert not isinstance(pcov[0][0], sc.Variable)
-    assert pcov[0][1].unit == sc.Unit('1/m')
-    assert pcov[1][0].unit == sc.Unit('1/m')
-    assert pcov[1][1].unit == sc.Unit('1/m**2')
+    assert not isinstance(popt['a'], sc.Variable)
+    assert popt['b'].unit == sc.Unit('1/m')
+    assert not isinstance(pcov['a']['a'], sc.Variable)
+    assert pcov['a']['b'].unit == sc.Unit('1/m')
+    assert pcov['b']['a'].unit == sc.Unit('1/m')
+    assert pcov['b']['b'].unit == sc.Unit('1/m**2')


### PR DESCRIPTION
- Fit function must take all but the `x` param as keyword argument.
- Initial guess `p0` must be provided as a dict.
- `popt` and `pcov` are returned as dicts and dict of dicts.
- `popt` includes the parameter variance as variance.