### PR TITLE
Update "Whats New" for 0.11 release

### DIFF
--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -35,7 +35,7 @@
     "tags": []
    },
    "source": [
-    "### Get unique dimension using `dim` property\n",
+    "### Unique dimensions and slicing of 1-D objects\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -56,6 +56,52 @@
    "source": [
     "x = sc.linspace(dim='x', start=0, stop=1, num=4)\n",
     "x.dim"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**New in 0.11**\n",
+    "\n",
+    "1-D objects can now be sliced without specifying a dimension.\n",
+    "</div>\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If an object is not 1-D then `DimensionError` is raised:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "var2d = sc.concat([x,x], 'y')\n",
+    "var2d[0]"
    ]
   },
   {
@@ -115,115 +161,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Indexing\n",
-    "\n",
-    "#### Ellipsis\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "    \n",
-    "Indexing with ellipsis (`...`) is now supported.\n",
-    "This can be used, e.g., to replace data in an existing object without re-pointing the underlying reference to the object given on the right-hand side.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "Example"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "var1 = sc.ones(dims=[\"x\"], shape=[4])\n",
-    "var2 = var1 + var1\n",
-    "da = sc.DataArray(data=sc.zeros(dims=[\"x\"], shape=[4]))\n",
-    "da.data = var1  # replace data variable\n",
-    "da.data[...] = var2  # assign to slice, copy into existing data variable\n",
-    "var1  # now holds values of var2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Changing `var2` has no effect on `da.data`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "var2 += 2222.0\n",
-    "da"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Operations\n",
     "\n",
-    "#### Creation functions\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.5**\n",
-    "\n",
-    "For convenience and similarity to `numpy` we added [functions that create variables](../reference/creation-functions.rst#creation-functions).\n",
-    "Our intention is to fully replace the need to use `sc.Variable` directly, but at this point this has not been rolled out to our documentation pages.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "Examples:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.array(dims=[\"x\"], values=np.array([1, 2, 3]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.zeros(dims=[\"x\"], shape=[3])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.scalar(17)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "All of these also take keyword arguments.\n",
-    "Note that we can still support creating scalars by multiplying with a unit:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "1.2 * sc.units.m"
+    "#### Creation functions"
    ]
   },
   {
@@ -232,67 +172,22 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**New in 0.7**\n",
+    "**New in 0.11**\n",
     "    \n",
-    "More creation functions were added:\n",
+    "Creation functions for datetimes where added:\n",
     "\n",
-    "- Added `zeros_like`, `ones_like`, and `empty_like`.\n",
-    "- Added `linspace`, `logspace`, `geomspace`, and `arange`.\n",
+    "- Added `epoch`, `datetime` and `datetimes`.\n",
     "\n",
     "</div>"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "    \n",
-    "More creation functions were added:\n",
-    "\n",
-    "- Added `full` and `full_like`.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Unit conversion\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.6**\n",
-    "\n",
-    "Conversions between different unit scales are now supported.\n",
-    "`to_unit` provides conversion of variables between, e.g., `mm` and `m`.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "- `to_unit` can now avoid making a copy if the input already has the desired unit.\n",
-    "  This can be used as a cheap way to ensure inputs have expected units.\n",
-    "- `to_unit` now also works for binned data, converting the unit of the underlying events in the bins\n",
-    "    \n",
-    "</div>\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "\n",
-    "- `to_unit` now has a `copy` argument.\n",
-    "   By default, `copy=True` and `to_unit` makes a copy even if the input already has the desired unit.\n",
-    "   For a cheap way to ensure inputs have expected units use `copy=False` to avoid copies if possible.\n",
-    "    \n",
-    "</div>\n",
-    "\n",
-    "Example:"
+    "sc.datetime('now', unit='ms')"
    ]
   },
   {
@@ -301,34 +196,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var = sc.array(dims=[\"x\"], unit=\"mm\", values=[3.2, 5.4, 7.6])\n",
-    "m = sc.to_unit(var, \"m\")\n",
-    "m"
+    "times = sc.datetimes(dims=['time'], values=['2022-01-11T10:24:03', '2022-01-11T10:24:03'])\n",
+    "times"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "No copy is made if the input has the requested unit when we specify `copy=False`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "sc.to_unit(m, \"m\", copy=False)  # no copy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Conversions also work for more specialized units such as electron-volt:"
+    "The new `epoch` function is useful for obtaining the time since epoch, i.e., a time difference (`dtype='int64'`) instead of a time point (`dtype='datetime64'`):"
    ]
   },
   {
@@ -337,7 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.to_unit(sc.scalar(1.0, unit=\"nJ\"), unit=\"meV\")"
+    "times - sc.epoch(unit=times.unit)"
    ]
   },
   {
@@ -457,226 +333,27 @@
     "tags": []
    },
    "source": [
-    "#### `fold` and `flatten`\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.6**\n",
-    "\n",
-    "`fold` and `flatten`, which are similar to [numpy.reshape](https://numpy.org/doc/stable/reference/generated/numpy.reshape.html), have been added.\n",
-    "In contrast to `reshape`, `fold` and `flatten` support data arrays and handle also meta data such as coord, masks, and attrs.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "- `fold` now always returns views of data and all meta data instead of making deep copies.\n",
-    "- `flatten` also preserves reshaped data as a view, but unlike `fold` the same is not true for meta data in general, since it may require duplication in the flatten operation.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "Example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "var = sc.ones(dims=[\"pixel\"], shape=[100])\n",
-    "xy = sc.fold(var, dim=\"pixel\", sizes={\"x\": 10, \"y\": 10})\n",
-    "xy = sc.DataArray(\n",
-    "    data=xy,\n",
-    "    coords={\n",
-    "        \"x\": sc.array(dims=[\"x\"], values=np.arange(10)),\n",
-    "        \"y\": sc.array(dims=[\"y\"], values=np.arange(10)),\n",
-    "    },\n",
-    ")\n",
-    "xy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Folding does not effect copies of either data or meta data, for example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xy[\"y\", 4] *= 0.0  # affects var (scipp-0.7 and higher)\n",
-    "var.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The reverse of `fold` is `flatten`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "flat = sc.flatten(xy, to=\"pixel\")\n",
-    "flat"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Flattening does not effect a copy of data, but meta data may get copied if values need to be duplicated by the operation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "flat[\"pixel\", 0] = 22  # modifies var (scipp-0.7 and higher)\n",
-    "var.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Vectors and matrices\n",
     "\n",
     "#### General\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "Several improvements for working with (3-D position) vectors and (3-D rotation) matrices are part of this release:\n",
-    "\n",
-    "- Creation functions were added:\n",
-    "  - `vector` (a single vector)\n",
-    "  - `vectors` (array of vectors)\n",
-    "  - `matrix` (a single matrix),\n",
-    "  - `matrices` (array of matrices).\n",
-    "- Direct creation and initialization of 2-D (or higher) arrays of matrices and vectors is now possible from numpy arrays.\n",
-    "- The values property now returns a numpy array with ndim+1 (vectors) or ndim+2 (matrices) axes, with the inner 1 (vectors) or 2 (matrices) axes corresponding to the vector or matrix axes.\n",
-    "- Vector or matrix elements can now be accessed and modified directly using the new `fields` property of variables.\n",
-    "  `fields` provides access to vector elements `x`, `y`, and `z` or matrix elements `xx`, `xy`, ..., `zz`.\n",
+    "**New in 0.11**\n",
     "    \n",
-    "</div>\n",
+    "`scipp.spatial` has been restructured and extended:\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "\n",
-    "The `fields` property can now be iterated and behaves similar to a `dict` with fixed keys.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.vector(value=[1, 2, 3])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vecs = sc.vectors(dims=[\"x\"], unit=\"m\", values=np.arange(12).reshape(4, 3))\n",
-    "vecs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vecs.values"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vecs.fields.y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vecs.fields.z += 0.666 * sc.units.m\n",
-    "vecs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "    \n",
-    "The `cross` function to compute the cross-product of vectors as added.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.cross(vecs, vecs[\"x\", 0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### `scipp.spatial.transform`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "    \n",
-    "The `scipp.spatial` (in the style of `scipy.spatial`) submodule was added.\n",
-    "This now provides:\n",
-    "\n",
-    "- `rotation_from_rotvec` to create rotation matrices from rotation vectors.\n",
-    "- `rotation_as_rotvec` to convert rotation matrices into rotation vectors.\n",
+    "- New data types for spatial transforms were added:\n",
+    "  - `vector3` (renamed from `vector3_float64`)\n",
+    "  - `rotation3` (3-D rotation defined using quaternion coeffiecients)\n",
+    "  - `translation3` (translation in 3-D)\n",
+    "  - `linear_transform3` (previously `matrix_3_float64`, 3-D linear transform with, e.g., rotation and scaling)\n",
+    "  - `affine_transform3` (affine transform in 3-D, combination of a linear transform and a translation, defined using 4x4 matrix)\n",
+    "- The [scipp.spatial](https://scipp.github.io/generated/modules/scipp.spatial.html) submodule was extended with a number of new creation functions, in particular for the new dtypes.\n",
     "\n",
     "</div>\n",
     "\n",
-    "As an example, the following creates a rotation matrix for rotation around the `x`-axis by 30 degrees:"
+    "Note that the `scipp.spatial` subpackage must be imported explicitly:"
    ]
   },
   {
@@ -685,10 +362,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipp.spatial import rotation_from_rotvec\n",
-    "\n",
-    "rot = rotation_from_rotvec(value=[30.0, 0, 0], unit=\"deg\")\n",
-    "rot"
+    "from scipp import spatial\n",
+    "linear = spatial.linear_transform(value=[[1,0,0],[0,2,0],[0,0,3]])\n",
+    "linear"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trans = spatial.translation(value=[1,2,3], unit='m')\n",
+    "trans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiplication can be used to combine the various transforms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linear * trans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in the case of `affine_transform3` the unit refers to the translation part.\n",
+    "A unit for the linear part is currently not supported."
    ]
   },
   {
@@ -779,68 +489,6 @@
    "outputs": [],
    "source": [
     "physical_constants(\"neutron mass\", with_variance=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Plotting\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "- Plotting supports `redraw()` method for updating existing plots with new data, without recreating the plot.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "\n",
-    "- Plotting 1-D binned (event) data is now supported.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Binned data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Buffer and meta data access\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "- The internal buffer holding the \"events\" underlying binned data can now be accessed directly using the new `events` property.\n",
-    "  **Update: This is deprecated as of 0.8.2.**\n",
-    "- HTML view now works for binned meta data access such as `binned.bins.coords['time']`\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.8**\n",
-    "\n",
-    "The mean of bins can now be computed using `binned.bins.mean()`.\n",
-    "This should general be used instead of `binned.bins.sum()` the if dtype is not \"summable\", i.e., typically anything that is not of unit \"counts\".\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "Consider the following example, representing a time series of temperature measurements on an x-y plane:"
    ]
   },
   {
@@ -955,28 +603,31 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "### Broadcasting dense variables to binned variables using `bins_like`\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.9**\n",
-    "    \n",
-    "- Added `bins_like`, for broadcasting dense variables to binned variables, e.g., for converting bin coordinates into event coordinates.\n",
-    "\n",
-    "</div>"
+    "## SciPy compatibility layer"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "temperature = sc.array(dims=['x'], unit='K', values=[3.,4.,5.,6.]) \n",
-    "binned.bins.coords['temperature'] = sc.bins_like(binned, fill_value=temperature)\n",
-    "binned"
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**New in 0.11**\n",
+    "    \n",
+    "A number of subpackages providing wrappers for a *subset* of functions from the corresponding packages in SciPy was added:\n",
+    "    \n",
+    "- [scipp.integrate](https://scipp.github.io/generated/modules/scipp.integrate.html) providing `simpson` and `trapezoid`.\n",
+    "- [scipp.interpolate](https://scipp.github.io/generated/modules/scipp.interpolate.html) providing `interp1d`.\n",
+    "- [scipp.optimize](https://scipp.github.io/generated/modules/scipp.optimize.html) providing `curve_fit`.\n",
+    "- [scipp.signal](https://scipp.github.io/generated/modules/scipp.signal.html) providing `butter` and `sosfiltfilt`.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "Please refer to the function documentation for working examples."
    ]
   },
   {
@@ -986,20 +637,6 @@
    },
    "source": [
     "## Performance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.7**\n",
-    "\n",
-    "- `sort` is now considerably faster for data with more rows.\n",
-    "- reduction operations such as `sum` and `mean` are now also multi-threaded and thus considerably faster.\n",
-    "\n",
-    "</div>"
    ]
   },
   {

--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -350,6 +350,7 @@
     "  - `linear_transform3` (previously `matrix_3_float64`, 3-D linear transform with, e.g., rotation and scaling)\n",
     "  - `affine_transform3` (affine transform in 3-D, combination of a linear transform and a translation, defined using 4x4 matrix)\n",
     "- The [scipp.spatial](https://scipp.github.io/generated/modules/scipp.spatial.html) submodule was extended with a number of new creation functions, in particular for the new dtypes.\n",
+    "- `matrix` and `matrices` for creating \"matrices\" have been deprecated. Use `scipp.spatial.linear_transform` and `scipp.spatial.linear_transforms` instead.\n",
     "\n",
     "</div>\n",
     "\n",

--- a/src/scipp/spatial/__init__.py
+++ b/src/scipp/spatial/__init__.py
@@ -14,10 +14,9 @@ def _to_eigen_layout(a):
     return _np.moveaxis(a, -1, -2)
 
 
-def translation_from_vector(*,
-                            unit: Union[_core_cpp.Unit,
-                                        str] = _core_cpp.units.dimensionless,
-                            value: Union[_np.ndarray, list]):
+def translation(*,
+                unit: Union[_core_cpp.Unit, str] = _core_cpp.units.dimensionless,
+                value: Union[_np.ndarray, list]):
     """
     Creates a translation transformation from a single provided 3-vector.
 
@@ -27,11 +26,10 @@ def translation_from_vector(*,
     return _core_cpp.translations(dims=[], unit=unit, values=value)
 
 
-def translations_from_vectors(*,
-                              dims: Sequence[str],
-                              unit: Union[_core_cpp.Unit,
-                                          str] = _core_cpp.units.dimensionless,
-                              values: Union[_np.ndarray, list]):
+def translations(*,
+                 dims: Sequence[str],
+                 unit: Union[_core_cpp.Unit, str] = _core_cpp.units.dimensionless,
+                 values: Union[_np.ndarray, list]):
     """
     Creates translation transformations from multiple 3-vectors.
 
@@ -230,7 +228,7 @@ def linear_transforms(*,
 
 __all__ = [
     'rotation', 'rotations', 'rotation_from_rotvec', 'rotations_from_rotvecs',
-    'rotation_as_rotvec', 'scaling_from_vector', 'scalings_from_vectors',
-    'translation_from_vector', 'translations_from_vectors', 'affine_transform',
-    'affine_transforms', 'linear_transform', 'linear_transforms'
+    'rotation_as_rotvec', 'scaling_from_vector', 'scalings_from_vectors', 'translation',
+    'translations', 'affine_transform', 'affine_transforms', 'linear_transform',
+    'linear_transforms'
 ]

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -32,9 +32,7 @@ vector = sc.vectors(dims=['x'], values=np.random.rand(4, 3))
 matrix = sc.spatial.linear_transforms(dims=['x'], values=np.random.rand(4, 3, 3))
 
 rotation = sc.spatial.rotations(dims=['x'], values=[[1, 2, 3, 4]])
-translation = sc.spatial.translations_from_vectors(dims=['x'],
-                                                   values=[[5, 6, 7]],
-                                                   unit=sc.units.m)
+translation = sc.spatial.translations(dims=['x'], values=[[5, 6, 7]], unit=sc.units.m)
 affine = sc.spatial.affine_transforms(dims=['x'],
                                       values=[[[0, 1, 2, 4], [5, 6, 7, 8],
                                                [9, 10, 11, 12], [13, 14, 15, 16]]],

--- a/tests/spatial/translation_test.py
+++ b/tests/spatial/translation_test.py
@@ -1,18 +1,18 @@
-from scipp.spatial import translation_from_vector, translations_from_vectors
+from scipp.spatial import translation, translations
 import scipp as sc
 
 
-def test_from_translation_vector():
-    transform = translation_from_vector(value=[1, -5, 5], unit=sc.units.m)
+def test_translation():
+    transform = translation(value=[1, -5, 5], unit=sc.units.m)
     vector = sc.vector(value=[1, 2, 3], unit=sc.units.m)
 
     assert sc.allclose(transform * vector, sc.vector(value=[2, -3, 8], unit=sc.units.m))
 
 
-def test_from_translation_vectors():
-    transforms = translations_from_vectors(dims=["x"],
-                                           values=[[1, 0, -2], [3, 4, 5]],
-                                           unit=sc.units.m)
+def test_translations():
+    transforms = translations(dims=["x"],
+                              values=[[1, 0, -2], [3, 4, 5]],
+                              unit=sc.units.m)
     vectors = sc.vectors(dims=["x"], values=[[1, 2, 3], [4, 5, 6]], unit=sc.units.m)
 
     assert sc.allclose(


### PR DESCRIPTION
Remove some old content from several release back.

Also made function naming for creating translations consistent with naming for other transform dtypes.