### PR TITLE
Do not configure logging by default

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,6 +28,7 @@ Breaking changes
   For consistency with other transformation creation functions, ``rotations_from_rotvecs`` now takes ``values``, ``dims``, and ``unit`` separately.
 * The matrix dtype ``matrix_3_float64`` has been renamed to ``linear_transform3``, and should now be constructed with :py:func:`scipp.spatial.transform.linear_transform`.
 * The vector dtype ``vector_3_float64`` has been renamed to ``vector3``.
+* Scipp's logger is no longer preconfigured, this has to be done by the user `#2372 <https://github.com/scipp/scipp/pull/2372>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/reference/logging.ipynb
+++ b/docs/reference/logging.ipynb
@@ -3,15 +3,18 @@
   {
    "cell_type": "markdown",
    "id": "94fac996-f1b9-4cea-ba12-1a3619f2ae27",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Logging\n",
     "\n",
-    "It is often useful to record a log of the operations that you perform.\n",
-    "Being a basic building block, scipp is generally quiet and does not produce any output except for warnings and errors.\n",
-    "It does however define and configure its own logger which allows customizing how those warnings and errors are reported.\n",
+    "Scipp is generally quiet because it mostly provides low level components.\n",
+    "It can however produce warnings and some functions (e.g. [scipp.transform_coords](../generated/functions/scipp.transform_coords.rst)) log at the info level.\n",
+    "For this purpose, scipp defines a logger which allows customizing how those warnings and errors are reported.\n",
     "\n",
-    "The logger is an instance of [logging.Logger](https://docs.python.org/3/library/logging.html#logging.Logger) and can be configured using the [logging](https://docs.python.org/3/library/logging.html) module of the standard library."
+    "The logger is an instance of [logging.Logger](https://docs.python.org/3/library/logging.html#logging.Logger) with name 'scipp'.\n",
+    "It has no handlers by default and needs to be configured using the [logging](https://docs.python.org/3/library/logging.html) module of the standard library."
    ]
   },
   {
@@ -27,11 +30,42 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86737c96-4689-4653-87d1-9d64efaafef4",
+   "id": "ed3fcbae-1a9e-492e-96fd-b46883d48483",
    "metadata": {},
    "source": [
-    "By default, scipp's logger outputs messages of level 'warning' and higher to `sys.stderr`.\n",
-    "Log files can be set up by adding appropriate handlers to the logger."
+    "You can silence scipp's info messages if they get in your way using"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6365de50-9a7c-42f7-9308-b73d6e10e527",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger.setLevel('WARNING')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90f3f6ec-79dc-472c-b7f4-1528f19bca48",
+   "metadata": {},
+   "source": [
+    "For illustration purposes, install a basic [logging.StreamHandler](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler) and enable logging of info messages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1456dece-9774-4aac-bea1-3b6baa872b99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "stream_handler = logging.StreamHandler()\n",
+    "stream_handler.setLevel(logging.INFO)\n",
+    "logger.addHandler(stream_handler)\n",
+    "logger.setLevel(logging.INFO)"
    ]
   },
   {
@@ -41,37 +75,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.info('Some general information')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "110c277f-2574-480c-8249-50565a3415a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "logger.warning('Be careful!')"
+    "logger.info('The stream handler simply prints messages')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2e5bd9bd-d1e3-4e4d-88e8-2da1ff96b426",
+   "id": "0fcd4bdd-9bd4-45f8-8738-6c18d1338ecb",
    "metadata": {},
    "source": [
-    "When running in Jupyter notebooks, scipp also registers a special handler with its logger which sends all messages of level 'info' and above to a widget.\n",
-    "The widget can be displayed using the following.\n",
-    "(Click and drag the bottom right corner to increase the size of the widget and see all messages.)"
+    "## Jupyter Log Widget\n",
+    "\n",
+    "When running in Jupyter notebooks, [scipp.logging](../generated/modules/scipp.logging.rst) provides a special handler which sends messages to a widget.\n",
+    "It can be added like any other handler.\n",
+    "Once scipp's logger has a [WidgetHandler](../generated/modules/scipp.logging.WidgetHandler.rst), [scipp.display_logs](../generated/modules/scipp.logging.display_logs.rst) can be used to render its widget in a notebook."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f15ac9fe-e9d3-4be1-8768-9f24cc956ee1",
+   "id": "39f1e3ae-16dd-4d43-beb1-c02908719882",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This only works in a Jupyter notebook.\n",
+    "logger.addHandler(sc.logging.make_widget_handler())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2cebf31-d262-4a5a-a077-398d8d6cbe29",
    "metadata": {},
    "outputs": [],
    "source": [
     "sc.display_logs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9349f14-2eee-4e84-b4bc-4e52a81d56d2",
+   "metadata": {},
+   "source": [
+    "(Click and drag the bottom right corner to increase the size of the widget if it is too small.)"
    ]
   },
   {
@@ -81,8 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.info('Some more text that only shows up in the widget')\n",
-    "logger.error('Something went wrong!')"
+    "logger.info('This shows up in the widget and error stream.')"
    ]
   },
   {
@@ -90,10 +134,17 @@
    "id": "22ba3fe2-4473-49e5-9562-22aadb105d4d",
    "metadata": {},
    "source": [
-    "Note how both logs from before and after the call to [scipp.display_logs](../generated/functions/scipp.display_logs.rst) are shown in the widget.\n",
+    "[scipp.logging](../generated/modules/scipp.logging.rst) provides a number of high level convenience functions for managing log widgets and handlers.\n",
+    "See the module documentation for more details.\n",
     "\n",
-    "Tip: In Jupyter lab, you can show the widget in a separate tab and keep it visible.\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "TIP\n",
+    "\n",
+    "In Jupyter lab, you can show the widget in a separate tab and keep it visible.\n",
     "To do so, right-click the widget and select 'Create New View for Output'.\n",
+    "</div>\n",
+    "\n",
     "\n",
     "## Formatting scipp Objects\n",
     "\n",
@@ -115,7 +166,7 @@
    },
    "outputs": [],
    "source": [
-    "logger.warning(sc.arange('x', 0, 5))"
+    "logger.info(sc.arange('x', 0, 5))"
    ]
   },
   {
@@ -141,7 +192,8 @@
    },
    "outputs": [],
    "source": [
-    "logger.warning('The HTML representation of a Variable: %s', sc.arange('h', 10, 100))"
+    "logger.info('The HTML representation of a Variable: %s',\n",
+    "            sc.arange('h', 10, 15))"
    ]
   },
   {
@@ -159,7 +211,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.warning('A Variable converted to string: %r', sc.arange('r', 100, 110))"
+    "logger.info('A Variable converted to string: %r', \n",
+    "            sc.arange('r', 100, 105))"
    ]
   },
   {
@@ -167,45 +220,7 @@
    "id": "b1884cd9",
    "metadata": {},
    "source": [
-    "The stream handler and all user defined handlers behave as normal and produce the string representation of scipp objects unless endowed with a custom formatter.\n",
-    "\n",
-    "## Advanced Configuration\n",
-    "\n",
-    "Utilities for managing the logger and log widget can be found in [scipp.logging](../generated/modules/scipp.logging.rst).\n",
-    "\n",
-    "It is possible to connect other loggers to the same widget by adding a [scipp.logging.WidgetHandler](../generated/modules/scipp.logging.WidgetHandler.rst):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69cd33cb",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "my_logger = logging.getLogger('my_logger')\n",
-    "my_logger.setLevel(logging.INFO)\n",
-    "my_logger.addHandler(sc.logging.WidgetHandler(logging.INFO,\n",
-    "                                              sc.logging.get_log_widget()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54a82daf-95a6-4435-840c-79be6b0c0417",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "my_logger.info('My own logger can also send messages to the widget.')"
+    "Our `stream_handler` and other handlers behave as normal and produce the string representation of scipp objects unless endowed with a custom formatter."
    ]
   }
  ],

--- a/src/scipp/logging.py
+++ b/src/scipp/logging.py
@@ -26,7 +26,7 @@ def get_logger() -> logging.Logger:
 
 
 @dataclass
-class _WidgetLogRecord:
+class WidgetLogRecord:
     name: str
     levelname: str
     time_stamp: str
@@ -45,7 +45,7 @@ if running_in_jupyter():
             self._rows_str = ''
             self._update()
 
-        def add_message(self, record: _WidgetLogRecord) -> None:
+        def add_message(self, record: WidgetLogRecord) -> None:
             """
             Add a message to the output.
             :param record: Log record formatted for the widget.
@@ -54,7 +54,7 @@ if running_in_jupyter():
             self._update()
 
         @staticmethod
-        def _format_row(record: _WidgetLogRecord) -> str:
+        def _format_row(record: WidgetLogRecord) -> str:
             # The message is assumed to be safe HTML.
             # It is WidgetHandler's responsibility to ensure that.
             return (
@@ -195,18 +195,17 @@ class WidgetHandler(logging.Handler):
         self.widget = widget
         self._rows = []
 
-    def format(self, record: logging.LogRecord) -> _WidgetLogRecord:
+    def format(self, record: logging.LogRecord) -> WidgetLogRecord:
         """
         Format the specified record for consumption by a LogWidget.
         """
         message = self._format_html(record) if _has_html_repr(
             record.msg) else self._format_text(record)
-        return _WidgetLogRecord(name=record.name,
-                                levelname=record.levelname,
-                                time_stamp=time.strftime('%Y-%m-%dT%H:%M:%S',
-                                                         time.localtime(
-                                                             record.created)),
-                                message=message)
+        return WidgetLogRecord(name=record.name,
+                               levelname=record.levelname,
+                               time_stamp=time.strftime('%Y-%m-%dT%H:%M:%S',
+                                                        time.localtime(record.created)),
+                               message=message)
 
     def _format_text(self, record: logging.LogRecord) -> str:
         args, replacements = _preprocess_format_args(record.args)

--- a/src/scipp/logging.py
+++ b/src/scipp/logging.py
@@ -4,7 +4,7 @@
 """
 Utilities for managing scipp's logger and log widget.
 
-See the `Logging <../../reference/logging.rst>`_ reference for an overview.
+See the https://scipp.github.io/reference/logging.html for an overview.
 """
 
 from copy import copy

--- a/src/scipp/logging.py
+++ b/src/scipp/logging.py
@@ -22,33 +22,7 @@ def get_logger() -> logging.Logger:
     """
     Return the global logger used by scipp.
     """
-    logger = logging.getLogger('scipp')
-    if not get_logger.is_set_up:
-        _setup_logger(logger)
-        get_logger.is_set_up = True
-    return logger
-
-
-get_logger.is_set_up = False
-
-
-def _setup_logger(logger: logging.Logger) -> None:
-    logger.setLevel(logging.INFO)
-    logger.addHandler(make_stream_handler())
-    if running_in_jupyter():
-        logger.addHandler(make_widget_handler())
-
-
-def make_stream_handler() -> logging.StreamHandler:
-    """
-    Make a new ``StreamHandler`` with default setup for scipp.
-    """
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.WARN)
-    handler.setFormatter(
-        logging.Formatter('[%(asctime)s] %(levelname)-8s : %(message)s',
-                          datefmt='%Y-%m-%dT%H:%M:%S'))
-    return handler
+    return logging.getLogger('scipp')
 
 
 @dataclass
@@ -120,7 +94,7 @@ def make_log_widget() -> 'LogWidget':
 
 def get_log_widget() -> Optional['LogWidget']:
     """
-    Return the log widget used by the global scipp logger.
+    Return the log widget used by the scipp logger.
     If multiple widget handlers are installed, only the first one is returned.
     If no widget handler is installed, returns ``None``.
     """
@@ -132,7 +106,8 @@ def get_log_widget() -> Optional['LogWidget']:
 
 def display_logs() -> None:
     """
-    Display the log widget associated with the global scipp logger.
+    Display the log widget associated with the scipp logger.
+    Only works in Jupyter notebooks.
     """
     widget = get_log_widget()
     if widget is None:
@@ -146,7 +121,7 @@ def display_logs() -> None:
 
 def clear_log_widget() -> None:
     """
-    Remove the current output of the log widget of the global scipp logger
+    Remove the current output of the log widget of the scipp logger
     if there is one.
     """
     widget = get_log_widget()
@@ -264,7 +239,7 @@ def make_widget_handler() -> WidgetHandler:
 
 def get_widget_handler() -> Optional[WidgetHandler]:
     """
-    Return the widget handler installed in the global scipp logger.
+    Return the widget handler installed in the scipp logger.
     If multiple widget handlers are installed, only the first one is returned.
     If no widget handler is installed, returns ``None``.
     """


### PR DESCRIPTION
Configuring our logger would make it harder for downstream software to pick a suitable configuration.
Instead, leave the scipp logger unconfigured and leave it to the user to set it up.