### PR TITLE
Improve interporability of DType

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -19,6 +19,7 @@ Features
 * Added :py:func:`scipp.Variable.to` and :py:func:`scipp.DataArray.to` as a convenience function for simultaneously converting dtype and units.
 * Added :py:func:`scipp.datetime`, :py:func:`scipp.datetimes`, and :py:func:`scipp.epoch` to conveniently construct variables containing datetimes `#2360 <https://github.com/scipp/scipp/pull/2360>`_.
 * Added ``camera`` option for 3-D scatter plots to control camera position and the point the camera is looking at `#2361 <https://github.com/scipp/scipp/pull/2361>`_.
+* Allow more interoperability between :py:class:`scipp.DType` and other ways of encoding dtypes `#2373 <https://github.com/scipp/scipp/pull/2373>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -30,6 +31,7 @@ Breaking changes
 * The matrix dtype ``matrix_3_float64`` has been renamed to ``linear_transform3``, and should now be constructed with :py:func:`scipp.spatial.transform.linear_transform`.
 * The vector dtype ``vector_3_float64`` has been renamed to ``vector3``.
 * Scipp's logger is no longer preconfigured, this has to be done by the user `#2372 <https://github.com/scipp/scipp/pull/2372>`_.
+* Data types are not attributes of the :py:class:`scipp.DType` class and the ``scipp.dtype`` module has been removed `#2373 <https://github.com/scipp/scipp/pull/2373>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -31,7 +31,7 @@ Breaking changes
 * The matrix dtype ``matrix_3_float64`` has been renamed to ``linear_transform3``, and should now be constructed with :py:func:`scipp.spatial.transform.linear_transform`.
 * The vector dtype ``vector_3_float64`` has been renamed to ``vector3``.
 * Scipp's logger is no longer preconfigured, this has to be done by the user `#2372 <https://github.com/scipp/scipp/pull/2372>`_.
-* Data types are not attributes of the :py:class:`scipp.DType` class and the ``scipp.dtype`` module has been removed `#2373 <https://github.com/scipp/scipp/pull/2373>`_.
+* Data types are now attributes of the :py:class:`scipp.DType` class and the ``scipp.dtype`` module has been removed `#2373 <https://github.com/scipp/scipp/pull/2373>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/reference/classes.rst
+++ b/docs/reference/classes.rst
@@ -14,6 +14,7 @@ General
    Bins
    DataArray
    Dataset
+   DType
    GroupByDataArray
    GroupByDataset
    Unit

--- a/docs/reference/dtype.ipynb
+++ b/docs/reference/dtype.ipynb
@@ -313,13 +313,6 @@
    "source": [
     "sc.scalar(value=np.datetime64('2021-09-03T12:30:00'))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/reference/dtype.ipynb
+++ b/docs/reference/dtype.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "The `dtype` may also be specified using a keyword argument to `sc.Variable` and most [creation functions](./creation-functions.rst#creation-functions).\n",
-    "It is possible to use scipp's own `scipp.dtype`, [numpy.dtype](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html), or (where a numpy equivalent exists) a string:"
+    "It is possible to use scipp's own [scipp.DType](../generated/classes/scipp.DType.rst), [numpy.dtype](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html), or (where a numpy equivalent exists) a string:"
    ]
   },
   {
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var = sc.zeros(dims=['x'], shape=[2], dtype=sc.dtype.float32)\n",
+    "var = sc.zeros(dims=['x'], shape=[2], dtype=sc.DType.float32)\n",
     "var.dtype"
    ]
   },
@@ -100,11 +100,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can get a full list using \n",
-    "```python\n",
-    "[s for s in dir(sc.dtype) if not s.startswith('__')]\n",
-    "```\n",
-    "but note that many of those dtypes are only meant for internal use."
+    "You can find a full list in the docs of the [scipp.DType](../generated/classes/scipp.DType.rst) class.\n",
+    "But note that many of those dtypes are only meant for internal use."
    ]
   },
   {
@@ -113,7 +110,7 @@
    "source": [
     "## Dates and Times\n",
     "\n",
-    "Scipp has a special dtype for time-points, `sc.dtype.datetime64`.\n",
+    "Scipp has a special dtype for time-points, `sc.DType.datetime64`.\n",
     "Variables can be constructed using [scipp.datetime](../generated/functions/scipp.datetime.rst) and [scipp.datetimes](../generated/functions/scipp.datetimes.rst):"
    ]
   },
@@ -191,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.scalar(value=24, unit='h', dtype=sc.dtype.datetime64)"
+    "sc.scalar(value=24, unit='h', dtype=sc.DType.datetime64)"
    ]
   },
   {
@@ -316,6 +313,13 @@
    "source": [
     "sc.scalar(value=np.datetime64('2021-09-03T12:30:00'))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var_0d = sc.scalar(value=1.0, variance=0.5, dtype=sc.dtype.float32, unit='kg')\n",
+    "var_0d = sc.scalar(value=1.0, variance=0.5, dtype=sc.DType.float32, unit='kg')\n",
     "var_0d"
    ]
   },

--- a/docs/user-guide/how_to.ipynb
+++ b/docs/user-guide/how_to.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.zeros(dims=['x'], shape=(2,), dtype=sc.dtype.bool)"
+    "sc.zeros(dims=['x'], shape=(2,), dtype=sc.DType.bool)"
    ]
   },
   {

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -52,7 +52,7 @@ void init_dtype(py::module &m) {
       .def(py::self == py::self)
       .def("__str__", [](const DType &self) { return to_string(self); })
       .def("__repr__", [](const DType &self) {
-        return "dtype('" + to_string(self) + "')";
+        return "DType('" + to_string(self) + "')";
       });
   auto dtype = m.def_submodule("dtype");
   for (const auto &[key, name] : core::dtypeNameRegistry()) {

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -50,9 +50,10 @@ constexpr bool operator==(const scipp::index a, const DTypeSize b) {
 void init_dtype(py::module &m) {
   py::class_<DType>(m, "DType")
       .def(py::init([](const py::object &x) { return scipp_dtype(x); }))
-      .def("__eq__", [](const DType &self, const py::object &other){
-        return self == scipp_dtype(other);
-      })
+      .def("__eq__",
+           [](const DType &self, const py::object &other) {
+             return self == scipp_dtype(other);
+           })
       .def("__str__", [](const DType &self) { return to_string(self); })
       .def("__repr__", [](const DType &self) {
         return "DType('" + to_string(self) + "')";

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -48,7 +48,9 @@ constexpr bool operator==(const scipp::index a, const DTypeSize b) {
 } // namespace
 
 void init_dtype(py::module &m) {
-  py::class_<DType> PyDType(m, "DType");
+  py::class_<DType> PyDType(m, "DType", R"(
+Representation of a data type of a Variable in scipp.
+See https://scipp.github.io/reference/dtype.html for details.)");
   PyDType.def(py::init([](const py::object &x) { return scipp_dtype(x); }))
       .def("__eq__",
            [](const DType &self, const py::object &other) {

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -48,8 +48,11 @@ constexpr bool operator==(const scipp::index a, const DTypeSize b) {
 } // namespace
 
 void init_dtype(py::module &m) {
-  py::class_<DType>(m, "_DType")
-      .def(py::self == py::self)
+  py::class_<DType>(m, "DType")
+      .def(py::init([](const py::object &x) { return scipp_dtype(x); }))
+      .def("__eq__", [](const DType &self, const py::object &other){
+        return self == scipp_dtype(other);
+      })
       .def("__str__", [](const DType &self) { return to_string(self); })
       .def("__repr__", [](const DType &self) {
         return "DType('" + to_string(self) + "')";

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -134,7 +134,7 @@ scipp::core::DType scipp_dtype(const py::object &type) {
 
 std::tuple<scipp::core::DType, scipp::units::Unit>
 cast_dtype_and_unit(const pybind11::object &dtype,
-                    const std::optional<ProtoUnit> unit) {
+                    const std::optional<ProtoUnit> &unit) {
   const auto scipp_dtype = ::scipp_dtype(dtype);
   if (scipp_dtype == core::dtype<core::time_point>) {
     units::Unit deduced_unit = parse_datetime_dtype(dtype);

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -48,8 +48,8 @@ constexpr bool operator==(const scipp::index a, const DTypeSize b) {
 } // namespace
 
 void init_dtype(py::module &m) {
-  py::class_<DType>(m, "DType")
-      .def(py::init([](const py::object &x) { return scipp_dtype(x); }))
+  py::class_<DType> PyDType(m, "DType");
+  PyDType.def(py::init([](const py::object &x) { return scipp_dtype(x); }))
       .def("__eq__",
            [](const DType &self, const py::object &other) {
              return self == scipp_dtype(other);
@@ -58,9 +58,9 @@ void init_dtype(py::module &m) {
       .def("__repr__", [](const DType &self) {
         return "DType('" + to_string(self) + "')";
       });
-  auto dtype = m.def_submodule("dtype");
   for (const auto &[key, name] : core::dtypeNameRegistry()) {
-    dtype.attr(name.c_str()) = key;
+    PyDType.def_property_readonly_static(
+        name.c_str(), [key = key](const py::object &) { return key; });
   }
 }
 

--- a/lib/python/dtype.cpp
+++ b/lib/python/dtype.cpp
@@ -50,7 +50,10 @@ constexpr bool operator==(const scipp::index a, const DTypeSize b) {
 void init_dtype(py::module &m) {
   py::class_<DType>(m, "_DType")
       .def(py::self == py::self)
-      .def("__repr__", [](const DType self) { return to_string(self); });
+      .def("__str__", [](const DType &self) { return to_string(self); })
+      .def("__repr__", [](const DType &self) {
+        return "dtype('" + to_string(self) + "')";
+      });
   auto dtype = m.def_submodule("dtype");
   for (const auto &[key, name] : core::dtypeNameRegistry()) {
     dtype.attr(name.c_str()) = key;

--- a/lib/python/dtype.h
+++ b/lib/python/dtype.h
@@ -21,7 +21,7 @@ scipp::core::DType scipp_dtype(const pybind11::object &type);
 
 std::tuple<scipp::core::DType, scipp::units::Unit>
 cast_dtype_and_unit(const pybind11::object &dtype,
-                    std::optional<ProtoUnit> unit);
+                    const std::optional<ProtoUnit> &unit);
 
 void ensure_conversion_possible(scipp::core::DType from, scipp::core::DType to,
                                 const std::string &data_name);

--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -252,7 +252,7 @@ if you want to preallocate memory to fill later, use :py:func:`scipp.empty`.
 :param variance: A single variance for constructing a scalar variable.
 :param unit: Physical unit, defaults to ``scipp.units.dimensionless``.
 :param dtype: Type of the variable's elements. Is deduced from other arguments
-              in most cases. Defaults to ``sc.dtype.float64`` if no deduction is
+              in most cases. Defaults to ``sc.DType.float64`` if no deduction is
               possible.
 
 :type dims: Sequence[str]

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -27,7 +27,7 @@ del runtime_config
 
 from .core import __version__
 # Import classes
-from .core import Variable, DataArray, Dataset, Unit
+from .core import Variable, DataArray, Dataset, DType, Unit
 # Import errors
 from .core import BinEdgeError, BinnedDataError, CoordError, \
                          DataArrayError, DatasetError, DimensionError, \

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -34,7 +34,6 @@ from .core import BinEdgeError, BinnedDataError, CoordError, \
                          DTypeError, NotFoundError, SizeError, SliceError, \
                          UnitError, VariableError, VariancesError
 # Import submodules
-from .core import dtype
 from . import units
 from . import geometry
 # Import functions

--- a/src/scipp/compat/dict.py
+++ b/src/scipp/compat/dict.py
@@ -5,8 +5,7 @@
 from __future__ import annotations
 
 from ..core import vector, vectors, matrix, matrices
-from ..core import dtype
-from ..core import Variable, DataArray, Dataset
+from ..core import DType, Variable, DataArray, Dataset
 from ..typing import VariableLike
 
 import numpy as np
@@ -60,9 +59,9 @@ def _variable_to_dict(v):
     # Using raw dtypes as dict keys doesn't appear to work, so we need to
     # convert to strings.
     dtype_parser.update({
-        str(dtype.vector3): _vec_parser,
-        str(dtype.linear_transform3): _vec_parser,
-        str(dtype.string): _vec_parser,
+        str(DType.vector3): _vec_parser,
+        str(DType.linear_transform3): _vec_parser,
+        str(DType.string): _vec_parser,
     })
 
     str_dtype = str(v.dtype)
@@ -139,7 +138,7 @@ def _dict_to_variable(d):
 
     for key in keylist:
         if key == "dtype" and isinstance(d[key], str):
-            out[key] = getattr(dtype, d[key])
+            out[key] = getattr(DType, d[key])
         else:
             out[key] = d[key]
     # Hack for types that cannot be directly constructed using Variable()

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -30,9 +30,6 @@ UnitError.__doc__ = 'Inappropriate unit value.'
 DimensionError.__doc__ = 'Inappropriate dimension labels and/or shape.'
 DTypeError.__doc__ = 'Inappropriate dtype.'
 
-# Import submodules
-from .._scipp.core import dtype
-
 from .._scipp.core import get_slice_params
 
 from .sizes import _make_sizes

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -17,7 +17,7 @@ if _debug_:
 
 from .._scipp import __version__
 from .._scipp.core import Variable, DataArray, Dataset, GroupByDataArray, \
-                         GroupByDataset, Unit
+                         GroupByDataset, DType, Unit
 # Import errors
 from .._scipp.core import BinEdgeError, BinnedDataError, CoordError, \
                          DataArrayError, DatasetError, DimensionError, \

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -13,7 +13,7 @@ from .operations import islinspace
 class Lookup:
     def __init__(self, func: _cpp.DataArray, dim: str):
         if func.ndim == 1 and func.dtype in [
-                _cpp.dtype.bool, _cpp.dtype.int32, _cpp.dtype.int64
+                _cpp.DType.bool, _cpp.DType.int32, _cpp.DType.int64
         ] and not islinspace(func.coords[dim], dim).value:
             # Significant speedup if `func` is large but mostly constant.
             func = merge_equal_adjacent(func)
@@ -272,7 +272,7 @@ def bins(*,
     internally.
 
     The variables ``begin`` and ``end`` must have the same dims and shape and
-    ``dtype=sc.dtype.int64``. The output dims and shape are given by ``begin``.
+    ``dtype=sc.DType.int64``. The output dims and shape are given by ``begin``.
     If only ``begin`` is given, each bucket is a slice containing a non-range
     slice of ``data`` at the given indices. If neither ``begin`` nor ``end``
     are given, the output has ``dims=[dim]`` and contains all non-range slices

--- a/src/scipp/core/operations.py
+++ b/src/scipp/core/operations.py
@@ -202,19 +202,17 @@ def to(var: Union[_cpp.Variable, _cpp.DataArray], *, unit=None, dtype=None, copy
     if unit is None:
         return var.astype(dtype, copy=copy)
 
-    if dtype == _cpp.dtype.float64 or dtype == "float64":
+    if dtype == _cpp.DType.float64:
         convert_dtype_first = True
-    elif var.dtype == _cpp.dtype.float64:
+    elif var.dtype == _cpp.DType.float64:
         convert_dtype_first = False
-    elif dtype == _cpp.dtype.float32 or dtype == "float32":
+    elif dtype == _cpp.DType.float32:
         convert_dtype_first = True
-    elif var.dtype == _cpp.dtype.float32:
+    elif var.dtype == _cpp.DType.float32:
         convert_dtype_first = False
-    elif var.dtype == _cpp.dtype.int64 and (dtype == _cpp.dtype.int32
-                                            or dtype == "int32"):
+    elif var.dtype == _cpp.DType.int64 and dtype == _cpp.DType.int32:
         convert_dtype_first = False
-    elif var.dtype == _cpp.dtype.int32 and (dtype == _cpp.dtype.int64
-                                            or dtype == "int64"):
+    elif var.dtype == _cpp.DType.int32 and dtype == _cpp.DType.int64:
         convert_dtype_first = True
     else:
         convert_dtype_first = True

--- a/src/scipp/core/structured.py
+++ b/src/scipp/core/structured.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from .._scipp.core import _element_keys, _get_elements, _set_elements, dtype
+from .._scipp.core import _element_keys, _get_elements, _set_elements, DType
 
 
 def _prop(key):
@@ -17,7 +17,7 @@ def _prop(key):
 def is_structured(obj):
     if obj.bins is not None:
         return is_structured(obj.bins.constituents['data'])
-    return obj.dtype in [dtype.vector3, dtype.linear_transform3]
+    return obj.dtype in [DType.vector3, DType.linear_transform3]
 
 
 def _fields(obj):

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -30,7 +30,7 @@ def _parse_dims_shape_sizes(dims, shape, sizes):
 def scalar(value: _Any,
            variance: _Any = None,
            unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-           dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+           dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
@@ -59,7 +59,7 @@ def zeros(*,
           shape: _Sequence[int] = None,
           sizes: dict = None,
           unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-          dtype: type(_cpp.dtype.float64) = _cpp.dtype.float64,
+          dtype: _cpp.DType = _cpp.DType.float64,
           with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with default initialized values with
     given dimension labels and shape.
@@ -108,7 +108,7 @@ def ones(*,
          shape: _Sequence[int] = None,
          sizes: dict = None,
          unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-         dtype: type(_cpp.dtype.float64) = _cpp.dtype.float64,
+         dtype: _cpp.DType = _cpp.DType.float64,
          with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values initialized to 1 with
     given dimension labels and shape.
@@ -152,7 +152,7 @@ def empty(*,
           shape: _Sequence[int] = None,
           sizes: dict = None,
           unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-          dtype: type(_cpp.dtype.float64) = _cpp.dtype.float64,
+          dtype: _cpp.DType = _cpp.DType.float64,
           with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with uninitialized values with given
     dimension labels and shape.
@@ -200,7 +200,7 @@ def full(*,
          shape: _Sequence[int] = None,
          sizes: dict = None,
          unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-         dtype: type(_cpp.dtype.float64) = _cpp.dtype.float64,
+         dtype: _cpp.DType = _cpp.DType.float64,
          value: _Any,
          variance: _Any = None) -> _cpp.Variable:
     """
@@ -322,7 +322,7 @@ def array(*,
           values: array_like,
           variances: _Optional[array_like] = None,
           unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-          dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+          dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
@@ -351,7 +351,7 @@ def linspace(dim: str,
              num: int,
              *,
              unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-             dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+             dtype: _cpp > DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with `num` evenly spaced samples,
     calculated over the interval `[start, stop]`.
 
@@ -378,7 +378,7 @@ def geomspace(dim: str,
               num: int,
               *,
               unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-              dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+              dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale
     (a geometric progression). This is similar to :py:func:`scipp.logspace`,
     but with endpoints specified directly.
@@ -407,7 +407,7 @@ def logspace(dim: str,
              num: int,
              *,
              unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-             dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+             dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale.
 
     :seealso: :py:func:`scipp.linspace` :py:func:`scipp.geomspace`
@@ -433,7 +433,7 @@ def arange(dim: str,
            step: _Union[int, float] = 1,
            *,
            unit: _Union[_cpp.Unit, str] = _cpp.units.dimensionless,
-           dtype: type(_cpp.dtype.float64) = None) -> _cpp.Variable:
+           dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with evenly spaced values within a given
     interval.
     Values are generated within the half-open interval [start, stop)
@@ -489,7 +489,7 @@ def datetime(value: _Union[str, int, _np.datetime64],
     """
     if isinstance(value, str):
         return scalar(_np.datetime64(value), unit=unit)
-    return scalar(value, unit=unit, dtype=_cpp.dtype.datetime64)
+    return scalar(value, unit=unit, dtype=_cpp.DType.datetime64)
 
 
 def datetimes(*,
@@ -537,4 +537,4 @@ def epoch(*, unit: _Union[_cpp.Unit, str]) -> _cpp.Variable:
       >>> sc.epoch(unit='s')
       <scipp.Variable> ()  datetime64              [s]  [1970-01-01T00:00:00]
     """
-    return scalar(0, unit=unit, dtype=_cpp.dtype.datetime64)
+    return scalar(0, unit=unit, dtype=_cpp.DType.datetime64)

--- a/src/scipp/interpolate/__init__.py
+++ b/src/scipp/interpolate/__init__.py
@@ -8,7 +8,7 @@ This subpackage provides wrappers for a subset of functions from
 """
 
 from ..core import empty, epoch, Variable, DataArray, DimensionError, UnitError
-from ..core import dtype, irreducible_mask
+from ..core import DType, irreducible_mask
 from ..compat.wrapping import wrap1d
 
 from typing import Any, Callable, Union
@@ -22,7 +22,7 @@ def _as_interpolation_type(x):
         if x.dtype.kind == 'M':
             return x.astype('int64', copy=False)
     else:
-        if x.dtype == dtype.datetime64:
+        if x.dtype == DType.datetime64:
             return x - epoch(unit=x.unit)
     return x
 

--- a/src/scipp/io/hdf5.py
+++ b/src/scipp/io/hdf5.py
@@ -11,7 +11,7 @@ from ..typing import VariableLike
 
 
 def _dtype_lut():
-    from .._scipp.core import dtype as d
+    from .._scipp.core import DType as d
     # For types understood by numpy we do not actually need this special
     # handling, but will do as we add support for other types such as
     # variable-length strings.
@@ -146,7 +146,7 @@ def _check_scipp_header(group, what):
 
 
 def _data_handler_lut():
-    from .._scipp.core import dtype as d
+    from .._scipp.core import DType as d
     handler = {}
     for dtype in [
             d.float64, d.float32, d.int64, d.int32, d.bool, d.datetime64, d.vector3,
@@ -193,7 +193,7 @@ class VariableIO:
     def read(cls, group):
         _check_scipp_header(group, 'Variable')
         from .._scipp import core as sc
-        from .._scipp.core import dtype as d
+        from .._scipp.core import DType as d
         values = group['values']
         contents = {key: values.attrs[key] for key in ['dims', 'shape']}
         contents['dtype'] = cls._dtypes[values.attrs['dtype']]

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -6,10 +6,9 @@ from enum import Enum
 
 from .. import units
 from ..core import bin as bin_
-from ..core import dtype
 from ..core import broadcast
 from ..core import linspace, rebin, get_slice_params, concat, histogram
-from ..core import DataArray, DimensionError
+from ..core import DataArray, DimensionError, DType
 from .tools import to_bin_edges
 
 
@@ -21,10 +20,10 @@ class ResamplingMode(Enum):
 def _resample(array, mode: ResamplingMode, dim, edges):
     if mode == ResamplingMode.sum:
         return rebin(array, dim, edges)
-    if array.dtype == dtype.float64:
+    if array.dtype == DType.float64:
         array = array.copy()
     else:
-        array = array.astype(dtype.float64)
+        array = array.astype(DType.float64)
     # Scale by bin widths, so `rebin` is effectively performing a "mean"
     # operation instead of "sum".
     # TODO
@@ -293,9 +292,9 @@ def _with_edges(array):
         new_array.coords[f'{prefix}_{dim}'] = var
         if var.sizes[dim] == array.sizes[dim]:
             new_array.coords[dim] = to_bin_edges(var, dim)
-        elif var.dtype not in [dtype.float32, dtype.float64]:
+        elif var.dtype not in [DType.float32, DType.float64]:
             # rebin does not support int coords right now
-            new_array.coords[dim] = var.astype(dtype.float64, copy=False)
+            new_array.coords[dim] = var.astype(DType.float64, copy=False)
     return new_array, prefix
 
 

--- a/src/scipp/plotting/tools.py
+++ b/src/scipp/plotting/tools.py
@@ -3,8 +3,8 @@
 # @author Neil Vaytet
 
 from .. import config, units
-from ..core import concat, values, dtype, nanmin, nanmax, histogram, full_like
-from ..core import Variable, DataArray
+from ..core import concat, values, nanmin, nanmax, histogram, full_like
+from ..core import DType, Variable, DataArray
 from ..core import abs as abs_
 import numpy as np
 from copy import copy
@@ -115,7 +115,7 @@ def find_log_limits(x):
     """
     from .. import flatten, ones
     volume = np.product(x.shape)
-    pixel = flatten(values(x.astype(dtype.float64)), to='pixel')
+    pixel = flatten(values(x.astype(DType.float64)), to='pixel')
     weights = ones(dims=['pixel'], shape=[volume], unit='counts')
     hist = histogram(DataArray(data=weights, coords={'order': pixel}),
                      bins=Variable(dims=['order'],
@@ -146,8 +146,8 @@ def find_linear_limits(x):
     Find variable min and max.
     """
     return [
-        values(nanmin(x).astype(dtype.float64)),
-        values(nanmax(x).astype(dtype.float64))
+        values(nanmin(x).astype(DType.float64)),
+        values(nanmax(x).astype(DType.float64))
     ]
 
 

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -19,21 +19,21 @@ def has_vector_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is vector3.
     """
-    return obj.dtype == sc.dtype.vector3
+    return obj.dtype == sc.DType.vector3
 
 
 def has_string_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is string.
     """
-    return obj.dtype == sc.dtype.string
+    return obj.dtype == sc.DType.string
 
 
 def has_datetime_type(obj: _std_typing.Any) -> bool:
     """
     Return True if the object dtype is datetime64.
     """
-    return obj.dtype == sc.dtype.datetime64
+    return obj.dtype == sc.DType.datetime64
 
 
 def has_numeric_type(obj: _std_typing.Any) -> bool:

--- a/src/scipp/utils/comparison.py
+++ b/src/scipp/utils/comparison.py
@@ -50,7 +50,7 @@ def isnear(x,
             raise sc.CoordError(
                 f'Coord (or attr) with key {key} have different'
                 f' shapes. For x, shape is {a.shape}. For y, shape = {b.shape}')
-        if val.dtype in [sc.dtype.float64, sc.dtype.float32]:
+        if val.dtype in [sc.DType.float64, sc.DType.float32]:
             if not sc.all(sc.isclose(a, b, rtol=rtol, atol=atol,
                                      equal_nan=equal_nan)).value:
                 return False

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -24,7 +24,7 @@ def test_bins_default_begin_end():
 
 def test_bins_default_end():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    begin = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.DType.int64)
     var = sc.bins(begin=begin, dim='x', data=data)
     assert var.dims == begin.dims
     assert var.shape == begin.shape
@@ -34,7 +34,7 @@ def test_bins_default_end():
 
 def test_bins_fail_only_end():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    end = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.dtype.int64)
+    end = sc.Variable(dims=['y'], values=[1, 3], dtype=sc.DType.int64)
     with pytest.raises(RuntimeError):
         sc.bins(end=end, dim='x', data=data)
 
@@ -45,8 +45,8 @@ def test_bins_constituents():
                         coords={'coord': var},
                         masks={'mask': var},
                         attrs={'attr': var})
-    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
-    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.DType.int64)
+    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.DType.int64)
     binned = sc.bins(begin=begin, end=end, dim='x', data=data)
     events = binned.bins.constituents['data']
     assert 'coord' in events.coords
@@ -73,8 +73,8 @@ def test_bins_constituents():
 
 def test_bins():
     data = sc.Variable(dims=['x'], values=[1, 2, 3, 4])
-    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
-    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.DType.int64)
+    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.DType.int64)
     var = sc.bins(begin=begin, end=end, dim='x', data=data)
     assert var.dims == begin.dims
     assert var.shape == begin.shape
@@ -84,7 +84,7 @@ def test_bins():
 
 def test_bins_of_transpose():
     data = sc.Variable(dims=['row'], values=[1, 2, 3, 4])
-    begin = sc.Variable(dims=['x', 'y'], values=[[0, 1], [2, 3]], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['x', 'y'], values=[[0, 1], [2, 3]], dtype=sc.DType.int64)
     end = begin + 1
     var = sc.bins(begin=begin, end=end, dim='row', data=data)
     assert sc.identical(sc.bins(**var.transpose().bins.constituents), var.transpose())
@@ -96,8 +96,8 @@ def make_binned():
                          coords={'time': col * 2.2},
                          attrs={'attr': col * 3.3},
                          masks={'mask': col == col})
-    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.dtype.int64)
-    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[0, 2], dtype=sc.DType.int64)
+    end = sc.Variable(dims=['y'], values=[2, 4], dtype=sc.DType.int64)
     return sc.bins(begin=begin, end=end, dim='event', data=table)
 
 
@@ -322,21 +322,21 @@ def test_bins_mean_with_masks():
 def test_bins_mean_using_bins():
     # Call to sc.bins gives different data structure compared to sc.bin
 
-    buffer = sc.arange('event', 5, unit=sc.units.ns, dtype=sc.dtype.float64)
-    begin = sc.array(dims=['x'], values=[0, 2], dtype=sc.dtype.int64)
-    end = sc.array(dims=['x'], values=[2, 5], dtype=sc.dtype.int64)
+    buffer = sc.arange('event', 5, unit=sc.units.ns, dtype=sc.DType.float64)
+    begin = sc.array(dims=['x'], values=[0, 2], dtype=sc.DType.int64)
+    end = sc.array(dims=['x'], values=[2, 5], dtype=sc.DType.int64)
     binned = sc.bins(data=buffer, dim='event', begin=begin, end=end)
     means = binned.bins.mean()
 
     assert sc.identical(
         means,
-        sc.array(dims=["x"], values=[0.5, 3], unit=sc.units.ns, dtype=sc.dtype.float64))
+        sc.array(dims=["x"], values=[0.5, 3], unit=sc.units.ns, dtype=sc.DType.float64))
 
 
 def test_bins_like():
     data = sc.array(dims=['row'], values=[1, 2, 3, 4])
-    begin = sc.array(dims=['x'], values=[0, 3], dtype=sc.dtype.int64)
-    end = sc.array(dims=['x'], values=[3, 4], dtype=sc.dtype.int64)
+    begin = sc.array(dims=['x'], values=[0, 3], dtype=sc.DType.int64)
+    end = sc.array(dims=['x'], values=[3, 4], dtype=sc.DType.int64)
     binned = sc.bins(begin=begin, end=end, dim='row', data=data)
     dense = sc.array(dims=['x'], values=[1.1, 2.2])
     expected_data = sc.array(dims=['row'], values=[1.1, 1.1, 1.1, 2.2])

--- a/tests/compat/dict_test.py
+++ b/tests/compat/dict_test.py
@@ -35,7 +35,7 @@ def test_variable_vector_to_dict():
     assert var_dict["dims"] == ['x']
     assert var_dict["shape"] == [10]
     assert var_dict["values"].shape == (10, 3)
-    assert var_dict["dtype"] == sc.dtype.vector3
+    assert var_dict["dtype"] == sc.DType.vector3
 
 
 def test_variable_0D_vector_to_dict():
@@ -44,7 +44,7 @@ def test_variable_0D_vector_to_dict():
     assert var_dict["dims"] == []
     assert var_dict["shape"] == []
     assert np.array_equal(var_dict["values"], [1, 2, 3])
-    assert var_dict["dtype"] == sc.dtype.vector3
+    assert var_dict["dtype"] == sc.DType.vector3
 
 
 def test_variable_matrix_to_dict():
@@ -58,7 +58,7 @@ def test_variable_matrix_to_dict():
     var_dict = sc.to_dict(var)
     assert var_dict["shape"] == [4]
     assert var_dict["values"].shape == (4, 3, 3)
-    assert var_dict["dtype"] == sc.dtype.linear_transform3
+    assert var_dict["dtype"] == sc.DType.linear_transform3
 
 
 def test_variable_0D_matrix_to_dict():
@@ -67,7 +67,7 @@ def test_variable_0D_matrix_to_dict():
     assert var_dict["dims"] == []
     assert var_dict["shape"] == []
     assert np.array_equal(var_dict["values"], [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    assert var_dict["dtype"] == sc.dtype.linear_transform3
+    assert var_dict["dtype"] == sc.DType.linear_transform3
 
 
 def test_variable_from_dict():
@@ -101,7 +101,7 @@ def test_variable_vector_from_dict():
     assert var.shape == [2]
     assert np.array_equal(np.array(var.values), [[0, 1, 2], [3, 4, 5]])
     assert var.unit == sc.units.one
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
 
 
 def test_variable_0D_vector_from_dict():
@@ -111,7 +111,7 @@ def test_variable_0D_vector_from_dict():
     assert var.shape == []
     assert np.array_equal(np.array(var.values), [1, 2, 3])
     assert var.unit == sc.units.one
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
 
 
 def test_variable_matrix_from_dict():
@@ -125,7 +125,7 @@ def test_variable_matrix_from_dict():
     assert var.shape == [2]
     assert np.array_equal(np.array(var.values), var_dict["values"])
     assert var.unit == sc.units.one
-    assert var.dtype == sc.dtype.linear_transform3
+    assert var.dtype == sc.DType.linear_transform3
 
 
 def test_variable_0D_matrix_from_dict():
@@ -139,7 +139,7 @@ def test_variable_0D_matrix_from_dict():
     assert var.shape == []
     assert np.array_equal(np.array(var.value), var_dict["values"])
     assert var.unit == sc.units.one
-    assert var.dtype == sc.dtype.linear_transform3
+    assert var.dtype == sc.DType.linear_transform3
 
 
 def test_variable_round_trip():

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -246,7 +246,7 @@ def test_rename_dims():
 def test_coord_setitem_can_change_dtype():
     a = np.arange(3)
     v1 = sc.array(dims=['x'], values=a)
-    v2 = v1.astype(sc.dtype.int32)
+    v2 = v1.astype(sc.DType.int32)
     data = sc.DataArray(data=v1, coords={'x': v1})
     data.coords['x'] = v2
 
@@ -261,20 +261,20 @@ def test_astype():
     a = sc.DataArray(data=sc.Variable(dims=['x'],
                                       values=np.arange(10.0, dtype=np.int64)),
                      coords={'x': sc.Variable(dims=['x'], values=np.arange(10.0))})
-    assert a.dtype == sc.dtype.int64
+    assert a.dtype == sc.DType.int64
 
-    a_as_float = a.astype(sc.dtype.float32)
-    assert a_as_float.dtype == sc.dtype.float32
+    a_as_float = a.astype(sc.DType.float32)
+    assert a_as_float.dtype == sc.DType.float32
 
 
 def test_astype_bad_conversion():
     a = sc.DataArray(data=sc.Variable(dims=['x'],
                                       values=np.arange(10.0, dtype=np.int64)),
                      coords={'x': sc.Variable(dims=['x'], values=np.arange(10.0))})
-    assert a.dtype == sc.dtype.int64
+    assert a.dtype == sc.DType.int64
 
     with pytest.raises(sc.DTypeError):
-        a.astype(sc.dtype.string)
+        a.astype(sc.DType.string)
 
 
 def test_reciprocal():

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -376,7 +376,7 @@ def test_mean_masked():
         data={
             'a':
             sc.Variable(
-                dims=['x'], values=np.array([1, 5, 4, 5, 1]), dtype=sc.dtype.float64)
+                dims=['x'], values=np.array([1, 5, 4, 5, 1]), dtype=sc.DType.float64)
         })
     d['a'].masks['m1'] = sc.Variable(dims=['x'],
                                      values=np.array([False, True, False, True, False]))

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -49,7 +49,7 @@ def test_construct_0d_datetime(unit):
                                                        values=value),
                 sc.Variable(dims=(), dtype=dtype,
                             values=value), sc.Variable(dims=(), values=value)):
-        assert var.dtype == sc.dtype.datetime64
+        assert var.dtype == sc.DType.datetime64
         assert var.unit == unit
         assert var.value.dtype == dtype
         assert var.value == value
@@ -57,7 +57,7 @@ def test_construct_0d_datetime(unit):
 
 def test_construct_0d_datetime_array():
     var = sc.Variable(dims=(), values=np.array(np.datetime64(123, 's')))
-    assert var.dtype == sc.dtype.datetime64
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == sc.units.s
     assert var.value == np.datetime64(123, 's')
 
@@ -65,8 +65,8 @@ def test_construct_0d_datetime_array():
 @pytest.mark.parametrize("unit", _UNIT_STRINGS)
 def test_construct_0d_datetime_from_int(unit):
     value = np.random.randint(0, 1000)
-    var = sc.Variable(dims=(), dtype=sc.dtype.datetime64, unit=unit, values=value)
-    assert var.dtype == sc.dtype.datetime64
+    var = sc.Variable(dims=(), dtype=sc.DType.datetime64, unit=unit, values=value)
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == unit
     assert var.value.dtype == f'datetime64[{unit}]'
     assert var.value == np.datetime64(value, unit)
@@ -90,8 +90,8 @@ def test_construct_0d_datetime_unit_conversion(unit1, unit2):
 def test_construct_0d_datetime_nounit():
     # Can make a datetime variable without unit but cannot do anything
     # with it except set its unit.
-    var = sc.Variable(dims=(), values=1, dtype=sc.dtype.datetime64)
-    assert var.dtype == sc.dtype.datetime64
+    var = sc.Variable(dims=(), values=1, dtype=sc.DType.datetime64)
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == sc.units.one
     with pytest.raises(sc.UnitError):
         str(var)
@@ -139,9 +139,9 @@ def test_construct_datetime(unit):
 @pytest.mark.parametrize("unit", _UNIT_STRINGS)
 def test_construct_datetime_from_int(unit):
     values = np.random.randint(0, 1000, np.random.randint(5, 100))
-    var = sc.Variable(dims=['x'], dtype=sc.dtype.datetime64, unit=unit, values=values)
+    var = sc.Variable(dims=['x'], dtype=sc.DType.datetime64, unit=unit, values=values)
     dtype_str = f'datetime64[{unit}]'
-    assert var.dtype == sc.dtype.datetime64
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == unit
     assert var.values.dtype == dtype_str
     np.testing.assert_array_equal(var.values, values.astype(dtype_str))
@@ -165,8 +165,8 @@ def test_construct_datetime_unit_conversion(unit1, unit2):
 def test_construct_datetime_nounit():
     # Can make a datetime variable without unit but cannot do anything
     # with it except set its unit.
-    var = sc.Variable(dims=['x'], values=[1, 2], dtype=sc.dtype.datetime64)
-    assert var.dtype == sc.dtype.datetime64
+    var = sc.Variable(dims=['x'], values=[1, 2], dtype=sc.DType.datetime64)
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == sc.units.one
     with pytest.raises(sc.UnitError):
         str(var)
@@ -228,7 +228,7 @@ def test_datetime_operations():
 
     shift = np.random.randint(0, 100, len(values))
     res = var - (var - sc.Variable(dims=['x'], values=shift, unit=sc.units.ns))
-    assert res.dtype == sc.dtype.int64
+    assert res.dtype == sc.DType.int64
     assert res.unit == sc.units.ns
     np.testing.assert_array_equal(res.values, shift)
 

--- a/tests/dtype_test.py
+++ b/tests/dtype_test.py
@@ -22,6 +22,8 @@ def test_dtype_comparison_not_equal(other):
 def test_dtype_comparison_str(name):
     assert sc.DType(name) == name
     assert name == sc.DType(name)
+    assert sc.DType(name) != 'bool'
+    assert 'bool' != sc.DType(name)
 
 
 def test_dtype_comparison_type():
@@ -32,12 +34,29 @@ def test_dtype_comparison_type():
     # Depends on OS
     assert int in (sc.DType.int64, sc.DType.int32)
 
+    assert sc.DType.float64 != int
+    assert int != sc.DType.float64
+    assert sc.DType.string != float
+    assert float != sc.DType.string
+
 
 def test_numpy_comparison():
     assert sc.DType.int32 == np.dtype(np.int32)
-    with pytest.raises(TypeError):
-        # Calls np.DType.__eq__ which does not know how to interpret sc.DType
-        assert np.dtype(np.int32) == sc.DType.int32
+    assert sc.DType.int32 != np.dtype(np.int64)
+
+
+def check_numpy_version_for_comaprison():
+    major, minor, patch = np.__version__.split('.')
+    if int(major) == 1 and int(minor) < 21:
+        return True
+    return False
+
+
+@pytest.mark.skipif(check_numpy_version_for_comaprison(),
+                    reason='at least numpy 1.21 required')
+def test_numpy_comparison_numpy_on_lhs():
+    assert np.dtype(np.int32) == sc.DType.int32
+    assert np.dtype(np.int32) != sc.DType.int64
 
 
 def test_dtype_string_construction():

--- a/tests/dtype_test.py
+++ b/tests/dtype_test.py
@@ -8,14 +8,68 @@ import numpy as np
 import scipp as sc
 
 
-def test_dtype():
-    assert sc.dtype.int32 == sc.dtype.int32
-    assert sc.dtype.int32 != sc.dtype.int64
+@pytest.mark.parametrize('dt', (sc.dtype.int32, sc.dtype.float64, sc.dtype.string))
+def test_dtype_comparison_equal(dt):
+    assert dt == dt
 
 
-@pytest.mark.skip(reason="Unfortunately the scipp dtype is currently not \
-        compatible with the numpy dtype. Scippy supports types such as \
-        strings which numpy cannot handle, so we cannot simply use \
-        numpy.dtype.")
+@pytest.mark.parametrize('other', (sc.dtype.int32, sc.dtype.float64, sc.dtype.string))
+def test_dtype_comparison_not_equal(other):
+    assert sc.dtype.int64 != other
+
+
+@pytest.mark.parametrize('name', ('int64', 'float32', 'str'))
+def test_dtype_comparison_str(name):
+    assert sc.DType(name) == name
+    assert name == sc.DType(name)
+
+
+def test_dtype_comparison_type():
+    assert sc.dtype.float64 == float
+    assert float == sc.dtype.float64
+    assert sc.dtype.string == str
+    assert str == sc.dtype.string
+    # Depends on OS
+    assert int in (sc.dtype.int64, sc.dtype.int32)
+
+
 def test_numpy_comparison():
     assert sc.dtype.int32 == np.dtype(np.int32)
+    with pytest.raises(TypeError):
+        # Calls np.dtype.__eq__ which does not know how to interpret sc.DType
+        assert np.dtype(np.int32) == sc.dtype.int32
+
+
+def test_dtype_string_construction():
+    assert sc.DType('int64') == sc.dtype.int64
+    assert sc.DType('float64') == sc.dtype.float64
+    assert sc.DType('float') == sc.dtype.float64
+    assert sc.DType('str') == sc.dtype.string
+
+
+def test_dtype_type_class_construction():
+    assert sc.DType(float) == sc.dtype.float64
+    assert sc.DType(str) == sc.dtype.string
+    # Depends on OS
+    assert sc.DType(int) in (sc.dtype.int64, sc.dtype.int32)
+
+
+def test_dtype_numpy_dtype_construction():
+    assert sc.DType(np.dtype('float')) == sc.dtype.float64
+    assert sc.DType(np.dtype('int64')) == sc.dtype.int64
+    assert sc.DType(np.dtype('str')) == sc.dtype.string
+
+
+def test_dtype_numpy_element_type_construction():
+    assert sc.DType(np.float64) == sc.dtype.float64
+    assert sc.DType(np.int32) == sc.dtype.int32
+
+
+def test_repr():
+    assert repr(sc.DType('int32')) == "DType('int32')"
+    assert repr(sc.DType('float')) == "DType('float64')"
+
+
+def test_str():
+    assert str(sc.DType('int32')) == 'int32'
+    assert str(sc.DType('float')) == 'float64'

--- a/tests/dtype_test.py
+++ b/tests/dtype_test.py
@@ -8,14 +8,14 @@ import numpy as np
 import scipp as sc
 
 
-@pytest.mark.parametrize('dt', (sc.dtype.int32, sc.dtype.float64, sc.dtype.string))
+@pytest.mark.parametrize('dt', (sc.DType.int32, sc.DType.float64, sc.DType.string))
 def test_dtype_comparison_equal(dt):
     assert dt == dt
 
 
-@pytest.mark.parametrize('other', (sc.dtype.int32, sc.dtype.float64, sc.dtype.string))
+@pytest.mark.parametrize('other', (sc.DType.int32, sc.DType.float64, sc.DType.string))
 def test_dtype_comparison_not_equal(other):
-    assert sc.dtype.int64 != other
+    assert sc.DType.int64 != other
 
 
 @pytest.mark.parametrize('name', ('int64', 'float32', 'str'))
@@ -25,44 +25,44 @@ def test_dtype_comparison_str(name):
 
 
 def test_dtype_comparison_type():
-    assert sc.dtype.float64 == float
-    assert float == sc.dtype.float64
-    assert sc.dtype.string == str
-    assert str == sc.dtype.string
+    assert sc.DType.float64 == float
+    assert float == sc.DType.float64
+    assert sc.DType.string == str
+    assert str == sc.DType.string
     # Depends on OS
-    assert int in (sc.dtype.int64, sc.dtype.int32)
+    assert int in (sc.DType.int64, sc.DType.int32)
 
 
 def test_numpy_comparison():
-    assert sc.dtype.int32 == np.dtype(np.int32)
+    assert sc.DType.int32 == np.dtype(np.int32)
     with pytest.raises(TypeError):
-        # Calls np.dtype.__eq__ which does not know how to interpret sc.DType
-        assert np.dtype(np.int32) == sc.dtype.int32
+        # Calls np.DType.__eq__ which does not know how to interpret sc.DType
+        assert np.dtype(np.int32) == sc.DType.int32
 
 
 def test_dtype_string_construction():
-    assert sc.DType('int64') == sc.dtype.int64
-    assert sc.DType('float64') == sc.dtype.float64
-    assert sc.DType('float') == sc.dtype.float64
-    assert sc.DType('str') == sc.dtype.string
+    assert sc.DType('int64') == sc.DType.int64
+    assert sc.DType('float64') == sc.DType.float64
+    assert sc.DType('float') == sc.DType.float64
+    assert sc.DType('str') == sc.DType.string
 
 
 def test_dtype_type_class_construction():
-    assert sc.DType(float) == sc.dtype.float64
-    assert sc.DType(str) == sc.dtype.string
+    assert sc.DType(float) == sc.DType.float64
+    assert sc.DType(str) == sc.DType.string
     # Depends on OS
-    assert sc.DType(int) in (sc.dtype.int64, sc.dtype.int32)
+    assert sc.DType(int) in (sc.DType.int64, sc.DType.int32)
 
 
 def test_dtype_numpy_dtype_construction():
-    assert sc.DType(np.dtype('float')) == sc.dtype.float64
-    assert sc.DType(np.dtype('int64')) == sc.dtype.int64
-    assert sc.DType(np.dtype('str')) == sc.dtype.string
+    assert sc.DType(np.dtype('float')) == sc.DType.float64
+    assert sc.DType(np.dtype('int64')) == sc.DType.int64
+    assert sc.DType(np.dtype('str')) == sc.DType.string
 
 
 def test_dtype_numpy_element_type_construction():
-    assert sc.DType(np.float64) == sc.dtype.float64
-    assert sc.DType(np.int32) == sc.dtype.int32
+    assert sc.DType(np.float64) == sc.DType.float64
+    assert sc.DType(np.int32) == sc.DType.int32
 
 
 def test_repr():
@@ -73,3 +73,8 @@ def test_repr():
 def test_str():
     assert str(sc.DType('int32')) == 'int32'
     assert str(sc.DType('float')) == 'float64'
+
+
+def test_predefined_dtypes_are_read_only():
+    with pytest.raises(AttributeError):
+        sc.DType.int64 = sc.DType('str')

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -8,7 +8,7 @@ import scipp as sc
 dim_list = ['xx', 'yy', 'zz', 'time', 'temperature']
 
 
-def make_scalar(with_variance=False, dtype=sc.dtype.float64, unit='counts'):
+def make_scalar(with_variance=False, dtype='float64', unit='counts'):
     var = sc.scalar(10.0 * np.random.rand(), unit=unit, dtype=dtype)
     if with_variance:
         var.variance = np.random.rand()
@@ -18,7 +18,7 @@ def make_scalar(with_variance=False, dtype=sc.dtype.float64, unit='counts'):
 def make_variable(ndim=1,
                   with_variance=False,
                   dims=None,
-                  dtype=sc.dtype.float64,
+                  dtype='float64',
                   unit='counts'):
 
     shapes = np.arange(50, 0, -10)[:ndim]
@@ -39,7 +39,7 @@ def make_scalar_array(with_variance=False,
                       label=False,
                       mask=False,
                       attr=False,
-                      dtype=sc.dtype.float64,
+                      dtype='float64',
                       unit='counts'):
 
     data = make_scalar(with_variance=with_variance, dtype=dtype, unit=unit)
@@ -66,7 +66,7 @@ def make_dense_data_array(ndim=1,
                           attrs=False,
                           ragged=False,
                           dims=None,
-                          dtype=sc.dtype.float64,
+                          dtype='float64',
                           unit='counts'):
 
     coord_units = dict(zip(dim_list, ['m', 'm', 'm', 's', 'K']))

--- a/tests/html_repr/html_repr_test.py
+++ b/tests/html_repr/html_repr_test.py
@@ -14,7 +14,7 @@ from ..factory import make_dense_data_array, make_dense_dataset, \
 
 
 def maybe_variances(variances, dtype):
-    if dtype in [sc.dtype.float64, sc.dtype.float32]:
+    if dtype in [sc.DType.float64, sc.DType.float32]:
         return variances
     else:
         return False
@@ -22,7 +22,7 @@ def maybe_variances(variances, dtype):
 
 @pytest.mark.parametrize("variance", [False, True])
 @pytest.mark.parametrize(
-    "dtype", [sc.dtype.float64, sc.dtype.float32, sc.dtype.int64, sc.dtype.int32])
+    "dtype", [sc.DType.float64, sc.DType.float32, sc.DType.int64, sc.DType.int32])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's', 'us'])
 def test_html_repr_scalar(variance, dtype, unit):
     var = make_scalar(with_variance=maybe_variances(variance, dtype),
@@ -36,7 +36,7 @@ def test_html_repr_scalar(variance, dtype, unit):
 @pytest.mark.parametrize("attr", [False, True])
 @pytest.mark.parametrize("mask", [False, True])
 @pytest.mark.parametrize(
-    "dtype", [sc.dtype.float64, sc.dtype.float32, sc.dtype.int64, sc.dtype.int32])
+    "dtype", [sc.DType.float64, sc.DType.float32, sc.DType.int64, sc.DType.int32])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's'])
 def test_html_repr_scalar_array(variance, label, attr, mask, dtype, unit):
     da = make_scalar_array(with_variance=maybe_variances(variance, dtype),
@@ -50,7 +50,7 @@ def test_html_repr_scalar_array(variance, label, attr, mask, dtype, unit):
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
 @pytest.mark.parametrize("variances", [False, True])
-@pytest.mark.parametrize("dtype", [sc.dtype.float64, sc.dtype.int64])
+@pytest.mark.parametrize("dtype", [sc.DType.float64, sc.DType.int64])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's'])
 def test_html_repr_variable(ndim, variances, dtype, unit):
     print(ndim, variances, dtype, unit)
@@ -72,7 +72,7 @@ def test_html_repr_variable_vector():
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
 @pytest.mark.parametrize("with_all", [True, False])
-@pytest.mark.parametrize("dtype", [sc.dtype.float64, sc.dtype.int64])
+@pytest.mark.parametrize("dtype", [sc.DType.float64, sc.DType.int64])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's'])
 def test_html_repr_data_array(ndim, with_all, dtype, unit):
     da = make_dense_data_array(ndim=ndim,
@@ -99,7 +99,7 @@ def test_html_repr_binned_data_array(ndim, variances, masks):
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
 @pytest.mark.parametrize("with_all", [True, False])
-@pytest.mark.parametrize("dtype", [sc.dtype.float64, sc.dtype.int64])
+@pytest.mark.parametrize("dtype", [sc.DType.float64, sc.DType.int64])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's'])
 def test_html_repr_dataset(ndim, with_all, dtype, unit):
     da = make_dense_dataset(ndim=ndim,

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -39,12 +39,12 @@ affine = sc.spatial.affine_transforms(dims=['x'],
                                       unit=sc.units.m)
 
 datetime64ms_1d = sc.Variable(dims=['x'],
-                              dtype=sc.dtype.datetime64,
+                              dtype=sc.DType.datetime64,
                               unit='ms',
                               values=np.arange(10))
 
 datetime64us_1d = sc.Variable(dims=['x'],
-                              dtype=sc.dtype.datetime64,
+                              dtype=sc.DType.datetime64,
                               unit='us',
                               values=np.arange(10))
 
@@ -118,15 +118,15 @@ def test_variable_datetime64():
 
 
 def test_variable_binned_variable():
-    begin = sc.Variable(dims=['y'], values=[0, 3], dtype=sc.dtype.int64)
-    end = sc.Variable(dims=['y'], values=[3, 4], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[0, 3], dtype=sc.DType.int64)
+    end = sc.Variable(dims=['y'], values=[3, 4], dtype=sc.DType.int64)
     binned = sc.bins(begin=begin, end=end, dim='x', data=x)
     check_roundtrip(binned)
 
 
 def test_variable_binned_variable_slice():
-    begin = sc.Variable(dims=['y'], values=[0, 3], dtype=sc.dtype.int64)
-    end = sc.Variable(dims=['y'], values=[3, 4], dtype=sc.dtype.int64)
+    begin = sc.Variable(dims=['y'], values=[0, 3], dtype=sc.DType.int64)
+    end = sc.Variable(dims=['y'], values=[3, 4], dtype=sc.DType.int64)
     binned = sc.bins(begin=begin, end=end, dim='x', data=x)
     # Note the current arbitrary limit is to avoid writing the buffer if it is
     # more than 50% too large. These cutoffs or the entiry mechanism may
@@ -177,7 +177,7 @@ def test_data_array_dtype_scipp_container():
     a = sc.DataArray(data=x)
     a.coords['variable'] = sc.scalar(x)
     a.coords['scalar'] = sc.scalar(a)
-    a.coords['1d'] = sc.empty(dims=x.dims, shape=x.shape, dtype=sc.dtype.DataArray)
+    a.coords['1d'] = sc.empty(dims=x.dims, shape=x.shape, dtype=sc.DType.DataArray)
     for i in range(4):
         a.coords['1d'].values[i] = sc.DataArray(float(i) * sc.units.m)
     a.coords['dataset'] = sc.scalar(sc.Dataset(data={'a': array_1d, 'b': array_2d}))

--- a/tests/lifetime_test.py
+++ b/tests/lifetime_test.py
@@ -77,7 +77,7 @@ def test_lifetime_coord_values():
 
 def test_lifetime_scalar_py_object():
     var = sc.scalar([1] * 100000)
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     val = var.copy().value
     import gc
     gc.collect()

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -11,14 +11,14 @@ import pytest
 def test_variable_0D_vector3_from_list():
     var = sc.vector(value=[1, 2, 3], unit=sc.units.m)
     np.testing.assert_array_equal(var.value, [1, 2, 3])
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
 
 def test_variable_0D_vector3_from_numpy():
     var = sc.vector(value=np.array([1, 2, 3]), unit=sc.units.m)
     np.testing.assert_array_equal(var.value, [1, 2, 3])
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
 
@@ -28,7 +28,7 @@ def test_variable_1D_vector3_from_list():
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
     assert var.dims == ['x']
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
 
@@ -40,7 +40,7 @@ def test_variable_1D_vector3_from_numpy():
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
     assert var.dims == ['x']
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
 
@@ -132,7 +132,7 @@ def test_variable_0D_matrix():
 def test_variable_0D_matrix_from_numpy():
     var = sc.matrix(value=np.arange(9).reshape(3, 3), unit=sc.units.m)
     np.testing.assert_array_equal(var.value, np.arange(9).reshape(3, 3))
-    assert var.dtype == sc.dtype.linear_transform3
+    assert var.dtype == sc.DType.linear_transform3
     assert var.unit == sc.units.m
 
 
@@ -148,7 +148,7 @@ def test_variable_1D_matrix_from_numpy():
     np.testing.assert_array_equal(var.values[1], [[5, 6, 7], [8, 9, 10], [11, 12, 13]])
     np.testing.assert_array_equal(var.values[2], [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert var.dims == ['x']
-    assert var.dtype == sc.dtype.linear_transform3
+    assert var.dtype == sc.DType.linear_transform3
     assert var.unit == sc.units.us
 
 

--- a/tests/ownership_variable_test.py
+++ b/tests/ownership_variable_test.py
@@ -394,7 +394,7 @@ def test_own_var_1d_bin_set():
     a_buffer = np.arange(5)
     a_indices = np.array([0, 2, 5], dtype=np.int64)
     buffer = make_variable(a_buffer, unit='m')
-    indices = make_variable(a_indices, dtype=sc.dtype.int64)
+    indices = make_variable(a_indices, dtype=sc.DType.int64)
     binned = sc.bins(data=buffer,
                      begin=indices['x', :-1],
                      end=indices['x', 1:],
@@ -432,14 +432,14 @@ def test_own_var_1d_bin_set():
     assert sc.identical(
         binned,
         sc.bins(data=make_variable([-1, -2, -3, -4, 4], unit='s'),
-                begin=make_variable([1, 2], dtype=sc.dtype.int64),
-                end=make_variable([2, 4], dtype=sc.dtype.int64),
+                begin=make_variable([1, 2], dtype=sc.DType.int64),
+                end=make_variable([2, 4], dtype=sc.DType.int64),
                 dim='x'))
 
 
 def test_own_var_1d_bin_get():
     # The buffer is shared.
-    indices = make_variable(np.array([0, 2, 5]), dtype=sc.dtype.int64)
+    indices = make_variable(np.array([0, 2, 5]), dtype=sc.DType.int64)
     binned = sc.bins(data=make_variable(np.arange(5), unit='m'),
                      begin=indices['x', :-1],
                      end=indices['x', 1:],
@@ -454,7 +454,7 @@ def test_own_var_1d_bin_get():
 
 def test_own_var_1d_bin_copy():
     # Depth of copies of variables can be controlled.
-    indices = make_variable(np.array([0, 2, 5]), dtype=sc.dtype.int64)
+    indices = make_variable(np.array([0, 2, 5]), dtype=sc.DType.int64)
     binned = sc.bins(data=make_variable(np.arange(5), unit='m'),
                      begin=indices['x', :-1],
                      end=indices['x', 1:],

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -334,7 +334,7 @@ def test_plot_redraw():
 
 
 def test_plot_redraw_int64():
-    da = make_dense_data_array(ndim=1, dtype=sc.dtype.int64)
+    da = make_dense_data_array(ndim=1, dtype=sc.DType.int64)
     p = sc.plot(da)
     assert p.view.figure._lines[''].data.get_ydata()[2] == int(10.0 * np.sin(2.0))
     da *= 5

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -379,11 +379,11 @@ def test_plot_access_ax_and_fig():
 
 
 def test_plot_2d_int32():
-    plot(make_dense_data_array(ndim=2, dtype=sc.dtype.int32))
+    plot(make_dense_data_array(ndim=2, dtype=sc.DType.int32))
 
 
 def test_plot_2d_int64_with_unit():
-    plot(make_dense_data_array(ndim=2, unit='K', dtype=sc.dtype.int64))
+    plot(make_dense_data_array(ndim=2, unit='K', dtype=sc.DType.int64))
 
 
 def test_plot_2d_int_coords():
@@ -424,7 +424,7 @@ def test_plot_redraw_dense():
 
 
 def test_plot_redraw_dense_int64():
-    da = make_dense_data_array(ndim=2, unit='K', dtype=sc.dtype.int64)
+    da = make_dense_data_array(ndim=2, unit='K', dtype=sc.DType.int64)
     p = sc.plot(da)
     before = p.view.figure.image_values.get_array()
     da *= 5

--- a/tests/setitem_test.py
+++ b/tests/setitem_test.py
@@ -29,13 +29,13 @@ def test_setitem_required_for_inplace_ops():
 
 
 def test_setitem_coords_required_for_inplace_ops():
-    var = sc.zeros(dims=['x'], shape=(4, ), dtype=sc.dtype.int64)
+    var = sc.zeros(dims=['x'], shape=(4, ), dtype=sc.DType.int64)
     da = sc.DataArray(data=var)
     da.coords['x'] = var
     da.coords['x']['x', 2:] += 1
     assert sc.identical(da.coords['x'],
-                        sc.array(dims=['x'], dtype=sc.dtype.int64, values=[0, 0, 1, 1]))
+                        sc.array(dims=['x'], dtype=sc.DType.int64, values=[0, 0, 1, 1]))
     ds = sc.Dataset(data={'a': da})
     ds.coords['x']['x', 2:] += 1
     assert sc.identical(ds.coords['x'],
-                        sc.array(dims=['x'], dtype=sc.dtype.int64, values=[0, 0, 2, 2]))
+                        sc.array(dims=['x'], dtype=sc.DType.int64, values=[0, 0, 2, 2]))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -28,7 +28,7 @@ def test_scalar_with_dtype():
     value = 1.0
     variance = 5.0
     unit = sc.units.m
-    dtype = sc.dtype.float64
+    dtype = sc.DType.float64
     var = sc.scalar(value=value, variance=variance, unit=unit, dtype=dtype)
     expected = sc.Variable(dims=(),
                            values=value,
@@ -47,7 +47,7 @@ def test_scalar_without_dtype():
 
 def test_scalar_throws_if_wrong_dtype_provided_for_str_types():
     with pytest.raises(ValueError):
-        sc.scalar(value='temp', unit=sc.units.one, dtype=sc.dtype.float64)
+        sc.scalar(value='temp', unit=sc.units.one, dtype=sc.DType.float64)
 
 
 def test_scalar_throws_UnitError_if_not_parsable():
@@ -59,8 +59,8 @@ def test_scalar_of_numpy_array():
     value = np.array([1, 2, 3])
     with pytest.raises(sc.DimensionError):
         sc.scalar(value)
-    var = sc.scalar(value, dtype=sc.dtype.PyObject)
-    assert var.dtype == sc.dtype.PyObject
+    var = sc.scalar(value, dtype=sc.DType.PyObject)
+    assert var.dtype == sc.DType.PyObject
     np.testing.assert_array_equal(var.value, value)
 
 
@@ -81,9 +81,9 @@ def test_zeros_with_variances():
 def test_zeros_with_dtype_and_unit():
     var = sc.zeros(dims=['x', 'y', 'z'],
                    shape=[1, 2, 3],
-                   dtype=sc.dtype.int32,
+                   dtype=sc.DType.int32,
                    unit='m')
-    assert var.dtype == sc.dtype.int32
+    assert var.dtype == sc.DType.int32
     assert var.unit == 'm'
 
 
@@ -94,9 +94,9 @@ def test_zeros_dtypes():
                     dtype='datetime64').value == np.datetime64(0, 's')
     assert sc.zeros(dims=(), shape=(), dtype=str).value == ''
     np.testing.assert_array_equal(
-        sc.zeros(dims=(), shape=(), dtype=sc.dtype.vector3).value, np.zeros(3))
+        sc.zeros(dims=(), shape=(), dtype=sc.DType.vector3).value, np.zeros(3))
     np.testing.assert_array_equal(
-        sc.zeros(dims=(), shape=(), dtype=sc.dtype.linear_transform3).value,
+        sc.zeros(dims=(), shape=(), dtype=sc.DType.linear_transform3).value,
         np.zeros((3, 3)))
 
 
@@ -115,8 +115,8 @@ def test_ones_with_variances():
 
 
 def test_ones_with_dtype_and_unit():
-    var = sc.ones(dims=['x', 'y', 'z'], shape=[1, 2, 3], dtype=sc.dtype.int64, unit='s')
-    assert var.dtype == sc.dtype.int64
+    var = sc.ones(dims=['x', 'y', 'z'], shape=[1, 2, 3], dtype=sc.DType.int64, unit='s')
+    assert var.dtype == sc.DType.int64
     assert var.unit == 's'
 
 
@@ -146,10 +146,10 @@ def test_full_with_variances():
 def test_full_with_dtype_and_unit():
     var = sc.full(dims=['x', 'y', 'z'],
                   shape=[1, 2, 3],
-                  dtype=sc.dtype.int64,
+                  dtype=sc.DType.int64,
                   unit='s',
                   value=1)
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
     assert var.unit == 's'
 
 
@@ -197,9 +197,9 @@ def test_empty_with_variances():
 def test_empty_with_dtype_and_unit():
     var = sc.empty(dims=['x', 'y', 'z'],
                    shape=[1, 2, 3],
-                   dtype=sc.dtype.int32,
+                   dtype=sc.DType.int32,
                    unit='s')
-    assert var.dtype == sc.dtype.int32
+    assert var.dtype == sc.DType.int32
     assert var.unit == 's'
 
 
@@ -220,7 +220,7 @@ def test_array_creates_correct_variable():
     values = [1, 2, 3]
     variances = [4, 5, 6]
     unit = sc.units.m
-    dtype = sc.dtype.float64
+    dtype = sc.DType.float64
     var = sc.array(dims=dims,
                    values=values,
                    variances=variances,
@@ -237,7 +237,7 @@ def test_array_creates_correct_variable():
 
 def test_array_empty_dims():
     assert sc.identical(sc.array(dims=[], values=[1]),
-                        sc.scalar([1], dtype=sc.dtype.PyObject))
+                        sc.scalar([1], dtype=sc.DType.PyObject))
     a = np.asarray(1.1)
     assert sc.identical(sc.array(dims=None, values=a), sc.scalar(1.1))
     assert sc.identical(sc.array(dims=[], values=a), sc.scalar(1.1))
@@ -258,12 +258,12 @@ def test_zeros_like_with_variances():
                       values=np.random.random([1, 2, 3]),
                       variances=np.random.random([1, 2, 3]),
                       unit='m',
-                      dtype=sc.dtype.float32)
+                      dtype=sc.DType.float32)
     expected = sc.zeros(dims=['x', 'y', 'z'],
                         shape=[1, 2, 3],
                         with_variances=True,
                         unit='m',
-                        dtype=sc.dtype.float32)
+                        dtype=sc.DType.float32)
     zeros = sc.zeros_like(var)
     _compare_properties(zeros, expected)
     np.testing.assert_array_equal(zeros.values, 0)
@@ -283,12 +283,12 @@ def test_ones_like_with_variances():
                       values=np.random.random([1, 2, 3]),
                       variances=np.random.random([1, 2, 3]),
                       unit='m',
-                      dtype=sc.dtype.float32)
+                      dtype=sc.DType.float32)
     expected = sc.ones(dims=['x', 'y', 'z'],
                        shape=[1, 2, 3],
                        with_variances=True,
                        unit='m',
-                       dtype=sc.dtype.float32)
+                       dtype=sc.DType.float32)
     ones = sc.ones_like(var)
     _compare_properties(ones, expected)
     np.testing.assert_array_equal(ones.values, 1)
@@ -306,44 +306,44 @@ def test_empty_like_with_variances():
                       values=np.random.random([1, 2, 3]),
                       variances=np.random.random([1, 2, 3]),
                       unit='m',
-                      dtype=sc.dtype.float32)
+                      dtype=sc.DType.float32)
     expected = make_dummy(dims=['x', 'y', 'z'],
                           shape=[1, 2, 3],
                           with_variances=True,
                           unit='m',
-                          dtype=sc.dtype.float32)
+                          dtype=sc.DType.float32)
     _compare_properties(sc.empty_like(var), expected)
 
 
 def test_linspace():
     values = np.linspace(1.2, 103., 51)
-    var = sc.linspace('x', 1.2, 103., 51, unit='m', dtype=sc.dtype.float32)
-    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.dtype.float32)
+    var = sc.linspace('x', 1.2, 103., 51, unit='m', dtype=sc.DType.float32)
+    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.DType.float32)
     assert sc.identical(var, expected)
 
 
 def test_logspace():
     values = np.logspace(2.0, 3.0, num=4)
     var = sc.logspace('y', 2.0, 3.0, num=4, unit='s')
-    expected = sc.Variable(dims=['y'], values=values, unit='s', dtype=sc.dtype.float64)
+    expected = sc.Variable(dims=['y'], values=values, unit='s', dtype=sc.DType.float64)
     assert sc.identical(var, expected)
 
 
 def test_geomspace():
     values = np.geomspace(1, 1000, num=4)
     var = sc.geomspace('z', 1, 1000, num=4)
-    expected = sc.Variable(dims=['z'], values=values, dtype=sc.dtype.float64)
+    expected = sc.Variable(dims=['z'], values=values, dtype=sc.DType.float64)
     assert sc.identical(var, expected)
 
 
 def test_arange():
     values = np.arange(21)
-    var = sc.arange('x', 21, unit='m', dtype=sc.dtype.int32)
-    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.dtype.int32)
+    var = sc.arange('x', 21, unit='m', dtype=sc.DType.int32)
+    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.DType.int32)
     assert sc.identical(var, expected)
     values = np.arange(10, 21, 2)
-    var = sc.arange(dim='x', start=10, stop=21, step=2, unit='m', dtype=sc.dtype.int32)
-    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.dtype.int32)
+    var = sc.arange(dim='x', start=10, stop=21, step=2, unit='m', dtype=sc.DType.int32)
+    expected = sc.Variable(dims=['x'], values=values, unit='m', dtype=sc.DType.int32)
     assert sc.identical(var, expected)
 
 

--- a/tests/variable_init_test.py
+++ b/tests/variable_init_test.py
@@ -13,8 +13,8 @@ import scipp as sc
 
 def representation_of_native_int():
     if platform.system() == 'Windows':
-        return sc.dtype.int32
-    return sc.dtype.int64
+        return sc.DType.int32
+    return sc.DType.int64
 
 
 # Tuples (dtype, expected, val) where
@@ -23,25 +23,25 @@ def representation_of_native_int():
 # - val: Value of a matching type
 DTYPE_INPUT_TO_EXPECTED = (
     (int, representation_of_native_int(), 0),
-    (float, sc.dtype.float64, 1.2),
-    (bool, sc.dtype.bool, True),
-    (str, sc.dtype.string, 'abc'),
-    (sc.dtype.int32, sc.dtype.int32, 2),
-    (sc.dtype.int64, sc.dtype.int64, 3),
-    (sc.dtype.float32, sc.dtype.float32, 4.5),
-    (sc.dtype.float64, sc.dtype.float64, 5.6),
-    (sc.dtype.bool, sc.dtype.bool, False),
-    (sc.dtype.string, sc.dtype.string, 'def'),
-    (sc.dtype.datetime64, sc.dtype.datetime64, 123),
-    (sc.dtype.PyObject, sc.dtype.PyObject, dict()),
-    (np.int32, sc.dtype.int32, 6),
-    (np.int64, sc.dtype.int64, 7),
-    (np.float32, sc.dtype.float32, 8.9),
-    (np.float64, sc.dtype.float64, 9.1),
-    (np.dtype(bool), sc.dtype.bool, True),
-    (np.dtype(str), sc.dtype.string, 'ghi'),
-    (np.dtype('datetime64'), sc.dtype.datetime64, 456),
-    (np.dtype('datetime64[ns]'), sc.dtype.datetime64, 789),
+    (float, sc.DType.float64, 1.2),
+    (bool, sc.DType.bool, True),
+    (str, sc.DType.string, 'abc'),
+    (sc.DType.int32, sc.DType.int32, 2),
+    (sc.DType.int64, sc.DType.int64, 3),
+    (sc.DType.float32, sc.DType.float32, 4.5),
+    (sc.DType.float64, sc.DType.float64, 5.6),
+    (sc.DType.bool, sc.DType.bool, False),
+    (sc.DType.string, sc.DType.string, 'def'),
+    (sc.DType.datetime64, sc.DType.datetime64, 123),
+    (sc.DType.PyObject, sc.DType.PyObject, dict()),
+    (np.int32, sc.DType.int32, 6),
+    (np.int64, sc.DType.int64, 7),
+    (np.float32, sc.DType.float32, 8.9),
+    (np.float64, sc.DType.float64, 9.1),
+    (np.dtype(bool), sc.DType.bool, True),
+    (np.dtype(str), sc.DType.string, 'ghi'),
+    (np.dtype('datetime64'), sc.DType.datetime64, 456),
+    (np.dtype('datetime64[ns]'), sc.DType.datetime64, 789),
 )
 
 
@@ -55,7 +55,7 @@ def test_create_scalar_with_float_value(value):
     assert var.value == value
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
 
 
@@ -70,7 +70,7 @@ def test_create_scalar_with_float_variance(variance):
     assert var.variance == variance
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
 
 
@@ -90,12 +90,12 @@ def test_create_scalar_with_float_value_and_variance(value, variance):
     assert var.variance == variance
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
 
 
-@pytest.mark.parametrize('args', ((sc.dtype.int64, 1), (sc.dtype.bool, True),
-                                  (sc.dtype.string, 'a')))
+@pytest.mark.parametrize('args', ((sc.DType.int64, 1), (sc.DType.bool, True),
+                                  (sc.DType.string, 'a')))
 def test_create_scalar_with_value(args):
     dtype, value = args
     var = sc.Variable(dims=(), values=value)
@@ -106,7 +106,7 @@ def test_create_scalar_with_value(args):
     assert var.unit == sc.units.dimensionless
 
 
-@pytest.mark.parametrize('args', ((sc.dtype.bool, True), (sc.dtype.string, 'a')))
+@pytest.mark.parametrize('args', ((sc.DType.bool, True), (sc.DType.string, 'a')))
 def test_create_scalar_with_value_array(args):
     dtype, value = args
     var = sc.Variable(dims=(), values=np.array(value))
@@ -123,7 +123,7 @@ def test_create_scalar_with_value_array_int():
     assert var.dims == []
     assert var.ndim == 0
     # The dtype varies between Windows and Linux / MacOS.
-    assert var.dtype in (sc.dtype.int32, sc.dtype.int64)
+    assert var.dtype in (sc.DType.int32, sc.DType.int64)
     assert var.unit == sc.units.dimensionless
 
 
@@ -156,7 +156,7 @@ def test_create_scalar_with_unit(unit):
     assert var.dims == []
     assert var.ndim == 0
     assert var.value == 1.0
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
 
 
@@ -165,7 +165,7 @@ def test_create_scalar_quantity():
     assert var.value == 1.2
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
 
 
@@ -177,47 +177,47 @@ def test_create_via_unit():
 
 def test_create_scalar_dtypes():
     for dtype, expected, val in DTYPE_INPUT_TO_EXPECTED:
-        unit = 'ns' if expected == sc.dtype.datetime64 else 'one'
+        unit = 'ns' if expected == sc.DType.datetime64 else 'one'
         assert sc.scalar(val, dtype=dtype, unit=unit).dtype == expected
 
 
-@pytest.mark.parametrize("dtype", (None, sc.dtype.Variable))
+@pytest.mark.parametrize("dtype", (None, sc.DType.Variable))
 def test_create_scalar_dtype_Variable(dtype):
     elem = sc.Variable(dims=['x'], values=np.arange(4.0))
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.Variable
+    assert var.dtype == sc.DType.Variable
     assert var.unit == sc.units.dimensionless
     var = sc.Variable(dims=(), values=elem['x', 1:3], dtype=dtype)
-    assert var.dtype == sc.dtype.Variable
+    assert var.dtype == sc.DType.Variable
 
 
-@pytest.mark.parametrize("dtype", (None, sc.dtype.DataArray))
+@pytest.mark.parametrize("dtype", (None, sc.DType.DataArray))
 def test_create_scalar_dtype_DataArray(dtype):
     elem = sc.DataArray(data=sc.Variable(dims=['x'], values=np.arange(4.0)))
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.DataArray
+    assert var.dtype == sc.DType.DataArray
     assert var.unit == sc.units.dimensionless
     var = sc.Variable(dims=(), values=elem['x', 1:3], dtype=dtype)
-    assert var.dtype == sc.dtype.DataArray
+    assert var.dtype == sc.DType.DataArray
 
 
-@pytest.mark.parametrize("dtype", (None, sc.dtype.Dataset))
+@pytest.mark.parametrize("dtype", (None, sc.DType.Dataset))
 def test_create_scalar_dtype_Dataset(dtype):
     elem = sc.Dataset(data={'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
     assert var.dims == []
     assert var.ndim == 0
-    assert var.dtype == sc.dtype.Dataset
+    assert var.dtype == sc.DType.Dataset
     assert var.unit == sc.units.dimensionless
     var = sc.Variable(dims=(), values=elem['x', 1:3], dtype=dtype)
-    assert var.dtype == sc.dtype.Dataset
+    assert var.dtype == sc.DType.Dataset
 
 
 @pytest.mark.parametrize('value', (1, 1.2, True))
@@ -229,14 +229,14 @@ def test_create_scalar_conversion(value, dtype):
 
 
 @pytest.mark.parametrize('value', (1, 1.2, True))
-@pytest.mark.parametrize('dtype', (sc.dtype.string, sc.dtype.Variable))
+@pytest.mark.parametrize('dtype', (sc.DType.string, sc.DType.Variable))
 def test_create_scalar_invalid_conversion_numeric(value, dtype):
     with pytest.raises(ValueError):
         sc.Variable(dims=(), values=value, dtype=dtype)
 
 
 @pytest.mark.parametrize(
-    'dtype', (sc.dtype.int32, sc.dtype.int64, sc.dtype.float64, sc.dtype.Variable))
+    'dtype', (sc.DType.int32, sc.DType.int64, sc.DType.float64, sc.DType.Variable))
 def test_create_scalar_invalid_conversion_str(dtype):
     with pytest.raises(ValueError):
         sc.Variable(dims=(), values='abc', dtype=dtype)
@@ -248,20 +248,20 @@ def test_create_1d_size_4():
     np.testing.assert_array_equal(var.values, [0, 1, 2, 3])
     assert var.dims == ['x']
     assert var.ndim == 1
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
 
 
 @pytest.mark.parametrize('values_type', (tuple, list, np.array))
 @pytest.mark.parametrize('dtype_and_values',
-                         ((sc.dtype.int64, [1, 2]), (sc.dtype.float64, [1.2, 3.4]),
-                          (sc.dtype.bool, [True, False]),
-                          (sc.dtype.string, ['a', 'bc'])))
+                         ((sc.DType.int64, [1, 2]), (sc.DType.float64, [1.2, 3.4]),
+                          (sc.DType.bool, [True, False]),
+                          (sc.DType.string, ['a', 'bc'])))
 def test_create_1d_dtype(values_type, dtype_and_values):
     def check(v):
-        if dtype == sc.dtype.int64:
+        if dtype == sc.DType.int64:
             # The dtype varies between Windows and Linux / MacOS.
-            assert v.dtype in (sc.dtype.int32, sc.dtype.int64)
+            assert v.dtype in (sc.DType.int32, sc.DType.int64)
         else:
             assert v.dtype == dtype
         np.testing.assert_array_equal(v.values, values)
@@ -276,28 +276,28 @@ def test_create_1d_dtype(values_type, dtype_and_values):
 
 def test_create_1d_dtype_precision():
     var = sc.Variable(dims=['x'], values=np.arange(4).astype(np.int64))
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
     var = sc.Variable(dims=['x'], values=np.arange(4).astype(np.int32))
-    assert var.dtype == sc.dtype.int32
+    assert var.dtype == sc.DType.int32
     var = sc.Variable(dims=['x'], values=np.arange(4).astype(np.float64))
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     var = sc.Variable(dims=['x'], values=np.arange(4).astype(np.float32))
-    assert var.dtype == sc.dtype.float32
+    assert var.dtype == sc.DType.float32
     var = sc.Variable(dims=['x'], values=np.arange(4), dtype=np.dtype(np.float64))
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     var = sc.Variable(dims=['x'], values=np.arange(4), dtype=np.dtype(np.float32))
-    assert var.dtype == sc.dtype.float32
+    assert var.dtype == sc.DType.float32
     var = sc.Variable(dims=['x'], values=np.arange(4), dtype=np.dtype(np.int64))
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
     var = sc.Variable(dims=['x'], values=np.arange(4), dtype=np.dtype(np.int32))
-    assert var.dtype == sc.dtype.int32
+    assert var.dtype == sc.DType.int32
 
 
 @pytest.mark.parametrize('values_type', (tuple, list, np.array))
 def test_create_1d_values_array_like(values_type):
     values = np.arange(5.0)
     var = sc.Variable(dims=['x'], values=values_type(values))
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     np.testing.assert_array_equal(var.values, values)
     assert var.variances is None
 
@@ -306,7 +306,7 @@ def test_create_1d_values_array_like(values_type):
 def test_create_1d_variances_array_like(variances_type):
     variances = np.arange(5.0)
     var = sc.Variable(dims=['x'], variances=variances_type(variances))
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     np.testing.assert_array_equal(var.values, np.zeros_like(variances))
     np.testing.assert_array_equal(var.variances, variances)
 
@@ -319,7 +319,7 @@ def test_create_1d_values_and_variances_array_like(values_type, variances_type):
     var = sc.Variable(dims=['x'],
                       values=values_type(values),
                       variances=variances_type(variances))
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     np.testing.assert_array_equal(var.values, values)
     np.testing.assert_array_equal(var.variances, variances)
 
@@ -341,7 +341,7 @@ def test_create_1d_values_and_variances_array_like(values_type, variances_type):
                          (tuple, list, lambda x: np.array(x, dtype=object)))
 def test_create_1d_dtype_object(values_type):
     def check(v):
-        assert v.dtype == sc.dtype.PyObject
+        assert v.dtype == sc.DType.PyObject
         # Cannot iterate over an ElementArrayView.
         assert v['x', 0].value == values[0]
         assert v['x', 1].value == values[1]
@@ -349,7 +349,7 @@ def test_create_1d_dtype_object(values_type):
     values = values_type([{1, 2}, (3, 4)])
     var = sc.Variable(dims=['x'], values=values)
     check(var)
-    var = sc.Variable(dims=['x'], values=values, dtype=sc.dtype.PyObject)
+    var = sc.Variable(dims=['x'], values=values, dtype=sc.DType.PyObject)
     check(var)
 
 
@@ -370,7 +370,7 @@ def test_create_1D_vector3():
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
     assert var.dims == ['x']
     assert var.ndim == 1
-    assert var.dtype == sc.dtype.vector3
+    assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
 
@@ -388,7 +388,7 @@ def test_create_2d_inner_size_3():
     np.testing.assert_array_equal(var.values[1], [3, 4, 5])
     assert var.dims == ['x', 'y']
     assert var.ndim == 2
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
 
 

--- a/tests/variable_py_object_test.py
+++ b/tests/variable_py_object_test.py
@@ -7,7 +7,7 @@ import scipp as sc
 
 def test_scalar_Variable_py_object_dict():
     var = sc.scalar({'a': 1, 'b': 2})
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     assert var.value == {'a': 1, 'b': 2}
     var.value['a'] = 3
     var.value['c'] = 4
@@ -16,7 +16,7 @@ def test_scalar_Variable_py_object_dict():
 
 def test_scalar_Variable_py_object_list():
     var = sc.scalar([1, 2, 3])
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     assert var.value == [1, 2, 3]
     var.value[0] = 2
     assert var.value == [2, 2, 3]
@@ -24,12 +24,12 @@ def test_scalar_Variable_py_object_list():
 
 def test_scalar_Variable_py_object_change():
     var = sc.scalar([1, 2, 3])
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     assert var.value == [1, 2, 3]
     # Value assignment cannot change dtype, so the result is still PyObject,
     # contrary to creating a variable directly from an integer.
     var.value = 1
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     assert var.value == 1
 
 

--- a/tests/variable_reduction_test.py
+++ b/tests/variable_reduction_test.py
@@ -59,7 +59,7 @@ def test_sum():
     var = sc.Variable(dims=['x', 'y'], values=np.arange(4.0).reshape(2, 2))
     assert sc.identical(sc.sum(var), sc.scalar(6.0))
     assert sc.identical(sc.sum(var, 'x'), sc.Variable(dims=['y'], values=[2.0, 4.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.dtype.float64)
+    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
     sc.sum(var, 'x', out=out)
     assert sc.identical(out, sc.Variable(dims=['y'], values=[2.0, 4.0]))
 
@@ -69,7 +69,7 @@ def test_nansum():
                       values=np.array([1.0, 1.0, 1.0, np.nan]).reshape(2, 2))
     assert sc.identical(sc.nansum(var), sc.scalar(3.0))
     assert sc.identical(sc.nansum(var, 'x'), sc.Variable(dims=['y'], values=[2.0, 1.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.dtype.float64)
+    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
     sc.nansum(var, 'x', out=out)
     assert sc.identical(out, sc.Variable(dims=['y'], values=[2.0, 1.0]))
 
@@ -78,7 +78,7 @@ def test_mean():
     var = sc.Variable(dims=['x', 'y'], values=np.arange(4.0).reshape(2, 2))
     assert sc.identical(sc.mean(var), sc.scalar(6.0 / 4))
     assert sc.identical(sc.mean(var, 'x'), sc.Variable(dims=['y'], values=[1.0, 2.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.dtype.float64)
+    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
     sc.mean(var, 'x', out=out)
     assert sc.identical(out, sc.Variable(dims=['y'], values=[1.0, 2.0]))
 
@@ -89,6 +89,6 @@ def test_nanmean():
     assert sc.identical(sc.nanmean(var), sc.scalar(3.0 / 3))
     assert sc.identical(sc.nanmean(var, 'x'), sc.Variable(dims=['y'], values=[1.0,
                                                                               1.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.dtype.float64)
+    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
     sc.mean(var, 'x', out=out)
     assert sc.identical(out, sc.Variable(dims=['y'], values=[1.0, 1.0]))

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -7,24 +7,24 @@ import scipp as sc
 
 def test_scalar_Variable_values_property_float():
     var = sc.scalar(value=1.0, variance=2.0)
-    assert var.dtype == sc.dtype.float64
+    assert var.dtype == sc.DType.float64
     assert var.values == 1.0
     assert var.variances == 2.0
 
 
 def test_scalar_Variable_values_property_int():
     var = sc.scalar(1)
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
     assert var.values == 1
 
 
 def test_scalar_Variable_values_property_string():
     var = sc.scalar('abc')
-    assert var.dtype == sc.dtype.string
+    assert var.dtype == sc.DType.string
     assert var.values == 'abc'
 
 
 def test_scalar_Variable_values_property_PyObject():
     var = sc.scalar([1, 2])
-    assert var.dtype == sc.dtype.PyObject
+    assert var.dtype == sc.DType.PyObject
     assert var.values == [1, 2]

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -24,33 +24,33 @@ def test_astype():
     var = sc.Variable(dims=['x'],
                       values=np.array([1, 2, 3, 4], dtype=np.int64),
                       unit='s')
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
     assert var.unit == sc.units.s
 
-    for target_dtype in (sc.dtype.float64, float, 'float64'):
+    for target_dtype in (sc.DType.float64, float, 'float64'):
         var_as_float = var.astype(target_dtype)
-        assert var_as_float.dtype == sc.dtype.float64
+        assert var_as_float.dtype == sc.DType.float64
         assert var_as_float.unit == sc.units.s
 
 
 def test_astype_bad_conversion():
     var = sc.Variable(dims=['x'], values=np.array([1, 2, 3, 4], dtype=np.int64))
-    assert var.dtype == sc.dtype.int64
+    assert var.dtype == sc.DType.int64
 
-    for target_dtype in (sc.dtype.string, str, 'str'):
+    for target_dtype in (sc.DType.string, str, 'str'):
         with pytest.raises(sc.DTypeError):
             var.astype(target_dtype)
 
 
 def test_astype_datetime():
     var = sc.arange('x', np.datetime64(1, 's'), np.datetime64(5, 's'))
-    assert var.dtype == sc.dtype.datetime64
+    assert var.dtype == sc.DType.datetime64
     assert var.unit == sc.units.s
 
-    for target_dtype in (sc.dtype.datetime64, np.datetime64, 'datetime64',
+    for target_dtype in (sc.DType.datetime64, np.datetime64, 'datetime64',
                          'datetime64[s]'):
         same = var.astype(target_dtype)
-        assert same.dtype == sc.dtype.datetime64
+        assert same.dtype == sc.DType.datetime64
         assert same.unit == sc.units.s
 
 
@@ -138,7 +138,7 @@ def test_1D_converting():
 
 
 def test_1D_dataset():
-    var = sc.empty(dims=['x'], shape=(2, ), dtype=sc.dtype.Dataset)
+    var = sc.empty(dims=['x'], shape=(2, ), dtype=sc.DType.Dataset)
     d1 = sc.Dataset(data={'a': 1.5 * sc.units.m})
     d2 = sc.Dataset(data={'a': 2.5 * sc.units.m})
     var.values = [d1, d2]
@@ -207,10 +207,10 @@ def test_getitem_range():
 
 
 def test_setitem_broadcast():
-    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4], dtype=sc.dtype.int64)
-    var['x', 1:3] = sc.scalar(5, dtype=sc.dtype.int64)
+    var = sc.Variable(dims=['x'], values=[1, 2, 3, 4], dtype=sc.DType.int64)
+    var['x', 1:3] = sc.scalar(5, dtype=sc.DType.int64)
     assert sc.identical(
-        var, sc.Variable(dims=['x'], values=[1, 5, 5, 4], dtype=sc.dtype.int64))
+        var, sc.Variable(dims=['x'], values=[1, 5, 5, 4], dtype=sc.DType.int64))
 
 
 def test_slicing():
@@ -877,26 +877,26 @@ def test_comparison():
 
 def test_radd_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var + 1).dtype == sc.dtype.int64
-    assert (1 + var).dtype == sc.dtype.int64
+    assert (var + 1).dtype == sc.DType.int64
+    assert (1 + var).dtype == sc.DType.int64
 
 
 def test_rsub_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var - 1).dtype == sc.dtype.int64
-    assert (1 - var).dtype == sc.dtype.int64
+    assert (var - 1).dtype == sc.DType.int64
+    assert (1 - var).dtype == sc.DType.int64
 
 
 def test_rmul_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var * 1).dtype == sc.dtype.int64
-    assert (1 * var).dtype == sc.dtype.int64
+    assert (var * 1).dtype == sc.DType.int64
+    assert (1 * var).dtype == sc.DType.int64
 
 
 def test_rtruediv_int():
     var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    assert (var / 1).dtype == sc.dtype.float64
-    assert (1 / var).dtype == sc.dtype.float64
+    assert (var / 1).dtype == sc.DType.float64
+    assert (1 / var).dtype == sc.DType.float64
 
 
 def test_sort():

--- a/tests/variable_view_test.py
+++ b/tests/variable_view_test.py
@@ -16,10 +16,10 @@ def test_type():
 def test_astype():
     variable_slice = sc.Variable(dims=['x'], values=np.arange(1, 10,
                                                               dtype=np.int64))['x', :]
-    assert variable_slice.dtype == sc.dtype.int64
+    assert variable_slice.dtype == sc.DType.int64
 
-    var_as_float = variable_slice.astype(sc.dtype.float32)
-    assert var_as_float.dtype == sc.dtype.float32
+    var_as_float = variable_slice.astype(sc.DType.float32)
+    assert var_as_float.dtype == sc.DType.float32
 
 
 def apply_test_op(op, a, b, data):


### PR DESCRIPTION
Fixes #2371

- Exposes the `DType` class publicly and makes all predefined dtypes class attributes of it.
- `DType.__eq__` now works with `str` and `type` both when `DType` is the LHS and RHS and it works with `numpy.dtype` when `DType` is the LHS.
- `__str__` returns the same concise strings as before and `__repr__` returns `DType('<name>')` as in numpy.