### PR TITLE
Use str of dtype in HTML

### DIFF
--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -316,7 +316,7 @@ def summarize_variable(name,
             "</span></div>", f"<div class='sc-var-dims'>{escape(dims_str)}</div>"
         ]
     html += [
-        f"<div class='sc-var-dtype'>{escape(repr(var.dtype))}</div>",
+        f"<div class='sc-var-dtype'>{escape(str(var.dtype))}</div>",
         f"<div class='sc-var-unit'>{escape(unit)}</div>",
         f"<div class='sc-value-preview sc-preview'><span>{preview}</span>",
         "{}</div>".format(f'<span>{variances_preview}</span>'


### PR DESCRIPTION
Fixes problem caused by #2373: dtypes were be shown as `DType('int64')` in HTML.

We need proper tests for the HTML repr...