### PR TITLE
Release tooling

### DIFF
--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -1,3 +1,4 @@
+<!-- DO NOT EDIT! This file is created using tools/release/prepare-release.html. -->
 <!-- Here, we override the default launchbuttons.html by replacing it with our
      version selection menu, since we do not intend to use the launchbuttons.
      This allows us to add the version selection menu in some unused white space

--- a/docs/reference/developer-documentation.rst
+++ b/docs/reference/developer-documentation.rst
@@ -15,6 +15,7 @@ Developer Documentation
    developer/deployment
    developer/how-to
    developer/multi_dimensional_indexing
+   developer/releasing-scipp
    developer/tooling
    developer/transform
    developer/variable_implementation

--- a/docs/reference/developer/releasing-scipp.rst
+++ b/docs/reference/developer/releasing-scipp.rst
@@ -1,0 +1,24 @@
+Releasing Scipp
+===============
+
+Purpose
+-------
+
+This document describes steps to be taken to prepare and make a new scipp release
+
+Steps
+-----
+
+1. Update ``docs/about/whats-new.ipynb`` as required to describe highlights and key changes of the release.
+   When doing this, also consider removing information about past releases.
+   We typically keep information on the "What's New" page for approximately two to four past releases.
+   The concrete duration is decided case-by-case, based on the relevance of a particular topic, e.g., how critical it is that users do not miss the change, and based on the frequency of releases.
+
+2. Run ``tools/release/prepare-release.py`` *after* inserting new entries to the version number and link target arrays.
+   This creates a new entry in the version select menu and a new section with subsections in the release notes.
+
+3. Committing and merge the changes on GitHub.
+
+4. Create a release in GitHub.
+   This triggers workflows to create conda packages and wheel.
+   They are automatically uploaded to conda-forge and PyPI, respectively.

--- a/docs/reference/developer/releasing-scipp.rst
+++ b/docs/reference/developer/releasing-scipp.rst
@@ -17,8 +17,8 @@ Steps
 2. Run ``tools/release/prepare-release.py`` *after* inserting new entries to the version number and link target arrays.
    This creates a new entry in the version select menu and a new section with subsections in the release notes.
 
-3. Committing and merge the changes on GitHub.
+3. Commit and merge the changes on GitHub.
 
 4. Create a release in GitHub.
-   This triggers workflows to create conda packages and wheel.
+   This triggers workflows to create conda packages and wheels.
    They are automatically uploaded to conda-forge and PyPI, respectively.

--- a/tools/release/prepare-release.py
+++ b/tools/release/prepare-release.py
@@ -9,15 +9,16 @@ BEFORE running this script update the list of versions and targets to include th
 new desired version (or remove old unused versions).
 """
 
-from datetime import datetime
 import pathlib
+from datetime import datetime
+from string import Template
 
 
 def make_version_select(root):
     version_select = f'{root}/docs/_templates/topbar/launchbuttons.html'
 
     with open(f'{root}/tools/release/templates/launchbuttons.html', 'r') as f:
-        contents = f.readlines()
+        contents = f.read()
 
     versions = ['0.11', '0.10', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3']
     targets = [
@@ -29,12 +30,12 @@ def make_version_select(root):
     for version, target in zip(versions, targets):
         entries.append(f"""        <a class="dropdown-buttons"
             href="https://scipp.github.io/release/{target}"><button type="button"
-                class="btn btn-secondary topbarbtn">v{version}</button></a>\n""")
+                class="btn btn-secondary topbarbtn">v{version}</button></a>""")
 
-    contents.insert(14, ''.join(entries))
+    contents = Template(contents).substitute(releases='\n'.join(entries))
+    contents = '<!-- DO NOT EDIT! This file is created using tools/release/prepare-release.html. -->\n' + contents  # noqa: E501
 
     with open(version_select, "w") as f:
-        contents = "".join(contents)
         f.write(contents)
 
 

--- a/tools/release/prepare-release.py
+++ b/tools/release/prepare-release.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+"""
+Use this script right before a release to:
+- Add a new entry to the version-selection menu in the documentation.
+- Update headings in release notes and add new empty sections for next release.
+
+BEFORE running this script update the list of versions and targets to include the
+new desired version (or remove old unused versions).
+"""
 
 from datetime import datetime
 import pathlib

--- a/tools/release/prepare-release.py
+++ b/tools/release/prepare-release.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
+from datetime import datetime
+import pathlib
+
+
+def make_version_select(root):
+    version_select = f'{root}/docs/_templates/topbar/launchbuttons.html'
+
+    with open(f'{root}/tools/release/templates/launchbuttons.html', 'r') as f:
+        contents = f.readlines()
+
+    versions = ['0.11', '0.10', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3']
+    targets = [
+        '0.11.0', '0.10.1', '0.9.0', '0.8.4', '0.7.1', '0.6.1', '0.5.0', '0.4.0',
+        '0.3.0'
+    ]
+
+    entries = []
+    for version, target in zip(versions, targets):
+        entries.append(f"""        <a class="dropdown-buttons"
+            href="https://scipp.github.io/release/{target}"><button type="button"
+                class="btn btn-secondary topbarbtn">v{version}</button></a>\n""")
+
+    contents.insert(14, ''.join(entries))
+
+    with open(version_select, "w") as f:
+        contents = "".join(contents)
+        f.write(contents)
+
+
+def update_release_notes(root):
+    release_notes = f'{root}/docs/about/release-notes.rst'
+    with open(release_notes, 'r') as f:
+        contents = f.readlines()
+    current = contents[5]
+    version = current.split()[0][1:].split('.')
+    major = int(version[0])
+    minor = int(version[1])
+    if 'unreleased' not in current:
+        raise RuntimeError("Expected current unreleased heading in line 5")
+    now = datetime.now()
+    contents[5] = current.replace('unreleased', f'{now.strftime("%B")} {now.year}')
+    contents[6] = '-' * (len(contents[5]) - 1) + '\n'
+    with open(f'{root}/tools/release/templates/release-notes.rst', 'r') as f:
+        lines = f.readlines()
+    lines.insert(0, f'v{major}.{minor+1}.0 (unreleased)\n')
+    lines.insert(1, '-' * (len(lines[0]) - 1) + '\n')
+    contents.insert(5, ''.join(lines))
+
+    with open(release_notes, "w") as f:
+        contents = "".join(contents)
+        f.write(contents)
+
+
+if __name__ == '__main__':
+    filedir = pathlib.Path(__file__).parent.resolve()
+    tools = filedir.parent.resolve()
+    root = tools.parent.resolve()
+    make_version_select(root)
+    update_release_notes(root)

--- a/tools/release/templates/launchbuttons.html
+++ b/tools/release/templates/launchbuttons.html
@@ -1,0 +1,33 @@
+<!-- DO NOT EDIT! This files is created using tools/release/prepare-release.html. -->
+<!-- Here, we override the default launchbuttons.html by replacing it with our
+     version selection menu, since we do not intend to use the launchbuttons.
+     This allows us to add the version selection menu in some unused white space
+     that is always visible. -->
+<div class="dropdown-buttons-trigger">
+    <button id="dropdown-buttons-trigger" class="btn btn-secondary topbarbtn" style="font-size: 1em;padding-top:0.33rem;">Scipp version
+      <i class="fa fa-caret-down"></i>
+    </button>
+
+    <div class="dropdown-buttons" style="transform:translate(10%);">
+        <a class="dropdown-buttons"
+            href="https://scipp.github.io"><button type="button"
+                class="btn btn-secondary topbarbtn">latest</button></a>
+    </div>
+</div>
+<div class="dropdown-buttons-trigger">
+    <button id="dropdown-buttons-trigger" class="btn btn-secondary topbarbtn" style="font-size: 1em;padding-top:0.33rem;">Related projects
+      <i class="fa fa-caret-down"></i>
+    </button>
+
+    <div class="dropdown-buttons" style="transform:translate(10%);">
+        <a class="dropdown-buttons"
+            href="https://scipp.github.io"><button type="button"
+                class="btn btn-secondary topbarbtn">scipp</button></a>
+        <a class="dropdown-buttons"
+            href="https://scipp.github.io/scippneutron"><button type="button"
+                class="btn btn-secondary topbarbtn">scippneutron</button></a>
+        <a class="dropdown-buttons"
+            href="https://scipp.github.io/ess"><button type="button"
+                class="btn btn-secondary topbarbtn">ess</button></a>
+    </div>
+</div>

--- a/tools/release/templates/launchbuttons.html
+++ b/tools/release/templates/launchbuttons.html
@@ -1,4 +1,3 @@
-<!-- DO NOT EDIT! This files is created using tools/release/prepare-release.html. -->
 <!-- Here, we override the default launchbuttons.html by replacing it with our
      version selection menu, since we do not intend to use the launchbuttons.
      This allows us to add the version selection menu in some unused white space
@@ -12,6 +11,7 @@
         <a class="dropdown-buttons"
             href="https://scipp.github.io"><button type="button"
                 class="btn btn-secondary topbarbtn">latest</button></a>
+$releases
     </div>
 </div>
 <div class="dropdown-buttons-trigger">

--- a/tools/release/templates/release-notes.rst
+++ b/tools/release/templates/release-notes.rst
@@ -1,0 +1,23 @@
+
+Features
+~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Bugfixes
+~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+


### PR DESCRIPTION
Closes https://github.com/scipp/scipp/issues/1958 (apart from things that need to be done in `scippneutron`).

To review this: Best is probably to just run the script and inspect if `git diff` looks reasonable.