### PR TITLE
sc.bin with attrs

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -17,6 +17,8 @@ Breaking changes
 Bugfixes
 ~~~~~~~~
 
+* ``sc.bin`` will now also look at attributes to perform the binning, instead of only looking at the coordinates `#2388 <https://github.com/scipp/scipp/pull/2388>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -10,14 +10,13 @@ Features
 ~~~~~~~~
 
 * Added support for :py:func:`abs` to :py:class:`scipp.DataArray`, :py:class:`scipp.Dataset`, :py:class:`scipp.Variable` `#2382 <https://github.com/scipp/scipp/pull/2382>`_.
+* ``sc.bin`` will now also look at attributes to perform the binning, instead of only looking at the coordinates `#2388 <https://github.com/scipp/scipp/pull/2388>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
 Bugfixes
 ~~~~~~~~
-
-* ``sc.bin`` will now also look at attributes to perform the binning, instead of only looking at the coordinates `#2388 <https://github.com/scipp/scipp/pull/2388>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -559,6 +559,7 @@ DataArray bin(const DataArray &array, const std::vector<Variable> &edges,
   validate_bin_args(array, edges, groups);
   const auto &data = array.data();
   const auto &coords = array.coords();
+  const auto &meta = array.meta();
   const auto &masks = array.masks();
   const auto &attrs = array.attrs();
   if (data.dtype() == dtype<core::bin<DataArray>>) {
@@ -581,7 +582,7 @@ DataArray bin(const DataArray &array, const std::vector<Variable> &edges,
             ? makeVariable<int64_t>(data.dims())
             : makeVariable<int32_t>(data.dims());
     auto builder = axis_actions(data, coords, edges, groups, erase);
-    builder.build(target_bins_buffer, coords);
+    builder.build(target_bins_buffer, meta);
     const auto target_bins =
         make_bins_no_validate(indices, dim, target_bins_buffer);
     return add_metadata(bin<DataArray>(drop_grouped_event_coords(tmp, groups),
@@ -612,7 +613,7 @@ DataArray bin(const Variable &data, const Coords &coords, const Masks &masks,
   auto builder = axis_actions(data, coords, edges, groups, erase);
   const auto masked = hide_masked(data, masks, builder.dims().labels());
   TargetBins<DataArray> target_bins(masked, builder.dims());
-  builder.build(*target_bins, bins_view<DataArray>(masked).coords(), coords);
+  builder.build(*target_bins, bins_view<DataArray>(masked).meta(), coords);
   return add_metadata(bin<DataArray>(drop_grouped_event_coords(masked, groups),
                                      *target_bins, builder),
                       coords, masks, attrs, builder.edges(), builder.groups(),

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -610,8 +610,7 @@ DataArray bin(const Variable &data, const Coords &coords, const Masks &masks,
               const Attrs &attrs, const std::vector<Variable> &edges,
               const std::vector<Variable> &groups,
               const std::vector<Dim> &erase) {
-  auto meta = attrs.merge_from(coords);
-  meta.set_readonly();
+  const auto meta = attrs.merge_from(coords);
   auto builder = axis_actions(data, meta, edges, groups, erase);
   const auto masked = hide_masked(data, masks, builder.dims().labels());
   TargetBins<DataArray> target_bins(masked, builder.dims());

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -581,7 +581,7 @@ DataArray bin(const DataArray &array, const std::vector<Variable> &edges,
         (data.dims().volume() > std::numeric_limits<int32_t>::max())
             ? makeVariable<int64_t>(data.dims())
             : makeVariable<int32_t>(data.dims());
-    auto builder = axis_actions(data, coords, edges, groups, erase);
+    auto builder = axis_actions(data, meta, edges, groups, erase);
     builder.build(target_bins_buffer, meta);
     const auto target_bins =
         make_bins_no_validate(indices, dim, target_bins_buffer);
@@ -610,7 +610,9 @@ DataArray bin(const Variable &data, const Coords &coords, const Masks &masks,
               const Attrs &attrs, const std::vector<Variable> &edges,
               const std::vector<Variable> &groups,
               const std::vector<Dim> &erase) {
-  auto builder = axis_actions(data, coords, edges, groups, erase);
+  auto meta = attrs.merge_from(coords);
+  meta.set_readonly();
+  auto builder = axis_actions(data, meta, edges, groups, erase);
   const auto masked = hide_masked(data, masks, builder.dims().labels());
   TargetBins<DataArray> target_bins(masked, builder.dims());
   builder.build(*target_bins, bins_view<DataArray>(masked).meta(), coords);
@@ -619,11 +621,5 @@ DataArray bin(const Variable &data, const Coords &coords, const Masks &masks,
                       coords, masks, attrs, builder.edges(), builder.groups(),
                       erase);
 }
-
-template SCIPP_DATASET_EXPORT DataArray
-bin(const Variable &, const std::map<Dim, Variable> &,
-    const std::map<std::string, Variable> &, const std::map<Dim, Variable> &,
-    const std::vector<Variable> &, const std::vector<Variable> &,
-    const std::vector<Dim> &);
 
 } // namespace scipp::dataset

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -181,21 +181,21 @@ TEST_P(BinTest, rebin_no_event_coord) {
 TEST_P(BinTest, bin_using_attr) {
   auto table = GetParam();
   const auto expected = bin(table, {edges_x});
-  const auto xcoord = table.coords()[Dim::X];
-  table.coords().erase(Dim::X);
-  table.attrs().set(Dim::X, xcoord);
+  table.attrs().set(Dim::X, table.coords().extract(Dim::X));
   const auto result = bin(table, {edges_x});
-  EXPECT_EQ(expected, );
+  auto view = bins_view<DataArray>(result.data());
+  view.coords().set(Dim::X, view.attrs().extract(Dim::X));
+  EXPECT_EQ(expected, result);
 }
 
 TEST_P(BinTest, rebin_using_attr) {
   auto table = GetParam();
   const auto expected = bin(bin(table, {edges_x}), {edges_x_coarse});
-  const auto xcoord = table.coords()[Dim::X];
-  table.coords().erase(Dim::X);
-  table.attrs().set(Dim::X, xcoord);
+  table.attrs().set(Dim::X, table.coords().extract(Dim::X));
   const auto result = bin(bin(table, {edges_x}), {edges_x_coarse});
-  EXPECT_EQ(expected, );
+  auto view = bins_view<DataArray>(result.data());
+  view.coords().set(Dim::X, view.attrs().extract(Dim::X));
+  EXPECT_EQ(expected, result);
 }
 
 TEST_P(BinTest, rebin_coarse_to_fine_1d) {

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -178,6 +178,26 @@ TEST_P(BinTest, rebin_no_event_coord) {
   EXPECT_THROW_DISCARD(bin(x, {edges_x}), except::BinEdgeError);
 }
 
+TEST_P(BinTest, bin_using_attr) {
+  auto table = GetParam();
+  const auto expected = bin(table, {edges_x});
+  const auto xcoord = table.coords()[Dim::X];
+  table.coords().erase(Dim::X);
+  table.attrs().set(Dim::X, xcoord);
+  const auto result = bin(table, {edges_x});
+  EXPECT_EQ(expected, );
+}
+
+TEST_P(BinTest, rebin_using_attr) {
+  auto table = GetParam();
+  const auto expected = bin(bin(table, {edges_x}), {edges_x_coarse});
+  const auto xcoord = table.coords()[Dim::X];
+  table.coords().erase(Dim::X);
+  table.attrs().set(Dim::X, xcoord);
+  const auto result = bin(bin(table, {edges_x}), {edges_x_coarse});
+  EXPECT_EQ(expected, );
+}
+
 TEST_P(BinTest, rebin_coarse_to_fine_1d) {
   const auto table = GetParam();
   EXPECT_EQ(bin(table, {edges_x}),


### PR DESCRIPTION
Until now, it was only possible to bin data using a coordinate for the binning, not an attribute.

With these changes, we can now do
```Py
import numpy as np
import scipp as sc
np.random.seed(1) # Fixed for reproducibility
N = 500
values = 10*np.random.rand(N)
data = sc.DataArray(
    data=sc.Variable(dims=['position'], unit=sc.units.counts, values=values, variances=values),
    coords={'y':sc.Variable(dims=['position'], unit=sc.units.m, values=np.random.rand(N))},
    attrs={'x':sc.Variable(dims=['position'], unit=sc.units.m, values=np.random.rand(N))})
xbins = sc.Variable(dims=['x'], unit=sc.units.m, values=[0.1,0.5,0.9])
ybins = sc.Variable(dims=['y'], unit=sc.units.m, values=[0.1,0.3,0.5,0.7,0.9])
binned = sc.bin(data, edges=[ybins, xbins])
```

Fixes #2341 