### PR TITLE
Rename <none> dtype to void

### DIFF
--- a/lib/core/dtype.cpp
+++ b/lib/core/dtype.cpp
@@ -44,6 +44,6 @@ std::ostream &operator<<(std::ostream &os, const DType &dtype) {
 }
 
 auto register_dtype_name_void(
-    (core::dtypeNameRegistry().emplace(dtype<void>, "<none>"), 0));
+    (core::dtypeNameRegistry().emplace(dtype<void>, "void"), 0));
 
 } // namespace scipp::core


### PR DESCRIPTION
Sphinx complained about this. We are binding all dtypes as attributes of `DType` and `<none>` is no valid Python identifier. So `DType.<none>` is ill formed but `getattr(DType, '<none>')` works.

For context, numpy also uses 'void' (or simply 'V').