### PR TITLE
Incomplete HTML table generation

### DIFF
--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -36,7 +36,7 @@ from . import geometry
 from ._scipp.core import as_const, choose, logical_and, logical_or, logical_xor
 # Import python functions
 from .show import show, make_svg
-from .table import table
+from .table import table, make_table
 
 from .plotting import plot
 

--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -11,6 +11,7 @@ from .._scipp import core as sc
 from ..core import stddevs
 from ..utils import value_to_string
 from .resources import load_icons, load_style
+from ..table import make_table
 
 BIN_EDGE_LABEL = "[bin-edge]"
 STDDEV_PREFIX = "σ = "
@@ -140,8 +141,11 @@ def _short_data_repr_html_events(var, variances=False):
 
 def short_data_repr_html(var, variances=False):
     """Format "data" for DataArray and Variable."""
-    data_repr = _short_data_repr_html_non_events(var, variances)
-    return escape(data_repr)
+    if var.bins is None:
+        data_repr = _short_data_repr_html_non_events(var, variances)
+        return escape(data_repr)
+    else:
+        return make_table(var.values[0])
 
 
 def format_dims(dims, sizes, coords):

--- a/src/scipp/table.py
+++ b/src/scipp/table.py
@@ -138,6 +138,9 @@ def _table_from_dict_of_variables(dict_of_variables,
         html += "</tr>"
     else:
         row_end = min(size, row_start + max_rows)
+        if row_end != size:
+            # Ensure we are printing same number of rows, including overflow
+            row_end -= 1
         # If we are not starting at the first row, add overflow
         if row_start > 0:
             html += _make_overflow_row(dict_of_variables)

--- a/src/scipp/table.py
+++ b/src/scipp/table.py
@@ -39,7 +39,7 @@ def _make_table_unit_headers(dict_of_variables):
         for name, val in section.items():
             html.append("<th class='sc-units' colspan='{}'>{}</th>".format(
                 1 + (val.variances is not None),
-                escape(su.name_with_unit(val, name=name))))
+                escape(name)))
     return "".join(html)
 
 
@@ -51,7 +51,8 @@ def _make_table_subsections(dict_of_variables, plural):
     html = []
     for key, section in dict_of_variables.items():
         for name, val in section.items():
-            html.append(f"<th class='sc-subheader'>Value{s}</th>")
+            unit = escape(str(val.unit))
+            html.append(f"<th class='sc-subheader'>Value{s} [{unit}]</th>")
             if val.variances is not None:
                 html.append(f"<th class='sc-subheader'>Variance{s}</th>")
     return "".join(html)


### PR DESCRIPTION
This is *not* intended for review, and possibly not even a path we may want to continue on, just digging out an old branch. What I have done here is a hack to be able to generate HTML tables, instead of relying on the widget-based `TableViewer`. The latter has its place, and we do want to keep it, but for other applications (such as displaying a table within the HTML view, which I experimented with here) a plain HTML table would be more useful.

What I have learned:

- The code for `TableViewer` is quite involved and we may need very little of it for a simple HTML table. It may even be easier to just write it from scratch.
- I am having trouble with CSS and formatting, not sure how much comes from trying to reuse the `TableViewer` code.

I think if we pursue the idea of having a plain HTML table, we should keep it really simple:
- Restrict ourselves to 1-D single-table cases. Do not support display of 0-D or multiple 1-D tables (unlike `TableViewer`).
- Do not use "offset" cells to display bin-edges. Apart form looking slightly odd, it likely makes the code more complicated than it has to be. Maybe we can find a simpler solution?

<img width="380" alt="image" src="https://user-images.githubusercontent.com/12912489/151497861-8b644d01-5a6a-4b46-9981-63f09fb2d914.png">
