### PR TITLE
Better error message for dict lookup

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -24,6 +24,7 @@ Breaking changes
 * The ``unit`` attribute now distinguishes ``None`` from ``dimensionless``. For number-like dtypes the default is ``dimensionless`` (unchanged) whereas all other dtypes such as strings default to ``None`` (new) `#2395 <https://github.com/scipp/scipp/pull/2395>`_.
 * :py:func:`scipp.spatial.rotations_from_rotvecs` has been changed to taking a variable input rather than separate values/dims/units.
 * ``scipp.NotFoundFound`` error has been replaced with ``KeyError`` in Python `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
+* Some functions now raise ``scipp.DimensionError`` instead of ``scipp.NotFoundFound`` `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -23,6 +23,7 @@ Breaking changes
 * :py:func:`scipp.rebin` now applies masks that depend on the rebinning dimension to avoid "growing" effect on masks which previously resulted in masking more than intended `#2383 <https://github.com/scipp/scipp/pull/2383>`_.
 * The ``unit`` attribute now distinguishes ``None`` from ``dimensionless``. For number-like dtypes the default is ``dimensionless`` (unchanged) whereas all other dtypes such as strings default to ``None`` (new) `#2395 <https://github.com/scipp/scipp/pull/2395>`_.
 * :py:func:`scipp.spatial.rotations_from_rotvecs` has been changed to taking a variable input rather than separate values/dims/units.
+* ``scipp.NotFoundFound`` error has been replaced with ``KeyError`` in Python `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -23,8 +23,8 @@ Breaking changes
 * :py:func:`scipp.rebin` now applies masks that depend on the rebinning dimension to avoid "growing" effect on masks which previously resulted in masking more than intended `#2383 <https://github.com/scipp/scipp/pull/2383>`_.
 * The ``unit`` attribute now distinguishes ``None`` from ``dimensionless``. For number-like dtypes the default is ``dimensionless`` (unchanged) whereas all other dtypes such as strings default to ``None`` (new) `#2395 <https://github.com/scipp/scipp/pull/2395>`_.
 * :py:func:`scipp.spatial.rotations_from_rotvecs` has been changed to taking a variable input rather than separate values/dims/units.
-* ``scipp.NotFoundFound`` error has been replaced with ``KeyError`` in Python `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
-* Some functions now raise ``scipp.DimensionError`` instead of ``scipp.NotFoundFound`` `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
+* ``scipp.NotFoundError`` error has been replaced with ``KeyError`` in Python `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
+* Some functions now raise ``scipp.DimensionError`` instead of ``scipp.NotFoundError`` `#2416 <https://github.com/scipp/scipp/pull/2416>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/lib/core/except.cpp
+++ b/lib/core/except.cpp
@@ -67,6 +67,24 @@ void throw_cannot_have_variances(const DType type) {
 
 } // namespace scipp::except
 
+namespace scipp::expect {
+namespace {
+template <class A, class B> void includes_impl(const A &a, const B &b) {
+  if (!a.includes(b))
+    throw except::DimensionError("Expected " + to_string(a) + " to include " +
+                                 to_string(b) + ".");
+}
+} // namespace
+
+void includes(const core::Sizes &a, const core::Sizes &b) {
+  includes_impl(a, b);
+}
+
+void includes(const core::Dimensions &a, const core::Dimensions &b) {
+  includes_impl(a, b);
+}
+} // namespace scipp::expect
+
 namespace scipp::core::expect {
 void ndim_is(const Sizes &dims, const scipp::index expected) {
   using std::to_string;

--- a/lib/core/include/scipp/core/except.h
+++ b/lib/core/include/scipp/core/except.h
@@ -95,12 +95,10 @@ template <class A, class B> void contains(const A &a, const B &b) {
     throw except::NotFoundError("Expected " + to_string(a) + " to contain " +
                                 to_string(b) + ".");
 }
-template <class A, class B> void includes(const A &a, const B &b) {
-  using core::to_string;
-  if (!a.includes(b))
-    throw except::NotFoundError("Expected " + to_string(a) + " to include " +
-                                to_string(b) + ".");
-}
+
+SCIPP_CORE_EXPORT void includes(const core::Sizes &a, const core::Sizes &b);
+SCIPP_CORE_EXPORT void includes(const core::Dimensions &a,
+                                const core::Dimensions &b);
 } // namespace scipp::expect
 
 namespace scipp::core::expect {

--- a/lib/dataset/except.cpp
+++ b/lib/dataset/except.cpp
@@ -46,6 +46,15 @@ CoordMismatchError::CoordMismatchError(const Dim dim, const Variable &a,
 
 } // namespace scipp::except
 
+namespace scipp::expect {
+template <>
+void contains(const scipp::dataset::Dataset &a, const std::string &b) {
+  if (!a.contains(b))
+    throw except::NotFoundError("Expected '" + b + "' in " +
+                                scipp::dataset::dict_keys_to_string(a) + ".");
+}
+} // namespace scipp::expect
+
 namespace scipp::dataset::expect {
 void coords_are_superset(const Coords &a_coords, const Coords &b_coords,
                          const std::string_view opname) {

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -53,12 +53,16 @@ struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
 
 namespace scipp::expect {
 template <class Key, class Value>
-void contains(const scipp::dataset::Dict<Key, Value> &map, const Key &key) {
+void contains(const scipp::dataset::Dict<Key, Value> &a, const Key &b) {
   using core::to_string;
-  if (!map.contains(key))
-    throw except::NotFoundError("Expected `" + to_string(key) + "` in " +
-                                scipp::dataset::dict_keys_to_string(map) + ".");
+  if (!a.contains(b))
+    throw except::NotFoundError("Expected '" + to_string(b) + "' in " +
+                                scipp::dataset::dict_keys_to_string(a) + ".");
 }
+
+template <>
+SCIPP_DATASET_EXPORT void contains(const scipp::dataset::Dataset &a,
+                                   const std::string &b);
 } // namespace scipp::expect
 
 namespace scipp::dataset::expect {

--- a/lib/dataset/include/scipp/dataset/except.h
+++ b/lib/dataset/include/scipp/dataset/except.h
@@ -51,6 +51,16 @@ struct SCIPP_DATASET_EXPORT CoordMismatchError : public DatasetError {
 
 } // namespace scipp::except
 
+namespace scipp::expect {
+template <class Key, class Value>
+void contains(const scipp::dataset::Dict<Key, Value> &map, const Key &key) {
+  using core::to_string;
+  if (!map.contains(key))
+    throw except::NotFoundError("Expected `" + to_string(key) + "` in " +
+                                scipp::dataset::dict_keys_to_string(map) + ".");
+}
+} // namespace scipp::expect
+
 namespace scipp::dataset::expect {
 
 SCIPP_DATASET_EXPORT void coords_are_superset(const DataArray &a,

--- a/lib/dataset/include/scipp/dataset/string.h
+++ b/lib/dataset/include/scipp/dataset/string.h
@@ -27,5 +27,6 @@ SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Masks &masks);
+SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Dataset &dataset);
 
 } // namespace scipp::dataset

--- a/lib/dataset/include/scipp/dataset/string.h
+++ b/lib/dataset/include/scipp/dataset/string.h
@@ -25,5 +25,7 @@ SCIPP_DATASET_EXPORT std::string to_string(const DataArray &data);
 SCIPP_DATASET_EXPORT std::string to_string(const Dataset &dataset);
 SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
+SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Coords &coords);
+SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Masks &masks);
 
 } // namespace scipp::dataset

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -125,10 +125,11 @@ std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }
 
 namespace {
-template <class Key, class Value>
-std::string dict_keys_to_string_impl(const Dict<Key, Value> &view) {
+template <class D>
+std::string dict_keys_to_string_impl(const D &view,
+                                     const std::string_view dict_name) {
   std::stringstream ss;
-  ss << "<scipp.Dict {";
+  ss << "<" << dict_name << " {";
   bool first = true;
   const auto end = view.keys_end();
   for (auto it = view.keys_begin(); it != end; ++it) {
@@ -145,11 +146,15 @@ std::string dict_keys_to_string_impl(const Dict<Key, Value> &view) {
 } // namespace
 
 std::string dict_keys_to_string(const Coords &coords) {
-  return dict_keys_to_string_impl(coords);
+  return dict_keys_to_string_impl(coords, "scipp.Dict");
 }
 
 std::string dict_keys_to_string(const Masks &masks) {
-  return dict_keys_to_string_impl(masks);
+  return dict_keys_to_string_impl(masks, "scipp.Dict");
+}
+
+std::string dict_keys_to_string(const Dataset &dataset) {
+  return dict_keys_to_string_impl(dataset, "scipp.Dataset");
 }
 
 } // namespace scipp::dataset

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -122,4 +122,32 @@ std::string dict_to_string(const Dict<Key, Value> &view) {
 std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }
 
+namespace {
+template <class Key, class Value>
+std::string dict_keys_to_string_impl(const Dict<Key, Value> &view) {
+  std::stringstream ss;
+  ss << "<scipp.Dict {";
+  bool first = true;
+  const auto end = view.keys_end();
+  for (auto it = view.keys_begin(); it != end; ++it) {
+    if (!first) {
+      ss << ", ";
+    } else {
+      first = false;
+    }
+    ss << *it;
+  }
+  ss << "}>";
+  return ss.str();
+}
+} // namespace
+
+std::string dict_keys_to_string(const Coords &coords) {
+  return dict_keys_to_string_impl(coords);
+}
+
+std::string dict_keys_to_string(const Masks &masks) {
+  return dict_keys_to_string_impl(masks);
+}
+
 } // namespace scipp::dataset

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -41,7 +41,6 @@ std::string format_variable(const std::string &key, const Variable &variable,
     << format_variable(variable, datasetSizes) << '\n';
   return s.str();
 }
-} // namespace
 
 template <class Key>
 auto format_data_view(const Key &name, const DataArray &data,
@@ -100,6 +99,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
   s << '\n';
   return s.str();
 }
+} // namespace
 
 std::string to_string(const DataArray &data) {
   return do_to_string(data, "<scipp.DataArray>", data.dims());
@@ -109,6 +109,7 @@ std::string to_string(const Dataset &dataset) {
   return do_to_string(dataset, "<scipp.Dataset>", dataset.sizes());
 }
 
+namespace {
 template <class Key, class Value>
 std::string dict_to_string(const Dict<Key, Value> &view) {
   std::stringstream ss;
@@ -118,6 +119,7 @@ std::string dict_to_string(const Dict<Key, Value> &view) {
   }
   return ss.str();
 }
+} // namespace
 
 std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }

--- a/lib/dataset/test/data_array_test.cpp
+++ b/lib/dataset/test/data_array_test.cpp
@@ -66,6 +66,14 @@ TEST_F(DataArrayTest, name) {
   EXPECT_EQ(array.name(), "newname");
 }
 
+TEST_F(DataArrayTest, get_coord) {
+  DataArray a(data);
+  a.coords().set(Dim::X, coord);
+  EXPECT_EQ(a.coords().at(Dim::X), coord);
+  EXPECT_THROW_DISCARD(a.attrs().at(Dim::X), except::NotFoundError);
+  EXPECT_THROW_DISCARD(a.coords().at(Dim::Y), except::NotFoundError);
+}
+
 TEST_F(DataArrayTest, erase_coord) {
   DataArray a(data);
   a.coords().set(Dim::X, coord);

--- a/lib/variable/test/concat_test.cpp
+++ b/lib/variable/test/concat_test.cpp
@@ -32,16 +32,16 @@ TEST_F(ConcatTest, dimension_mismatch) {
   // Size mismatch
   EXPECT_THROW_DISCARD(
       concat(std::vector{base, base.slice({Dim::Y, 0, 1})}, Dim::X),
-      except::NotFoundError);
+      except::DimensionError);
   // Label mismatch
   auto xz = base;
   xz.rename(Dim::Y, Dim::Z);
   EXPECT_THROW_DISCARD(concat(std::vector{xz, base}, Dim::X),
-                       except::NotFoundError);
+                       except::DimensionError);
   // Missing label in first arg can (right now) not lead to braodcast
   EXPECT_THROW_DISCARD(
       concat(std::vector{base.slice({Dim::Y, 0}), base}, Dim::Z),
-      except::NotFoundError);
+      except::DimensionError);
   // Missing label in second arg, but this broadcasts
   EXPECT_NO_THROW_DISCARD(
       concat(std::vector{base, base.slice({Dim::Y, 0})}, Dim::Z));

--- a/lib/variable/test/shape_test.cpp
+++ b/lib/variable/test/shape_test.cpp
@@ -49,7 +49,7 @@ TEST(ShapeTest, broadcast_output_is_not_readonly_if_not_broadcast) {
 TEST(ShapeTest, broadcast_fail) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                   Values{1, 2, 3, 4});
-  EXPECT_THROW_DISCARD(broadcast(var, {Dim::X, 3}), except::NotFoundError);
+  EXPECT_THROW_DISCARD(broadcast(var, {Dim::X, 3}), except::DimensionError);
 }
 
 class SqueezeTest : public ::testing::Test {

--- a/lib/variable/test/transform_test.cpp
+++ b/lib/variable/test/transform_test.cpp
@@ -174,7 +174,7 @@ TEST_F(TransformInPlaceDryRunTest, dimensions_fail) {
 
   EXPECT_THROW(
       dry_run::transform_in_place<pair_self_t<double>>(a, b, binary, name),
-      except::NotFoundError);
+      except::DimensionError);
   EXPECT_EQ(a, original);
 }
 

--- a/lib/variable/test/variable_test.cpp
+++ b/lib/variable/test/variable_test.cpp
@@ -588,7 +588,7 @@ TEST(VariableView, slice_copy_from_variable_dimension_fail) {
   const auto source = makeVariable<double>(Dims{Dim::Y}, Shape{1});
   auto target = makeVariable<double>(Dims{Dim::X}, Shape{2});
   EXPECT_THROW(copy(source, target.slice({Dim::X, 1, 2})),
-               except::NotFoundError);
+               except::DimensionError);
 }
 
 TEST(VariableView, slice_copy_from_variable_full_slice_can_change_unit) {

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -27,7 +27,7 @@ from .core import Variable, DataArray, Dataset, DType, Unit
 # Import errors
 from .core import BinEdgeError, BinnedDataError, CoordError, \
                          DataArrayError, DatasetError, DimensionError, \
-                         DTypeError, NotFoundError, SizeError, SliceError, \
+                         DTypeError, SizeError, SliceError, \
                          UnitError, VariableError, VariancesError
 # Import submodules
 from . import units

--- a/src/scipp/coords/graph.py
+++ b/src/scipp/coords/graph.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from graphlib import TopologicalSorter
 from typing import Callable, Dict, Iterable, List, Set, Tuple, Union
 
-from ..core import DataArray, NotFoundError
+from ..core import DataArray
 from .rule import ComputeRule, FetchRule, RenameRule, Rule
 
 GraphDict = Dict[Union[str, Tuple[str, ...]], Union[str, Callable]]
@@ -70,9 +70,8 @@ class Graph:
         try:
             return self._rules[out_name]
         except KeyError:
-            raise NotFoundError(
-                f"Coordinate '{out_name}' does not exist in the input data "
-                "and no rule has been provided to compute it.") from None
+            raise KeyError(f"Coordinate '{out_name}' does not exist in the input data "
+                           "and no rule has been provided to compute it.") from None
 
     def show(self, size=None, simplified=False):
         dot = _make_graphviz_digraph(strict=True)

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -21,7 +21,7 @@ from .._scipp.core import Variable, DataArray, Dataset, GroupByDataArray, \
 # Import errors
 from .._scipp.core import BinEdgeError, BinnedDataError, CoordError, \
                          DataArrayError, DatasetError, DimensionError, \
-                         DTypeError, NotFoundError, SizeError, SliceError, \
+                         DTypeError, SizeError, SliceError, \
                          UnitError, VariableError, VariancesError
 
 BinEdgeError.__doc__ = 'Inappropriate bin-edge coordinate.'

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -146,7 +146,8 @@ class ResamplingModel():
         for edge in plan:
             try:
                 array = _resample(array, self.mode, dim, edge)
-            except RuntimeError:  # Limitation of rebin for slice of inner dim
+            except (KeyError,
+                    DimensionError):  # Limitation of rebin for slice of inner dim
                 array = _resample(array.copy(), self.mode, edge.dims[-1], edge)
         return array
 

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -350,6 +350,6 @@ def test_bins_like():
     expected_data = sc.array(dims=['row'], values=[1.1, 1.1, 1.1, 1.1])
     expected = sc.bins(begin=begin, end=end, dim='row', data=expected_data)
     assert sc.identical(sc.bins_like(binned, dense['x', 0]), expected)
-    with pytest.raises(KeyError):
+    with pytest.raises(sc.DimensionError):
         dense = dense.rename_dims({'x': 'y'})
         sc.bins_like(binned, dense),

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -350,6 +350,6 @@ def test_bins_like():
     expected_data = sc.array(dims=['row'], values=[1.1, 1.1, 1.1, 1.1])
     expected = sc.bins(begin=begin, end=end, dim='row', data=expected_data)
     assert sc.identical(sc.bins_like(binned, dense['x', 0]), expected)
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(KeyError):
         dense = dense.rename_dims({'x': 'y'})
         sc.bins_like(binned, dense),

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -710,7 +710,7 @@ def test_only_outputs_in_graph_are_stored(a):
     graph = {'b': split}
     da = original.transform_coords(['b'], graph=graph)
     assert 'c' not in da.meta  # c is not stored
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(sc.KeyError):
         # c is not computable
         original.transform_coords(['c'], graph=graph)
 
@@ -746,9 +746,9 @@ def test_raises_when_expected_multiple_outputs_but_returned_non_dict(a):
 def test_inaccessible_coord(a, b):
     original = sc.DataArray(data=a + b, coords={'a': a})
     graph = {'ab': ab}
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(sc.KeyError):
         original.transform_coords(['ab'], graph)
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(sc.KeyError):
         original.transform_coords(['c'], graph)
 
     def abc(a, b, c):
@@ -756,7 +756,7 @@ def test_inaccessible_coord(a, b):
 
     original = sc.DataArray(data=a + b, coords={'a': a, 'b': b})
     graph = {'ab': ab, 'abc': abc}
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(sc.KeyError):
         original.transform_coords(['ab', 'abc'], graph)
 
 

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -710,7 +710,7 @@ def test_only_outputs_in_graph_are_stored(a):
     graph = {'b': split}
     da = original.transform_coords(['b'], graph=graph)
     assert 'c' not in da.meta  # c is not stored
-    with pytest.raises(sc.KeyError):
+    with pytest.raises(KeyError):
         # c is not computable
         original.transform_coords(['c'], graph=graph)
 
@@ -746,9 +746,9 @@ def test_raises_when_expected_multiple_outputs_but_returned_non_dict(a):
 def test_inaccessible_coord(a, b):
     original = sc.DataArray(data=a + b, coords={'a': a})
     graph = {'ab': ab}
-    with pytest.raises(sc.KeyError):
+    with pytest.raises(KeyError):
         original.transform_coords(['ab'], graph)
-    with pytest.raises(sc.KeyError):
+    with pytest.raises(KeyError):
         original.transform_coords(['c'], graph)
 
     def abc(a, b, c):
@@ -756,7 +756,7 @@ def test_inaccessible_coord(a, b):
 
     original = sc.DataArray(data=a + b, coords={'a': a, 'b': b})
     graph = {'ab': ab, 'abc': abc}
-    with pytest.raises(sc.KeyError):
+    with pytest.raises(KeyError):
         original.transform_coords(['ab', 'abc'], graph)
 
 

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -119,7 +119,7 @@ def test_del_item():
 
 def test_del_item_missing():
     d = sc.Dataset()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         del d['not an item']
 
 

--- a/tests/optimize/curve_fit_test.py
+++ b/tests/optimize/curve_fit_test.py
@@ -40,10 +40,10 @@ def test_should_raise_TypeError_when_sigma_given_as_param():
         curve_fit(func, array1d(), sigma=np.arange(4))
 
 
-def test_should_raise_NotFoundError_when_data_array_has_no_coord():
+def test_should_raise_KeyError_when_data_array_has_no_coord():
     da = array1d()
     del da.coords[da.dim]
-    with pytest.raises(sc.NotFoundError):
+    with pytest.raises(KeyError):
         curve_fit(func, da)
 
 

--- a/tests/slicebyvalue_test.py
+++ b/tests/slicebyvalue_test.py
@@ -135,7 +135,7 @@ class TestSliceByValue:
             _ = self._d['a']['x', 5.0 * sc.units.dimensionless]
 
     def test_assign_incompatible_variable_throws(self):
-        with pytest.raises(RuntimeError) as e_info:
+        with pytest.raises(sc.DimensionError) as e_info:
             self._d['a']['x', 1.5 * sc.units.dimensionless:4.5 *
                          sc.units.dimensionless] = sc.Variable(dims=['x'],
                                                                values=[6.0, 6.0],

--- a/tests/utils/comparision_test.py
+++ b/tests/utils/comparision_test.py
@@ -21,7 +21,7 @@ def test_wont_match_when_meta_keys_unequal():
     point = sc.scalar(value=1.0)
     a = sc.DataArray(data=point, attrs={'x': point})
     b = sc.DataArray(data=point, attrs={'y': point})
-    with pytest.raises(RuntimeError):
+    with pytest.raises(KeyError):
         su.isnear(a, b, rtol=0 * sc.units.one, atol=1.0 * sc.units.one)
     # Raise nothing if we are ignoring differing parts
     su.isnear(a, b, rtol=0 * sc.units.one, atol=1.0 * sc.units.one, include_attrs=False)


### PR DESCRIPTION
I got really annoyed by having to read through pages of error messages because `expect::contains` prints the full contents of a dict.
Printing only the keys should be enough.

Question: Should we change to `KeyError` in Python? I think we had this discussion at some point. Did we make a clear decision?