### PR TITLE
Parallellise sphinx-build

### DIFF
--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -12,7 +12,7 @@ function(add_docs_target name)
   add_custom_target(
     ${name}
     COMMAND
-      ${Python_EXECUTABLE} -m sphinx -v -b ${ADD_DOCS_TARGET_BUILDER} -d
+      ${Python_EXECUTABLE} -m sphinx -v -b ${ADD_DOCS_TARGET_BUILDER} -d -j2
       ${CMAKE_BINARY_DIR}/.doctrees ${CMAKE_SOURCE_DIR}/docs
       ${CMAKE_BINARY_DIR}/html
     DEPENDS ${ADD_DOCS_TARGET_DEPENDS}

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -12,7 +12,7 @@ function(add_docs_target name)
   add_custom_target(
     ${name}
     COMMAND
-      ${Python_EXECUTABLE} -m sphinx -v -b ${ADD_DOCS_TARGET_BUILDER} -d -j2
+      ${Python_EXECUTABLE} -m sphinx -j2 -v -b ${ADD_DOCS_TARGET_BUILDER} -d
       ${CMAKE_BINARY_DIR}/.doctrees ${CMAKE_SOURCE_DIR}/docs
       ${CMAKE_BINARY_DIR}/html
     DEPENDS ${ADD_DOCS_TARGET_DEPENDS}


### PR DESCRIPTION
Add -j2 flag to sphinx-build to speed up the docs building.
2 is because the VMs on gh actions have 2 cores (3 for osx).