### PR TITLE
Unlimited dimension count (except for operations)

### DIFF
--- a/docs/reference/developer/customizing.rst
+++ b/docs/reference/developer/customizing.rst
@@ -9,7 +9,7 @@ Overview
 A number of concepts and components of **scipp** can and should be customized to the needs of higher-level libraries or to a particular use case.
 At this point we support compile-time customization of:
 
-- The maximum number of dimensions supported by ``Variable`` is configured using the ``NDIM_MAX`` constant.
+- The maximum number of dimensions supported by operations with ``Variable`` is configured using the ``NDIM_OP_MAX`` constant.
 - New or custom ``dtype`` that can be stored as elements in a ``Variable`` and used with the ``transform`` algorithms.
 
 Source code for scipp is hosted in a github repository `here <https://github.com/scipp/scipp>`_.

--- a/lib/core/dimensions.cpp
+++ b/lib/core/dimensions.cpp
@@ -56,6 +56,8 @@ Dim Dimensions::inner() const noexcept {
   return labels().back();
 }
 
+Dimensions merge(const Dimensions &a) { return a; }
+
 /// Return the direct sum, i.e., the combination of dimensions in a and b.
 ///
 /// Throws if there is a mismatching dimension extent.

--- a/lib/core/element_array_view.cpp
+++ b/lib/core/element_array_view.cpp
@@ -45,6 +45,7 @@ ElementArrayViewParams::ElementArrayViewParams(
       m_bucketParams(other.m_bucketParams) {
   expectCanBroadcastFromTo(other.m_iterDims, m_iterDims);
 
+  m_strides.resize(iterDims.ndim());
   for (scipp::index dim = 0; dim < iterDims.ndim(); ++dim) {
     auto label = iterDims.label(dim);
     if (other.m_iterDims.contains(label)) {

--- a/lib/core/include/scipp/core/dimensions.h
+++ b/lib/core/include/scipp/core/dimensions.h
@@ -19,7 +19,7 @@ namespace scipp::core {
 /// dimension is inner dimension.
 class SCIPP_CORE_EXPORT Dimensions : public Sizes {
 public:
-  constexpr Dimensions() noexcept = default;
+  Dimensions() noexcept = default;
   Dimensions(const Dim dim, const scipp::index size)
       : Dimensions({{dim, size}}) {}
   Dimensions(scipp::span<const Dim> labels,
@@ -33,7 +33,7 @@ public:
       addInner(dim, len);
   }
 
-  constexpr bool operator==(const Dimensions &other) const noexcept {
+  bool operator==(const Dimensions &other) const noexcept {
     if (ndim() != other.ndim())
       return false;
     for (int32_t i = 0; i < ndim(); ++i) {
@@ -44,18 +44,17 @@ public:
     }
     return true;
   }
-  constexpr bool operator!=(const Dimensions &other) const noexcept {
+  bool operator!=(const Dimensions &other) const noexcept {
     return !(*this == other);
   }
 
   /// Return the shape of the space defined by *this.
-  [[nodiscard]] constexpr scipp::span<const scipp::index>
-  shape() const &noexcept {
+  [[nodiscard]] scipp::span<const scipp::index> shape() const &noexcept {
     return sizes();
   }
 
   /// Return the volume of the space defined by *this.
-  [[nodiscard]] constexpr scipp::index volume() const noexcept {
+  [[nodiscard]] scipp::index volume() const noexcept {
     scipp::index volume{1};
     for (const auto &length : shape())
       volume *= length;
@@ -63,9 +62,7 @@ public:
   }
 
   /// Return number of dims
-  [[nodiscard]] constexpr scipp::index ndim() const noexcept {
-    return Sizes::size();
-  }
+  [[nodiscard]] scipp::index ndim() const noexcept { return Sizes::size(); }
 
   [[nodiscard]] Dim inner() const noexcept;
 
@@ -78,10 +75,7 @@ public:
   void addInner(const Dim label, const scipp::index size);
 };
 
-[[nodiscard]] SCIPP_CORE_EXPORT constexpr Dimensions
-merge(const Dimensions &a) noexcept {
-  return a;
-}
+[[nodiscard]] SCIPP_CORE_EXPORT Dimensions merge(const Dimensions &a);
 
 [[nodiscard]] SCIPP_CORE_EXPORT Dimensions merge(const Dimensions &a,
                                                  const Dimensions &b);

--- a/lib/core/include/scipp/core/multi_index.h
+++ b/lib/core/include/scipp/core/multi_index.h
@@ -337,11 +337,11 @@ private:
   std::array<scipp::index, N> m_data_index = {};
   // This does *not* 0-init the inner arrays!
   /// Stride for each operand in each dimension.
-  std::array<std::array<scipp::index, N>, NDIM_MAX> m_stride = {};
+  std::array<std::array<scipp::index, N>, NDIM_OP_MAX> m_stride = {};
   /// Current index in iteration dimensions for both bin and inner dims.
-  std::array<scipp::index, NDIM_MAX + 1> m_coord = {};
+  std::array<scipp::index, NDIM_OP_MAX + 1> m_coord = {};
   /// Shape of the iteration dimensions for both bin and inner dims.
-  std::array<scipp::index, NDIM_MAX + 1> m_shape = {};
+  std::array<scipp::index, NDIM_OP_MAX + 1> m_shape = {};
   /// Total number of dimensions.
   scipp::index m_ndim{0};
   /// Number of dense dimensions, i.e. same as m_ndim when not binned,

--- a/lib/core/include/scipp/core/sizes.h
+++ b/lib/core/include/scipp/core/sizes.h
@@ -17,6 +17,7 @@
 namespace scipp::core {
 
 constexpr int32_t NDIM_MAX = 6;
+constexpr int32_t NDIM_STACK = 4;
 
 class Dimensions;
 
@@ -67,9 +68,10 @@ private:
 };
 
 /// Similar to class Dimensions but without implied ordering
-class SCIPP_CORE_EXPORT Sizes : public small_stable_map<Dim, scipp::index, 4> {
+class SCIPP_CORE_EXPORT Sizes
+    : public small_stable_map<Dim, scipp::index, NDIM_STACK> {
 private:
-  using base = small_stable_map<Dim, scipp::index, 4>;
+  using base = small_stable_map<Dim, scipp::index, NDIM_STACK>;
 
 protected:
   using base::assign;

--- a/lib/core/include/scipp/core/sizes.h
+++ b/lib/core/include/scipp/core/sizes.h
@@ -16,7 +16,9 @@
 
 namespace scipp::core {
 
-constexpr int32_t NDIM_MAX = 6;
+/// Maximum number of dimensions supported by transform-based operations
+constexpr int32_t NDIM_OP_MAX = 6;
+/// Number of dimension labels/sizes/strides storable without heap allocation
 constexpr int32_t NDIM_STACK = 4;
 
 class Dimensions;

--- a/lib/core/include/scipp/core/sizes.h
+++ b/lib/core/include/scipp/core/sizes.h
@@ -6,6 +6,8 @@
 
 #include <array>
 
+#include <boost/container/small_vector.hpp>
+
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 #include "scipp/common/span.h"
@@ -37,10 +39,11 @@ public:
   [[nodiscard]] auto rend() const noexcept {
     return std::reverse_iterator(begin());
   }
-  [[nodiscard]] typename std::array<Key, Capacity>::const_iterator
+  [[nodiscard]]
+  typename boost::container::small_vector<Key, Capacity>::const_iterator
   find(const Key &key) const;
-  [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
-  [[nodiscard]] constexpr scipp::index size() const noexcept { return m_size; }
+  [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+  [[nodiscard]] scipp::index size() const noexcept { return m_keys.size(); }
   [[nodiscard]] bool contains(const Key &key) const;
   [[nodiscard]] scipp::index index(const Key &key) const;
   [[nodiscard]] const Value &operator[](const Key &key) const;
@@ -51,24 +54,22 @@ public:
   void erase(const Key &key);
   void clear() noexcept;
   void replace_key(const Key &from, const Key &to);
-  [[nodiscard]] constexpr scipp::span<const Key> keys() const &noexcept {
+  [[nodiscard]] scipp::span<const Key> keys() const &noexcept {
     return {m_keys.data(), static_cast<size_t>(size())};
   }
-  [[nodiscard]] constexpr scipp::span<const Value> values() const &noexcept {
+  [[nodiscard]] scipp::span<const Value> values() const &noexcept {
     return {m_values.data(), static_cast<size_t>(size())};
   }
 
 private:
-  int16_t m_size{0};
-  std::array<Key, Capacity> m_keys{};
-  std::array<Value, Capacity> m_values{};
+  boost::container::small_vector<Key, Capacity> m_keys{};
+  boost::container::small_vector<Value, Capacity> m_values{};
 };
 
 /// Similar to class Dimensions but without implied ordering
-class SCIPP_CORE_EXPORT Sizes
-    : public small_stable_map<Dim, scipp::index, NDIM_MAX> {
+class SCIPP_CORE_EXPORT Sizes : public small_stable_map<Dim, scipp::index, 4> {
 private:
-  using base = small_stable_map<Dim, scipp::index, NDIM_MAX>;
+  using base = small_stable_map<Dim, scipp::index, 4>;
 
 protected:
   using base::assign;
@@ -76,7 +77,7 @@ protected:
   using base::insert_right;
 
 public:
-  constexpr Sizes() noexcept = default;
+  Sizes() noexcept = default;
 
   void set(const Dim dim, const scipp::index size);
   void resize(const Dim dim, const scipp::index size);
@@ -84,9 +85,9 @@ public:
   [[nodiscard]] Sizes slice(const Slice &params) const;
 
   /// Return the labels of the space defined by *this.
-  [[nodiscard]] constexpr auto labels() const &noexcept { return keys(); }
+  [[nodiscard]] auto labels() const &noexcept { return keys(); }
   /// Return the shape of the space defined by *this.
-  [[nodiscard]] constexpr auto sizes() const &noexcept { return values(); }
+  [[nodiscard]] auto sizes() const &noexcept { return values(); }
 };
 
 [[nodiscard]] SCIPP_CORE_EXPORT Sizes

--- a/lib/core/include/scipp/core/strides.h
+++ b/lib/core/include/scipp/core/strides.h
@@ -33,6 +33,8 @@ public:
   bool operator==(const Strides &other) const noexcept;
   bool operator!=(const Strides &other) const noexcept;
 
+  void emplace_back(const scipp::index i);
+  void clear();
   void resize(const scipp::index size);
 
   scipp::index operator[](const scipp::index i) const {

--- a/lib/core/include/scipp/core/strides.h
+++ b/lib/core/include/scipp/core/strides.h
@@ -33,7 +33,7 @@ public:
   bool operator==(const Strides &other) const noexcept;
   bool operator!=(const Strides &other) const noexcept;
 
-  void emplace_back(const scipp::index i);
+  void push_back(const scipp::index i);
   void clear();
   void resize(const scipp::index size);
 

--- a/lib/core/include/scipp/core/strides.h
+++ b/lib/core/include/scipp/core/strides.h
@@ -4,6 +4,8 @@
 /// @author Simon Heybrock
 #pragma once
 
+#include <boost/container/small_vector.hpp>
+
 #include "scipp-core_export.h"
 #include "scipp/common/index.h"
 #include "scipp/core/dimensions.h"
@@ -31,27 +33,23 @@ public:
   bool operator==(const Strides &other) const noexcept;
   bool operator!=(const Strides &other) const noexcept;
 
-  constexpr scipp::index operator[](const scipp::index i) const {
+  void resize(const scipp::index size);
+
+  scipp::index operator[](const scipp::index i) const {
     return m_strides.at(i);
   }
 
-  constexpr scipp::index &operator[](const scipp::index i) {
-    return m_strides.at(i);
-  }
+  scipp::index &operator[](const scipp::index i) { return m_strides.at(i); }
 
-  [[nodiscard]] constexpr auto begin() const { return m_strides.begin(); }
-  [[nodiscard]] constexpr auto begin() { return m_strides.begin(); }
-  [[nodiscard]] constexpr auto end(const scipp::index ndim) const {
-    return std::next(m_strides.begin(), ndim);
-  }
-  [[nodiscard]] constexpr auto end(const scipp::index ndim) {
-    return std::next(m_strides.begin(), ndim);
-  }
+  [[nodiscard]] auto begin() const { return m_strides.begin(); }
+  [[nodiscard]] auto begin() { return m_strides.begin(); }
+  [[nodiscard]] auto end() const { return m_strides.end(); }
+  [[nodiscard]] auto end() { return m_strides.end(); }
 
   void erase(scipp::index i);
 
 private:
-  std::array<scipp::index, NDIM_MAX> m_strides{0};
+  boost::container::small_vector<scipp::index, NDIM_STACK> m_strides;
 };
 
 Strides SCIPP_CORE_EXPORT transpose(const Strides &strides, Dimensions from,

--- a/lib/core/include/scipp/core/strides.h
+++ b/lib/core/include/scipp/core/strides.h
@@ -33,6 +33,8 @@ public:
   bool operator==(const Strides &other) const noexcept;
   bool operator!=(const Strides &other) const noexcept;
 
+  [[nodiscard]] scipp::index size() const noexcept { return m_strides.size(); }
+
   void push_back(const scipp::index i);
   void clear();
   void resize(const scipp::index size);

--- a/lib/core/include/scipp/core/view_index.h
+++ b/lib/core/include/scipp/core/view_index.h
@@ -37,12 +37,12 @@ public:
     ++m_view_index;
   }
 
-  constexpr void set_index(const scipp::index index) noexcept {
+  void set_index(const scipp::index index) noexcept {
     m_view_index = index;
     extract_indices(index, m_shape.begin(), m_shape.begin() + m_ndim,
                     m_coord.begin());
     m_memory_index = flat_index_from_strides(
-        m_strides.begin(), m_strides.end(m_ndim), m_coord.begin());
+        m_strides.begin(), m_strides.begin() + m_ndim, m_coord.begin());
   }
 
   [[nodiscard]] constexpr scipp::index get() const noexcept {
@@ -71,7 +71,7 @@ private:
   /// Shape in iteration dimensions.
   std::array<scipp::index, NDIM_MAX> m_shape = {};
   /// Strides in memory.
-  Strides m_strides;
+  std::array<scipp::index, NDIM_MAX> m_strides = {};
   /// Number of dimensions.
   int32_t m_ndim;
 };

--- a/lib/core/include/scipp/core/view_index.h
+++ b/lib/core/include/scipp/core/view_index.h
@@ -22,8 +22,8 @@ public:
   ViewIndex(const Dimensions &target_dimensions, const Strides &strides);
 
   constexpr void increment_outer() noexcept {
-    for (scipp::index d = 0; (d < NDIM_MAX - 1) && (m_coord[d] == m_shape[d]);
-         ++d) {
+    for (scipp::index d = 0;
+         (d < NDIM_OP_MAX - 1) && (m_coord[d] == m_shape[d]); ++d) {
       m_memory_index += m_delta[d + 1];
       ++m_coord[d + 1];
       m_coord[d] = 0;
@@ -65,13 +65,13 @@ private:
   /// Index in iteration dimensions.
   scipp::index m_view_index{0};
   /// Steps in memory to advance one element.
-  std::array<scipp::index, NDIM_MAX> m_delta = {};
+  std::array<scipp::index, NDIM_OP_MAX> m_delta = {};
   /// Multi-dimensional index in iteration dimensions.
-  std::array<scipp::index, NDIM_MAX> m_coord = {};
+  std::array<scipp::index, NDIM_OP_MAX> m_coord = {};
   /// Shape in iteration dimensions.
-  std::array<scipp::index, NDIM_MAX> m_shape = {};
+  std::array<scipp::index, NDIM_OP_MAX> m_shape = {};
   /// Strides in memory.
-  std::array<scipp::index, NDIM_MAX> m_strides = {};
+  std::array<scipp::index, NDIM_OP_MAX> m_strides = {};
   /// Number of dimensions.
   int32_t m_ndim;
 };

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -60,7 +60,7 @@ auto get_slice_dim(const T &param, const Ts &... params) {
 template <class T>
 [[nodiscard]] auto make_span(T &&array, const scipp::index begin) {
   return scipp::span{array.data() + begin,
-                     static_cast<size_t>(NDIM_MAX - begin)};
+                     static_cast<size_t>(NDIM_OP_MAX - begin)};
 }
 
 template <size_t... I, class... StridesArgs>
@@ -86,9 +86,9 @@ flatten_dims(const scipp::span<std::array<scipp::index, sizeof...(StridesArgs)>>
              const scipp::span<scipp::index> &out_shape, const Dimensions &dims,
              const scipp::index non_flattenable_dim,
              const StridesArgs &... strides) {
-  if (dims.ndim() > NDIM_MAX)
+  if (dims.ndim() > NDIM_OP_MAX)
     throw std::runtime_error("Operations with more than " +
-                             std::to_string(NDIM_MAX) +
+                             std::to_string(NDIM_OP_MAX) +
                              " dimensions are not supported.");
   constexpr scipp::index N = sizeof...(StridesArgs);
   std::array strides_array{std::ref(strides)...};

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -94,15 +94,15 @@ flatten_dims(const scipp::span<std::array<scipp::index, sizeof...(StridesArgs)>>
              const scipp::span<scipp::index> &out_shape, const Dimensions &dims,
              const scipp::index non_flattenable_dim,
              const StridesArgs &... strides) {
-  if (dims.ndim() > NDIM_OP_MAX)
-    throw std::runtime_error("Operations with more than " +
-                             std::to_string(NDIM_OP_MAX) +
-                             " dimensions are not supported.");
   constexpr scipp::index N = sizeof...(StridesArgs);
   std::array strides_array{std::ref(strides)...};
   std::array<scipp::index, N> strides_for_contiguous{};
   scipp::index dim_write = 0;
   for (scipp::index dim_read = dims.ndim() - 1; dim_read >= 0; --dim_read) {
+    if (dim_write >= NDIM_OP_MAX)
+      throw std::runtime_error("Operations with more than " +
+                               std::to_string(NDIM_OP_MAX) +
+                               " dimensions are not supported.");
     const auto size = dims.size(dim_read);
     if (dim_read > non_flattenable_dim &&
         can_be_flattened(dim_read, size, std::make_index_sequence<N>{},

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -129,7 +129,7 @@ MultiIndex<N>::MultiIndex(binned_tag, const Dimensions &inner_dims,
   m_inner_ndim = flatten_dims(
       make_span(m_stride, 0), make_span(m_shape, 0), inner_dims,
       inner_dims.index(slice_dim),
-      params.bucketParams() ? params.bucketParams().strides : Strides{}...);
+      params.bucketParams() ? params.bucketParams().strides : Strides{0}...);
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   m_ndim = m_inner_ndim + flatten_dims(make_span(m_stride, m_inner_ndim),
                                        make_span(m_shape, m_inner_ndim),

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -126,10 +126,11 @@ MultiIndex<N>::MultiIndex(binned_tag, const Dimensions &inner_dims,
   const Dim slice_dim = get_slice_dim(params.bucketParams()...);
 
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
-  m_inner_ndim = flatten_dims(
-      make_span(m_stride, 0), make_span(m_shape, 0), inner_dims,
-      inner_dims.index(slice_dim),
-      params.bucketParams() ? params.bucketParams().strides : Strides{0}...);
+  m_inner_ndim =
+      flatten_dims(make_span(m_stride, 0), make_span(m_shape, 0), inner_dims,
+                   inner_dims.index(slice_dim),
+                   params.bucketParams() ? params.bucketParams().strides
+                                         : Strides{0, 0, 0, 0, 0, 0}...);
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   m_ndim = m_inner_ndim + flatten_dims(make_span(m_stride, m_inner_ndim),
                                        make_span(m_shape, m_inner_ndim),

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -86,6 +86,10 @@ flatten_dims(const scipp::span<std::array<scipp::index, sizeof...(StridesArgs)>>
              const scipp::span<scipp::index> &out_shape, const Dimensions &dims,
              const scipp::index non_flattenable_dim,
              const StridesArgs &... strides) {
+  if (dims.ndim() > NDIM_MAX)
+    throw std::runtime_error("Operations with more than " +
+                             std::to_string(NDIM_MAX) +
+                             " dimensions are not supported.");
   constexpr scipp::index N = sizeof...(StridesArgs);
   std::array strides_array{std::ref(strides)...};
   std::array<scipp::index, N> strides_for_contiguous{};

--- a/lib/core/sizes.cpp
+++ b/lib/core/sizes.cpp
@@ -123,7 +123,7 @@ void small_stable_map<Key, Value, Capacity>::replace_key(const Key &key,
   m_keys[index(key)] = new_key;
 }
 
-template class small_stable_map<Dim, scipp::index, 4>;
+template class small_stable_map<Dim, scipp::index, NDIM_STACK>;
 
 void Sizes::set(const Dim dim, const scipp::index size) {
   expect::validDim(dim);

--- a/lib/core/sizes.cpp
+++ b/lib/core/sizes.cpp
@@ -15,12 +15,6 @@ template <class T> void expectUnique(const T &map, const Dim label) {
     throw except::DimensionError("Duplicate dimension.");
 }
 
-template <class T> void expectExtendable(const T &map) {
-  if (map.size() == T::capacity)
-    throw except::DimensionError(
-        "Maximum number of allowed dimensions exceeded.");
-}
-
 template <class T> std::string to_string(const T &map) {
   std::string repr("[");
   for (const auto &key : map)
@@ -56,7 +50,7 @@ bool small_stable_map<Key, Value, Capacity>::operator!=(
 }
 
 template <class Key, class Value, int16_t Capacity>
-typename std::array<Key, Capacity>::const_iterator
+typename boost::container::small_vector<Key, Capacity>::const_iterator
 small_stable_map<Key, Value, Capacity>::find(const Key &key) const {
   return std::find(begin(), end(), key);
 }
@@ -96,38 +90,29 @@ template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::insert_left(const Key &key,
                                                          const Value &value) {
   expectUnique(*this, key);
-  expectExtendable(*this);
-  for (scipp::index i = size(); i > 0; --i) {
-    m_keys[i] = m_keys[i - 1];
-    m_values[i] = m_values[i - 1];
-  }
-  m_keys[0] = key;
-  m_values[0] = value;
-  m_size++;
+  m_keys.insert(m_keys.begin(), key);
+  m_values.insert(m_values.begin(), value);
 }
 
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::insert_right(const Key &key,
                                                           const Value &value) {
   expectUnique(*this, key);
-  expectExtendable(*this);
-  m_keys[m_size] = key;
-  m_values[m_size] = value;
-  m_size++;
+  m_keys.push_back(key);
+  m_values.push_back(value);
 }
 
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::erase(const Key &key) {
-  for (scipp::index i = index(key); i < size() - 1; ++i) {
-    m_keys[i] = m_keys[i + 1];
-    m_values[i] = m_values[i + 1];
-  }
-  m_size--;
+  const auto i = index(key);
+  m_keys.erase(m_keys.begin() + i);
+  m_values.erase(m_values.begin() + i);
 }
 
 template <class Key, class Value, int16_t Capacity>
 void small_stable_map<Key, Value, Capacity>::clear() noexcept {
-  m_size = 0;
+  m_keys.clear();
+  m_values.clear();
 }
 
 template <class Key, class Value, int16_t Capacity>
@@ -138,7 +123,7 @@ void small_stable_map<Key, Value, Capacity>::replace_key(const Key &key,
   m_keys[index(key)] = new_key;
 }
 
-template class small_stable_map<Dim, scipp::index, NDIM_MAX>;
+template class small_stable_map<Dim, scipp::index, 4>;
 
 void Sizes::set(const Dim dim, const scipp::index size) {
   expect::validDim(dim);

--- a/lib/core/strides.cpp
+++ b/lib/core/strides.cpp
@@ -6,17 +6,15 @@
 
 namespace scipp::core {
 
-Strides::Strides(const scipp::span<const scipp::index> &strides) {
-  scipp::index i = 0;
-  for (const auto &stride : strides)
-    m_strides.at(i++) = stride;
-}
+Strides::Strides(const scipp::span<const scipp::index> &strides)
+    : m_strides(strides.begin(), strides.end()) {}
 
 Strides::Strides(const std::initializer_list<scipp::index> strides)
-    : Strides{{strides.begin(), strides.end()}} {}
+    : m_strides(strides) {}
 
 Strides::Strides(const Dimensions &dims) {
   scipp::index offset{1};
+  resize(dims.ndim());
   for (scipp::index i = dims.ndim() - 1; i >= 0; --i) {
     m_strides[i] = offset;
     offset *= dims.size(i);
@@ -31,10 +29,10 @@ bool Strides::operator!=(const Strides &other) const noexcept {
   return !operator==(other);
 }
 
+void Strides::resize(const scipp::index size) { m_strides.resize(size); }
+
 void Strides::erase(const scipp::index i) {
-  for (scipp::index j = i; j < scipp::size(m_strides) - 1; ++j)
-    m_strides[j] = m_strides[j + 1];
-  m_strides.back() = 0;
+  m_strides.erase(m_strides.begin() + i);
 }
 
 Strides transpose(const Strides &strides, Dimensions from,

--- a/lib/core/strides.cpp
+++ b/lib/core/strides.cpp
@@ -29,7 +29,7 @@ bool Strides::operator!=(const Strides &other) const noexcept {
   return !operator==(other);
 }
 
-void Strides::emplace_back(const scipp::index i) { m_strides.emplace_back(i); }
+void Strides::push_back(const scipp::index i) { m_strides.push_back(i); }
 
 void Strides::clear() { m_strides.clear(); }
 

--- a/lib/core/strides.cpp
+++ b/lib/core/strides.cpp
@@ -29,6 +29,10 @@ bool Strides::operator!=(const Strides &other) const noexcept {
   return !operator==(other);
 }
 
+void Strides::emplace_back(const scipp::index i) { m_strides.emplace_back(i); }
+
+void Strides::clear() { m_strides.clear(); }
+
 void Strides::resize(const scipp::index size) { m_strides.resize(size); }
 
 void Strides::erase(const scipp::index i) {

--- a/lib/core/test/CMakeLists.txt
+++ b/lib/core/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   slice_test.cpp
   sizes_test.cpp
   spatial_transforms_test.cpp
+  strides_test.cpp
   string_test.cpp
   subbin_sizes_test.cpp
   time_point_test.cpp

--- a/lib/core/test/dimensions_test.cpp
+++ b/lib/core/test/dimensions_test.cpp
@@ -12,13 +12,6 @@
 using namespace scipp;
 using namespace scipp::core;
 
-TEST(DimensionsTest, footprint) {
-  EXPECT_EQ(sizeof(Dimensions), 64ul);
-  // TODO Do we want to align this? Need to run benchmarks when implementation
-  // is more mature.
-  // EXPECT_EQ(std::alignment_of<Dimensions>(), 64);
-}
-
 TEST(DimensionsTest, construct) {
   EXPECT_NO_THROW(Dimensions());
   EXPECT_NO_THROW(Dimensions{});

--- a/lib/core/test/multi_index_test.cpp
+++ b/lib/core/test/multi_index_test.cpp
@@ -128,6 +128,7 @@ protected:
 
 Strides make_strides(const Dimensions &iter_dims, const Dimensions &data_dims) {
   Strides strides;
+  strides.resize(iter_dims.ndim());
   scipp::index d = 0;
   for (const auto &dim : iter_dims.labels()) {
     if (data_dims.contains(dim))

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -9,7 +9,7 @@
 using namespace scipp;
 
 using SmallMap =
-    scipp::core::small_stable_map<Dim, scipp::index, core::NDIM_OP_MAX>;
+    scipp::core::small_stable_map<Dim, scipp::index, core::NDIM_STACK>;
 
 TEST(SmallMapTest, empty_size) {
   SmallMap map;

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -63,7 +63,7 @@ TEST_F(SizesTest, 2d) {
   EXPECT_EQ(sizes[Dim::Y], 3);
 }
 
-TEST_F(SizesTest, max_dims) {
+TEST_F(SizesTest, many_dims) {
   Sizes sizes;
   sizes.set(Dim("axis-0"), 2);
   sizes.set(Dim("axis-1"), 2);
@@ -71,7 +71,10 @@ TEST_F(SizesTest, max_dims) {
   sizes.set(Dim("axis-3"), 2);
   sizes.set(Dim("axis-4"), 2);
   sizes.set(Dim("axis-5"), 2);
-  EXPECT_THROW(sizes.set(Dim("axis-6"), 2), std::runtime_error);
+  sizes.set(Dim("axis-6"), 2);
+  sizes.set(Dim("axis-7"), 2);
+  sizes.set(Dim("axis-8"), 2);
+  sizes.set(Dim("axis-9"), 2);
 }
 
 TEST_F(SizesTest, comparison) {

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -66,15 +66,17 @@ TEST_F(SizesTest, 2d) {
 TEST_F(SizesTest, many_dims) {
   Sizes sizes;
   sizes.set(Dim("axis-0"), 2);
-  sizes.set(Dim("axis-1"), 2);
-  sizes.set(Dim("axis-2"), 2);
-  sizes.set(Dim("axis-3"), 2);
-  sizes.set(Dim("axis-4"), 2);
-  sizes.set(Dim("axis-5"), 2);
-  sizes.set(Dim("axis-6"), 2);
-  sizes.set(Dim("axis-7"), 2);
-  sizes.set(Dim("axis-8"), 2);
-  sizes.set(Dim("axis-9"), 2);
+  sizes.set(Dim("axis-1"), 3);
+  sizes.set(Dim("axis-2"), 4);
+  sizes.set(Dim("axis-3"), 5);
+  sizes.set(Dim("axis-4"), 6);
+  sizes.set(Dim("axis-5"), 7);
+  sizes.set(Dim("axis-6"), 8);
+  sizes.set(Dim("axis-7"), 9);
+  sizes.set(Dim("axis-8"), 10);
+  sizes.set(Dim("axis-9"), 11);
+  EXPECT_EQ(sizes.size(), 10);
+  EXPECT_EQ(sizes[Dim("axis-0")], 2);
 }
 
 TEST_F(SizesTest, comparison) {

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -9,7 +9,7 @@
 using namespace scipp;
 
 using SmallMap =
-    scipp::core::small_stable_map<Dim, scipp::index, core::NDIM_MAX>;
+    scipp::core::small_stable_map<Dim, scipp::index, core::NDIM_OP_MAX>;
 
 TEST(SmallMapTest, empty_size) {
   SmallMap map;

--- a/lib/core/test/strides_test.cpp
+++ b/lib/core/test/strides_test.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+
+#include "scipp/core/strides.h"
+
+using namespace scipp;
+
+TEST(StridesTest, resize_keeps_old_elements) {
+  Strides strides{2, 3};
+  strides.resize(3);
+  ASSERT_EQ(strides, Strides({2, 3, 0}));
+}
+
+TEST(StridesTest, clear_results_in_empty_strides) {
+  Strides strides{2, 3};
+  strides.clear();
+  ASSERT_EQ(strides, Strides());
+}

--- a/lib/variable/include/scipp/variable/structure_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/structure_array_variable.tcc
@@ -29,7 +29,7 @@ Variable Variable::elements_impl(Is... index) const {
   if constexpr (sizeof...(Is) == 0) {
     // Get all elements by setting up internal dim and stride
     elements.unchecked_dims().addInner(Dim::InternalStructureComponent, N);
-    elements.unchecked_strides().emplace_back(1);
+    elements.unchecked_strides().push_back(1);
   } else {
     // Get specific element at offset
     const auto offset = structure_element_offset<T>(index...);

--- a/lib/variable/include/scipp/variable/structure_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/structure_array_variable.tcc
@@ -29,7 +29,7 @@ Variable Variable::elements_impl(Is... index) const {
   if constexpr (sizeof...(Is) == 0) {
     // Get all elements by setting up internal dim and stride
     elements.unchecked_dims().addInner(Dim::InternalStructureComponent, N);
-    elements.unchecked_strides()[dims().ndim()] = 1;
+    elements.unchecked_strides().emplace_back(1);
   } else {
     // Get specific element at offset
     const auto offset = structure_element_offset<T>(index...);

--- a/lib/variable/test/operations_test.cpp
+++ b/lib/variable/test/operations_test.cpp
@@ -962,7 +962,7 @@ TEST(VariableTest, divide_vector) {
 }
 
 TEST(Variable, 6d) {
-  ASSERT_EQ(core::NDIM_MAX, 6); // update this test if limit is increased
+  ASSERT_EQ(core::NDIM_OP_MAX, 6); // update this test if limit is increased
   auto a = makeVariable<double>(
       Dims{Dim("1"), Dim("2"), Dim("3"), Dim("4"), Dim("5"), Dim("6")},
       Shape{1, 2, 3, 4, 5, 6});

--- a/lib/variable/test/variable_test.cpp
+++ b/lib/variable/test/variable_test.cpp
@@ -32,12 +32,13 @@ TEST(Variable, construct) {
 TEST(Variable, many_dims_works_or_fails_gracefully) {
   Dimensions dims;
   for (const auto dim : "abcdefghijklmn")
-    dims.addInner(Dim(std::string(1, dim)), 2);
-  auto var = makeVariable<double>(dims);
+    dims.addInner(Dim(std::string(1, dim)), 1);
+  auto var = makeVariable<double>(dims, Values{1});
   EXPECT_EQ(var.ndim(), 15);
+  EXPECT_EQ(copy(var), var);
+  EXPECT_EQ(var + var, makeVariable<double>(dims, Values{2}));
   // TODO In principle we should be able to support all of the below with
-  // flattening, but the current implementation fails in some cases and is
-  // therefore disabled for many dims.
+  // flattening, but the current implementation dos not handle this.
   ASSERT_THROW(var += 1.0 * units::one, std::runtime_error);
   ASSERT_THROW(var +=
                makeVariable<double>(Dims{Dim("a")}, Shape{2}, Values{1, 2}),
@@ -48,8 +49,6 @@ TEST(Variable, many_dims_works_or_fails_gracefully) {
   ASSERT_THROW(var +=
                makeVariable<double>(Dims{Dim("n")}, Shape{2}, Values{1, 2}),
                std::runtime_error);
-  ASSERT_THROW(copy(var), std::runtime_error);
-  ASSERT_THROW(var + var, std::runtime_error);
 }
 
 TEST(Variable, default_unit_of_numeric_is_dimensionless) {

--- a/lib/variable/test/variable_test.cpp
+++ b/lib/variable/test/variable_test.cpp
@@ -29,6 +29,29 @@ TEST(Variable, construct) {
   EXPECT_EQ(data.size(), 2);
 }
 
+TEST(Variable, many_dims_works_or_fails_gracefully) {
+  Dimensions dims;
+  for (const auto dim : "abcdefghijklmn")
+    dims.addInner(Dim(std::string(1, dim)), 2);
+  auto var = makeVariable<double>(dims);
+  EXPECT_EQ(var.ndim(), 15);
+  // TODO In principle we should be able to support all of the below with
+  // flattening, but the current implementation fails in some cases and is
+  // therefore disabled for many dims.
+  ASSERT_THROW(var += 1.0 * units::one, std::runtime_error);
+  ASSERT_THROW(var +=
+               makeVariable<double>(Dims{Dim("a")}, Shape{2}, Values{1, 2}),
+               std::runtime_error);
+  ASSERT_THROW(var +=
+               makeVariable<double>(Dims{Dim("g")}, Shape{2}, Values{1, 2}),
+               std::runtime_error);
+  ASSERT_THROW(var +=
+               makeVariable<double>(Dims{Dim("n")}, Shape{2}, Values{1, 2}),
+               std::runtime_error);
+  ASSERT_THROW(copy(var), std::runtime_error);
+  ASSERT_THROW(var + var, std::runtime_error);
+}
+
 TEST(Variable, default_unit_of_numeric_is_dimensionless) {
   EXPECT_EQ(makeVariable<double>(Dimensions{}).unit(), units::one);
   EXPECT_EQ(makeVariable<float>(Dimensions{}).unit(), units::one);

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -235,23 +235,24 @@ Variable Variable::broadcast(const Dimensions &target) const {
   expect::includes(target, dims());
   auto out = target.volume() == dims().volume() ? *this : as_const();
   out.m_dims = target;
-  scipp::index i = 0;
+  out.m_strides.clear();
   for (const auto &d : target.labels())
-    out.m_strides[i++] = dims().contains(d) ? m_strides[dims().index(d)] : 0;
+    out.m_strides.emplace_back(dims().contains(d) ? m_strides[dims().index(d)]
+                                                  : 0);
   return out;
 }
 
 Variable Variable::fold(const Dim dim, const Dimensions &target) const {
   auto out(*this);
   out.m_dims = core::fold(dims(), dim, target);
+  out.m_strides.clear();
   const Strides substrides(target);
-  scipp::index i_out = 0;
   for (scipp::index i_in = 0; i_in < dims().ndim(); ++i_in) {
     if (dims().label(i_in) == dim)
       for (scipp::index i_target = 0; i_target < target.ndim(); ++i_target)
-        out.m_strides[i_out++] = m_strides[i_in] * substrides[i_target];
+        out.m_strides.emplace_back(m_strides[i_in] * substrides[i_target]);
     else
-      out.m_strides[i_out++] = m_strides[i_in];
+      out.m_strides.emplace_back(m_strides[i_in]);
   }
   return out;
 }

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -237,8 +237,8 @@ Variable Variable::broadcast(const Dimensions &target) const {
   out.m_dims = target;
   out.m_strides.clear();
   for (const auto &d : target.labels())
-    out.m_strides.emplace_back(dims().contains(d) ? m_strides[dims().index(d)]
-                                                  : 0);
+    out.m_strides.push_back(dims().contains(d) ? m_strides[dims().index(d)]
+                                               : 0);
   return out;
 }
 
@@ -250,9 +250,9 @@ Variable Variable::fold(const Dim dim, const Dimensions &target) const {
   for (scipp::index i_in = 0; i_in < dims().ndim(); ++i_in) {
     if (dims().label(i_in) == dim)
       for (scipp::index i_target = 0; i_target < target.ndim(); ++i_target)
-        out.m_strides.emplace_back(m_strides[i_in] * substrides[i_target]);
+        out.m_strides.push_back(m_strides[i_in] * substrides[i_target]);
     else
-      out.m_strides.emplace_back(m_strides[i_in]);
+      out.m_strides.push_back(m_strides[i_in]);
   }
   return out;
 }

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -743,3 +743,13 @@ def test_iteration():
     expected = ['a', 'b']
     for k in d:
         assert k in expected
+
+
+def test_many_independent_dims_are_supported():
+    ds = sc.Dataset()
+    for i in range(100):
+        dim = f'dim{i}'
+        ds[dim] = sc.linspace(dim=dim, start=0, stop=1, num=i)
+    assert 'dim45' in ds
+    assert sc.identical(ds.copy(), ds)
+    ds + ds


### PR DESCRIPTION
Fixes #2415.

@jl-wynen I think it should be possible to support operations with high-dimensional variables in many cases, based on flattening. However, I had an issue with out-of-bounds writes, and did not feel confident to modify the flattening code. Do you feel like having a look at this? See the added exception, and test in `variable_test.cpp`.