### PR TITLE
Support strides when slicing

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -17,6 +17,7 @@ Features
 * :py:func:`sc.fold` now supports ``-1`` for one of the dimension sizes, to indicate automatic shape `#2414 <https://github.com/scipp/scipp/pull/2414>`_.
 * Made it possible to use ``-1`` for one of the dimension sizes when using ``sc.fold`` `#2414 <https://github.com/scipp/scipp/pull/2414>`_.
 * Added ``quiet`` argument to :py:func:`scipp.transform_coords` `#2420 <https://github.com/scipp/scipp/pull/2420>`_.
+* Added support for strides for positional slicing. Negative strides are not supported for now `#2423 <https://github.com/scipp/scipp/pull/2423>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -173,6 +173,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Positional index also supports an optional stride (step):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var['x', 1:4:1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Negative step sizes are current not supported."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Data arrays\n",
     "\n",
     "Slicing for data arrays works in the same way, but some additional rules apply.\n",

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -182,7 +182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var['x', 1:4:1]"
+    "var['x', 1:4:2]"
    ]
   },
   {

--- a/lib/core/include/scipp/core/slice.h
+++ b/lib/core/include/scipp/core/slice.h
@@ -14,22 +14,25 @@ namespace scipp::core {
 /// range
 class SCIPP_CORE_EXPORT Slice {
 public:
-  Slice() : m_dim(Dim::None), m_begin(-1), m_end(-1) {}
-  Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_);
+  Slice() : m_dim(Dim::None), m_begin(-1), m_end(-1), m_stride(1) {}
+  Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
+        const scipp::index stride = 1);
   Slice(const Dim dim_, const scipp::index begin_);
   Slice(const Slice &) = default;
   Slice &operator=(const Slice &) = default;
   bool operator==(const Slice &other) const noexcept;
   bool operator!=(const Slice &other) const noexcept;
-  scipp::index begin() const noexcept { return m_begin; };
-  scipp::index end() const noexcept { return m_end; };
-  Dim dim() const noexcept { return m_dim; };
-  bool isRange() const noexcept { return m_end != -1; };
+  scipp::index begin() const noexcept { return m_begin; }
+  scipp::index end() const noexcept { return m_end; }
+  Dim dim() const noexcept { return m_dim; }
+  scipp::index stride() const noexcept { return m_stride; }
+  bool isRange() const noexcept { return m_end != -1; }
 
 private:
   Dim m_dim;
   scipp::index m_begin;
   scipp::index m_end;
+  scipp::index m_stride;
 };
 
 } // namespace scipp::core

--- a/lib/core/include/scipp/core/slice.h
+++ b/lib/core/include/scipp/core/slice.h
@@ -16,7 +16,7 @@ class SCIPP_CORE_EXPORT Slice {
 public:
   Slice() : m_dim(Dim::None), m_begin(-1), m_end(-1), m_stride(1) {}
   Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
-        const scipp::index stride = 1);
+        const scipp::index stride_ = 1);
   Slice(const Dim dim_, const scipp::index begin_);
   Slice(const Slice &) = default;
   Slice &operator=(const Slice &) = default;

--- a/lib/core/sizes.cpp
+++ b/lib/core/sizes.cpp
@@ -153,9 +153,14 @@ Sizes Sizes::slice(const Slice &params) const {
   Sizes sliced(*this);
   if (params == Slice{})
     return sliced;
-  if (params.isRange())
-    sliced.resize(params.dim(), params.end() - params.begin());
-  else
+  if (params.isRange()) {
+    const auto remainder =
+        (params.end() - params.begin()) % params.stride() != 0;
+    sliced.resize(params.dim(),
+                  std::max(scipp::index{0},
+                           (params.end() - params.begin()) / params.stride() +
+                               remainder));
+  } else
     sliced.erase(params.dim());
   return sliced;
 }

--- a/lib/core/slice.cpp
+++ b/lib/core/slice.cpp
@@ -10,10 +10,10 @@
 namespace scipp::core {
 
 namespace {
-void validate_begin(const scipp::index begin_) {
-  if (begin_ < 0)
+void validate_begin(const scipp::index begin) {
+  if (begin < 0)
     throw except::SliceError("begin must be >= 0. Given " +
-                             std::to_string(begin_));
+                             std::to_string(begin));
 }
 } // namespace
 
@@ -23,8 +23,9 @@ void validate_begin(const scipp::index begin_) {
 /// \param end_ end index for the range. Note that -1 indicates a point slice,
 /// not before-end.
 ///
-Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_)
-    : m_dim(dim_), m_begin(begin_), m_end(end_) {
+Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
+             const scipp::index stride)
+    : m_dim(dim_), m_begin(begin_), m_end(end_), m_stride(stride) {
   validate_begin(begin_);
   if (end_ != -1 && begin_ > end_)
     throw except::SliceError("end must be >= begin. Given begin " +
@@ -43,7 +44,7 @@ Slice::Slice(const Dim dim_, const index begin_)
 
 bool Slice::operator==(const Slice &other) const noexcept {
   return m_dim == other.dim() && m_begin == other.m_begin &&
-         m_end == other.m_end;
+         m_end == other.m_end && m_stride == other.m_stride;
 }
 bool Slice::operator!=(const Slice &other) const noexcept {
   return !(*this == other);

--- a/lib/core/slice.cpp
+++ b/lib/core/slice.cpp
@@ -38,7 +38,7 @@ Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
 /// \param begin_ start index or single index of the slice
 ///
 Slice::Slice(const Dim dim_, const index begin_)
-    : m_dim(dim_), m_begin(begin_), m_end(-1) {
+    : m_dim(dim_), m_begin(begin_), m_end(-1), m_stride(1) {
   validate_begin(begin_);
 }
 

--- a/lib/core/slice.cpp
+++ b/lib/core/slice.cpp
@@ -24,13 +24,15 @@ void validate_begin(const scipp::index begin) {
 /// not before-end.
 ///
 Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
-             const scipp::index stride)
-    : m_dim(dim_), m_begin(begin_), m_end(end_), m_stride(stride) {
+             const scipp::index stride_)
+    : m_dim(dim_), m_begin(begin_), m_end(end_), m_stride(stride_) {
   validate_begin(begin_);
   if (end_ != -1 && begin_ > end_)
     throw except::SliceError("end must be >= begin. Given begin " +
                              std::to_string(begin_) + " end " +
                              std::to_string(end_));
+  if (stride_ == 0)
+    throw except::SliceError("slice step cannot be zero");
 }
 
 /// Constructor for point slice

--- a/lib/core/slice.cpp
+++ b/lib/core/slice.cpp
@@ -33,6 +33,8 @@ Slice::Slice(const Dim dim_, const scipp::index begin_, const scipp::index end_,
                              std::to_string(end_));
   if (stride_ == 0)
     throw except::SliceError("slice step cannot be zero");
+  if (stride_ < 0)
+    throw except::SliceError("negative slice step support not implemented");
 }
 
 /// Constructor for point slice

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -121,3 +121,33 @@ TEST_F(SizesTest, slice_none) {
   sizes.set(Dim::Z, 4);
   EXPECT_EQ(sizes.slice({}), sizes);
 }
+
+TEST_F(SizesTest, full_slice_with_stride_1_yields_original) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  EXPECT_EQ(sizes.slice({Dim::Z, 0, 4, 1}), sizes);
+}
+
+TEST_F(SizesTest, slice_with_stride_2_yields_smaller) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  EXPECT_EQ(sizes.slice({Dim::Z, 0, 4, 2}), sizes.slice({Dim::Z, 0, 2}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 1, 4, 2}), sizes.slice({Dim::Z, 0, 2}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 2, 4, 2}), sizes.slice({Dim::Z, 0, 1}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 3, 4, 2}), sizes.slice({Dim::Z, 0, 1}));
+}
+
+TEST_F(SizesTest, slice_with_stride_3_yields_smaller) {
+  Sizes sizes;
+  sizes.set(Dim::X, 2);
+  sizes.set(Dim::Y, 3);
+  sizes.set(Dim::Z, 4);
+  EXPECT_EQ(sizes.slice({Dim::Z, 0, 4, 3}), sizes.slice({Dim::Z, 0, 2}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 1, 4, 3}), sizes.slice({Dim::Z, 0, 1}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 2, 4, 3}), sizes.slice({Dim::Z, 0, 1}));
+  EXPECT_EQ(sizes.slice({Dim::Z, 3, 4, 3}), sizes.slice({Dim::Z, 0, 1}));
+}

--- a/lib/core/test/sizes_test.cpp
+++ b/lib/core/test/sizes_test.cpp
@@ -151,3 +151,9 @@ TEST_F(SizesTest, slice_with_stride_3_yields_smaller) {
   EXPECT_EQ(sizes.slice({Dim::Z, 2, 4, 3}), sizes.slice({Dim::Z, 0, 1}));
   EXPECT_EQ(sizes.slice({Dim::Z, 3, 4, 3}), sizes.slice({Dim::Z, 0, 1}));
 }
+
+TEST_F(SizesTest, slice_with_stride_exceeding_size_yields_length_1) {
+  Sizes sizes;
+  sizes.set(Dim::X, 4);
+  EXPECT_EQ(sizes.slice({Dim::X, 1, 3, 10}), sizes.slice({Dim::X, 0, 1}));
+}

--- a/lib/core/test/slice_test.cpp
+++ b/lib/core/test/slice_test.cpp
@@ -60,3 +60,18 @@ TEST(SliceTest, stride_is_1_if_not_specified) {
   EXPECT_EQ(Slice(Dim::X, 2).stride(), 1);
   EXPECT_EQ(Slice(Dim::X, 2, 4).stride(), 1);
 }
+
+TEST(SliceTest, positive_stride_can_be_set) {
+  Slice slice(Dim::X, 1, 10, 3);
+  EXPECT_EQ(slice.stride(), 3);
+}
+
+TEST(SliceTest, negative_stride_can_be_set) {
+  Slice slice(Dim::X, 1, 10, -3);
+  EXPECT_EQ(slice.stride(), -3);
+}
+
+TEST(SliceTest, zero_stride_can_be_set) {
+  Slice slice(Dim::X, 1, 10, 0);
+  EXPECT_EQ(slice.stride(), 0);
+}

--- a/lib/core/test/slice_test.cpp
+++ b/lib/core/test/slice_test.cpp
@@ -66,7 +66,13 @@ TEST(SliceTest, positive_stride_can_be_set) {
   EXPECT_EQ(slice.stride(), 3);
 }
 
-TEST(SliceTest, negative_stride_can_be_set) {
+TEST(SliceTest, negative_stride_throws_SliceError) {
+  // Not implemented yet, this is not based on a requirement
+  EXPECT_THROW(Slice(Dim::X, 1, 10, -1), except::SliceError);
+}
+
+// DISABLED since support not implemented yet
+TEST(SliceTest, DISABLED_negative_stride_can_be_set) {
   Slice slice(Dim::X, 1, 10, -3);
   EXPECT_EQ(slice.stride(), -3);
 }

--- a/lib/core/test/slice_test.cpp
+++ b/lib/core/test/slice_test.cpp
@@ -54,3 +54,9 @@ TEST(SliceTest, test_end_valid) {
                }),
                except::SliceError);
 }
+
+TEST(SliceTest, stride_is_1_if_not_specified) {
+  EXPECT_EQ(Slice().stride(), 1);
+  EXPECT_EQ(Slice(Dim::X, 2).stride(), 1);
+  EXPECT_EQ(Slice(Dim::X, 2, 4).stride(), 1);
+}

--- a/lib/core/test/slice_test.cpp
+++ b/lib/core/test/slice_test.cpp
@@ -71,7 +71,6 @@ TEST(SliceTest, negative_stride_can_be_set) {
   EXPECT_EQ(slice.stride(), -3);
 }
 
-TEST(SliceTest, zero_stride_can_be_set) {
-  Slice slice(Dim::X, 1, 10, 0);
-  EXPECT_EQ(slice.stride(), 0);
+TEST(SliceTest, zero_stride_throws_SliceError) {
+  EXPECT_THROW(Slice(Dim::X, 1, 10, 0), except::SliceError);
 }

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -175,7 +175,7 @@ void Dataset::setData(const std::string &name, const DataArray &data) {
 }
 
 /// Return slice of the dataset along given dimension with given extents.
-Dataset Dataset::slice(const Slice s) const {
+Dataset Dataset::slice(const Slice &s) const {
   Dataset out;
   out.m_data = slice_map(m_coords.sizes(), m_data, s);
   auto [coords, attrs] = m_coords.slice_coords(s);
@@ -191,7 +191,7 @@ Dataset Dataset::slice(const Slice s) const {
   return out;
 }
 
-Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
+Dataset &Dataset::setSlice(const Slice &s, const Dataset &data) {
   // Validate slice on all items as a dry-run
   expect::coords_are_superset(slice(s).coords(), data.coords(), "");
   for (const auto &[name, item] : m_data)
@@ -202,7 +202,7 @@ Dataset &Dataset::setSlice(const Slice s, const Dataset &data) {
   return *this;
 }
 
-Dataset &Dataset::setSlice(const Slice s, const DataArray &data) {
+Dataset &Dataset::setSlice(const Slice &s, const DataArray &data) {
   // Validate slice on all items as a dry-run
   expect::coords_are_superset(slice(s).coords(), data.coords(), "");
   for (const auto &item : m_data)
@@ -213,7 +213,7 @@ Dataset &Dataset::setSlice(const Slice s, const DataArray &data) {
   return *this;
 }
 
-Dataset &Dataset::setSlice(const Slice s, const Variable &data) {
+Dataset &Dataset::setSlice(const Slice &s, const Variable &data) {
   for (auto &&item : *this)
     item.setSlice(s, data);
   return *this;

--- a/lib/dataset/include/scipp/dataset/dataset.h
+++ b/lib/dataset/include/scipp/dataset/dataset.h
@@ -165,10 +165,10 @@ public:
                const AttrPolicy attrPolicy = AttrPolicy::Drop);
   void setData(const std::string &name, const DataArray &data);
 
-  Dataset slice(const Slice s) const;
-  [[maybe_unused]] Dataset &setSlice(const Slice s, const Dataset &dataset);
-  [[maybe_unused]] Dataset &setSlice(const Slice s, const DataArray &array);
-  [[maybe_unused]] Dataset &setSlice(const Slice s, const Variable &var);
+  Dataset slice(const Slice &s) const;
+  [[maybe_unused]] Dataset &setSlice(const Slice &s, const Dataset &dataset);
+  [[maybe_unused]] Dataset &setSlice(const Slice &s, const DataArray &array);
+  [[maybe_unused]] Dataset &setSlice(const Slice &s, const Variable &var);
 
   void rename(const Dim from, const Dim to);
 

--- a/lib/dataset/include/scipp/dataset/map_view.h
+++ b/lib/dataset/include/scipp/dataset/map_view.h
@@ -151,8 +151,8 @@ public:
 
   Dict slice(const Slice &params) const;
   std::tuple<Dict, Dict> slice_coords(const Slice &params) const;
-  void validateSlice(const Slice s, const Dict &dict) const;
-  [[maybe_unused]] Dict &setSlice(const Slice s, const Dict &dict);
+  void validateSlice(const Slice &s, const Dict &dict) const;
+  [[maybe_unused]] Dict &setSlice(const Slice &s, const Dict &dict);
 
   void rename(const Dim from, const Dim to);
 

--- a/lib/dataset/include/scipp/dataset/map_view.h
+++ b/lib/dataset/include/scipp/dataset/map_view.h
@@ -44,6 +44,11 @@ auto slice_map(const Sizes &sizes, const T &map, const Slice &params) {
       if (value.dims()[params.dim()] == sizes[params.dim()]) {
         out[key] = value.slice(params);
       } else { // bin edge
+        if (params.stride() != 1)
+          throw except::SliceError(
+              "Object has bin-edges along dimension " +
+              to_string(params.dim()) + " so slicing with stride " +
+              std::to_string(params.stride()) + " != 1 is not valid.");
         const auto end = params.end() == -1 ? params.begin() + 2
                                             : params.begin() == params.end()
                                                   ? params.end()

--- a/lib/dataset/map_view.cpp
+++ b/lib/dataset/map_view.cpp
@@ -246,7 +246,7 @@ Dict<Key, Value>::slice_coords(const Slice &params) const {
 }
 
 template <class Key, class Value>
-void Dict<Key, Value>::validateSlice(const Slice s, const Dict &dict) const {
+void Dict<Key, Value>::validateSlice(const Slice &s, const Dict &dict) const {
   using core::to_string;
   using units::to_string;
   for (const auto &[key, item] : dict) {
@@ -268,7 +268,7 @@ void Dict<Key, Value>::validateSlice(const Slice s, const Dict &dict) const {
 }
 
 template <class Key, class Value>
-Dict<Key, Value> &Dict<Key, Value>::setSlice(const Slice s, const Dict &dict) {
+Dict<Key, Value> &Dict<Key, Value>::setSlice(const Slice &s, const Dict &dict) {
   validateSlice(s, dict);
   for (const auto &[key, item] : dict) {
     const auto it = find(key);

--- a/lib/dataset/test/slice_test.cpp
+++ b/lib/dataset/test/slice_test.cpp
@@ -659,3 +659,17 @@ TEST_F(CoordToAttrMappingTest, DatasetConstView) {
   const Dataset d({{"a", a}});
   test_dataset_coord_aligned_to_unaligned_mapping(d);
 }
+
+TEST(SliceWithStrideTest, throws_SliceError_if_bin_edges_along_slice_dim) {
+  DataArray da(makeVariable<double>(Dims{Dim::X}, Shape{4}));
+  da.coords().set(Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{5}));
+  Slice params(Dim::X, 0, 4, 2);
+  EXPECT_THROW(da.slice(params), except::SliceError);
+}
+
+TEST(SliceWithStrideTest, works_if_bin_edges_along_unrelated_dim) {
+  DataArray da(makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 4}));
+  da.coords().set(Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{5}));
+  Slice params(Dim::Y, 0, 4, 2);
+  EXPECT_NO_THROW_DISCARD(da.slice(params));
+}

--- a/lib/python/bind_slice_methods.h
+++ b/lib/python/bind_slice_methods.h
@@ -38,12 +38,10 @@ auto from_py_slice(const T &source,
   const auto size = dim_extent(source, dim);
   if (!indices.compute(size, &start, &stop, &step, &slicelength))
     throw py::error_already_set();
-  if (step != 1)
-    throw std::runtime_error("Step must be 1");
   if (slicelength == 0) {
     stop = start; // Propagate vanishing slice length downstream.
   }
-  return Slice(dim, start, stop);
+  return Slice(dim, start, stop, step);
 }
 
 template <class View> struct SetData {

--- a/lib/variable/include/scipp/variable/accumulate.h
+++ b/lib/variable/include/scipp/variable/accumulate.h
@@ -25,7 +25,7 @@ static void do_accumulate(const std::tuple<Ts...> &types, Op op,
       (sizeof...(other) != 1 && var.dims().ndim() == 0))
     return in_place<false>::transform_data(types, op, name, var, other...);
 
-  const auto reduce_chunk = [&](auto &&out, const Slice slice) {
+  const auto reduce_chunk = [&](auto &&out, const Slice &slice) {
     // A typical cache line has 64 Byte, which would fit, e.g., 8 doubles. If
     // multiple threads write to different elements in the same cache lines we
     // have "false sharing", with a severe negative performance impact. 128 is a

--- a/lib/variable/test/CMakeLists.txt
+++ b/lib/variable/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   reduce_logical_test.cpp
   reduce_various_test.cpp
   shape_test.cpp
+  slice_test.cpp
   sort_test.cpp
   special_values_test.cpp
   subspan_view_test.cpp

--- a/lib/variable/test/slice_test.cpp
+++ b/lib/variable/test/slice_test.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+
+#include "scipp/core/except.h"
+#include "scipp/variable/variable.h"
+
+using namespace scipp;
+
+auto make_range() {
+  return makeVariable<double>(Dims{Dim::X}, Shape{10},
+                              Values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+}
+
+TEST(VariableSliceTest, full_slice_with_stride_1_gives_original) {
+  const auto var = make_range();
+  EXPECT_EQ(var.slice({Dim::X, 0, 10}), var);
+  EXPECT_EQ(var.slice({Dim::X, 0, 10, 1}), var);
+}
+
+TEST(VariableSliceTest, stride_2_gives_every_other) {
+  const auto var = make_range();
+  EXPECT_EQ(
+      var.slice({Dim::X, 0, 10, 2}),
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{1, 3, 5, 7, 9}));
+  EXPECT_EQ(
+      var.slice({Dim::X, 1, 10, 2}),
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{2, 4, 6, 8, 10}));
+  EXPECT_EQ(var.slice({Dim::X, 2, 10, 2}),
+            makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{3, 5, 7, 9}));
+}
+
+TEST(VariableSliceTest, stride_3_gives_every_third) {
+  const auto var = make_range();
+  EXPECT_EQ(var.slice({Dim::X, 0, 10, 3}),
+            makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 4, 7, 10}));
+  EXPECT_EQ(var.slice({Dim::X, 1, 10, 3}),
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{2, 5, 8}));
+  EXPECT_EQ(var.slice({Dim::X, 2, 10, 3}),
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{3, 6, 9}));
+  EXPECT_EQ(var.slice({Dim::X, 3, 10, 3}),
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{4, 7, 10}));
+}
+
+TEST(VariableSliceTest, negative_stride_1_with_positive_range_is_empty) {
+  const auto var = make_range();
+  EXPECT_EQ(var.slice({Dim::X, 0, 10, -1}),
+            makeVariable<double>(Dims{Dim::X}, Shape{0}));
+}
+
+TEST(VariableSliceTest, negative_stride_1_with_negative_range_reverses) {
+  const auto var = make_range();
+  // Note the missing 1
+  EXPECT_EQ(var.slice({Dim::X, 10, 0, -1}),
+            makeVariable<double>(Dims{Dim::X}, Shape{9},
+                                 Values{10, 9, 8, 7, 6, 5, 4, 3, 2}));
+}

--- a/lib/variable/test/slice_test.cpp
+++ b/lib/variable/test/slice_test.cpp
@@ -44,13 +44,23 @@ TEST(VariableSliceTest, stride_3_gives_every_third) {
             makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{4, 7, 10}));
 }
 
-TEST(VariableSliceTest, negative_stride_1_with_positive_range_is_empty) {
+TEST(VariableSliceTest, negative_stride_throws) {
+  // Currently class Slice cannot be created with negative stride. This is a
+  // sanity check since Variable::slice needs modifications if class Slice
+  // started to suppor this. See DISABLED tests below.
+  const auto var = make_range();
+  ASSERT_ANY_THROW(var.slice({Dim::X, 0, 10, -1}));
+}
+
+TEST(VariableSliceTest,
+     DISABLED_negative_stride_1_with_positive_range_is_empty) {
   const auto var = make_range();
   EXPECT_EQ(var.slice({Dim::X, 0, 10, -1}),
             makeVariable<double>(Dims{Dim::X}, Shape{0}));
 }
 
-TEST(VariableSliceTest, negative_stride_1_with_negative_range_reverses) {
+TEST(VariableSliceTest,
+     DISABLED_negative_stride_1_with_negative_range_reverses) {
   const auto var = make_range();
   // Note the missing 1
   EXPECT_EQ(var.slice({Dim::X, 10, 0, -1}),

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -189,13 +189,18 @@ Variable Variable::slice(const Slice params) const {
   const auto dim = params.dim();
   const auto begin = params.begin();
   const auto end = params.end();
+  const auto stride = params.stride();
   const auto index = out.m_dims.index(dim);
   out.m_offset += begin * m_strides[index];
   if (end == -1) {
     out.m_strides.erase(index);
     out.m_dims.erase(dim);
-  } else
-    out.m_dims.resize(dim, end - begin);
+  } else {
+    const auto remainder = (end - begin) % stride != 0;
+    out.m_dims.resize(
+        dim, std::max(scipp::index{0}, (end - begin) / stride + remainder));
+    out.m_strides[index] *= stride;
+  }
   return out;
 }
 

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -196,9 +196,7 @@ Variable Variable::slice(const Slice params) const {
     out.m_strides.erase(index);
     out.m_dims.erase(dim);
   } else {
-    const auto remainder = (end - begin) % stride != 0;
-    out.m_dims.resize(
-        dim, std::max(scipp::index{0}, (end - begin) / stride + remainder));
+    static_cast<Sizes &>(out.m_dims) = out.m_dims.slice(params);
     out.m_strides[index] *= stride;
   }
   return out;

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -69,3 +69,9 @@ def test_getitem_with_stride_equivalent_to_numpy():
     assert np.array_equal(var['x', 4:7:3].values, var.values[4:7:3])
     assert np.array_equal(var['x', 5:7:3].values, var.values[5:7:3])
     assert np.array_equal(var['x', 2:7:99].values, var.values[2:7:99])
+
+
+def test_setitem_with_stride_2_sets_every_other_element():
+    var = sc.array(dims=['x'], values=[1, 2, 3, 4, 5, 6])
+    var['x', 1:5:2] = sc.array(dims=['x'], values=[11, 22])
+    assert sc.identical(var, sc.array(dims=['x'], values=[1, 11, 3, 22, 5, 6]))

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -69,6 +69,11 @@ def test_getitem_with_stride_equivalent_to_numpy():
     assert np.array_equal(var['x', 4:7:3].values, var.values[4:7:3])
     assert np.array_equal(var['x', 5:7:3].values, var.values[5:7:3])
     assert np.array_equal(var['x', 2:7:99].values, var.values[2:7:99])
+    assert np.array_equal(var['x', :7:2].values, var.values[:7:2])
+    assert np.array_equal(var['x', 2::2].values, var.values[2::2])
+    assert np.array_equal(var['x', ::2].values, var.values[::2])
+    assert np.array_equal(var['x', -4::2].values, var.values[-4::2])
+    assert np.array_equal(var['x', :-4:2].values, var.values[:-4:2])
 
 
 def test_setitem_with_stride_2_sets_every_other_element():

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -3,6 +3,7 @@
 # @file
 # @author Simon Heybrock
 import pytest
+import numpy as np
 import scipp as sc
 
 
@@ -57,3 +58,14 @@ def test_slice_implicit_dim(obj):
     assert sc.identical(obj[1], obj['xx', 0])
     obj[1:3] = obj[0]
     assert sc.identical(obj[2], obj['xx', 0])
+
+
+def test_getitem_with_stride_equivalent_to_numpy():
+    var = sc.arange('x', 10)
+    assert np.array_equal(var['x', 2:7:2].values, var.values[2:7:2])
+    assert np.array_equal(var['x', 7:7:2].values, var.values[7:7:2])
+    assert np.array_equal(var['x', 2:7:3].values, var.values[2:7:3])
+    assert np.array_equal(var['x', 3:7:3].values, var.values[3:7:3])
+    assert np.array_equal(var['x', 4:7:3].values, var.values[4:7:3])
+    assert np.array_equal(var['x', 5:7:3].values, var.values[5:7:3])
+    assert np.array_equal(var['x', 2:7:99].values, var.values[2:7:99])


### PR DESCRIPTION
- Fixes #860.
- Does not support negative strides, since this is (maybe) considerably more complex and (definitely) more risky (in terms of test coverage).