### PR TITLE
Zeros, Ones, Empty, Full like for data array

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -18,7 +18,7 @@ Features
 * Made it possible to use ``-1`` for one of the dimension sizes when using ``sc.fold`` `#2414 <https://github.com/scipp/scipp/pull/2414>`_.
 * Added ``quiet`` argument to :py:func:`scipp.transform_coords` `#2420 <https://github.com/scipp/scipp/pull/2420>`_.
 * Added support for strides for positional slicing. Negative strides are not supported for now `#2423 <https://github.com/scipp/scipp/pull/2423>`_.
-* ``:py:func:scipp.zeros_like``, ``:py:func:scipp.ones_like``, ``:py:func:scipp.empty_like``, and ``:py:func:scipp.full_like`` now accept and return data arrays `#2425 <https://github.com/scipp/scipp/pull/2425>`_.
+* :py:func:`scipp.zeros_like`, :py:func:`scipp.ones_like`, :py:func:`scipp.empty_like`, and :py:func:`scipp.full_like` now accept and return data arrays `#2425 <https://github.com/scipp/scipp/pull/2425>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -18,7 +18,7 @@ Features
 * Made it possible to use ``-1`` for one of the dimension sizes when using ``sc.fold`` `#2414 <https://github.com/scipp/scipp/pull/2414>`_.
 * Added ``quiet`` argument to :py:func:`scipp.transform_coords` `#2420 <https://github.com/scipp/scipp/pull/2420>`_.
 * Added support for strides for positional slicing. Negative strides are not supported for now `#2423 <https://github.com/scipp/scipp/pull/2423>`_.
-* ``sc.zeros_like``, ``sc.ones_like``, ``sc.empty_like``, and ``sc.full_like`` now accept and return data arrays `#2425 <https://github.com/scipp/scipp/pull/2425>`_.
+* ``:py:func:scipp.zeros_like``, ``:py:func:scipp.ones_like``, ``:py:func:scipp.empty_like``, and ``:py:func:scipp.full_like`` now accept and return data arrays `#2425 <https://github.com/scipp/scipp/pull/2425>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -18,6 +18,7 @@ Features
 * Made it possible to use ``-1`` for one of the dimension sizes when using ``sc.fold`` `#2414 <https://github.com/scipp/scipp/pull/2414>`_.
 * Added ``quiet`` argument to :py:func:`scipp.transform_coords` `#2420 <https://github.com/scipp/scipp/pull/2420>`_.
 * Added support for strides for positional slicing. Negative strides are not supported for now `#2423 <https://github.com/scipp/scipp/pull/2423>`_.
+* ``sc.zeros_like``, ``sc.ones_like``, ``sc.empty_like``, and ``sc.full_like`` now accept and return data arrays `#2425 <https://github.com/scipp/scipp/pull/2425>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -80,4 +80,5 @@ from .reduction import mean, nanmean, sum, nansum, min, max, nanmin, nanmax, all
 from .shape import broadcast, concat, fold, flatten, squeeze, transpose
 from .trigonometry import sin, cos, tan, asin, acos, atan, atan2
 from .unary import isnan, isinf, isfinite, isposinf, isneginf, to_unit
-from .variable import scalar, index, zeros, zeros_like, ones, ones_like, empty, empty_like, full, full_like, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes, epoch
+from .variable import scalar, index, zeros, ones, empty, full, matrix, matrices, vector, vectors, array, linspace, geomspace, logspace, arange, datetime, datetimes, epoch
+from .like import zeros_like, ones_like, empty_like, full_like

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -23,15 +23,11 @@ def zeros_like(
     var: _Union[_cpp.Variable,
                 _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
-    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
-    dims, shape, unit and dtype, but with all values initialized to 0. If the input
-    has variances, all variances in the output are set to 0.
-
-    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
-    coordinates, attributes and masks as the input, but sets the data values to 1.
-    If the input data has variances, all variances in the output are set to 0.
-    Note that coordinates and attributes are shallow-copied, while masks are
-    deep-copied.
+    Constructs a new object with the same dims, shape, unit and dtype as the input
+    (:class:`Variable` or :class:`DataArray`), but with all values initialized to 0.
+    If the input has variances, all variances in the output are set to 0.
+    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
+    and masks are deep copied.
 
     :param var: Input variable or data array.
 
@@ -49,15 +45,11 @@ def ones_like(
     var: _Union[_cpp.Variable,
                 _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
-    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
-    dims, shape, unit and dtype, but with all values initialized to 1. If the input
-    has variances, all variances in the output are set to 1.
-
-    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
-    coordinates, attributes and masks as the input, but sets the data values to 1.
-    If the input data has variances, all variances in the output are set to 1.
-    Note that coordinates and attributes are shallow-copied, while masks are
-    deep-copied.
+    Constructs a new object with the same dims, shape, unit and dtype as the input
+    (:class:`Variable` or :class:`DataArray`), but with all values initialized to 1.
+    If the input has variances, all variances in the output are set to 1.
+    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
+    and masks are deep copied.
 
     :param var: Input variable or data array.
 
@@ -75,16 +67,11 @@ def empty_like(
     var: _Union[_cpp.Variable,
                 _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
-    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
-    dims, shape, unit and dtype as the input variable, but with uninitialized values.
+    Constructs a new object with the same dims, shape, unit and dtype as the input
+    (:class:`Variable` or :class:`DataArray`), but with all values uninitialized.
     If the input has variances, all variances in the output exist but are uninitialized.
-
-    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
-    coordinates, attributes and masks as the input, but replaces the data with a
-    :class:`Variable` containing uninitialized values. If the input data has variances,
-    all variances in the output exist but are uninitialized.
-    Note that coordinates and attributes are shallow-copied, while masks are
-    deep-copied.
+    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
+    and masks are deep copied.
 
     :param var: Input variable or data array.
 
@@ -101,15 +88,11 @@ def empty_like(
 
 def full_like(var: _cpp.Variable, value: _Any, variance: _Any = None) -> _cpp.Variable:
     """
-    If input is a :class:`Variable`, it constructs a :class:`Variable` with values
-    initialized to the specified value with dimensions labels and shape provided by an
-    existing variable.
-
-    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
-    coordinates, attributes and masks as the input, but replaces the data with a
-    :class:`Variable` containing values initialized to the specified value.
-    Note that coordinates and attributes are shallow-copied, while masks are
-    deep-copied.
+    Constructs a new object with the same dims, shape, unit and dtype as the input
+    (:class:`Variable` or :class:`DataArray`), but with all values, and optionally
+    variances, initialized to the specified ``value`` and ``variance``.
+    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
+    and masks are deep copied.
 
     :param var: Input variable or data array.
     :param value: The value to fill the data with.

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
+from typing import Any as _Any, Union as _Union
+from .._scipp import core as _cpp
+from .variable import ones, zeros, empty, full
+
+
+def _to_variable_or_data_array(var, new_values):
+    if isinstance(var, _cpp.DataArray):
+        return _cpp.DataArray(data=new_values,
+                              coords={c: coord
+                                      for c, coord in var.coords.items()},
+                              attrs={a: attr
+                                     for a, attr in var.attrs.items()},
+                              masks={m: mask.copy()
+                                     for m, mask in var.masks.items()})
+    else:
+        return new_values
+
+
+def zeros_like(
+    var: _Union[_cpp.Variable,
+                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+    """
+    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
+    dims, shape, unit and dtype, but with all values initialized to 0. If the input
+    has variances, all variances in the output are set to 0.
+
+    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
+    coordinates, attributes and masks as the input, but sets the data values to 1.
+    If the input data has variances, all variances in the output are set to 0.
+    Note that coordinates and attributes are shallow-copied, while masks are
+    deep-copied.
+
+    :param var: Input variable or data array.
+
+    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones_like`
+    """
+    new_values = zeros(dims=var.dims,
+                       shape=var.shape,
+                       unit=var.unit,
+                       dtype=var.dtype,
+                       with_variances=var.variances is not None)
+    return _to_variable_or_data_array(var, new_values)
+
+
+def ones_like(
+    var: _Union[_cpp.Variable,
+                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+    """
+    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
+    dims, shape, unit and dtype, but with all values initialized to 1. If the input
+    has variances, all variances in the output are set to 1.
+
+    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
+    coordinates, attributes and masks as the input, but sets the data values to 1.
+    If the input data has variances, all variances in the output are set to 1.
+    Note that coordinates and attributes are shallow-copied, while masks are
+    deep-copied.
+
+    :param var: Input variable or data array.
+
+    :seealso: :py:func:`scipp.ones` :py:func:`scipp.zeros_like`
+    """
+    new_values = ones(dims=var.dims,
+                      shape=var.shape,
+                      unit=var.unit,
+                      dtype=var.dtype,
+                      with_variances=var.variances is not None)
+    return _to_variable_or_data_array(var, new_values)
+
+
+def empty_like(
+    var: _Union[_cpp.Variable,
+                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+    """
+    If input is a :class:`Variable`, it constructs a :class:`Variable` with the same
+    dims, shape, unit and dtype as the input variable, but with uninitialized values.
+    If the input has variances, all variances in the output exist but are uninitialized.
+
+    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
+    coordinates, attributes and masks as the input, but replaces the data with a
+    :class:`Variable` containing uninitialized values. If the input data has variances,
+    all variances in the output exist but are uninitialized.
+    Note that coordinates and attributes are shallow-copied, while masks are
+    deep-copied.
+
+    :param var: Input variable or data array.
+
+    :seealso: :py:func:`scipp.empty` :py:func:`scipp.zeros_like`
+              :py:func:`scipp.ones_like`
+    """
+    new_values = empty(dims=var.dims,
+                       shape=var.shape,
+                       unit=var.unit,
+                       dtype=var.dtype,
+                       with_variances=var.variances is not None)
+    return _to_variable_or_data_array(var, new_values)
+
+
+def full_like(var: _cpp.Variable, value: _Any, variance: _Any = None) -> _cpp.Variable:
+    """
+    If input is a :class:`Variable`, it constructs a :class:`Variable` with values
+    initialized to the specified value with dimensions labels and shape provided by an
+    existing variable.
+
+    If input is a :class:`DataArray`, it constructs a :class:`DataArray` with the same
+    coordinates, attributes and masks as the input, but replaces the data with a
+    :class:`Variable` containing values initialized to the specified value.
+    Note that coordinates and attributes are shallow-copied, while masks are
+    deep-copied.
+
+    :param var: Input variable or data array.
+    :param value: The value to fill the data with.
+    :param variance: Optional, the variance to fill the Variable with. If None
+        or not provided, the variances will not be set.
+
+    :seealso: :py:func:`scipp.zeros_like` :py:func:`scipp.ones_like`
+              :py:func:`scipp.empty_like`
+    """
+    new_values = full(dims=var.dims,
+                      shape=var.shape,
+                      unit=var.unit,
+                      dtype=var.dtype,
+                      value=value,
+                      variance=variance)
+    return _to_variable_or_data_array(var, new_values)

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -102,23 +102,6 @@ def zeros(*,
                       with_variances=with_variances)
 
 
-def zeros_like(var: _cpp.Variable) -> _cpp.Variable:
-    """Constructs a :class:`Variable` with the same dims, shape, unit and dtype
-    as the input variable, but with all values initialized to 0. If the input
-    has variances, all variances in the output are set to 0.
-
-
-    :param var: Input variable.
-
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones_like`
-    """
-    return zeros(dims=var.dims,
-                 shape=var.shape,
-                 unit=var.unit,
-                 dtype=var.dtype,
-                 with_variances=var.variances is not None)
-
-
 def ones(*,
          dims: _Sequence[str] = None,
          shape: _Sequence[int] = None,
@@ -146,23 +129,6 @@ def ones(*,
                      unit=unit,
                      dtype=dtype,
                      with_variances=with_variances)
-
-
-def ones_like(var: _cpp.Variable) -> _cpp.Variable:
-    """Constructs a :class:`Variable` with the same dims, shape, unit and dtype
-    as the input variable, but with all values initialized to 1. If the input
-    has variances, all variances in the output are set to 1.
-
-
-    :param var: Input variable.
-
-    :seealso: :py:func:`scipp.ones` :py:func:`scipp.zeros_like`
-    """
-    return ones(dims=var.dims,
-                shape=var.shape,
-                unit=var.unit,
-                dtype=var.dtype,
-                with_variances=var.variances is not None)
 
 
 def empty(*,
@@ -197,24 +163,6 @@ def empty(*,
                       with_variances=with_variances)
 
 
-def empty_like(var: _cpp.Variable) -> _cpp.Variable:
-    """Constructs a :class:`Variable` with the same dims, shape, unit and dtype
-    as the input variable, but with uninitialized values. If the input
-    has variances, all variances in the output exist but are uninitialized.
-
-
-    :param var: Input variable.
-
-    :seealso: :py:func:`scipp.empty` :py:func:`scipp.zeros_like`
-              :py:func:`scipp.ones_like`
-    """
-    return empty(dims=var.dims,
-                 shape=var.shape,
-                 unit=var.unit,
-                 dtype=var.dtype,
-                 with_variances=var.variances is not None)
-
-
 def full(*,
          dims: _Sequence[str] = None,
          shape: _Sequence[int] = None,
@@ -242,27 +190,6 @@ def full(*,
     """
     return scalar(value=value, variance=variance, unit=unit, dtype=dtype)\
         .broadcast(**_parse_dims_shape_sizes(dims, shape, sizes)).copy()
-
-
-def full_like(var: _cpp.Variable, value: _Any, variance: _Any = None) -> _cpp.Variable:
-    """
-    Constructs a :class:`Variable` with values initialized to the specified
-    value with dimensions labels and shape provided by an existing variable.
-
-
-    :param var: Input variable to copy dimensions, sizes, unit and dtype from.
-    :param value: The value to fill the Variable with
-    :param variance: Optional, the variance to fill the Variable with. If None
-        or not provided, the variances will not be set.
-
-    :seealso: :py:func:`scipp.zeros_like` :py:func:`scipp.ones_like`
-    """
-    return full(dims=var.dims,
-                shape=var.shape,
-                unit=var.unit,
-                dtype=var.dtype,
-                value=value,
-                variance=variance)
 
 
 def matrix(*,

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -326,9 +326,6 @@ def test_empty_like():
     assert a.unit == b.unit
     assert a.dtype == b.dtype
     assert (a.variances is None) == (b.variances is None)
-    assert not sc.identical(a.data, b.data)
-    assert not sc.identical(sc.zeros_like(a.data), b.data)
-    assert not sc.identical(sc.ones_like(a.data), b.data)
 
 
 def test_full_like():
@@ -338,3 +335,14 @@ def test_full_like():
     a.data *= 0.
     a.data += 2.
     assert sc.identical(a, b)
+
+
+def test_zeros_like_deep_copy_masks():
+    a = make_dataarray()
+    a.masks['m'] = sc.array(dims=['x'], values=[True, False])
+    c = sc.scalar(33., unit='m')
+    b = sc.zeros_like(a)
+    a.coords['x'][0] = c
+    a.masks['m'][0] = False
+    assert sc.identical(b.coords['x'][0], c)
+    assert sc.identical(b.masks['m'][0], sc.scalar(True))

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -298,3 +298,43 @@ def test_to():
     assert sc.identical(
         da.to(unit="mm", dtype="int64"),
         sc.DataArray(data=sc.scalar(value=1000, dtype="int64", unit="mm")))
+
+
+def test_zeros_like():
+    a = make_dataarray()
+    a.masks['m'] = sc.array(dims=['x'], values=[True, False])
+    b = sc.zeros_like(a)
+    a.data *= 0.
+    assert sc.identical(a, b)
+
+
+def test_ones_like():
+    a = make_dataarray()
+    a.masks['m'] = sc.array(dims=['x'], values=[True, False])
+    b = sc.ones_like(a)
+    a.data *= 0.
+    a.data += 1.
+    assert sc.identical(a, b)
+
+
+def test_empty_like():
+    a = make_dataarray()
+    a.masks['m'] = sc.array(dims=['x'], values=[True, False])
+    b = sc.empty_like(a)
+    assert a.dims == b.dims
+    assert a.shape == b.shape
+    assert a.unit == b.unit
+    assert a.dtype == b.dtype
+    assert (a.variances is None) == (b.variances is None)
+    assert not sc.identical(a.data, b.data)
+    assert not sc.identical(sc.zeros_like(a.data), b.data)
+    assert not sc.identical(sc.ones_like(a.data), b.data)
+
+
+def test_full_like():
+    a = make_dataarray()
+    a.masks['m'] = sc.array(dims=['x'], values=[True, False])
+    b = sc.full_like(a, 2.)
+    a.data *= 0.
+    a.data += 2.
+    assert sc.identical(a, b)


### PR DESCRIPTION
Make functions `zeros_like`, `ones_like`, `empty_like`, `full_like` accept data array as well as variables.
If data array is the input, it returns a data array with the same coords, attrs and masks, but new values for the data.
Coords and attrs are shallow copied, masks are deep copied.

Fixes #2422