### PR TITLE
Fix 1d plots y-axis limits when toggling log-scale with buttons and fix 2d plot colorbar when Inf values

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -40,6 +40,7 @@ Bugfixes
 
 * Fix :py:func:`full`, which previously converted or attempted to convert all values to ``float64`` unless the ``dtype`` was specified explicitly `#2395 <https://github.com/scipp/scipp/pull/2395>`_.
 * Fix :py:func:`transform_coords` for sliced binned data, used to raise an exception `#2406 <https://github.com/scipp/scipp/pull/2406>`_.
+* Fix 1d plots y-axis limits when toggling log-scale with buttons and fix 2d plot colorbar when Inf values `#2426 <https://github.com/scipp/scipp/pull/2426>`_.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/src/scipp/plotting/controller1d.py
+++ b/src/scipp/plotting/controller1d.py
@@ -50,3 +50,16 @@ class PlotController1d(PlotController):
             if with_max_padding or (button is not None):
                 vmax += delta
         self.view.rescale_to_data(vmin, vmax)
+
+    def toggle_norm(self, owner):
+        """
+        Toggle data normalization from toolbar button signal.
+        """
+        self.norm = "log" if owner.value else "linear"
+        vmin, vmax = self.find_vmin_vmax()
+        if self.norm == "log":
+            self.rescale_to_data()
+            self.view.toggle_norm(self.norm, vmin, vmax)
+        else:
+            self.view.toggle_norm(self.norm, vmin, vmax)
+            self.rescale_to_data()

--- a/src/scipp/plotting/figure1d.py
+++ b/src/scipp/plotting/figure1d.py
@@ -336,12 +336,7 @@ class PlotFigure1d(PlotFigure):
         """
         Rescale y axis to the contents of the plot.
         """
-        if (vmin is None) and (vmax is None):
-            self.ax.autoscale(True)
-            self.ax.relim()
-            self.ax.autoscale_view()
-        else:
-            self.ax.set_ylim(vmin, vmax)
+        self.ax.set_ylim(vmin, vmax)
         self.draw()
 
     def show_legend(self):

--- a/src/scipp/plotting/tools.py
+++ b/src/scipp/plotting/tools.py
@@ -144,8 +144,10 @@ def find_log_limits(x):
 def find_linear_limits(x):
     """
     Find variable finite min and max.
+    TODO: If we implement finitemin and finitemax for Variable, we would no longer need
+    to go via Numpy's isfinite.
     """
-    v = values(x).values
+    v = x.values
     finite_vals = v[np.isfinite(v)]
     finite_min = np.amin(finite_vals)
     finite_max = np.amax(finite_vals)

--- a/src/scipp/plotting/tools.py
+++ b/src/scipp/plotting/tools.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 from .. import config, units
-from ..core import concat, values, nanmin, nanmax, histogram, full_like
+from ..core import concat, values, scalar, histogram, full_like
 from ..core import DType, Variable, DataArray
 from ..core import abs as abs_
 import numpy as np
@@ -143,11 +143,15 @@ def find_log_limits(x):
 
 def find_linear_limits(x):
     """
-    Find variable min and max.
+    Find variable finite min and max.
     """
+    v = values(x).values
+    finite_vals = v[np.isfinite(v)]
+    finite_min = np.amin(finite_vals)
+    finite_max = np.amax(finite_vals)
     return [
-        values(nanmin(x).astype(DType.float64)),
-        values(nanmax(x).astype(DType.float64))
+        scalar(finite_min, unit=x.unit, dtype='float64'),
+        scalar(finite_max, unit=x.unit, dtype='float64')
     ]
 
 


### PR DESCRIPTION
**1d plots:**

Toggling to `log` scale using the toolbar button when the current axis limit goes below 0 (which is quite common because we add a little padding around the range of values) would cause the axis to completely mess up.
This is due to a behaviour in matplotlib that when axis limits are not explicitly set, the change to log scale correctly figrues out the limits, but when the limits are set (and we always set the limits), then it tries to use the number that were set and it gets a negative number as the starting point for the log scale.

We now use `rescale_to_data` to set the limits on the axis before changing the axis scaling to log.

Example:
```Py
import scipp as sc
sc.plot(sc.arange('x', 100.))
```

**Note** that the issue only appeared when using the toolbar button. Doing `sc.plot(..., norm='log')` found the correct limits.

**Before:**
![Screenshot at 2022-02-08 14-30-53](https://user-images.githubusercontent.com/39047984/152998025-0a667e8e-9e96-4b42-802a-2b9d58afaa66.png)

**After:**
![Screenshot at 2022-02-08 14-37-39](https://user-images.githubusercontent.com/39047984/152998161-9fcdc390-a048-48f4-9ae2-8bcc67750305.png)


**2d plots:**

Issue when trying to find colorbar limits when `Inf` values present (which happens often when you are normalizing and you divide by 0)

```Py
import numpy as np
import scipp as sc

a = np.arange(100.0)
a[0] = np.nan
a[-1] = np.inf
b = sc.array(dims=['x'], values=a, unit='K').fold('x', sizes={'x': 10, 'y': -1})
sc.plot(b)
```

**Before:**
![Screenshot at 2022-02-08 14-28-47](https://user-images.githubusercontent.com/39047984/152998909-0e5e6551-0063-4e12-933e-c4ff2a8ec171.png)

**After:**
![Screenshot at 2022-02-08 14-42-36](https://user-images.githubusercontent.com/39047984/152998992-14e41901-6260-4188-8f48-9bafd62f6334.png)
