### PR TITLE
Cache friendly 1-D binning

### DIFF
--- a/lib/core/include/scipp/core/element/bin.h
+++ b/lib/core/include/scipp/core/element/bin.h
@@ -140,43 +140,6 @@ static constexpr auto update_indices_from_existing = overloaded{
       index += bin_index;
     }};
 
-// - Each span covers an *input* bin.
-// - `offsets` Start indices of the output bins
-// - `bin_indices` Target output bin index (within input bin)
-template <class T, class Index>
-using bin_arg = std::tuple<scipp::span<T>, SubbinSizes, scipp::span<const T>,
-                           scipp::span<const Index>>;
-static constexpr auto bin = overloaded{
-    element::arg_list<
-        bin_arg<double, int64_t>, bin_arg<double, int32_t>,
-        bin_arg<float, int64_t>, bin_arg<float, int32_t>,
-        bin_arg<int64_t, int64_t>, bin_arg<int64_t, int32_t>,
-        bin_arg<int32_t, int64_t>, bin_arg<int32_t, int32_t>,
-        bin_arg<bool, int64_t>, bin_arg<bool, int32_t>,
-        bin_arg<Eigen::Vector3d, int64_t>, bin_arg<Eigen::Vector3d, int32_t>,
-        bin_arg<std::string, int64_t>, bin_arg<std::string, int32_t>,
-        bin_arg<time_point, int64_t>, bin_arg<time_point, int32_t>>,
-    transform_flags::expect_in_variance_if_out_variance,
-    [](units::Unit &binned, const units::Unit &, const units::Unit &data,
-       const units::Unit &) { binned = data; },
-    [](const auto &binned, const auto &offsets, const auto &data,
-       const auto &bin_indices) {
-      auto bins(offsets.sizes());
-      const auto size = scipp::size(bin_indices);
-      using T = std::decay_t<decltype(data)>;
-      for (scipp::index i = 0; i < size; ++i) {
-        const auto i_bin = bin_indices[i];
-        if (i_bin < 0)
-          continue;
-        if constexpr (is_ValueAndVariance_v<T>) {
-          binned.variance[bins[i_bin]] = data.variance[i];
-          binned.value[bins[i_bin]++] = data.value[i];
-        } else {
-          binned[bins[i_bin]++] = data[i];
-        }
-      }
-    }};
-
 static constexpr auto count_indices = overloaded{
     element::arg_list<
         std::tuple<scipp::span<const int64_t>, scipp::index, scipp::index>,

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -39,15 +39,80 @@ static constexpr auto bin = overloaded{
       auto bins(offsets.sizes());
       const auto size = scipp::size(bin_indices);
       using T = std::decay_t<decltype(data)>;
-      for (scipp::index i = 0; i < size; ++i) {
-        const auto i_bin = bin_indices[i];
-        if (i_bin < 0)
-          continue;
-        if constexpr (is_ValueAndVariance_v<T>) {
-          binned.variance[bins[i_bin]] = data.variance[i];
-          binned.value[bins[i_bin]++] = data.value[i];
-        } else {
-          binned[bins[i_bin]++] = data[i];
+      // If there are many bins, we have two performance issues:
+      // 1. `bins` is large and will not fit into L1, L2, or L3 cache.
+      // 2. Writes to output are very random, implying a cache miss for every
+      //    event.
+      // We can avoid some of this issue by first sorting into chunks, then
+      // chunks into bins. For example, instead of mapping directly to 65536
+      // bins, we may map to 256 chunks, and each chunk to 256 bins.
+      // TODO Ideally we should recurse this approach, with optimal
+      // intermediate chunk sizes. These will in principle depend on cache
+      // sizes.
+      if (bins.size() > 512 && size > 128 * 1024) { // avoid overhead
+        using Val = std::conditional_t<is_ValueAndVariance_v<T>,
+                                       typename T::value_type, T>;
+        // TODO Ideally this buffer would be reused (on a per-thread basis)
+        // for every application of the kernel.
+        // std::unordered_map<scipp::index,
+        //                   std::tuple<std::vector<typename Val::value_type>,
+        //                              std::vector<uint8_t>>>
+        std::vector<std::tuple<std::vector<typename Val::value_type>,
+                               std::vector<uint8_t>>>
+            chunks;
+        chunks.resize(bins.size() / 256);
+        for (scipp::index i = 0; i < size;) {
+          // We operate in blocks so the size of the map of buffers, i.e.,
+          // additional memory use of the algorithm, is bounded. This also
+          // avoids costly allocations from resize operations.
+          scipp::index max = std::min(size, i + scipp::size(bins) * 64);
+          // 1. Map to chunks
+          for (; i < max; ++i) {
+            const auto i_bin = bin_indices[i];
+            if (i_bin < 0)
+              continue;
+            // TODO use sqrt rounded to power of 2
+            const uint8_t j = i_bin % 256; // compiler is smart for mod 2**N
+            // const auto i_chunk = i_bin - j;
+            const auto i_chunk = i_bin / 256;
+            auto &[vals, ind] = chunks[i_chunk];
+            if constexpr (is_ValueAndVariance_v<T>) {
+              vals.emplace_back(data.value[i]);
+              vals.emplace_back(data.variance[i]);
+            } else {
+              vals.emplace_back(data[i]);
+            }
+            ind.emplace_back(j);
+          }
+          // 2. Map chunks to bins
+          // for (auto &[i_chunk, chunk] : chunks)
+          for (scipp::index i_chunk = 0; i_chunk < scipp::size(chunks);
+               ++i_chunk) {
+            auto &[vals, ind] = chunks[i_chunk];
+            for (scipp::index j = 0; j < scipp::size(ind); ++j) {
+              const auto i_bin = 256 * i_chunk + ind[j];
+              if constexpr (is_ValueAndVariance_v<T>) {
+                binned.variance[bins[i_bin]] = vals[2 * j + 1];
+                binned.value[bins[i_bin]++] = vals[2 * j];
+              } else {
+                binned[bins[i_bin]++] = vals[j];
+              }
+            }
+            vals.clear();
+            ind.clear();
+          }
+        }
+      } else {
+        for (scipp::index i = 0; i < size; ++i) {
+          const auto i_bin = bin_indices[i];
+          if (i_bin < 0)
+            continue;
+          if constexpr (is_ValueAndVariance_v<T>) {
+            binned.variance[bins[i_bin]] = data.variance[i];
+            binned.value[bins[i_bin]++] = data.value[i];
+          } else {
+            binned[bins[i_bin]++] = data[i];
+          }
         }
       }
     }};

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -32,9 +32,13 @@ auto map_to_bins_direct = [](const auto &binned, auto &bins, const auto &data,
   }
 };
 
+constexpr bool is_powerof2(int v) { return v && ((v & (v - 1)) == 0); }
+
 template <int chunksize>
 auto map_to_bins_chunkwise = [](const auto &binned, auto &bins,
                                 const auto &data, const auto &bin_indices) {
+  // compiler is smart for div or mod 2**N, otherwise this would be too slow
+  static_assert(is_powerof2(chunksize));
   const auto size = scipp::size(bin_indices);
   using T = std::decay_t<decltype(data)>;
 
@@ -56,7 +60,7 @@ auto map_to_bins_chunkwise = [](const auto &binned, auto &bins,
       const auto i_bin = bin_indices[i];
       if (i_bin < 0)
         continue;
-      const uint8_t j = i_bin % chunksize; // compiler is smart for mod 2**N
+      const uint8_t j = i_bin % chunksize;
       const auto i_chunk = i_bin / chunksize;
       auto &[vals, ind] = chunks[i_chunk];
       if constexpr (is_ValueAndVariance_v<T>) {
@@ -116,11 +120,11 @@ static constexpr auto bin = overloaded{
       // chunks into bins. For example, instead of mapping directly to 65536
       // bins, we may map to 256 chunks, and each chunk to 256 bins.
       if (bins.size() > 512 && size > 128 * 1024) { // avoid overhead
-        if (128 * 128 >= bins.size())
+        if (bins.size() <= 128 * 128)
           map_to_bins_chunkwise<128>(binned, bins, data, bin_indices);
-        else if (256 * 256 >= bins.size())
+        else if (bins.size() <= 256 * 256)
           map_to_bins_chunkwise<256>(binned, bins, data, bin_indices);
-        else if (512 * 512 >= bins.size())
+        else if (bins.size() <= 512 * 512)
           map_to_bins_chunkwise<512>(binned, bins, data, bin_indices);
         else
           map_to_bins_chunkwise<1024>(binned, bins, data, bin_indices);

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -16,7 +16,7 @@
 
 namespace scipp::core::element {
 
-auto map_to_bins_direct = [](const auto &binned, auto &bins, const auto &data,
+auto map_to_bins_direct = [](auto &binned, auto &bins, const auto &data,
                              const auto &bin_indices) {
   const auto size = scipp::size(bin_indices);
   using T = std::decay_t<decltype(data)>;
@@ -36,8 +36,8 @@ auto map_to_bins_direct = [](const auto &binned, auto &bins, const auto &data,
 constexpr bool is_powerof2(int v) { return v && ((v & (v - 1)) == 0); }
 
 template <int chunksize>
-auto map_to_bins_chunkwise = [](const auto &binned, auto &bins,
-                                const auto &data, const auto &bin_indices) {
+auto map_to_bins_chunkwise = [](auto &binned, auto &bins, const auto &data,
+                                const auto &bin_indices) {
   // compiler is smart for div or mod 2**N, otherwise this would be too slow
   static_assert(is_powerof2(chunksize));
   using InnerIndex = int16_t;

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -56,7 +56,7 @@ auto map_to_bins_chunkwise = [](auto &binned, auto &bins, const auto &data,
     // We operate in blocks so the size of the map of buffers, i.e.,
     // additional memory use of the algorithm, is bounded. This also
     // avoids costly allocations from resize operations.
-    scipp::index max = std::min(size, i + scipp::size(bins) * 8);
+    const scipp::index max = std::min(size, i + scipp::size(bins) * 8);
     // 1. Map to chunks
     for (; i < max; ++i) {
       const auto i_bin = bin_indices[i];
@@ -120,8 +120,8 @@ static constexpr auto bin = overloaded{
       // We can avoid some of this issue by first sorting into chunks, then
       // chunks into bins. For example, instead of mapping directly to 65536
       // bins, we may map to 256 chunks, and each chunk to 256 bins.
-      bool many_bins = bins.size() > 512;
-      bool multiple_events_per_bin = bins.size() * 4 < bin_indices.size();
+      const bool many_bins = bins.size() > 512;
+      const bool multiple_events_per_bin = bins.size() * 4 < bin_indices.size();
       if (many_bins && multiple_events_per_bin) { // avoid overhead
         if (bins.size() <= 128 * 128)
           map_to_bins_chunkwise<128>(binned, bins, data, bin_indices);

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -44,7 +44,7 @@ auto map_to_bins_chunkwise = [](const auto &binned, auto &bins,
   std::vector<
       std::tuple<std::vector<typename Val::value_type>, std::vector<uint8_t>>>
       chunks;
-  chunks.resize(bins.size() / 256);
+  chunks.resize((bins.size() - 1) / 256 + 1);
   for (scipp::index i = 0; i < size;) {
     // We operate in blocks so the size of the map of buffers, i.e.,
     // additional memory use of the algorithm, is bounded. This also

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -118,7 +118,7 @@ static constexpr auto bin = overloaded{
       // chunks into bins. For example, instead of mapping directly to 65536
       // bins, we may map to 256 chunks, and each chunk to 256 bins.
       bool many_bins = bins.size() > 512;
-      bool multiple_events_per_bin = bins.size() * 16 < bin_indices.size();
+      bool multiple_events_per_bin = bins.size() * 4 < bin_indices.size();
       if (many_bins && multiple_events_per_bin) { // avoid overhead
         if (bins.size() <= 128 * 128)
           map_to_bins_chunkwise<128>(binned, bins, data, bin_indices);

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
+#include "scipp/core/element/arg_list.h"
+#include "scipp/core/element/util.h"
+#include "scipp/core/histogram.h"
+#include "scipp/core/subbin_sizes.h"
+#include "scipp/core/time_point.h"
+#include "scipp/core/transform_common.h"
+
+namespace scipp::core::element {
+
+// - Each span covers an *input* bin.
+// - `offsets` Start indices of the output bins
+// - `bin_indices` Target output bin index (within input bin)
+template <class T, class Index>
+using bin_arg = std::tuple<scipp::span<T>, SubbinSizes, scipp::span<const T>,
+                           scipp::span<const Index>>;
+static constexpr auto bin = overloaded{
+    element::arg_list<
+        bin_arg<double, int64_t>, bin_arg<double, int32_t>,
+        bin_arg<float, int64_t>, bin_arg<float, int32_t>,
+        bin_arg<int64_t, int64_t>, bin_arg<int64_t, int32_t>,
+        bin_arg<int32_t, int64_t>, bin_arg<int32_t, int32_t>,
+        bin_arg<bool, int64_t>, bin_arg<bool, int32_t>,
+        bin_arg<Eigen::Vector3d, int64_t>, bin_arg<Eigen::Vector3d, int32_t>,
+        bin_arg<std::string, int64_t>, bin_arg<std::string, int32_t>,
+        bin_arg<time_point, int64_t>, bin_arg<time_point, int32_t>>,
+    transform_flags::expect_in_variance_if_out_variance,
+    [](units::Unit &binned, const units::Unit &, const units::Unit &data,
+       const units::Unit &) { binned = data; },
+    [](const auto &binned, const auto &offsets, const auto &data,
+       const auto &bin_indices) {
+      auto bins(offsets.sizes());
+      const auto size = scipp::size(bin_indices);
+      using T = std::decay_t<decltype(data)>;
+      for (scipp::index i = 0; i < size; ++i) {
+        const auto i_bin = bin_indices[i];
+        if (i_bin < 0)
+          continue;
+        if constexpr (is_ValueAndVariance_v<T>) {
+          binned.variance[bins[i_bin]] = data.variance[i];
+          binned.value[bins[i_bin]++] = data.value[i];
+        } else {
+          binned[bins[i_bin]++] = data[i];
+        }
+      }
+    }};
+
+} // namespace scipp::core::element

--- a/lib/core/test/CMakeLists.txt
+++ b/lib/core/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   element_geometric_operations_test.cpp
   element_histogram_test.cpp
   element_logical_test.cpp
+  element_map_to_bins_test.cpp
   element_math_test.cpp
   element_special_values_test.cpp
   element_to_unit_test.cpp

--- a/lib/core/test/element_map_to_bins_test.cpp
+++ b/lib/core/test/element_map_to_bins_test.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
+#include "scipp/core/element/map_to_bins.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <iterator>
+#include <random>
+#include <vector>
+
+using namespace scipp;
+using namespace scipp::core::element;
+
+auto random_shuffled(const scipp::index nevent, const scipp::index nbin) {
+  std::random_device rnd_device;
+  std::mt19937 mersenne_engine{rnd_device()};
+  std::uniform_int_distribution<scipp::index> dist{0, nbin - 1};
+  auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+  std::vector<scipp::index> vec(nevent);
+  std::generate(begin(vec), end(vec), gen);
+  std::shuffle(begin(vec), end(vec), mersenne_engine);
+  return vec;
+}
+
+class ElementMapToBinsTest : public ::testing::Test {
+protected:
+  ElementMapToBinsTest()
+      : binned(nevent), bin_indices(random_shuffled(nevent, nbin)),
+        data(bin_indices.begin(), bin_indices.end()) {
+    scipp::index current = 0;
+    for (scipp::index i = 0; i < nbin; ++i) {
+      bins.push_back(current);
+      current += std::count(bin_indices.begin(), bin_indices.end(), i);
+    }
+  }
+  const scipp::index nevent = 1033;
+  const scipp::index nbin = 17;
+  std::vector<double> binned;
+  std::vector<scipp::index> bins;
+  std::vector<scipp::index> bin_indices;
+  std::vector<double> data;
+
+  template <int N> void check_direct_equivalent_to_chunkwise() {
+    auto binned1 = binned;
+    auto binned2 = binned;
+    auto bins1 = bins;
+    auto bins2 = bins;
+    map_to_bins_direct(binned1, bins1, data, bin_indices);
+    map_to_bins_chunkwise<N>(binned2, bins2, data, bin_indices);
+    EXPECT_EQ(binned1, binned2);
+  }
+};
+
+TEST_F(ElementMapToBinsTest, data_matching_index_equivalent_to_sort) {
+  map_to_bins_direct(binned, bins, data, bin_indices);
+  std::sort(data.begin(), data.end());
+  EXPECT_EQ(binned, data);
+}
+
+TEST_F(ElementMapToBinsTest, direct_equivalent_to_chunkwise) {
+  check_direct_equivalent_to_chunkwise<1>();
+  check_direct_equivalent_to_chunkwise<2>();
+  check_direct_equivalent_to_chunkwise<4>();
+  check_direct_equivalent_to_chunkwise<16>();
+  check_direct_equivalent_to_chunkwise<64>();
+  check_direct_equivalent_to_chunkwise<256>();
+}

--- a/lib/dataset/CMakeLists.txt
+++ b/lib/dataset/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRC_FILES
     arithmetic.cpp
     astype.cpp
     bin.cpp
+    bin_detail.cpp
     bins.cpp
     counts.cpp
     data_array.cpp

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -24,10 +24,12 @@
 #include "scipp/dataset/bins_view.h"
 #include "scipp/dataset/except.h"
 
+#include "bin_detail.h"
 #include "bins_util.h"
 #include "dataset_operations_common.h"
 
 using namespace scipp::variable::bin_detail;
+using namespace scipp::dataset::bin_detail;
 
 namespace scipp::dataset {
 
@@ -154,10 +156,10 @@ auto bin(const Variable &data, const Variable &indices,
             var.template constituents<Variable>();
         static_cast<void>(input_indices);
         auto out = resize_default_init(in_buffer, buffer_dim, total_size);
-        transform_in_place(
-            subspan_view(out, buffer_dim, filtered_input_bin_ranges), offsets,
-            as_subspan_view(var), as_subspan_view(indices), core::element::bin,
-            "bin");
+        auto out_subspans =
+            subspan_view(out, buffer_dim, filtered_input_bin_ranges);
+        map_to_bins(out_subspans, as_subspan_view(var), offsets,
+                    as_subspan_view(indices));
         return out;
       });
 

--- a/lib/dataset/bin_detail.cpp
+++ b/lib/dataset/bin_detail.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/element/map_to_bins.h"
+
+#include "scipp/variable/subspan_view.h"
+#include "scipp/variable/transform.h"
+
+#include "bin_detail.h"
+
+namespace scipp::dataset::bin_detail {
+/// Implementation detail of dataset::bin
+void map_to_bins(Variable &out, const Variable &var, const Variable &offsets,
+                 const Variable &indices) {
+  transform_in_place(out, offsets, var, indices, core::element::bin, "bin");
+}
+} // namespace scipp::dataset::bin_detail

--- a/lib/dataset/bin_detail.h
+++ b/lib/dataset/bin_detail.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <unordered_map>
+
+#include "scipp/dataset/dataset.h"
+#include "scipp/dataset/except.h"
+#include "scipp/variable/arithmetic.h"
+
+namespace scipp::dataset::bin_detail {
+
+SCIPP_DATASET_EXPORT void map_to_bins(Variable &out, const Variable &var,
+                                      const Variable &offsets,
+                                      const Variable &indices);
+
+} // namespace scipp::dataset::bin_detail


### PR DESCRIPTION
This change mainly affects 1-D binning, i.e., binning a table by one of its columns.

Benchmark results (using `asv`), quite noisy:
![bin_1d](https://user-images.githubusercontent.com/12912489/153389934-13dcf844-325d-4261-9a5d-25a7c3defe77.png)

Real world improvement: When loading a single bank from a SNAP file (64k pixels, 14 GByte loaded size, 1.3e9 events), `main` takes 38 seconds to `bin` into pixels and 17 seconds with this branch, i.e., a 2x speedup.