### PR TITLE
Try Napoleon

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -49,6 +49,9 @@ requirements:
     - sphinx
     - sphinx-book-theme
     - sphinx-copybutton
+    - pip
+    - pip:
+      - sphinx-autodoc-typehints>=1.17.0
   run:
     - confuse
     - numpy>=1.20.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ autosummary_generate = True
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_use_param = True
-napoleon_use_rtype = True
+napoleon_use_rtype = False
 napoleon_preprocess_types = True
 napoleon_type_aliases = {
     # objects without namespace: scipp
@@ -87,6 +87,8 @@ napoleon_type_aliases = {
     # objects without namespace: numpy
     "ndarray": "~numpy.ndarray",
 }
+typehints_defaults = 'comma'
+typehints_use_rtype = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,16 +40,16 @@ html_show_sourcelink = True
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
-    'sphinx.ext.doctest',
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
     'sphinx_copybutton',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'nbsphinx',
 ]
-
-autodoc_typehints = 'description'
 
 autodoc_type_aliases = {
     'VariableLike': 'VariableLike',
@@ -73,6 +73,21 @@ intersphinx_mapping = {
 # looks more suitable in the long run when the API grows.
 # For a nice example see how xarray handles its API documentation.
 autosummary_generate = True
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    # objects without namespace: scipp
+    "DataArray": "~scipp.DataArray",
+    "Dataset": "~scipp.Dataset",
+    "Variable": "~scipp.Variable",
+    # objects without namespace: numpy
+    "ndarray": "~numpy.ndarray",
+}
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,6 @@ napoleon_type_aliases = {
     "ndarray": "~numpy.ndarray",
 }
 
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ setup(name='scipp',
           'pyyaml',
       ],
       extras_require={
-          "test": ["pytest", "matplotlib", "xarray", "pandas", "pythreejs"],
+          "test": [
+              "pytest", "matplotlib", "xarray", "pandas", "pythreejs",
+              "sphinx-autodoc-typehints>=1.17.0"
+          ],
           'all': ['h5py', 'scipy>=1.7.0', 'graphviz'],
           'interactive': [
               'ipykernel==6.3.1', 'ipympl', 'ipython', 'ipywidgets', 'matplotlib',

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -42,7 +42,8 @@ def zeros_like(
 
     See Also
     --------
-    zeros, ones_like : similar functionality
+    zeros: Create zeros but based on given dims and shape
+    ones_like : Create and object initialized with ones
     """
     new_values = zeros(dims=var.dims,
                        shape=var.shape,

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -23,15 +23,26 @@ def zeros_like(
     var: _Union[_cpp.Variable,
                 _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
-    Constructs a new object with the same dims, shape, unit and dtype as the input
-    (:class:`Variable` or :class:`DataArray`), but with all values initialized to 0.
+    Return a Variable or DataArray with the same dims, shape, unit, and dtype as the
+    input and all values initialized to 0.
+
     If the input has variances, all variances in the output are set to 0.
-    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
+    If the input is a data array, coordinates and attributes are shallow-copied
     and masks are deep copied.
 
-    :param var: Input variable or data array.
+    Parameters
+    ----------
+    var:
+        Input object defining dims, shape, unit, and dtype of the output
 
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones_like`
+    Returns
+    -------
+    :
+        New object of zeros.
+
+    See Also
+    --------
+    zeros, ones_like : similar functionality
     """
     new_values = zeros(dims=var.dims,
                        shape=var.shape,

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -43,7 +43,7 @@ def zeros_like(
     See Also
     --------
     zeros: Create zeros but based on given dims and shape
-    ones_like : Create and object initialized with ones
+    ones_like : Create an object initialized with ones
     """
     new_values = zeros(dims=var.dims,
                        shape=var.shape,


### PR DESCRIPTION
Experimenting for #2431. Napoleon on its own did not handle type-hints nicely, but I found another extension. You have to ~`pip install sphinx-autodoc-typehints==1.14.1`~ `pip install sphinx-autodoc-typehints>=1.17.0` if you want to try yourself. The result after rewriting the docstring is (sorry, I made some minor changes, to see how the return value is documented) can be seen below.

That that *writing* the docstring also becomes more convenient, since we can use aliases and even link to terms (like a glossary) defined somewhere (see xarray config linked in issue).

## Sphinx pages

![image](https://user-images.githubusercontent.com/12912489/153549487-45ebe841-6aeb-4ad5-b035-81a2744e5e98.png)

compared to the current:

<img width="826" alt="image" src="https://user-images.githubusercontent.com/12912489/153549577-e564e7e9-6322-483b-bab5-06537bf0f6b3.png">

## Help strings

New:
```
Help on function zeros_like in module scipp.core.like:

zeros_like(var: Union[scipp._scipp.core.Variable, scipp._scipp.core.DataArray]) -> Union[scipp._scipp.core.Variable, scipp._scipp.core.DataArray]
    Return a Variable or DataArray with the same dims, shape, unit, and dtype as the input
    and all values initialized to 0.
    
    If the input has variances, all variances in the output are set to 0.
    If the input is a data array, coordinates and attributes are shallow-copied
    and masks are deep copied.
    
    Parameters
    ----------
    var:
        Input object defining dims, shape, unit, and dtype of the output
    
    Returns
    -------
    :
        New object of zeros.
    
    See Also
    --------
    zeros, ones_like : similar functionality
```

Old:
```
Help on function zeros_like in module scipp.core.like:

zeros_like(var: Union[scipp._scipp.core.Variable, scipp._scipp.core.DataArray]) -> Union[scipp._scipp.core.Variable, scipp._scipp.core.DataArray]
    Constructs a new object with the same dims, shape, unit and dtype as the input
    (:class:`Variable` or :class:`DataArray`), but with all values initialized to 0.
    If the input has variances, all variances in the output are set to 0.
    If the input is a :class:`DataArray`, coordinates and attributes are shallow-copied
    and masks are deep copied.
    
    :param var: Input variable or data array.
    
    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones_like`
```