### PR TITLE
Fix width issues in dims and unit columns of `_repr_html_`

### DIFF
--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -235,7 +235,7 @@
   grid-column: 4;
   text-align: left;
   color: var(--sc-font-color1);
-  max-width: 80px;
+  max-width: 50pt;
   text-overflow: ellipsis;
 }
 .sc-value-preview {

--- a/src/scipp/html/style.css.template
+++ b/src/scipp/html/style.css.template
@@ -122,7 +122,7 @@
 }
 
 .sc-section-inline-details {
-  grid-column: 2 / 5;
+  grid-column: 2 / 6;
 }
 
 .sc-section-details {
@@ -235,6 +235,8 @@
   grid-column: 4;
   text-align: left;
   color: var(--sc-font-color1);
+  max-width: 80px;
+  text-overflow: ellipsis;
 }
 .sc-value-preview {
   grid-column: 5;


### PR DESCRIPTION
Two fixes:
- Width of datasets dims (in `Dimensions:` section) influenced everything, since it did not span to column 6.
- Elide unit column. This tends to happen for weird units that contain numbers.