### PR TITLE
Fixes for plotting with masks

### DIFF
--- a/src/scipp/plotting/view1d.py
+++ b/src/scipp/plotting/view1d.py
@@ -41,6 +41,7 @@ class PlotView1d(PlotView):
         for m in mask_info:
             if m in array.masks:
                 msk = base_mask * Variable(dims=array.masks[m].dims,
+                                           unit=None,
                                            values=array.masks[m].values)
                 masks[m] = msk.values
             else:

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import scipp as sc
-from ..factory import make_dense_data_array, make_dense_dataset
+from ..factory import make_dense_data_array, make_dense_dataset, make_binned_data_array
 from .plot_helper import plot
 import matplotlib
 
@@ -355,3 +355,8 @@ def test_scale_arg_subplots_independent_dims():
     d['a'] = sc.DataArray(sc.arange('x', 10), coords={'x': sc.arange('x', 10)})
     d['b'] = sc.DataArray(sc.arange('y', 5), coords={'y': sc.arange('y', 5)})
     d.plot(scale={'x': 'log'}).close()
+
+
+def test_plot_binned_with_mask():
+    da = make_binned_data_array(ndim=1, masks=True)
+    da.plot()


### PR DESCRIPTION
- Fix `UnitError` when plotting 1d binned data. Introduced when unit of `bool` was changed to default to `None`.
- Fix 2d plotting of masks. Masks were invisible since `rebin` was recently changed to rebin (not resample) also for `bool`, so floating-point values were returned.

No release notes since these bugs have not been released.