### PR TITLE
Add script for migrating scipp HDF5 files for 0.12

### DIFF
--- a/tools/migration/scipp-0.11-hdf5-files.py
+++ b/tools/migration/scipp-0.11-hdf5-files.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+"""
+Convert pre-0.11 HDF5 files to 0.11-compatible files.
+
+Changes are:
+
+* Rename dtype vector_3_float64 to vector3
+* Rename dtype matrix_3_float64 to linear_transform3
+"""
 import h5py
 import sys
 from shutil import copyfile

--- a/tools/migration/scipp-0.12-hdf5-files.py
+++ b/tools/migration/scipp-0.12-hdf5-files.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import h5py
+import sys
+from shutil import copyfile
+
+
+def migrate_object(name, obj):
+    if obj.attrs.get('dtype') in ('VariableView', 'DataArrayView', 'DatasetView'):
+        del obj['begin/values'].attrs['unit']
+        del obj['end/values'].attrs['unit']
+
+
+def migrate_file(filename):
+    with h5py.File(filename, 'r+') as f:
+        f.visititems(migrate_object)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print('Usage: python scipp-0.12-hdf5-files.py filename1 [filename2...]')
+    for filename in sys.argv[1:]:
+        backup = f'{filename}.pre-0.12'
+        print(f'Backing up original file to {backup}')
+        copyfile(filename, backup)
+        migrate_file(filename)

--- a/tools/migration/scipp-0.12-hdf5-files.py
+++ b/tools/migration/scipp-0.12-hdf5-files.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+"""
+Convert pre-0.12 HDF5 files to 0.12-compatible files.
+
+Changes are:
+
+* Unit of values of `begin` and `end` indices for binned data removed
+"""
 import h5py
 import sys
 from shutil import copyfile


### PR DESCRIPTION
The breaking change is that `begin` and `end` of event data indices should not have a unit any more.