### PR TITLE
Allow for creation of Dataset with items given as positional argument

### DIFF
--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -204,10 +204,9 @@ void init_dataset(py::module &m) {
           d.setCoord(dim, coord);
         return d;
       }),
-      py::kw_only(),
       py::arg("data") =
           std::map<std::string, std::variant<Variable, DataArray>>{},
-      py::arg("coords") = std::map<Dim, Variable>{},
+      py::kw_only(), py::arg("coords") = std::map<Dim, Variable>{},
       R"(__init__(self, data: Dict[str, Union[Variable, DataArray]] = {}, coords: Dict[str, Variable] = {}) -> None
 
               Dataset initializer.

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -76,7 +76,7 @@ def test_create_from_data_array_and_variable_mix():
     var_1 = sc.Variable(dims=['x'], values=np.arange(4))
     var_2 = sc.Variable(dims=['x'], values=np.arange(4))
     da = sc.DataArray(data=var_1, coords={'x': var_1, 'aux': var_1})
-    d = sc.Dataset(data={'array': da, 'variable': var_2})
+    d = sc.Dataset({'array': da, 'variable': var_2})
     assert sc.identical(d['array'], da)
     assert sc.identical(d['variable'].data, var_2)
 


### PR DESCRIPTION
For some reason `DataArray` accepts its `data` as positional argument, but `Dataset` did not. Since (as far as I can tell) more than 80% of datasets are created from a single dict, with no other options the keyword-only requirement for the `data` argument does not really make sense.

In fact, since there is no `data` property of `Dataset` (unlike for `DataArray`) the keyword name is even misleading.

We can even consider switching this to position-only when we drop Python 3.7 support.