### PR TITLE
Require Python>=3.8 (dropping 3.7 support)

### DIFF
--- a/.github/workflows/package_nightly_and_release.yml
+++ b/.github/workflows/package_nightly_and_release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
           path: conda/package/*/scipp*.tar.bz2
 
       - uses: actions/upload-artifact@v2
-        if: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.7' }}
+        if: ${{ contains(matrix.os, 'ubuntu') && matrix.python-version == '3.8' }}
         with:
           name: html
           path: docs_html

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
         include:
         - os: ubuntu-latest
           cmake-preset: ci-linux

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # ~~~
-find_package(Python 3.7 REQUIRED COMPONENTS Interpreter)
+find_package(Python 3.8 REQUIRED COMPONENTS Interpreter)
 function(add_docs_target name)
   set(oneValueArgs BUILDER)
   set(multiValueArgs DEPENDS)

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Scipp requires Python 3.7 or above.
+Scipp requires Python 3.8 or above.
 
 Conda
 -----

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -63,7 +63,7 @@ find_package(Sanitizers REQUIRED)
 find_package(GTest CONFIG REQUIRED)
 # libpython is not available on `manylinux` images, use `Development.Module`
 # instead of `Development`
-find_package(Python 3.7 REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(LLNL-Units REQUIRED)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name='scipp',
       cmake_args=get_cmake_args(),
       cmake_install_dir='src/scipp',
       include_package_data=True,
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       install_requires=[
           'confuse',
           'graphlib-backport',


### PR DESCRIPTION
Dropping Python 3.7 support after 0.12 release.