### PR TITLE
Log usage of preexisting coords or attrs in transform_coords

### DIFF
--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -139,6 +139,7 @@ def _log_transform(rules: List[Rule], targets: Set[str],
                      | set(rule_output_names(rules, ComputeRule))) - targets
         if coords.total_usages(name) < 0
     }
+    steps = [rule for rule in rules if not isinstance(rule, FetchRule)]
 
     message = f'Transformed coords ({", ".join(sorted(inputs))}) ' \
               f'-> ({", ".join(sorted(targets))})'
@@ -148,8 +149,8 @@ def _log_transform(rules: List[Rule], targets: Set[str],
         dim_rename_steps = '\n'.join(f'    {t} <- {f}'
                                      for f, t in dim_name_changes.items())
         message += '\n  Renamed dimensions:\n' + dim_rename_steps
-    message += '\n  Steps:\n' + '\n'.join(
-        f'    {rule}' for rule in rules if not isinstance(rule, FetchRule))
+    message += '\n  Steps:\n' + ('\n'.join(f'    {rule}'
+                                           for rule in steps) if steps else '    None')
 
     get_logger().info(message)
 

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -139,6 +139,7 @@ def _log_transform(rules: List[Rule], targets: Set[str],
                      | set(rule_output_names(rules, ComputeRule))) - targets
         if coords.total_usages(name) < 0
     }
+    preexisting = {target for target in targets if target in inputs}
     steps = [rule for rule in rules if not isinstance(rule, FetchRule)]
 
     message = f'Transformed coords ({", ".join(sorted(inputs))}) ' \
@@ -149,6 +150,9 @@ def _log_transform(rules: List[Rule], targets: Set[str],
         dim_rename_steps = '\n'.join(f'    {t} <- {f}'
                                      for f, t in dim_name_changes.items())
         message += '\n  Renamed dimensions:\n' + dim_rename_steps
+    if preexisting:
+        message += ('\n  Outputs already present in input:'
+                    f'\n    {", ".join(sorted(preexisting))}')
     message += '\n  Steps:\n' + ('\n'.join(f'    {rule}'
                                            for rule in steps) if steps else '    None')
 


### PR DESCRIPTION
Fixes  #2068

I don't think a warning is the right solution because `transform_coords` might be used specifically to turn an attr into a coord.

This only handles cases where a requested output exists in the input. It is not tied to whether it is an attr or a coord because that would need more complicated changes, `transform_coords` pulls its inputs from `meta` and thus does not know exactly where they come from.