### PR TITLE
Move MSVC version from 2019 to 2022

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,7 @@
       "name": "ci-windows",
       "inherits": "base",
       "description": "Windows options for CI build (PR and Main)",
-      "generator": "Visual Studio 16 2019",
+      "generator": "Visual Studio 17 2022",
       "architecture": "x64"
     },
     {
@@ -67,7 +67,7 @@
       "name": "package-windows",
       "inherits": "package",
       "description": "Windows options for package build",
-      "generator": "Visual Studio 16 2019",
+      "generator": "Visual Studio 17 2022",
       "architecture": "x64"
     },
     {

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,7 +26,7 @@ source:
 requirements:
   build:
     - cmake
-    - conan
+    - conan>=1.45.0
     - markupsafe>=1.1.1,<2.1.0  # see https://github.com/pallets/markupsafe/issues/284
     - gxx_linux-64 11.1.* [linux64]
     - git
@@ -64,7 +64,7 @@ test:
     - scipp
   requires:
     - cmake
-    - conan
+    - conan>=1.45.0
     - markupsafe>=1.1.1,<2.1.0  # see https://github.com/pallets/markupsafe/issues/284
     - gxx_linux-64 11.1.* [linux64]
     - h5py

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -66,7 +66,7 @@ For a more up-to-date version, the `scipp/label/dev` channel can be used instead
    conda install -c conda-forge -c scipp/label/dev scipp
 
 .. note::
-   Installing ``scipp`` on Windows requires ``Microsoft Visual Studio 2019 C++ Runtime`` installed.
+   Installing ``scipp`` on Windows requires ``Microsoft Visual Studio 2019 C++ Runtime`` (and versions above) installed.
    Visit https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0 for the up to date version of the library.
 
 After installation the module ``scipp`` can be imported in Python.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,10 +27,10 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
   )
   file(
     DOWNLOAD
-    "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+    "https://raw.githubusercontent.com/conan-io/cmake-conan/0.17.0/conan.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake"
     EXPECTED_HASH
-      SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
+      SHA256=3bef79da16c2e031dc429e1dac87a08b9226418b300ce004cc125a82687baeef
     TLS_VERIFY ON
   )
 endif()


### PR DESCRIPTION
Version 17 2022 is now needed for image `windows-latest`.