### PR TITLE
Fix plotting when 2d data has masks and a coord with None unit

### DIFF
--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -13,7 +13,7 @@
             href="https://scipp.github.io"><button type="button"
                 class="btn btn-secondary topbarbtn">latest</button></a>
         <a class="dropdown-buttons"
-            href="https://scipp.github.io/release/0.12.0"><button type="button"
+            href="https://scipp.github.io/release/0.12.1"><button type="button"
                 class="btn btn-secondary topbarbtn">v0.12</button></a>
         <a class="dropdown-buttons"
             href="https://scipp.github.io/release/0.11.1"><button type="button"

--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -13,7 +13,7 @@
             href="https://scipp.github.io"><button type="button"
                 class="btn btn-secondary topbarbtn">latest</button></a>
         <a class="dropdown-buttons"
-            href="https://scipp.github.io/release/0.12.1"><button type="button"
+            href="https://scipp.github.io/release/0.12.0"><button type="button"
                 class="btn btn-secondary topbarbtn">v0.12</button></a>
         <a class="dropdown-buttons"
             href="https://scipp.github.io/release/0.11.1"><button type="button"

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -34,7 +34,7 @@ v0.12.1 (February 2022)
 Bugfixes
 ~~~~~~~~
 
-* Fix a plotting bug when 2d data has masks and a coord with no (``None``) unit `#2470 <https://github.com/scipp/scipp/pull/2470>`_.
+* Fix a plotting bug when 2d data has masks and a coord with no unit `#2470 <https://github.com/scipp/scipp/pull/2470>`_.
 
 Contributors
 ~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,6 +28,21 @@ Simon Heybrock :sup:`a`\ ,
 Neil Vaytet :sup:`a`\ ,
 and Jan-Lukas Wynen :sup:`a`
 
+v0.12.1 (February 2022)
+-----------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix a plotting bug when 2d data has masks and a coord with no (``None``) unit `#2470 <https://github.com/scipp/scipp/pull/2470>`_.
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.12.0 (February 2022)
 -----------------------
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,6 +28,21 @@ Simon Heybrock :sup:`a`\ ,
 Neil Vaytet :sup:`a`\ ,
 and Jan-Lukas Wynen :sup:`a`
 
+v0.12.1 (February 2022)
+-----------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix a plotting bug when 2d data has masks and a coord with no unit `#2470 <https://github.com/scipp/scipp/pull/2470>`_.
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.12.0 (February 2022)
 -----------------------
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,21 +28,6 @@ Simon Heybrock :sup:`a`\ ,
 Neil Vaytet :sup:`a`\ ,
 and Jan-Lukas Wynen :sup:`a`
 
-v0.12.1 (February 2022)
------------------------
-
-Bugfixes
-~~~~~~~~
-
-* Fix a plotting bug when 2d data has masks and a coord with no unit `#2470 <https://github.com/scipp/scipp/pull/2470>`_.
-
-Contributors
-~~~~~~~~~~~~
-
-Simon Heybrock :sup:`a`\ ,
-Neil Vaytet :sup:`a`\ ,
-and Jan-Lukas Wynen :sup:`a`
-
 v0.12.0 (February 2022)
 -----------------------
 

--- a/src/scipp/plotting/formatters.py
+++ b/src/scipp/plotting/formatters.py
@@ -67,7 +67,7 @@ class DateFormatter:
             return dt
         trim = 0
         bounds = get_axis_bounds(axis)
-        diff = sc.scalar(bounds[1] - bounds[0], unit=self.offset.unit)
+        diff = scalar(bounds[1] - bounds[0], unit=self.offset.unit)
         label = self.dim
         if pos == 0:
             self.indicators.clear()

--- a/src/scipp/plotting/formatters.py
+++ b/src/scipp/plotting/formatters.py
@@ -1,6 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
 from .. import typing
 from ..utils import name_with_unit, value_to_string
-from ..core import arange, to_unit, Unit
+from ..core import arange, to_unit, Unit, scalar
 import enum
 import numpy as np
 
@@ -58,19 +61,21 @@ class DateFormatter:
 
     def formatter(self, val, pos, axis=None, get_axis_bounds=None, set_axis_label=None):
         index = np.abs(self.coord_values - val).argmin()
-        d = (self.offset + (index * self.offset.unit)).value
+        d = (self.offset + scalar(index, unit=self.offset.unit)).value
         dt = str(d)
         if pos is None:  # Return full string, not split into label + offset
             return dt
         trim = 0
         bounds = get_axis_bounds(axis)
-        diff = (bounds[1] - bounds[0]) * self.offset.unit
+        diff = sc.scalar(bounds[1] - bounds[0], unit=self.offset.unit)
         label = self.dim
         if pos == 0:
             self.indicators.clear()
 
-        date_min = str((int(bounds[0]) * self.offset.unit + self.offset).value)
-        date_max = str((int(bounds[1]) * self.offset.unit + self.offset).value)
+        date_min = str(
+            (scalar(int(bounds[0]), unit=self.offset.unit) + self.offset).value)
+        date_max = str(
+            (scalar(int(bounds[1]), unit=self.offset.unit) + self.offset).value)
 
         check_transition = True
         check_time = True

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -127,8 +127,10 @@ class ResamplingModel():
                                          shape=[coord.sizes[d]] + data.shape)
         array = DataArray(data=data)
         for dim in coords:
-            if coords[dim].dim in array.dims:
+            try:
                 array.coords[dim] = coords[dim]
+            except DimensionError:  # Masks may be lower-dimensional
+                pass
         if sanitize:
             array, _ = _with_edges(array)
         plan = []

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -145,7 +145,7 @@ class ResamplingModel():
                 plan.insert(0, edge)
         for edge in plan:
             if edge.unit is None:
-                # We cannot rebin with such a unit.
+                # We cannot use rebin with no unit, so we change it to dimensionless
                 edge = edge.copy()
                 edge.unit = ''
             try:

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -129,10 +129,6 @@ class ResamplingModel():
         for dim in coords:
             if coords[dim].dim in array.dims:
                 array.coords[dim] = coords[dim]
-            # try:
-            #     array.coords[dim] = coords[dim]
-            # except DimensionError:  # Masks may be lower-dimensional
-            #     pass
         if sanitize:
             array, _ = _with_edges(array)
         plan = []
@@ -151,7 +147,6 @@ class ResamplingModel():
                 edge = edge.copy()
                 edge.unit = ''
             try:
-                # array = _resample(array, self.mode, dim, edge)
                 array = _resample(array, self.mode, edge.dims[-1], edge)
             except (KeyError,
                     DimensionError):  # Limitation of rebin for slice of inner dim

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -127,10 +127,12 @@ class ResamplingModel():
                                          shape=[coord.sizes[d]] + data.shape)
         array = DataArray(data=data)
         for dim in coords:
-            try:
+            if coords[dim].dim in array.dims:
                 array.coords[dim] = coords[dim]
-            except DimensionError:  # Masks may be lower-dimensional
-                pass
+            # try:
+            #     array.coords[dim] = coords[dim]
+            # except DimensionError:  # Masks may be lower-dimensional
+            #     pass
         if sanitize:
             array, _ = _with_edges(array)
         plan = []
@@ -144,8 +146,13 @@ class ResamplingModel():
             else:
                 plan.insert(0, edge)
         for edge in plan:
+            if edge.unit is None:
+                # We cannot rebin with such a unit.
+                edge = edge.copy()
+                edge.unit = ''
             try:
-                array = _resample(array, self.mode, dim, edge)
+                # array = _resample(array, self.mode, dim, edge)
+                array = _resample(array, self.mode, edge.dims[-1], edge)
             except (KeyError,
                     DimensionError):  # Limitation of rebin for slice of inner dim
                 array = _resample(array.copy(), self.mode, edge.dims[-1], edge)

--- a/src/scipp/plotting/tools.py
+++ b/src/scipp/plotting/tools.py
@@ -33,7 +33,7 @@ def to_bin_edges(x, dim):
     """
     idim = x.dims.index(dim)
     if x.shape[idim] < 2:
-        one = 1.0 * x.unit
+        one = scalar(1.0, unit=x.unit)
         return concat([x[dim, 0:1] - one, x[dim, 0:1] + one], dim)
     else:
         center = to_bin_centers(x, dim)
@@ -122,7 +122,7 @@ def find_log_limits(x):
                                    values=np.geomspace(1e-30, 1e30, num=61),
                                    unit=x.unit))
     # Find the first and the last non-zero bins
-    inds = np.nonzero((hist.data > 0.0 * units.counts).values)
+    inds = np.nonzero((hist.data > scalar(0.0, unit=units.counts)).values)
     ar = np.arange(hist.data.shape[0])[inds]
     # Safety check in case there are no values in range 1.0e-30:1.0e+30:
     # fall back to the linear method and replace with arbitrary values if the
@@ -178,12 +178,12 @@ def fix_empty_range(lims, replacement=None):
     """
     Range correction in case xmin == xmax
     """
-    dx = 0.0 * lims[0].unit
+    dx = scalar(0.0, unit=lims[0].unit)
     if lims[0].value == lims[1].value:
         if replacement is not None:
             dx = 0.5 * replacement
         elif lims[0].value == 0.0:
-            dx = 0.5 * lims[0].unit
+            dx = scalar(0.5, unit=lims[0].unit)
         else:
             dx = 0.5 * abs_(lims[0])
     return [lims[0] - dx, lims[1] + dx]

--- a/src/scipp/plotting/view.py
+++ b/src/scipp/plotting/view.py
@@ -11,7 +11,8 @@ def _slice_params(array, dim, loc):
     if not isinstance(array, core.DataArray):
         array = next(iter(array.values()))
     if array.sizes[dim] + 1 == coord.sizes[dim]:
-        _, i = core.get_slice_params(array.data, coord, loc * coord.unit)
+        _, i = core.get_slice_params(array.data, coord, core.scalar(loc,
+                                                                    unit=coord.unit))
         if i < 0 or i + 1 >= coord.sizes[dim]:
             return None
         return coord[dim, i], coord[dim, i + 1]

--- a/src/scipp/plotting/view2d.py
+++ b/src/scipp/plotting/view2d.py
@@ -3,7 +3,7 @@
 # @author Neil Vaytet
 
 from .view import PlotView
-from ..core import zeros
+from ..core import zeros, scalar
 import numpy as np
 from matplotlib.collections import PathCollection
 
@@ -107,7 +107,7 @@ class PlotView2d(PlotView):
         for dim in self.dims:
             low, high = self.current_lims[dim]
             unit = self._data.coords[dim].unit
-            limits[dim] = [low * unit, high * unit]
+            limits[dim] = [scalar(low, unit=unit), scalar(high, unit=unit)]
         return limits
 
     @property
@@ -116,7 +116,7 @@ class PlotView2d(PlotView):
         for dim in self.dims:
             low, high = self.global_lims[dim]
             unit = self._data.coords[dim].unit
-            limits[dim] = [low * unit, high * unit]
+            limits[dim] = [scalar(low, unit=unit), scalar(high, unit=unit)]
         return limits
 
     def _update_axes(self):

--- a/tests/plotting/plot_2d_test.py
+++ b/tests/plotting/plot_2d_test.py
@@ -515,3 +515,11 @@ def test_when_2d_data_has_y_coord_associated_with_dim_x():
                           'y': sc.arange('x', 1, N + 1)
                       })
     plot(da)
+
+
+def test_when_2d_data_has_masks_and_coord_with_none_unit():
+    da = make_binned_data_array(ndim=2)
+    da.masks['mask_x'] = da.coords['xx'] > 0.5 * sc.units.m
+    da.bins.constituents['data'].coords['xx'].unit = None
+    da.coords['xx'].unit = None
+    plot(da)


### PR DESCRIPTION
This happens e.g. when the spectrum dimension has unit `None`, and you make a 2d plot with masks.

Also fix an issue when zooming and one of the axes has a coord with `None` as unit, because it was using the syntax `number * unit` and python complains that `number * None` has no defined operator. Changed the syntax to use `sc.scalar(number, unit=unit)` is all relevant places (i.e. when the unit is not immediately known).