### PR TITLE
Use position-only args

### DIFF
--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -255,10 +255,8 @@ void init_dataset(py::module &m) {
   bind_binary<DataArray>(dataset);
   bind_binary<Variable>(dataset);
 
-  dataArray.def("rename_dims", &rename_dims<DataArray>, py::arg("dims_dict"),
-                "Rename dimensions.");
-  dataset.def("rename_dims", &rename_dims<Dataset>, py::arg("dims_dict"),
-              "Rename dimensions.");
+  dataArray.def("rename_dims", &rename_dims<DataArray>, "Rename dimensions.");
+  dataset.def("rename_dims", &rename_dims<Dataset>, "Rename dimensions.");
 
   m.def(
       "merge",

--- a/lib/python/variable.cpp
+++ b/lib/python/variable.cpp
@@ -89,9 +89,7 @@ Array of values with dimension labels and a unit, optionally including an array
 of variances.)");
 
   bind_init(variable);
-  variable
-      .def("rename_dims", &rename_dims<Variable>, py::arg("dims_dict"),
-           "Rename dimensions.")
+  variable.def("rename_dims", &rename_dims<Variable>, "Rename dimensions.")
       .def_property_readonly("dtype", &Variable::dtype)
       .def(
           "__radd__",

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -12,7 +12,7 @@ def _make_sizes(obj):
     return dict(zip(obj.dims, obj.shape))
 
 
-def _rename_variable(var: Variable, dims_dict: dict = None, **names) -> Variable:
+def _rename_variable(var: Variable, dims_dict: dict = None, /, **names) -> Variable:
     """
     Rename the dimensions labels of a Variable.
     The renaming can be defined:
@@ -22,7 +22,7 @@ def _rename_variable(var: Variable, dims_dict: dict = None, **names) -> Variable
     return var.rename_dims({**({} if dims_dict is None else dims_dict), **names})
 
 
-def _rename_data_array(da: DataArray, dims_dict: dict = None, **names) -> DataArray:
+def _rename_data_array(da: DataArray, dims_dict: dict = None, /, **names) -> DataArray:
     """
     Rename the dimensions, coordinates and attributes of a Dataset.
     The renaming can be defined:
@@ -42,7 +42,7 @@ def _rename_data_array(da: DataArray, dims_dict: dict = None, **names) -> DataAr
     return out
 
 
-def _rename_dataset(ds: Dataset, dims_dict: dict = None, **names) -> Dataset:
+def _rename_dataset(ds: Dataset, dims_dict: dict = None, /, **names) -> Dataset:
     """
     Rename the dimensions, coordinates and attributes of all the items in a dataset.
     The renaming can be defined:

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -53,7 +53,7 @@ def _rename_dataset(ds: Dataset, dims_dict: dict = None, /, **names) -> Dataset:
     ds_from_items = Dataset()
     for key, item in ds.items():
         dims_dict = {old: new for old, new in renaming_dict.items() if old in item.dims}
-        ds_from_items[key] = _rename_data_array(item, dims_dict=dims_dict)
+        ds_from_items[key] = _rename_data_array(item, dims_dict)
     dict_of_coords = {}
     for dim, coord in ds.coords.items():
         if dim not in ds_from_items.coords:
@@ -61,7 +61,5 @@ def _rename_dataset(ds: Dataset, dims_dict: dict = None, /, **names) -> Dataset:
                 old: new
                 for old, new in renaming_dict.items() if old in coord.dims
             }
-            dict_of_coords[dims_dict.get(dim,
-                                         dim)] = _rename_variable(coord,
-                                                                  dims_dict=dims_dict)
+            dict_of_coords[dims_dict.get(dim, dim)] = _rename_variable(coord, dims_dict)
     return merge(ds_from_items, Dataset(coords=dict_of_coords))

--- a/src/scipp/core/groupby.py
+++ b/src/scipp/core/groupby.py
@@ -5,11 +5,11 @@
 from typing import Optional, Union
 
 from .._scipp import core as _cpp
-from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 
 def groupby(
     data: Union[_cpp.DataArray, _cpp.Dataset],
+    /,
     group: Union[_cpp.Variable, str],
     *,
     bins: Optional[_cpp.Variable] = None
@@ -23,6 +23,6 @@ def groupby(
     :return: GroupBy helper object.
     """
     if bins is None:
-        return _call_cpp_func(_cpp.groupby, data, group)
+        return _cpp.groupby(data, group)
     else:
-        return _call_cpp_func(_cpp.groupby, data, group, bins)
+        return _cpp.groupby(data, group, bins)

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -19,9 +19,8 @@ def _to_variable_or_data_array(var, new_values):
         return new_values
 
 
-def zeros_like(
-    var: _Union[_cpp.Variable,
-                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+def zeros_like(var: _Union[_cpp.Variable, _cpp.DataArray],
+               /) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
     Return a Variable or DataArray with the same dims, shape, unit, and dtype as the
     input and all values initialized to 0.
@@ -53,9 +52,8 @@ def zeros_like(
     return _to_variable_or_data_array(var, new_values)
 
 
-def ones_like(
-    var: _Union[_cpp.Variable,
-                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+def ones_like(var: _Union[_cpp.Variable, _cpp.DataArray],
+              /) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
     Constructs a new object with the same dims, shape, unit and dtype as the input
     (:class:`Variable` or :class:`DataArray`), but with all values initialized to 1.
@@ -75,9 +73,8 @@ def ones_like(
     return _to_variable_or_data_array(var, new_values)
 
 
-def empty_like(
-    var: _Union[_cpp.Variable,
-                _cpp.DataArray]) -> _Union[_cpp.Variable, _cpp.DataArray]:
+def empty_like(var: _Union[_cpp.Variable, _cpp.DataArray],
+               /) -> _Union[_cpp.Variable, _cpp.DataArray]:
     """
     Constructs a new object with the same dims, shape, unit and dtype as the input
     (:class:`Variable` or :class:`DataArray`), but with all values uninitialized.
@@ -98,7 +95,11 @@ def empty_like(
     return _to_variable_or_data_array(var, new_values)
 
 
-def full_like(var: _cpp.Variable, value: _Any, variance: _Any = None) -> _cpp.Variable:
+def full_like(var: _cpp.Variable,
+              /,
+              value: _Any,
+              *,
+              variance: _Any = None) -> _cpp.Variable:
     """
     Constructs a new object with the same dims, shape, unit and dtype as the input
     (:class:`Variable` or :class:`DataArray`), but with all values, and optionally

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -236,7 +236,7 @@ def test_rename_dims():
     renamed.coords['z'] = renamed.coords['y']
     del renamed.coords['y']
     assert sc.identical(renamed, make_dataarray('x', 'z', seed=0))
-    renamed = renamed.rename_dims(dims_dict={'x': 'y', 'z': 'x'})
+    renamed = renamed.rename_dims({'x': 'y', 'z': 'x'})
     renamed.coords['y'] = renamed.coords['x']
     renamed.coords['x'] = renamed.coords['z']
     del renamed.coords['z']
@@ -249,7 +249,7 @@ def test_rename():
     renamed = d.rename({'y': 'z'})
     assert sc.identical(d, original)
     assert sc.identical(renamed, make_dataarray('x', 'z', seed=0))
-    renamed = renamed.rename(dims_dict={'x': 'y', 'z': 'x'})
+    renamed = renamed.rename({'x': 'y', 'z': 'x'})
     assert sc.identical(renamed, make_dataarray('y', 'x', seed=0))
 
 

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -639,7 +639,7 @@ def test_rename_dims():
     renamed.coords['z'] = renamed.coords['y']
     del renamed.coords['y']
     assert sc.identical(renamed, make_simple_dataset('x', 'z', seed=0))
-    renamed = renamed.rename_dims(dims_dict={'x': 'y', 'z': 'x'})
+    renamed = renamed.rename_dims({'x': 'y', 'z': 'x'})
     renamed.coords['y'] = renamed.coords['x']
     renamed.coords['x'] = renamed.coords['z']
     del renamed.coords['z']
@@ -652,14 +652,14 @@ def test_rename():
     renamed = d.rename({'y': 'z'})
     assert sc.identical(d, original)
     assert sc.identical(renamed, make_simple_dataset('x', 'z', seed=0))
-    renamed = renamed.rename(dims_dict={'x': 'y', 'z': 'x'})
+    renamed = renamed.rename({'x': 'y', 'z': 'x'})
     assert sc.identical(renamed, make_simple_dataset('y', 'x', seed=0))
 
 
 def test_rename_intersection_of_dims():
     d = make_simple_dataset('x', 'y', seed=0)
     d['c'] = sc.Variable(dims=['time', 'y'], values=np.random.rand(4, 3))
-    renamed = d.rename(dims_dict={'x': 'u', 'time': 'v'})
+    renamed = d.rename({'x': 'u', 'time': 'v'})
     expected = make_simple_dataset('u', 'y', seed=0)
     expected['c'] = sc.Variable(dims=['v', 'y'], values=np.random.rand(4, 3))
     assert sc.identical(renamed, expected)

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -662,6 +662,16 @@ def test_rename_kwargs():
     assert sc.identical(xy.rename(x='z'), zy)
 
 
+def test_rename_self_and_dims_dict_are_position_only():
+    values = np.arange(6).reshape(2, 3)
+    xy = sc.Variable(dims=['x', 'y'], values=values)
+    zy = sc.Variable(dims=['z', 'y'], values=values)
+    # `var` is a position-only arg, so it *can* be used as a keyword
+    assert sc.identical(xy.rename(x='var').rename(var='z'), zy)
+    # `dims_dict` is a position-only arg, so it *can* be used as a keyword
+    assert sc.identical(xy.rename(x='dims_dict').rename(dims_dict='z'), zy)
+
+
 def test_bool_variable_repr():
     a = sc.Variable(dims=['x'], values=np.array([False, True, True, False, True]))
     assert [expected in repr(a) for expected in ["True", "False", "..."]]


### PR DESCRIPTION
After dropping Python 3.7 support we can now make use of position-only arguments. This PR adds this in some (but not all) cases.

To be extended to more cases as we encounter them.