### PR TITLE
Add python-graphviz dependency to environment

### DIFF
--- a/docs/environments/scipp.yml
+++ b/docs/environments/scipp.yml
@@ -17,3 +17,4 @@ dependencies:
   - pythreejs
   - scipp
   - scipy
+  - python-graphviz


### PR DESCRIPTION
`show_graph` requires graphviz to visualize conversions.