### PR TITLE
Add `sizes` argument to `broadcast`, and support for DataArray

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,6 +12,7 @@ Features
 * Added ``is_edges`` method to ``coords``, ``attrs``, ``masks``, and ``meta`` properties of DataArray and Dataset `#2469 <https://github.com/scipp/scipp/pull/2469>`_.
 * Added support for arithmetic of :class:`scipp.DataArray` and :class:`scipp.Dataset` with builtin ``int`` and ``float`` `#2473 <https://github.com/scipp/scipp/pull/2473>`_.
 * Added advanced indexing support: boolean variable indexing `#2477 <https://github.com/scipp/scipp/pull/2477>`_.
+* ``broadcast`` now supports :class:`scipp.DataArray`, and the ``sizes`` argument `#2488 <https://github.com/scipp/scipp/pull/2488>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scipp/core/_sizes.py
+++ b/src/scipp/core/_sizes.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+
+def _parse_dims_shape_sizes(dims: Optional[Union[List[str], Tuple[str, ...]]] = None,
+                            shape: Optional[Sequence[int]] = None,
+                            sizes: Optional[Dict[str, int]] = None):
+    if sizes is not None:
+        if dims is not None or shape is not None:
+            raise ValueError("When sizes is specified, dims and shape must "
+                             "both be None. Got dims: {}, shape: {}".format(
+                                 dims, shape))
+        dims = list(sizes.keys())
+        shape = list(sizes.values())
+    return {"dims": dims, "shape": shape}

--- a/src/scipp/core/shape.py
+++ b/src/scipp/core/shape.py
@@ -18,15 +18,18 @@ def broadcast(
     shape: Optional[Sequence[int]] = None,
     sizes: Optional[Dict[str, int]] = None,
 ) -> _cpp.Variable:
-    """Broadcast a variable.
+    """Broadcast a Variable or a DataArray.
+    If the input is a DataArray, coordinates and attributes are shallow-copied
+    and masks are deep copied.
 
     Note that scipp operations broadcast automatically, so using this function
     directly is rarely required.
 
-    :param x: Variable to broadcast.
-    :param dims: List of new dimensions.
-    :param shape: New extents in each dimension.
-    :return: New variable with requested dimension labels and shape.
+    :param x: Variable or DataArray to broadcast.
+    :param dims: Optional (if sizes is specified), list of new dimensions.
+    :param shape: Optional (if sizes is specified), new extents in each dimension.
+    :param sizes: Optional, new dimension labels to sizes map.
+    :return: New Variable or DataArray with requested dimension labels and shape.
     """
     sizes = _parse_dims_shape_sizes(dims=dims, shape=shape, sizes=sizes)
     if isinstance(x, _cpp.Variable):

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -15,17 +15,7 @@ from numpy.typing import ArrayLike as array_like
 
 from .._scipp import core as _cpp
 from ..units import default_unit
-
-
-def _parse_dims_shape_sizes(dims, shape, sizes):
-    if sizes is not None:
-        if dims is not None or shape is not None:
-            raise ValueError("When sizes is specified, dims and shape must "
-                             "both be None. Got dims: {}, shape: {}".format(
-                                 dims, shape))
-        dims = list(sizes.keys())
-        shape = list(sizes.values())
-    return {"dims": dims, "shape": shape}
+from ._sizes import _parse_dims_shape_sizes
 
 
 def scalar(value: _Any,

--- a/tests/shape_test.py
+++ b/tests/shape_test.py
@@ -8,6 +8,12 @@ import scipp as sc
 from .common import assert_export
 
 
+def test_broadcast():
+    x = sc.array(dims=['x'], values=np.arange(6.0))
+    assert_export(sc.broadcast, x=x, sizes={'x': 6, 'y': 3})
+    assert_export(sc.broadcast, x=x, dims=['x', 'y'], shape=[6, 3])
+
+
 def test_concat():
     var = sc.scalar(1.0)
     assert sc.identical(sc.concat([var, var + var, 3 * var], 'x'),

--- a/tests/shape_test.py
+++ b/tests/shape_test.py
@@ -12,6 +12,20 @@ def test_broadcast():
     x = sc.array(dims=['x'], values=np.arange(6.0))
     assert_export(sc.broadcast, x=x, sizes={'x': 6, 'y': 3})
     assert_export(sc.broadcast, x=x, dims=['x', 'y'], shape=[6, 3])
+    assert sc.identical(sc.broadcast(x, sizes={
+        'x': 6,
+        'y': 3
+    }), sc.broadcast(x, dims=['x', 'y'], shape=[6, 3]))
+
+
+def test_broadcast_fails_with_bad_inputs():
+    x = sc.array(dims=['x'], values=np.arange(6.0))
+    with pytest.raises(ValueError):
+        _ = sc.broadcast(x, sizes={'x': 6, 'y': 3}, dims=['x', 'y'], shape=[6, 3])
+    with pytest.raises(ValueError):
+        _ = sc.broadcast(x, sizes={'x': 6, 'y': 3}, dims=['x', 'y'])
+    with pytest.raises(ValueError):
+        _ = sc.broadcast(x, sizes={'x': 6, 'y': 3}, shape=[6, 3])
 
 
 def test_concat():
@@ -71,6 +85,7 @@ def test_fold_raises_two_minus_1():
     da = sc.DataArray(x)
     with pytest.raises(sc.DimensionError):
         sc.fold(x, dim='x', sizes={'x': -1, 'y': -1})
+    with pytest.raises(sc.DimensionError):
         sc.fold(da, dim='x', sizes={'x': -1, 'y': -1})
 
 
@@ -79,6 +94,7 @@ def test_fold_raises_non_divisible():
     da = sc.DataArray(x)
     with pytest.raises(ValueError):
         sc.fold(x, dim='x', sizes={'x': 3, 'y': -1})
+    with pytest.raises(ValueError):
         sc.fold(da, dim='x', sizes={'x': -1, 'y': 3})
 
 

--- a/tests/shape_test.py
+++ b/tests/shape_test.py
@@ -8,7 +8,7 @@ import scipp as sc
 from .common import assert_export
 
 
-def test_broadcast():
+def test_broadcast_variable():
     x = sc.array(dims=['x'], values=np.arange(6.0))
     assert_export(sc.broadcast, x=x, sizes={'x': 6, 'y': 3})
     assert_export(sc.broadcast, x=x, dims=['x', 'y'], shape=[6, 3])
@@ -16,6 +16,24 @@ def test_broadcast():
         'x': 6,
         'y': 3
     }), sc.broadcast(x, dims=['x', 'y'], shape=[6, 3]))
+
+
+def test_broadcast_data_array():
+    N = 6
+    d = sc.linspace('x', 2., 10., N)
+    x = sc.arange('x', float(N))
+    a = sc.arange('x', float(N)) + 3.0
+    m = x < 3.
+    da = sc.DataArray(d, coords={'x': x}, attrs={'a': a}, masks={'m': m})
+    expected = sc.DataArray(sc.broadcast(d, sizes={
+        'x': 6,
+        'y': 3
+    }),
+                            coords={'x': x},
+                            attrs={'a': a},
+                            masks={'m': m})
+    assert sc.identical(sc.broadcast(da, sizes={'x': 6, 'y': 3}), expected)
+    assert sc.identical(sc.broadcast(da, dims=['x', 'y'], shape=[6, 3]), expected)
 
 
 def test_broadcast_fails_with_bad_inputs():


### PR DESCRIPTION
In line with other functions, this adds the option of doing `sc.broadcast(var, sizes=other_var.sizes)`.
`broadcast` now also supports data arrays as inputs: the output will be the `.data` broadcasted, with coords and attrs shallow copied, and masks deep-copied.

Also changed the implementation of `fold` binding to accept dims/shape instead of sizes, in-line with `brodcast`.