### PR TITLE
Clear readonly flag in squeeze for data array / set

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -14,6 +14,7 @@ Features
 * Added advanced indexing support: boolean variable indexing `#2477 <https://github.com/scipp/scipp/pull/2477>`_.
 * Added or exposed to Python more functions for boolean logic `#2480 <https://github.com/scipp/scipp/pull/2480>`_, `#2489 <https://github.com/scipp/scipp/pull/2489>`_.
 * ``broadcast`` now supports :class:`scipp.DataArray`, and the ``sizes`` argument `#2488 <https://github.com/scipp/scipp/pull/2488>`_.
+* The output of :py:`squeeze` is no longer read-only `2494 <https://github.com/scipp/scipp/pull/2494>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -307,22 +307,26 @@ Dataset transpose(const Dataset &d, const scipp::span<const Dim> dims) {
       d, [](auto &&... _) { return transpose(_...); }, dims);
 }
 
-DataArray squeeze(const DataArray &a,
-                  const std::optional<scipp::span<const Dim>> dims) {
-  auto squeezed = a;
-  for (const auto &dim : dims_for_squeezing(a.dims(), dims)) {
+namespace {
+template <class T>
+T squeeze_impl(const T &x, const std::optional<scipp::span<const Dim>> dims) {
+  auto squeezed = x;
+  for (const auto &dim : dims_for_squeezing(x.dims(), dims)) {
     squeezed = squeezed.slice({dim, 0});
   }
-  return squeezed;
+  // Copy explicitly to make sure the output does not have its read-only flag
+  // set.
+  return T(squeezed);
+}
+} // namespace
+DataArray squeeze(const DataArray &a,
+                  const std::optional<scipp::span<const Dim>> dims) {
+  return squeeze_impl(a, dims);
 }
 
 Dataset squeeze(const Dataset &d,
                 const std::optional<scipp::span<const Dim>> dims) {
-  auto squeezed = d;
-  for (const auto &dim : dims_for_squeezing(d.dims(), dims)) {
-    squeezed = squeezed.slice({dim, 0});
-  }
-  return squeezed;
+  return squeeze_impl(d, dims);
 }
 
 } // namespace scipp::dataset

--- a/lib/dataset/test/shape_test.cpp
+++ b/lib/dataset/test/shape_test.cpp
@@ -614,6 +614,13 @@ TEST_F(SqueezeTest, data_array_3d_wrong_length_throws) {
                        except::DimensionError);
 }
 
+TEST_F(SqueezeTest, data_array_output_is_not_readonly) {
+  auto squeezed = squeeze(a, std::nullopt);
+  EXPECT_NO_THROW_DISCARD(squeezed.data().setSlice(
+      Slice{Dim::Z, 0}, makeVariable<double>(Dims{}, Values{-10.0})));
+  EXPECT_NO_THROW_DISCARD(squeezed.coords().erase(Dim::Z));
+}
+
 class SqueezeDatasetTest : public SqueezeTest {
 protected:
   SqueezeDatasetTest()
@@ -663,4 +670,11 @@ TEST_F(SqueezeDatasetTest, dataset_3d_all) {
   EXPECT_EQ(squeezed["a"], squeeze(a, dims));
   EXPECT_EQ(squeezed["b"], squeeze(b, std::vector<Dim>({Dim::Y})));
   EXPECT_EQ(squeezed["c"], squeeze(c, std::vector<Dim>({Dim::X})));
+}
+
+TEST_F(SqueezeDatasetTest, dataset_output_is_not_readonly) {
+  auto squeezed = squeeze(dset, std::nullopt);
+  EXPECT_NO_THROW_DISCARD(squeezed["a"].data().setSlice(
+      Slice{Dim::Z, 0}, makeVariable<double>(Dims{}, Values{-10.0})));
+  EXPECT_NO_THROW_DISCARD(squeezed.coords().erase(Dim::Z));
 }


### PR DESCRIPTION
This allows modification of the output without users having to explicitly copy.

No modification for `squeeze(Variable)` needed, this already works: https://github.com/scipp/scipp/blob/4aa2ee664f20bbf9979f8cc88bc070fd892e4a9a/lib/variable/test/shape_test.cpp#L114-L120