### PR TITLE
Support variables in args of arange

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ extensions = [
 ]
 
 autodoc_type_aliases = {
+    'DTypeLike': 'DTypeLike',
     'VariableLike': 'VariableLike',
     'MetaDataMap': 'MetaDataMap',
     'array_like': 'array_like',

--- a/docs/reference/classes.rst
+++ b/docs/reference/classes.rst
@@ -58,5 +58,6 @@ Typing
    :template: scipp-class-template.rst
    :recursive:
 
-   typing.VariableLike
+   typing.DTypeLike
    typing.MetaDataMap
+   typing.VariableLike

--- a/docs/reference/developer/tooling.rst
+++ b/docs/reference/developer/tooling.rst
@@ -24,7 +24,7 @@ Static Analysis and Formatters
 - ``clang-format`` 10.0
 - ``cmake-format`` 0.6.9
 - ``flake8``
-- ``yapf`` 0.30.0
+- ``yapf`` 0.32.0
 
 ``clang-format`` may be installed via the LLVM repositories.
 
@@ -35,4 +35,4 @@ Static Analysis and Formatters
   pip install \
     cmake-format==0.6.9 \
     flake8 \
-    yapf==0.30.0
+    yapf==0.32.0

--- a/lib/python/bind_units.cpp
+++ b/lib/python/bind_units.cpp
@@ -31,7 +31,8 @@ void init_units(py::module &m) {
       .def("__pow__", [](const units::Unit &self,
                          const int64_t power) { return pow(self, power); })
       .def(py::self == py::self)
-      .def(py::self != py::self);
+      .def(py::self != py::self)
+      .def(hash(py::self));
 
   m.def("abs", [](const units::Unit &u) { return abs(u); });
   m.def("pow", [](const units::Unit &u, const int64_t power) {

--- a/lib/units/include/scipp/units/unit.h
+++ b/lib/units/include/scipp/units/unit.h
@@ -5,6 +5,7 @@
 /// @author Neil Vaytet
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -86,3 +87,11 @@ constexpr Unit c{
     {llnl::units::precise::m / llnl::units::precise::s, 299792458}};
 
 } // namespace scipp::units
+
+namespace std {
+template <> struct hash<scipp::units::Unit> {
+  std::size_t operator()(const scipp::units::Unit &u) const {
+    return hash<std::string>()(u.name());
+  }
+};
+} // namespace std

--- a/lib/units/include/scipp/units/unit.h
+++ b/lib/units/include/scipp/units/unit.h
@@ -91,7 +91,7 @@ constexpr Unit c{
 namespace std {
 template <> struct hash<scipp::units::Unit> {
   std::size_t operator()(const scipp::units::Unit &u) const {
-    return hash<std::string>()(u.name());
+    return hash<llnl::units::precise_unit>()(u.underlying());
   }
 };
 } // namespace std

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -33,14 +33,14 @@ def scalar(value: Any,
     value:
         Initial value.
     variance:
-        Optional, initial variance, Default=None
+        Optional, initial variance.
     unit:
-        Optional, unit. Default=dimensionless
+        Optional, unit.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Optional, type of underlying data. By default,
+        the dtype is inferred from the `value` argument.
         Cannot be specified for value types of
-        str, Dataset or DataArray.
+        Dataset or DataArray.
 
     Returns
     -------
@@ -50,6 +50,27 @@ def scalar(value: Any,
     See Also
     --------
     scipp.array, scipp.empty, scipp.index, scipp.ones, scipp.zeros
+
+    Examples
+    --------
+    With deduced dtype and default unit:
+
+      >>> sc.scalar(3.14)
+      <scipp.Variable> ()    float64  [dimensionless]  [3.14]
+
+      >>> sc.scalar('a string')
+      <scipp.Variable> ()     string           [None]  ["a string"]
+
+    Or specifying a unit and dtype:
+
+      >>> sc.scalar(3.14, unit='m', dtype=int)
+      <scipp.Variable> ()      int64              [m]  [3]
+
+    Calling ``scalar`` with a list (or similar array-like object) will store that
+    object in a scalar variable and *not* create an array variable:
+
+      >>> sc.scalar([1, 2, 3])
+      <scipp.Variable> ()   PyObject           [None]  [[1, 2, 3]]
     """
     return _cpp.Variable(dims=(),
                          values=value,
@@ -68,8 +89,8 @@ def index(value: Any, dtype: Optional[DTypeLike] = None) -> Variable:
     value:
         Initial value.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Optional, type of underlying data. By default,
+        the dtype is inferred from the `value` argument.
 
     Returns
     -------
@@ -79,6 +100,12 @@ def index(value: Any, dtype: Optional[DTypeLike] = None) -> Variable:
     See Also
     --------
     scipp.scalar, scipp.array
+
+    Examples
+    --------
+
+      >>> sc.index(123)
+      <scipp.Variable> ()      int64           [None]  [123]
     """
     return scalar(value=value, dtype=dtype, unit=None)
 
@@ -93,7 +120,7 @@ def zeros(*,
     """Constructs a :class:`Variable` with default initialized values with
     given dimension labels and shape.
 
-    The dims and shape can also be specified using a sizes dict.
+    The dims and shape can also be specified using a `sizes` dict.
     Optionally can add default initialized variances.
     Only keyword arguments accepted.
 
@@ -106,18 +133,30 @@ def zeros(*,
     sizes:
         Optional, dimension label to size map.
     unit:
-        Optional, unit of contents. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=float64
+        Type of underlying data.
     with_variances:
-        Optional, boolean flag, if True includes variances
-        initialized to the default value for dtype.
-        For example for a float type values and variances would all be
-        initialized to 0.0. Default=False
+        If True includes variances initialized to 0.
 
     See Also
     --------
-    scipp.array, scipp.empty, scipp.index, scipp.ones, scipp.scalar
+    scipp.array, scipp.empty, scipp.ones, scipp.scalar, scipp.zeros_like
+
+    Examples
+    --------
+
+      >>> sc.zeros(dims=['x'], shape=[4])
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [0, 0, 0, 0]
+
+      >>> sc.zeros(sizes={'x': 4})
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [0, 0, 0, 0]
+
+      >>> sc.zeros(sizes={'y': 3}, with_variances=True)
+      <scipp.Variable> (y: 3)    float64  [dimensionless]  [0, 0, 0]  [0, 0, 0]
+
+      >>> sc.zeros(sizes={'z': 3}, unit='kg', dtype=int)
+      <scipp.Variable> (z: 3)      int64             [kg]  [0, 0, 0]
     """
 
     return _cpp.zeros(**_parse_dims_shape_sizes(dims, shape, sizes),
@@ -136,7 +175,7 @@ def ones(*,
     """Constructs a :class:`Variable` with values initialized to 1 with
     given dimension labels and shape.
 
-    The dims and shape can also be specified using a sizes dict.
+    The dims and shape can also be specified using a `sizes` dict.
 
     Parameters
     ----------
@@ -147,18 +186,30 @@ def ones(*,
     sizes:
         Optional, dimension label to size map.
     unit:
-        Optional, unit of contents. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=float64
+        Type of underlying data.
     with_variances:
-        Optional, boolean flag, if True includes variances
-        initialized to the default value for dtype.
-        For example for a float type values and variances would all be
-        initialized to 0.0. Default=False
+        If True includes variances initialized to 1.
 
     See Also
     --------
-    scipp.array, scipp.empty, scipp.index, scipp.scalar, scipp.zeros
+    scipp.array, scipp.empty, scipp.ones_like, scipp.scalar, scipp.zeros
+
+    Examples
+    --------
+
+      >>> sc.ones(dims=['x'], shape=[4])
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [1, 1, 1, 1]
+
+      >>> sc.ones(sizes={'x': 4})
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [1, 1, 1, 1]
+
+      >>> sc.ones(sizes={'y': 3}, with_variances=True)
+      <scipp.Variable> (y: 3)    float64  [dimensionless]  [1, 1, 1]  [1, 1, 1]
+
+      >>> sc.ones(sizes={'z': 3}, unit='kg', dtype=int)
+      <scipp.Variable> (z: 3)      int64             [kg]  [1, 1, 1]
     """
     return _cpp.ones(**_parse_dims_shape_sizes(dims, shape, sizes),
                      unit=unit,
@@ -176,8 +227,12 @@ def empty(*,
     """Constructs a :class:`Variable` with uninitialized values with given
     dimension labels and shape.
 
-    The dims and shape can also be specified using a sizes dict.
-    USE WITH CARE! Uninitialized means that values have undetermined values.
+    The dims and shape can also be specified using a `sizes` dict.
+
+    Warning
+    -------
+    'Uninitialized' means that values have undetermined values.
+    Reading elements before writing to them is undefined behavior.
     Consider using :py:func:`scipp.zeros` unless you
     know what you are doing and require maximum performance.
 
@@ -190,18 +245,23 @@ def empty(*,
     sizes:
         Optional, dimension label to size map.
     unit:
-        Optional, unit of contents. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=float64
+        Type of underlying data.
     with_variances:
-        Optional, boolean flag, if True includes variances
-        initialized to the default value for dtype.
-        For example for a float type values and variances would all be
-        initialized to 0.0. Default=False
+        If True includes uninitialized variances.
 
     See Also
     --------
-    scipp.array, scipp.index, scipp.ones, scipp.scalar, scipp.zeros
+    scipp.array, scipp.empty_like, scipp.ones, scipp.scalar, scipp.zeros
+
+    Examples
+    --------
+
+      >>> var = sc.empty(dims=['x'], shape=[4])
+      >>> var[:] = sc.scalar(2.0)  # initialize values before printing
+      >>> var
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [2, 2, 2, 2]
     """
     return _cpp.empty(**_parse_dims_shape_sizes(dims, shape, sizes),
                       unit=unit,
@@ -210,20 +270,24 @@ def empty(*,
 
 
 def full(*,
+         value: Any,
+         variance: Any = None,
          dims: Sequence[str] = None,
          shape: Sequence[int] = None,
          sizes: dict = None,
          unit: Union[Unit, str, None] = default_unit,
-         dtype: Optional[DTypeLike] = None,
-         value: Any,
-         variance: Any = None) -> Variable:
+         dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with values initialized to the specified
     value with given dimension labels and shape.
 
-    The dims and shape can also be specified using a sizes dict.
+    The dims and shape can also be specified using a `sizes` dict.
 
     Parameters
     ----------
+    value:
+        The value to fill the Variable with.
+    variance:
+        The variance to fill the Variable with.
     dims:
         Optional (if sizes is specified), dimension labels.
     shape:
@@ -231,15 +295,28 @@ def full(*,
     sizes:
         Optional, dimension label to size map.
     unit:
-        Optional, unit of contents. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=float64
-    value:
-        The value to fill the Variable with
+        Type of underlying data.
 
     See Also
     --------
-    scipp.empty, scipp.ones, scipp.zeros
+    scipp.empty, scipp.full_like, scipp.ones, scipp.zeros
+
+    Examples
+    --------
+
+      >>> sc.full(value=2, dims=['x'], shape=[2])
+      <scipp.Variable> (x: 2)      int64  [dimensionless]  [2, 2]
+
+      >>> sc.full(value=2, sizes={'x': 2})
+      <scipp.Variable> (x: 2)      int64  [dimensionless]  [2, 2]
+
+      >>> sc.full(value=5, sizes={'y': 3, 'x': 2})
+      <scipp.Variable> (y: 3, x: 2)      int64  [dimensionless]  [5, 5, ..., 5, 5]
+
+      >>> sc.full(value=2.0, variance=0.1, sizes={'x': 3}, unit='s')
+      <scipp.Variable> (x: 3)    float64              [s]  [2, 2, 2]  [0.1, 0.1, 0.1]
     """
     return scalar(value=value, variance=variance, unit=unit, dtype=dtype)\
         .broadcast(**_parse_dims_shape_sizes(dims, shape, sizes)).copy()
@@ -247,7 +324,7 @@ def full(*,
 
 def matrix(*,
            unit: Union[Unit, str, None] = default_unit,
-           value: Union[ndarray, list]) -> Variable:
+           value: Union[_np.ndarray, list]) -> Variable:
     """Constructs a zero dimensional :class:`Variable` holding a single 3x3
     matrix.
 
@@ -289,8 +366,8 @@ def matrices(*,
 
 
 def vector(*,
-           unit: Union[Unit, str, None] = default_unit,
-           value: Union[_np.ndarray, list]) -> Variable:
+           value: Union[_np.ndarray, list],
+           unit: Union[Unit, str, None] = default_unit) -> Variable:
     """Constructs a zero dimensional :class:`Variable` holding a single length-3
     vector.
 
@@ -299,7 +376,7 @@ def vector(*,
     value:
         Initial value, a list or 1-D numpy array.
     unit:
-        Optional, unit. Default=dimensionless
+        Unit of contents.
 
     Returns
     -------
@@ -309,14 +386,23 @@ def vector(*,
     See Also
     --------
     scipp.vectors
+
+    Examples
+    --------
+
+      >>> sc.vector(value=[1, 2, 3])
+      <scipp.Variable> ()    vector3  [dimensionless]  [(1, 2, 3)]
+
+      >>> sc.vector(value=[4, 5, 6], unit='m')
+      <scipp.Variable> ()    vector3              [m]  [(4, 5, 6)]
     """
     return _cpp.vectors(dims=[], unit=unit, values=value)
 
 
 def vectors(*,
             dims: Sequence[str],
-            unit: Union[Unit, str, None] = default_unit,
-            values: Union[_np.ndarray, list]) -> Variable:
+            values: Union[_np.ndarray, list],
+            unit: Union[Unit, str, None] = default_unit) -> Variable:
     """Constructs a :class:`Variable` with given dimensions holding an array
     of length-3 vectors.
 
@@ -327,11 +413,27 @@ def vectors(*,
     values:
         Initial values.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents.
 
     See Also
     --------
     scipp.vector
+
+    Examples
+    --------
+
+      >>> sc.vectors(dims=['x'], values=[[1, 2, 3]])
+      <scipp.Variable> (x: 1)    vector3  [dimensionless]  [(1, 2, 3)]
+
+      >>> var = sc.vectors(dims=['x'], values=[[1, 2, 3], [4, 5, 6]])
+      >>> var
+      <scipp.Variable> (x: 2)    vector3  [dimensionless]  [(1, 2, 3), (4, 5, 6)]
+      >>> var.values
+      array([[1., 2., 3.],
+             [4., 5., 6.]])
+
+      >>> sc.vectors(dims=['x'], values=[[1, 2, 3], [4, 5, 6]], unit='mm')
+      <scipp.Variable> (x: 2)    vector3             [mm]  [(1, 2, 3), (4, 5, 6)]
     """
     return _cpp.vectors(dims=dims, unit=unit, values=values)
 
@@ -344,6 +446,7 @@ def array(*,
           dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
+
     Only keyword arguments accepted.
 
     Parameters
@@ -353,17 +456,46 @@ def array(*,
     values:
         Initial values.
     variances:
-        Optional, initial variances, must be same shape
-        and size as values. Default=None
+        Initial variances, must be same shape and size as values.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Type of underlying data. By default, inferred from `values` argument.
 
     See Also
     --------
     scipp.empty, scipp.ones, scipp.scalar, scipp.zeros
+
+    Examples
+    --------
+
+      >>> sc.array(dims=['x'], values=[1, 2, 3])
+      <scipp.Variable> (x: 3)      int64  [dimensionless]  [1, 2, 3]
+
+    Multiple dimensions:
+
+      >>> sc.array(dims=['x', 'y'], values=[[1, 2, 3], [4, 5, 6]])
+      <scipp.Variable> (x: 2, y: 3)      int64  [dimensionless]  [1, 2, ..., 5, 6]
+
+    DType upcasting:
+
+      >>> sc.array(dims=['x'], values=[1, 2, 3.0])
+      <scipp.Variable> (x: 3)    float64  [dimensionless]  [1, 2, 3]
+
+    Manually specified dtype:
+
+      >>> sc.array(dims=['x'], values=[1, 2, 3], dtype=float)
+      <scipp.Variable> (x: 3)    float64  [dimensionless]  [1, 2, 3]
+
+    Set unit:
+
+      >>> sc.array(dims=['x'], values=[1, 2, 3], unit='m')
+      <scipp.Variable> (x: 3)      int64              [m]  [1, 2, 3]
+
+    Setting variances:
+
+      >>> sc.array(dims=['x'], values=[1.0, 2.0, 3.0], variances=[0.1, 0.2, 0.3])
+      <scipp.Variable> (x: 3)    float64  [dimensionless]  [1, 2, 3]  [0.1, 0.2, 0.3]
     """
     return _cpp.Variable(dims=dims,
                          values=values,
@@ -438,14 +570,24 @@ def linspace(dim: str,
         If True, `step` is the last returned value.
         Otherwise, it is not included.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Type of underlying data. By default, inferred from `value` argument.
 
     See Also
     --------
     scipp.arange, scipp.geomspace, scipp.logspace
+
+    Examples
+    --------
+
+      >>> sc.linspace('x', 2.0, 4.0, num=4)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [2, 2.66667, 3.33333, 4]
+      >>> sc.linspace('x', 2.0, 4.0, num=4, endpoint=False)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [2, 2.5, 3, 3.5]
+
+      >>> sc.linspace('x', 1.5, 3.0, num=4, unit='m')
+      <scipp.Variable> (x: 4)    float64              [m]  [1.5, 2, 2.5, 3]
     """
     range_args, unit = _normalize_range_args(unit=unit, start=start, stop=stop)
     return array(dims=[dim],
@@ -483,14 +625,24 @@ def geomspace(dim: str,
         If True, `step` is the last returned value.
         Otherwise, it is not included.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Type of underlying data. By default, inferred from `value` argument.
 
     See Also
     --------
     scipp.arange, scipp.linspace, scipp.logspace
+
+    Examples
+    --------
+
+      >>> sc.geomspace('x', 1.0, 1000.0, num=4)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [1, 10, 100, 1000]
+      >>> sc.geomspace('x', 1.0, 1000.0, num=4, endpoint=False)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [1, 5.62341, 31.6228, 177.828]
+
+      >>> sc.geomspace('x', 1.0, 100.0, num=3, unit='s')
+      <scipp.Variable> (x: 3)    float64              [s]  [1, 10, 100]
     """
     range_args, unit = _normalize_range_args(unit=unit, start=start, stop=stop)
     return array(dims=[dim],
@@ -529,14 +681,31 @@ def logspace(dim: str,
         If True, `step` is the last returned value.
         Otherwise, it is not included.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Type of underlying data. By default, inferred from `value` argument.
 
     See Also
     --------
     scipp.arange, scipp.geomspace, scipp.linspace
+
+    Examples
+    --------
+
+      >>> sc.logspace('x', 1, 4, num=4)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [10, 100, 1000, 10000]
+      >>> sc.logspace('x', 1, 4, num=4, endpoint=False)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [10, 56.2341, 316.228, 1778.28]
+
+    Set a different base:
+
+      >>> sc.logspace('x', 1, 4, num=4, base=2)
+      <scipp.Variable> (x: 4)    float64  [dimensionless]  [2, 4, 8, 16]
+
+    Set a unit:
+
+      >>> sc.logspace('x', 1, 3, num=3, unit='m')
+      <scipp.Variable> (x: 3)    float64              [m]  [10, 100, 1000]
     """
     # Passing unit='one' enforces that start and stop are dimensionless.
     range_args, _ = _normalize_range_args(unit='one', start=start, stop=stop)
@@ -561,6 +730,11 @@ def arange(dim: str,
     Values are generated within the half-open interval [start, stop)
     (in other words, the interval including start but excluding stop).
 
+    Warning
+    -------
+    The length of the output might not be numerically stable.
+    See :func:`numpy.arange`.
+
     Parameters
     ----------
     dim:
@@ -569,19 +743,29 @@ def arange(dim: str,
         Optional, the starting value of the sequence. Default=0.
     stop:
         End of interval. The interval does not include this value,
-        except in some (rare) cases where step is not an integer and floating-
-        point round-off can come into play.
+        except in some (rare) cases where step is not an integer and
+        floating-point round-off can come into play.
     step:
-        Optional, spacing between values. Default=1.
+        Spacing between values.
     unit:
-        Optional, data unit. Default=dimensionless
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
-        Optional, type of underlying data. Default=None,
-        in which case type is inferred from value input.
+        Type of underlying data. By default, inferred from `value` argument.
 
     See Also
     --------
     scipp.geomspace, scipp.linspace, scipp.logspace
+
+    Examples
+    --------
+
+      >>> sc.arange('x', 1, 5)
+      <scipp.Variable> (x: 4)      int64  [dimensionless]  [1, 2, 3, 4]
+      >>> sc.arange('x', 1, 5, 0.5)
+      <scipp.Variable> (x: 8)    float64  [dimensionless]  [1, 1.5, ..., 4, 4.5]
+
+      >>> sc.arange('x', 1, 5, unit='m')
+      <scipp.Variable> (x: 4)      int64              [m]  [1, 2, 3, 4]
     """
     range_args, unit = _normalize_range_args(unit=unit,
                                              start=start,

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -6,11 +6,10 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable as _Iterable
-from typing import Any, Optional, Sequence, TypeVar, Union
+from typing import Any, Iterable, Optional, Sequence, TypeVar, Union
 
 import numpy as _np
-from numpy.typing import ArrayLike as array_like
+from numpy.typing import ArrayLike
 
 from .._scipp import core as _cpp
 from .cpp_classes import DType, Unit, Variable
@@ -439,9 +438,9 @@ def vectors(*,
 
 
 def array(*,
-          dims: _Iterable[str],
-          values: array_like,
-          variances: Optional[array_like] = None,
+          dims: Iterable[str],
+          values: ArrayLike,
+          variances: Optional[ArrayLike] = None,
           unit: Union[Unit, str, None] = default_unit,
           dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
@@ -814,7 +813,7 @@ def datetime(value: Union[str, int, _np.datetime64],
 
 def datetimes(*,
               dims,
-              values: array_like,
+              values: ArrayLike,
               unit: Optional[Union[Unit, str, None]] = default_unit) -> Variable:
     """Constructs an array :class:`Variable` with a dtype of datetime64.
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -457,7 +457,7 @@ def array(*,
     variances: numpy.typing.ArrayLike
         Initial variances, must be same shape and size as values.
     unit:
-        Unit of contents
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
         Type of underlying data. By default, inferred from `values` argument.
 
@@ -569,7 +569,7 @@ def linspace(dim: str,
         If True, `step` is the last returned value.
         Otherwise, it is not included.
     unit:
-        Unit of contents
+        Unit of contents.
     dtype: scipp.typing.DTypeLike
         Type of underlying data. By default, inferred from `value` argument.
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -290,6 +290,16 @@ def array(*,
                          dtype=dtype)
 
 
+def _expect_no_variances(args):
+    has_variances = [
+        key for key, val in args.items()
+        if val is not None and val.variances is not None
+    ]
+    if has_variances:
+        raise _cpp.VariancesError('Arguments cannot have variances. '
+                                  f'Passed variances in {has_variances}')
+
+
 # Assumes that all arguments are Variable or None.
 def _ensure_same_unit(*, unit, args: dict):
     if unit == default_unit:
@@ -316,6 +326,7 @@ def _normalize_range_args(*, unit, **kwargs):
             arg_types = {key: type(val) for key, val in kwargs.items()}
             raise TypeError('Either all of the following arguments or none have to '
                             f'be variables: {arg_types}')
+        _expect_no_variances(kwargs)
         return _ensure_same_unit(unit=unit, args=kwargs)
     return kwargs, unit
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -352,8 +352,8 @@ def linspace(dim: str,
 
 
 def geomspace(dim: str,
-              start: Union[int, float],
-              stop: Union[int, float],
+              start: NumberOrVar,
+              stop: NumberOrVar,
               num: int,
               *,
               endpoint: bool = True,
@@ -379,15 +379,16 @@ def geomspace(dim: str,
     :seealso: :py:func:`scipp.linspace` :py:func:`scipp.logspace`
               :py:func:`scipp.arange` :py:func:`numpy.geomspace`
     """
+    range_args, unit = _normalize_range_args(unit=unit, start=start, stop=stop)
     return array(dims=[dim],
-                 values=_np.geomspace(start, stop, num, endpoint=endpoint),
+                 values=_np.geomspace(**range_args, num=num, endpoint=endpoint),
                  unit=unit,
                  dtype=dtype)
 
 
 def logspace(dim: str,
-             start: Union[int, float],
-             stop: Union[int, float],
+             start: NumberOrVar,
+             stop: NumberOrVar,
              num: int,
              *,
              endpoint: bool = True,
@@ -413,8 +414,13 @@ def logspace(dim: str,
     :seealso: :py:func:`scipp.linspace` :py:func:`scipp.geomspace`
               :py:func:`scipp.arange` :py:func:`numpy.logspace`
     """
+    # Passing unit='one' enforces that start and stop are dimensionless.
+    range_args, _ = _normalize_range_args(unit='one', start=start, stop=stop)
     return array(dims=[dim],
-                 values=_np.logspace(start, stop, num, base=base, endpoint=endpoint),
+                 values=_np.logspace(**range_args,
+                                     num=num,
+                                     base=base,
+                                     endpoint=endpoint),
                  unit=unit,
                  dtype=dtype)
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -16,12 +16,13 @@ from .._scipp import core as _cpp
 from .cpp_classes import DType, Unit, Variable
 from ..units import default_unit
 from ._sizes import _parse_dims_shape_sizes
+from ..typing import DTypeLike
 
 
 def scalar(value: Any,
            variance: Any = None,
            unit: Union[Unit, str, None] = default_unit,
-           dtype: DType = None) -> Variable:
+           dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
@@ -45,7 +46,7 @@ def scalar(value: Any,
                          dtype=dtype)
 
 
-def index(value: Any, dtype: DType = None) -> Variable:
+def index(value: Any, dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` representing an index.
 
     This is equivalent to calling :py:func:`scipp.scalar` with unit=None.
@@ -63,7 +64,7 @@ def zeros(*,
           shape: Sequence[int] = None,
           sizes: dict = None,
           unit: Union[Unit, str, None] = default_unit,
-          dtype: DType = DType.float64,
+          dtype: DTypeLike = DType.float64,
           with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with default initialized values with
     given dimension labels and shape.
@@ -97,7 +98,7 @@ def ones(*,
          shape: Sequence[int] = None,
          sizes: dict = None,
          unit: Union[Unit, str, None] = default_unit,
-         dtype: DType = DType.float64,
+         dtype: DTypeLike = DType.float64,
          with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with values initialized to 1 with
     given dimension labels and shape.
@@ -126,7 +127,7 @@ def empty(*,
           shape: Sequence[int] = None,
           sizes: dict = None,
           unit: Union[Unit, str, None] = default_unit,
-          dtype: DType = DType.float64,
+          dtype: DTypeLike = DType.float64,
           with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with uninitialized values with given
     dimension labels and shape.
@@ -158,7 +159,7 @@ def full(*,
          shape: Sequence[int] = None,
          sizes: dict = None,
          unit: Union[Unit, str, None] = default_unit,
-         dtype: DType = None,
+         dtype: Optional[DTypeLike] = None,
          value: Any,
          variance: Any = None) -> Variable:
     """
@@ -263,7 +264,7 @@ def array(*,
           values: array_like,
           variances: Optional[array_like] = None,
           unit: Union[Unit, str, None] = default_unit,
-          dtype: DType = None) -> Variable:
+          dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
@@ -294,7 +295,7 @@ def linspace(dim: str,
              *,
              endpoint: bool = True,
              unit: Union[Unit, str, None] = default_unit,
-             dtype: DType = None) -> Variable:
+             dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with `num` evenly spaced samples,
     calculated over the interval `[start, stop]`.
 
@@ -324,7 +325,7 @@ def geomspace(dim: str,
               *,
               endpoint: bool = True,
               unit: Union[Unit, str, None] = default_unit,
-              dtype: DType = None) -> Variable:
+              dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale
     (a geometric progression).
 
@@ -359,7 +360,7 @@ def logspace(dim: str,
              endpoint: bool = True,
              base: Union[int, float] = 10.0,
              unit: Union[Unit, str, None] = default_unit,
-             dtype: DType = None) -> Variable:
+             dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale.
 
     This is similar to :py:func:`scipp.geomspace`, but with endpoints specified
@@ -417,7 +418,7 @@ def arange(dim: str,
            step: Union[int, float] = None,
            *,
            unit: Union[Unit, str, None] = default_unit,
-           dtype: DType = None) -> Variable:
+           dtype: Optional[DTypeLike] = None) -> Variable:
     """Constructs a :class:`Variable` with evenly spaced values within a given
     interval.
     Values are generated within the half-open interval [start, stop)

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -260,7 +260,7 @@ def vectors(*,
 
 
 def array(*,
-          dims: _Iterable,
+          dims: _Iterable[str],
           values: array_like,
           variances: Optional[array_like] = None,
           unit: Union[Unit, str, None] = default_unit,

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -28,18 +28,28 @@ def scalar(value: Any,
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
+    Parameters
+    ----------
+    value:
+        Initial value.
+    variance:
+        Optional, initial variance, Default=None
+    unit:
+        Optional, unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
+        Cannot be specified for value types of
+        str, Dataset or DataArray.
 
-    :param value: Initial value.
-    :param variance: Optional, initial variance, Default=None
-    :param unit: Optional, unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
-      Cannot be specified for value types of
-      str, Dataset or DataArray.
-    :returns: A scalar (zero-dimensional) Variable.
+    Returns
+    -------
+    :
+        A scalar (zero-dimensional) Variable.
 
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
-              :py:func:`scipp.empty` :py:func:`scipp.array`
+    See Also
+    --------
+    scipp.array, scipp.empty, scipp.index, scipp.ones, scipp.zeros
     """
     return _cpp.Variable(dims=(),
                          values=value,
@@ -53,10 +63,22 @@ def index(value: Any, dtype: Optional[DTypeLike] = None) -> Variable:
 
     This is equivalent to calling :py:func:`scipp.scalar` with unit=None.
 
-    :param value: Initial value.
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
-    :returns: A scalar (zero-dimensional) variable without unit.
+    Parameters
+    ----------
+    value:
+        Initial value.
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
+
+    Returns
+    -------
+    :
+        A scalar (zero-dimensional) variable without unit.
+
+    See Also
+    --------
+    scipp.scalar, scipp.array
     """
     return scalar(value=value, dtype=dtype, unit=None)
 
@@ -70,23 +92,32 @@ def zeros(*,
           with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with default initialized values with
     given dimension labels and shape.
+
     The dims and shape can also be specified using a sizes dict.
     Optionally can add default initialized variances.
     Only keyword arguments accepted.
 
+    Parameters
+    ----------
+    dims:
+        Optional (if sizes is specified), dimension labels.
+    shape:
+        Optional (if sizes is specified), dimension sizes.
+    sizes:
+        Optional, dimension label to size map.
+    unit:
+        Optional, unit of contents. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=float64
+    with_variances:
+        Optional, boolean flag, if True includes variances
+        initialized to the default value for dtype.
+        For example for a float type values and variances would all be
+        initialized to 0.0. Default=False
 
-    :param dims: Optional (if sizes is specified), dimension labels.
-    :param shape: Optional (if sizes is specified), dimension sizes.
-    :param sizes: Optional, dimension label to size map.
-    :param unit: Optional, unit of contents. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=float64
-    :param with_variances: Optional, boolean flag, if True includes variances
-      initialized to the default value for dtype.
-      For example for a float type values and variances would all be
-      initialized to 0.0. Default=False
-
-    :seealso: :py:func:`scipp.ones` :py:func:`scipp.empty`
-              :py:func:`scipp.scalar` :py:func:`scipp.array`
+    See Also
+    --------
+    scipp.array, scipp.empty, scipp.index, scipp.ones, scipp.scalar
     """
 
     return _cpp.zeros(**_parse_dims_shape_sizes(dims, shape, sizes),
@@ -104,19 +135,30 @@ def ones(*,
          with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with values initialized to 1 with
     given dimension labels and shape.
+
     The dims and shape can also be specified using a sizes dict.
 
+    Parameters
+    ----------
+    dims:
+        Optional (if sizes is specified), dimension labels.
+    shape:
+        Optional (if sizes is specified), dimension sizes.
+    sizes:
+        Optional, dimension label to size map.
+    unit:
+        Optional, unit of contents. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=float64
+    with_variances:
+        Optional, boolean flag, if True includes variances
+        initialized to the default value for dtype.
+        For example for a float type values and variances would all be
+        initialized to 0.0. Default=False
 
-    :param dims: Optional (if sizes is specified), dimension labels.
-    :param shape: Optional (if sizes is specified), dimension sizes.
-    :param sizes: Optional, dimension label to size map.
-    :param unit: Optional, unit of contents. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=float64
-    :param with_variances: Optional, boolean flag, if True includes variances
-                      initialized to 1. Default=False
-
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.empty`
-              :py:func:`scipp.scalar` :py:func:`scipp.array`
+    See Also
+    --------
+    scipp.array, scipp.empty, scipp.index, scipp.scalar, scipp.zeros
     """
     return _cpp.ones(**_parse_dims_shape_sizes(dims, shape, sizes),
                      unit=unit,
@@ -133,22 +175,33 @@ def empty(*,
           with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with uninitialized values with given
     dimension labels and shape.
+
     The dims and shape can also be specified using a sizes dict.
     USE WITH CARE! Uninitialized means that values have undetermined values.
     Consider using :py:func:`scipp.zeros` unless you
     know what you are doing and require maximum performance.
 
+    Parameters
+    ----------
+    dims:
+        Optional (if sizes is specified), dimension labels.
+    shape:
+        Optional (if sizes is specified), dimension sizes.
+    sizes:
+        Optional, dimension label to size map.
+    unit:
+        Optional, unit of contents. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=float64
+    with_variances:
+        Optional, boolean flag, if True includes variances
+        initialized to the default value for dtype.
+        For example for a float type values and variances would all be
+        initialized to 0.0. Default=False
 
-    :param dims: Optional (if sizes is specified), dimension labels.
-    :param shape: Optional (if sizes is specified), dimension sizes.
-    :param sizes: Optional, dimension label to size map.
-    :param unit: Optional, unit of contents. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=float64
-    :param with_variances: Optional, boolean flag, if True includes
-                    uninitialized variances. Default=False
-
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
-              :py:func:`scipp.scalar` :py:func:`scipp.array`
+    See Also
+    --------
+    scipp.array, scipp.index, scipp.ones, scipp.scalar, scipp.zeros
     """
     return _cpp.empty(**_parse_dims_shape_sizes(dims, shape, sizes),
                       unit=unit,
@@ -164,22 +217,29 @@ def full(*,
          dtype: Optional[DTypeLike] = None,
          value: Any,
          variance: Any = None) -> Variable:
-    """
-    Constructs a :class:`Variable` with values initialized to the specified
+    """Constructs a :class:`Variable` with values initialized to the specified
     value with given dimension labels and shape.
+
     The dims and shape can also be specified using a sizes dict.
 
+    Parameters
+    ----------
+    dims:
+        Optional (if sizes is specified), dimension labels.
+    shape:
+        Optional (if sizes is specified), dimension sizes.
+    sizes:
+        Optional, dimension label to size map.
+    unit:
+        Optional, unit of contents. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=float64
+    value:
+        The value to fill the Variable with
 
-    :param dims: Optional (if sizes is specified), dimension labels.
-    :param shape: Optional (if sizes is specified), dimension sizes.
-    :param sizes: Optional, dimension label to size map.
-    :param unit: Optional, unit of contents. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Deduced from 'value' if not given.
-    :param value: The value to fill the Variable with
-    :param variance: Optional, the variance to fill the Variable with. If None
-        or not provided, the variances will not be set.
-
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
+    See Also
+    --------
+    scipp.empty, scipp.ones, scipp.zeros
     """
     return scalar(value=value, variance=variance, unit=unit, dtype=dtype)\
         .broadcast(**_parse_dims_shape_sizes(dims, shape, sizes)).copy()
@@ -234,12 +294,21 @@ def vector(*,
     """Constructs a zero dimensional :class:`Variable` holding a single length-3
     vector.
 
+    Parameters
+    ----------
+    value:
+        Initial value, a list or 1-D numpy array.
+    unit:
+        Optional, unit. Default=dimensionless
 
-    :param value: Initial value, a list or 1-D numpy array.
-    :param unit: Optional, unit. Default=dimensionless
-    :returns: A scalar (zero-dimensional) Variable.
+    Returns
+    -------
+    :
+        A scalar (zero-dimensional) Variable.
 
-    :seealso: :py:func:`scipp.vectors`
+    See Also
+    --------
+    scipp.vectors
     """
     return _cpp.vectors(dims=[], unit=unit, values=value)
 
@@ -251,12 +320,18 @@ def vectors(*,
     """Constructs a :class:`Variable` with given dimensions holding an array
     of length-3 vectors.
 
+    Parameters
+    ----------
+    dims:
+        Dimension labels.
+    values:
+        Initial values.
+    unit:
+        Optional, data unit. Default=dimensionless
 
-    :param dims: Dimension labels.
-    :param values: Initial values.
-    :param unit: Optional, data unit. Default=dimensionless
-
-    :seealso: :py:func:`scipp.vector`
+    See Also
+    --------
+    scipp.vector
     """
     return _cpp.vectors(dims=dims, unit=unit, values=values)
 
@@ -271,17 +346,24 @@ def array(*,
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
 
+    Parameters
+    ----------
+    dims:
+        Dimension labels
+    values:
+        Initial values.
+    variances:
+        Optional, initial variances, must be same shape
+        and size as values. Default=None
+    unit:
+        Optional, data unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
 
-    :param dims: Dimension labels
-    :param values: Initial values.
-    :param variances: Optional, initial variances, must be same shape
-      and size as values. Default=None
-    :param unit: Optional, data unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
-
-    :seealso: :py:func:`scipp.zeros` :py:func:`scipp.ones`
-              :py:func:`scipp.empty` :py:func:`scipp.scalar`
+    See Also
+    --------
+    scipp.empty, scipp.ones, scipp.scalar, scipp.zeros
     """
     return _cpp.Variable(dims=dims,
                          values=values,
@@ -342,18 +424,28 @@ def linspace(dim: str,
     """Constructs a :class:`Variable` with `num` evenly spaced samples,
     calculated over the interval `[start, stop]`.
 
-    :param dim: Dimension label.
-    :param start: The starting value of the sequence.
-    :param stop: The end value of the sequence.
-    :param num: Number of samples to generate.
-    :param endpoint: If True, `step` is the last returned value.
-                     Otherwise, it is not included.
-    :param unit: Optional, data unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
+    Parameters
+    ----------
+    dim:
+        Dimension label.
+    start:
+        The starting value of the sequence.
+    stop:
+        The end value of the sequence.
+    num:
+        Number of samples to generate.
+    endpoint:
+        If True, `step` is the last returned value.
+        Otherwise, it is not included.
+    unit:
+        Optional, data unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
 
-    :seealso: :py:func:`scipp.geomspace` :py:func:`scipp.logspace`
-              :py:func:`scipp.arange`
+    See Also
+    --------
+    scipp.arange, scipp.geomspace, scipp.logspace
     """
     range_args, unit = _normalize_range_args(unit=unit, start=start, stop=stop)
     return array(dims=[dim],
@@ -377,18 +469,28 @@ def geomspace(dim: str,
     directly instead of as exponents.
     Each output sample is a constant multiple of the previous.
 
-    :param dim: Dimension label.
-    :param start: The starting value of the sequence.
-    :param stop: The end value of the sequence.
-    :param num: Number of samples to generate.
-    :param endpoint: If True, `step` is the last returned value.
-                     Otherwise, it is not included.
-    :param unit: Optional, data unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
+    Parameters
+    ----------
+    dim:
+        Dimension label.
+    start:
+        The starting value of the sequence.
+    stop:
+        The end value of the sequence.
+    num:
+        Number of samples to generate.
+    endpoint:
+        If True, `step` is the last returned value.
+        Otherwise, it is not included.
+    unit:
+        Optional, data unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
 
-    :seealso: :py:func:`scipp.linspace` :py:func:`scipp.logspace`
-              :py:func:`scipp.arange` :py:func:`numpy.geomspace`
+    See Also
+    --------
+    scipp.arange, scipp.linspace, scipp.logspace
     """
     range_args, unit = _normalize_range_args(unit=unit, start=start, stop=stop)
     return array(dims=[dim],
@@ -411,19 +513,30 @@ def logspace(dim: str,
     This is similar to :py:func:`scipp.geomspace`, but with endpoints specified
     as exponents.
 
-    :param dim: Dimension label.
-    :param start: ``base ** start`` is the starting value of the sequence.
-    :param stop: ``base ** end`` is the end value of the sequence.
-    :param num: Number of samples to generate.
-    :param base: The base of the log space.
-    :param endpoint: If True, `step` is the last returned value.
-                     Otherwise, it is not included.
-    :param unit: Optional, data unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
+    Parameters
+    ----------
+    dim:
+        Dimension label.
+    start:
+        The starting value of the sequence.
+    stop:
+        The end value of the sequence.
+    num:
+        Number of samples to generate.
+    base:
+        The base of the log space.
+    endpoint:
+        If True, `step` is the last returned value.
+        Otherwise, it is not included.
+    unit:
+        Optional, data unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
 
-    :seealso: :py:func:`scipp.linspace` :py:func:`scipp.geomspace`
-              :py:func:`scipp.arange` :py:func:`numpy.logspace`
+    See Also
+    --------
+    scipp.arange, scipp.geomspace, scipp.linspace
     """
     # Passing unit='one' enforces that start and stop are dimensionless.
     range_args, _ = _normalize_range_args(unit='one', start=start, stop=stop)
@@ -448,18 +561,27 @@ def arange(dim: str,
     Values are generated within the half-open interval [start, stop)
     (in other words, the interval including start but excluding stop).
 
-    :param dim: Dimension label.
-    :param start: Optional, the starting value of the sequence. Default=0.
-    :param stop: End of interval. The interval does not include this value,
-      except in some (rare) cases where step is not an integer and floating-
-      point round-off can come into play.
-    :param step: Optional, spacing between values. Default=1.
-    :param unit: Optional, data unit. Default=dimensionless
-    :param dtype: Optional, type of underlying data. Default=None,
-      in which case type is inferred from value input.
+    Parameters
+    ----------
+    dim:
+        Dimension label.
+    start:
+        Optional, the starting value of the sequence. Default=0.
+    stop:
+        End of interval. The interval does not include this value,
+        except in some (rare) cases where step is not an integer and floating-
+        point round-off can come into play.
+    step:
+        Optional, spacing between values. Default=1.
+    unit:
+        Optional, data unit. Default=dimensionless
+    dtype: scipp.typing.DTypeLike
+        Optional, type of underlying data. Default=None,
+        in which case type is inferred from value input.
 
-    :seealso: :py:func:`scipp.linspace` :py:func:`scipp.geomspace`
-              :py:func:`scipp.logspace`
+    See Also
+    --------
+    scipp.geomspace, scipp.linspace, scipp.logspace
     """
     range_args, unit = _normalize_range_args(unit=unit,
                                              start=start,
@@ -473,19 +595,26 @@ def datetime(value: Union[str, int, _np.datetime64],
              unit: Optional[Union[Unit, str, None]] = default_unit) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a dtype of datetime64.
 
-    :param value:
+    Parameters
+    ----------
+    value:
      - `str`: Interpret the string according to the ISO 8601 date time format.
      - `int`: Number of time units (see argument ``unit``) since scipp's epoch
               (see :py:func:`scipp.epoch`).
      - `np.datetime64`: Construct equivalent datetime of scipp.
-    :param unit: Unit of the resulting datetime.
+    unit: Unit of the resulting datetime.
                  Can be deduced if ``value`` is a str or np.datetime64 but
                  is required if it is an int.
 
-    :seealso: :py:func:`scipp.datetimes` :py:func:`scipp.epoch`
-              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+    See Also
+    --------
+    scipp.datetimes:
+    scipp.epoch:
+    Details in:
+        'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
 
-    Examples:
+    Examples
+    --------
 
       >>> sc.datetime('2021-01-10T14:16:15')
       <scipp.Variable> ()  datetime64              [s]  [2021-01-10T14:16:15]
@@ -505,16 +634,26 @@ def datetimes(*,
               unit: Optional[Union[Unit, str, None]] = default_unit) -> Variable:
     """Constructs an array :class:`Variable` with a dtype of datetime64.
 
-    :param dims: Dimension labels
-    :param values: Numpy array or something that can be converted to a
-                   Numpy array of datetimes.
-    :param unit: Unit for the resulting Variable.
-                 Can be deduced if ``values`` contains strings or np.datetime64's.
+    Parameters
+    ----------
+    dims:
+        Dimension labels
+    values:
+        Numpy array or something that can be converted to a
+        Numpy array of datetimes.
+    unit:
+        Unit for the resulting Variable.
+        Can be deduced if ``values`` contains strings or np.datetime64's.
 
-    :seealso: :py:func:`scipp.datetime` :py:func:`scipp.epoch`
-              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+    See Also
+    --------
+    scipp.datetime:
+    scipp.epoch:
+    Details in:
+        'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
 
-    Examples:
+    Examples
+    --------
 
       >>> sc.datetimes(dims=['t'], values=['2021-01-10T01:23:45', '2021-01-11T01:23:45'])
       <scipp.Variable> (t: 2)  datetime64              [s]  [2021-01-10T01:23:45, 2021-01-11T01:23:45]
@@ -537,12 +676,20 @@ def epoch(*, unit: Union[Unit, str]) -> Variable:
 
     Currently, the epoch of datetimes in scipp is the Unix epoch 1970-01-01T00:00:00.
 
-    :param unit: Unit of the resulting Variable.
+    Parameters
+    ----------
+    unit:
+        Unit of the resulting Variable.
 
-    :seealso: :py:func:`scipp.datetime` :py:func:`scipp.datetimes`
-              'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
+    See Also
+    --------
+    scipp.datetime:
+    scipp.datetimes:
+    Details in:
+        'Dates and Times' section in `Data Types <../../reference/dtype.rst>`_
 
-    Examples:
+    Examples
+    --------
 
       >>> sc.epoch(unit='s')
       <scipp.Variable> ()  datetime64              [s]  [1970-01-01T00:00:00]

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -13,14 +13,15 @@ import numpy as _np
 from numpy.typing import ArrayLike as array_like
 
 from .._scipp import core as _cpp
+from .cpp_classes import DType, Unit, Variable
 from ..units import default_unit
 from ._sizes import _parse_dims_shape_sizes
 
 
 def scalar(value: Any,
            variance: Any = None,
-           unit: Union[_cpp.Unit, str, None] = default_unit,
-           dtype: _cpp.DType = None) -> _cpp.Variable:
+           unit: Union[Unit, str, None] = default_unit,
+           dtype: DType = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
 
@@ -44,7 +45,7 @@ def scalar(value: Any,
                          dtype=dtype)
 
 
-def index(value: Any, dtype: _cpp.DType = None) -> _cpp.Variable:
+def index(value: Any, dtype: DType = None) -> Variable:
     """Constructs a zero dimensional :class:`Variable` representing an index.
 
     This is equivalent to calling :py:func:`scipp.scalar` with unit=None.
@@ -61,9 +62,9 @@ def zeros(*,
           dims: Sequence[str] = None,
           shape: Sequence[int] = None,
           sizes: dict = None,
-          unit: Union[_cpp.Unit, str, None] = default_unit,
-          dtype: _cpp.DType = _cpp.DType.float64,
-          with_variances: bool = False) -> _cpp.Variable:
+          unit: Union[Unit, str, None] = default_unit,
+          dtype: DType = DType.float64,
+          with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with default initialized values with
     given dimension labels and shape.
     The dims and shape can also be specified using a sizes dict.
@@ -95,9 +96,9 @@ def ones(*,
          dims: Sequence[str] = None,
          shape: Sequence[int] = None,
          sizes: dict = None,
-         unit: Union[_cpp.Unit, str, None] = default_unit,
-         dtype: _cpp.DType = _cpp.DType.float64,
-         with_variances: bool = False) -> _cpp.Variable:
+         unit: Union[Unit, str, None] = default_unit,
+         dtype: DType = DType.float64,
+         with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with values initialized to 1 with
     given dimension labels and shape.
     The dims and shape can also be specified using a sizes dict.
@@ -124,9 +125,9 @@ def empty(*,
           dims: Sequence[str] = None,
           shape: Sequence[int] = None,
           sizes: dict = None,
-          unit: Union[_cpp.Unit, str, None] = default_unit,
-          dtype: _cpp.DType = _cpp.DType.float64,
-          with_variances: bool = False) -> _cpp.Variable:
+          unit: Union[Unit, str, None] = default_unit,
+          dtype: DType = DType.float64,
+          with_variances: bool = False) -> Variable:
     """Constructs a :class:`Variable` with uninitialized values with given
     dimension labels and shape.
     The dims and shape can also be specified using a sizes dict.
@@ -156,10 +157,10 @@ def full(*,
          dims: Sequence[str] = None,
          shape: Sequence[int] = None,
          sizes: dict = None,
-         unit: Union[_cpp.Unit, str, None] = default_unit,
-         dtype: _cpp.DType = None,
+         unit: Union[Unit, str, None] = default_unit,
+         dtype: DType = None,
          value: Any,
-         variance: Any = None) -> _cpp.Variable:
+         variance: Any = None) -> Variable:
     """
     Constructs a :class:`Variable` with values initialized to the specified
     value with given dimension labels and shape.
@@ -182,8 +183,8 @@ def full(*,
 
 
 def matrix(*,
-           unit: Union[_cpp.Unit, str, None] = default_unit,
-           value: Union[_np.ndarray, list]):
+           unit: Union[Unit, str, None] = default_unit,
+           value: Union[ndarray, list]) -> Variable:
     """Constructs a zero dimensional :class:`Variable` holding a single 3x3
     matrix.
 
@@ -204,8 +205,8 @@ def matrix(*,
 
 def matrices(*,
              dims: Sequence[str],
-             unit: Union[_cpp.Unit, str, None] = default_unit,
-             values: Union[_np.ndarray, list]):
+             unit: Union[Unit, str, None] = default_unit,
+             values: Union[_np.ndarray, list]) -> Variable:
     """Constructs a :class:`Variable` with given dimensions holding an array
     of 3x3 matrices.
 
@@ -225,8 +226,8 @@ def matrices(*,
 
 
 def vector(*,
-           unit: Union[_cpp.Unit, str, None] = default_unit,
-           value: Union[_np.ndarray, list]):
+           unit: Union[Unit, str, None] = default_unit,
+           value: Union[_np.ndarray, list]) -> Variable:
     """Constructs a zero dimensional :class:`Variable` holding a single length-3
     vector.
 
@@ -242,8 +243,8 @@ def vector(*,
 
 def vectors(*,
             dims: Sequence[str],
-            unit: Union[_cpp.Unit, str, None] = default_unit,
-            values: Union[_np.ndarray, list]):
+            unit: Union[Unit, str, None] = default_unit,
+            values: Union[_np.ndarray, list]) -> Variable:
     """Constructs a :class:`Variable` with given dimensions holding an array
     of length-3 vectors.
 
@@ -261,8 +262,8 @@ def array(*,
           dims: _Iterable,
           values: array_like,
           variances: Optional[array_like] = None,
-          unit: Union[_cpp.Unit, str, None] = default_unit,
-          dtype: _cpp.DType = None) -> _cpp.Variable:
+          unit: Union[Unit, str, None] = default_unit,
+          dtype: DType = None) -> Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
     Only keyword arguments accepted.
@@ -292,8 +293,8 @@ def linspace(dim: str,
              num: int,
              *,
              endpoint: bool = True,
-             unit: Union[_cpp.Unit, str, None] = default_unit,
-             dtype: _cpp.DType = None) -> _cpp.Variable:
+             unit: Union[Unit, str, None] = default_unit,
+             dtype: DType = None) -> Variable:
     """Constructs a :class:`Variable` with `num` evenly spaced samples,
     calculated over the interval `[start, stop]`.
 
@@ -322,8 +323,8 @@ def geomspace(dim: str,
               num: int,
               *,
               endpoint: bool = True,
-              unit: Union[_cpp.Unit, str, None] = default_unit,
-              dtype: _cpp.DType = None) -> _cpp.Variable:
+              unit: Union[Unit, str, None] = default_unit,
+              dtype: DType = None) -> Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale
     (a geometric progression).
 
@@ -357,8 +358,8 @@ def logspace(dim: str,
              *,
              endpoint: bool = True,
              base: Union[int, float] = 10.0,
-             unit: Union[_cpp.Unit, str, None] = default_unit,
-             dtype: _cpp.DType = None) -> _cpp.Variable:
+             unit: Union[Unit, str, None] = default_unit,
+             dtype: DType = None) -> Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale.
 
     This is similar to :py:func:`scipp.geomspace`, but with endpoints specified
@@ -415,8 +416,8 @@ def arange(dim: str,
            stop: Union[int, float, _np.datetime64] = None,
            step: Union[int, float] = None,
            *,
-           unit: Union[_cpp.Unit, str, None] = default_unit,
-           dtype: _cpp.DType = None) -> _cpp.Variable:
+           unit: Union[Unit, str, None] = default_unit,
+           dtype: DType = None) -> Variable:
     """Constructs a :class:`Variable` with evenly spaced values within a given
     interval.
     Values are generated within the half-open interval [start, stop)
@@ -439,10 +440,9 @@ def arange(dim: str,
     return array(dims=[dim], values=_np.arange(**range_args), unit=unit, dtype=dtype)
 
 
-def datetime(
-        value: Union[str, int, _np.datetime64],
-        *,
-        unit: Optional[Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
+def datetime(value: Union[str, int, _np.datetime64],
+             *,
+             unit: Optional[Union[Unit, str, None]] = default_unit) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a dtype of datetime64.
 
     :param value:
@@ -471,11 +471,10 @@ def datetime(
     return scalar(value, unit=unit, dtype=_cpp.DType.datetime64)
 
 
-def datetimes(
-        *,
-        dims,
-        values: array_like,
-        unit: Optional[Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
+def datetimes(*,
+              dims,
+              values: array_like,
+              unit: Optional[Union[Unit, str, None]] = default_unit) -> Variable:
     """Constructs an array :class:`Variable` with a dtype of datetime64.
 
     :param dims: Dimension labels
@@ -504,7 +503,7 @@ def datetimes(
                  values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))
 
 
-def epoch(*, unit: Union[_cpp.Unit, str]) -> _cpp.Variable:
+def epoch(*, unit: Union[Unit, str]) -> Variable:
     """Constructs a zero dimensional :class:`Variable` with a dtype of
     datetime64 that contains scipp's epoch.
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -452,9 +452,9 @@ def array(*,
     ----------
     dims:
         Dimension labels
-    values:
+    values: numpy.typing.ArrayLike
         Initial values.
-    variances:
+    variances: numpy.typing.ArrayLike
         Initial variances, must be same shape and size as values.
     unit:
         Unit of contents
@@ -821,7 +821,7 @@ def datetimes(*,
     ----------
     dims:
         Dimension labels
-    values:
+    values: numpy.typing.ArrayLike
         Numpy array or something that can be converted to a
         Numpy array of datetimes.
     unit:

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable as _Iterable
-from typing import Any as _Any, Sequence as _Sequence, Union as _Union,\
-    Optional as _Optional
+from typing import Any, Sequence, Union, Optional
 
 import numpy as _np
 from numpy.typing import ArrayLike as array_like
@@ -18,9 +17,9 @@ from ..units import default_unit
 from ._sizes import _parse_dims_shape_sizes
 
 
-def scalar(value: _Any,
-           variance: _Any = None,
-           unit: _Union[_cpp.Unit, str, None] = default_unit,
+def scalar(value: Any,
+           variance: Any = None,
+           unit: Union[_cpp.Unit, str, None] = default_unit,
            dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a zero dimensional :class:`Variable` with a unit and optional
     variance.
@@ -45,7 +44,7 @@ def scalar(value: _Any,
                          dtype=dtype)
 
 
-def index(value: _Any, dtype: _cpp.DType = None) -> _cpp.Variable:
+def index(value: Any, dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a zero dimensional :class:`Variable` representing an index.
 
     This is equivalent to calling :py:func:`scipp.scalar` with unit=None.
@@ -59,10 +58,10 @@ def index(value: _Any, dtype: _cpp.DType = None) -> _cpp.Variable:
 
 
 def zeros(*,
-          dims: _Sequence[str] = None,
-          shape: _Sequence[int] = None,
+          dims: Sequence[str] = None,
+          shape: Sequence[int] = None,
           sizes: dict = None,
-          unit: _Union[_cpp.Unit, str, None] = default_unit,
+          unit: Union[_cpp.Unit, str, None] = default_unit,
           dtype: _cpp.DType = _cpp.DType.float64,
           with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with default initialized values with
@@ -93,10 +92,10 @@ def zeros(*,
 
 
 def ones(*,
-         dims: _Sequence[str] = None,
-         shape: _Sequence[int] = None,
+         dims: Sequence[str] = None,
+         shape: Sequence[int] = None,
          sizes: dict = None,
-         unit: _Union[_cpp.Unit, str, None] = default_unit,
+         unit: Union[_cpp.Unit, str, None] = default_unit,
          dtype: _cpp.DType = _cpp.DType.float64,
          with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values initialized to 1 with
@@ -122,10 +121,10 @@ def ones(*,
 
 
 def empty(*,
-          dims: _Sequence[str] = None,
-          shape: _Sequence[int] = None,
+          dims: Sequence[str] = None,
+          shape: Sequence[int] = None,
           sizes: dict = None,
-          unit: _Union[_cpp.Unit, str, None] = default_unit,
+          unit: Union[_cpp.Unit, str, None] = default_unit,
           dtype: _cpp.DType = _cpp.DType.float64,
           with_variances: bool = False) -> _cpp.Variable:
     """Constructs a :class:`Variable` with uninitialized values with given
@@ -154,13 +153,13 @@ def empty(*,
 
 
 def full(*,
-         dims: _Sequence[str] = None,
-         shape: _Sequence[int] = None,
+         dims: Sequence[str] = None,
+         shape: Sequence[int] = None,
          sizes: dict = None,
-         unit: _Union[_cpp.Unit, str, None] = default_unit,
+         unit: Union[_cpp.Unit, str, None] = default_unit,
          dtype: _cpp.DType = None,
-         value: _Any,
-         variance: _Any = None) -> _cpp.Variable:
+         value: Any,
+         variance: Any = None) -> _cpp.Variable:
     """
     Constructs a :class:`Variable` with values initialized to the specified
     value with given dimension labels and shape.
@@ -183,8 +182,8 @@ def full(*,
 
 
 def matrix(*,
-           unit: _Union[_cpp.Unit, str, None] = default_unit,
-           value: _Union[_np.ndarray, list]):
+           unit: Union[_cpp.Unit, str, None] = default_unit,
+           value: Union[_np.ndarray, list]):
     """Constructs a zero dimensional :class:`Variable` holding a single 3x3
     matrix.
 
@@ -204,9 +203,9 @@ def matrix(*,
 
 
 def matrices(*,
-             dims: _Sequence[str],
-             unit: _Union[_cpp.Unit, str, None] = default_unit,
-             values: _Union[_np.ndarray, list]):
+             dims: Sequence[str],
+             unit: Union[_cpp.Unit, str, None] = default_unit,
+             values: Union[_np.ndarray, list]):
     """Constructs a :class:`Variable` with given dimensions holding an array
     of 3x3 matrices.
 
@@ -226,8 +225,8 @@ def matrices(*,
 
 
 def vector(*,
-           unit: _Union[_cpp.Unit, str, None] = default_unit,
-           value: _Union[_np.ndarray, list]):
+           unit: Union[_cpp.Unit, str, None] = default_unit,
+           value: Union[_np.ndarray, list]):
     """Constructs a zero dimensional :class:`Variable` holding a single length-3
     vector.
 
@@ -242,9 +241,9 @@ def vector(*,
 
 
 def vectors(*,
-            dims: _Sequence[str],
-            unit: _Union[_cpp.Unit, str, None] = default_unit,
-            values: _Union[_np.ndarray, list]):
+            dims: Sequence[str],
+            unit: Union[_cpp.Unit, str, None] = default_unit,
+            values: Union[_np.ndarray, list]):
     """Constructs a :class:`Variable` with given dimensions holding an array
     of length-3 vectors.
 
@@ -261,8 +260,8 @@ def vectors(*,
 def array(*,
           dims: _Iterable,
           values: array_like,
-          variances: _Optional[array_like] = None,
-          unit: _Union[_cpp.Unit, str, None] = default_unit,
+          variances: Optional[array_like] = None,
+          unit: Union[_cpp.Unit, str, None] = default_unit,
           dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with given dimensions, containing given
     values and optional variances. Dimension and value shape must match.
@@ -288,12 +287,12 @@ def array(*,
 
 
 def linspace(dim: str,
-             start: _Union[int, float],
-             stop: _Union[int, float],
+             start: Union[int, float],
+             stop: Union[int, float],
              num: int,
              *,
              endpoint: bool = True,
-             unit: _Union[_cpp.Unit, str, None] = default_unit,
+             unit: Union[_cpp.Unit, str, None] = default_unit,
              dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with `num` evenly spaced samples,
     calculated over the interval `[start, stop]`.
@@ -318,12 +317,12 @@ def linspace(dim: str,
 
 
 def geomspace(dim: str,
-              start: _Union[int, float],
-              stop: _Union[int, float],
+              start: Union[int, float],
+              stop: Union[int, float],
               num: int,
               *,
               endpoint: bool = True,
-              unit: _Union[_cpp.Unit, str, None] = default_unit,
+              unit: Union[_cpp.Unit, str, None] = default_unit,
               dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale
     (a geometric progression).
@@ -352,13 +351,13 @@ def geomspace(dim: str,
 
 
 def logspace(dim: str,
-             start: _Union[int, float],
-             stop: _Union[int, float],
+             start: Union[int, float],
+             stop: Union[int, float],
              num: int,
              *,
              endpoint: bool = True,
-             base: _Union[int, float] = 10.0,
-             unit: _Union[_cpp.Unit, str, None] = default_unit,
+             base: Union[int, float] = 10.0,
+             unit: Union[_cpp.Unit, str, None] = default_unit,
              dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with values spaced evenly on a log scale.
 
@@ -412,11 +411,11 @@ def _normalize_args(*, unit, **kwargs):
 
 
 def arange(dim: str,
-           start: _Union[int, float, _np.datetime64],
-           stop: _Union[int, float, _np.datetime64] = None,
-           step: _Union[int, float] = None,
+           start: Union[int, float, _np.datetime64],
+           stop: Union[int, float, _np.datetime64] = None,
+           step: Union[int, float] = None,
            *,
-           unit: _Union[_cpp.Unit, str, None] = default_unit,
+           unit: Union[_cpp.Unit, str, None] = default_unit,
            dtype: _cpp.DType = None) -> _cpp.Variable:
     """Constructs a :class:`Variable` with evenly spaced values within a given
     interval.
@@ -441,9 +440,9 @@ def arange(dim: str,
 
 
 def datetime(
-        value: _Union[str, int, _np.datetime64],
+        value: Union[str, int, _np.datetime64],
         *,
-        unit: _Optional[_Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
+        unit: Optional[Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
     """Constructs a zero dimensional :class:`Variable` with a dtype of datetime64.
 
     :param value:
@@ -476,7 +475,7 @@ def datetimes(
         *,
         dims,
         values: array_like,
-        unit: _Optional[_Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
+        unit: Optional[Union[_cpp.Unit, str, None]] = default_unit) -> _cpp.Variable:
     """Constructs an array :class:`Variable` with a dtype of datetime64.
 
     :param dims: Dimension labels
@@ -505,7 +504,7 @@ def datetimes(
                  values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))
 
 
-def epoch(*, unit: _Union[_cpp.Unit, str]) -> _cpp.Variable:
+def epoch(*, unit: Union[_cpp.Unit, str]) -> _cpp.Variable:
     """Constructs a zero dimensional :class:`Variable` with a dtype of
     datetime64 that contains scipp's epoch.
 

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -46,16 +46,24 @@ def has_numeric_type(obj: _std_typing.Any) -> bool:
     return (not has_vector_type(obj)) and (not has_string_type(obj))
 
 
-#: Any object that behaves like a scipp.Variable,
-#:  that is an array with labeled dimensions.
 VariableLike = _std_typing.Union[Variable, DataArray, Dataset]
+"""Any object that behaves like a :class:`scipp.Variable`.
 
-#: dict-like object mapping dimension labels to Variables.
+More concretely, an array with labeled dimensions:
+
+- :class:`scipp.DataArray`
+- :class:`scipp.Dataset`
+- :class:`scipp.Variable`
+"""
+
 MetaDataMap = _std_typing.MutableMapping[str, Variable]
+"""dict-like object mapping dimension labels to Variables."""
 
-# TypeVar for use in annotations.
-# Should be hidden in rendered documentation in favor of VariableLike.
 VariableLikeType = _std_typing.TypeVar('VariableLikeType', Variable, DataArray, Dataset)
+"""TypeVar for use in annotations.
+
+Should be hidden in rendered documentation in favor of VariableLike.
+"""
 
 DTypeLike = _std_typing.Union[numpy.typing.DTypeLike, DType]
 """Anything that can be interpreted as a dtype.

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -54,3 +54,7 @@ MetaDataMap = _std_typing.MutableMapping[str, sc.Variable]
 # Should be hidden in rendered documentation in favor of VariableLike.
 VariableLikeType = _std_typing.TypeVar('VariableLikeType', sc.Variable, sc.DataArray,
                                        sc.Dataset)
+
+#: Anything that can be interpreted as a dtype.
+DTypeLike = _std_typing.Union[sc.DType, str, _std_typing.Type[int],
+                              _std_typing.Type[float], _std_typing.Type[bool]]

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -5,7 +5,10 @@
 
 import typing as _std_typing
 
+import numpy.typing
+
 from ._scipp import core as sc
+from .core.cpp_classes import DataArray, Dataset, DType, Variable
 
 
 def is_scalar(obj: _std_typing.Any) -> bool:
@@ -45,16 +48,26 @@ def has_numeric_type(obj: _std_typing.Any) -> bool:
 
 #: Any object that behaves like a scipp.Variable,
 #:  that is an array with labeled dimensions.
-VariableLike = _std_typing.Union[sc.Variable, sc.DataArray, sc.Dataset]
+VariableLike = _std_typing.Union[Variable, DataArray, Dataset]
 
 #: dict-like object mapping dimension labels to Variables.
-MetaDataMap = _std_typing.MutableMapping[str, sc.Variable]
+MetaDataMap = _std_typing.MutableMapping[str, Variable]
 
 # TypeVar for use in annotations.
 # Should be hidden in rendered documentation in favor of VariableLike.
-VariableLikeType = _std_typing.TypeVar('VariableLikeType', sc.Variable, sc.DataArray,
-                                       sc.Dataset)
+VariableLikeType = _std_typing.TypeVar('VariableLikeType', Variable, DataArray, Dataset)
 
-#: Anything that can be interpreted as a dtype.
-DTypeLike = _std_typing.Union[sc.DType, str, _std_typing.Type[int],
-                              _std_typing.Type[float], _std_typing.Type[bool]]
+DTypeLike = _std_typing.Union[numpy.typing.DTypeLike, DType]
+"""Anything that can be interpreted as a dtype.
+
+This includes
+
+- :class:`scipp.DType`
+- everything that is supported by
+  `numpy.DTypeLike <https://numpy.org/devdocs/reference/typing.html#numpy.typing.DTypeLike>`_
+  e.g.
+
+  - :class:`numpy.dtype`
+  - :class:`type` objects like :class:`int` and :class:`float`
+  - names of dtypes as strings like ``'int32'`` and ``'float64'``
+"""  # noqa: E501

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -570,6 +570,18 @@ def test_arange_with_variables_requires_scalar():
         sc.arange('x', sc.scalar(1), sc.array(dims=['x'], values=[1, 2]))
 
 
+def test_arange_with_variables_does_not_allow_variances():
+    start = sc.scalar(1)
+    stop = sc.scalar(4)
+    step = sc.scalar(1)
+    with pytest.raises(sc.VariancesError):
+        sc.arange('x', start, stop, sc.scalar(1.0, 0.1))
+    with pytest.raises(sc.VariancesError):
+        sc.arange('x', start, sc.scalar(4.0, 0.1), step)
+    with pytest.raises(sc.VariancesError):
+        sc.arange('x', sc.scalar(1.0, 0.1), stop, step)
+
+
 def test_arange_with_variables_mixed_dtype():
     assert sc.identical(sc.arange('x', sc.scalar(1), sc.scalar(4.0), sc.scalar(1)),
                         sc.array(dims=['x'], values=[1.0, 2.0, 3.0], dtype='float64'))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -477,6 +477,14 @@ def test_arange_with_variables_requires_scalar():
         sc.arange('x', sc.scalar(1), sc.array(dims=['x'], values=[1, 2]))
 
 
+def test_arange_with_variables_mixed_dtype():
+    assert sc.identical(sc.arange('x', sc.scalar(1), sc.scalar(4.0), sc.scalar(1)),
+                        sc.array(dims=['x'], values=[1.0, 2.0, 3.0], dtype='float64'))
+    assert sc.identical(
+        sc.arange('x', sc.scalar(1), sc.scalar(4.0), sc.scalar(1), dtype='int64'),
+        sc.array(dims=['x'], values=[1, 2, 3], dtype='int64'))
+
+
 def test_zeros_sizes():
     dims = ['x', 'y', 'z']
     shape = [2, 3, 4]

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -397,6 +397,27 @@ def test_linspace_none_unit():
     assert sc.linspace('x', 1.2, 103., 51, unit=None).unit is None
 
 
+def test_linspace_with_variables():
+    start = sc.scalar(1, unit='m')
+    stop = sc.scalar(3, unit='m')
+    assert sc.identical(sc.linspace('x', start, stop, 3),
+                        sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='m'))
+
+
+def test_linspace_with_variables_set_unit():
+    start = sc.scalar(1, unit='m')
+    stop = sc.scalar(3000, unit='mm')
+    assert sc.identical(sc.linspace('x', start, stop, 3, unit='m'),
+                        sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='m'))
+
+
+def test_linspace_with_variables_num_cannot_be_variable():
+    start = sc.scalar(1)
+    stop = sc.scalar(3)
+    with pytest.raises(TypeError):
+        sc.linspace('x', start, stop, sc.scalar(3))  # type: ignore
+
+
 def test_logspace():
     values = np.logspace(2.0, 3.0, num=4)
     var = sc.logspace('y', 2.0, 3.0, num=4, unit='s')

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -575,11 +575,11 @@ def test_arange_with_variables_does_not_allow_variances():
     stop = sc.scalar(4)
     step = sc.scalar(1)
     with pytest.raises(sc.VariancesError):
-        sc.arange('x', start, stop, sc.scalar(1.0, 0.1))
+        sc.arange('x', start, stop, sc.scalar(1.0, variance=0.1))
     with pytest.raises(sc.VariancesError):
-        sc.arange('x', start, sc.scalar(4.0, 0.1), step)
+        sc.arange('x', start, sc.scalar(4.0, variance=0.1), step)
     with pytest.raises(sc.VariancesError):
-        sc.arange('x', sc.scalar(1.0, 0.1), stop, step)
+        sc.arange('x', sc.scalar(1.0, variance=0.1), stop, step)
 
 
 def test_arange_with_variables_mixed_dtype():

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -422,6 +422,61 @@ def test_arange():
     assert sc.identical(var, expected)
 
 
+def test_arange_with_variables():
+    start = sc.scalar(1)
+    stop = sc.scalar(4)
+    step = sc.scalar(1)
+    unit = 'one'
+    assert sc.identical(sc.arange('x', start, stop, step, unit=unit),
+                        sc.array(dims=['x'], values=[1, 2, 3], unit='one'))
+    assert sc.identical(sc.arange('x', start, stop, unit=unit),
+                        sc.array(dims=['x'], values=[1, 2, 3], unit='one'))
+    assert sc.identical(sc.arange('x', stop, unit=unit),
+                        sc.array(dims=['x'], values=[0, 1, 2, 3], unit='one'))
+
+    assert sc.identical(sc.arange('x', start, stop, step),
+                        sc.array(dims=['x'], values=[1, 2, 3], unit='one'))
+    assert sc.identical(sc.arange('x', start, stop),
+                        sc.array(dims=['x'], values=[1, 2, 3], unit='one'))
+    assert sc.identical(sc.arange('x', stop),
+                        sc.array(dims=['x'], values=[0, 1, 2, 3], unit='one'))
+
+
+def test_arange_with_variables_set_unit():
+    start = sc.scalar(1, unit='m')
+    stop = sc.scalar(4, unit='m')
+    step = sc.scalar(1, unit='m')
+    unit = 'm'
+    assert sc.identical(sc.arange('x', start, stop, step, unit=unit),
+                        sc.array(dims=['x'], values=[1, 2, 3], unit='m'))
+    assert sc.identical(sc.arange('x', start, stop, step, unit='mm'),
+                        sc.array(dims=['x'], values=[1000, 2000, 3000], unit='mm'))
+    assert sc.identical(
+        sc.arange('x', start, stop, sc.scalar(500, unit='mm'), unit='mm'),
+        sc.array(dims=['x'], values=[1000, 1500, 2000, 2500, 3000, 3500], unit='mm'))
+
+    with pytest.raises(sc.UnitError):
+        sc.arange('x', start, stop, sc.scalar(500, unit='mm'))
+
+
+def test_arange_with_variables_mixed_types_not_allowed():
+    start = sc.scalar(1, unit='m')
+    stop = 4
+    step = sc.scalar(1, unit='m')
+    unit = 'm'
+    with pytest.raises(TypeError):
+        sc.arange('x', start, stop, step)
+    with pytest.raises(TypeError):
+        sc.arange('x', start, stop, step, unit=unit)
+
+
+def test_arange_with_variables_requires_scalar():
+    with pytest.raises(sc.DimensionError):
+        sc.arange('x', sc.array(dims=['x'], values=[1, 2]))
+    with pytest.raises(sc.DimensionError):
+        sc.arange('x', sc.scalar(1), sc.array(dims=['x'], values=[1, 2]))
+
+
 def test_zeros_sizes():
     dims = ['x', 'y', 'z']
     shape = [2, 3, 4]


### PR DESCRIPTION
Proposing this as a solution for #2140

The interaction between different arguments (start, stop, step) is fairly straight forward. See the tests for examples.
1. Either all or no arguments are variables
2. If they are variables, they must all have the same unit or
3. if `unit` is given, it overrides the units of the arguments. This is similar to `dtype` apart from point 2.
4. `dtypes` are handled the same way as for number input.
5. Inputs must be scalar.

It can of course do with more tests and a refactoring.

Concerning https://github.com/scipp/scipp/issues/2140#issuecomment-920647091 I don't think there is a risk of a 'super function'  in this implementation because the unit handling is essentially a simplified form of how  `dtype` is handled. It uses the input if possible and allows the user to override. But it does not attempt to convert automatically.