### PR TITLE
Cache conan dir

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -61,7 +61,7 @@ jobs:
           submodules: true
           fetch-depth: 0  # history required so cmake can determine version
           ref: ${{ github.head_ref }}
-      
+
       - uses: ilammy/msvc-dev-cmd@v1  # Required to set up MSVC dev environment for Ninja builds.
 
       - name: Setup conda environment
@@ -76,6 +76,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.1
         with:
           key: ${{ matrix.os }}
+
+      - run: echo "CONAN_CONFIG_HOME=$(conan config home)" >> $GITHUB_ENV
+      - name: Cache conan
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CONAN_CONFIG_HOME }}
+          key: conan-${{ matrix.os }}-${{ hashFiles('lib/conanfile.txt') }}
 
       - run: cmake --preset ${{ matrix.cmake-preset }}
       - run: cmake --build --preset build

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.conan-cache-key.outputs.path }}
-          key: conan-${{ matrix.os }}-${{ hashFiles('lib/conanfile.txt') }}-${{ steps.conan-cache-key.outputs.key }}
+          key: conan-${{ matrix.os }}-${{ steps.conan-cache-key.outputs.key }}
 
       - run: cmake --preset ${{ matrix.cmake-preset }}
       - run: cmake --build --preset build

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -77,12 +77,16 @@ jobs:
         with:
           key: ${{ matrix.os }}
 
-      - run: echo "CONAN_CONFIG_HOME=$(conan config home)" >> $GITHUB_ENV
+      - name: Cache conan setup
+        id: conan-cache-key
+        run: |
+          echo "::set-output name=key::$(/bin/date -u "+%Y%m%d")"
+          echo "::set-output name=path::$(conan config home)"
       - name: Cache conan
         uses: actions/cache@v1
         with:
-          path: ${{ env.CONAN_CONFIG_HOME }}
-          key: conan-${{ matrix.os }}-${{ hashFiles('lib/conanfile.txt') }}
+          path: ${{ steps.conan-cache-key.outputs.path }}
+          key: conan-${{ matrix.os }}-${{ hashFiles('lib/conanfile.txt') }}-${{ steps.conan-cache-key.outputs.key }}
 
       - run: cmake --preset ${{ matrix.cmake-preset }}
       - run: cmake --build --preset build


### PR DESCRIPTION
This uses the github cache action to cache the contents of `~/.conan` (or equivalent). The reason for this is that our initial `cmake` run takes a significant amount of time, since a number of dependencies are built every time.

Results:
- Linux: 58s -> 3s + 3s
- Windows: 2m11s -> 1m12s + 48s (edit: I have seen a case now where the non-cache cmake run takes 4 minutes! edit2: 12s + 1m11s in another run with cache)

The speedup is much less on Windows. As encountered in #2512 this is likely the very slow file-system on Windows.

Notes:
- Do we need to have some mechanism for expiring the cache? Maybe on a daily or weekly basis?