### PR TITLE
Disable accidental support for slicing with label range without dim

### DIFF
--- a/tests/slicebyvalue_test.py
+++ b/tests/slicebyvalue_test.py
@@ -169,3 +169,10 @@ class TestSliceByValue:
         by_value = self._d['x', :2.5 * sc.units.dimensionless]
         by_index = self._d['x', :2]
         assert sc.identical(by_value, by_index)
+
+
+def test_raises_DimensionError_if_dim_not_given():
+    var = sc.arange('x', 4)
+    da = sc.DataArray(var, coords={'x': var})
+    with pytest.raises(sc.DimensionError):
+        da[sc.scalar(1):sc.scalar(3)]


### PR DESCRIPTION
This was temporarily supported "by accident". Note that this never worked:

```python
da[sc.scalar(3)]
```
but
```python
da[sc.scalar(3):sc.scalar(5)]
```
did. This is also contrary to the intention expressed in a code comment (near the changes here).

Here we disable the second case.