### PR TITLE
Python builtin number conversion

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -10,6 +10,7 @@ Features
 ~~~~~~~~
 
 * Added argument `max_rows` to :func:`scipp.table` `#2526 <https://github.com/scipp/scipp/pull/2526>`_.
+* Added support for converting scalars to builtin objects via :func:`int` and :func:`float` `#2529 <https://github.com/scipp/scipp/pull/2529>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ archs = ["x86_64", "arm64"]
 [tool.pytest.ini_options]
 addopts = "-ra -v"
 filterwarnings = [
-  'ignore:You are running a "Debug" build of scipp:'
+  'ignore:You are running a "Debug" build of scipp:',
+  'ignore:sc.matrix\(\) has been deprecated:DeprecationWarning',
+  'ignore:sc.matrices\(\) has been deprecated:DeprecationWarning',
 ]
 testpaths = "tests"

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -86,6 +86,7 @@ from . import _binding
 
 _binding.bind_get()
 _binding.bind_pop()
+_binding.bind_conversion_to_builtin(Variable)
 # Assign method binding for both Variable and DataArray
 for _cls in (Variable, DataArray):
     _binding.bind_functions_as_methods(

--- a/src/scipp/_binding.py
+++ b/src/scipp/_binding.py
@@ -30,6 +30,19 @@ def bind_get():
         setattr(cls, 'get', method)
 
 
+def _int_dunder(self) -> int:
+    return int(self.value)
+
+
+def _float_dunder(self) -> float:
+    return float(self.value)
+
+
+def bind_conversion_to_builtin(cls):
+    setattr(cls, '__int__', _convert_to_method(name='__int__', func=_int_dunder))
+    setattr(cls, '__float__', _convert_to_method(name='__float__', func=_float_dunder))
+
+
 class _NoDefaultType:
     def __repr__(self):
         return 'NotSpecified'

--- a/src/scipp/_binding.py
+++ b/src/scipp/_binding.py
@@ -30,11 +30,18 @@ def bind_get():
         setattr(cls, 'get', method)
 
 
+def _expect_dimensionless_or_unitless(x):
+    if x.unit is not None and x.unit != core.units.dimensionless:
+        raise core.UnitError(f'Expected unit dimensionless or no unit, got {x.unit}.')
+
+
 def _int_dunder(self) -> int:
+    _expect_dimensionless_or_unitless(self)
     return int(self.value)
 
 
 def _float_dunder(self) -> float:
+    _expect_dimensionless_or_unitless(self)
     return float(self.value)
 
 

--- a/src/scipp/_binding.py
+++ b/src/scipp/_binding.py
@@ -35,13 +35,20 @@ def _expect_dimensionless_or_unitless(x):
         raise core.UnitError(f'Expected unit dimensionless or no unit, got {x.unit}.')
 
 
+def _expect_no_variance(x):
+    if x.variance is not None:
+        raise core.VariancesError('Expected input without variances.')
+
+
 def _int_dunder(self) -> int:
     _expect_dimensionless_or_unitless(self)
+    _expect_no_variance(self)
     return int(self.value)
 
 
 def _float_dunder(self) -> float:
     _expect_dimensionless_or_unitless(self)
+    _expect_no_variance(self)
     return float(self.value)
 
 

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -48,6 +48,12 @@ def test_scalar_Variable_conversion_to_builtin_int_bad_dtype():
         int(var)
 
 
+def test_scalar_Variable_conversion_to_builtin_int_bad_unit():
+    var = sc.scalar(7, unit='m')
+    with pytest.raises(sc.UnitError):
+        int(var)
+
+
 @pytest.mark.parametrize('var', (sc.scalar(-3), sc.scalar(-3.0), sc.scalar('-3.0')))
 def test_scalar_Variable_conversion_to_builtin_float(var):
     assert float(var) == -3.0
@@ -56,4 +62,10 @@ def test_scalar_Variable_conversion_to_builtin_float(var):
 def test_scalar_Variable_conversion_to_builtin_float_bad_dtype():
     var = sc.vector(value=[1.0, 2.0, 3.0])
     with pytest.raises(TypeError):
+        float(var)
+
+
+def test_scalar_Variable_conversion_to_builtin_float_bad_unit():
+    var = sc.scalar(7, unit='m')
+    with pytest.raises(sc.UnitError):
         float(var)

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -54,6 +54,12 @@ def test_scalar_Variable_conversion_to_builtin_int_bad_unit():
         int(var)
 
 
+def test_scalar_Variable_conversion_to_builtin_int_with_variance():
+    var = sc.scalar(7.0, variance=2.0)
+    with pytest.raises(sc.VariancesError):
+        int(var)
+
+
 @pytest.mark.parametrize('var', (sc.scalar(-3), sc.scalar(-3.0), sc.scalar('-3.0')))
 def test_scalar_Variable_conversion_to_builtin_float(var):
     assert float(var) == -3.0
@@ -68,4 +74,10 @@ def test_scalar_Variable_conversion_to_builtin_float_bad_dtype():
 def test_scalar_Variable_conversion_to_builtin_float_bad_unit():
     var = sc.scalar(7, unit='m')
     with pytest.raises(sc.UnitError):
+        float(var)
+
+
+def test_scalar_Variable_conversion_to_builtin_float_with_variance():
+    var = sc.scalar(7.0, variance=2.0)
+    with pytest.raises(sc.VariancesError):
         float(var)

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -60,6 +60,12 @@ def test_scalar_Variable_conversion_to_builtin_int_with_variance():
         int(var)
 
 
+def test_scalar_Variable_conversion_to_builtin_int_fails_with_array():
+    var = sc.array(dims=['x'], values=[1])
+    with pytest.raises(sc.DimensionError):
+        int(var)
+
+
 @pytest.mark.parametrize('var', (sc.scalar(-3), sc.scalar(-3.0), sc.scalar('-3.0')))
 def test_scalar_Variable_conversion_to_builtin_float(var):
     assert float(var) == -3.0
@@ -80,4 +86,10 @@ def test_scalar_Variable_conversion_to_builtin_float_bad_unit():
 def test_scalar_Variable_conversion_to_builtin_float_with_variance():
     var = sc.scalar(7.0, variance=2.0)
     with pytest.raises(sc.VariancesError):
+        float(var)
+
+
+def test_scalar_Variable_conversion_to_builtin_float_fails_with_array():
+    var = sc.array(dims=['x'], values=[1.0])
+    with pytest.raises(sc.DimensionError):
         float(var)

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -35,3 +35,25 @@ def test_scalar_Variable_values_property_PyObject():
     'var', (sc.scalar(3.1), sc.scalar(-2), sc.scalar('abc'), sc.scalar([1, 2])))
 def test_scalar_Variable_value_is_same_as_values(var):
     assert var.value == var.values
+
+
+@pytest.mark.parametrize('var', (sc.scalar(4), sc.scalar(4.61), sc.scalar('4')))
+def test_scalar_Variable_conversion_to_builtin_int(var):
+    assert int(var) == 4
+
+
+def test_scalar_Variable_conversion_to_builtin_int_bad_dtype():
+    var = sc.vector(value=[1, 2, 3])
+    with pytest.raises(TypeError):
+        int(var)
+
+
+@pytest.mark.parametrize('var', (sc.scalar(-3), sc.scalar(-3.0), sc.scalar('-3.0')))
+def test_scalar_Variable_conversion_to_builtin_float(var):
+    assert float(var) == -3.0
+
+
+def test_scalar_Variable_conversion_to_builtin_float_bad_dtype():
+    var = sc.vector(value=[1.0, 2.0, 3.0])
+    with pytest.raises(TypeError):
+        float(var)

--- a/tests/variable_scalar_test.py
+++ b/tests/variable_scalar_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
+import pytest
 import scipp as sc
 
 
@@ -28,3 +29,9 @@ def test_scalar_Variable_values_property_PyObject():
     var = sc.scalar([1, 2])
     assert var.dtype == sc.DType.PyObject
     assert var.values == [1, 2]
+
+
+@pytest.mark.parametrize(
+    'var', (sc.scalar(3.1), sc.scalar(-2), sc.scalar('abc'), sc.scalar([1, 2])))
+def test_scalar_Variable_value_is_same_as_values(var):
+    assert var.value == var.values


### PR DESCRIPTION
Fixes #2524

- I chose `float(v.value)` over `v.astype(float).value` because this way, we get the same conversion from `int` and `str` as for builtin types.
- Length-1 arrays are not supported in contrast with numpy because that would not match our usage of singular properties elsewhere (e.g. `.value`).
