### PR TITLE
Improve `to_unit` precision with datetime64 and int64

### DIFF
--- a/lib/core/include/scipp/core/element/to_unit.h
+++ b/lib/core/include/scipp/core/element/to_unit.h
@@ -39,11 +39,12 @@ constexpr auto round = [](const auto x) {
 } // namespace
 
 constexpr auto to_unit = overloaded{
-    arg_list<
-        double, std::tuple<float, double>, std::tuple<int64_t, double>,
-        std::tuple<int32_t, double>, std::tuple<time_point, double>,
-        std::tuple<time_point, int64_t>, std::tuple<Eigen::Vector3d, double>,
-        std::tuple<Eigen::Affine3d, double>, std::tuple<Translation, double>>,
+    arg_list<double, std::tuple<float, double>, std::tuple<int64_t, double>,
+             std::tuple<int64_t, int64_t>, std::tuple<int32_t, double>,
+             std::tuple<time_point, double>, std::tuple<time_point, int64_t>,
+             std::tuple<Eigen::Vector3d, double>,
+             std::tuple<Eigen::Affine3d, double>,
+             std::tuple<Translation, double>>,
     transform_flags::expect_no_variance_arg<1>,
     [](const units::Unit &, const units::Unit &target) { return target; },
     [](const time_point &x, const auto &scale) {

--- a/lib/core/include/scipp/core/element/to_unit.h
+++ b/lib/core/include/scipp/core/element/to_unit.h
@@ -39,11 +39,11 @@ constexpr auto round = [](const auto x) {
 } // namespace
 
 constexpr auto to_unit = overloaded{
-    arg_list<double, std::tuple<float, double>, std::tuple<int64_t, double>,
-             std::tuple<int32_t, double>, std::tuple<time_point, double>,
-             std::tuple<Eigen::Vector3d, double>,
-             std::tuple<Eigen::Affine3d, double>,
-             std::tuple<Translation, double>>,
+    arg_list<
+        double, std::tuple<float, double>, std::tuple<int64_t, double>,
+        std::tuple<int32_t, double>, std::tuple<time_point, double>,
+        std::tuple<time_point, int64_t>, std::tuple<Eigen::Vector3d, double>,
+        std::tuple<Eigen::Affine3d, double>, std::tuple<Translation, double>>,
     transform_flags::expect_no_variance_arg<1>,
     [](const units::Unit &, const units::Unit &target) { return target; },
     [](const time_point &x, const auto &scale) {

--- a/lib/variable/to_unit.cpp
+++ b/lib/variable/to_unit.cpp
@@ -50,8 +50,9 @@ Variable to_unit(const Variable &var, const units::Unit &unit,
   }
   Variable scalevar;
   if (const auto iscale = std::round(scale);
-      var.dtype() == dtype<core::time_point> &&
-      std::abs(scale - iscale) < 1e-12 * std::abs(scale))
+      (var.dtype() == dtype<int64_t> ||
+       var.dtype() == dtype<core::time_point>)&&(std::abs(scale - iscale) <
+                                                 1e-12 * std::abs(scale)))
     scalevar = static_cast<int64_t>(iscale) * unit;
   else
     scalevar = scale * unit;

--- a/lib/variable/to_unit.cpp
+++ b/lib/variable/to_unit.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include <cmath>
 #include <units/units.hpp>
 
 #include "scipp/core/element/to_unit.h"
@@ -47,8 +48,14 @@ Variable to_unit(const Variable &var, const units::Unit &unit,
         "This limitation exists because such conversions would require "
         "information about calendars and time zones.");
   }
-  return variable::transform(var, scale * unit, core::element::to_unit,
-                             "to_unit");
+  Variable scalevar;
+  if (const auto iscale = std::round(scale);
+      var.dtype() == dtype<core::time_point> &&
+      std::abs(scale - iscale) < 1e-12 * std::abs(scale))
+    scalevar = static_cast<int64_t>(iscale) * unit;
+  else
+    scalevar = scale * unit;
+  return variable::transform(var, scalevar, core::element::to_unit, "to_unit");
 }
 
 } // namespace scipp::variable

--- a/tests/to_unit_test.py
+++ b/tests/to_unit_test.py
@@ -30,3 +30,9 @@ def test_datetime64_to_ns_is_precise(year):
     assert sc.identical(
         sc.datetime(f'{year}-01-01T12:00:00', unit='s').to(unit='ns'),
         sc.datetime(f'{year}-01-01T12:00:00.000000000', unit='ns'))
+
+
+def test_int64_seconds_to_ns_is_precise():
+    assert sc.identical(
+            sc.scalar(9223372036, unit='s').to(unit='ns'),
+            sc.scalar(9223372036000000000, unit='ns'))

--- a/tests/to_unit_test.py
+++ b/tests/to_unit_test.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import pytest
+import scipp as sc
+
+
+def test_to_unit():
+    var = sc.scalar(1, unit='m')
+    assert sc.to_unit(var, unit='mm').unit == sc.Unit('mm')
+    assert sc.to_unit(var, unit=sc.Unit('mm')).unit == sc.Unit('mm')
+    with pytest.raises(sc.UnitError):
+        sc.to_unit(var, unit='abcdef')  # does not parse
+    with pytest.raises(TypeError):
+        sc.to_unit(var, unit=5)  # neither str nor Unit
+
+
+@pytest.mark.parametrize('year', [1800, 1911, 1956, 1984, 2001, 2022, 2036, 2100, 2467])
+def test_datetime64_with_explicit_ns_unit_is_consistent_irrespective_of_decimals(year):
+    assert sc.identical(sc.datetime(f'{year}-01-01T12:00:00', unit='ns'),
+                        sc.datetime(f'{year}-01-01T12:00:00.000', unit='ns'))
+    assert sc.identical(sc.datetime(f'{year}-01-01T12:00:00', unit='ns'),
+                        sc.datetime(f'{year}-01-01T12:00:00.000000', unit='ns'))
+    assert sc.identical(sc.datetime(f'{year}-01-01T12:00:00', unit='ns'),
+                        sc.datetime(f'{year}-01-01T12:00:00.000000000', unit='ns'))
+
+
+@pytest.mark.parametrize('year', [1800, 1911, 1956, 1984, 2001, 2022, 2036, 2100, 2467])
+def test_datetime64_to_ns_is_precise(year):
+    assert sc.identical(
+        sc.datetime(f'{year}-01-01T12:00:00', unit='s').to(unit='ns'),
+        sc.datetime(f'{year}-01-01T12:00:00.000000000', unit='ns'))

--- a/tests/to_unit_test.py
+++ b/tests/to_unit_test.py
@@ -34,5 +34,5 @@ def test_datetime64_to_ns_is_precise(year):
 
 def test_int64_seconds_to_ns_is_precise():
     assert sc.identical(
-            sc.scalar(9223372036, unit='s').to(unit='ns'),
-            sc.scalar(9223372036000000000, unit='ns'))
+            sc.scalar(9223372036, dtype='int64', unit='s').to(unit='ns'),
+            sc.scalar(9223372036000000000, dtype='int64', unit='ns'))

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -49,13 +49,3 @@ def test_explicit_default_unit_for_string_gives_none():
 def test_default_unit_for_string_is_none():
     var = sc.scalar('abcdef')
     assert var.unit is None
-
-
-def test_to_unit():
-    var = sc.scalar(1, unit='m')
-    assert sc.to_unit(var, unit='mm').unit == sc.Unit('mm')
-    assert sc.to_unit(var, unit=sc.Unit('mm')).unit == sc.Unit('mm')
-    with pytest.raises(sc.UnitError):
-        sc.to_unit(var, unit='abcdef')  # does not parse
-    with pytest.raises(TypeError):
-        sc.to_unit(var, unit=5)  # neither str nor Unit


### PR DESCRIPTION
Fixes #2531.

I was considering to use this also for `int32` (which would result in converting the result to `int64`), but decided against this, since it would be inconsistent: In other cases conversion of `int32` keeps the dtype.