### PR TITLE
Improve scipp import times further by delaying plotting-related imports

### DIFF
--- a/.buildconfig/macos-latest.yml
+++ b/.buildconfig/macos-latest.yml
@@ -8,7 +8,7 @@ dependencies:
   - graphlib-backport
   - h5py
   - hypothesis
-  - ipympl
+  - ipympl<0.9
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base

--- a/.buildconfig/macos-latest.yml
+++ b/.buildconfig/macos-latest.yml
@@ -11,6 +11,7 @@ dependencies:
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base
+  - nbconvert=6.4.5
   - ninja
   - nomkl
   - numpy>=1.20.0

--- a/.buildconfig/macos-latest.yml
+++ b/.buildconfig/macos-latest.yml
@@ -8,6 +8,7 @@ dependencies:
   - graphlib-backport
   - h5py
   - hypothesis
+  - ipympl
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base

--- a/.buildconfig/ubuntu-latest.yml
+++ b/.buildconfig/ubuntu-latest.yml
@@ -10,6 +10,7 @@ dependencies:
   - gxx_linux-64 11.1.*
   - h5py
   - hypothesis
+  - ipympl
   - ipywidgets
   - jinja2==3.0.3  # jupyter/nbconvert#1736
   - markupsafe>=1.1.1,<2.1.0

--- a/.buildconfig/ubuntu-latest.yml
+++ b/.buildconfig/ubuntu-latest.yml
@@ -14,6 +14,7 @@ dependencies:
   - jinja2==3.0.3  # jupyter/nbconvert#1736
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base
+  - nbconvert=6.4.5
   - nbsphinx
   - ninja
   - nomkl

--- a/.buildconfig/ubuntu-latest.yml
+++ b/.buildconfig/ubuntu-latest.yml
@@ -10,7 +10,7 @@ dependencies:
   - gxx_linux-64 11.1.*
   - h5py
   - hypothesis
-  - ipympl
+  - ipympl<0.9
   - ipywidgets
   - jinja2==3.0.3  # jupyter/nbconvert#1736
   - markupsafe>=1.1.1,<2.1.0

--- a/.buildconfig/windows-latest.yml
+++ b/.buildconfig/windows-latest.yml
@@ -8,7 +8,7 @@ dependencies:
   - graphlib-backport
   - h5py
   - hypothesis
-  - ipympl
+  - ipympl<0.9
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base

--- a/.buildconfig/windows-latest.yml
+++ b/.buildconfig/windows-latest.yml
@@ -11,6 +11,7 @@ dependencies:
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base
+  - nbconvert=6.4.5
   - ninja
   - nomkl
   - numpy>=1.20.0

--- a/.buildconfig/windows-latest.yml
+++ b/.buildconfig/windows-latest.yml
@@ -8,6 +8,7 @@ dependencies:
   - graphlib-backport
   - h5py
   - hypothesis
+  - ipympl
   - ipywidgets
   - markupsafe>=1.1.1,<2.1.0
   - matplotlib-base

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           python-version: "3.8"
-          environment-file: developer-extra.yml
-          activate-environment: developer-extra
+          environment-file: .buildconfig/ubuntu-latest.yml
+          activate-environment: ubuntu-latest
           auto-activate-base: false
       - uses: actions/download-artifact@v2
         with:

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -3,20 +3,19 @@
 # @file
 # @author Neil Vaytet
 
+from functools import lru_cache
 import warnings
 from .plot import plot as _plot
 from ..utils import running_in_jupyter
 
-is_doc_build = False
-initialized = False
 
-
-def initialize(is_doc_build):
-
+@lru_cache
+def initialize():
+    is_doc_build = False
     try:
         import matplotlib as mpl
     except ImportError:
-        return
+        return is_doc_build
 
     # If we are running inside a notebook, then make plot interactive by default.
     if running_in_jupyter():
@@ -56,6 +55,7 @@ def initialize(is_doc_build):
             "figure.figsize": [6.4, 4.8],
             "figure.dpi": 96
         })
+    return is_doc_build
 
 
 def plot(*args, **kwargs):
@@ -185,13 +185,7 @@ def plot(*args, **kwargs):
     :type vmax: float, optional
 
     """
-    global initialized
-    global is_doc_build
-
-    if not initialized:
-        initialize(is_doc_build)
-        initialized = True
-
+    is_doc_build = initialize()
     import matplotlib.pyplot as plt
 
     # Switch auto figure display off for better control over when figures are

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -7,56 +7,6 @@ import warnings
 from .plot import plot as _plot
 from ..utils import running_in_jupyter
 
-is_doc_build = False
-
-try:
-    import matplotlib as mpl
-except ImportError:
-    mpl = None
-
-# If we are running inside a notebook, then make plot interactive by default.
-if running_in_jupyter():
-    from IPython import get_ipython
-    ipy = get_ipython()
-
-    # Check if a docs build is requested in the metadata. If so,
-    # use the default Qt/inline backend.
-    cfg = ipy.config
-    meta = cfg["Session"]["metadata"]
-    if hasattr(meta, "to_dict"):
-        meta = meta.to_dict()
-    if "scipp_docs_build" in meta:
-        is_doc_build = meta["scipp_docs_build"]
-    if mpl is not None:
-        try:
-            # Attempt to use ipympl backend
-            from ipympl.backend_nbagg import Canvas
-            mpl.use('module://ipympl.backend_nbagg')
-            # Hide the figure header:
-            # see https://github.com/matplotlib/ipympl/issues/229
-            Canvas.header_visible.default_value = False
-        except ImportError:
-            warnings.warn("The ipympl backend, which is required for "
-                          "interactive plots in Jupyter, was not found. "
-                          "Falling back to a static backend. Use "
-                          "conda install -c conda-forge ipympl to install ipympl.")
-
-# Note: due to some strange behavior when importing matplotlib and pyplot in
-# different order, we need to import pyplot after switching to the ipympl
-# backend (see https://github.com/matplotlib/matplotlib/issues/19032).
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    plt = None
-
-if is_doc_build and plt is not None:
-    plt.rcParams.update({
-        "figure.max_open_warning": 0,
-        "interactive": False,
-        "figure.figsize": [6.4, 4.8],
-        "figure.dpi": 96
-    })
-
 
 def plot(*args, **kwargs):
     """
@@ -185,6 +135,56 @@ def plot(*args, **kwargs):
     :type vmax: float, optional
 
     """
+
+    is_doc_build = False
+
+    try:
+        import matplotlib as mpl
+    except ImportError:
+        mpl = None
+
+    # If we are running inside a notebook, then make plot interactive by default.
+    if running_in_jupyter():
+        from IPython import get_ipython
+        ipy = get_ipython()
+
+        # Check if a docs build is requested in the metadata. If so,
+        # use the default Qt/inline backend.
+        cfg = ipy.config
+        meta = cfg["Session"]["metadata"]
+        if hasattr(meta, "to_dict"):
+            meta = meta.to_dict()
+        if "scipp_docs_build" in meta:
+            is_doc_build = meta["scipp_docs_build"]
+        if mpl is not None:
+            try:
+                # Attempt to use ipympl backend
+                from ipympl.backend_nbagg import Canvas
+                mpl.use('module://ipympl.backend_nbagg')
+                # Hide the figure header:
+                # see https://github.com/matplotlib/ipympl/issues/229
+                Canvas.header_visible.default_value = False
+            except ImportError:
+                warnings.warn("The ipympl backend, which is required for "
+                              "interactive plots in Jupyter, was not found. "
+                              "Falling back to a static backend. Use "
+                              "conda install -c conda-forge ipympl to install ipympl.")
+
+    # Note: due to some strange behavior when importing matplotlib and pyplot in
+    # different order, we need to import pyplot after switching to the ipympl
+    # backend (see https://github.com/matplotlib/matplotlib/issues/19032).
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        plt = None
+
+    if is_doc_build and plt is not None:
+        plt.rcParams.update({
+            "figure.max_open_warning": 0,
+            "interactive": False,
+            "figure.figsize": [6.4, 4.8],
+            "figure.dpi": 96
+        })
 
     if plt is None:
         raise RuntimeError("Matplotlib not found. Matplotlib is required to "

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -8,25 +8,11 @@ from .plot import plot as _plot
 from ..utils import running_in_jupyter
 
 is_doc_build = False
-matplotlib_first_import = True
+initialized = False
 plt = None
 
-# If we are running inside a notebook, then make plot interactive by default.
-if running_in_jupyter():
-    from IPython import get_ipython
-    ipy = get_ipython()
 
-    # Check if a docs build is requested in the metadata. If so,
-    # use the default Qt/inline backend.
-    cfg = ipy.config
-    meta = cfg["Session"]["metadata"]
-    if hasattr(meta, "to_dict"):
-        meta = meta.to_dict()
-    if "scipp_docs_build" in meta:
-        is_doc_build = meta["scipp_docs_build"]
-
-
-def import_matplotlib_and_set_backend():
+def initialize(is_doc_build):
 
     try:
         import matplotlib as mpl
@@ -35,6 +21,18 @@ def import_matplotlib_and_set_backend():
 
     # If we are running inside a notebook, then make plot interactive by default.
     if running_in_jupyter():
+        from IPython import get_ipython
+        ipy = get_ipython()
+
+        # Check if a docs build is requested in the metadata. If so,
+        # use the default Qt/inline backend.
+        cfg = ipy.config
+        meta = cfg["Session"]["metadata"]
+        if hasattr(meta, "to_dict"):
+            meta = meta.to_dict()
+        if "scipp_docs_build" in meta:
+            is_doc_build = meta["scipp_docs_build"]
+
         try:
             # Attempt to use ipympl backend
             from ipympl.backend_nbagg import Canvas
@@ -190,13 +188,13 @@ def plot(*args, **kwargs):
 
     """
 
-    global matplotlib_first_import
+    global initialized
     global is_doc_build
     global plt
 
-    if matplotlib_first_import:
-        plt = import_matplotlib_and_set_backend()
-        matplotlib_first_import = False
+    if not initialized:
+        plt = initialize(is_doc_build)
+        initialized = True
 
     if plt is None:
         raise RuntimeError("Matplotlib not found. Matplotlib is required to "

--- a/src/scipp/plotting/__init__.py
+++ b/src/scipp/plotting/__init__.py
@@ -9,7 +9,6 @@ from ..utils import running_in_jupyter
 
 is_doc_build = False
 initialized = False
-plt = None
 
 
 def initialize(is_doc_build):
@@ -49,15 +48,14 @@ def initialize(is_doc_build):
     # Note: due to some strange behavior when importing matplotlib and pyplot in
     # different order, we need to import pyplot after switching to the ipympl
     # backend (see https://github.com/matplotlib/matplotlib/issues/19032).
-    import matplotlib.pyplot as _plt
+    import matplotlib.pyplot as plt
     if is_doc_build:
-        _plt.rcParams.update({
+        plt.rcParams.update({
             "figure.max_open_warning": 0,
             "interactive": False,
             "figure.figsize": [6.4, 4.8],
             "figure.dpi": 96
         })
-    return _plt
 
 
 def plot(*args, **kwargs):
@@ -187,18 +185,14 @@ def plot(*args, **kwargs):
     :type vmax: float, optional
 
     """
-
     global initialized
     global is_doc_build
-    global plt
 
     if not initialized:
-        plt = initialize(is_doc_build)
+        initialize(is_doc_build)
         initialized = True
 
-    if plt is None:
-        raise RuntimeError("Matplotlib not found. Matplotlib is required to "
-                           "use plotting in Scipp.")
+    import matplotlib.pyplot as plt
 
     # Switch auto figure display off for better control over when figures are
     # displayed.


### PR DESCRIPTION
This is a proof-of-concept! It *passes the tests* and *does improve import times drastically* (by about 700 ms), but I think we should probably avoid re-executing some of this code on every call to `plot`.

@nvaytet can you continue on this line of change (please push to this branch)? You are more familiar with how this works and what can/should be called only once. Te only change I did so far was to move the entire setup chunk into `plot()`, with no further changes.