### PR TITLE
Remove Dim from Python

### DIFF
--- a/lib/python/bind_data_array.h
+++ b/lib/python/bind_data_array.h
@@ -79,9 +79,9 @@ void bind_is_edges(py::class_<T, Ignored...> &view) {
   view.def(
       "is_edges",
       [](const T &self, const std::string &key,
-         const std::optional<std::string> dim) {
+         const std::optional<std::string> &dim) {
         return self.is_edges(typename T::key_type{key},
-                             dim.has_value() ? std::optional{Dim{*dim}}
+                             dim.has_value() ? std::optional{Dim(*dim)}
                                              : std::optional<Dim>{});
       },
       py::arg("key"), py::arg("dim") = std::nullopt,

--- a/lib/python/bind_units.cpp
+++ b/lib/python/bind_units.cpp
@@ -17,13 +17,6 @@ namespace py = pybind11;
 
 void init_units(py::module &m) {
   py::class_<DefaultUnit>(m, "DefaultUnit");
-  py::class_<units::Dim>(m, "Dim", "Dimension label")
-      .def(py::init<const std::string &>())
-      .def(py::self == py::self)
-      .def(py::self != py::self)
-      .def(hash(py::self))
-      .def("__repr__", [](const Dim &dim) { return dim.name(); });
-
   py::class_<units::Unit>(m, "Unit", "A physical unit.")
       .def(py::init<const std::string &>())
       .def("__repr__", [](const units::Unit &u) { return u.name(); })

--- a/lib/python/counts.cpp
+++ b/lib/python/counts.cpp
@@ -14,27 +14,29 @@ namespace py = pybind11;
 void init_counts(py::module &m) {
   m.def(
       "counts_to_density",
-      [](const Dataset &d, const Dim dim) { return counts::toDensity(d, dim); },
+      [](const Dataset &d, const std::string &dim) {
+        return counts::toDensity(d, Dim{dim});
+      },
       py::arg("x"), py::arg("dim"));
 
   m.def(
       "counts_to_density",
-      [](const DataArray &d, const Dim dim) {
-        return counts::toDensity(d, dim);
+      [](const DataArray &d, const std::string &dim) {
+        return counts::toDensity(d, Dim{dim});
       },
       py::arg("x"), py::arg("dim"));
 
   m.def(
       "density_to_counts",
-      [](const Dataset &d, const Dim dim) {
-        return counts::fromDensity(d, dim);
+      [](const Dataset &d, const std::string &dim) {
+        return counts::fromDensity(d, Dim{dim});
       },
       py::arg("x"), py::arg("dim"));
 
   m.def(
       "density_to_counts",
-      [](const DataArray &d, const Dim dim) {
-        return counts::fromDensity(d, dim);
+      [](const DataArray &d, const std::string &dim) {
+        return counts::fromDensity(d, Dim{dim});
       },
       py::arg("x"), py::arg("dim"));
 }

--- a/lib/python/cumulative.cpp
+++ b/lib/python/cumulative.cpp
@@ -29,8 +29,8 @@ template <class T> void bind_cumsum(py::module &m) {
       py::call_guard<py::gil_scoped_release>());
   m.def(
       "cumsum",
-      [](const T &a, const Dim dim, const std::string &mode) {
-        return cumsum(a, dim, cumsum_mode(mode));
+      [](const T &a, const std::string &dim, const std::string &mode) {
+        return cumsum(a, Dim{dim}, cumsum_mode(mode));
       },
       py::arg("a"), py::arg("dim"), py::arg("mode") = "inclusive",
       py::call_guard<py::gil_scoped_release>());

--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -291,7 +291,7 @@ Returned by :py:func:`DataArray.masks`)");
 
   m.def(
       "irreducible_mask",
-      [](const Masks &masks, const std::string dim) {
+      [](const Masks &masks, const std::string &dim) {
         py::gil_scoped_release release;
         auto mask = irreducible_mask(masks, Dim{dim});
         py::gil_scoped_acquire acquire;

--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -166,28 +166,36 @@ Returned by :py:func:`DataArray.masks`)");
     Named variable with associated coords, masks, and attributes.)");
   py::options options;
   options.disable_function_signatures();
-  dataArray
-      .def(
-          py::init([](const Variable &data, const py::dict &coords,
-                      std::unordered_map<std::string, Variable> masks,
-                      const py::dict &attrs, const std::string &name) {
-            return DataArray{data, to_cpp_dim_map<Variable>(coords),
-                             std::move(masks), to_cpp_dim_map<Variable>(attrs),
-                             name};
-          }),
-          py::arg("data"), py::kw_only(), py::arg("coords") = py::dict(),
-          py::arg("masks") = std::unordered_map<std::string, Variable>{},
-          py::arg("attrs") = py::dict(), py::arg("name") = std::string{},
-          R"(__init__(self, data: Variable, coords: Dict[str, Variable] = {}, masks: Dict[str, Variable] = {}, attrs: Dict[str, Variable] = {}, name: str = '') -> None
+  dataArray.def(
+      py::init([](const Variable &data, const py::dict &coords,
+                  std::unordered_map<std::string, Variable> masks,
+                  const py::dict &attrs, const std::string &name) {
+        return DataArray{data, to_cpp_dim_map<Variable>(coords),
+                         std::move(masks), to_cpp_dim_map<Variable>(attrs),
+                         name};
+      }),
+      py::arg("data"), py::kw_only(), py::arg("coords") = py::dict(),
+      py::arg("masks") = std::unordered_map<std::string, Variable>{},
+      py::arg("attrs") = py::dict(), py::arg("name") = std::string{},
+      R"doc(__init__(self, data: Variable, coords: Dict[str, Variable] = {}, masks: Dict[str, Variable] = {}, attrs: Dict[str, Variable] = {}, name: str = '') -> None
 
           DataArray initializer.
 
-          :param data: Data and optionally variances.
-          :param coords: Coordinates referenced by dimension.
-          :param masks: Masks referenced by name.
-          :param attrs: Attributes referenced by dimension.
-          :param name: Name of DataArray.
-          )")
+          Parameters
+          ----------
+          data:
+              Data and optionally variances.
+          coords:
+              Coordinates referenced by dimension.
+          masks:
+              Masks referenced by name.
+          attrs:
+              Attributes referenced by dimension.
+          name:
+              Name of DataArray.
+          )doc");
+  options.enable_function_signatures();
+  dataArray
       .def("__sizeof__",
            [](const DataArray &array) {
              return size_of(array, SizeofTag::ViewOnly, true);
@@ -195,13 +203,12 @@ Returned by :py:func:`DataArray.masks`)");
       .def("underlying_size", [](const DataArray &self) {
         return size_of(self, SizeofTag::Underlying);
       });
-  options.enable_function_signatures();
 
   bind_data_array(dataArray);
 
   py::class_<Dataset> dataset(m, "Dataset", R"(
   Dict of data arrays with aligned dimensions.)");
-
+  options.disable_function_signatures();
   dataset.def(
       py::init([](const std::map<std::string, std::variant<Variable, DataArray>>
                       &data,
@@ -220,15 +227,17 @@ Returned by :py:func:`DataArray.masks`)");
       py::arg("data") =
           std::map<std::string, std::variant<Variable, DataArray>>{},
       py::kw_only(), py::arg("coords") = std::map<std::string, Variable>{},
-      R"(__init__(self, data: Dict[str, Union[Variable, DataArray]] = {}, coords: Dict[str, Variable] = {}) -> None
+      R"doc(__init__(self, data: Dict[str, Union[Variable, DataArray]] = {}, coords: Dict[str, Variable] = {}) -> None
 
-              Dataset initializer.
+      Dataset initializer.
 
-             :param data: Dictionary of name and data pairs.
-             :param coords: Dictionary of name and coord pairs.
-             :type data: Dict[str, Union[Variable, DataArray]]
-             :type coords: Dict[str, Variable]
-             )");
+      Parameters
+      ----------
+      data:
+          Dictionary of name and data pairs.
+      coords:
+          Dictionary of name and coord pairs.
+      )doc");
   options.enable_function_signatures();
 
   dataset

--- a/lib/python/dim.h
+++ b/lib/python/dim.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Jan-Lukas Wynen
+
+#include <vector>
+
+#include "scipp/core/dimensions.h"
+#include "scipp/units/dim.h"
+
+inline auto to_dim_type(const scipp::span<const std::string> dim_strings) {
+  std::vector<scipp::Dim> dims;
+  dims.reserve(dim_strings.size());
+  std::transform(begin(dim_strings), end(dim_strings), std::back_inserter(dims),
+                 [](const std::string &d) { return scipp::Dim{d}; });
+  return dims;
+}
+
+inline scipp::core::Dimensions
+make_dims(const scipp::span<const std::string> dim_strings,
+          scipp::span<const scipp::index> shape) {
+  const auto dims = to_dim_type(dim_strings);
+  return scipp::core::Dimensions{dims, shape};
+}

--- a/lib/python/groupby.cpp
+++ b/lib/python/groupby.cpp
@@ -28,14 +28,19 @@ template <class T> Docstring docstring_groupby(const std::string &op) {
 }
 
 template <class T> void bind_groupby(py::module &m, const std::string &name) {
-  m.def("groupby", py::overload_cast<const T &, const Dim>(&groupby),
-        py::arg("data"), py::arg("group"),
-        py::call_guard<py::gil_scoped_release>());
+  m.def(
+      "groupby",
+      [](const T &x, const std::string &dim) { return groupby(x, Dim{dim}); },
+      py::arg("data"), py::arg("group"),
+      py::call_guard<py::gil_scoped_release>());
 
-  m.def("groupby",
-        py::overload_cast<const T &, const Dim, const Variable &>(&groupby),
-        py::arg("data"), py::arg("group"), py::arg("bins"),
-        py::call_guard<py::gil_scoped_release>());
+  m.def(
+      "groupby",
+      [](const T &x, const std::string &dim, const Variable &bins) {
+        return groupby(x, Dim{dim}, bins);
+      },
+      py::arg("data"), py::arg("group"), py::arg("bins"),
+      py::call_guard<py::gil_scoped_release>());
 
   m.def("groupby",
         py::overload_cast<const T &, const Variable &, const Variable &>(
@@ -46,33 +51,61 @@ template <class T> void bind_groupby(py::module &m, const std::string &name) {
   py::class_<GroupBy<T>> groupBy(m, name.c_str(), R"(
     GroupBy object implementing split-apply-combine mechanism.)");
 
-  groupBy.def("mean", &GroupBy<T>::mean, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("mean").c_str());
+  groupBy.def(
+      "mean",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.mean(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("mean").c_str());
 
-  groupBy.def("sum", &GroupBy<T>::sum, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("sum").c_str());
+  groupBy.def(
+      "sum",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.sum(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("sum").c_str());
 
-  groupBy.def("all", &GroupBy<T>::all, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("all").c_str());
+  groupBy.def(
+      "all",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.all(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("all").c_str());
 
-  groupBy.def("any", &GroupBy<T>::any, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("any").c_str());
+  groupBy.def(
+      "any",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.any(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("any").c_str());
 
-  groupBy.def("min", &GroupBy<T>::min, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("min").c_str());
+  groupBy.def(
+      "min",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.min(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("min").c_str());
 
-  groupBy.def("max", &GroupBy<T>::max, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("max").c_str());
+  groupBy.def(
+      "max",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.max(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("max").c_str());
 
-  groupBy.def("concat", &GroupBy<T>::concat, py::arg("dim"),
-              py::call_guard<py::gil_scoped_release>(),
-              docstring_groupby<T>("concat").c_str());
+  groupBy.def(
+      "concat",
+      [](const GroupBy<T> &self, const std::string &dim) {
+        return self.concat(Dim{dim});
+      },
+      py::arg("dim"), py::call_guard<py::gil_scoped_release>(),
+      docstring_groupby<T>("concat").c_str());
 
   groupBy.def(
       "copy",

--- a/lib/python/operations.cpp
+++ b/lib/python/operations.cpp
@@ -46,8 +46,8 @@ template <typename T> void bind_sort(py::module &m) {
 template <typename T> void bind_sort_dim(py::module &m) {
   m.def(
       "sort",
-      [](const T &x, const Dim &dim, const std::string &order) {
-        return sort(x, dim, get_sort_order(order));
+      [](const T &x, const std::string &dim, const std::string &order) {
+        return sort(x, Dim{dim}, get_sort_order(order));
       },
       py::arg("x"), py::arg("key"), py::arg("order"),
       py::call_guard<py::gil_scoped_release>());
@@ -56,8 +56,8 @@ template <typename T> void bind_sort_dim(py::module &m) {
 void bind_issorted(py::module &m) {
   m.def(
       "issorted",
-      [](const Variable &x, const Dim dim, const std::string &order) {
-        return issorted(x, dim, get_sort_order(order));
+      [](const Variable &x, const std::string &dim, const std::string &order) {
+        return issorted(x, Dim{dim}, get_sort_order(order));
       },
       py::arg("x"), py::arg("dim"), py::arg("order") = "ascending",
       py::call_guard<py::gil_scoped_release>());
@@ -66,14 +66,19 @@ void bind_issorted(py::module &m) {
 void bind_allsorted(py::module &m) {
   m.def(
       "allsorted",
-      [](const Variable &x, const Dim dim, const std::string &order) {
-        return allsorted(x, dim, get_sort_order(order));
+      [](const Variable &x, const std::string &dim, const std::string &order) {
+        return allsorted(x, Dim{dim}, get_sort_order(order));
       },
       py::arg("x"), py::arg("dim"), py::arg("order") = "ascending",
       py::call_guard<py::gil_scoped_release>());
 }
 
-void bind_midpoints(py::module &m) { m.def("midpoints", midpoints); }
+void bind_midpoints(py::module &m) {
+  m.def("midpoints", [](const Variable &var,
+                        const std::optional<std::string> &dim) {
+    return midpoints(var, dim.has_value() ? Dim{*dim} : std::optional<Dim>{});
+  });
+}
 
 void init_operations(py::module &m) {
   bind_dot<Variable>(m);

--- a/lib/python/reduction.cpp
+++ b/lib/python/reduction.cpp
@@ -18,14 +18,17 @@ template <class T> void bind_mean(py::module &m) {
       "mean", [](const T &x) { return mean(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "mean", [](const T &x, const Dim dim) { return mean(x, dim); },
+      "mean",
+      [](const T &x, const std::string &dim) { return mean(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_mean_out(py::module &m) {
   m.def(
       "mean",
-      [](const T &x, const Dim dim, T &out) { return mean(x, dim, out); },
+      [](const T &x, const std::string &dim, T &out) {
+        return mean(x, Dim{dim}, out);
+      },
       py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
       py::call_guard<py::gil_scoped_release>());
 }
@@ -34,14 +37,17 @@ template <class T> void bind_nanmean(py::module &m) {
       "nanmean", [](const T &x) { return nanmean(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "nanmean", [](const T &x, const Dim dim) { return nanmean(x, dim); },
+      "nanmean",
+      [](const T &x, const std::string &dim) { return nanmean(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_nanmean_out(py::module &m) {
   m.def(
       "nanmean",
-      [](const T &x, const Dim dim, T &out) { return mean(x, dim, out); },
+      [](const T &x, const std::string &dim, T &out) {
+        return mean(x, Dim{dim}, out);
+      },
       py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
       py::call_guard<py::gil_scoped_release>());
 }
@@ -51,13 +57,17 @@ template <class T> void bind_sum(py::module &m) {
       "sum", [](const T &x) { return sum(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "sum", [](const T &x, const Dim dim) { return sum(x, dim); },
+      "sum",
+      [](const T &x, const std::string &dim) { return sum(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_sum_out(py::module &m) {
   m.def(
-      "sum", [](const T &x, const Dim dim, T &out) { return sum(x, dim, out); },
+      "sum",
+      [](const T &x, const std::string &dim, T &out) {
+        return sum(x, Dim{dim}, out);
+      },
       py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
       py::call_guard<py::gil_scoped_release>());
 }
@@ -68,14 +78,17 @@ template <class T> void bind_nansum(py::module &m) {
       py::call_guard<py::gil_scoped_release>());
 
   m.def(
-      "nansum", [](const T &x, const Dim dim) { return nansum(x, dim); },
+      "nansum",
+      [](const T &x, const std::string &dim) { return nansum(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_nansum_out(py::module &m) {
   m.def(
       "nansum",
-      [](const T &x, const Dim dim, T &out) { return nansum(x, dim, out); },
+      [](const T &x, const std::string &dim, T &out) {
+        return nansum(x, Dim{dim}, out);
+      },
       py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
       py::call_guard<py::gil_scoped_release>());
 }
@@ -85,7 +98,8 @@ template <class T> void bind_min(py::module &m) {
       "min", [](const T &x) { return min(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "min", [](const T &x, const Dim dim) { return min(x, dim); },
+      "min",
+      [](const T &x, const std::string &dim) { return min(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
@@ -94,7 +108,8 @@ template <class T> void bind_max(py::module &m) {
       "max", [](const T &x) { return max(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "max", [](const T &x, const Dim dim) { return max(x, dim); },
+      "max",
+      [](const T &x, const std::string &dim) { return max(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
@@ -103,7 +118,8 @@ template <class T> void bind_nanmin(py::module &m) {
       "nanmin", [](const T &x) { return nanmin(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "nanmin", [](const T &x, const Dim dim) { return nanmin(x, dim); },
+      "nanmin",
+      [](const T &x, const std::string &dim) { return nanmin(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
@@ -112,7 +128,8 @@ template <class T> void bind_nanmax(py::module &m) {
       "nanmax", [](const T &x) { return nanmax(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "nanmax", [](const T &x, const Dim dim) { return nanmax(x, dim); },
+      "nanmax",
+      [](const T &x, const std::string &dim) { return nanmax(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
@@ -121,7 +138,8 @@ template <class T> void bind_all(py::module &m) {
       "all", [](const T &x) { return all(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "all", [](const T &x, const Dim dim) { return all(x, dim); },
+      "all",
+      [](const T &x, const std::string &dim) { return all(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
@@ -130,7 +148,8 @@ template <class T> void bind_any(py::module &m) {
       "any", [](const T &x) { return any(x); }, py::arg("x"),
       py::call_guard<py::gil_scoped_release>());
   m.def(
-      "any", [](const T &x, const Dim dim) { return any(x, dim); },
+      "any",
+      [](const T &x, const std::string &dim) { return any(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 

--- a/lib/python/rename.h
+++ b/lib/python/rename.h
@@ -6,9 +6,10 @@
 
 #include "scipp/dataset/dataset.h"
 
-template <class T> T rename_dims(T &self, const std::map<Dim, Dim> &name_dict) {
+template <class T>
+T rename_dims(T &self, const std::map<std::string, std::string> &name_dict) {
   auto out(self);
   for (const auto &[from, to] : name_dict)
-    out.rename(from, to);
+    out.rename(Dim{from}, Dim{to});
   return out;
 }

--- a/lib/python/variable_creation.cpp
+++ b/lib/python/variable_creation.cpp
@@ -4,7 +4,6 @@
 /// @author Simon Heybrock
 #include "scipp/core/eigen.h"
 #include "scipp/core/tag_util.h"
-#include "scipp/dataset/dataset.h"
 #include "scipp/variable/creation.h"
 
 #include "dim.h"

--- a/lib/python/variable_creation.cpp
+++ b/lib/python/variable_creation.cpp
@@ -7,6 +7,7 @@
 #include "scipp/dataset/dataset.h"
 #include "scipp/variable/creation.h"
 
+#include "dim.h"
 #include "dtype.h"
 #include "pybind11.h"
 #include "unit.h"
@@ -16,36 +17,36 @@ using namespace scipp;
 namespace py = pybind11;
 
 template <class T> struct MakeZeros {
-  static variable::Variable apply(const std::vector<Dim> &dims,
+  static variable::Variable apply(const std::vector<std::string> &dims,
                                   const std::vector<scipp::index> &shape,
                                   const units::Unit &unit,
                                   const bool with_variances) {
     return with_variances
-               ? makeVariable<T>(Dimensions{dims, shape}, unit, Values{},
+               ? makeVariable<T>(make_dims(dims, shape), unit, Values{},
                                  Variances{})
-               : makeVariable<T>(Dimensions{dims, shape}, unit, Values{});
+               : makeVariable<T>(make_dims(dims, shape), unit, Values{});
   }
 };
 
 void init_creation(py::module &m) {
   m.def(
       "empty",
-      [](const std::vector<Dim> &dims, const std::vector<scipp::index> &shape,
-         const ProtoUnit &unit, const py::object &dtype,
-         const bool with_variances) {
+      [](const std::vector<std::string> &dims,
+         const std::vector<scipp::index> &shape, const ProtoUnit &unit,
+         const py::object &dtype, const bool with_variances) {
         const auto dtype_ = scipp_dtype(dtype);
         py::gil_scoped_release release;
         const auto unit_ = unit_or_default(unit, dtype_);
-        return variable::empty(Dimensions(dims, shape), unit_, dtype_,
+        return variable::empty(make_dims(dims, shape), unit_, dtype_,
                                with_variances);
       },
       py::arg("dims"), py::arg("shape"), py::arg("unit") = DefaultUnit{},
       py::arg("dtype") = py::none(), py::arg("with_variances") = std::nullopt);
   m.def(
       "zeros",
-      [](const std::vector<Dim> &dims, const std::vector<scipp::index> &shape,
-         const ProtoUnit &unit, const py::object &dtype,
-         const bool with_variances) {
+      [](const std::vector<std::string> &dims,
+         const std::vector<scipp::index> &shape, const ProtoUnit &unit,
+         const py::object &dtype, const bool with_variances) {
         const auto dtype_ = scipp_dtype(dtype);
         py::gil_scoped_release release;
         const auto unit_ = unit_or_default(unit, dtype_);
@@ -59,13 +60,13 @@ void init_creation(py::module &m) {
       py::arg("dtype") = py::none(), py::arg("with_variances") = std::nullopt);
   m.def(
       "ones",
-      [](const std::vector<Dim> &dims, const std::vector<scipp::index> &shape,
-         const ProtoUnit &unit, const py::object &dtype,
-         const bool with_variances) {
+      [](const std::vector<std::string> &dims,
+         const std::vector<scipp::index> &shape, const ProtoUnit &unit,
+         const py::object &dtype, const bool with_variances) {
         const auto dtype_ = scipp_dtype(dtype);
         py::gil_scoped_release release;
         const auto unit_ = unit_or_default(unit, dtype_);
-        return variable::ones(Dimensions(dims, shape), unit_, dtype_,
+        return variable::ones(make_dims(dims, shape), unit_, dtype_,
                               with_variances);
       },
       py::arg("dims"), py::arg("shape"), py::arg("unit") = DefaultUnit{},

--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -87,7 +87,8 @@ Dimensions build_dimensions(py::iterator &&label_it, py::iterator &&shape_it,
   scipp::index dim = 0;
   for (; label_it != label_it.end() && shape_it != shape_it.end();
        ++label_it, ++shape_it, ++dim) {
-    dims.addInner(label_it->cast<Dim>(), shape_it->cast<scipp::index>());
+    dims.addInner(Dim{label_it->cast<std::string>()},
+                  shape_it->cast<scipp::index>());
   }
   if (label_it != label_it.end() || shape_it != shape_it.end()) {
     throw_ndim_mismatch_error(dim + n_remaining(label_it), "dims",

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -276,11 +276,18 @@ class DataArray():
         """
         DataArray initializer.
 
-        :param data: Data and optionally variances.
-        :param coords: Coordinates referenced by dimension.
-        :param masks: Masks referenced by name.
-        :param attrs: Attributes referenced by dimension.
-        :param name: Name of DataArray.
+        Parameters
+        ----------
+        data:
+            Data and optionally variances.
+        coords:
+            Coordinates referenced by dimension.
+        masks:
+            Masks referenced by name.
+        attrs:
+            Attributes referenced by dimension.
+        name:
+            Name of DataArray.
         """
     def __invert__(self) -> DataArray: ...
     @typing.overload
@@ -447,6 +454,7 @@ class DataArray():
         """
         Rename dimensions.
         """
+    def underlying_size(self) -> int: ...
     @property
     def attrs(self) -> Coords:
         """
@@ -701,18 +709,17 @@ class Dataset():
     def __imul__(self, arg0: float) -> object: ...
     @typing.overload
     def __imul__(self, arg0: int) -> object: ...
-    @typing.overload
     def __init__(self, data: typing.Dict[str, typing.Union[Variable, DataArray]] = {}, coords: typing.Dict[str, Variable] = {}) -> None: 
         """
-         Dataset initializer.
+        Dataset initializer.
 
-        :param data: Dictionary of name and data pairs.
-        :param coords: Dictionary of name and coord pairs.
-        :type data: Dict[str, Union[Variable, DataArray]]
-        :type coords: Dict[str, Variable]
+        Parameters
+        ----------
+        data:
+            Dictionary of name and data pairs.
+        coords:
+            Dictionary of name and coord pairs.
         """
-    @typing.overload
-    def __init__(self, data: typing.Dict[str, typing.Union[Variable, DataArray]] = {}, *, coords: typing.Dict[str, Variable] = {}) -> None: ...
     @typing.overload
     def __isub__(self, arg0: DataArray) -> object: ...
     @typing.overload

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -25,7 +25,6 @@ __all__ = [
     "Dataset_keys_view",
     "Dataset_values_view",
     "DefaultUnit",
-    "Dim",
     "DimensionError",
     "ElementArrayView_DataArray",
     "ElementArrayView_DataArray_const",
@@ -92,17 +91,17 @@ class Coords():
     Returned by :py:func:`DataArray.coords`, :py:func:`DataArray.attrs`, :py:func:`DataArray.meta`,
     and the corresponding properties of :py:class:`Dataset`.
     """
-    def __contains__(self, arg0: Dim) -> bool: ...
-    def __delitem__(self, arg0: Dim) -> None: ...
+    def __contains__(self, arg0: str) -> bool: ...
+    def __delitem__(self, arg0: str) -> None: ...
     def __eq__(self, arg0: Coords) -> bool: ...
-    def __getitem__(self, arg0: Dim) -> Variable: ...
+    def __getitem__(self, arg0: str) -> Variable: ...
     def __iter__(self) -> typing.Iterator: ...
     def __len__(self) -> int: ...
     def __ne__(self, arg0: Coords) -> bool: ...
-    def __setitem__(self, arg0: Dim, arg1: Variable) -> None: ...
+    def __setitem__(self, arg0: str, arg1: Variable) -> None: ...
     def _ipython_key_completions_(self) -> list: ...
-    def _pop(self, k: Dim) -> object: ...
-    def is_edges(self, key: Dim, dim: typing.Optional[Dim] = None) -> bool: 
+    def _pop(self, k: str) -> object: ...
+    def is_edges(self, key: str, dim: typing.Optional[str] = None) -> bool: 
         """
         Return True if the given key contains bin-edges in the given dim.
         """
@@ -234,13 +233,13 @@ class DataArray():
     @typing.overload
     def __getitem__(self, arg0: typing.List[int]) -> DataArray: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, Variable]) -> DataArray: ...
+    def __getitem__(self, arg0: typing.Tuple[str, Variable]) -> DataArray: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, int]) -> DataArray: ...
+    def __getitem__(self, arg0: typing.Tuple[str, int]) -> DataArray: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, slice]) -> DataArray: ...
+    def __getitem__(self, arg0: typing.Tuple[str, slice]) -> DataArray: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, typing.List[int]]) -> DataArray: ...
+    def __getitem__(self, arg0: typing.Tuple[str, typing.List[int]]) -> DataArray: ...
     @typing.overload
     def __gt__(self, arg0: DataArray) -> DataArray: ...
     @typing.overload
@@ -282,11 +281,6 @@ class DataArray():
         :param masks: Masks referenced by name.
         :param attrs: Attributes referenced by dimension.
         :param name: Name of DataArray.
-        :type data: Variable
-        :type coords: Dict[str, Variable]
-        :type masks: Dict[str, Variable]
-        :type attrs: Dict[str, Variable]
-        :type name: str
         """
     def __invert__(self) -> DataArray: ...
     @typing.overload
@@ -387,6 +381,9 @@ class DataArray():
     def __rtruediv__(self, arg0: float) -> DataArray: ...
     @typing.overload
     def __rtruediv__(self, arg0: int) -> DataArray: ...
+    @staticmethod
+    @typing.overload
+    def __setitem__(*args, **kwargs) -> typing.Any: ...
     @typing.overload
     def __setitem__(self, arg0: ellipsis, arg1: object) -> None: ...
     @typing.overload
@@ -394,13 +391,9 @@ class DataArray():
     @typing.overload
     def __setitem__(self, arg0: slice, arg1: object) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, Variable], arg1: DataArray) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, int], arg1: object) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, Variable], arg1: Variable) -> None: ...
-    @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, int], arg1: object) -> None: ...
-    @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, slice], arg1: object) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, slice], arg1: object) -> None: ...
     @staticmethod
     @typing.overload
     def __sub__(*args, **kwargs) -> typing.Any: ...
@@ -450,7 +443,7 @@ class DataArray():
         copy is made, and the returned data (and meta data) values are new views
         of the data and meta data values of this object.
         """
-    def rename_dims(self, dims_dict: typing.Dict[Dim, Dim], /) -> DataArray: 
+    def rename_dims(self, dims_dict: typing.Dict[str, str], /) -> DataArray: 
         """
         Rename dimensions.
         """
@@ -681,13 +674,13 @@ class Dataset():
     @typing.overload
     def __getitem__(self, arg0: typing.List[int]) -> Dataset: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, Variable]) -> Dataset: ...
+    def __getitem__(self, arg0: typing.Tuple[str, Variable]) -> Dataset: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, int]) -> Dataset: ...
+    def __getitem__(self, arg0: typing.Tuple[str, int]) -> Dataset: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, slice]) -> Dataset: ...
+    def __getitem__(self, arg0: typing.Tuple[str, slice]) -> Dataset: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, typing.List[int]]) -> Dataset: ...
+    def __getitem__(self, arg0: typing.Tuple[str, typing.List[int]]) -> Dataset: ...
     @typing.overload
     def __iadd__(self, arg0: DataArray) -> object: ...
     @typing.overload
@@ -719,7 +712,7 @@ class Dataset():
         :type coords: Dict[str, Variable]
         """
     @typing.overload
-    def __init__(self, data: typing.Dict[str, typing.Union[Variable, DataArray]] = {}, *, coords: typing.Dict[Dim, Variable] = {}) -> None: ...
+    def __init__(self, data: typing.Dict[str, typing.Union[Variable, DataArray]] = {}, *, coords: typing.Dict[str, Variable] = {}) -> None: ...
     @typing.overload
     def __isub__(self, arg0: DataArray) -> object: ...
     @typing.overload
@@ -749,6 +742,9 @@ class Dataset():
     @typing.overload
     def __mul__(self, arg0: Variable) -> Dataset: ...
     def __repr__(self) -> str: ...
+    @staticmethod
+    @typing.overload
+    def __setitem__(*args, **kwargs) -> typing.Any: ...
     @typing.overload
     def __setitem__(self, arg0: ellipsis, arg1: object) -> None: ...
     @typing.overload
@@ -760,11 +756,9 @@ class Dataset():
     @typing.overload
     def __setitem__(self, arg0: str, arg1: Variable) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, Variable], arg1: Dataset) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, int], arg1: object) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, int], arg1: object) -> None: ...
-    @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, slice], arg1: object) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, slice], arg1: object) -> None: ...
     @typing.overload
     def __sub__(self, arg0: DataArray) -> Dataset: ...
     @typing.overload
@@ -799,7 +793,7 @@ class Dataset():
         """
         view on self's keys
         """
-    def rename_dims(self, dims_dict: typing.Dict[Dim, Dim], /) -> Dataset: 
+    def rename_dims(self, dims_dict: typing.Dict[str, str], /) -> Dataset: 
         """
         Rename dimensions.
         """
@@ -894,16 +888,6 @@ class Dataset_values_view():
     def __len__(self) -> int: ...
     pass
 class DefaultUnit():
-    pass
-class Dim():
-    """
-    Dimension label
-    """
-    def __eq__(self, arg0: Dim) -> bool: ...
-    def __hash__(self) -> int: ...
-    def __init__(self, arg0: str) -> None: ...
-    def __ne__(self, arg0: Dim) -> bool: ...
-    def __repr__(self) -> str: ...
     pass
 class DimensionError(RuntimeError, Exception, BaseException):
     """
@@ -1130,7 +1114,7 @@ class GroupByDataArray():
     """
     GroupBy object implementing split-apply-combine mechanism.
     """
-    def all(self, dim: Dim) -> DataArray: 
+    def all(self, dim: str) -> DataArray: 
         """
         Element-wise all over the specified dimension within a group.
 
@@ -1139,7 +1123,7 @@ class GroupByDataArray():
         :return: The computed all over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: DataArray
         """
-    def any(self, dim: Dim) -> DataArray: 
+    def any(self, dim: str) -> DataArray: 
         """
         Element-wise any over the specified dimension within a group.
 
@@ -1148,7 +1132,7 @@ class GroupByDataArray():
         :return: The computed any over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: DataArray
         """
-    def concat(self, dim: Dim) -> DataArray: 
+    def concat(self, dim: str) -> DataArray: 
         """
         Element-wise concat over the specified dimension within a group.
 
@@ -1165,7 +1149,7 @@ class GroupByDataArray():
         :type group: 
         :rtype: DataArray
         """
-    def max(self, dim: Dim) -> DataArray: 
+    def max(self, dim: str) -> DataArray: 
         """
         Element-wise max over the specified dimension within a group.
 
@@ -1174,7 +1158,7 @@ class GroupByDataArray():
         :return: The computed max over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: DataArray
         """
-    def mean(self, dim: Dim) -> DataArray: 
+    def mean(self, dim: str) -> DataArray: 
         """
         Element-wise mean over the specified dimension within a group.
 
@@ -1183,7 +1167,7 @@ class GroupByDataArray():
         :return: The computed mean over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: DataArray
         """
-    def min(self, dim: Dim) -> DataArray: 
+    def min(self, dim: str) -> DataArray: 
         """
         Element-wise min over the specified dimension within a group.
 
@@ -1192,7 +1176,7 @@ class GroupByDataArray():
         :return: The computed min over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: DataArray
         """
-    def sum(self, dim: Dim) -> DataArray: 
+    def sum(self, dim: str) -> DataArray: 
         """
         Element-wise sum over the specified dimension within a group.
 
@@ -1211,7 +1195,7 @@ class GroupByDataset():
     """
     GroupBy object implementing split-apply-combine mechanism.
     """
-    def all(self, dim: Dim) -> Dataset: 
+    def all(self, dim: str) -> Dataset: 
         """
         Element-wise all over the specified dimension within a group.
 
@@ -1220,7 +1204,7 @@ class GroupByDataset():
         :return: The computed all over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: Dataset
         """
-    def any(self, dim: Dim) -> Dataset: 
+    def any(self, dim: str) -> Dataset: 
         """
         Element-wise any over the specified dimension within a group.
 
@@ -1229,7 +1213,7 @@ class GroupByDataset():
         :return: The computed any over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: Dataset
         """
-    def concat(self, dim: Dim) -> Dataset: 
+    def concat(self, dim: str) -> Dataset: 
         """
         Element-wise concat over the specified dimension within a group.
 
@@ -1246,7 +1230,7 @@ class GroupByDataset():
         :type group: 
         :rtype: Dataset
         """
-    def max(self, dim: Dim) -> Dataset: 
+    def max(self, dim: str) -> Dataset: 
         """
         Element-wise max over the specified dimension within a group.
 
@@ -1255,7 +1239,7 @@ class GroupByDataset():
         :return: The computed max over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: Dataset
         """
-    def mean(self, dim: Dim) -> Dataset: 
+    def mean(self, dim: str) -> Dataset: 
         """
         Element-wise mean over the specified dimension within a group.
 
@@ -1264,7 +1248,7 @@ class GroupByDataset():
         :return: The computed mean over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: Dataset
         """
-    def min(self, dim: Dim) -> Dataset: 
+    def min(self, dim: str) -> Dataset: 
         """
         Element-wise min over the specified dimension within a group.
 
@@ -1273,7 +1257,7 @@ class GroupByDataset():
         :return: The computed min over each group, combined along the dimension specified when calling :py:func:`scipp.groupby`.
         :rtype: Dataset
         """
-    def sum(self, dim: Dim) -> Dataset: 
+    def sum(self, dim: str) -> Dataset: 
         """
         Element-wise sum over the specified dimension within a group.
 
@@ -1304,7 +1288,7 @@ class Masks():
     def __setitem__(self, arg0: str, arg1: Variable) -> None: ...
     def _ipython_key_completions_(self) -> list: ...
     def _pop(self, k: str) -> object: ...
-    def is_edges(self, key: str, dim: typing.Optional[Dim] = None) -> bool: 
+    def is_edges(self, key: str, dim: typing.Optional[str] = None) -> bool: 
         """
         Return True if the given key contains bin-edges in the given dim.
         """
@@ -1429,11 +1413,11 @@ class Variable():
     @typing.overload
     def __getitem__(self, arg0: typing.List[int]) -> Variable: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, int]) -> Variable: ...
+    def __getitem__(self, arg0: typing.Tuple[str, int]) -> Variable: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, slice]) -> Variable: ...
+    def __getitem__(self, arg0: typing.Tuple[str, slice]) -> Variable: ...
     @typing.overload
-    def __getitem__(self, arg0: typing.Tuple[Dim, typing.List[int]]) -> Variable: ...
+    def __getitem__(self, arg0: typing.Tuple[str, typing.List[int]]) -> Variable: ...
     @typing.overload
     def __gt__(self, arg0: Variable) -> Variable: ...
     @typing.overload
@@ -1593,9 +1577,9 @@ class Variable():
     @typing.overload
     def __setitem__(self, arg0: slice, arg1: object) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, int], arg1: object) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, int], arg1: object) -> None: ...
     @typing.overload
-    def __setitem__(self, arg0: typing.Tuple[Dim, slice], arg1: object) -> None: ...
+    def __setitem__(self, arg0: typing.Tuple[str, slice], arg1: object) -> None: ...
     @staticmethod
     @typing.overload
     def __sub__(*args, **kwargs) -> typing.Any: ...
@@ -1638,7 +1622,7 @@ class Variable():
         copy is made, and the returned data (and meta data) values are new views
         of the data and meta data values of this object.
         """
-    def rename_dims(self, dims_dict: typing.Dict[Dim, Dim], /) -> Variable: 
+    def rename_dims(self, dims_dict: typing.Dict[str, str], /) -> Variable: 
         """
         Rename dimensions.
         """

--- a/src/scipp/core/cumulative.py
+++ b/src/scipp/core/cumulative.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
-from typing import Optional
+from typing import Literal, Optional
 
 from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
@@ -10,18 +10,26 @@ from ._cpp_wrapper_util import call_func as _call_cpp_func
 
 def cumsum(a: _cpp.Variable,
            dim: Optional[str] = None,
-           mode: Optional[str] = 'inclusive') -> _cpp.Variable:
+           mode: Literal['exclusive', 'inclusive'] = 'inclusive') -> _cpp.Variable:
     """Return the cumulative sum along the specified dimension.
 
     See :py:func:`scipp.sum` on how rounding errors for float32 inputs are handled.
 
-    :param a: Input data.
-    :param dim: Optional dimension along which to calculate the sum. If not
-                given, the cumulative sum along all dimensions is calculated.
-    :param mode: Include or exclude the ith element (along dim) in the sum.
-                 Options are 'inclusive' and 'exclusive'. Defaults to
-                 'inclusive'.
-    :return: The cumulative sum of the input values.
+    Parameters
+    ----------
+    a:
+        Input data.
+    dim:
+        Optional dimension along which to calculate the sum. If not
+        given, the cumulative sum along all dimensions is calculated.
+    mode:
+        Include or exclude the ith element (along dim) in the sum.
+        Options are 'inclusive' and 'exclusive'. Defaults to 'inclusive'.
+
+    Returns
+    -------
+    :
+        The cumulative sum of the input values.
     """
     if dim is None:
         return _call_cpp_func(_cpp.cumsum, a, mode=mode)

--- a/src/scipp/utils/collapse_and_slices.py
+++ b/src/scipp/utils/collapse_and_slices.py
@@ -13,7 +13,7 @@ def _to_slices(scipp_obj, slice_dims, slice_shape, volume):
 
     # Go through the dims that need to be collapsed, and create an array that
     # holds the range of indices for each dimension
-    # Say we have [Dim.Y, 5], and [Dim.Z, 3], then dim_list will contain
+    # Say we have [Y, 5], and [Z, 3], then dim_list will contain
     # [[0, 1, 2, 3, 4], [0, 1, 2]]
     dim_list = []
     for dim in slice_dims:
@@ -28,24 +28,20 @@ def _to_slices(scipp_obj, slice_dims, slice_shape, volume):
     #   [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2] ]
     res = np.reshape(grid, (len(slice_dims), volume))
     # Now make a master array which also includes the dimension labels, i.e.
-    # [ [Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y,
-    #    Dim.Y, Dim.Y, Dim.Y, Dim.Y, Dim.Y],
-    #   [    0,     1,     2,     3,     4,     0,     1,     2,     3,     4,
-    #        0,     1,     2,     3,     4],
-    #   [Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z,
-    #    Dim.Z, Dim.Z, Dim.Z, Dim.Z, Dim.Z],
-    #   [    0,     0,     0,     0,     0,     1,     1,     1,     1,     1,
-    #        2,     2,     2,     2,     2] ]
+    # [ [Y, Y, Y, Y, Y, Y, Y, Y, Y, Y, Y, Y, Y, Y, Y],
+    #   [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+    #   [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z],
+    #   [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2] ]
     slice_list = []
     for i, dim in enumerate(slice_dims):
         slice_list.append([dim] * volume)
         slice_list.append(res[i])
     # Finally reshape the master array to look like
-    # [ [[Dim.Y, 0], [Dim.Z, 0]], [[Dim.Y, 1], [Dim.Z, 0]],
-    #   [[Dim.Y, 2], [Dim.Z, 0]], [[Dim.Y, 3], [Dim.Z, 0]],
-    #   [[Dim.Y, 4], [Dim.Z, 0]], [[Dim.Y, 0], [Dim.Z, 1]],
-    #   [[Dim.Y, 1], [Dim.Z, 1]], [[Dim.Y, 2], [Dim.Z, 1]],
-    #   [[Dim.Y, 3], [Dim.Z, 1]],
+    # [ [[Y, 0], [Z, 0]], [[Y, 1], [Z, 0]],
+    #   [[Y, 2], [Z, 0]], [[Y, 3], [Z, 0]],
+    #   [[Y, 4], [Z, 0]], [[Y, 0], [Z, 1]],
+    #   [[Y, 1], [Z, 1]], [[Y, 2], [Z, 1]],
+    #   [[Y, 3], [Z, 1]],
     # ...
     # ]
     slice_list = np.reshape(np.transpose(np.array(slice_list, dtype=np.dtype('O'))),


### PR DESCRIPTION
We sort of removed `Dim` from the Python API in the past by allowing implicit conversion to / from `str`. But the stubs still listed `Dim` as an argument type which broke type checkers.

This solution unfortunately introduces a lot of noise in the bindings because we can't rely on pybind11 to do conversions for us. But I did not observe any functional differences. And `Dim` no longer shows up anywhere in Python.