### PR TITLE
Improvements of type (hints) of properties

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,8 @@ Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+* Changed :meth:`scipp.Variable.dims` and :meth:`scipp.Variable.shape` and corresponding properties in `DataArray` and `Dataset` to return tuples `2543 <https://github.com/scipp/scipp/pull/2543>`_.
+
 Bugfixes
 ~~~~~~~~
 

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -263,6 +263,9 @@ Dim Dataset::dim() const {
   core::expect::ndim_is(sizes(), 1);
   return *sizes().begin();
 }
+scipp::index Dataset::ndim() const {
+  return scipp::size(m_coords.sizes());
+}
 
 bool Dataset::is_readonly() const noexcept { return m_readonly; }
 

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -263,9 +263,7 @@ Dim Dataset::dim() const {
   core::expect::ndim_is(sizes(), 1);
   return *sizes().begin();
 }
-scipp::index Dataset::ndim() const {
-  return scipp::size(m_coords.sizes());
-}
+scipp::index Dataset::ndim() const { return scipp::size(m_coords.sizes()); }
 
 bool Dataset::is_readonly() const noexcept { return m_readonly; }
 

--- a/lib/dataset/include/scipp/dataset/data_array.h
+++ b/lib/dataset/include/scipp/dataset/data_array.h
@@ -52,7 +52,7 @@ public:
 
   Coords meta() const;
 
-  [[nodiscard]] Dimensions dims() const { return m_data->dims(); }
+  [[nodiscard]] const Dimensions &dims() const { return m_data->dims(); }
   [[nodiscard]] Dim dim() const { return m_data->dim(); }
   [[nodiscard]] scipp::index ndim() const { return m_data->ndim(); }
   [[nodiscard]] scipp::span<const scipp::index> strides() const {

--- a/lib/dataset/include/scipp/dataset/dataset.h
+++ b/lib/dataset/include/scipp/dataset/dataset.h
@@ -191,6 +191,7 @@ public:
   const Sizes &sizes() const;
   const Sizes &dims() const;
   Dim dim() const;
+  [[nodiscard]] scipp::index ndim() const;
 
   bool is_readonly() const noexcept;
 

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -459,9 +459,11 @@ void bind_common_data_properties(pybind11::class_<T, Ignored...> &c) {
       "sizes",
       [](const T &self) {
         const auto &dims = self.dims();
-        std::map<std::string, scipp::index> sizes;
+        // Use py::dict directly instead of std::map in order to guarantee
+        // that items are stored in the order of insertion.
+        py::dict sizes;
         for (const auto label : dims.labels()) {
-          sizes.emplace(label.name(), dims[label]);
+          sizes[label.name().c_str()] = dims[label];
         }
         return sizes;
       },

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -429,9 +429,10 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
       "dims",
       [](const T &self) {
         const auto &dims_ = self.dims();
-        std::vector<std::string> dims;
-        for (const auto &dim : dims_.labels()) {
-          dims.push_back(dim.name());
+        const auto ndim = static_cast<size_t>(self.ndim());
+        py::tuple dims(ndim);
+        for (size_t i = 0; i < ndim; ++i) {
+          dims[i] = dims_.labels()[i].name();
         }
         return dims;
       },

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -425,11 +425,11 @@ void bind_common_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly(
       "dims",
       [](const T &self) {
-        const auto &dims_ = self.dims();
+        const auto &labels = self.dims().labels();
         const auto ndim = static_cast<size_t>(self.ndim());
         py::tuple dims(ndim);
         for (size_t i = 0; i < ndim; ++i) {
-          dims[i] = dims_.labels()[i].name();
+          dims[i] = labels[i].name();
         }
         return dims;
       },
@@ -446,11 +446,11 @@ void bind_common_data_properties(pybind11::class_<T, Ignored...> &c) {
   c.def_property_readonly(
       "shape",
       [](const T &self) {
-        const auto &dims = self.dims();
+        const auto &sizes = self.dims().sizes();
         const auto ndim = static_cast<size_t>(self.ndim());
         py::tuple shape(ndim);
         for (size_t i = 0; i < ndim; ++i) {
-          shape[i] = dims.sizes()[i];
+          shape[i] = sizes[i];
         }
         return shape;
       },

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -455,6 +455,18 @@ void bind_common_data_properties(pybind11::class_<T, Ignored...> &c) {
         return shape;
       },
       "Shape of the data (read-only).", py::return_value_policy::move);
+  c.def_property_readonly(
+      "sizes",
+      [](const T &self) {
+        const auto &dims = self.dims();
+        std::map<std::string, scipp::index> sizes;
+        for (const auto label : dims.labels()) {
+          sizes.emplace(label.name(), dims[label]);
+        }
+        return sizes;
+      },
+      "dict mapping dimension labels to dimension sizes (read-only).",
+      py::return_value_policy::move);
 }
 
 template <class T, class... Ignored>

--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -72,31 +72,7 @@ void bind_dataset_view_methods(py::class_<T, Ignored...> &c) {
     }
     return out;
   });
-  c.def_property_readonly(
-      "dims",
-      [](const T &self) {
-        std::vector<std::string> dims;
-        for (const auto &dim : self.sizes()) {
-          dims.push_back(dim.name());
-        }
-        return dims;
-      },
-      R"(List of dimensions.)", py::return_value_policy::move);
-  // TODO should this be removed?
-  c.def_property_readonly(
-      "shape",
-      [](const T &self) {
-        std::vector<int64_t> shape;
-        for (const auto &size : self.sizes().sizes()) {
-          shape.push_back(size);
-        }
-        return shape;
-      },
-      R"(List of shapes.)", py::return_value_policy::move);
-  c.def_property_readonly(
-      "dim", [](const T &self) { return self.dim().name(); },
-      "The only dimension label for 1-dimensional data, raising an exception "
-      "if the data is not 1-dimensional.");
+  bind_common_data_properties(c);
   bind_pop(c);
 }
 

--- a/src/scipp/compat/dict.py
+++ b/src/scipp/compat/dict.py
@@ -93,7 +93,7 @@ def _dims_to_strings(dims):
     """
     Convert dims that may or may not be strings to strings.
     """
-    return [str(dim) for dim in dims]
+    return tuple(str(dim) for dim in dims)
 
 
 def from_dict(dict_obj: dict) -> VariableLike:

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -25,11 +25,8 @@ from .cpp_classes import BinEdgeError, BinnedDataError, CoordError, \
 
 from .._scipp.core import get_slice_params
 
-from .dimensions import _make_sizes, _rename_variable, _rename_data_array, _rename_dataset
+from .dimensions import _rename_variable, _rename_data_array, _rename_dataset
 
-setattr(Variable, 'sizes', property(_make_sizes))
-setattr(DataArray, 'sizes', property(_make_sizes))
-setattr(Dataset, 'sizes', property(_make_sizes))
 setattr(Variable, 'rename', _rename_variable)
 setattr(DataArray, 'rename', _rename_data_array)
 setattr(Dataset, 'rename', _rename_dataset)

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -552,12 +552,11 @@ class DataArray():
         :type: tuple
         """
     @property
-    def sizes(self) -> None:
+    def sizes(self) -> typing.Dict[str, int]:
         """
-            Makes a dictionary of dimensions labels to dimension sizes
-            
+        dict mapping dimension labels to dimension sizes (read-only).
 
-        :type: None
+        :type: typing.Dict[str, int]
         """
     @property
     def unit(self) -> object:
@@ -861,12 +860,11 @@ class Dataset():
         :type: tuple
         """
     @property
-    def sizes(self) -> None:
+    def sizes(self) -> typing.Dict[str, int]:
         """
-            Makes a dictionary of dimensions labels to dimension sizes
-            
+        dict mapping dimension labels to dimension sizes (read-only).
 
-        :type: None
+        :type: typing.Dict[str, int]
         """
     __array_ufunc__ = None
     pass
@@ -1693,12 +1691,11 @@ class Variable():
         :type: tuple
         """
     @property
-    def sizes(self) -> None:
+    def sizes(self) -> typing.Dict[str, int]:
         """
-            Makes a dictionary of dimensions labels to dimension sizes
-            
+        dict mapping dimension labels to dimension sizes (read-only).
 
-        :type: None
+        :type: typing.Dict[str, int]
         """
     @property
     def unit(self) -> object:

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -498,11 +498,11 @@ class DataArray():
         :type: str
         """
     @property
-    def dims(self) -> typing.List[str]:
+    def dims(self) -> tuple:
         """
         Dimension labels of the data (read-only).
 
-        :type: typing.List[str]
+        :type: tuple
         """
     @property
     def dtype(self) -> DType:
@@ -1651,11 +1651,11 @@ class Variable():
         :type: str
         """
     @property
-    def dims(self) -> typing.List[str]:
+    def dims(self) -> tuple:
         """
         Dimension labels of the data (read-only).
 
-        :type: typing.List[str]
+        :type: tuple
         """
     @property
     def dtype(self) -> DType:
@@ -1760,7 +1760,7 @@ class Variable():
     def any(self, dim: 'typing.Optional[str]' = None, *, out: 'typing.Optional[Variable]' = None) -> 'Variable': ...
     def broadcast(self, dims: typing.Union[typing.List[str], typing.Tuple[str, ...], None] = None, shape: typing.Union[typing.Sequence[int], None] = None, sizes: typing.Union[typing.Dict[str, int], None] = None) -> Variable: ...
     def ceil(self, *, out: 'typing.Optional[VariableLike]' = None) -> 'VariableLike': ...
-    def cumsum(self, dim: typing.Union[str, None] = None, mode: typing.Union[str, None] = 'inclusive') -> Variable: ...
+    def cumsum(self, dim: typing.Union[str, None] = None, mode: Literal['exclusive', 'inclusive'] = 'inclusive') -> Variable: ...
     def flatten(self, dims: typing.Union[typing.List[str], typing.Tuple[str, ...], None] = None, to: typing.Union[str, None] = None) -> typing.Union[Variable, DataArray, Dataset]: ...
     def floor(self, *, out: 'typing.Optional[VariableLike]' = None) -> 'VariableLike': ...
     def fold(self, dim: str, sizes: typing.Union[typing.Dict[str, int], None] = None, dims: typing.Union[typing.List[str], typing.Tuple[str, ...], None] = None, shape: typing.Union[typing.Sequence[int], None] = None) -> typing.Union[Variable, DataArray, Dataset]: ...

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -545,11 +545,11 @@ class DataArray():
         :type: int
         """
     @property
-    def shape(self) -> typing.List[int]:
+    def shape(self) -> tuple:
         """
         Shape of the data (read-only).
 
-        :type: typing.List[int]
+        :type: tuple
         """
     @property
     def sizes(self) -> None:
@@ -833,11 +833,11 @@ class Dataset():
         :type: str
         """
     @property
-    def dims(self) -> typing.List[str]:
+    def dims(self) -> tuple:
         """
-        List of dimensions.
+        Dimension labels of the data (read-only).
 
-        :type: typing.List[str]
+        :type: tuple
         """
     @property
     def meta(self) -> Coords:
@@ -847,11 +847,18 @@ class Dataset():
         :type: Coords
         """
     @property
-    def shape(self) -> typing.List[int]:
+    def ndim(self) -> int:
         """
-        List of shapes.
+        Number of dimensions of the data (read-only).
 
-        :type: typing.List[int]
+        :type: int
+        """
+    @property
+    def shape(self) -> tuple:
+        """
+        Shape of the data (read-only).
+
+        :type: tuple
         """
     @property
     def sizes(self) -> None:
@@ -1679,11 +1686,11 @@ class Variable():
         :type: int
         """
     @property
-    def shape(self) -> typing.List[int]:
+    def shape(self) -> tuple:
         """
         Shape of the data (read-only).
 
-        :type: typing.List[int]
+        :type: tuple
         """
     @property
     def sizes(self) -> None:

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -5,13 +5,6 @@ from .._scipp.core import Variable, DataArray, Dataset, CoordError
 from .dataset import merge
 
 
-def _make_sizes(obj):
-    """
-    Makes a dictionary of dimensions labels to dimension sizes
-    """
-    return dict(zip(obj.dims, obj.shape))
-
-
 def _rename_variable(var: Variable, dims_dict: dict = None, /, **names) -> Variable:
     """
     Rename the dimensions labels of a Variable.

--- a/src/scipp/plotting/resampling_model.py
+++ b/src/scipp/plotting/resampling_model.py
@@ -123,8 +123,8 @@ class ResamplingModel():
                 for d in coord_dims:
                     if d not in data_dims:
                         data = broadcast(data,
-                                         dims=[d] + data.dims,
-                                         shape=[sizes[d]] + data.shape)
+                                         dims=(d, *data.dims),
+                                         shape=(sizes[d], *data.shape))
         array = DataArray(data=data)
         for dim in coords:
             try:

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -12,7 +12,7 @@ def is_scalar(obj: _std_typing.Any) -> bool:
     """
     Return True if the input is a scalar.
     """
-    return obj.dims == ()
+    return obj.ndim == 0
 
 
 def has_vector_type(obj: _std_typing.Any) -> bool:

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -12,7 +12,7 @@ def is_scalar(obj: _std_typing.Any) -> bool:
     """
     Return True if the input is a scalar.
     """
-    return obj.dims == []
+    return obj.dims == ()
 
 
 def has_vector_type(obj: _std_typing.Any) -> bool:

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -240,8 +240,8 @@ def test_bins_mean():
     # Mean of last (empty) bin should be NaN
     assert isnan(binned.bins.mean().values[2])
 
-    assert binned.bins.mean().dims == ["x"]
-    assert binned.bins.mean().shape == [3]
+    assert binned.bins.mean().dims == ('x', )
+    assert binned.bins.mean().shape == (3, )
     assert binned.bins.mean().unit == sc.units.counts
 
 
@@ -272,8 +272,8 @@ def test_bins_mean_with_masks():
     # Mean of last (empty) bin should be NaN
     assert isnan(binned.bins.mean().values[2])
 
-    assert binned.bins.mean().dims == ["x"]
-    assert binned.bins.mean().shape == [3]
+    assert binned.bins.mean().dims == ('x', )
+    assert binned.bins.mean().shape == (3, )
     assert binned.bins.mean().unit == sc.units.counts
 
 

--- a/tests/compat/dict_test.py
+++ b/tests/compat/dict_test.py
@@ -24,16 +24,16 @@ def test_variable_to_dict():
 def test_variable_0D_to_dict():
     var = 12.0 * sc.units.one
     var_dict = sc.to_dict(var)
-    assert var_dict["dims"] == []
-    assert var_dict["shape"] == []
+    assert var_dict["dims"] == ()
+    assert var_dict["shape"] == ()
     assert var_dict["values"] == 12.0
 
 
 def test_variable_vector_to_dict():
     var = sc.vectors(dims=['x'], values=np.random.random([10, 3]))
     var_dict = sc.to_dict(var)
-    assert var_dict["dims"] == ['x']
-    assert var_dict["shape"] == [10]
+    assert var_dict["dims"] == ('x', )
+    assert var_dict["shape"] == (10, )
     assert var_dict["values"].shape == (10, 3)
     assert var_dict["dtype"] == sc.DType.vector3
 
@@ -41,8 +41,8 @@ def test_variable_vector_to_dict():
 def test_variable_0D_vector_to_dict():
     var = sc.vector(value=[1, 2, 3])
     var_dict = sc.to_dict(var)
-    assert var_dict["dims"] == []
-    assert var_dict["shape"] == []
+    assert var_dict["dims"] == ()
+    assert var_dict["shape"] == ()
     assert np.array_equal(var_dict["values"], [1, 2, 3])
     assert var_dict["dtype"] == sc.DType.vector3
 
@@ -56,7 +56,7 @@ def test_variable_matrix_to_dict():
     ])
     var = sc.matrices(dims=['x'], values=data, unit=sc.units.m)
     var_dict = sc.to_dict(var)
-    assert var_dict["shape"] == [4]
+    assert var_dict["shape"] == (4, )
     assert var_dict["values"].shape == (4, 3, 3)
     assert var_dict["dtype"] == sc.DType.linear_transform3
 
@@ -64,51 +64,55 @@ def test_variable_matrix_to_dict():
 def test_variable_0D_matrix_to_dict():
     var = sc.matrix(value=np.arange(1, 10).reshape(3, 3))
     var_dict = sc.to_dict(var)
-    assert var_dict["dims"] == []
-    assert var_dict["shape"] == []
+    assert var_dict["dims"] == ()
+    assert var_dict["shape"] == ()
     assert np.array_equal(var_dict["values"], [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert var_dict["dtype"] == sc.DType.linear_transform3
 
 
 def test_variable_from_dict():
     var_dict = {
-        "dims": ['x'],
+        "dims": ('x', ),
         "values": np.random.random(10),
         "variances": np.random.random(10)
     }
     var = sc.from_dict(var_dict)
     assert var.dims == var_dict["dims"]
-    assert var.shape == [10]
+    assert var.shape == (10, )
     assert np.array_equal(var.values, var_dict["values"])
     assert np.array_equal(var.variances, var_dict["variances"])
     assert var.unit == sc.units.one
 
 
 def test_variable_0D_from_dict():
-    var_dict = {"dims": [], "values": 17., "variances": 0.2}
+    var_dict = {"dims": (), "values": 17., "variances": 0.2}
     var = sc.from_dict(var_dict)
-    assert var.dims == []
-    assert var.shape == []
+    assert var.dims == ()
+    assert var.shape == ()
     assert var.value == 17.0
     assert var.variance == 0.2
     assert var.unit == sc.units.one
 
 
 def test_variable_vector_from_dict():
-    var_dict = {"dims": ['x'], "values": np.arange(6).reshape(2, 3), "dtype": "vector3"}
+    var_dict = {
+        "dims": ('x', ),
+        "values": np.arange(6).reshape(2, 3),
+        "dtype": "vector3"
+    }
     var = sc.from_dict(var_dict)
     assert var.dims == var_dict["dims"]
-    assert var.shape == [2]
+    assert var.shape == (2, )
     assert np.array_equal(np.array(var.values), [[0, 1, 2], [3, 4, 5]])
     assert var.unit == sc.units.one
     assert var.dtype == sc.DType.vector3
 
 
 def test_variable_0D_vector_from_dict():
-    var_dict = {"dims": [], "values": [1, 2, 3], "dtype": "vector3"}
+    var_dict = {"dims": (), "values": [1, 2, 3], "dtype": "vector3"}
     var = sc.from_dict(var_dict)
-    assert var.dims == []
-    assert var.shape == []
+    assert var.dims == ()
+    assert var.shape == ()
     assert np.array_equal(np.array(var.values), [1, 2, 3])
     assert var.unit == sc.units.one
     assert var.dtype == sc.DType.vector3
@@ -116,13 +120,13 @@ def test_variable_0D_vector_from_dict():
 
 def test_variable_matrix_from_dict():
     var_dict = {
-        "dims": ['x'],
+        "dims": ('x', ),
         "values": np.arange(18).reshape(2, 3, 3),
         "dtype": "linear_transform3"
     }
     var = sc.from_dict(var_dict)
     assert var.dims == var_dict["dims"]
-    assert var.shape == [2]
+    assert var.shape == (2, )
     assert np.array_equal(np.array(var.values), var_dict["values"])
     assert var.unit == sc.units.one
     assert var.dtype == sc.DType.linear_transform3
@@ -130,13 +134,13 @@ def test_variable_matrix_from_dict():
 
 def test_variable_0D_matrix_from_dict():
     var_dict = {
-        "dims": [],
+        "dims": (),
         "values": np.arange(9).reshape(3, 3),
         "dtype": "linear_transform3"
     }
     var = sc.from_dict(var_dict)
-    assert var.dims == []
-    assert var.shape == []
+    assert var.dims == ()
+    assert var.shape == ()
     assert np.array_equal(np.array(var.value), var_dict["values"])
     assert var.unit == sc.units.one
     assert var.dtype == sc.DType.linear_transform3
@@ -152,7 +156,6 @@ def test_variable_round_trip():
 
 def test_variable_0D_round_trip():
     var = 12.0 * sc.units.one
-    print(sc.to_dict(var))
     assert sc.identical(var, sc.from_dict(sc.to_dict(var)))
 
 

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -11,7 +11,7 @@ import scipp as sc
 def test_shape():
     a = sc.scalar(1)
     d = sc.Dataset(data={'a': a})
-    assert d.shape == []
+    assert d.shape == ()
     a = sc.empty(dims=['x'], shape=[2])
     b = sc.empty(dims=['y', 'z'], shape=[3, 4])
     d = sc.Dataset(data={'a': a, 'b': b})

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -129,7 +129,7 @@ def test_construct_datetime(unit):
                 sc.Variable(dims=['x'], unit=unit, values=values),
                 sc.Variable(dims=['x'], dtype=dtype,
                             values=values), sc.Variable(dims=['x'], values=values)):
-        assert var.dims == ['x']
+        assert var.dims == ('x', )
         assert str(var.dtype) == 'datetime64'
         assert var.unit == unit
         assert var.values.dtype == dtype

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -27,7 +27,7 @@ def test_variable_1D_vector3_from_list():
     assert len(var.values) == 2
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
-    assert var.dims == ['x']
+    assert var.dims == ('x', )
     assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
@@ -39,7 +39,7 @@ def test_variable_1D_vector3_from_numpy():
     assert len(var.values) == 2
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
-    assert var.dims == ['x']
+    assert var.dims == ('x', )
     assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
 
@@ -147,7 +147,7 @@ def test_variable_1D_matrix_from_numpy():
     np.testing.assert_array_equal(var.values[0], [[0, 1, 2], [3, 4, 5], [6, 7, 8]])
     np.testing.assert_array_equal(var.values[1], [[5, 6, 7], [8, 9, 10], [11, 12, 13]])
     np.testing.assert_array_equal(var.values[2], [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    assert var.dims == ['x']
+    assert var.dims == ('x', )
     assert var.dtype == sc.DType.linear_transform3
     assert var.unit == sc.units.us
 

--- a/tests/plotting/plot_1d_test.py
+++ b/tests/plotting/plot_1d_test.py
@@ -277,8 +277,8 @@ def test_plot_access_ax_and_fig_two_entries():
     d = make_dense_dataset(ndim=1)
     d['b'].unit = 'kg'
     out = sc.plot(d)
-    out["['xx'].counts"].ax.set_xlabel("MyXlabel")
-    out["['xx'].counts"].fig.set_dpi(120.)
+    out["('xx',).counts"].ax.set_xlabel("MyXlabel")
+    out["('xx',).counts"].fig.set_dpi(120.)
     out.close()
 
 

--- a/tests/variable_init_test.py
+++ b/tests/variable_init_test.py
@@ -53,7 +53,7 @@ DTYPE_INPUT_TO_EXPECTED = (
 def test_create_scalar_with_float_value(value):
     var = sc.Variable(dims=(), values=value)
     assert var.value == value
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
@@ -68,7 +68,7 @@ def test_create_scalar_with_float_variance(variance):
     var = sc.Variable(dims=(), variances=variance)
     assert var.value == 0.0
     assert var.variance == variance
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
@@ -88,7 +88,7 @@ def test_create_scalar_with_float_value_and_variance(value, variance):
     var = sc.Variable(dims=(), values=value, variances=variance)
     assert var.value == value
     assert var.variance == variance
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.dimensionless
@@ -100,7 +100,7 @@ def test_create_scalar_with_value(args):
     dtype, value = args
     var = sc.Variable(dims=(), values=value)
     assert var.value == value
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == dtype
     if dtype in (sc.DType.string, sc.DType.bool):
@@ -114,7 +114,7 @@ def test_create_scalar_with_value_array(args):
     dtype, value = args
     var = sc.Variable(dims=(), values=np.array(value))
     assert var.value == value
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == dtype
     if dtype in (sc.DType.string, sc.DType.bool):
@@ -126,7 +126,7 @@ def test_create_scalar_with_value_array(args):
 def test_create_scalar_with_value_array_int():
     var = sc.Variable(dims=(), values=np.array(2))
     assert var.value == 2
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     # The dtype varies between Windows and Linux / MacOS.
     assert var.dtype in (sc.DType.int32, sc.DType.int64)
@@ -159,7 +159,7 @@ def test_create_scalar_invalid_variance(variance):
 ])
 def test_create_scalar_with_unit(unit):
     var = sc.Variable(dims=(), values=1.0, unit=unit)
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.value == 1.0
     assert var.dtype == sc.DType.float64
@@ -169,7 +169,7 @@ def test_create_scalar_with_unit(unit):
 def test_create_scalar_quantity():
     var = sc.Variable(dims=(), values=1.2, unit=sc.units.m)
     assert var.value == 1.2
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
@@ -192,7 +192,7 @@ def test_create_scalar_dtype_Variable(dtype):
     elem = sc.Variable(dims=['x'], values=np.arange(4.0))
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.Variable
     assert var.unit is None
@@ -205,7 +205,7 @@ def test_create_scalar_dtype_DataArray(dtype):
     elem = sc.DataArray(data=sc.Variable(dims=['x'], values=np.arange(4.0)))
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.DataArray
     assert var.unit is None
@@ -218,7 +218,7 @@ def test_create_scalar_dtype_Dataset(dtype):
     elem = sc.Dataset(data={'a': sc.Variable(dims=['x'], values=np.arange(4.0))})
     var = sc.Variable(dims=(), values=elem, dtype=dtype)
     assert sc.identical(var.value, elem)
-    assert var.dims == []
+    assert var.dims == ()
     assert var.ndim == 0
     assert var.dtype == sc.DType.Dataset
     assert var.unit is None
@@ -250,9 +250,9 @@ def test_create_scalar_invalid_conversion_str(dtype):
 
 def test_create_1d_size_4():
     var = sc.Variable(dims=['x'], values=np.arange(4.0), unit=sc.units.m)
-    assert var.shape == [4]
+    assert var.shape == (4, )
     np.testing.assert_array_equal(var.values, [0, 1, 2, 3])
-    assert var.dims == ['x']
+    assert var.dims == ('x', )
     assert var.ndim == 1
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m
@@ -374,7 +374,7 @@ def test_create_1D_vector3():
     assert len(var.values) == 2
     np.testing.assert_array_equal(var.values[0], [1, 2, 3])
     np.testing.assert_array_equal(var.values[1], [4, 5, 6])
-    assert var.dims == ['x']
+    assert var.dims == ('x', )
     assert var.ndim == 1
     assert var.dtype == sc.DType.vector3
     assert var.unit == sc.units.m
@@ -389,10 +389,10 @@ def test_create_2d_inner_size_3():
     var = sc.Variable(dims=['x', 'y'],
                       values=np.arange(6.0).reshape(2, 3),
                       unit=sc.units.m)
-    assert var.shape == [2, 3]
+    assert var.shape == (2, 3)
     np.testing.assert_array_equal(var.values[0], [0, 1, 2])
     np.testing.assert_array_equal(var.values[1], [3, 4, 5])
-    assert var.dims == ['x', 'y']
+    assert var.dims == ('x', 'y')
     assert var.ndim == 2
     assert var.dtype == sc.DType.float64
     assert var.unit == sc.units.m

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -251,6 +251,15 @@ def test_sizes():
     assert a.sizes == {'y': 3, 'z': 4}
 
 
+def test_dims():
+    a = sc.scalar(1)
+    assert a.dims == ()
+    a = sc.empty(dims=['x'], shape=[2])
+    assert a.dims == ('x', )
+    a = sc.empty(dims=['y', 'z'], shape=[3, 4])
+    assert a.dims == ('y', 'z')
+
+
 def test_concat():
     assert_export(sc.concat,
                   [sc.Variable(dims=(), values=0.0),


### PR DESCRIPTION
- Return tuples from `dims` and `shape` properties as per #2521
- Define `sizes` property in C++. This produces a proper type annotation in the stub file, where previously, the combination of calling `setattr` and `property` in Python produced an incorrect return type of `None`.

I tried to get `Tuple[str]` and `Tuple[int]` in `dims` and `shape`, respectively. But the only way to achieve that which I could find is providing an explicit annotation in the doctstring to be picked up by the stub generator. But that would not be very nice either.