### PR TITLE
Fix vtable visibility for StructureArrayModel

### DIFF
--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -38,6 +38,8 @@ public:
       : VariableConcept(units::one), // unit ignored
         m_elements(std::move(elements)) {}
 
+  ~StructureArrayModel() override;
+
   static DType static_dtype() noexcept { return scipp::dtype<T>; }
   DType dtype() const noexcept override { return scipp::dtype<T>; }
   scipp::index size() const override {

--- a/lib/variable/variable_instantiate_linalg.cpp
+++ b/lib/variable/variable_instantiate_linalg.cpp
@@ -68,6 +68,14 @@ std::vector<std::string> element_keys(const Variable &var) {
   throw except::TypeError("dtype is not structured");
 }
 
+// Defining the destructor here ensures that all users of StructureArrayModel
+// use the same visibility of that class. Otherwise, instantiating the
+// StructureArrayModel template creates a class without visibility attribute.
+// But INSTANTIATE_STRUCTURE_ARRAY_VARIABLE below gives it SCIPP_EXPORT
+// visibility which would cause a mismatch.
+// With this explicit definition, instantiation is deferred.
+// This was observed with Apple Clang 13 and using
+// std::make_shared<StructureArrayModel<T, Elem>> in structures.cpp
 template <class T_, class Elem_>
 StructureArrayModel<T_, Elem_>::~StructureArrayModel() = default;
 

--- a/lib/variable/variable_instantiate_linalg.cpp
+++ b/lib/variable/variable_instantiate_linalg.cpp
@@ -68,6 +68,9 @@ std::vector<std::string> element_keys(const Variable &var) {
   throw except::TypeError("dtype is not structured");
 }
 
+template <class T_, class Elem_>
+StructureArrayModel<T_, Elem_>::~StructureArrayModel() = default;
+
 INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(vector3, Eigen::Vector3d, double)
 INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(linear_transform3, Eigen::Matrix3d, double)
 INSTANTIATE_STRUCTURE_ARRAY_VARIABLE(affine_transform3, Eigen::Affine3d, double)


### PR DESCRIPTION
See explanation in `variable_instantiate_linalg.cpp`. I am not 100% certain about the reason why it happened. Does the explanation make sense?

This came up when compiling with Apple Clang and linking `scipp-variable`:
```
ld: warning: direct access in function 'scipp::variable::StructureArrayModel<scipp::core::Translation, double>::~StructureArrayModel()' from file 'CMakeFiles/scipp-variable.dir/structures.cpp.o' to global weak symbol 'vtable for scipp::variable::StructureArrayModel<scipp::core::Translation, double>' from file 'CMakeFiles/scipp-variable.dir/variable_instantiate_linalg.cpp.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```
There were similar warnings for the other instances of `StructureArrayModel`.

Note that the warning refers to the destructor, hence the change I made. I tried moving other member functions into cpp files but could not make it compile. Maybe my explanation is not correct and this is a specific problem with the destructor?