### PR TITLE
Treat warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,26 @@ archs = ["x86_64", "arm64"]
 [tool.pytest.ini_options]
 addopts = "-ra -v"
 filterwarnings = [
+  'error',
   'ignore:You are running a "Debug" build of scipp:',
   'ignore:sc.matrix\(\) has been deprecated:DeprecationWarning',
   'ignore:sc.matrices\(\) has been deprecated:DeprecationWarning',
-  # Explained in variable_init_test.py
+  # Explained in variable_init_test.py. TODO Address this!
   'ignore:Creating an ndarray from ragged nested sequences:DeprecationWarning',
+  'ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning',
   # Comes from pytest_asyncio and is not our fault.
   "ignore:The 'asyncio_mode' default value will change to 'strict' in future:DeprecationWarning",
+  'ignore::scipy.optimize._optimize.OptimizeWarning',
+  # Plotting related warnings.
+  'ignore:More than 20 figures have been opened:RuntimeWarning',
+  'ignore:Attempted to set non-positive :UserWarning',
+  'ignore:Attempting to set identical bottom == top == 0.0 results in singular transformations; automatically expanding.:UserWarning',
+  # TODO Plotting related deprecation warnings which should be addressed!
+  'ignore:NONE is deprecated and will be removed in Pillow 10 \(2023-07-01\). Use Resampling.NEAREST or Dither.NONE instead.:DeprecationWarning',
+  'ignore:ADAPTIVE is deprecated and will be removed in Pillow 10 \(2023-07-01\). Use Palette.ADAPTIVE instead.:DeprecationWarning',
+  'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
+  'ignore:Keyword `trait` is deprecated in traitlets 5.0, use `value_trait` instead:DeprecationWarning',
+  'ignore:Keyword `traits` is deprecated in traitlets 5.0, use `per_key_traits` instead:DeprecationWarning',
+  'ignore:Support for mapping types has been deprecated and will be dropped in a future release.:DeprecationWarning',
 ]
 testpaths = "tests"


### PR DESCRIPTION
There is a number of ignored `DeprecationWarning` cases which we should look into addressing. Otherwise we risk things breaking randomly at some point.

The goal of enabling this is to avoid even more warnings creeping in. Addressing *existing* warnings can be done separately.

@nvaytet @jl-wynen Please take note of this.