### PR TITLE
Increase deadline for HTML repr tests

### DIFF
--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -284,6 +284,7 @@ def test_coords_update_from_sequence_of_tuples_adds_items():
 
 
 def test_coords_update_from_iterable_of_tuples_adds_items():
+
     def extra_items():
         yield 'b', sc.scalar(3.0)
         yield 'c', sc.scalar(4.0)

--- a/tests/hypothesis/html_repr_test.py
+++ b/tests/hypothesis/html_repr_test.py
@@ -2,23 +2,35 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Jan-Lukas Wynen
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from scipp.testing import strategies as scst
 import scipp as sc
 
 
+# Tests have an increased deadline because the default was not enough for our MacOS CI.
+# hypothesis failed the tests because of it but subsequent invocations during
+# minimization of the failing example could not reproduce the time-based failure,
+# making hypothesis flag the test as flaky.
+#
+# This might indicate some hidden start up cost.
+# It might be related to complicated utf-8 strings as all failing cases contain many
+# unusual characters, many of which cannot be rendered properly on GitHub.
+
+@settings(deadline=1000)
 @given(scst.variables(ndim=0))
 def test_html_repr_scalar(var):
     sc.make_html(var)
 
 
+@settings(deadline=1000)
 @given(scst.variables(ndim=st.integers(1, 4)))
 def test_html_repr_array(var):
     sc.make_html(var)
 
 
+@settings(deadline=1000)
 @given(scst.dataarrays())
 def test_html_repr_data_array(da):
     sc.make_html(da)

--- a/tests/hypothesis/html_repr_test.py
+++ b/tests/hypothesis/html_repr_test.py
@@ -8,7 +8,6 @@ from hypothesis import strategies as st
 from scipp.testing import strategies as scst
 import scipp as sc
 
-
 # Tests have an increased deadline because the default was not enough for our MacOS CI.
 # hypothesis failed the tests because of it but subsequent invocations during
 # minimization of the failing example could not reproduce the time-based failure,
@@ -17,6 +16,7 @@ import scipp as sc
 # This might indicate some hidden start up cost.
 # It might be related to complicated utf-8 strings as all failing cases contain many
 # unusual characters, many of which cannot be rendered properly on GitHub.
+
 
 @settings(deadline=1000)
 @given(scst.variables(ndim=0))


### PR DESCRIPTION
Hope this is enough. Did you see longer run times than 1s?

We will ultimately have to try it out and see if we still get failures.