### PR TITLE
Remove out parameter from reduction operations

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -19,6 +19,7 @@ Breaking changes
 
 * Changed :meth:`scipp.Variable.dims` and :meth:`scipp.Variable.shape` and corresponding properties in `DataArray` and `Dataset` to return tuples `2543 <https://github.com/scipp/scipp/pull/2543>`_.
 * :func:`scipp.scalar` and :func:`scipp.index` now require keyword arguments for all but the ``value`` argument and :func:`scipp.vector` can take ``value`` positionally `2585 <https://github.com/scipp/scipp/pull/2585>`_.
+* Removed ``out`` argument from reduction operations (e.g. :func:`scipp.sum`) `2591 <https://github.com/scipp/scipp/pull/2591>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -366,12 +366,12 @@ Variable bins_sum(const Variable &data) {
     const auto &&[indices, dim, buffer] = data.constituents<DataArray>();
     if (const auto mask_union = irreducible_mask(buffer.masks(), dim);
         mask_union.is_valid()) {
-      variable::sum_impl(summed, applyMask(buffer, indices, dim, mask_union));
+      variable::sum_into(summed, applyMask(buffer, indices, dim, mask_union));
     } else {
-      variable::sum_impl(summed, data);
+      variable::sum_into(summed, data);
     }
   } else {
-    variable::sum_impl(summed, data);
+    variable::sum_into(summed, data);
   }
 
   return summed;

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -153,8 +153,6 @@ template <class T, class Func> DataArray transform(const T &a, Func func) {
 [[nodiscard]] Variable sum(const Variable &var, const Masks &masks);
 [[nodiscard]] Variable sum(const Variable &var, const Dim dim,
                            const Masks &masks);
-Variable &sum(const Variable &var, const Dim dim, const Masks &masks,
-              Variable &out);
 [[nodiscard]] Variable nansum(const Variable &var, const Masks &masks);
 [[nodiscard]] Variable nansum(const Variable &var, const Dim dim,
                               const Masks &masks);

--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -174,40 +174,22 @@ template <class T> T GroupBy<T>::sum(const Dim reductionDim) const {
 
 /// Reduce each group using `all` and return combined data.
 template <class T> T GroupBy<T>::all(const Dim reductionDim) const {
-  return reduce(
-      [](Variable &out, const Variable &var) {
-        accumulate_in_place(out, var, core::element::logical_and_equals,
-                            "groupby.all");
-      },
-      reductionDim, FillValue::True);
+  return reduce(variable::all_into, reductionDim, FillValue::True);
 }
 
 /// Reduce each group using `any` and return combined data.
 template <class T> T GroupBy<T>::any(const Dim reductionDim) const {
-  return reduce(
-      [](Variable &out, const Variable &var) {
-        accumulate_in_place(out, var, core::element::logical_or_equals,
-                            "groupby.any");
-      },
-      reductionDim, FillValue::False);
+  return reduce(variable::any_into, reductionDim, FillValue::False);
 }
 
 /// Reduce each group using `max` and return combined data.
 template <class T> T GroupBy<T>::max(const Dim reductionDim) const {
-  return reduce(
-      [](Variable &out, const Variable &var) {
-        accumulate_in_place(out, var, core::element::max_equals, "groupby.max");
-      },
-      reductionDim, FillValue::Lowest);
+  return reduce(variable::max_into, reductionDim, FillValue::Lowest);
 }
 
 /// Reduce each group using `min` and return combined data.
 template <class T> T GroupBy<T>::min(const Dim reductionDim) const {
-  return reduce(
-      [](Variable &out, const Variable &var) {
-        accumulate_in_place(out, var, core::element::min_equals, "groupby.min");
-      },
-      reductionDim, FillValue::Max);
+  return reduce(variable::min_into, reductionDim, FillValue::Max);
 }
 
 /// Combine groups without changes, effectively sorting data.

--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -166,7 +166,7 @@ template <class T> T GroupBy<T>::concat(const Dim reductionDim) const {
 
 /// Reduce each group using `sum` and return combined data.
 template <class T> T GroupBy<T>::sum(const Dim reductionDim) const {
-  return reduce(sum_impl, reductionDim, FillValue::ZeroNotBool);
+  return reduce(sum_into, reductionDim, FillValue::ZeroNotBool);
 }
 
 /// Reduce each group using `all` and return combined data.

--- a/lib/dataset/variable_reduction.cpp
+++ b/lib/dataset/variable_reduction.cpp
@@ -24,16 +24,6 @@ Variable sum(const Variable &var, const Dim dim, const Masks &masks) {
   return sum(var, dim);
 }
 
-Variable &sum(const Variable &var, const Dim dim, const Masks &masks,
-              // cppcheck-suppress constParameter  # intentional out param
-              Variable &out) {
-  if (const auto mask_union = irreducible_mask(masks, dim);
-      mask_union.is_valid()) {
-    return sum(where(mask_union, zero_like(var), var), dim, out);
-  }
-  return sum(var, dim, out);
-}
-
 Variable nansum(const Variable &var, const Dim dim, const Masks &masks) {
   if (const auto mask_union = irreducible_mask(masks, dim);
       mask_union.is_valid()) {

--- a/lib/python/reduction.cpp
+++ b/lib/python/reduction.cpp
@@ -23,15 +23,6 @@ template <class T> void bind_mean(py::module &m) {
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
-template <class T> void bind_mean_out(py::module &m) {
-  m.def(
-      "mean",
-      [](const T &x, const std::string &dim, T &out) {
-        return mean(x, Dim{dim}, out);
-      },
-      py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>());
-}
 template <class T> void bind_nanmean(py::module &m) {
   m.def(
       "nanmean", [](const T &x) { return nanmean(x); }, py::arg("x"),
@@ -40,16 +31,6 @@ template <class T> void bind_nanmean(py::module &m) {
       "nanmean",
       [](const T &x, const std::string &dim) { return nanmean(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
-}
-
-template <class T> void bind_nanmean_out(py::module &m) {
-  m.def(
-      "nanmean",
-      [](const T &x, const std::string &dim, T &out) {
-        return mean(x, Dim{dim}, out);
-      },
-      py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_sum(py::module &m) {
@@ -62,16 +43,6 @@ template <class T> void bind_sum(py::module &m) {
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
 }
 
-template <class T> void bind_sum_out(py::module &m) {
-  m.def(
-      "sum",
-      [](const T &x, const std::string &dim, T &out) {
-        return sum(x, Dim{dim}, out);
-      },
-      py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>());
-}
-
 template <class T> void bind_nansum(py::module &m) {
   m.def(
       "nansum", [](const T &x) { return nansum(x); }, py::arg("x"),
@@ -81,16 +52,6 @@ template <class T> void bind_nansum(py::module &m) {
       "nansum",
       [](const T &x, const std::string &dim) { return nansum(x, Dim{dim}); },
       py::arg("x"), py::arg("dim"), py::call_guard<py::gil_scoped_release>());
-}
-
-template <class T> void bind_nansum_out(py::module &m) {
-  m.def(
-      "nansum",
-      [](const T &x, const std::string &dim, T &out) {
-        return nansum(x, Dim{dim}, out);
-      },
-      py::arg("x"), py::arg("dim"), py::kw_only(), py::arg("out"),
-      py::call_guard<py::gil_scoped_release>());
 }
 
 template <class T> void bind_min(py::module &m) {
@@ -157,22 +118,18 @@ void init_reduction(py::module &m) {
   bind_mean<Variable>(m);
   bind_mean<DataArray>(m);
   bind_mean<Dataset>(m);
-  bind_mean_out<Variable>(m);
 
   bind_nanmean<Variable>(m);
   bind_nanmean<DataArray>(m);
   bind_nanmean<Dataset>(m);
-  bind_nanmean_out<Variable>(m);
 
   bind_sum<Variable>(m);
   bind_sum<DataArray>(m);
   bind_sum<Dataset>(m);
-  bind_sum_out<Variable>(m);
 
   bind_nansum<Variable>(m);
   bind_nansum<DataArray>(m);
   bind_nansum<Dataset>(m);
-  bind_nansum_out<Variable>(m);
 
   bind_min<Variable>(m);
   bind_max<Variable>(m);

--- a/lib/variable/include/scipp/variable/reduction.h
+++ b/lib/variable/include/scipp/variable/reduction.h
@@ -12,14 +12,10 @@ namespace scipp::variable {
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable mean(const Variable &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable mean(const Variable &var,
                                                   const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable &mean(const Variable &var, const Dim dim,
-                                     Variable &out);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const Variable &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable sum(const Variable &var,
                                                  const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable &sum(const Variable &var, const Dim dim,
-                                    Variable &out);
 
 // Logical reductions
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable any(const Variable &var);
@@ -46,12 +42,8 @@ SCIPP_VARIABLE_EXPORT Variable &sum(const Variable &var, const Dim dim,
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable nansum(const Variable &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable nansum(const Variable &var,
                                                     const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable &nansum(const Variable &var, const Dim dim,
-                                       Variable &out);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable nanmean(const Variable &var);
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable nanmean(const Variable &var,
                                                      const Dim dim);
-SCIPP_VARIABLE_EXPORT Variable &nanmean(const Variable &var, const Dim dim,
-                                        Variable &out);
 
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/reduction.h
+++ b/lib/variable/include/scipp/variable/reduction.h
@@ -46,4 +46,12 @@ namespace scipp::variable {
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable nanmean(const Variable &var,
                                                      const Dim dim);
 
+// These reductions accumulate their results in their first argument
+// without erasing its current contents.
+SCIPP_VARIABLE_EXPORT void sum_into(Variable &accum, const Variable &var);
+SCIPP_VARIABLE_EXPORT void all_into(Variable &accum, const Variable &var);
+SCIPP_VARIABLE_EXPORT void any_into(Variable &accum, const Variable &var);
+SCIPP_VARIABLE_EXPORT void max_into(Variable &accum, const Variable &var);
+SCIPP_VARIABLE_EXPORT void min_into(Variable &accum, const Variable &var);
+
 } // namespace scipp::variable

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -11,10 +11,6 @@
 
 namespace scipp::variable {
 
-/// Sum elements of `var` and add to `summed` along dims
-/// present in `var` but not in `summed`.
-SCIPP_VARIABLE_EXPORT void sum_into(Variable &summed, const Variable &var);
-
 // Helpers for in-place reductions and reductions with groupby.
 SCIPP_VARIABLE_EXPORT Variable mean_impl(const Variable &var, const Dim dim,
                                          const Variable &masks_sum);

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -22,14 +22,8 @@ SCIPP_VARIABLE_EXPORT void max_impl(Variable &out, const Variable &var);
 SCIPP_VARIABLE_EXPORT void min_impl(Variable &out, const Variable &var);
 SCIPP_VARIABLE_EXPORT Variable mean_impl(const Variable &var, const Dim dim,
                                          const Variable &masks_sum);
-SCIPP_VARIABLE_EXPORT Variable &mean_impl(const Variable &var, const Dim dim,
-                                          const Variable &masks_sum,
-                                          Variable &out);
 SCIPP_VARIABLE_EXPORT Variable nanmean_impl(const Variable &var, const Dim dim,
                                             const Variable &masks_sum);
-SCIPP_VARIABLE_EXPORT Variable &nanmean_impl(const Variable &var, const Dim dim,
-                                             const Variable &masks_sum,
-                                             Variable &out);
 
 template <class T> T normalize_impl(const T &numerator, T denominator) {
   // Numerator may be an int or a Eigen::Vector3d => use double

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -16,10 +16,6 @@ namespace scipp::variable {
 SCIPP_VARIABLE_EXPORT void sum_into(Variable &summed, const Variable &var);
 
 // Helpers for in-place reductions and reductions with groupby.
-SCIPP_VARIABLE_EXPORT void all_impl(Variable &out, const Variable &var);
-SCIPP_VARIABLE_EXPORT void any_impl(Variable &out, const Variable &var);
-SCIPP_VARIABLE_EXPORT void max_impl(Variable &out, const Variable &var);
-SCIPP_VARIABLE_EXPORT void min_impl(Variable &out, const Variable &var);
 SCIPP_VARIABLE_EXPORT Variable mean_impl(const Variable &var, const Dim dim,
                                          const Variable &masks_sum);
 SCIPP_VARIABLE_EXPORT Variable nanmean_impl(const Variable &var, const Dim dim,
@@ -33,12 +29,6 @@ template <class T> T normalize_impl(const T &numerator, T denominator) {
   denominator.setUnit(units::one);
   return numerator *
          reciprocal(astype(denominator, type, CopyPolicy::TryAvoid));
-}
-
-template <class T> void normalize_inplace_impl(T &numerator, T denominator) {
-  denominator.setUnit(units::one);
-  numerator *= reciprocal(
-      astype(denominator, core::dtype<double>, CopyPolicy::TryAvoid));
 }
 
 SCIPP_VARIABLE_EXPORT void expect_valid_bin_indices(const Variable &indices,

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -11,8 +11,11 @@
 
 namespace scipp::variable {
 
+/// Sum elements of `var` and add to `summed` along dims
+/// present in `var` but not in `summed`.
+SCIPP_VARIABLE_EXPORT void sum_into(Variable &summed, const Variable &var);
+
 // Helpers for in-place reductions and reductions with groupby.
-SCIPP_VARIABLE_EXPORT void sum_impl(Variable &summed, const Variable &var);
 SCIPP_VARIABLE_EXPORT void all_impl(Variable &out, const Variable &var);
 SCIPP_VARIABLE_EXPORT void any_impl(Variable &out, const Variable &var);
 SCIPP_VARIABLE_EXPORT void max_impl(Variable &out, const Variable &var);

--- a/lib/variable/rebin.cpp
+++ b/lib/variable/rebin.cpp
@@ -3,12 +3,12 @@
 /// @file
 /// @author Simon Heybrock, Igor Gudich
 #include "scipp/core/element/rebin.h"
-#include "operations_common.h"
 #include "scipp/core/parallel.h"
 #include "scipp/units/except.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/astype.h"
 #include "scipp/variable/rebin.h"
+#include "scipp/variable/reduction.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/transform_subspan.h"
 #include "scipp/variable/util.h"

--- a/lib/variable/rebin.cpp
+++ b/lib/variable/rebin.cpp
@@ -3,12 +3,12 @@
 /// @file
 /// @author Simon Heybrock, Igor Gudich
 #include "scipp/core/element/rebin.h"
+#include "operations_common.h"
 #include "scipp/core/parallel.h"
 #include "scipp/units/except.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/astype.h"
 #include "scipp/variable/rebin.h"
-#include "scipp/variable/reduction.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/transform_subspan.h"
 #include "scipp/variable/util.h"
@@ -52,7 +52,7 @@ void rebin_non_inner(const Dim dim, const Variable &oldT, Variable &newT,
     begin = std::max(scipp::index(0), begin - 1);
     add_from_bin(slice, xn_low, xn_high, begin);
     if (begin + 1 < end - 1)
-      sum(oldT.slice({dim, begin + 1, end - 1}), dim, slice);
+      sum_into(slice, oldT.slice({dim, begin + 1, end - 1}));
     if (begin != end - 1 && end < oldSize + 1)
       add_from_bin(slice, xn_low, xn_high, end - 1);
   };

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -43,10 +43,10 @@ Variable make_accumulant(const Variable &var, const Dim dim,
 
 } // namespace
 
-void sum_impl(Variable &summed, const Variable &var) {
+void sum_into(Variable &summed, const Variable &var) {
   if (summed.dtype() == dtype<float>) {
     auto accum = astype(summed, dtype<double>);
-    sum_impl(accum, var);
+    sum_into(accum, var);
     copy(astype(accum, dtype<float>), summed);
   } else {
     accumulate_in_place(summed, var, element::add_equals, "sum");
@@ -92,7 +92,7 @@ Variable &sum_with_dim_inplace_impl(Op op, const Variable &var, const Dim dim,
 }
 
 Variable sum(const Variable &var, const Dim dim) {
-  return sum_with_dim_impl(sum_impl, var, dim);
+  return sum_with_dim_impl(sum_into, var, dim);
 }
 
 Variable nansum(const Variable &var, const Dim dim) {
@@ -100,7 +100,7 @@ Variable nansum(const Variable &var, const Dim dim) {
 }
 
 Variable &sum(const Variable &var, const Dim dim, Variable &out) {
-  return sum_with_dim_inplace_impl(sum_impl, var, dim, out);
+  return sum_with_dim_inplace_impl(sum_into, var, dim, out);
 }
 
 Variable &nansum(const Variable &var, const Dim dim, Variable &out) {

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -11,7 +11,6 @@
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/astype.h"
 #include "scipp/variable/creation.h"
-#include "scipp/variable/math.h"
 #include "scipp/variable/special_values.h"
 #include "scipp/variable/util.h"
 #include "scipp/variable/variable_factory.h"
@@ -137,26 +136,14 @@ Variable reduce_idempotent(const Variable &var, const Dim dim, Op op,
   return out;
 }
 
-void any_impl(Variable &out, const Variable &var) {
-  reduce_impl(out, var, core::element::logical_or_equals, "any");
-}
-
 Variable any(const Variable &var, const Dim dim) {
   return reduce_idempotent(var, dim, core::element::logical_or_equals,
                            FillValue::False, "any");
 }
 
-void all_impl(Variable &out, const Variable &var) {
-  reduce_impl(out, var, core::element::logical_and_equals, "all");
-}
-
 Variable all(const Variable &var, const Dim dim) {
   return reduce_idempotent(var, dim, core::element::logical_and_equals,
                            FillValue::True, "all");
-}
-
-void max_impl(Variable &out, const Variable &var) {
-  reduce_impl(out, var, core::element::max_equals, "max");
 }
 
 /// Return the maximum along given dimension.
@@ -175,10 +162,6 @@ Variable max(const Variable &var, const Dim dim) {
 Variable nanmax(const Variable &var, const Dim dim) {
   return reduce_idempotent(var, dim, core::element::nanmax_equals,
                            FillValue::Lowest, "nanmax");
-}
-
-void min_impl(Variable &out, const Variable &var) {
-  reduce_impl(out, var, core::element::min_equals, "min");
 }
 
 /// Return the minimum along given dimension.

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -39,16 +39,6 @@ Variable make_accumulant(const Variable &var, const Dim dim,
 
 } // namespace
 
-void sum_into(Variable &summed, const Variable &var) {
-  if (summed.dtype() == dtype<float>) {
-    auto accum = astype(summed, dtype<double>);
-    sum_into(accum, var);
-    copy(astype(accum, dtype<float>), summed);
-  } else {
-    accumulate_in_place(summed, var, element::add_equals, "sum");
-  }
-}
-
 void nansum_impl(Variable &summed, const Variable &var) {
   if (summed.dtype() == dtype<float>) {
     auto accum = astype(summed, dtype<double>);
@@ -214,6 +204,32 @@ Variable all(const Variable &var) {
 /// Return the logical OR along all dimensions.
 Variable any(const Variable &var) {
   return reduce_all_dims(var, [](auto &&... _) { return any(_...); });
+}
+
+void sum_into(Variable &accum, const Variable &var) {
+  if (accum.dtype() == dtype<float>) {
+    auto x = astype(accum, dtype<double>);
+    sum_into(x, var);
+    copy(astype(x, dtype<float>), accum);
+  } else {
+    accumulate_in_place(accum, var, element::add_equals, "sum");
+  }
+}
+
+void all_into(Variable &accum, const Variable &var) {
+  accumulate_in_place(accum, var, core::element::logical_and_equals, "all");
+}
+
+void any_into(Variable &accum, const Variable &var) {
+  accumulate_in_place(accum, var, core::element::logical_or_equals, "any");
+}
+
+void max_into(Variable &accum, const Variable &var) {
+  accumulate_in_place(accum, var, core::element::max_equals, "max");
+}
+
+void min_into(Variable &accum, const Variable &var) {
+  accumulate_in_place(accum, var, core::element::min_equals, "min");
 }
 
 } // namespace scipp::variable

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -116,12 +116,6 @@ Variable nanmean(const Variable &var, const Dim dim) {
   return nanmean_impl(var, dim, sum(isfinite(var), dim));
 }
 
-template <class Op>
-void reduce_impl(Variable &out, const Variable &var, Op op,
-                 const std::string_view name) {
-  accumulate_in_place(out, var, op, name);
-}
-
 /// Reduction for idempotent operations such that op(a,a) = a.
 ///
 /// The requirement for idempotency comes from the way the reduction output is
@@ -132,7 +126,7 @@ template <class Op>
 Variable reduce_idempotent(const Variable &var, const Dim dim, Op op,
                            const FillValue &init, const std::string_view name) {
   auto out = make_accumulant(var, dim, init);
-  reduce_impl(out, var, op, name);
+  accumulate_in_place(out, var, op, name);
   return out;
 }
 

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -72,7 +72,7 @@ TEST(RebinTest, outer_increasing_1_inner) {
   };
   const auto oldY = varY(0, 1, 2, 3, 4);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1}, Values{value},
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1}, Values{value},
                                 units::counts);
   };
   // full range
@@ -149,7 +149,7 @@ TEST(RebinTest, outer_decreasing_1_inner) {
   };
   const auto oldY = varY(4, 3, 2, 1, 0);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1}, Values{value},
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1}, Values{value},
                                 units::counts);
   };
   // full range

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -63,6 +63,9 @@ TEST(RebinTest, outer) {
   }
 }
 
+// Code in this test uses a different branch in rebin compared to
+// outer_increasing_2_inner because rebin uses an optimization
+// for stride[rebin_dim] == 1.
 TEST(RebinTest, outer_increasing_1_inner) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
                                         Values{1, 2, 3, 4}, units::counts);

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -110,7 +110,7 @@ TEST(RebinTest, outer_increasing_2_inner) {
                                 Values{vals...});
   };
   const auto oldY = varY(0, 1, 2, 3, 4);
-  constexpr auto var1x1 = [](const double value) {
+  constexpr auto var1x2 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
                                 Values{value, 2 * value}, units::counts);
   };
@@ -187,7 +187,7 @@ TEST(RebinTest, outer_decreasing_2_inner) {
                                 Values{vals...});
   };
   const auto oldY = varY(4, 3, 2, 1, 0);
-  constexpr auto var1x1 = [](const double value) {
+  constexpr auto var1x2 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
                                 Values{value, 2 * value}, units::counts);
   };

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -63,7 +63,7 @@ TEST(RebinTest, outer) {
   }
 }
 
-TEST(RebinTest, outer_increasing) {
+TEST(RebinTest, outer_increasing_1_inner) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
                                         Values{1, 2, 3, 4}, units::counts);
   constexpr auto varY = [](const auto... vals) {
@@ -72,8 +72,8 @@ TEST(RebinTest, outer_increasing) {
   };
   const auto oldY = varY(0, 1, 2, 3, 4);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
-                                Values{value}, units::counts);
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1}, Values{value},
+                                units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -101,7 +101,46 @@ TEST(RebinTest, outer_increasing) {
             var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
 }
 
-TEST(RebinTest, outer_decreasing) {
+TEST(RebinTest, outer_increasing_2_inner) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 2},
+                           Values{1, 2, 2, 4, 3, 6, 4, 8}, units::counts);
+  constexpr auto varY = [](const auto... vals) {
+    return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
+                                Values{vals...});
+  };
+  const auto oldY = varY(0, 1, 2, 3, 4);
+  constexpr auto var1x1 = [](const double value) {
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
+                                Values{value, 2 * value}, units::counts);
+  };
+  // full range
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
+  // aligned old/bew edges
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 4)), var1x1(10));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 2)), var1x1(3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1, 3)), var1x1(5));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 4)), var1x1(7));
+  // crossing 0 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 0.3)), var1x1((0.3 - 0.1) * 1));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 1.3)), var1x1((1.3 - 1.1) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.1, 3.3)), var1x1((3.3 - 3.1) * 4));
+  // crossing 1 bin bound
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.0)), var1x1(0.9 * 1 + 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 1.3)),
+            var1x1((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 2.3)),
+            var1x1((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.1, 3.3)),
+            var1x1((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
+  // crossing 2 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.3)),
+            var1x1((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 3.3)),
+            var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
+}
+
+TEST(RebinTest, outer_decreasing_1_inner) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
                                         Values{4, 3, 2, 1}, units::counts);
   constexpr auto varY = [](const auto... vals) {
@@ -110,8 +149,47 @@ TEST(RebinTest, outer_decreasing) {
   };
   const auto oldY = varY(4, 3, 2, 1, 0);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
-                                Values{value}, units::counts);
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1}, Values{value},
+                                units::counts);
+  };
+  // full range
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
+  // aligned old/bew edges
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 0)), var1x1(10));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 0)), var1x1(3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3, 1)), var1x1(5));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 2)), var1x1(7));
+  // crossing 0 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.3, 0.1)), var1x1((0.3 - 0.1) * 1));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.3, 1.1)), var1x1((1.3 - 1.1) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 3.1)), var1x1((3.3 - 3.1) * 4));
+  // crossing 1 bin bound
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.0, 0.1)), var1x1(0.9 * 1 + 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.3, 0.1)),
+            var1x1((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.3, 1.1)),
+            var1x1((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 2.1)),
+            var1x1((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
+  // crossing 2 bin bounds
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.3, 0.1)),
+            var1x1((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 1.1)),
+            var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
+}
+
+TEST(RebinTest, outer_decreasing_2_inner) {
+  const auto var =
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 2},
+                           Values{4, 8, 3, 6, 2, 4, 1, 2}, units::counts);
+  constexpr auto varY = [](const auto... vals) {
+    return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
+                                Values{vals...});
+  };
+  const auto oldY = varY(4, 3, 2, 1, 0);
+  constexpr auto var1x1 = [](const double value) {
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
+                                Values{value, 2 * value}, units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -120,27 +120,27 @@ TEST(RebinTest, outer_increasing_2_inner) {
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
   // aligned old/bew edges
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 4)), var1x1(10));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 2)), var1x1(3));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1, 3)), var1x1(5));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 4)), var1x1(7));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 4)), var1x2(10));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0, 2)), var1x2(3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1, 3)), var1x2(5));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 4)), var1x2(7));
   // crossing 0 bin bounds
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 0.3)), var1x1((0.3 - 0.1) * 1));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 1.3)), var1x1((1.3 - 1.1) * 2));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.1, 3.3)), var1x1((3.3 - 3.1) * 4));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 0.3)), var1x2((0.3 - 0.1) * 1));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 1.3)), var1x2((1.3 - 1.1) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.1, 3.3)), var1x2((3.3 - 3.1) * 4));
   // crossing 1 bin bound
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.0)), var1x1(0.9 * 1 + 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.0)), var1x2(0.9 * 1 + 2));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 1.3)),
-            var1x1((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
+            var1x2((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 2.3)),
-            var1x1((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
+            var1x2((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.1, 3.3)),
-            var1x1((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
+            var1x2((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
   // crossing 2 bin bounds
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.1, 2.3)),
-            var1x1((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
+            var1x2((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.1, 3.3)),
-            var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
+            var1x2((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
 }
 
 TEST(RebinTest, outer_decreasing_1_inner) {
@@ -197,27 +197,27 @@ TEST(RebinTest, outer_decreasing_2_inner) {
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
   // aligned old/bew edges
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 0)), var1x1(10));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 0)), var1x1(3));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3, 1)), var1x1(5));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 2)), var1x1(7));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 0)), var1x2(10));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2, 0)), var1x2(3));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3, 1)), var1x2(5));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(4, 2)), var1x2(7));
   // crossing 0 bin bounds
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.3, 0.1)), var1x1((0.3 - 0.1) * 1));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.3, 1.1)), var1x1((1.3 - 1.1) * 2));
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 3.1)), var1x1((3.3 - 3.1) * 4));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(0.3, 0.1)), var1x2((0.3 - 0.1) * 1));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.3, 1.1)), var1x2((1.3 - 1.1) * 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 3.1)), var1x2((3.3 - 3.1) * 4));
   // crossing 1 bin bound
-  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.0, 0.1)), var1x1(0.9 * 1 + 2));
+  EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.0, 0.1)), var1x2(0.9 * 1 + 2));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(1.3, 0.1)),
-            var1x1((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
+            var1x2((1.0 - 0.1) * 1 + (1.3 - 1.0) * 2));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.3, 1.1)),
-            var1x1((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
+            var1x2((2.0 - 1.1) * 2 + (2.3 - 2.0) * 3));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 2.1)),
-            var1x1((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
+            var1x2((3.0 - 2.1) * 3 + (3.3 - 3.0) * 4));
   // crossing 2 bin bounds
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(2.3, 0.1)),
-            var1x1((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
+            var1x2((1.0 - 0.1) * 1 + 2 + (2.3 - 2.0) * 3));
   EXPECT_EQ(rebin(var, Dim::Y, oldY, varY(3.3, 1.1)),
-            var1x1((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
+            var1x2((2.0 - 1.1) * 2 + 3 + (3.3 - 3.0) * 4));
 }
 
 class RebinBool1DTest : public ::testing::Test {

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -72,8 +72,8 @@ TEST(RebinTest, outer_increasing_1_inner) {
   };
   const auto oldY = varY(0, 1, 2, 3, 4);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1}, Values{value},
-                                units::counts);
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
+                                Values{value}, units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -149,8 +149,8 @@ TEST(RebinTest, outer_decreasing_1_inner) {
   };
   const auto oldY = varY(4, 3, 2, 1, 0);
   constexpr auto var1x1 = [](const double value) {
-    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1}, Values{value},
-                                units::counts);
+    return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
+                                Values{value}, units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);

--- a/lib/variable/test/reduce_various_test.cpp
+++ b/lib/variable/test/reduce_various_test.cpp
@@ -116,25 +116,6 @@ TYPED_TEST(NansumTest, nansum_with_dim) {
   }
 }
 
-TYPED_TEST(NansumTest, nansum_with_dim_out) {
-  auto x = makeVariable<TypeParam>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                   Values{1.0, 2.0, 3.0, 4.0});
-  if constexpr (std::is_floating_point_v<TypeParam>) {
-    x.template values<TypeParam>()[2] = TypeParam(NAN);
-    auto out = makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2});
-    const auto expected =
-        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{1, 6});
-    nansum(x, Dim::X, out);
-    EXPECT_EQ(out, expected);
-  } else {
-    auto out = makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2});
-    const auto expected =
-        makeVariable<TypeParam>(Dims{Dim::Y}, Shape{2}, Values{4, 6});
-    nansum(x, Dim::X, out);
-    EXPECT_EQ(out, expected);
-  }
-}
-
 class ReduceBinnedTest : public ::testing::Test {
 protected:
   Variable indices =

--- a/lib/variable/test/sum_test.cpp
+++ b/lib/variable/test/sum_test.cpp
@@ -38,27 +38,6 @@ TEST_F(SumTest, sum_with_empty_dim) {
             makeVariable<double>(Dims{Dim::X}, Shape{0}, units::m, Values{}));
 }
 
-TEST_F(SumTest, sum_in_place) {
-  auto out = makeVariable<double>(Dims{Dim::Y}, Shape{2});
-  auto &view = sum(var, Dim::X, out);
-  EXPECT_EQ(out, makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
-                                      Values{3.0, 7.0}));
-  EXPECT_EQ(&view, &out);
-}
-
-TEST_F(SumTest, sum_in_place_bool) {
-  auto out = makeVariable<int64_t>(Dims{Dim::Y}, Shape{2});
-  auto &view = sum(var_bool, Dim::X, out);
-  EXPECT_EQ(out, makeVariable<int64_t>(Dims{Dim::Y}, Shape{2}, units::m,
-                                       Values{1, 2}));
-  EXPECT_EQ(&view, &out);
-}
-
-TEST_F(SumTest, sum_in_place_bool_incorrect_out_type) {
-  auto out = makeVariable<bool>(Dims{Dim::Y}, Shape{2});
-  EXPECT_THROW(sum(var_bool, Dim::X, out), except::TypeError);
-}
-
 TEST(VectorReduceTest, sum_vector) {
   const auto vector_var = makeVariable<Eigen::Vector3d>(
       Dims{Dim::X}, Shape{2}, units::m,

--- a/src/scipp/core/reduction.py
+++ b/src/scipp/core/reduction.py
@@ -10,10 +10,7 @@ from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLikeType
 
 
-def mean(x: VariableLikeType,
-         dim: Optional[str] = None,
-         *,
-         out: Optional[VariableLikeType] = None) -> VariableLikeType:
+def mean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
     """Arithmetic mean of elements in the input.
 
     If the input has variances, the variances stored in the output are based on
@@ -32,8 +29,6 @@ def mean(x: VariableLikeType,
     dim:
         Dimension along which to calculate the mean. If not
         given, the mean over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -46,15 +41,12 @@ def mean(x: VariableLikeType,
         Ignore NaN's when calculating the mean.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.mean, x, out=out)
+        return _call_cpp_func(_cpp.mean, x)
     else:
-        return _call_cpp_func(_cpp.mean, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.mean, x, dim=dim)
 
 
-def nanmean(x: VariableLikeType,
-            dim: Optional[str] = None,
-            *,
-            out: Optional[VariableLikeType] = None) -> VariableLikeType:
+def nanmean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
     """Arithmetic mean of elements in the input ignoring NaN's.
 
     If the input has variances, the variances stored in the output are based on
@@ -73,8 +65,6 @@ def nanmean(x: VariableLikeType,
     dim:
         Dimension along which to calculate the mean. If not
         given, the nanmean over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -87,15 +77,12 @@ def nanmean(x: VariableLikeType,
         Compute the mean without special handling of NaN.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmean, x, out=out)
+        return _call_cpp_func(_cpp.nanmean, x)
     else:
-        return _call_cpp_func(_cpp.nanmean, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.nanmean, x, dim=dim)
 
 
-def sum(x: VariableLikeType,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[VariableLikeType] = None) -> VariableLikeType:
+def sum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
     """Sum of elements in the input.
 
     If the input data is in single precision (dtype='float32') this internally uses
@@ -111,8 +98,6 @@ def sum(x: VariableLikeType,
     dim:
         Optional dimension along which to calculate the sum. If not
         given, the sum over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -125,15 +110,12 @@ def sum(x: VariableLikeType,
         Ignore NaN's when calculating the sum.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.sum, x, out=out)
+        return _call_cpp_func(_cpp.sum, x)
     else:
-        return _call_cpp_func(_cpp.sum, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.sum, x, dim=dim)
 
 
-def nansum(x: VariableLikeType,
-           dim: Optional[str] = None,
-           *,
-           out: Optional[VariableLikeType] = None) -> VariableLikeType:
+def nansum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
     """Sum of elements in the input ignoring NaN's.
 
     See :py:func:`scipp.sum` on how rounding errors for float32 inputs are handled.
@@ -145,8 +127,6 @@ def nansum(x: VariableLikeType,
     dim:
         Optional dimension along which to calculate the sum. If not
         given, the sum over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -159,15 +139,12 @@ def nansum(x: VariableLikeType,
        Compute the sum without special handling of NaN.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nansum, x, out=out)
+        return _call_cpp_func(_cpp.nansum, x)
     else:
-        return _call_cpp_func(_cpp.nansum, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.nansum, x, dim=dim)
 
 
-def min(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def min(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Minimum of elements in the input.
 
     Parameters
@@ -177,8 +154,6 @@ def min(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the min. If not
         given, the min over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -195,15 +170,12 @@ def min(x: _cpp.Variable,
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.min, x, out=out)
+        return _call_cpp_func(_cpp.min, x)
     else:
-        return _call_cpp_func(_cpp.min, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.min, x, dim=dim)
 
 
-def max(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def max(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Maximum of elements in the input.
 
     Parameters
@@ -213,8 +185,6 @@ def max(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the max. If not
         given, the max over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -231,15 +201,12 @@ def max(x: _cpp.Variable,
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.max, x, out=out)
+        return _call_cpp_func(_cpp.max, x)
     else:
-        return _call_cpp_func(_cpp.max, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.max, x, dim=dim)
 
 
-def nanmin(x: _cpp.Variable,
-           dim: Optional[str] = None,
-           *,
-           out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def nanmin(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Minimum of elements in the input ignoring NaN's.
 
     Parameters
@@ -249,8 +216,6 @@ def nanmin(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the min. If not
         given, the min over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -267,15 +232,12 @@ def nanmin(x: _cpp.Variable,
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmin, x, out=out)
+        return _call_cpp_func(_cpp.nanmin, x)
     else:
-        return _call_cpp_func(_cpp.nanmin, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.nanmin, x, dim=dim)
 
 
-def nanmax(x: _cpp.Variable,
-           dim: Optional[str] = None,
-           *,
-           out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def nanmax(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Maximum of elements in the input ignoring NaN's.
 
     Parameters
@@ -285,8 +247,6 @@ def nanmax(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the max. If not
         given, the max over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -303,15 +263,12 @@ def nanmax(x: _cpp.Variable,
         Same as min but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmax, x, out=out)
+        return _call_cpp_func(_cpp.nanmax, x)
     else:
-        return _call_cpp_func(_cpp.nanmax, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.nanmax, x, dim=dim)
 
 
-def all(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def all(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Logical AND over input values.
 
     Parameters
@@ -321,8 +278,6 @@ def all(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the AND. If not
         given, the AND over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -336,15 +291,12 @@ def all(x: _cpp.Variable,
         Logical OR.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.all, x, out=out)
+        return _call_cpp_func(_cpp.all, x)
     else:
-        return _call_cpp_func(_cpp.all, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.all, x, dim=dim)
 
 
-def any(x: _cpp.Variable,
-        dim: Optional[str] = None,
-        *,
-        out: Optional[_cpp.Variable] = None) -> _cpp.Variable:
+def any(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
     """Logical OR over input values.
 
     Parameters
@@ -354,8 +306,6 @@ def any(x: _cpp.Variable,
     dim:
         Optional dimension along which to calculate the OR. If not
         given, the OR over all dimensions is calculated.
-    out:
-        Optional output buffer.
 
     Returns
     -------
@@ -369,6 +319,6 @@ def any(x: _cpp.Variable,
         Logical AND.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.any, x, out=out)
+        return _call_cpp_func(_cpp.any, x)
     else:
-        return _call_cpp_func(_cpp.any, x, dim=dim, out=out)
+        return _call_cpp_func(_cpp.any, x, dim=dim)

--- a/src/scipp/core/reduction.py
+++ b/src/scipp/core/reduction.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Optional
 
 from .._scipp import core as _cpp
-from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLikeType
 
 
@@ -41,9 +40,9 @@ def mean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
         Ignore NaN's when calculating the mean.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.mean, x)
+        return _cpp.mean(x)
     else:
-        return _call_cpp_func(_cpp.mean, x, dim=dim)
+        return _cpp.mean(x, dim=dim)
 
 
 def nanmean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
@@ -77,9 +76,9 @@ def nanmean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
         Compute the mean without special handling of NaN.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmean, x)
+        return _cpp.nanmean(x)
     else:
-        return _call_cpp_func(_cpp.nanmean, x, dim=dim)
+        return _cpp.nanmean(x, dim=dim)
 
 
 def sum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
@@ -110,9 +109,9 @@ def sum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
         Ignore NaN's when calculating the sum.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.sum, x)
+        return _cpp.sum(x)
     else:
-        return _call_cpp_func(_cpp.sum, x, dim=dim)
+        return _cpp.sum(x, dim=dim)
 
 
 def nansum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
@@ -139,9 +138,9 @@ def nansum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
        Compute the sum without special handling of NaN.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nansum, x)
+        return _cpp.nansum(x)
     else:
-        return _call_cpp_func(_cpp.nansum, x, dim=dim)
+        return _cpp.nansum(x, dim=dim)
 
 
 def min(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -170,9 +169,9 @@ def min(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.min, x)
+        return _cpp.min(x)
     else:
-        return _call_cpp_func(_cpp.min, x, dim=dim)
+        return _cpp.min(x, dim=dim)
 
 
 def max(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -201,9 +200,9 @@ def max(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.max, x)
+        return _cpp.max(x)
     else:
-        return _call_cpp_func(_cpp.max, x, dim=dim)
+        return _cpp.max(x, dim=dim)
 
 
 def nanmin(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -232,9 +231,9 @@ def nanmin(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Same as max but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmin, x)
+        return _cpp.nanmin(x)
     else:
-        return _call_cpp_func(_cpp.nanmin, x, dim=dim)
+        return _cpp.nanmin(x, dim=dim)
 
 
 def nanmax(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -263,9 +262,9 @@ def nanmax(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Same as min but ignoring NaN's.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.nanmax, x)
+        return _cpp.nanmax(x)
     else:
-        return _call_cpp_func(_cpp.nanmax, x, dim=dim)
+        return _cpp.nanmax(x, dim=dim)
 
 
 def all(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -291,9 +290,9 @@ def all(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Logical OR.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.all, x)
+        return _cpp.all(x)
     else:
-        return _call_cpp_func(_cpp.all, x, dim=dim)
+        return _cpp.all(x, dim=dim)
 
 
 def any(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
@@ -319,6 +318,6 @@ def any(x: _cpp.Variable, dim: Optional[str] = None) -> _cpp.Variable:
         Logical AND.
     """
     if dim is None:
-        return _call_cpp_func(_cpp.any, x)
+        return _cpp.any(x)
     else:
-        return _call_cpp_func(_cpp.any, x, dim=dim)
+        return _cpp.any(x, dim=dim)

--- a/tests/lifetime_test.py
+++ b/tests/lifetime_test.py
@@ -160,11 +160,3 @@ def test_lifetime_atan2_out_arg():
     var = 1.0 * sc.units.one
     var = sc.atan2(y=var, x=var, out=var)
     var *= 1.0  # var would be an invalid view is keep_alive not correct
-
-
-@pytest.mark.parametrize("func", [sc.mean, sc.sum])
-def test_lifetime_reduction_out_arg(func):
-    var = sc.Variable(dims=['x'], values=[1, 2, 3])
-    out = 0.0 * sc.units.one
-    out = func(var, dim='x', out=out)
-    out *= 1.0  # out would be an invalid view is keep_alive not correct

--- a/tests/variable_reduction_test.py
+++ b/tests/variable_reduction_test.py
@@ -59,9 +59,6 @@ def test_sum():
     var = sc.Variable(dims=['x', 'y'], values=np.arange(4.0).reshape(2, 2))
     assert sc.identical(sc.sum(var), sc.scalar(6.0))
     assert sc.identical(sc.sum(var, 'x'), sc.Variable(dims=['y'], values=[2.0, 4.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
-    sc.sum(var, 'x', out=out)
-    assert sc.identical(out, sc.Variable(dims=['y'], values=[2.0, 4.0]))
 
 
 def test_nansum():
@@ -69,18 +66,12 @@ def test_nansum():
                       values=np.array([1.0, 1.0, 1.0, np.nan]).reshape(2, 2))
     assert sc.identical(sc.nansum(var), sc.scalar(3.0))
     assert sc.identical(sc.nansum(var, 'x'), sc.Variable(dims=['y'], values=[2.0, 1.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
-    sc.nansum(var, 'x', out=out)
-    assert sc.identical(out, sc.Variable(dims=['y'], values=[2.0, 1.0]))
 
 
 def test_mean():
     var = sc.Variable(dims=['x', 'y'], values=np.arange(4.0).reshape(2, 2))
     assert sc.identical(sc.mean(var), sc.scalar(6.0 / 4))
     assert sc.identical(sc.mean(var, 'x'), sc.Variable(dims=['y'], values=[1.0, 2.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
-    sc.mean(var, 'x', out=out)
-    assert sc.identical(out, sc.Variable(dims=['y'], values=[1.0, 2.0]))
 
 
 def test_nanmean():
@@ -89,6 +80,3 @@ def test_nanmean():
     assert sc.identical(sc.nanmean(var), sc.scalar(3.0 / 3))
     assert sc.identical(sc.nanmean(var, 'x'), sc.Variable(dims=['y'], values=[1.0,
                                                                               1.0]))
-    out = sc.Variable(dims=['y'], values=np.zeros(2), dtype=sc.DType.float64)
-    sc.mean(var, 'x', out=out)
-    assert sc.identical(out, sc.Variable(dims=['y'], values=[1.0, 1.0]))

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -266,37 +266,9 @@ def test_concat():
                    sc.Variable(dims=(), values=0.0)], 'x')
 
 
-def test_mean():
-    assert_export(sc.mean, sc.Variable(dims=(), values=0.0), 'x')
-
-
-def test_mean_in_place():
-    var = sc.Variable(dims=(), values=0.0)
-    assert_export(sc.mean, sc.Variable(dims=(), values=0.0), 'x', var)
-
-
 def test_values_variances():
     assert_export(sc.values, sc.Variable(dims=(), values=0.0))
     assert_export(sc.variances, sc.Variable(dims=(), values=0.0))
-
-
-def test_sum():
-    var = sc.Variable(dims=['x', 'y'],
-                      values=np.array([[0.1, 0.3], [0.2, 0.6]]),
-                      unit=sc.units.m)
-    expected = sc.Variable(dims=['x'], values=np.array([0.4, 0.8]), unit=sc.units.m)
-    assert sc.identical(sc.sum(var, 'y'), expected)
-
-
-def test_sum_in_place():
-    var = sc.Variable(dims=['x', 'y'],
-                      values=np.array([[0.1, 0.3], [0.2, 0.6]]),
-                      unit=sc.units.m)
-    out_var = sc.Variable(dims=['x'], values=np.array([0.0, 0.0]), unit=sc.units.m)
-    expected = sc.Variable(dims=['x'], values=np.array([0.4, 0.8]), unit=sc.units.m)
-    out_view = sc.sum(var, 'y', out=out_var)
-    assert sc.identical(out_var, expected)
-    assert sc.identical(out_view, expected)
 
 
 def test_variance_acess():


### PR DESCRIPTION
Fixes #2587.

It straight up removed the parameter instead of deprecating it first because there do not seem to be any users of it.