### PR TITLE
Add wrappers for `scipy.ndimage`

### DIFF
--- a/docs/reference/modules.rst
+++ b/docs/reference/modules.rst
@@ -14,6 +14,7 @@ Core Functionality
    constants
    integrate
    interpolate
+   ndimage
    optimize
    signal
    spatial

--- a/src/scipp/data/__init__.py
+++ b/src/scipp/data/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from functools import lru_cache
-import numpy as np
 
 from ..core import array, bin, linspace, ones
 from ..core import DataArray
@@ -95,7 +94,9 @@ def binned_xy(nevent: int, nx: int, ny: int) -> DataArray:
 
 
 def data_xy() -> DataArray:
-    da = DataArray(array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    from numpy.random import default_rng
+    rng = default_rng(seed=1234)
+    da = DataArray(array(dims=['x', 'y'], values=rng.random((100, 100))))
     da.coords['x'] = linspace('x', 0.0, 1.0, num=100, unit='mm')
     da.coords['y'] = linspace('y', 0.0, 5.0, num=100, unit='mm')
     return da

--- a/src/scipp/data/__init__.py
+++ b/src/scipp/data/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from functools import lru_cache
+import numpy as np
 
 from ..core import array, bin, linspace, ones
 from ..core import DataArray
@@ -91,3 +92,10 @@ def binned_xy(nevent: int, nx: int, ny: int) -> DataArray:
     x = linspace(dim='x', unit='m', start=0.0, stop=1.0, num=nx + 1)
     y = linspace(dim='y', unit='m', start=0.0, stop=1.0, num=ny + 1)
     return bin(table, edges=[x, y])
+
+
+def data_xy() -> DataArray:
+    da = DataArray(array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    da.coords['x'] = linspace('x', 0.0, 1.0, num=100, unit='mm')
+    da.coords['y'] = linspace('y', 0.0, 5.0, num=100, unit='mm')
+    return da

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -92,7 +92,7 @@ def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
     return footprint
 
 
-def _make_footprint_filter(name, extra_args=''):
+def _make_footprint_filter(name, example=True, extra_args=''):
 
     def footprint_filter(x: Union[Variable, DataArray],
                          /,
@@ -118,7 +118,7 @@ def _make_footprint_filter(name, extra_args=''):
     footprint_filter.__name__ = name
     if extra_args:
         extra_args = f', {extra_args}'
-    footprint_filter.__doc__ = f"""
+    doc = f"""
     Calculate a multidimensional {name.replace('_', ' ')}.
 
     This is a wrapper around :py:func:`scipy.ndimage.{name}`. See there for full
@@ -154,23 +154,34 @@ def _make_footprint_filter(name, extra_args=''):
     origin:
         Integer or scalar variable or mapping from dimension labels to integers or
         scalar variables. Controls the placement of the filter on the input array.
-
+    """
+    if example:
+        doc += f"""
     Examples
     --------
 
       >>> from scipp.ndimage import {name}
       >>> da = sc.data.data_xy()
+
+    Given size as integer:
+
       >>> filtered = {name}(da, size=4{extra_args})
+
+    Given size based on input coordinate values:
+
+      >>> filtered = {name}(da, size=sc.scalar(1.2, unit='mm'){extra_args})
     """
+    footprint_filter.__doc__ = doc
     return _ndfilter(footprint_filter)
 
 
-generic_filter = _make_footprint_filter('generic_filter')
+generic_filter = _make_footprint_filter('generic_filter', example=False)
 maximum_filter = _make_footprint_filter('maximum_filter')
 median_filter = _make_footprint_filter('median_filter')
 minimum_filter = _make_footprint_filter('minimum_filter')
-percentile_filter = _make_footprint_filter('percentile_filter')
-rank_filter = _make_footprint_filter('rank_filter', 'rank=3')
+percentile_filter = _make_footprint_filter('percentile_filter',
+                                           extra_args='percentile=80')
+rank_filter = _make_footprint_filter('rank_filter', extra_args='rank=3')
 
 __all__ = [
     'gaussian_filter',

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -46,7 +46,7 @@ def _delta_to_positional(x: Union[Variable, DataArray], dim, index, dtype):
 
 
 def _positional_index(x: Union[Variable, DataArray], index, name=None, dtype=int):
-    if not hasattr(index, '__iter__'):
+    if not isinstance(index, dict):
         return [_delta_to_positional(x, dim, index, dtype=dtype) for dim in x.dims]
     if set(index) != set(x.dims):
         raise ValueError(f"Data has dims={x.dims} but input argument '{name}' provides "

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -7,7 +7,7 @@ This subpackage provides wrappers for a subset of functions from
 :py:mod:`scipy.ndimage`.
 """
 from functools import wraps
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Optional, Union
 
 import scipy.ndimage
 
@@ -80,7 +80,7 @@ def gaussian_filter(x: Union[Variable, DataArray],
 
     Warning
     -------
-    When ``sigma`` is an integer or an mapping to integers coordinate values are
+    If ``sigma`` is an integer or a mapping to integers then coordinate values are
     ignored. That is, the filter is applied even if the data points are not evenly
     spaced. The resulting filtered data may thus have no meaningful interpretation.
 
@@ -90,13 +90,18 @@ def gaussian_filter(x: Union[Variable, DataArray],
         Input variable or data array.
     sigma:
         Standard deviation for Gaussian kernel. The standard deviations of the Gaussian
-        filter are given as a mapping from dimension labels to numbers, or as a single
-        number, in which case it is equal for all axes.
+        filter are given as a mapping from dimension labels to numbers or scalar
+        variables, or as a single number or scalar variable, in which case it is equal
+        for all axes.
     order:
         The order of the filter along each dimension, given as mapping from dimension
         labels to integers, or as a single integer. An order of 0 corresponds to
         convolution with a Gaussian kernel. A positive order corresponds to convolution
         with that derivative of a Gaussian.
+
+    Returns:
+    :
+        Filtered variable or data array
 
     Examples
     --------
@@ -146,11 +151,11 @@ def _make_footprint_filter(name, example=True, extra_args=''):
     def footprint_filter(x: Union[Variable, DataArray],
                          /,
                          *,
-                         size: Union[int, Variable, Dict[str, Union[int,
-                                                                    Variable]]] = None,
-                         footprint: Variable = None,
-                         origin: Union[int, Variable, Dict[str, Union[int,
-                                                                      Variable]]] = 0,
+                         size: Optional[Union[int, Variable,
+                                              Dict[str, Union[int, Variable]]]] = None,
+                         footprint: Optional[Variable] = None,
+                         origin: Optional[Union[int, Variable,
+                                                Dict[str, Union[int, Variable]]]] = 0,
                          **kwargs) -> Union[Variable, DataArray]:
         footprint = _make_footprint(x, size=size, footprint=footprint)
         origin = _positional_index(x, origin, name='origin')
@@ -183,7 +188,7 @@ def _make_footprint_filter(name, example=True, extra_args=''):
 
     Warning
     -------
-    When ``size`` is an integer or an mapping to integers or when ``footprint`` is
+    When ``size`` is an integer or a mapping to integers or when ``footprint`` is
     given, coordinate values are ignored. That is, the filter is applied even if the
     data points are not evenly spaced. The resulting filtered data may thus have no
     meaningful interpretation.
@@ -202,6 +207,10 @@ def _make_footprint_filter(name, example=True, extra_args=''):
     origin:
         Integer or scalar variable or mapping from dimension labels to integers or
         scalar variables. Controls the placement of the filter on the input array.
+
+    Returns:
+    :
+        Filtered variable or data array
     """
     if example:
         doc += f"""

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+"""Sub-package for multidimensional image processing.
+
+This subpackage provides wrappers for a subset of functions from
+:py:mod:`scipy.ndimage`.
+"""
+from functools import wraps
+from typing import Callable, Union
+
+from ..core import Variable, DataArray
+from ..core import CoordError
+from ..core import empty_like, islinspace
+
+
+def ndfilter(func: Callable) -> Callable:
+
+    @wraps(func)
+    def function(x: Union[Variable, DataArray], **kwargs) -> Union[Variable, DataArray]:
+        if 'output' in kwargs:
+            raise ValueError("The 'output' argument is not supported")
+        if x.variances is not None:
+            raise ValueError("Filter cannot be applied to input array with variances.")
+        if getattr(x, 'masks', None):
+            raise ValueError("Filter cannot be applied to input array with masks.")
+        return func(x, **kwargs)
+
+    return function
+
+
+def _delta_to_positional(x: Union[Variable, DataArray], dim, index):
+    coord = x.coords[dim]
+    if not islinspace(coord, dim).value:
+        raise CoordError(
+            f"Data points not regularly spaced along {dim}. To ignore this, "
+            "provide a plain value (int or float) instead of a scalar variable. "
+            "Note that this will correspond to plain positional indices/offsets.")
+    return (len(coord) - 1) * (index.to(unit=coord.unit) / (coord[-1] - coord[0])).value
+
+
+def _positional_index(x: Union[Variable, DataArray], index, name):
+    if isinstance(index, int):
+        return index
+    if isinstance(index, Variable):
+        return [_delta_to_positional(x, dim, index) for dim in x.dims]
+    if set(index) != set(x.dims):
+        raise ValueError(f"Data has dims={x.dims} but input argument '{name}' provides "
+                         f"values only for {tuple(index)}")
+
+
+@ndfilter
+def gaussian_filter(x: Union[Variable, DataArray], /, *, sigma,
+                    **kwargs) -> Union[Variable, DataArray]:
+    from scipy.ndimage import gaussian_filter
+    out = empty_like(x)
+
+    gaussian_filter(x.values,
+                    sigma=_positional_index(x, sigma, name='sigma'),
+                    output=out.values,
+                    **kwargs)
+    return out
+
+
+__all__ = ['gaussian_filter']

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -9,6 +9,8 @@ This subpackage provides wrappers for a subset of functions from
 from functools import wraps
 from typing import Callable, Union
 
+import scipy.ndimage
+
 from ..core import Variable, DataArray
 from ..core import CoordError, DimensionError
 from ..core import empty_like, islinspace, ones
@@ -57,11 +59,14 @@ def gaussian_filter(x: Union[Variable, DataArray],
                     sigma,
                     order=0,
                     **kwargs) -> Union[Variable, DataArray]:
-    from scipy.ndimage import gaussian_filter
     sigma = _positional_index(x, sigma, name='sigma')
     order = order if isinstance(order, int) else [order[dim] for dim in x.dims]
     out = empty_like(x)
-    gaussian_filter(x.values, sigma=sigma, order=order, output=out.values, **kwargs)
+    scipy.ndimage.gaussian_filter(x.values,
+                                  sigma=sigma,
+                                  order=order,
+                                  output=out.values,
+                                  **kwargs)
     return out
 
 
@@ -88,7 +93,6 @@ def _make_footprint_filter(name):
                          footprint=None,
                          origin=0,
                          **kwargs) -> Union[Variable, DataArray]:
-        import scipy.ndimage
         footprint = _make_footprint(x, size=size, footprint=footprint)
         origin = _positional_index(x, origin, name='origin')
         origin = [int(s) for s in origin]

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -30,6 +30,8 @@ def ndfilter(func: Callable) -> Callable:
 
 
 def _delta_to_positional(x: Union[Variable, DataArray], dim, index):
+    if isinstance(index, int):
+        return index
     coord = x.coords[dim]
     if not islinspace(coord, dim).value:
         raise CoordError(
@@ -39,14 +41,13 @@ def _delta_to_positional(x: Union[Variable, DataArray], dim, index):
     return (len(coord) - 1) * (index.to(unit=coord.unit) / (coord[-1] - coord[0])).value
 
 
-def _positional_index(x: Union[Variable, DataArray], index, name):
-    if isinstance(index, int):
-        return index
+def _positional_index(x: Union[Variable, DataArray], index, name=None):
     if isinstance(index, Variable):
         return [_delta_to_positional(x, dim, index) for dim in x.dims]
     if set(index) != set(x.dims):
         raise ValueError(f"Data has dims={x.dims} but input argument '{name}' provides "
-                         f"values only for {tuple(index)}")
+                         f"values for {tuple(index)}")
+    return [_delta_to_positional(x, dim, index[dim]) for dim in x.dims]
 
 
 @ndfilter

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -58,9 +58,9 @@ def gaussian_filter(x: Union[Variable, DataArray],
                     order=0,
                     **kwargs) -> Union[Variable, DataArray]:
     from scipy.ndimage import gaussian_filter
-    out = empty_like(x)
     sigma = _positional_index(x, sigma, name='sigma')
     order = order if isinstance(order, int) else [order[dim] for dim in x.dims]
+    out = empty_like(x)
     gaussian_filter(x.values, sigma=sigma, order=order, output=out.values, **kwargs)
     return out
 
@@ -73,10 +73,9 @@ def median_filter(x: Union[Variable, DataArray],
                   footprint=None,
                   **kwargs) -> Union[Variable, DataArray]:
     from scipy.ndimage import median_filter
-    out = empty_like(x)
     if footprint is None:
-        if isinstance(size, int):
-            size = [size] * x.ndim
+        size = _positional_index(x, size, name='size')
+        size = [int(s) for s in size]
         footprint = ones(dims=x.dims, shape=size, dtype='bool')
     else:
         if size is not None:
@@ -84,6 +83,7 @@ def median_filter(x: Union[Variable, DataArray],
         if set(footprint.dims) != set(x.dims):
             raise DimensionError(
                 f"Dimensions {footprint.dims} must match data dimensions {x.dim}")
+    out = empty_like(x)
     median_filter(x.values, footprint=footprint.values, output=out.values, **kwargs)
     return out
 

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -19,7 +19,7 @@ def _ndfilter(func: Callable) -> Callable:
     @wraps(func)
     def function(x: Union[Variable, DataArray], **kwargs) -> Union[Variable, DataArray]:
         if 'output' in kwargs:
-            raise ValueError("The 'output' argument is not supported")
+            raise TypeError("The 'output' argument is not supported")
         if x.variances is not None:
             raise ValueError("Filter cannot be applied to input array with variances.")
         if getattr(x, 'masks', None):

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -92,7 +92,7 @@ def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
     return footprint
 
 
-def _make_footprint_filter(name):
+def _make_footprint_filter(name, extra_args=''):
 
     def footprint_filter(x: Union[Variable, DataArray],
                          /,
@@ -116,6 +116,8 @@ def _make_footprint_filter(name):
         return out
 
     footprint_filter.__name__ = name
+    if extra_args:
+        extra_args = f', {extra_args}'
     footprint_filter.__doc__ = f"""
     Calculate a multidimensional {name.replace('_', ' ')}.
 
@@ -158,7 +160,7 @@ def _make_footprint_filter(name):
 
       >>> from scipp.ndimage import {name}
       >>> da = sc.data.data_xy()
-      >>> filtered = {name}(da,size=4)
+      >>> filtered = {name}(da, size=4{extra_args})
     """
     return _ndfilter(footprint_filter)
 
@@ -168,7 +170,7 @@ maximum_filter = _make_footprint_filter('maximum_filter')
 median_filter = _make_footprint_filter('median_filter')
 minimum_filter = _make_footprint_filter('minimum_filter')
 percentile_filter = _make_footprint_filter('percentile_filter')
-rank_filter = _make_footprint_filter('rank_filter')
+rank_filter = _make_footprint_filter('rank_filter', 'rank=3')
 
 __all__ = [
     'gaussian_filter',

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -14,7 +14,7 @@ from ..core import CoordError, DimensionError
 from ..core import empty_like, islinspace, ones
 
 
-def ndfilter(func: Callable) -> Callable:
+def _ndfilter(func: Callable) -> Callable:
 
     @wraps(func)
     def function(x: Union[Variable, DataArray], **kwargs) -> Union[Variable, DataArray]:
@@ -50,7 +50,7 @@ def _positional_index(x: Union[Variable, DataArray], index, name=None):
     return [_delta_to_positional(x, dim, index[dim]) for dim in x.dims]
 
 
-@ndfilter
+@_ndfilter
 def gaussian_filter(x: Union[Variable, DataArray],
                     /,
                     *,
@@ -103,11 +103,22 @@ def _make_footprint_filter(name):
 
     footprint_filter.__name__ = name
     footprint_filter.__doc__ = f'Forwards to scipy.ndimage.{name}'
-    return ndfilter(footprint_filter)
+    return _ndfilter(footprint_filter)
 
 
-median_filter = _make_footprint_filter('median_filter')
+generic_filter = _make_footprint_filter('generic_filter')
 maximum_filter = _make_footprint_filter('maximum_filter')
+median_filter = _make_footprint_filter('median_filter')
 minimum_filter = _make_footprint_filter('minimum_filter')
+percentile_filter = _make_footprint_filter('percentile_filter')
+rank_filter = _make_footprint_filter('rank_filter')
 
-__all__ = ['gaussian_filter', 'median_filter', 'maximum_filter', 'minimum_filter']
+__all__ = [
+    'gaussian_filter',
+    'generic_filter',
+    'maximum_filter',
+    'median_filter',
+    'minimum_filter',
+    'percentile_filter',
+    'rank_filter',
+]

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -70,11 +70,11 @@ def gaussian_filter(x: Union[Variable, DataArray],
 
     - This wrapper uses explicit dimension labels in the ``sigma`` and ``order``
       arguments. For example, instead of ``sigma=[4, 6]`` use
-      ``sigma={{'time':4, 'space':6}}``
+      ``sigma={'time':4, 'space':6}``
       (with appropriate dimension labels for the data).
     - Coordinate values can be used (and should be preferred) for ``sigma``. For
       example, instead of ``sigma=[4, 6]`` use
-      ``sigma={{'time':sc.scalar(5.0, unit='ms'), 'space':sc.scalar(1.2, unit='mm')}}``.
+      ``sigma={'time':sc.scalar(5.0, unit='ms'), 'space':sc.scalar(1.2, unit='mm')}``.
       In this case it is required that the corresponding coordinates exist and form a
       "linspace", i.e., are evenly spaced.
 

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -14,6 +14,7 @@ import scipy.ndimage
 from ..core import Variable, DataArray
 from ..core import CoordError, DimensionError, VariancesError
 from ..core import empty_like, islinspace, ones
+from ..typing import VariableLike, VariableLikeType
 
 
 def _ndfilter(func: Callable) -> Callable:
@@ -60,12 +61,13 @@ def _positional_index(x: Union[Variable, DataArray], index, name=None, dtype=int
 
 
 @_ndfilter
-def gaussian_filter(x: Union[Variable, DataArray],
+def gaussian_filter(x: VariableLikeType,
                     /,
                     *,
-                    sigma,
-                    order=0,
-                    **kwargs) -> Union[Variable, DataArray]:
+                    sigma: Union[int, float, Variable, Dict[str, Union[int, float,
+                                                                       Variable]]],
+                    order: Optional[Union[int, Dict[str, int]]] = 0,
+                    **kwargs) -> VariableLikeType:
     """
     Multidimensional Gaussian filter.
 
@@ -90,7 +92,7 @@ def gaussian_filter(x: Union[Variable, DataArray],
 
     Parameters
     ----------
-    x:
+    x: scipp.typing.VariableLike
         Input variable or data array.
     sigma:
         Standard deviation for Gaussian kernel. The standard deviations of the Gaussian
@@ -105,7 +107,7 @@ def gaussian_filter(x: Union[Variable, DataArray],
 
     Returns
     -------
-    :
+    : scipp.typing.VariableLike
         Filtered variable or data array
 
     Examples
@@ -155,7 +157,7 @@ def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
 
 def _make_footprint_filter(name, example=True, extra_args=''):
 
-    def footprint_filter(x: Union[Variable, DataArray],
+    def footprint_filter(x: VariableLike,
                          /,
                          *,
                          size: Optional[Union[int, Variable,
@@ -163,7 +165,7 @@ def _make_footprint_filter(name, example=True, extra_args=''):
                          footprint: Optional[Variable] = None,
                          origin: Optional[Union[int, Variable,
                                                 Dict[str, Union[int, Variable]]]] = 0,
-                         **kwargs) -> Union[Variable, DataArray]:
+                         **kwargs) -> VariableLike:
         footprint = _make_footprint(x, size=size, footprint=footprint)
         origin = _positional_index(x, origin, name='origin')
         out = empty_like(x)
@@ -202,7 +204,7 @@ def _make_footprint_filter(name, example=True, extra_args=''):
 
     Parameters
     ----------
-    x:
+    x: scipp.typing.VariableLike
         Input variable or data array.
     size:
         Integer or scalar variable or mapping from dimension labels to integers or
@@ -217,7 +219,7 @@ def _make_footprint_filter(name, example=True, extra_args=''):
 
     Returns
     -------
-    :
+    : scipp.typing.VariableLike
         Filtered variable or data array
     """
     if example:

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -42,7 +42,7 @@ def _delta_to_positional(x: Union[Variable, DataArray], dim, index):
 
 
 def _positional_index(x: Union[Variable, DataArray], index, name=None):
-    if isinstance(index, Variable):
+    if isinstance(index, (int, Variable)):
         return [_delta_to_positional(x, dim, index) for dim in x.dims]
     if set(index) != set(x.dims):
         raise ValueError(f"Data has dims={x.dims} but input argument '{name}' provides "

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -81,19 +81,24 @@ def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
 
 def _make_footprint_filter(name):
 
-    def footprint_filter(
-            x: Union[Variable, DataArray],
-            /,
-            *,
-            size=None,
-            footprint=None,
-            # TODO origin
-            **kwargs) -> Union[Variable, DataArray]:
+    def footprint_filter(x: Union[Variable, DataArray],
+                         /,
+                         *,
+                         size=None,
+                         footprint=None,
+                         origin=0,
+                         **kwargs) -> Union[Variable, DataArray]:
         import scipy.ndimage
         footprint = _make_footprint(x, size=size, footprint=footprint)
+        origin = _positional_index(x, origin, name='origin')
+        origin = [int(s) for s in origin]
         out = empty_like(x)
         scipy_filter = getattr(scipy.ndimage, name)
-        scipy_filter(x.values, footprint=footprint.values, output=out.values, **kwargs)
+        scipy_filter(x.values,
+                     footprint=footprint.values,
+                     origin=origin,
+                     output=out.values,
+                     **kwargs)
         return out
 
     footprint_filter.__name__ = name

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -65,14 +65,7 @@ def gaussian_filter(x: Union[Variable, DataArray],
     return out
 
 
-@ndfilter
-def median_filter(x: Union[Variable, DataArray],
-                  /,
-                  *,
-                  size=None,
-                  footprint=None,
-                  **kwargs) -> Union[Variable, DataArray]:
-    from scipy.ndimage import median_filter
+def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
     if footprint is None:
         size = _positional_index(x, size, name='size')
         size = [int(s) for s in size]
@@ -83,6 +76,20 @@ def median_filter(x: Union[Variable, DataArray],
         if set(footprint.dims) != set(x.dims):
             raise DimensionError(
                 f"Dimensions {footprint.dims} must match data dimensions {x.dim}")
+    return footprint
+
+
+@ndfilter
+def median_filter(
+        x: Union[Variable, DataArray],
+        /,
+        *,
+        size=None,
+        footprint=None,
+        # TODO origin
+        **kwargs) -> Union[Variable, DataArray]:
+    from scipy.ndimage import median_filter
+    footprint = _make_footprint(x, size=size, footprint=footprint)
     out = empty_like(x)
     median_filter(x.values, footprint=footprint.values, output=out.values, **kwargs)
     return out

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -34,7 +34,7 @@ def _ndfilter(func: Callable) -> Callable:
 
 def _delta_to_positional(x: Union[Variable, DataArray], dim, index, dtype):
     if not isinstance(index, Variable):
-        return dtype(index)
+        return index
     coord = x.coords[dim]
     if not islinspace(coord, dim).value:
         raise CoordError(
@@ -131,7 +131,6 @@ def gaussian_filter(x: Union[Variable, DataArray],
 def _make_footprint(x: Union[Variable, DataArray], size, footprint) -> Variable:
     if footprint is None:
         size = _positional_index(x, size, name='size')
-        size = [int(s) for s in size]
         footprint = ones(dims=x.dims, shape=size, dtype='bool')
     else:
         if size is not None:
@@ -155,7 +154,6 @@ def _make_footprint_filter(name, example=True, extra_args=''):
                          **kwargs) -> Union[Variable, DataArray]:
         footprint = _make_footprint(x, size=size, footprint=footprint)
         origin = _positional_index(x, origin, name='origin')
-        origin = [int(s) for s in origin]
         out = empty_like(x)
         scipy_filter = getattr(scipy.ndimage, name)
         scipy_filter(x.values,

--- a/src/scipp/ndimage/__init__.py
+++ b/src/scipp/ndimage/__init__.py
@@ -103,7 +103,8 @@ def gaussian_filter(x: Union[Variable, DataArray],
         convolution with a Gaussian kernel. A positive order corresponds to convolution
         with that derivative of a Gaussian.
 
-    Returns:
+    Returns
+    -------
     :
         Filtered variable or data array
 
@@ -214,7 +215,8 @@ def _make_footprint_filter(name, example=True, extra_args=''):
         Integer or scalar variable or mapping from dimension labels to integers or
         scalar variables. Controls the placement of the filter on the input array.
 
-    Returns:
+    Returns
+    -------
     :
         Filtered variable or data array
     """

--- a/tests/ndimage/footprint_filter_test.py
+++ b/tests/ndimage/footprint_filter_test.py
@@ -76,7 +76,7 @@ def test_raises_TypeError_if_size_is_not_integral(filter_func):
     with pytest.raises(TypeError):
         filter_func(da, size=1.5)
     with pytest.raises(TypeError):
-        filter_func(da, size=[2.5, 3.5])
+        filter_func(da, size={'x': 2.5, 'y': 3.5})
 
 
 def test_raises_TypeError_if_origin_is_not_integral(filter_func):

--- a/tests/ndimage/footprint_filter_test.py
+++ b/tests/ndimage/footprint_filter_test.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import numpy as np
+import scipp as sc
+import scipy.ndimage
+from scipp.ndimage import (generic_filter, maximum_filter, median_filter,
+                           minimum_filter, percentile_filter, rank_filter)
+import pytest
+
+filters = (generic_filter, maximum_filter, median_filter, minimum_filter,
+           percentile_filter, rank_filter)
+
+
+def make_histogram2d():
+    da = sc.DataArray(sc.array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    da.coords['x'] = sc.linspace('x', 0.0, 10.0, num=101, unit='mm')
+    da.coords['y'] = sc.linspace('y', 0.0, 50.0, num=101, unit='mm')
+    return da
+
+
+def make_data2d():
+    da = sc.DataArray(sc.array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    da.coords['x'] = sc.arange('x', 0.0, 10.0, 0.1, unit='mm')
+    da.coords['y'] = sc.arange('y', 0.0, 50.0, 0.5, unit='mm')
+    return da
+
+
+@pytest.fixture(scope="module",
+                params=[
+                    generic_filter, maximum_filter, median_filter, minimum_filter,
+                    percentile_filter, rank_filter
+                ])
+def filter_func(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[maximum_filter, median_filter, minimum_filter])
+def simple_filter_func(request):
+    return request.param
+
+
+def test_raises_TypeError_when_output_arg_given(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(TypeError):
+        filter_func(da, size=2, output=da.values)
+
+
+def test_raises_VariancesError_when_data_has_variances(filter_func):
+    da = make_histogram2d()
+    da.variances = da.values
+    with pytest.raises(sc.VariancesError):
+        filter_func(da, size=2)
+
+
+def test_raises_ValueError_when_data_has_masks(filter_func):
+    da = make_histogram2d()
+    da.masks['mask'] = da.coords['x'] == da.coords['x']
+    with pytest.raises(ValueError):
+        filter_func(da, size=2)
+
+
+def test_raises_TypeError_if_size_given_as_array_like(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(TypeError):
+        filter_func(da, size=[2, 3])
+
+
+def test_raises_TypeError_if_origin_given_as_array_like(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(TypeError):
+        filter_func(da, size=[2, 3])
+
+
+def test_raises_TypeError_if_size_is_not_integral(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(TypeError):
+        filter_func(da, size=1.5)
+    with pytest.raises(TypeError):
+        filter_func(da, size=[2.5, 3.5])
+
+
+def test_raises_TypeError_if_origin_is_not_integral(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(TypeError):
+        filter_func(da, size=3, origin=1.5)
+    with pytest.raises(TypeError):
+        filter_func(da, size=3, origin=[1.5, 0.5])
+
+
+def test_raises_CoordError_with_label_based_size_or_origin_if_coord_not_linspace(
+        filter_func):
+    da = make_histogram2d()
+    da.coords['x'][-1] *= 1.1
+    with pytest.raises(sc.CoordError):
+        filter_func(da, size=sc.scalar(1.2, unit='mm'))
+    with pytest.raises(sc.CoordError):
+        filter_func(da, size=2, origin=sc.scalar(1.2, unit='mm'))
+
+
+def test_raises_KeyError_with_label_based_size_if_coord_missing(filter_func):
+    da = make_histogram2d()
+    del da.coords['y']
+    with pytest.raises(KeyError):
+        filter_func(da, size=sc.scalar(1.2, unit='mm'))
+    with pytest.raises(KeyError):
+        filter_func(da, size=2, origin=sc.scalar(1.2, unit='mm'))
+
+
+def test_input_with_non_linspace_coord_accepted_if_size_is_positional(
+        simple_filter_func):
+    da = make_histogram2d()
+    da.coords['x'][-1] *= 1.1
+    simple_filter_func(da, size=3)
+
+
+def test_input_with_missing_coord_accepted_if_size_is_positional(simple_filter_func):
+    da = make_histogram2d()
+    del da.coords['x']
+    simple_filter_func(da, size=3.4)
+
+
+def test_size_accepts_mixed_label_based_and_positional_param(simple_filter_func):
+    da = make_histogram2d()
+    simple_filter_func(da, size={'x': sc.scalar(1.5, unit='mm'), 'y': 2})
+
+
+def test_label_based_size_equivalent_to_positional_size_given_bin_edge_coord(
+        simple_filter_func):
+    da = make_histogram2d()
+    result = simple_filter_func(da,
+                                size={
+                                    'x': sc.scalar(1.0, unit='mm'),
+                                    'y': sc.scalar(5.0, unit='mm')
+                                })
+    reference = simple_filter_func(da, size=10)
+    assert sc.identical(result, reference)
+
+
+def test_label_based_size_equivalent_to_positional_size(simple_filter_func):
+    da = make_data2d()
+    result = simple_filter_func(da,
+                                size={
+                                    'x': sc.scalar(1.0, unit='mm'),
+                                    'y': sc.scalar(5.0, unit='mm')
+                                })
+    reference = simple_filter_func(da, size=10)
+    assert sc.identical(result, reference)
+
+
+@pytest.mark.parametrize('origin', [0, 1, -1, {'x': 0, 'y': 1}])
+def test_origin_is_equivalent_to_scipy_origin(origin):
+    da = make_histogram2d()
+    result = median_filter(da, size=4, origin=origin)
+    reference = da.copy()
+    reference.values = scipy.ndimage.median_filter(
+        reference.values,
+        size=4,
+        origin=origin if isinstance(origin, int) else origin.values())
+    assert sc.identical(result, reference)
+
+
+@pytest.mark.parametrize('size', [2, 3, {'x': 2, 'y': 1}])
+def test_size_is_equivalent_to_scipy_size(size):
+    da = make_histogram2d()
+    result = median_filter(da, size=size)
+    reference = da.copy()
+    reference.values = scipy.ndimage.median_filter(
+        reference.values, size=size if isinstance(size, int) else size.values())
+    assert sc.identical(result, reference)
+
+
+def test_attributes_are_propagated(simple_filter_func):
+    da = make_histogram2d()
+    da.attrs['attr'] = sc.scalar(1.2)
+    result = simple_filter_func(da, size=2)
+    assert set(result.attrs) == set(['attr'])
+    assert sc.identical(result.attrs['attr'], da.attrs['attr'])
+
+
+def test_coordinates_are_propagated(simple_filter_func):
+    da = make_histogram2d()
+    result = simple_filter_func(da, size=2)
+    assert set(result.coords) == set(['x', 'y'])
+    assert sc.identical(result.coords['x'], da.coords['x'])
+    assert sc.identical(result.coords['y'], da.coords['y'])
+
+
+def test_input_is_not_modified(simple_filter_func):
+    original = make_histogram2d()
+    da = original.copy()
+    simple_filter_func(da, size=2)
+    assert sc.identical(da, original)

--- a/tests/ndimage/footprint_filter_test.py
+++ b/tests/ndimage/footprint_filter_test.py
@@ -116,7 +116,7 @@ def test_input_with_non_linspace_coord_accepted_if_size_is_positional(
 def test_input_with_missing_coord_accepted_if_size_is_positional(simple_filter_func):
     da = make_histogram2d()
     del da.coords['x']
-    simple_filter_func(da, size=3.4)
+    simple_filter_func(da, size=3)
 
 
 def test_size_accepts_mixed_label_based_and_positional_param(simple_filter_func):

--- a/tests/ndimage/footprint_filter_test.py
+++ b/tests/ndimage/footprint_filter_test.py
@@ -84,7 +84,7 @@ def test_raises_TypeError_if_origin_is_not_integral(filter_func):
     with pytest.raises(TypeError):
         filter_func(da, size=3, origin=1.5)
     with pytest.raises(TypeError):
-        filter_func(da, size=3, origin=[1.5, 0.5])
+        filter_func(da, size=3, origin={'x': 1.5, 'y': 0.5})
 
 
 def test_raises_CoordError_with_label_based_size_or_origin_if_coord_not_linspace(

--- a/tests/ndimage/footprint_filter_test.py
+++ b/tests/ndimage/footprint_filter_test.py
@@ -87,6 +87,30 @@ def test_raises_TypeError_if_origin_is_not_integral(filter_func):
         filter_func(da, size=3, origin={'x': 1.5, 'y': 0.5})
 
 
+def test_raises_KeyError_if_size_has_missing_labels(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        filter_func(da, size={'x': 4})
+
+
+def test_raises_KeyError_if_size_has_extra_labels(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        filter_func(da, size={'x': 4, 'y': 4, 'z': 4})
+
+
+def test_raises_KeyError_if_origin_has_missing_labels(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        filter_func(da, size=4, origin={'x': -1})
+
+
+def test_raises_KeyError_if_origin_has_extra_labels(filter_func):
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        filter_func(da, size=4, origin={'x': -1, 'y': -1, 'z': -1})
+
+
 def test_raises_CoordError_with_label_based_size_or_origin_if_coord_not_linspace(
         filter_func):
     da = make_histogram2d()

--- a/tests/ndimage/gaussian_filter_test.py
+++ b/tests/ndimage/gaussian_filter_test.py
@@ -8,55 +8,102 @@ from scipp.ndimage import gaussian_filter
 import pytest
 
 
-def make_array2d():
+def make_histogram2d():
     da = sc.DataArray(sc.array(dims=['x', 'y'], values=np.random.rand(100, 100)))
-    da.coords['x'] = sc.linspace('x', 0.0, 10.0, num=100, unit='mm')
-    da.coords['y'] = sc.linspace('y', 0.0, 50.0, num=100, unit='mm')
+    da.coords['x'] = sc.linspace('x', 0.0, 10.0, num=101, unit='mm')
+    da.coords['y'] = sc.linspace('y', 0.0, 50.0, num=101, unit='mm')
+    return da
+
+
+def make_data2d():
+    da = sc.DataArray(sc.array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    da.coords['x'] = sc.arange('x', 0.0, 10.0, 0.1, unit='mm')
+    da.coords['y'] = sc.arange('y', 0.0, 50.0, 0.5, unit='mm')
     return da
 
 
 def test_raises_TypeError_when_output_arg_given():
-    da = make_array2d()
+    da = make_histogram2d()
     with pytest.raises(TypeError):
         gaussian_filter(da, sigma=1.5, output=da.values)
 
 
 def test_raises_VariancesError_when_data_has_variances():
-    da = make_array2d()
+    da = make_histogram2d()
     da.variances = da.values
     with pytest.raises(sc.VariancesError):
         gaussian_filter(da, sigma=1.5)
 
 
 def test_raises_ValueError_when_data_has_masks():
-    da = make_array2d()
+    da = make_histogram2d()
     da.masks['mask'] = da.coords['x'] == da.coords['x']
     with pytest.raises(ValueError):
         gaussian_filter(da, sigma=1.5)
 
 
 def test_raises_TypeError_if_sigma_given_as_array_like():
-    da = make_array2d()
+    da = make_histogram2d()
     with pytest.raises(TypeError):
         gaussian_filter(da, sigma=[1.5, 2.5])
 
 
-def test_various_options_for_sigma():
-    da = make_array2d()
-    gaussian_filter(da, sigma=1.5)
-    gaussian_filter(da, sigma=sc.scalar(1.5, unit='mm'))
-    gaussian_filter(da, sigma={'x': 1.5, 'y': 2.5})
+def test_raises_CoordError_with_label_based_sigma_if_coord_is_not_linspace():
+    da = make_histogram2d()
+    da.coords['x'][-1] *= 1.1
+    with pytest.raises(sc.CoordError):
+        gaussian_filter(da, sigma=sc.scalar(1.2, unit='mm'))
+
+
+def test_raises_KeyError_with_label_based_sigma_if_coord_missing():
+    da = make_histogram2d()
+    del da.coords['y']
+    with pytest.raises(KeyError):
+        gaussian_filter(da, sigma=sc.scalar(1.2, unit='mm'))
+
+
+def test_input_with_non_linspace_coord_accepted_if_sigma_is_positional():
+    da = make_histogram2d()
+    da.coords['x'][-1] *= 1.1
+    gaussian_filter(da, sigma=3.4)
+
+
+def test_input_with_missing_coord_accepted_if_sigma_is_positional():
+    da = make_histogram2d()
+    del da.coords['x']
+    gaussian_filter(da, sigma=3.4)
+
+
+def test_sigma_accepts_mixed_label_based_and_positional_param():
+    da = make_histogram2d()
     gaussian_filter(da, sigma={'x': sc.scalar(1.5, unit='mm'), 'y': 3.7})
-    gaussian_filter(da,
-                    sigma={
-                        'x': sc.scalar(1.5, unit='mm'),
-                        'y': sc.scalar(2.5, unit='mm')
-                    })
+
+
+def test_label_based_sigma_equivalent_to_positional_sigma_given_bin_edge_coord():
+    da = make_histogram2d()
+    result = gaussian_filter(da,
+                             sigma={
+                                 'x': sc.scalar(1.0, unit='mm'),
+                                 'y': sc.scalar(5.0, unit='mm')
+                             })
+    reference = gaussian_filter(da, sigma=10)
+    assert sc.identical(result, reference)
+
+
+def test_label_based_sigma_equivalent_to_positional_sigma():
+    da = make_data2d()
+    result = gaussian_filter(da,
+                             sigma={
+                                 'x': sc.scalar(1.0, unit='mm'),
+                                 'y': sc.scalar(5.0, unit='mm')
+                             })
+    reference = gaussian_filter(da, sigma=10)
+    assert sc.identical(result, reference)
 
 
 @pytest.mark.parametrize('order', [0, 1, {'x': 0, 'y': 1}])
 def test_order_is_equivalent_to_scipy_order(order):
-    da = make_array2d()
+    da = make_histogram2d()
     result = gaussian_filter(da, sigma=1.5, order=order)
     reference = da.copy()
     reference.values = scipy.ndimage.gaussian_filter(
@@ -68,8 +115,15 @@ def test_order_is_equivalent_to_scipy_order(order):
 
 @pytest.mark.parametrize('sigma', [2, 1.7, 3.33])
 def test_sigma_is_equivalent_to_scipy_sigma(sigma):
-    da = make_array2d()
+    da = make_histogram2d()
     result = gaussian_filter(da, sigma=sigma)
     reference = da.copy()
     reference.values = scipy.ndimage.gaussian_filter(reference.values, sigma=sigma)
     assert sc.identical(result, reference)
+
+
+def test_input_is_not_modified():
+    original = make_histogram2d()
+    da = original.copy()
+    gaussian_filter(da, sigma=3.4)
+    assert sc.identical(da, original)

--- a/tests/ndimage/gaussian_filter_test.py
+++ b/tests/ndimage/gaussian_filter_test.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import numpy as np
+import scipp as sc
+import scipy.ndimage
+from scipp.ndimage import gaussian_filter
+
+import pytest
+
+
+def make_array2d():
+    da = sc.DataArray(sc.array(dims=['x', 'y'], values=np.random.rand(100, 100)))
+    da.coords['x'] = sc.linspace('x', 0.0, 10.0, num=100, unit='mm')
+    da.coords['y'] = sc.linspace('y', 0.0, 50.0, num=100, unit='mm')
+    return da
+
+
+def test_raises_TypeError_when_output_arg_given():
+    da = make_array2d()
+    with pytest.raises(TypeError):
+        gaussian_filter(da, sigma=1.5, output=da.values)
+
+
+def test_raises_VariancesError_when_data_has_variances():
+    da = make_array2d()
+    da.variances = da.values
+    with pytest.raises(sc.VariancesError):
+        gaussian_filter(da, sigma=1.5)
+
+
+def test_raises_ValueError_when_data_has_masks():
+    da = make_array2d()
+    da.masks['mask'] = da.coords['x'] == da.coords['x']
+    with pytest.raises(ValueError):
+        gaussian_filter(da, sigma=1.5)
+
+
+def test_raises_TypeError_if_sigma_given_as_array_like():
+    da = make_array2d()
+    with pytest.raises(TypeError):
+        gaussian_filter(da, sigma=[1.5, 2.5])
+
+
+def test_various_options_for_sigma():
+    da = make_array2d()
+    gaussian_filter(da, sigma=1.5)
+    gaussian_filter(da, sigma=sc.scalar(1.5, unit='mm'))
+    gaussian_filter(da, sigma={'x': 1.5, 'y': 2.5})
+    gaussian_filter(da, sigma={'x': sc.scalar(1.5, unit='mm'), 'y': 3.7})
+    gaussian_filter(da,
+                    sigma={
+                        'x': sc.scalar(1.5, unit='mm'),
+                        'y': sc.scalar(2.5, unit='mm')
+                    })
+
+
+@pytest.mark.parametrize('order', [0, 1, {'x': 0, 'y': 1}])
+def test_order_is_equivalent_to_scipy_order(order):
+    da = make_array2d()
+    result = gaussian_filter(da, sigma=1.5, order=order)
+    reference = da.copy()
+    reference.values = scipy.ndimage.gaussian_filter(
+        reference.values,
+        sigma=1.5,
+        order=order if isinstance(order, int) else order.values())
+    assert sc.identical(result, reference)
+
+
+@pytest.mark.parametrize('sigma', [2, 1.7, 3.33])
+def test_sigma_is_equivalent_to_scipy_sigma(sigma):
+    da = make_array2d()
+    result = gaussian_filter(da, sigma=sigma)
+    reference = da.copy()
+    reference.values = scipy.ndimage.gaussian_filter(reference.values, sigma=sigma)
+    assert sc.identical(result, reference)

--- a/tests/ndimage/gaussian_filter_test.py
+++ b/tests/ndimage/gaussian_filter_test.py
@@ -48,6 +48,30 @@ def test_raises_TypeError_if_sigma_given_as_array_like():
         gaussian_filter(da, sigma=[1.5, 2.5])
 
 
+def test_raises_KeyError_if_sigma_has_missing_labels():
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        gaussian_filter(da, sigma={'x': 1.5})
+
+
+def test_raises_KeyError_if_sigma_has_extra_labels():
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        gaussian_filter(da, sigma={'x': 1.5, 'y': 1.5, 'z': 1.5})
+
+
+def test_raises_KeyError_if_order_has_missing_labels():
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        gaussian_filter(da, sigma=4, order={'x': 0})
+
+
+def test_raises_KeyError_if_order_has_extra_labels():
+    da = make_histogram2d()
+    with pytest.raises(KeyError):
+        gaussian_filter(da, sigma=4, order={'x': 0, 'y': 0, 'z': 0})
+
+
 def test_raises_CoordError_with_label_based_sigma_if_coord_is_not_linspace():
     da = make_histogram2d()
     da.coords['x'][-1] *= 1.1

--- a/tests/ndimage/gaussian_filter_test.py
+++ b/tests/ndimage/gaussian_filter_test.py
@@ -122,6 +122,22 @@ def test_sigma_is_equivalent_to_scipy_sigma(sigma):
     assert sc.identical(result, reference)
 
 
+def test_attributes_are_propagated():
+    da = make_histogram2d()
+    da.attrs['attr'] = sc.scalar(1.2)
+    result = gaussian_filter(da, sigma=3.4)
+    assert set(result.attrs) == set(['attr'])
+    assert sc.identical(result.attrs['attr'], da.attrs['attr'])
+
+
+def test_coordinates_are_propagated():
+    da = make_histogram2d()
+    result = gaussian_filter(da, sigma=3.4)
+    assert set(result.coords) == set(['x', 'y'])
+    assert sc.identical(result.coords['x'], da.coords['x'])
+    assert sc.identical(result.coords['y'], da.coords['y'])
+
+
 def test_input_is_not_modified():
     original = make_histogram2d()
     da = original.copy()


### PR DESCRIPTION
Fixes #2569.

Features:
- Works with variables as well as data arrays.
- `sigma` and `size` arguments passed as dicts of scalar variables instead of tuples.
- Can pass int/float instead of variable. In that case it refers to "positional" size. As discussed on Slack this may be too implicit, so we are considering to require an extra flag argument in that case (to ignore coords).

This is a draft for discussion.

TODO:
- [x] Add and require arg to explicitly ignore coords when passing sizes/sigma/other-params as plain indices instead of variables. -> see discussion below.
- [x] Docstrings
- [x] Unit tests
- [x] More functions