### PR TITLE
Add `tox -e linkcheck` and run linkcheck only on `main` to avoid flaky PR and release builds

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -84,6 +84,10 @@ jobs:
       - run: tox -e docs
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
+      - run: tox -e linkcheck
+        # Linkcheck can be flaky. Avoid randomly breaking PR builds by running only on `main`
+        if: ${{ contains(matrix.os, 'ubuntu') }} && github.ref == 'refs/heads/main'
+
       - uses: actions/upload-artifact@v2
         if: ${{ contains(matrix.os, 'ubuntu') }}
         with:

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -86,7 +86,7 @@ jobs:
 
       - run: tox -e linkcheck
         # Linkcheck can be flaky. Avoid randomly breaking PR builds by running only on `main`
-        if: ${{ contains(matrix.os, 'ubuntu') }} && github.ref == 'refs/heads/main'
+        if: ${{ contains(matrix.os, 'ubuntu') && github.ref == 'refs/heads/main' }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,13 @@ allowlist_externals = find
 commands =
   python -m sphinx -j2 -v -b html -d doctrees docs html
   python -m sphinx -j2 -v -b doctest -d doctrees docs html
-  python -m sphinx -j4 -v -b linkcheck -d doctrees docs html
   find html -type f -name "*.ipynb" -not -path "html/_sources/*" -delete
+
+[testenv:linkcheck]
+description = Run Sphinx linkcheck
+deps = -r requirements/docs.txt
+commands =
+  python -m sphinx -j4 -v -b linkcheck -d doctrees docs html
 
 [testenv:static]
 description = Code formatting and static analysis


### PR DESCRIPTION
Fixes #2599.