### PR TITLE
Make scipp compatible with gcc 12

### DIFF
--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -272,7 +272,7 @@ template <class T> bool nan_sensitive_equal(const T &a, const T &b) {
 } // namespace
 
 template <class T> struct MakeGroups {
-  static auto apply(const Variable &key, const Dim targetDim) {
+  static GroupByGrouping apply(const Variable &key, const Dim targetDim) {
     expect::is_key(key);
     const auto &values = key.values<T>();
 
@@ -301,12 +301,12 @@ template <class T> struct MakeGroups {
     }
     auto keys_ = makeVariable<T>(Dimensions{dims}, Values(std::move(keys)));
     keys_.setUnit(key.unit());
-    return GroupByGrouping{dim, std::move(keys_), std::move(groups)};
+    return {dim, std::move(keys_), std::move(groups)};
   }
 };
 
 template <class T> struct MakeBinGroups {
-  static auto apply(const Variable &key, const Variable &bins) {
+  static GroupByGrouping apply(const Variable &key, const Variable &bins) {
     expect::is_key(key);
     if (bins.dims().ndim() != 1)
       throw except::DimensionError("Group-by bins must be 1-dimensional");
@@ -332,7 +332,7 @@ template <class T> struct MakeBinGroups {
         groups[std::distance(edges.begin(), left)].emplace_back(dim, begin, i);
       }
     }
-    return GroupByGrouping{dim, bins, std::move(groups)};
+    return {dim, bins, std::move(groups)};
   }
 };
 

--- a/lib/python/variable.cpp
+++ b/lib/python/variable.cpp
@@ -63,13 +63,13 @@ void bind_structured_creation(py::module &m, const std::string &name) {
 }
 
 template <class T> struct GetElements {
-  static auto apply(Variable &var, const std::string &key) {
+  static Variable apply(Variable &var, const std::string &key) {
     return var.elements<T>(key);
   }
 };
 
 template <class T> struct SetElements {
-  static auto apply(Variable &var, const std::string &key,
+  static void apply(Variable &var, const std::string &key,
                     const Variable &elems) {
     copy(elems, var.elements<T>(key));
   }

--- a/lib/variable/string.cpp
+++ b/lib/variable/string.cpp
@@ -42,12 +42,12 @@ std::string make_dims_labels(const Variable &variable,
 }
 
 template <class T> struct ValuesToString {
-  static auto apply(const Variable &var) {
+  static std::string apply(const Variable &var) {
     return core::array_to_string(var.template values<T>(), var.unit());
   }
 };
 template <class T> struct VariancesToString {
-  static auto apply(const Variable &var) {
+  static std::string apply(const Variable &var) {
     if constexpr (core::canHaveVariances<T>())
       return core::array_to_string(var.template variances<T>());
     else


### PR DESCRIPTION
This is a workaround for a regression in gcc 12: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105716

Surprisingly, there are no new warnings. At least not with the current settings.