### PR TITLE
Fix `to_unit` with scale exceeding int64_max

### DIFF
--- a/lib/variable/test/to_unit_test.cpp
+++ b/lib/variable/test/to_unit_test.cpp
@@ -282,3 +282,11 @@ TEST(ToUnitTest, small_number_to_small_unit) {
   EXPECT_EQ(result.unit(), area);
   EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
 }
+
+TEST(ToUnitTest, small_number_to_small_unit_non_power_of_10) {
+  const auto area = units::Unit("1.45e-21");
+  const auto small = makeVariable<double>(units::one, Values{1.45e-21});
+  const auto result = to_unit(small, area);
+  EXPECT_EQ(result.unit(), area);
+  EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
+}

--- a/lib/variable/test/to_unit_test.cpp
+++ b/lib/variable/test/to_unit_test.cpp
@@ -274,3 +274,11 @@ TEST(ToUnitTest, small_to_large_rounding_error_double) {
                     units::Unit("m")),
             one_m);
 }
+
+TEST(ToUnitTest, small_number_to_small_unit) {
+  const auto area = units::angstrom * units::angstrom;
+  const auto small = makeVariable<double>(units::Unit("m**2"), Values{1e-20});
+  const auto result = to_unit(small, area);
+  EXPECT_EQ(result.unit(), area);
+  EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
+}

--- a/lib/variable/test/to_unit_test.cpp
+++ b/lib/variable/test/to_unit_test.cpp
@@ -276,17 +276,17 @@ TEST(ToUnitTest, small_to_large_rounding_error_double) {
 }
 
 TEST(ToUnitTest, small_number_to_small_unit) {
-  const auto area = units::angstrom * units::angstrom;
+  const auto unit = units::angstrom * units::angstrom;
   const auto small = makeVariable<double>(units::Unit("m**2"), Values{1e-20});
-  const auto result = to_unit(small, area);
-  EXPECT_EQ(result.unit(), area);
+  const auto result = to_unit(small, unit);
+  EXPECT_EQ(result.unit(), unit);
   EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
 }
 
 TEST(ToUnitTest, small_number_to_small_unit_non_power_of_10) {
-  const auto area = units::Unit("1.45e-21");
+  const auto unit = units::Unit("1.45e-21");
   const auto small = makeVariable<double>(units::one, Values{1.45e-21});
-  const auto result = to_unit(small, area);
-  EXPECT_EQ(result.unit(), area);
+  const auto result = to_unit(small, unit);
+  EXPECT_EQ(result.unit(), unit);
   EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
 }

--- a/lib/variable/to_unit.cpp
+++ b/lib/variable/to_unit.cpp
@@ -54,13 +54,15 @@ Variable to_unit(const Variable &var, const units::Unit &unit,
   // decimal places, otherwise the approach based on std::round will do nothing.
   const auto base_scale = scale > 1e6 ? scale * 1e-6 : scale;
   if (const auto iscale = std::round(base_scale);
-      (std::abs(base_scale - iscale) < 1e-12 * std::abs(base_scale)))
-    scalevar = int64_t{scale > 1e6 ? 1000000 : 1} *
-               static_cast<int64_t>(iscale) * unit;
-  else
+      (std::abs(base_scale - iscale) < 1e-12 * std::abs(base_scale))) {
+    if (var.dtype() == dtype<int64_t> || var.dtype() == dtype<core::time_point>)
+      scalevar = int64_t{scale > 1e6 ? 1000000 : 1} *
+                 static_cast<int64_t>(iscale) * unit;
+    else
+      scalevar = (scale > 1e6 ? 1000000 : 1) * iscale * unit;
+  } else {
     scalevar = scale * unit;
-  if (var.dtype() != dtype<int64_t> && var.dtype() != dtype<core::time_point>)
-    scalevar = astype(scalevar, dtype<double>);
+  }
   return variable::transform(var, scalevar, core::element::to_unit, "to_unit");
 }
 

--- a/tests/hypothesis/to_unit_test.py
+++ b/tests/hypothesis/to_unit_test.py
@@ -11,10 +11,10 @@ import scipp as sc
 @given(st.floats(min_value=1e-300, max_value=1e300))
 def test_to_unit_value_1(x):
     unit = sc.Unit(f'{x:.12E}')
-    var = sc.scalar(1.23 * x, unit='')
+    var = sc.scalar(x, unit='')
     result = sc.to_unit(var, unit)
     assert result.unit == unit
-    assert pytest.approx(result.value, 1e-14) == 1.23
+    assert pytest.approx(result.value, 1e-14) == 1.0
 
 
 @given(st.floats(min_value=1e-300, max_value=1e300))

--- a/tests/hypothesis/to_unit_test.py
+++ b/tests/hypothesis/to_unit_test.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Jan-Lukas Wynen
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+import scipp as sc
+
+
+@given(st.floats(min_value=1e-300, max_value=1e300))
+def test_to_unit_value_1(x):
+    unit = sc.Unit(f'{x:.12E}')
+    var = sc.scalar(1.23 * x, unit='')
+    result = sc.to_unit(var, unit)
+    assert result.unit == unit
+    assert pytest.approx(result.value, 1e-14) == 1.23
+
+
+@given(st.floats(min_value=1e-300, max_value=1e300))
+def test_to_unit_small_value(x):
+    unit = sc.Unit(f'{x:.12E}')
+    var = sc.scalar(1.2345e-6 * x, unit='')
+    result = sc.to_unit(var, unit)
+    assert result.unit == unit
+    assert pytest.approx(result.value, 1e-20) == 1.2345e-6
+
+
+@given(st.floats(min_value=1e-300, max_value=1e300))
+def test_to_unit_large_value(x):
+    unit = sc.Unit(f'{x:.12E}')
+    var = sc.scalar(1.2345e6 * x, unit='')
+    result = sc.to_unit(var, unit)
+    assert result.unit == unit
+    assert pytest.approx(result.value, 1e-8) == 1.2345e6

--- a/tests/hypothesis/to_unit_test.py
+++ b/tests/hypothesis/to_unit_test.py
@@ -14,26 +14,26 @@ import scipp as sc
 
 @given(st.floats(min_value=1e-300, max_value=1e300))
 def test_to_unit_value_1(x):
-    unit = sc.Unit(f'{x:.12E}')
+    unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(x, unit='')
     result = sc.to_unit(var, unit)
     assert result.unit == unit
-    assert pytest.approx(result.value, 1e-14) == 1.0
+    assert pytest.approx(result.value, abs=0.0, rel=1e-14) == 1.0
 
 
 @given(st.floats(min_value=1e-300, max_value=1e300))
 def test_to_unit_small_value(x):
-    unit = sc.Unit(f'{x:.12E}')
+    unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(1.2345e-6 * x, unit='')
     result = sc.to_unit(var, unit)
     assert result.unit == unit
-    assert pytest.approx(result.value, 1e-20) == 1.2345e-6
+    assert pytest.approx(result.value, abs=0.0, rel=1e-14) == 1.2345e-6
 
 
 @given(st.floats(min_value=1e-300, max_value=1e300))
 def test_to_unit_large_value(x):
-    unit = sc.Unit(f'{x:.12E}')
+    unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(1.2345e6 * x, unit='')
     result = sc.to_unit(var, unit)
     assert result.unit == unit
-    assert pytest.approx(result.value, 1e-8) == 1.2345e6
+    assert pytest.approx(result.value, abs=0.0, rel=1e-14) == 1.2345e6

--- a/tests/hypothesis/to_unit_test.py
+++ b/tests/hypothesis/to_unit_test.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
-# @author Jan-Lukas Wynen
+# @author Simon Heybrock
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
 import scipp as sc
+
+# to_unit has non-trivial logic to reduce the effect of rounding errors. The following
+# test attempt to cover a wide range of potential unit scales in conversion to detect
+# potential bugs.
 
 
 @given(st.floats(min_value=1e-300, max_value=1e300))


### PR DESCRIPTION
This was introduced by #2607. No released version is affected.