### PR TITLE
Add Python to conda run requirements

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - git
     - markupsafe>=1.1.1,<2.1.0  # see https://github.com/pallets/markupsafe/issues/284
     - ninja
-    - python
   host:
     - python
     - tbb-devel=2020.2.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,15 +33,17 @@ requirements:
     - git
     - markupsafe>=1.1.1,<2.1.0  # see https://github.com/pallets/markupsafe/issues/284
     - ninja
+    - python
   host:
     - python
     - tbb-devel=2020.2.*
   run:
     - confuse
+    - graphlib-backport # for python < 3.9
     - numpy
+    - python
     - pyyaml
     - tbb=2020.2.*
-    - graphlib-backport # for python < 3.9
 
 # Only the cmake-package-test works when cross compiling.
 # But it is not very important at the moment and


### PR DESCRIPTION
Python version was missing from OSX conda package names. This is an attempt to fix this.