### PR TITLE
Prototype new proposed API for histogramming and friends

### DIFF
--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -8,6 +8,7 @@ from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ..typing import VariableLike, MetaDataMap
 from .domains import merge_equal_adjacent
 from .operations import islinspace
+from .variable import Variable, linspace, arange
 
 
 class Lookup:
@@ -378,8 +379,37 @@ def _groupby_bins(obj):
     return GroupbyBins(obj)
 
 
-def histogram(x: Union[_cpp.DataArray, _cpp.Dataset], *,
-              bins: _cpp.Variable) -> Union[_cpp.DataArray, _cpp.Dataset]:
+def _get_coord(x, name):
+    event_coord = x.bins.meta.get(name) if x.bins is not None else None
+    return x.meta.get(name, event_coord)
+
+
+def _upper_bound(x):
+    import numpy as np
+    bound = x.max()
+    bound.value = np.nextafter(bound.value, np.inf)
+    return bound
+
+
+def _parse_coords_arg(x, name, arg):
+    coord = _get_coord(x, name)
+    if isinstance(arg, int):
+        coord = linspace(name, coord.min(), _upper_bound(coord), num=arg + 1)
+    elif isinstance(arg, Variable):
+        if arg.ndim == 0:
+            start = coord.min()
+            step = arg.to(dtype=start.dtype, unit=start.unit)
+            stop = _upper_bound(coord) + step
+            coord = arange(name, start, stop, step=step)
+        else:
+            coord = arg
+    return coord
+
+
+def histogram(x: Union[_cpp.DataArray, _cpp.Dataset],
+              edges: Dict[str, Union[int, Variable]] = None,
+              /,
+              **kwargs) -> Union[_cpp.DataArray, _cpp.Dataset]:
     """Create dense data by histogramming data along all dimension given by
     edges.
 
@@ -394,7 +424,12 @@ def histogram(x: Union[_cpp.DataArray, _cpp.Dataset], *,
     scipp.bin:
         For binning data.
     """
-    return _call_cpp_func(_cpp.histogram, x, bins)
+    if edges is not None:
+        kwargs = dict(**edges, **kwargs)
+    if len(kwargs) != 1:
+        raise ValueError("Currently only 1-D histogramming is supported.")
+    name, arg = next(iter(kwargs.items()))
+    return _cpp.histogram(x, bins=_parse_coords_arg(x, name, arg))
 
 
 def bin(x: _cpp.DataArray,


### PR DESCRIPTION
This is a draft, just want to hear some initial opinions.

Suggestion for new API of `histogram`:

- Use keyword arg, accepting integer, bin size (as scalar variable), or actual edges.
- Alternatively, accept a `dict` (e.g., when coord name is not a valid variable name).

The plan is to support the same in other cases, such as the `edges` argument of `sc.bin`. I am not sure a keyword syntax makes sense in that case, since we also have the `groups` and `erase` arguments... unless someone can think of a clean way to distinguish?

`sc.groupby` is another candidate for this updated API. Here the `bins` keyword argument should change, but I am not sure yet how exactly.