### PR TITLE
Fix linspace optimization

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -21,9 +21,9 @@ Bugfixes
 ~~~~~~~~
 
 * Fix bug where coordinates in were dropped by :func:`scipp.transform_coords` with ``keep_*=False`` even through they were specified as ``targets`` `#2642 <https://github.com/scipp/scipp/pull/2642>`_.
-* Fix segmentation fault in :func:`scipp.bin` when binning in 2 or more dimensions withs certain coordinate values `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
+* Fix segmentation fault in :func:`scipp.bin` when binning in 2 or more dimensions with certain coordinate values `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
 * Fix issue with events close to upper or lower bin bounds getting dropped by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
-* Fix minor issue with events close bin bounds getting assign to wrong bin by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
+* Fix minor issue with events close to bin bounds getting assigned to the wrong bin by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -21,6 +21,9 @@ Bugfixes
 ~~~~~~~~
 
 * Fix bug where coordinates in were dropped by :func:`scipp.transform_coords` with ``keep_*=False`` even through they were specified as ``targets`` `#2642 <https://github.com/scipp/scipp/pull/2642>`_.
+* Fix segmentation fault in :func:`scipp.bin` when binning in 2 or more dimensions withs certain coordinate values `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
+* Fix issue with events close to upper or lower bin bounds getting dropped by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
+* Fix minor issue with events close bin bounds getting assign to wrong bin by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/lib/core/include/scipp/core/element/bin.h
+++ b/lib/core/include/scipp/core/element/bin.h
@@ -51,17 +51,18 @@ static constexpr auto update_indices_by_binning = overloaded{
     transform_flags::expect_no_variance_arg<2>};
 
 // Special faster implementation for linear bins.
-static constexpr auto update_indices_by_binning_linspace =
-    overloaded{update_indices_by_binning,
-               [](auto &index, const auto &x, const auto &edges) {
-                 if (index == -1)
-                   return;
-                 const auto [offset, nbin, scale] =
-                     core::linear_edge_params(edges);
-                 const double bin = (x - offset) * scale;
-                 index *= scipp::size(edges) - 1;
-                 index = (bin < 0.0 || bin >= nbin) ? -1 : (index + bin);
-               }};
+static constexpr auto update_indices_by_binning_linspace = overloaded{
+    update_indices_by_binning,
+    [](auto &index, const auto &x, const auto &edges) {
+      if (index == -1)
+        return;
+      const auto [offset, nbin, scale] = core::linear_edge_params(edges);
+      const double bin = (x - offset) * scale;
+      index *= nbin;
+      using Index = std::decay_t<decltype(index)>;
+      index =
+          (bin < 0.0 || bin >= nbin) ? -1 : (index + static_cast<Index>(bin));
+    }};
 
 static constexpr auto update_indices_by_binning_sorted_edges =
     overloaded{update_indices_by_binning,

--- a/lib/core/include/scipp/core/element/bin.h
+++ b/lib/core/include/scipp/core/element/bin.h
@@ -51,18 +51,31 @@ static constexpr auto update_indices_by_binning = overloaded{
     transform_flags::expect_no_variance_arg<2>};
 
 // Special faster implementation for linear bins.
-static constexpr auto update_indices_by_binning_linspace = overloaded{
-    update_indices_by_binning,
-    [](auto &index, const auto &x, const auto &edges) {
-      if (index == -1)
-        return;
-      const auto [offset, nbin, scale] = core::linear_edge_params(edges);
-      const double bin = (x - offset) * scale;
-      index *= nbin;
-      using Index = std::decay_t<decltype(index)>;
-      index =
-          (bin < 0.0 || bin >= nbin) ? -1 : (index + static_cast<Index>(bin));
-    }};
+static constexpr auto update_indices_by_binning_linspace =
+    overloaded{update_indices_by_binning,
+               [](auto &index, const auto &x, const auto &edges) {
+                 if (index == -1)
+                   return;
+                 const auto [offset, nbin, scale] =
+                     core::linear_edge_params(edges);
+                 using Index = std::decay_t<decltype(index)>;
+                 Index bin = (x - offset) * scale;
+                 bin = std::clamp(bin, Index(0), Index(nbin - 1));
+                 index *= nbin;
+                 if (x < edges[bin]) {
+                   if (bin != 0 && x >= edges[bin - 1])
+                     index += bin - 1;
+                   else
+                     index = -1;
+                 } else if (x >= edges[bin + 1]) {
+                   if (bin != nbin - 1)
+                     index += bin + 1;
+                   else
+                     index = -1;
+                 } else {
+                   index += bin;
+                 }
+               }};
 
 static constexpr auto update_indices_by_binning_sorted_edges =
     overloaded{update_indices_by_binning,

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -602,3 +602,72 @@ TEST_P(BinTest, new_dim_existing_coord) {
   da.coords().set(Dim::Y, edges);
   EXPECT_EQ(bin(da, {edges_y}), expected);
 }
+
+TEST(BinLinspaceTest, event_mapped_to_correct_bin) {
+  const auto val10 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 0});
+  const auto val01 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
+  for (auto step = 1.23546e-6; step < 1e4; step *= 1.08354345) {
+    const auto edges = makeVariable<double>(
+        Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
+    const auto mid = edges.values<double>()[1];
+    for (const auto pos :
+         {mid, std::nextafter(mid, 0.0), std::nextafter(mid, 1e30)}) {
+      const auto x = makeVariable<double>(dims, Values{pos});
+      const DataArray da(data, {{Dim::X, x}});
+      const auto hist = bins_sum(bin(da, {edges}));
+      if (pos < mid) {
+        EXPECT_EQ(hist.data(), val10) << step << pos;
+      } else {
+        EXPECT_EQ(hist.data(), val01) << step << pos;
+      }
+    }
+  }
+}
+
+TEST(BinLinspaceTest, event_mapped_to_correct_bin_at_begin) {
+  const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
+  const auto val10 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 0});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
+  for (auto step = 1.23546e-6; step < 1e4; step *= 1.08354345) {
+    const auto edges = makeVariable<double>(
+        Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
+    const auto begin = edges.values<double>()[0];
+    for (const auto pos :
+         {begin, std::nextafter(begin, 0.0), std::nextafter(begin, 1e30)}) {
+      const auto x = makeVariable<double>(dims, Values{pos});
+      const DataArray da(data, {{Dim::X, x}});
+      const auto hist = bins_sum(bin(da, {edges}));
+      if (pos < begin) {
+        EXPECT_EQ(hist.data(), val00) << step << pos;
+      } else {
+        EXPECT_EQ(hist.data(), val10) << step << pos;
+      }
+    }
+  }
+}
+
+TEST(BinLinspaceTest, event_mapped_to_correct_bin_at_end) {
+  const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
+  const auto val01 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
+  for (auto step = 1.23546e-6; step < 1e4; step *= 1.08354345) {
+    const auto edges = makeVariable<double>(
+        Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
+    const auto end = edges.values<double>()[2];
+    for (const auto pos :
+         {end, std::nextafter(end, 0.0), std::nextafter(end, 1e30)}) {
+      const auto x = makeVariable<double>(dims, Values{pos});
+      const DataArray da(data, {{Dim::X, x}});
+      const auto hist = bins_sum(bin(da, {edges}));
+      if (pos < end) {
+        EXPECT_EQ(hist.data(), val01) << step << pos;
+      } else {
+        EXPECT_EQ(hist.data(), val00) << step << pos;
+      }
+    }
+  }
+}

--- a/lib/dataset/test/histogram_test.cpp
+++ b/lib/dataset/test/histogram_test.cpp
@@ -379,14 +379,14 @@ TEST_F(Histogram2DTest, noncontiguous_slice) {
 TEST(HistogramLinspaceTest, event_mapped_to_correct_bin) {
   const auto val10 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 0});
   const auto val01 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
   for (auto step = 1.23546e-6; step < 1e4; step *= 1.004354345) {
     const auto edges = makeVariable<double>(
         Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
     const auto mid = edges.values<double>()[1];
     for (const auto pos :
          {mid, std::nextafter(mid, 0.0), std::nextafter(mid, 1e30)}) {
-      const Dimensions dims(Dim::Row, 1);
-      const auto data = makeVariable<double>(dims, Values{1.0});
       const auto x = makeVariable<double>(dims, Values{pos});
       const DataArray da(data, {{Dim::X, x}});
       const auto hist = histogram(da, edges);
@@ -402,14 +402,14 @@ TEST(HistogramLinspaceTest, event_mapped_to_correct_bin) {
 TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_begin) {
   const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
   const auto val10 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 0});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
   for (auto step = 1.23546e-6; step < 1e4; step *= 1.004354345) {
     const auto edges = makeVariable<double>(
         Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
     const auto begin = edges.values<double>()[0];
     for (const auto pos :
          {begin, std::nextafter(begin, 0.0), std::nextafter(begin, 1e30)}) {
-      const Dimensions dims(Dim::Row, 1);
-      const auto data = makeVariable<double>(dims, Values{1.0});
       const auto x = makeVariable<double>(dims, Values{pos});
       const DataArray da(data, {{Dim::X, x}});
       const auto hist = histogram(da, edges);
@@ -425,14 +425,14 @@ TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_begin) {
 TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_end) {
   const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
   const auto val01 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  const Dimensions dims(Dim::Row, 1);
+  const auto data = makeVariable<double>(dims, Values{1.0});
   for (auto step = 1.23546e-6; step < 1e4; step *= 1.004354345) {
     const auto edges = makeVariable<double>(
         Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
     const auto end = edges.values<double>()[2];
     for (const auto pos :
          {end, std::nextafter(end, 0.0), std::nextafter(end, 1e30)}) {
-      const Dimensions dims(Dim::Row, 1);
-      const auto data = makeVariable<double>(dims, Values{1.0});
       const auto x = makeVariable<double>(dims, Values{pos});
       const DataArray da(data, {{Dim::X, x}});
       const auto hist = histogram(da, edges);

--- a/lib/dataset/test/histogram_test.cpp
+++ b/lib/dataset/test/histogram_test.cpp
@@ -398,3 +398,49 @@ TEST(HistogramLinspaceTest, event_mapped_to_correct_bin) {
     }
   }
 }
+
+TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_begin) {
+  const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
+  const auto val10 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 0});
+  for (auto step = 1.23546e-6; step < 1e4; step *= 1.004354345) {
+    const auto edges = makeVariable<double>(
+        Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
+    const auto begin = edges.values<double>()[0];
+    for (const auto pos :
+         {begin, std::nextafter(begin, 0.0), std::nextafter(begin, 1e30)}) {
+      const Dimensions dims(Dim::Row, 1);
+      const auto data = makeVariable<double>(dims, Values{1.0});
+      const auto x = makeVariable<double>(dims, Values{pos});
+      const DataArray da(data, {{Dim::X, x}});
+      const auto hist = histogram(da, edges);
+      if (pos < begin) {
+        EXPECT_EQ(hist.data(), val00) << step << pos;
+      } else {
+        EXPECT_EQ(hist.data(), val10) << step << pos;
+      }
+    }
+  }
+}
+
+TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_end) {
+  const auto val00 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 0});
+  const auto val01 = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  for (auto step = 1.23546e-6; step < 1e4; step *= 1.004354345) {
+    const auto edges = makeVariable<double>(
+        Dims{Dim::X}, Shape{3}, Values{1.0 * step, 2.0 * step, 3.0 * step});
+    const auto end = edges.values<double>()[2];
+    for (const auto pos :
+         {end, std::nextafter(end, 0.0), std::nextafter(end, 1e30)}) {
+      const Dimensions dims(Dim::Row, 1);
+      const auto data = makeVariable<double>(dims, Values{1.0});
+      const auto x = makeVariable<double>(dims, Values{pos});
+      const DataArray da(data, {{Dim::X, x}});
+      const auto hist = histogram(da, edges);
+      if (pos < end) {
+        EXPECT_EQ(hist.data(), val01) << step << pos;
+      } else {
+        EXPECT_EQ(hist.data(), val00) << step << pos;
+      }
+    }
+  }
+}

--- a/tests/hypothesis/bin_test.py
+++ b/tests/hypothesis/bin_test.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from hypothesis import given
+from hypothesis import strategies as st
+
+import scipp as sc
+import numpy as np
+
+float_args = dict(min_value=-1e300,
+                  max_value=1e300,
+                  allow_nan=False,
+                  allow_infinity=False,
+                  allow_subnormal=False)
+
+
+@given(st.floats(**float_args), st.floats(**float_args))
+def test_bin_2d_linspace_bounds(a, b):
+    x = sc.array(dims=['row'], values=[a, b])
+    table = sc.DataArray(sc.ones(dims=['row'], shape=[2]))
+    table.coords['x'] = x
+    table.coords['y'] = x
+    upper = x.max()
+    upper.value = np.nextafter(upper.value, np.inf)
+    x_edges = sc.linspace('x', x.min(), upper, num=3)
+    y_edges = sc.linspace('y', x.min(), upper, num=3)
+    binned = sc.bin(table, edges=[x_edges, y_edges])
+    assert binned.sum().value == 2

--- a/tests/hypothesis/histogram_test.py
+++ b/tests/hypothesis/histogram_test.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from hypothesis import given
+from hypothesis import strategies as st
+
+import scipp as sc
+import numpy as np
+
+float_args = dict(min_value=-1e300,
+                  max_value=1e300,
+                  allow_nan=False,
+                  allow_infinity=False,
+                  allow_subnormal=False)
+
+
+@given(st.floats(**float_args), st.floats(**float_args))
+def test_histogram_linspace_bounds(a, b):
+    x = sc.array(dims=['row'], values=[a, b])
+    table = sc.DataArray(sc.ones(dims=['row'], shape=[2]))
+    table.coords['x'] = x
+    upper = x.max()
+    upper.value = np.nextafter(upper.value, np.inf)
+    edges = sc.linspace('x', x.min(), upper, num=3)
+    hist = sc.histogram(table, bins=edges)
+    assert hist.sum().value == 2


### PR DESCRIPTION
- Fix out-of-bounds write when binning by 2 coords
- Add tests, highlighting that current implementation drops events (currently failing tests).

How should we address the latter? We can add special-case handling to make sure we always check upper/lower bounds exactly? Strictly speaking we will still get events in the *wrong* bin in the "interior", so do we also have to address that? We could use the linspace-optimization to provide a "starting guess" for a search (would probably need to consider only 2 or 3 bins). How much performance would we lose?