### PR TITLE
Fixes for copying binned structured data

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -24,6 +24,7 @@ Bugfixes
 * Fix segmentation fault in :func:`scipp.bin` when binning in 2 or more dimensions with certain coordinate values `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
 * Fix issue with events close to upper or lower bin bounds getting dropped by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
 * Fix minor issue with events close to bin bounds getting assigned to the wrong bin by :func:`scipp.bin` and :func:`scipp.histogram` when binning with edges that form a "linspace" `#2644 <https://github.com/scipp/scipp/pull/2644>`_.
+* Fix issues with copying binned structured data or fields of binned structured data `#2650 <https://github.com/scipp/scipp/pull/2650>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/lib/core/dtype.cpp
+++ b/lib/core/dtype.cpp
@@ -33,12 +33,6 @@ bool is_span(DType tp) {
   return is_span_impl<double, float, int64_t, int32_t, bool, time_point>(tp);
 }
 
-bool is_structured(DType tp) {
-  return tp == dtype<Eigen::Vector3d> || tp == dtype<Eigen::Matrix3d> ||
-         tp == dtype<scipp::core::Quaternion> || tp == dtype<Eigen::Affine3d> ||
-         tp == dtype<scipp::core::Translation>;
-}
-
 std::ostream &operator<<(std::ostream &os, const DType &dtype) {
   return os << to_string(dtype);
 }

--- a/lib/core/include/scipp/core/dtype.h
+++ b/lib/core/include/scipp/core/dtype.h
@@ -103,7 +103,6 @@ SCIPP_CORE_EXPORT bool is_float(DType tp);
 SCIPP_CORE_EXPORT bool is_fundamental(DType tp);
 SCIPP_CORE_EXPORT bool is_total_orderable(DType tp);
 SCIPP_CORE_EXPORT bool is_span(DType tp);
-SCIPP_CORE_EXPORT bool is_structured(DType tp);
 
 template <class T> constexpr bool canHaveVariances() noexcept {
   using U = std::remove_const_t<T>;

--- a/lib/core/include/scipp/core/dtype.h
+++ b/lib/core/include/scipp/core/dtype.h
@@ -95,8 +95,7 @@ inline constexpr DType dtype<std::unordered_map<core::time_point, int32_t>>{
 // scipp::variable types start at 1000
 // scipp::dataset types start at 2000
 // scipp::python types start at 3000
-// Eigen types start at 4000
-// Spatial transform types start at 5000
+// Spatial transform (Eigen) types start at 4000
 // User types should start at 10000
 
 SCIPP_CORE_EXPORT bool is_int(DType tp);

--- a/lib/core/include/scipp/core/eigen.h
+++ b/lib/core/include/scipp/core/eigen.h
@@ -7,6 +7,7 @@
 #include <Eigen/Geometry>
 
 #include "scipp/common/numeric.h"
+#include "scipp/core/bucket.h"
 #include "scipp/core/dtype.h"
 #include "scipp/core/spatial_transforms.h"
 
@@ -17,6 +18,12 @@ template <> inline constexpr DType dtype<Eigen::Vector3d>{4000};
 template <>
 inline constexpr DType dtype<scipp::span<const Eigen::Vector3d>>{4100};
 template <> inline constexpr DType dtype<scipp::span<Eigen::Vector3d>>{4200};
+
+constexpr bool is_structured(DType tp) {
+  return tp == dtype<Eigen::Vector3d> || tp == dtype<Eigen::Matrix3d> ||
+         tp == dtype<scipp::core::Quaternion> || tp == dtype<Eigen::Affine3d> ||
+         tp == dtype<scipp::core::Translation> || tp == dtype<index_pair>;
+}
 
 } // namespace scipp::core
 

--- a/lib/core/include/scipp/core/multi_index.h
+++ b/lib/core/include/scipp/core/multi_index.h
@@ -265,12 +265,11 @@ private:
       m_data_index[data] = flat_index(data, 0, m_ndim);
     } else if (!at_end()) {
       // All bins are guaranteed to have the same size.
-      // Use common m_shape and m_nested_stride for all.
       if (m_bin[data].m_indices != nullptr) {
         const auto [begin, end] =
             m_bin[data].m_indices[m_bin[data].m_bin_index];
         m_shape[m_nested_dim_index] = end - begin;
-        m_data_index[data] = m_bin_stride * begin;
+        m_data_index[data] = m_stride[m_nested_dim_index][data] * begin;
       } else {
         // m_indices can be nullptr if there are bins, but they are empty.
         m_shape[m_nested_dim_index] = 0;
@@ -347,8 +346,6 @@ private:
   /// Number of dense dimensions, i.e. same as m_ndim when not binned,
   /// else number of dims in bins.
   scipp::index m_inner_ndim{0};
-  /// Stride from one bin to the next.
-  scipp::index m_bin_stride = {};
   /// Index of dim referred to by bin indices to distinguish, e.g., 2D bins
   /// slicing along first or second dim.
   /// -1 if not binned.

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -149,8 +149,6 @@ MultiIndex<N>::MultiIndex(binned_tag, const Dimensions &inner_dims,
                                        bin_dims, 0, params.strides()...);
 
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
-  m_bin_stride = inner_dims.offset(slice_dim);
-  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   m_nested_dim_index = m_inner_ndim - inner_dims.index(slice_dim) - 1;
 
   for (scipp::index data = 0; data < N; ++data) {

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 /// @file
 /// @author Simon Heybrock
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 
 #include "scipp/variable/bins.h"
@@ -14,6 +15,13 @@
 #include "operations_common.h"
 
 namespace scipp::variable {
+
+void copy_data(const Variable &src, Variable &dst) {
+  transform_in_place<double, float, int64_t, int32_t, bool, std::string,
+                     core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
+                     Eigen::Affine3d, core::Translation, core::Quaternion>(
+      dst, src, [](auto &a, const auto &b) { a = b; }, "copy");
+}
 
 Variable bin_sizes(const Variable &var) {
   if (is_bins(var)) {

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -16,6 +16,10 @@
 
 namespace scipp::variable {
 
+/// Used internally by BinArrayModel to implement copying.
+///
+/// This is using transform, so only data (no coords, etc.) is copied, but we
+/// only use this for buffers of type Variable.
 void copy_data(const Variable &src, Variable &dst) {
   transform_in_place<double, float, int64_t, int32_t, bool, std::string,
                      core::time_point, Eigen::Vector3d, Eigen::Matrix3d,

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -21,6 +21,8 @@ namespace scipp::variable {
 /// This is using transform, so only data (no coords, etc.) is copied, but we
 /// only use this for buffers of type Variable.
 void copy_data(const Variable &src, Variable &dst) {
+  assert(src.dtype() == dtype<bucket<Variable>>);
+  assert(dst.dtype() == dtype<bucket<Variable>>);
   transform_in_place<double, float, int64_t, int32_t, bool, std::string,
                      core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
                      Eigen::Affine3d, core::Translation, core::Quaternion>(

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -10,6 +10,7 @@
 #include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/bins.h"
 #include "scipp/variable/cumulative.h"
 #include "scipp/variable/element_array_model.h"
 #include "scipp/variable/except.h"
@@ -131,10 +132,7 @@ bool BinArrayModel<T>::equals_nan(const Variable &a, const Variable &b) const {
 template <class T>
 void BinArrayModel<T>::copy(const Variable &src, Variable &dest) const {
   if constexpr (std::is_same_v<T, Variable>) {
-    transform_in_place<double, float, int64_t, int32_t, bool, std::string,
-                       core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
-                       Eigen::Affine3d, core::Translation, core::Quaternion>(
-        dest, src, [](auto &a, const auto &b) { a = b; }, "copy");
+    copy_data(src, dest);
   } else {
     const auto &[indices0, dim0, buffer0] = src.constituents<T>();
     auto &&[indices1, dim1, buffer1] = dest.constituents<T>();

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -7,6 +7,7 @@
 
 #include "scipp/core/bucket_array_view.h"
 #include "scipp/core/dimensions.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/except.h"
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/cumulative.h"
@@ -131,7 +132,8 @@ template <class T>
 void BinArrayModel<T>::copy(const Variable &src, Variable &dest) const {
   if constexpr (std::is_same_v<T, Variable>) {
     transform_in_place<double, float, int64_t, int32_t, bool, std::string,
-                       core::time_point>(
+                       core::time_point, Eigen::Vector3d, Eigen::Matrix3d,
+                       Eigen::Affine3d, core::Translation, core::Quaternion>(
         dest, src, [](auto &a, const auto &b) { a = b; }, "copy");
   } else {
     const auto &[indices0, dim0, buffer0] = src.constituents<T>();

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -129,10 +129,16 @@ bool BinArrayModel<T>::equals_nan(const Variable &a, const Variable &b) const {
 
 template <class T>
 void BinArrayModel<T>::copy(const Variable &src, Variable &dest) const {
-  const auto &[indices0, dim0, buffer0] = src.constituents<T>();
-  auto &&[indices1, dim1, buffer1] = dest.constituents<T>();
-  static_cast<void>(dim1);
-  copy_slices(buffer0, buffer1, dim0, indices0, indices1);
+  if constexpr (std::is_same_v<T, Variable>) {
+    transform_in_place<double, float, int64_t, int32_t, bool, std::string,
+                       core::time_point>(
+        dest, src, [](auto &a, const auto &b) { a = b; }, "copy");
+  } else {
+    const auto &[indices0, dim0, buffer0] = src.constituents<T>();
+    auto &&[indices1, dim1, buffer1] = dest.constituents<T>();
+    static_cast<void>(dim1);
+    copy_slices(buffer0, buffer1, dim0, indices0, indices1);
+  }
 }
 
 template <class T>

--- a/lib/variable/include/scipp/variable/bins.h
+++ b/lib/variable/include/scipp/variable/bins.h
@@ -8,6 +8,8 @@
 
 namespace scipp::variable {
 
+SCIPP_VARIABLE_EXPORT void copy_data(const Variable &src, Variable &dst);
+
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable bin_sizes(const Variable &var);
 
 SCIPP_VARIABLE_EXPORT void copy_slices(const Variable &src, Variable dst,

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -3,16 +3,18 @@
 /// @file
 /// @author Simon Heybrock
 #pragma once
+#include <optional>
+
 #include "scipp/common/initialization.h"
 #include "scipp/common/numeric.h"
 #include "scipp/core/dimensions.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element_array_view.h"
 #include "scipp/core/except.h"
 #include "scipp/units/unit.h"
 #include "scipp/variable/except.h"
 #include "scipp/variable/transform.h"
 #include "scipp/variable/variable_concept.h"
-#include <optional>
 
 namespace scipp::variable {
 
@@ -58,6 +60,7 @@ bool equals_nan_impl(const T1 &view1, const T2 &view2) {
 /// Implementation of VariableConcept that holds an array with element type T.
 template <class T> class ElementArrayModel : public VariableConcept {
 public:
+  static_assert(!core::is_structured(core::template dtype<T>));
   using value_type = T;
 
   ElementArrayModel(const scipp::index size, const units::Unit &unit,

--- a/lib/variable/include/scipp/variable/variable.tcc
+++ b/lib/variable/include/scipp/variable/variable.tcc
@@ -4,6 +4,7 @@
 /// @author Simon Heybrock
 #include "scipp/core/array_to_string.h"
 #include "scipp/core/dimensions.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element_array_view.h"
 #include "scipp/core/except.h"
 #include "scipp/core/has_eval.h"
@@ -55,6 +56,7 @@ auto make_model(const units::Unit unit, const Dimensions &dimensions,
                 element_array<T> values,
                 std::optional<element_array<T>> variances) {
   if constexpr (std::is_same_v<model_t<T>, ElementArrayModel<T>>) {
+    static_assert(!std::is_same_v<T, Eigen::Vector3d>);
     return std::make_unique<model_t<T>>(
         dimensions.volume(), unit, std::move(values), std::move(variances));
   } else {

--- a/lib/variable/include/scipp/variable/variable.tcc
+++ b/lib/variable/include/scipp/variable/variable.tcc
@@ -56,7 +56,6 @@ auto make_model(const units::Unit unit, const Dimensions &dimensions,
                 element_array<T> values,
                 std::optional<element_array<T>> variances) {
   if constexpr (std::is_same_v<model_t<T>, ElementArrayModel<T>>) {
-    static_assert(!std::is_same_v<T, Eigen::Vector3d>);
     return std::make_unique<model_t<T>>(
         dimensions.volume(), unit, std::move(values), std::move(variances));
   } else {

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -239,14 +239,19 @@ class VariableBinnedStructuredTest : public ::testing::Test {
 protected:
   Dimensions dims{Dim::Y, 2};
   Variable indices = makeVariable<scipp::index_pair>(
-      dims, Values{std::pair{0, 1}, std::pair{1, 2}});
-  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 2), units::m,
-                                           {1, 2, 3, 4, 5, 6});
+      dims, Values{std::pair{0, 1}, std::pair{1, 3}});
+  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), units::m,
+                                           {1, 2, 3, 4, 5, 6, 7, 8, 9});
   Variable var = make_bins(indices, Dim::X, buffer);
 };
 
 TEST_F(VariableBinnedStructuredTest, copy_vector) { ASSERT_EQ(copy(var), var); }
 
 TEST_F(VariableBinnedStructuredTest, copy_vector_field) {
-  copy(var.elements<Eigen::Vector3d>("x"));
+  const auto &elem = var.elements<Eigen::Vector3d>("x");
+  ASSERT_EQ(copy(elem), elem);
+  const auto expected = make_bins(
+      indices, Dim::X,
+      makeVariable<double>(Dimensions(Dim::X, 3), units::m, Values{1, 4, 7}));
+  ASSERT_EQ(copy(elem), expected);
 }

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -2,9 +2,11 @@
 // Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
 
+#include "scipp/core/eigen.h"
 #include "scipp/variable/bins.h"
 #include "scipp/variable/operations.h"
 #include "scipp/variable/shape.h"
+#include "scipp/variable/structures.h"
 
 using namespace scipp;
 
@@ -231,4 +233,20 @@ TEST_F(VariableBinsTest, setSlice) {
       indices, Dim::X,
       makeVariable<double>(buffer.dims(), Values{1.1, 1.1, 1.1, 1.1}));
   EXPECT_EQ(var, expected);
+}
+
+class VariableBinnedStructuredTest : public ::testing::Test {
+protected:
+  Dimensions dims{Dim::Y, 2};
+  Variable indices = makeVariable<scipp::index_pair>(
+      dims, Values{std::pair{0, 1}, std::pair{1, 2}});
+  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 2), units::m,
+                                           {1, 2, 3, 4, 5, 6});
+  Variable var = make_bins(indices, Dim::X, buffer);
+};
+
+TEST_F(VariableBinnedStructuredTest, copy_vector) { ASSERT_EQ(copy(var), var); }
+
+TEST_F(VariableBinnedStructuredTest, copy_vector_field) {
+  copy(var.elements<Eigen::Vector3d>("x"));
 }

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -247,6 +247,20 @@ protected:
 
 TEST_F(VariableBinnedStructuredTest, copy_vector) { ASSERT_EQ(copy(var), var); }
 
+TEST_F(VariableBinnedStructuredTest, copy_translation) {
+  auto translations = variable::make_translations(
+      Dimensions(Dim::X, 3), units::m, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+  auto binned = make_bins(indices, Dim::X, translations);
+  ASSERT_EQ(copy(binned), binned);
+}
+
+TEST_F(VariableBinnedStructuredTest, copy_rotations) {
+  auto rotations = variable::make_rotations(
+      Dimensions(Dim::X, 3), units::m, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  auto binned = make_bins(indices, Dim::X, rotations);
+  ASSERT_EQ(copy(binned), binned);
+}
+
 TEST_F(VariableBinnedStructuredTest, copy_vector_field) {
   const auto &elem = var.elements<Eigen::Vector3d>("x");
   ASSERT_EQ(copy(elem), elem);

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -240,12 +240,14 @@ protected:
   Dimensions dims{Dim::Y, 2};
   Variable indices = makeVariable<scipp::index_pair>(
       dims, Values{std::pair{0, 1}, std::pair{1, 3}});
+};
+
+TEST_F(VariableBinnedStructuredTest, copy_vector) {
   Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), units::m,
                                            {1, 2, 3, 4, 5, 6, 7, 8, 9});
   Variable var = make_bins(indices, Dim::X, buffer);
-};
-
-TEST_F(VariableBinnedStructuredTest, copy_vector) { ASSERT_EQ(copy(var), var); }
+  ASSERT_EQ(copy(var), var);
+}
 
 TEST_F(VariableBinnedStructuredTest, copy_translation) {
   auto translations = variable::make_translations(
@@ -262,6 +264,9 @@ TEST_F(VariableBinnedStructuredTest, copy_rotations) {
 }
 
 TEST_F(VariableBinnedStructuredTest, copy_vector_field) {
+  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), units::m,
+                                           {1, 2, 3, 4, 5, 6, 7, 8, 9});
+  Variable var = make_bins(indices, Dim::X, buffer);
   const auto &elem = var.elements<Eigen::Vector3d>("x");
   ASSERT_EQ(copy(elem), elem);
   const auto expected = make_bins(


### PR DESCRIPTION
Two fixes here:

- Fixes #2641.
- Fix a bug in `MultiIndex` for buffers with stride.
- Implement copy of binned data with structured buffer dtypes (such as vector, matrix, ...).

I spent a long time hunting down a bug I introduced during the fix. This was caused by a wrong instantiation (`ElementArrayModel` instead of `StructureArrayModel`) when using `transform` in `bin_array_model.h` due to visibility of specializations. I have not added a `static_assert` in `ElementArrayModel` which should catch more such problems at compile time in the future.