### PR TITLE
Change `flatten` to drop bin edges on mismatch, instead of raising

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Breaking changes
 
 * :func:`scipp.optimize.curve_fit` now raises ``ValueError`` if the input variance contains a 0 `#2620 <https://github.com/scipp/scipp/pull/2620>`_.
 * Replaced the widget-based :func:`scipp.table` viewer with a simpler pure-HTML table `#2613 <https://github.com/scipp/scipp/pull/2613>`_.
+* :func:`scipp.flatten` now drops mismatching bin edge coordinates instead of raising a ``BinEdgeError`` `#2652 <https://github.com/scipp/scipp/pull/2652>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -125,10 +125,16 @@ Dataset apply_to_items(const Dataset &d, Func func, Args &&...args) {
 
 /// Return a copy of map-like objects such as Coords with `func` applied to each
 /// item.
+///
+/// If `func` return an invalid object it will not be inserted into the output
+/// map. This can be used to drop/filter items.
 template <class T, class Func> auto transform_map(const T &map, Func func) {
   std::unordered_map<typename T::key_type, typename T::mapped_type> out;
-  for (const auto &[key, item] : map)
-    out.emplace(key, func(item));
+  for (const auto &[key, item] : map) {
+    auto transformed = func(item);
+    if (transformed.is_valid())
+      out.emplace(key, transformed);
+  }
   return out;
 }
 

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -126,14 +126,14 @@ Dataset apply_to_items(const Dataset &d, Func func, Args &&...args) {
 /// Return a copy of map-like objects such as Coords with `func` applied to each
 /// item.
 ///
-/// If `func` return an invalid object it will not be inserted into the output
+/// If `func` returns an invalid object it will not be inserted into the output
 /// map. This can be used to drop/filter items.
 template <class T, class Func> auto transform_map(const T &map, Func func) {
   std::unordered_map<typename T::key_type, typename T::mapped_type> out;
   for (const auto &[key, item] : map) {
     auto transformed = func(item);
     if (transformed.is_valid())
-      out.emplace(key, transformed);
+      out.emplace(key, std::move(transformed));
   }
   return out;
 }

--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -231,8 +231,7 @@ Variable flatten_bin_edge(const Variable &var,
   const auto back_flat = flatten(back, back.dims().labels(), to_dim);
   if (front_flat.slice({to_dim, 1, front.dims().volume()}) !=
       back_flat.slice({to_dim, 0, back.dims().volume() - 1}))
-    throw except::BinEdgeError(
-        "Flatten: the bin edges cannot be joined together.");
+    return {};
 
   // Make the bulk slice of the coord, leaving out the last bin edge
   const auto bulk =

--- a/lib/dataset/test/shape_test.cpp
+++ b/lib/dataset/test/shape_test.cpp
@@ -190,26 +190,24 @@ TEST(ReshapeTest, flatten_binedges_1d) {
   EXPECT_EQ(flat, expected);
 }
 
-TEST(ReshapeTest, flatten_binedges_x_fails) {
+TEST(ReshapeTest, flatten_drops_unjoinable_outer_binedges) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
   a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * units::one);
   a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
 
-  // Throws because x coord has mismatching bin edges.
-  EXPECT_THROW_DISCARD(flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z),
-                       except::BinEdgeError);
+  const auto flat = flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
+  EXPECT_FALSE(flat.coords().contains(Dim::X));
 }
 
-TEST(ReshapeTest, flatten_binedges_y_fails) {
+TEST(ReshapeTest, flatten_drops_unjoinable_inner_binedges) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
   a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
   a.coords().set(Dim::Y, arange(Dim::Y, 5) + 0.2 * units::one);
 
-  // Throws because y coord has mismatching bin edges.
-  EXPECT_THROW_DISCARD(flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z),
-                       except::BinEdgeError);
+  const auto flat = flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
+  EXPECT_FALSE(flat.coords().contains(Dim::Y));
 }
 
 TEST(ReshapeTest, round_trip_binedges) {

--- a/src/scipp/core/shape.py
+++ b/src/scipp/core/shape.py
@@ -222,6 +222,9 @@ def flatten(x: VariableLikeType,
             to: Optional[str] = None) -> VariableLikeType:
     """Flatten multiple dimensions into a single dimension.
 
+    If the input has a bin-edge coordinate that cannot be joined together it will not
+    be included in the output.
+
     Parameters
     ----------
     x: scipp.typing.VariableLike
@@ -243,8 +246,6 @@ def flatten(x: VariableLikeType,
         If the input does not have a contiguous memory layout,
         i.e. flattening would require moving data around.
         This can be resolved by (deep-)copying the input.
-    scipp.BinEdgeError
-        If the bin edge coordinates cannot be stitched back together.
 
     Examples
     --------


### PR DESCRIPTION
Fixes #2640.