### PR TITLE
Start experimenting with conan-2.0

### DIFF
--- a/lib/.conan-recipes/llnl-units/conanfile.py
+++ b/lib/.conan-recipes/llnl-units/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
 import os
 
 CMAKE_PROJECT_STR = """project(
@@ -9,7 +9,7 @@ CMAKE_PROJECT_STR = """project(
 
 
 class UnitsConan(ConanFile):
-    name = "LLNL-Units"
+    name = "llnl-units"
     # Version past patch is ours, increment when moving branch/commit forward
     version = "0.5.0.1"
     license = "BSD-3"
@@ -50,7 +50,7 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()""")
 
     def build(self):
-        cmake = CMake(self)
+        cmake = tools.CMake(self)
         units_namespace = self.options.get_safe("namespace")
         cmake.definitions["UNITS_ENABLE_TESTS"] = "OFF"
         cmake.definitions["UNITS_BASE_TYPE"] = self.options.base_type

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,6 +13,10 @@ set(CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake"
 )
 
+# Without this we get an error about a missing default profile
+execute_process(
+  COMMAND conan profile detect COMMAND_ECHO STDOUT
+)
 execute_process(
   COMMAND conan export .
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.conan-recipes/llnl-units"
@@ -21,18 +25,11 @@ execute_process(
 
 # Conan dependencies
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
-  message(
-    STATUS
-      "Downloading conan.cmake from https://github.com/conan-io/cmake-conan"
-  )
+  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
   file(
-    DOWNLOAD
-    "https://raw.githubusercontent.com/conan-io/cmake-conan/0.17.0/conan.cmake"
+    DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake"
-    EXPECTED_HASH
-      SHA256=3bef79da16c2e031dc429e1dac87a08b9226418b300ce004cc125a82687baeef
-    TLS_VERIFY ON
-  )
+    TLS_VERIFY ON)
 endif()
 
 include(${CMAKE_CURRENT_BINARY_DIR}/conan.cmake)
@@ -57,17 +54,20 @@ conan_cmake_configure(
   boost/1.76.0
   eigen/3.3.9
   gtest/1.11.0
-  LLNL-Units/0.5.0.1
+  llnl-units/0.5.0.1
   pybind11/2.6.2
   ${CONAN_ONETBB}
   OPTIONS
+  # Currently we get this error, is cmake-conan not compatible with conan-2.0?
+  #    ERROR: Error while parsing [options] in conanfile
+  #    Options should be specified as 'pkg:option=value'
   benchmark:shared=False
   boost:header_only=True
   gtest:shared=False
-  LLNL-Units:shared=False
-  LLNL-Units:fPIC=True
-  LLNL-Units:base_type=uint64_t
-  LLNL-Units:namespace=llnl::units
+  llnl-units:shared=False
+  llnl-units:fPIC=True
+  llnl-units:base_type=uint64_t
+  llnl-units:namespace=llnl::units
   GENERATORS
   cmake_find_package_multi
   ${CONAN_DEPLOY}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ requires = [
   "setuptools>=42",
   "wheel",
   "cmake>=3.21",
-  "conan@git+https://github.com/gabyx/conan.git@feature/improve-cmakedeps-find-package",
+  #"conan@git+https://github.com/gabyx/conan.git@feature/improve-cmakedeps-find-package",
+  #"conan@git+https://github.com/conan-io/conan.git@develop2",
+  "conan>=2.0.0.dev0",
   "markupsafe>=1.1.1,<2.1.0",  # see https://github.com/pallets/markupsafe/issues/284
   "ninja",
   "scikit-build==0.13.1",


### PR DESCRIPTION
This is not working at all for now. Related to #2589. This branch includes some minor updates for porting to 2.0. This should *not* be merged, since it is likely incompatible with the current conan.

Problems (seen when running `pip install .`):

- Options (set by `conan_cmake_configure` in `lib/CMakeLists.txt`) lead to an error. Is `cmake-conan` missing 2.0 support?
- Without options, our conan dependencies yield errors, I think because their conan files are not compatible with conan-2.0.

Conclusion:
- More work needed.
- Likely need to wait until dependencies support 2.0.
- I almost wish we would have keep the "old" way, using `cmake`'s `ExternalProject` to get our .