### PR TITLE
Optimization for auto-grouping

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -488,8 +488,21 @@ def _make_groups(x, arg):
     _require_coord(arg, coord)
     if coord.bins is not None:
         coord = coord.copy().bins.constituents['data']
+    if coord.dtype in (_cpp.DType.int32, _cpp.DType.int64):
+        min_ = coord.min().value
+        max_ = coord.max().value
+        values = coord.values
+        pivot = len(values) // 100
+        unique = np.unique(values[:pivot])
+        if unique.min() != min_ or unique.max() != max_:
+            pivot = len(values) // 10
+            unique = np.unique(values[:pivot])
+        if unique.min() != min_ or unique.max() != max_:
+            unique = np.unique(values)
+    else:
+        unique = np.unique(coord.values)
     # TODO Very inefficient np.unique
-    return array(dims=[arg], values=np.unique(coord.values), unit=coord.unit)
+    return array(dims=[arg], values=unique, unit=coord.unit)
 
 
 def group(x: Union[_cpp.DataArray, _cpp.Dataset], /,

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -494,10 +494,10 @@ def _make_groups(x, arg):
         values = coord.values
         pivot = len(values) // 100
         unique = np.unique(values[:pivot])
-        if unique.min() != min_ or unique.max() != max_:
+        if len(unique) != max_ - min_ + 1:
             pivot = len(values) // 10
             unique = np.unique(values[:pivot])
-        if unique.min() != min_ or unique.max() != max_:
+        if len(unique) != max_ - min_ + 1:
             unique = np.unique(values)
     else:
         unique = np.unique(coord.values)

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -488,20 +488,20 @@ def _make_groups(x, arg):
     _require_coord(arg, coord)
     if coord.bins is not None:
         coord = coord.copy().bins.constituents['data']
+    # We are currently using np.unique to find all unique groups. This can be very slow
+    # for large inputs. In many cases groups are in a bounded range of integers and we
+    # can sometimes bypass a full call to np.unique by checking a sub-range first
     if coord.dtype in (_cpp.DType.int32, _cpp.DType.int64):
         min_ = coord.min().value
         max_ = coord.max().value
         values = coord.values
-        pivot = len(values) // 100
-        unique = np.unique(values[:pivot])
-        if len(unique) != max_ - min_ + 1:
-            pivot = len(values) // 10
-            unique = np.unique(values[:pivot])
-        if len(unique) != max_ - min_ + 1:
-            unique = np.unique(values)
+        unique = values[0:0]
+        for pivot in [1000, 100, 10, 1]:
+            if len(unique) == max_ - min_ + 1:
+                break
+            unique = np.unique(values[:len(values) // pivot])
     else:
         unique = np.unique(coord.values)
-    # TODO Very inefficient np.unique
     return array(dims=[arg], values=unique, unit=coord.unit)
 
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -186,6 +186,15 @@ def test_group_after_bin_considers_event_value():
     assert da.sizes == {'label': 10}
 
 
+def test_group_by_2d():
+    table = sc.data.table_xyz(100)
+    table.coords['label'] = (table.coords['x'] * 10).to(dtype='int64')
+    da = table.bin(y=333).group('label')
+    da.coords['label'] = (sc.arange('y', 0, 333) * da.coords['label']) % 23
+    grouped = da.group('label')
+    assert grouped.sizes == {'y': 333, 'label': 23}
+
+
 def test_bin_erases_dims_automatically_if_labels_for_same_dim():
     table = sc.data.table_xyz(100)
     table.coords['x2'] = table.coords['x'] * 2

--- a/tests/hypothesis/bin_test.py
+++ b/tests/hypothesis/bin_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import scipp as sc
@@ -26,3 +26,18 @@ def test_bin_2d_linspace_bounds(a, b):
     y_edges = sc.linspace('y', x.min(), upper, num=3)
     binned = table.bin(x=x_edges, y=y_edges)
     assert binned.sum().value == 2
+
+
+@settings(max_examples=1000)
+@given(st.integers(min_value=0, max_value=5555), st.integers(min_value=0,
+                                                             max_value=1234),
+       st.integers(min_value=0, max_value=1234))
+def test_automatic_grouping_optimization(nrow, i, j):
+    base = sc.DataArray(sc.ones(dims=['row'], shape=[nrow]))
+    base.coords['label'] = sc.arange('row', 0, nrow, dtype='int64')
+    # Use overlapping or non-overlapping sections to simulate labels with duplicates as
+    # well as gaps
+    table = sc.concat([base[:i], base[j:]], 'row')
+    assert sc.identical(
+        table.group('label').coords['label'],
+        sc.array(dims=['label'], values=np.unique(table.coords['label'].values)))


### PR DESCRIPTION
~This is a proof of concept, not final code.~ Currently binning by groups as added in a recent PR can be very slow. Example:

```python
import scipp as sc
da = sc.data.table_xyz(100_000_000)
da.coords['pixel'] = (da.coords['x'] * 10000).to(dtype='int64')
da.coords['pixel'].unit = None
```
then
```python
da.group('pixel')
```
takes almost `6 seconds`, due to a call to `np.unique`.

This PR adds an simple optimization that can avoid calling `np.unique` on the full grouping coord. This simple approach does not help in all cases. Another (more complex?) option would be to implement something similar directly in scipp. With this branch the above takes just over `1 second`.

Thoughts?