### PR TITLE
Pin versions in ci buildconfig environments

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan>=1.45.0
+  - conan=1.48.1
   - cppcheck=2.6.2
   - graphviz=3.0.0
   - gxx_linux-64=11.1.*

--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -1,14 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
 name: ubuntu-latest
 channels:
   - conda-forge
 dependencies:
-  - cmake
+  - cmake=3.23.2
   - conan>=1.45.0
-  - cppcheck
+  - cppcheck=2.6.2
   - graphviz=3.0.0
-  - gxx_linux-64 11.1.*
-  - ninja
-  - pandoc
+  - gxx_linux-64=11.1.*
+  - ninja=1.11.0
+  - pandoc=2.18
   - tbb=2020.2.*
   - tbb-devel=2020.2.*
-  - tox
+  - tox=3.25.0

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -1,10 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
 name: macos-latest
 channels:
   - conda-forge
 dependencies:
-  - cmake
+  - cmake=3.23.2
   - conan>=1.45.0
-  - ninja
+  - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*
-  - tox
+  - tox=3.25.0

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan>=1.45.0
+  - conan=1.48.1
   - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -1,10 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+
 name: windows-latest
 channels:
   - conda-forge
 dependencies:
-  - cmake
+  - cmake=3.23.2
   - conan>=1.45.0
-  - ninja
+  - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*
-  - tox
+  - tox=3.25.0

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan>=1.45.0
+  - conan=1.48.1
   - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*


### PR DESCRIPTION
A change of version in `cppcheck` caused a build failure: see https://github.com/scipp/scipp/runs/7090085711?check_suite_focus=true#step:9:17

We pin all versions of listed packages, including `cppcheck` to 2.6.2.