### PR TITLE
Support variables in `hist`, `nanhist`, and `bin`.

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,6 +12,7 @@ Features
 * Added conversion from Scipp objects to Xarray objects (previously only converting from Xarray to Scipp was available) `#2624 <https://github.com/scipp/scipp/pull/2624>`_.
 * Overhauled and streamlined usability of functions related to binning, grouping, and histogramming with additional features such as automatic bin edges and histogramming ignoring NaN values.
   See :func:`scipp.bin`, :func:`scipp.group`, :func:`scipp.hist`, :func:`scipp.nanhist`, and :func:`scipp.rebin` `#2633 <https://github.com/scipp/scipp/pull/2633>`_.
+* Added support for histogramming and binning variables, in addition to existing support for data arrays `#2677 <https://github.com/scipp/scipp/pull/2677>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,7 +12,7 @@ Features
 * Added conversion from Scipp objects to Xarray objects (previously only converting from Xarray to Scipp was available) `#2624 <https://github.com/scipp/scipp/pull/2624>`_.
 * Overhauled and streamlined usability of functions related to binning, grouping, and histogramming with additional features such as automatic bin edges and histogramming ignoring NaN values.
   See :func:`scipp.bin`, :func:`scipp.group`, :func:`scipp.hist`, :func:`scipp.nanhist`, and :func:`scipp.rebin` `#2633 <https://github.com/scipp/scipp/pull/2633>`_.
-* Added support for histogramming and binning variables, in addition to existing support for data arrays `#2677 <https://github.com/scipp/scipp/pull/2677>`_.
+* Added support for histogramming and binning variables, in addition to existing support for data arrays `#2678 <https://github.com/scipp/scipp/pull/2678>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -107,6 +107,8 @@ _binding.bind_functions_as_methods(Dataset, globals(), ('squeeze', ))
 for _cls in (DataArray, Dataset):
     _binding.bind_functions_as_methods(_cls, globals(), ('groupby', 'transform_coords'))
 del _cls
+_binding.bind_functions_as_methods(Variable, globals(),
+                                   ('bin', 'hist', 'nanhist'))
 _binding.bind_functions_as_methods(DataArray, globals(),
                                    ('bin', 'group', 'hist', 'nanhist', 'rebin'))
 _binding.bind_functions_as_methods(Dataset, globals(), ('hist', 'rebin'))

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -107,8 +107,7 @@ _binding.bind_functions_as_methods(Dataset, globals(), ('squeeze', ))
 for _cls in (DataArray, Dataset):
     _binding.bind_functions_as_methods(_cls, globals(), ('groupby', 'transform_coords'))
 del _cls
-_binding.bind_functions_as_methods(Variable, globals(),
-                                   ('bin', 'hist', 'nanhist'))
+_binding.bind_functions_as_methods(Variable, globals(), ('bin', 'hist', 'nanhist'))
 _binding.bind_functions_as_methods(DataArray, globals(),
                                    ('bin', 'group', 'hist', 'nanhist', 'rebin'))
 _binding.bind_functions_as_methods(Dataset, globals(), ('hist', 'rebin'))

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -99,7 +99,7 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
     if edges is None:
         edges = []
     if isinstance(x, Variable):
-        coords = [*edges , *groups]
+        coords = [*edges, *groups]
         if len(coords) != 1:
             raise ValueError("Edges for exactly one dimension must be specified when "
                              "binning or histogramming a variable.")

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -99,7 +99,7 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
     if edges is None:
         edges = []
     if isinstance(x, Variable):
-        coords = edges + groups
+        coords = [*edges , *groups]
         if len(coords) != 1:
             raise ValueError("Edges for exactly one dimension must be specified when "
                              "binning or histogramming a variable.")

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -9,7 +9,7 @@ from .variable import array, Variable, linspace, arange, epoch, scalar
 from .math import round as round_
 
 
-def make_histogrammed(x: Union[_cpp.DataArray, _cpp.Dataset], *,
+def make_histogrammed(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset], *,
                       edges: _cpp.Variable) -> Union[_cpp.DataArray, _cpp.Dataset]:
     """Create dense data by histogramming data into given bins.
 
@@ -45,7 +45,7 @@ def make_histogrammed(x: Union[_cpp.DataArray, _cpp.Dataset], *,
     return _cpp.histogram(x, edges)
 
 
-def make_binned(x: _cpp.DataArray,
+def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
                 *,
                 edges: Optional[Sequence[_cpp.Variable]] = None,
                 groups: Optional[Sequence[_cpp.Variable]] = None,
@@ -152,7 +152,7 @@ def _parse_coords_arg(x, name, arg):
     return arange(name, start, stop, step=step, dtype=start.dtype)
 
 
-def _make_edges(x: Union[_cpp.DataArray,
+def _make_edges(x: Union[_cpp.Variable, _cpp.DataArray,
                          _cpp.Dataset], arg_dict: Dict[str, Union[int, Variable]],
                 kwargs: Dict[str, Union[int, Variable]]) -> List[Variable]:
     if arg_dict is not None:
@@ -171,7 +171,7 @@ def _find_replaced_dims(x, dims):
     return [dim for dim in erase if dim not in dims]
 
 
-def hist(x: Union[_cpp.DataArray, _cpp.Dataset],
+def hist(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset],
          arg_dict: Optional[Dict[str, Union[int, Variable]]] = None,
          /,
          **kwargs: Union[int, Variable]) -> Union[_cpp.DataArray, _cpp.Dataset]:
@@ -286,7 +286,7 @@ def hist(x: Union[_cpp.DataArray, _cpp.Dataset],
     return out
 
 
-def nanhist(x: Union[_cpp.DataArray, _cpp.Dataset],
+def nanhist(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset],
             arg_dict: Optional[Dict[str, Union[int, Variable]]] = None,
             /,
             **kwargs: Union[int, Variable]) -> Union[_cpp.DataArray, _cpp.Dataset]:
@@ -317,7 +317,7 @@ def nanhist(x: Union[_cpp.DataArray, _cpp.Dataset],
     return x.bins.nansum()
 
 
-def bin(x: Union[_cpp.DataArray, _cpp.Dataset],
+def bin(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset],
         arg_dict: Dict[str, Union[int, Variable]] = None,
         /,
         **kwargs: Union[int, Variable]) -> Union[_cpp.DataArray, _cpp.Dataset]:

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -5,7 +5,7 @@ import warnings
 from typing import Dict, List, Optional, Union, Sequence
 
 from .._scipp import core as _cpp
-from .variable import array, Variable, linspace, arange, epoch
+from .variable import array, Variable, linspace, arange, epoch, scalar
 from .math import round as round_
 
 
@@ -39,6 +39,9 @@ def make_histogrammed(x: Union[_cpp.DataArray, _cpp.Dataset], *,
     scipp.bin:
         For binning data.
     """
+    if isinstance(x, Variable):
+        data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes)
+        x = _cpp.DataArray(data, coords={edges.dim: x})
     return _cpp.histogram(x, edges)
 
 
@@ -95,6 +98,13 @@ def make_binned(x: _cpp.DataArray,
         groups = []
     if edges is None:
         edges = []
+    if isinstance(x, Variable):
+        coords = edges + groups
+        if len(coords) != 1:
+            raise ValueError("Edges for exactly one dimension must be specified when "
+                             "binning or histogramming a variable.")
+        data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes).copy()
+        x = _cpp.DataArray(data, coords={coords[0].dim: x})
     return _cpp.bin(x, edges, groups, erase)
 
 
@@ -104,6 +114,8 @@ def _require_coord(name, coord):
 
 
 def _get_coord(x, name):
+    if isinstance(x, Variable):
+        return x
     event_coord = x.bins.meta.get(name) if x.bins is not None else None
     coord = x.meta.get(name, event_coord)
     _require_coord(name, coord)
@@ -254,6 +266,9 @@ def hist(x: Union[_cpp.DataArray, _cpp.Dataset],
     """  # noqa #501
     edges = _make_edges(x, arg_dict, kwargs)
     erase = _find_replaced_dims(x, edges)
+    if isinstance(x, Variable) and len(edges) != 1:
+        raise ValueError("Edges for exactly one dimension must be specified when "
+                         "binning or histogramming a variable.")
     if len(edges) == 0:
         if x.bins is None:
             raise TypeError("Data is not binned so bin edges must be provided.")

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -507,3 +507,31 @@ def test_rebin_deprecated_positional_arguments():
     with pytest.warns(UserWarning):
         result = sc.rebin(da, 'x', x)
     assert sc.identical(result, da.rebin(x=x))
+
+
+@pytest.mark.parametrize('op', ['bin', 'hist', 'nanhist'])
+def test_raises_ValueError_given_variable_and_multiple_edges(op):
+    var = sc.array(dims=['row'], values=[1, 2, 3])
+    with pytest.raises(ValueError):
+        getattr(var, op)(x=2, y=2)
+
+
+def test_variable_hist_equivalent_to_hist_of_data_array_with_counts():
+    data = sc.ones(dims=['row'], shape=[4], unit='counts')
+    coord = sc.array(dims=['row'], values=[2, 2, 1, 3])
+    da = sc.DataArray(data, coords={'x': coord})
+    assert sc.identical(coord.hist(x=3), da.hist(x=3))
+
+
+def test_variable_nanhist_equivalent_to_nanhist_of_data_array_with_counts():
+    data = sc.ones(dims=['row'], shape=[4], unit='counts')
+    coord = sc.array(dims=['row'], values=[2, 2, 1, 3])
+    da = sc.DataArray(data, coords={'x': coord})
+    assert sc.identical(coord.nanhist(x=3), da.nanhist(x=3))
+
+
+def test_variable_bin_equivalent_to_bin_of_data_array_with_counts():
+    data = sc.ones(dims=['row'], shape=[4], unit='counts')
+    coord = sc.array(dims=['row'], values=[2, 2, 1, 3])
+    da = sc.DataArray(data, coords={'x': coord})
+    assert sc.identical(coord.bin(x=3), da.bin(x=3))


### PR DESCRIPTION
Note that strictly speaking `nanhist` is superfluous since the implicit ones in the counts are never NaN, but maybe it is useful for generic code.

Fixes #2676.