### PR TITLE
Generalize `lookup`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -24,7 +24,7 @@ Breaking changes
 * Replaced the widget-based :func:`scipp.table` viewer with a simpler pure-HTML table `#2613 <https://github.com/scipp/scipp/pull/2613>`_.
 * :func:`scipp.flatten` now drops mismatching bin edge coordinates instead of raising a ``BinEdgeError`` `#2652 <https://github.com/scipp/scipp/pull/2652>`_.
 * The ``targets`` argument of :func:`scipp.transform_coords` is not position-only `#2670 <https://github.com/scipp/scipp/pull/2670>`_.
-* :func:`scipp.lookup` now used NaN as fill value for floating-point valued functions (for points out of bounds or masked points).
+* :func:`scipp.lookup` now uses NaN as fill value for floating-point valued functions (for points out of bounds or masked points).
    Integral-valued functions are unchanged (using 0 as before).
    See also new argument for custom fill values `#2681 <https://github.com/scipp/scipp/pull/2681>`_.
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -33,6 +33,7 @@ Bugfixes
 * Fix issues with copying binned structured data or fields of binned structured data `#2650 <https://github.com/scipp/scipp/pull/2650>`_.
 * Fix various missing dimension and/or shape checks when slicing with a condition variable `#2657 <https://github.com/scipp/scipp/pull/2657>`_.
 * Fix serious bug in :func:`scipp.bin` that was introduced in scipp-0.12.0. This corrupts data when binning into more than 65536 at a time `#2680 <https://github.com/scipp/scipp/pull/2680>`_.
+* Fix issue in :func:`scipp.lookup`, which led to ignored masks in case of integral function values with non-linspace coordinates `#2681 <https://github.com/scipp/scipp/pull/2681>`_.
 * Fix reduction operations of 0-D binned data, which previously returned the input unchanged `#2685 <https://github.com/scipp/scipp/pull/2685>`_.
 
 Documentation

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -14,6 +14,8 @@ Features
   See :func:`scipp.bin`, :func:`scipp.group`, :func:`scipp.hist`, :func:`scipp.nanhist`, and :func:`scipp.rebin` `#2633 <https://github.com/scipp/scipp/pull/2633>`_.
 * Added support for histogramming and binning variables, in addition to existing support for data arrays `#2678 <https://github.com/scipp/scipp/pull/2678>`_.
 * Added keyword argument syntax to :func:`scipp.transform_coords` for more concise user experience in simple single-step transformations `#2670 <https://github.com/scipp/scipp/pull/2670>`_.
+* Generalized :func:`scipp.lookup` to also support non-histogram functions for value lookup, with supported modes "previous" and "nearest".
+  Also adding support for custom fill values `#2681 <https://github.com/scipp/scipp/pull/2681>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -22,6 +24,9 @@ Breaking changes
 * Replaced the widget-based :func:`scipp.table` viewer with a simpler pure-HTML table `#2613 <https://github.com/scipp/scipp/pull/2613>`_.
 * :func:`scipp.flatten` now drops mismatching bin edge coordinates instead of raising a ``BinEdgeError`` `#2652 <https://github.com/scipp/scipp/pull/2652>`_.
 * The ``targets`` argument of :func:`scipp.transform_coords` is not position-only `#2670 <https://github.com/scipp/scipp/pull/2670>`_.
+* :func:`scipp.lookup` now used NaN as fill value for floating-point valued functions (for points out of bounds or masked points).
+   Integral-valued functions are unchanged (using 0 as before).
+   See also new argument for custom fill values `#2681 <https://github.com/scipp/scipp/pull/2681>`_.
 
 Bugfixes
 ~~~~~~~~

--- a/lib/core/include/scipp/core/element/event_operations.h
+++ b/lib/core/include/scipp/core/element/event_operations.h
@@ -103,6 +103,14 @@ constexpr auto map_sorted_edges =
                             : get(weights, --it - edges.begin());
                }};
 
+constexpr auto lookup_previous =
+    overloaded{map, [](const auto &point, const auto &x, const auto &weights,
+                       const auto &fill) {
+                 auto it = std::upper_bound(x.begin(), x.end(), point);
+                 using T = std::decay_t<decltype(get(weights, 0))>;
+                 return it == x.begin() ? fill : get(weights, --it - x.begin());
+               }};
+
 namespace map_and_mul_detail {
 template <class Data, class Coord, class Edge, class Weight>
 using args =

--- a/lib/core/include/scipp/core/element/event_operations.h
+++ b/lib/core/include/scipp/core/element/event_operations.h
@@ -26,8 +26,8 @@ constexpr auto get = [](const auto &x, const scipp::index i) {
 
 namespace map_detail {
 template <class Coord, class Edge, class Weight>
-using args =
-    std::tuple<Coord, scipp::span<const Edge>, scipp::span<const Weight>>;
+using args = std::tuple<Coord, scipp::span<const Edge>,
+                        scipp::span<const Weight>, Weight>;
 } // namespace map_detail
 
 constexpr auto map = overloaded{
@@ -78,27 +78,30 @@ constexpr auto map = overloaded{
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     [](const units::Unit &x, const units::Unit &edges,
-       const units::Unit &weights) {
+       const units::Unit &weights, const units::Unit &fill) {
       expect::equals(x, edges);
+      expect::equals(weights, fill);
       return weights;
     }};
 
-constexpr auto map_linspace = overloaded{
-    map, [](const auto &coord, const auto &edges, const auto &weights) {
-      const auto [offset, nbin, factor] = linear_edge_params(edges);
-      const auto bin = (coord - offset) * factor;
-      using T = std::decay_t<decltype(get(weights, 0))>;
-      return (bin < 0.0 || bin >= nbin) ? T{0} : get(weights, bin);
-    }};
+constexpr auto map_linspace =
+    overloaded{map, [](const auto &coord, const auto &edges,
+                       const auto &weights, const auto &fill) {
+                 const auto [offset, nbin, factor] = linear_edge_params(edges);
+                 const auto bin = (coord - offset) * factor;
+                 using T = std::decay_t<decltype(get(weights, 0))>;
+                 return (bin < 0.0 || bin >= nbin) ? fill : get(weights, bin);
+               }};
 
-constexpr auto map_sorted_edges = overloaded{
-    map, [](const auto &coord, const auto &edges, const auto &weights) {
-      auto it = std::upper_bound(edges.begin(), edges.end(), coord);
-      using T = std::decay_t<decltype(get(weights, 0))>;
-      return (it == edges.end() || it == edges.begin())
-                 ? T{0}
-                 : get(weights, --it - edges.begin());
-    }};
+constexpr auto map_sorted_edges =
+    overloaded{map, [](const auto &coord, const auto &edges,
+                       const auto &weights, const auto &fill) {
+                 auto it = std::upper_bound(edges.begin(), edges.end(), coord);
+                 using T = std::decay_t<decltype(get(weights, 0))>;
+                 return (it == edges.end() || it == edges.begin())
+                            ? fill
+                            : get(weights, --it - edges.begin());
+               }};
 
 namespace map_and_mul_detail {
 template <class Data, class Coord, class Edge, class Weight>

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -13,6 +13,7 @@ template class SCIPP_CORE_EXPORT MultiIndex<1>;
 template class SCIPP_CORE_EXPORT MultiIndex<2>;
 template class SCIPP_CORE_EXPORT MultiIndex<3>;
 template class SCIPP_CORE_EXPORT MultiIndex<4>;
+template class SCIPP_CORE_EXPORT MultiIndex<5>;
 
 namespace {
 void validate_bin_indices_impl(const ElementArrayViewParams &param0,
@@ -169,6 +170,9 @@ template SCIPP_CORE_EXPORT MultiIndex<3>::MultiIndex(const Dimensions &,
 template SCIPP_CORE_EXPORT
 MultiIndex<4>::MultiIndex(const Dimensions &, const Strides &, const Strides &,
                           const Strides &, const Strides &);
+template SCIPP_CORE_EXPORT
+MultiIndex<5>::MultiIndex(const Dimensions &, const Strides &, const Strides &,
+                          const Strides &, const Strides &, const Strides &);
 
 template SCIPP_CORE_EXPORT
 MultiIndex<1>::MultiIndex(binned_tag, const Dimensions &, const Dimensions &,
@@ -186,5 +190,10 @@ template SCIPP_CORE_EXPORT MultiIndex<4>::MultiIndex(
     binned_tag, const Dimensions &, const Dimensions &,
     const ElementArrayViewParams &, const ElementArrayViewParams &,
     const ElementArrayViewParams &, const ElementArrayViewParams &);
+template SCIPP_CORE_EXPORT MultiIndex<5>::MultiIndex(
+    binned_tag, const Dimensions &, const Dimensions &,
+    const ElementArrayViewParams &, const ElementArrayViewParams &,
+    const ElementArrayViewParams &, const ElementArrayViewParams &,
+    const ElementArrayViewParams &);
 
 } // namespace scipp::core

--- a/lib/core/test/element_event_operations_test.cpp
+++ b/lib/core/test/element_event_operations_test.cpp
@@ -10,6 +10,7 @@
 using namespace scipp;
 using namespace scipp::core;
 
+using element::event::lookup_previous;
 using element::event::map_linspace;
 using element::event::map_sorted_edges;
 
@@ -102,4 +103,36 @@ TYPED_TEST(ElementEventMapTest, variances_variable_bin_width) {
             ValueAndVariance<float>(66, 0));
   EXPECT_EQ(map_sorted_edges(TypeParam{5}, edges, weights, fill),
             ValueAndVariance<float>(66, 0));
+}
+
+class ElementLookupPreviousTest : public ::testing::Test {
+protected:
+  std::vector<double> x{0, 2, 4};
+  std::vector<double> weights{11, 22, 33};
+  double fill = 66;
+};
+
+TEST_F(ElementLookupPreviousTest, below_gives_fill_value) {
+  fill = 66;
+  EXPECT_EQ(lookup_previous(-0.1, x, weights, fill), 66);
+}
+
+TEST_F(ElementLookupPreviousTest, at_lowest_gives_lowest) {
+  EXPECT_EQ(lookup_previous(0, x, weights, fill), 11);
+}
+
+TEST_F(ElementLookupPreviousTest, below_second_gives_lowest) {
+  EXPECT_EQ(lookup_previous(1, x, weights, fill), 11);
+}
+
+TEST_F(ElementLookupPreviousTest, at_second_gives_second) {
+  EXPECT_EQ(lookup_previous(2, x, weights, fill), 22);
+}
+
+TEST_F(ElementLookupPreviousTest, below_third_gives_second) {
+  EXPECT_EQ(lookup_previous(3, x, weights, fill), 22);
+}
+
+TEST_F(ElementLookupPreviousTest, large_value_gives_last) {
+  EXPECT_EQ(lookup_previous(123456789, x, weights, fill), 33);
 }

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -310,7 +310,7 @@ Variable map(const DataArray &function, const Variable &x, Dim dim,
   if (!is_edges(function.dims(), edges.dims(), dim))
     throw except::BinEdgeError(
         "Function used as lookup table in map operation must be a histogram");
-  const auto data = masked_data(function, dim);
+  const auto data = masked_data(function, dim, fill);
   const auto weights = subspan_view(data, dim);
   if (all(islinspace(edges, dim)).value<bool>()) {
     return variable::transform(x, subspan_view(edges, dim), weights, fill,

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -11,6 +11,7 @@
 
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/bins.h"
+#include "scipp/variable/creation.h"
 #include "scipp/variable/cumulative.h"
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/subspan_view.h"
@@ -289,6 +290,7 @@ Variable histogram(const Variable &data, const Variable &binEdges) {
 }
 
 Variable map(const DataArray &function, const Variable &x, Dim dim) {
+  const auto fill = zero_like(function.data());
   if (dim == Dim::Invalid)
     dim = edge_dimension(function);
   const auto &edges = function.meta()[dim];
@@ -298,12 +300,12 @@ Variable map(const DataArray &function, const Variable &x, Dim dim) {
   const auto data = masked_data(function, dim);
   const auto weights = subspan_view(data, dim);
   if (all(islinspace(edges, dim)).value<bool>()) {
-    return variable::transform(x, subspan_view(edges, dim), weights,
+    return variable::transform(x, subspan_view(edges, dim), weights, fill,
                                core::element::event::map_linspace, "map");
   } else {
     if (!allsorted(edges, dim))
       throw except::BinEdgeError("Bin edges of histogram must be sorted.");
-    return variable::transform(x, subspan_view(edges, dim), weights,
+    return variable::transform(x, subspan_view(edges, dim), weights, fill,
                                core::element::event::map_sorted_edges, "map");
   }
 }

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -174,6 +174,8 @@ template <class T, class Func> DataArray transform(const T &a, Func func) {
 [[nodiscard]] Variable any(const Variable &var, const Dim dim,
                            const Masks &masks);
 
-[[nodiscard]] Variable masked_data(const DataArray &array, const Dim dim);
+[[nodiscard]] Variable
+masked_data(const DataArray &array, const Dim dim,
+            const std::optional<Variable> &fill_value = std::nullopt);
 
 } // namespace scipp::dataset

--- a/lib/dataset/groupby.cpp
+++ b/lib/dataset/groupby.cpp
@@ -458,7 +458,7 @@ template <class T> T extract_impl(const T &obj, const Variable &condition) {
     throw except::DimensionError(
         "Condition dimensions " + to_string(condition.dims()) +
         " must be be included in the dimensions of the sliced object " +
-        to_string(condition.dims()) + '.');
+        to_string(obj.dims()) + '.');
   if (all(condition).value<bool>())
     return copy(obj);
   if (!any(condition).value<bool>())

--- a/lib/dataset/include/scipp/dataset/bins.h
+++ b/lib/dataset/include/scipp/dataset/bins.h
@@ -56,9 +56,9 @@ SCIPP_DATASET_EXPORT void append(DataArray &a, const DataArray &b);
 [[nodiscard]] SCIPP_DATASET_EXPORT Variable histogram(const Variable &data,
                                                       const Variable &binEdges);
 
-[[nodiscard]] SCIPP_DATASET_EXPORT Variable map(const DataArray &function,
-                                                const Variable &x,
-                                                Dim hist_dim);
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+map(const DataArray &function, const Variable &x, Dim dim,
+    const std::optional<Variable> &fill_value = std::nullopt);
 
 SCIPP_DATASET_EXPORT void scale(DataArray &data, const DataArray &histogram,
                                 Dim dim = Dim::Invalid);

--- a/lib/dataset/include/scipp/dataset/bins.h
+++ b/lib/dataset/include/scipp/dataset/bins.h
@@ -36,6 +36,10 @@ make_bins_no_validate(Variable indices, const Dim dim, Dataset buffer);
 [[nodiscard]] SCIPP_DATASET_EXPORT bool is_bins(const DataArray &array);
 [[nodiscard]] SCIPP_DATASET_EXPORT bool is_bins(const Dataset &dataset);
 
+[[nodiscard]] SCIPP_DATASET_EXPORT Variable
+lookup_previous(const DataArray &function, const Variable &x, Dim dim,
+                const std::optional<Variable> &fill_value = std::nullopt);
+
 } // namespace scipp::dataset
 
 namespace scipp::dataset::buckets {

--- a/lib/dataset/operations.cpp
+++ b/lib/dataset/operations.cpp
@@ -110,10 +110,10 @@ Dataset copy(const Dataset &dataset, Dataset &&out,
 /// fill_value. If not provided, values are replaced by zero.
 Variable masked_data(const DataArray &array, const Dim dim,
                      const std::optional<Variable> &fill_value) {
-  const auto fill = fill_value.value_or(zero_like(array.data()));
   const auto mask = irreducible_mask(array.masks(), dim);
   if (mask.is_valid()) {
     const auto &data = array.data();
+    const auto fill = fill_value.value_or(zero_like(array.data()));
     return where(mask, fill, data);
   } else
     return array.data();

--- a/lib/dataset/operations.cpp
+++ b/lib/dataset/operations.cpp
@@ -106,12 +106,15 @@ Dataset copy(const Dataset &dataset, Dataset &&out,
 
 /// Return data of data array, applying masks along dim if applicable.
 ///
-/// Only in the latter case a copy is returned.
-Variable masked_data(const DataArray &array, const Dim dim) {
+/// Only in the latter case a copy is returned. Masked values are replaced by
+/// fill_value. If not provided, values are replaced by zero.
+Variable masked_data(const DataArray &array, const Dim dim,
+                     const std::optional<Variable> &fill_value) {
+  const auto fill = fill_value.value_or(zero_like(array.data()));
   const auto mask = irreducible_mask(array.masks(), dim);
   if (mask.is_valid()) {
     const auto &data = array.data();
-    return where(mask, zero_like(data), data);
+    return where(mask, fill, data);
   } else
     return array.data();
 }

--- a/lib/dataset/test/bins_test.cpp
+++ b/lib/dataset/test/bins_test.cpp
@@ -248,14 +248,14 @@ TEST_F(DataArrayBinsMapTest, fail_no_bin_edges) {
                        except::BinEdgeError);
 }
 
-TEST_F(DataArrayBinsMapTest, map_masked) {
+TEST_F(DataArrayBinsMapTest, map_masked_values_replaced_by_fill_value) {
   const auto &coord = bins_view<DataArray>(buckets).meta()[Dim::Z];
   histogram.masks().set(
       "mask", makeVariable<bool>(histogram.dims(), Values{false, true, false}));
   const auto fill_value = makeVariable<double>(units::K, Values{1234});
   const auto out = buckets::map(histogram, coord, Dim::Z, fill_value);
   const auto expected_scale = makeVariable<double>(
-      Dims{Dim::X}, Shape{4}, units::K, Values{0, 4, 4, 1234});
+      Dims{Dim::X}, Shape{4}, units::K, Values{1234, 4, 4, 1234});
   EXPECT_EQ(out, make_bins(indices, Dim::X, expected_scale));
 }
 

--- a/lib/python/bins.cpp
+++ b/lib/python/bins.cpp
@@ -148,6 +148,14 @@ void init_buckets(py::module &m) {
                             to_string(dt));
   });
 
+  m.def(
+      "lookup_previous",
+      [](const DataArray &function, const Variable &x, const std::string &dim,
+         const std::optional<Variable> &fill_value) {
+        return dataset::lookup_previous(function, x, Dim{dim}, fill_value);
+      },
+      py::call_guard<py::gil_scoped_release>());
+
   auto buckets = m.def_submodule("buckets");
   buckets.def(
       "concatenate",

--- a/lib/python/bins.cpp
+++ b/lib/python/bins.cpp
@@ -187,8 +187,9 @@ void init_buckets(py::module &m) {
       py::call_guard<py::gil_scoped_release>());
   buckets.def(
       "map",
-      [](const DataArray &function, const Variable &x, const std::string &dim) {
-        return dataset::buckets::map(function, x, Dim{dim});
+      [](const DataArray &function, const Variable &x, const std::string &dim,
+         const std::optional<Variable> &fill_value) {
+        return dataset::buckets::map(function, x, Dim{dim}, fill_value);
       },
       py::call_guard<py::gil_scoped_release>());
   buckets.def(

--- a/src/scipp/coords/rule.py
+++ b/src/scipp/coords/rule.py
@@ -213,5 +213,5 @@ def _arg_names(func) -> Dict[str, str]:
         # functions, but nevertheless do not have 'self'.
         args = spec.args[1:]
     names = tuple(args + spec.kwonlyargs)
-    coords = getattr(func, 'inputs', names)
+    coords = getattr(func, '__transform_coords_input_keys__', names)
     return dict(zip(coords, names))

--- a/src/scipp/coords/rule.py
+++ b/src/scipp/coords/rule.py
@@ -213,5 +213,5 @@ def _arg_names(func) -> Dict[str, str]:
         # functions, but nevertheless do not have 'self'.
         args = spec.args[1:]
     names = tuple(args + spec.kwonlyargs)
-    coords = getattr(func, 'input_coords', names)
+    coords = getattr(func, 'inputs', names)
     return {coord: name for coord, name in zip(coords, names)}

--- a/src/scipp/coords/rule.py
+++ b/src/scipp/coords/rule.py
@@ -214,4 +214,4 @@ def _arg_names(func) -> Dict[str, str]:
         args = spec.args[1:]
     names = tuple(args + spec.kwonlyargs)
     coords = getattr(func, 'inputs', names)
-    return {coord: name for coord, name in zip(coords, names)}
+    return dict(zip(coords, names))

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -48,7 +48,10 @@ def transform_coords(x: Union[DataArray, Dataset],
           If :class:`str`, this is a synonym for renaming a coord.
           If a callable, it must either return a single variable or a dict of
           variables. The argument names of callables must be coords
-          in ``x`` or be computable by other nodes in ``graph``.
+          in ``x`` or be computable by other nodes in ``graph``. The coord names
+          can be overridden by the callable by providing a ``input_coords``
+          property, returning a list of coord names in the same order as the
+          function arguments.
     rename_dims:
         Rename dimensions if the corresponding dimension coords
         are used as inputs and there is a single output coord

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -49,7 +49,7 @@ def transform_coords(x: Union[DataArray, Dataset],
           If a callable, it must either return a single variable or a dict of
           variables. The argument names of callables must be coords
           in ``x`` or be computable by other nodes in ``graph``. The coord names
-          can be overridden by the callable by providing a ``input_coords``
+          can be overridden by the callable by providing a ``inputs``
           property, returning a list of coord names in the same order as the
           function arguments.
     rename_dims:

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -47,11 +47,10 @@ def transform_coords(x: Union[DataArray, Dataset],
         - Dict values are :class:`str` or a callable (function).
           If :class:`str`, this is a synonym for renaming a coord.
           If a callable, it must either return a single variable or a dict of
-          variables. The argument names of callables must be coords
-          in ``x`` or be computable by other nodes in ``graph``. The coord names
-          can be overridden by the callable by providing a ``inputs``
-          property, returning a list of coord names in the same order as the
-          function arguments.
+          variables. The argument names of callables must be coords in ``x`` or be
+          computable by other nodes in ``graph``. The coord names can be overridden by
+          the callable by providing a ``__transform_coords_input_keys__`` property,
+          returning a list of coord names in the same order as the function arguments.
     rename_dims:
         Rename dimensions if the corresponding dimension coords
         are used as inputs and there is a single output coord

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -89,10 +89,11 @@ def lookup(func: _cpp.DataArray,
     elif mode not in ['previous', 'nearest']:
         raise ValueError(f"Mode most be one of ['previous', 'nearest'], got '{mode}'")
     if mode == 'nearest':
-        coord = midpoints(func.meta[dim])
-        lowest = coord[0:0].max()  # trick to get lowest representable value
+        coord = func.meta[dim]
+        lowest = coord[dim, 0:0].max()  # trick to get lowest representable value
+        parts = [lowest] if coord.sizes[dim] < 2 else [lowest, midpoints(coord, dim)]
         func = func.copy(deep=False)
-        func.coords[dim] = concat([lowest, coord], dim)
+        func.coords[dim] = concat(parts, dim)
     return Lookup(_cpp.lookup_previous, func, dim, fill_value)
 
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -19,12 +19,12 @@ class Lookup:
                  func: _cpp.DataArray,
                  dim: str,
                  fill_value: Optional[_cpp.Variable] = None):
-        if func.ndim == 1 and len(func) > 0 and func.dtype in [
+        if not func.masks and func.ndim == 1 and len(func) > 0 and func.dtype in [
                 _cpp.DType.bool, _cpp.DType.int32, _cpp.DType.int64
         ]:
             # Significant speedup if `func` is large but mostly constant.
             if op == _cpp.buckets.map:
-                if not func.masks and not islinspace(func.coords[dim], dim).value:
+                if not islinspace(func.coords[dim], dim).value:
                     func = merge_equal_adjacent(func)
             else:
                 # In this case the C++ implementation currently used no linspace

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -24,7 +24,7 @@ class Lookup:
         ]:
             # Significant speedup if `func` is large but mostly constant.
             if op == _cpp.buckets.map:
-                if not islinspace(func.coords[dim], dim).value:
+                if not func.masks and not islinspace(func.coords[dim], dim).value:
                     func = merge_equal_adjacent(func)
             else:
                 # In this case the C++ implementation currently used no linspace

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -34,7 +34,6 @@ class Lookup:
 
 
 def lookup(func: _cpp.DataArray,
-           /,
            dim: Optional[str] = None,
            *,
            mode: Optional[Literal['previous', 'nearest']] = None,
@@ -51,9 +50,10 @@ def lookup(func: _cpp.DataArray,
     dim:
         Dimension along which the lookup occurs.
     fill_value:
-        Value to use for points outside the range of the histogram or data. If set to
-        None (the default) this will use NaN for floating point types and 0 for
-        integral types. Must have the same dtype and unit as the function values.
+        Value to use for points outside the range of the function as well as points in
+        masked regions of the function. If set to None (the default) this will use NaN
+        for floating point types and 0 for integral types. Must have the same dtype and
+        unit as the function values.
 
     Examples
     --------

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -35,7 +35,7 @@ class Lookup:
         self.func = func
         self.dim = dim
         self.fill_value = fill_value
-        self.inputs = (dim, )  # for transform_coords
+        self.__transform_coords_input_keys__ = (dim, )  # for transform_coords
 
     def __call__(self, var):
         return self.op(self.func, var, self.dim, self.fill_value)

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -29,6 +29,7 @@ class Lookup:
         self.func = func
         self.dim = dim
         self.fill_value = fill_value
+        self.input_coords = [dim]
 
     def __call__(self, var):
         return self.op(self.func, var, self.dim, self.fill_value)

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -19,7 +19,7 @@ class Lookup:
                  func: _cpp.DataArray,
                  dim: str,
                  fill_value: Optional[_cpp.Variable] = None):
-        if func.ndim == 1 and func.dtype in [
+        if func.ndim == 1 and len(func) > 0 and func.dtype in [
                 _cpp.DType.bool, _cpp.DType.int32, _cpp.DType.int64
         ]:
             # Significant speedup if `func` is large but mostly constant.
@@ -88,7 +88,7 @@ def lookup(func: _cpp.DataArray,
         mode = 'nearest'
     elif mode not in ['previous', 'nearest']:
         raise ValueError(f"Mode most be one of ['previous', 'nearest'], got '{mode}'")
-    if mode == 'nearest':
+    if mode == 'nearest' and func.sizes[dim] != 0:
         coord = func.meta[dim]
         lowest = coord[dim, 0:0].max()  # trick to get lowest representable value
         parts = [lowest] if coord.sizes[dim] < 2 else [lowest, midpoints(coord, dim)]

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -41,7 +41,7 @@ class Lookup:
         return self.op(self.func, var, self.dim, self.fill_value)
 
     def __getitem__(self, var):
-        return self.__call__(var)
+        return self(var)
 
 
 def lookup(func: _cpp.DataArray,
@@ -57,7 +57,7 @@ def lookup(func: _cpp.DataArray,
     Parameters
     ----------
     func:
-        Histogram or data defining the lookup table.
+        Data array defining the lookup table.
     dim:
         Dimension along which the lookup occurs.
     mode:
@@ -77,7 +77,7 @@ def lookup(func: _cpp.DataArray,
       >>> hist = sc.DataArray(data=vals, coords={'x': x})
       >>> sc.lookup(hist, 'x')[sc.array(dims=['event'], values=[0.1,0.4,0.1,0.6,0.9])]
       <scipp.Variable> (event: 5)      int64  [dimensionless]  [3, 2, ..., 2, 1]
-        """
+    """
     if dim is None:
         dim = func.dim
     if func.meta.is_edges(dim):

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -53,7 +53,7 @@ def lookup(func: _cpp.DataArray,
     fill_value:
         Value to use for points outside the range of the histogram or data. If set to
         None (the default) this will use NaN for floating point types and 0 for
-        integral types. Must have the same dtype as the function values.
+        integral types. Must have the same dtype and unit as the function values.
 
     Examples
     --------

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -172,22 +172,6 @@ def test_bins_arithmetic():
                         sc.Variable(dims=['event'], values=[1.0, 2.0, 6.0, 8.0]))
 
 
-@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
-def test_lookup_getitem(dtype):
-    x_lin = sc.linspace(dim='xx', start=0, stop=1, num=4)
-    x = x_lin.copy()
-    x.values[0] -= 0.01
-    data = sc.array(dims=['xx'], values=[0, 1, 0], dtype=dtype)
-    hist_lin = sc.DataArray(data=data, coords={'xx': x_lin})
-    hist = sc.DataArray(data=data, coords={'xx': x})
-    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 0.2])
-    lut = sc.lookup(hist, 'xx')
-    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 0], dtype=dtype)
-    assert sc.identical(lut[var], expected)
-    lut = sc.lookup(hist_lin, 'xx')
-    assert sc.identical(lut[var], expected)
-
-
 def test_bins_sum_with_masked_buffer():
     N = 5
     values = np.ones(N)

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -1032,7 +1032,7 @@ def test_input_coords_can_be_defined_via_property():
     def f(a, b):
         return a - b
 
-    f.inputs = ['x', 'y']
+    f.__transform_coords_input_keys__ = ['x', 'y']
     da = sc.data.table_xyz(nrow=10)
     assert sc.identical(da.transform_coords(diff=f),
                         da.transform_coords(diff=lambda x, y: f(x, y)))

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import functools
 import pytest
 import numpy as np
 import scipp as sc
@@ -1003,3 +1004,23 @@ def test_raises_when_keyword_syntax_clashes_with_options(option):
     da = sc.data.table_xyz(nrow=10)
     with pytest.raises(TypeError):
         da.transform_coords(**{option: lambda x: x})
+
+
+def test_works_with_partial():
+
+    def f(a, x):
+        return a * x
+
+    g = functools.partial(f, sc.scalar(5))
+    da = sc.data.table_xyz(nrow=10)
+    assert 'ax' in da.transform_coords(ax=g).coords
+
+
+def test_works_with_class_defining___call__():
+
+    class A:
+        def __call__(self, x):
+            return x*x
+
+    da = sc.data.table_xyz(nrow=10)
+    assert 'xx' in da.transform_coords(xx=A()).coords

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -1019,8 +1019,9 @@ def test_works_with_partial():
 def test_works_with_class_defining___call__():
 
     class A:
+
         def __call__(self, x):
-            return x*x
+            return x * x
 
     da = sc.data.table_xyz(nrow=10)
     assert 'xx' in da.transform_coords(xx=A()).coords

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -1024,3 +1024,14 @@ def test_works_with_class_defining___call__():
 
     da = sc.data.table_xyz(nrow=10)
     assert 'xx' in da.transform_coords(xx=A()).coords
+
+
+def test_input_coords_can_be_defined_via_property():
+
+    def f(a, b):
+        return a - b
+
+    f.inputs = ['x', 'y']
+    da = sc.data.table_xyz(nrow=10)
+    assert sc.identical(da.transform_coords(diff=f),
+                        da.transform_coords(diff=lambda x, y: f(x, y)))

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import pytest
+import scipp as sc
+
+
+@pytest.mark.parametrize('mode', ['nearest', 'previous'])
+def test_raises_with_histogram_if_mode_set(mode):
+    da = sc.DataArray(sc.arange('x', 4), coords={'x': sc.arange('x', 5)})
+    with pytest.raises(ValueError):
+        sc.lookup(da, mode=mode)

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -69,6 +69,30 @@ def test_nearest(dtype):
     assert sc.identical(sc.lookup(da, mode='nearest')(var), expected)
 
 
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_previous_masked_points_replaced_by_fill_value(dtype):
+    x = sc.linspace(dim='xx', start=0, stop=1, num=4)
+    data = sc.array(dims=['xx'], values=[0, 1, 0, 2], dtype=dtype)
+    da = sc.DataArray(data=data, coords={'xx': x})
+    da.masks['mask'] = sc.array(dims=['xx'], values=[False, False, True, False])
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
+    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 666, 2, 0], dtype=dtype)
+    fill = sc.scalar(666, dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='previous', fill_value=fill)(var), expected)
+
+
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_nearest_masked_points_replaced_by_fill_value(dtype):
+    x = sc.linspace(dim='xx', start=0, stop=1, num=5)
+    data = sc.array(dims=['xx'], values=[0, 1, 0, 2, 2], dtype=dtype)
+    da = sc.DataArray(data=data, coords={'xx': x})
+    da.masks['mask'] = sc.array(dims=['xx'], values=[False, False, True, False, False])
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
+    expected = sc.array(dims=['event'], values=[0, 666, 0, 666, 2, 2, 1], dtype=dtype)
+    fill = sc.scalar(666, dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='nearest', fill_value=fill)(var), expected)
+
+
 def outofbounds(dtype):
     if dtype in ['float32', 'float64']:
         return np.NaN

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -54,9 +54,10 @@ def test_previous(dtype):
     x = sc.linspace(dim='xx', start=0, stop=1, num=4)
     data = sc.array(dims=['xx'], values=[0, 1, 0, 2], dtype=dtype)
     da = sc.DataArray(data=data, coords={'xx': x})
-    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
-    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 2, 0], dtype=dtype)
-    assert sc.identical(sc.lookup(da, mode='previous')(var), expected)
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2, -0.1])
+    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 2, 0, 666], dtype=dtype)
+    fill = sc.scalar(666, dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='previous', fill_value=fill)(var), expected)
 
 
 @pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
@@ -64,9 +65,10 @@ def test_nearest(dtype):
     x = sc.linspace(dim='xx', start=0, stop=1, num=5)
     data = sc.array(dims=['xx'], values=[0, 1, 0, 2, 2], dtype=dtype)
     da = sc.DataArray(data=data, coords={'xx': x})
-    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
-    expected = sc.array(dims=['event'], values=[0, 0, 0, 0, 2, 2, 1], dtype=dtype)
-    assert sc.identical(sc.lookup(da, mode='nearest')(var), expected)
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2, -0.1])
+    expected = sc.array(dims=['event'], values=[0, 0, 0, 0, 2, 2, 1, 0], dtype=dtype)
+    fill = sc.scalar(666, dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='nearest', fill_value=fill)(var), expected)
 
 
 @pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -5,8 +5,44 @@ import pytest
 import scipp as sc
 
 
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_getitem(dtype):
+    x_lin = sc.linspace(dim='xx', start=0, stop=1, num=4)
+    x = x_lin.copy()
+    x.values[0] -= 0.01
+    data = sc.array(dims=['xx'], values=[0, 1, 0], dtype=dtype)
+    hist_lin = sc.DataArray(data=data, coords={'xx': x_lin})
+    hist = sc.DataArray(data=data, coords={'xx': x})
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 0.2])
+    lut = sc.lookup(hist, 'xx')
+    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 0], dtype=dtype)
+    assert sc.identical(lut[var], expected)
+    lut = sc.lookup(hist_lin, 'xx')
+    assert sc.identical(lut[var], expected)
+
+
 @pytest.mark.parametrize('mode', ['nearest', 'previous'])
 def test_raises_with_histogram_if_mode_set(mode):
     da = sc.DataArray(sc.arange('x', 4), coords={'x': sc.arange('x', 5)})
     with pytest.raises(ValueError):
         sc.lookup(da, mode=mode)
+
+
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_previous(dtype):
+    x = sc.linspace(dim='xx', start=0, stop=1, num=4)
+    data = sc.array(dims=['xx'], values=[0, 1, 0, 2], dtype=dtype)
+    da = sc.DataArray(data=data, coords={'xx': x})
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
+    expected = sc.array(dims=['event'], values=[0, 1, 0, 1, 0, 2, 0], dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='previous')(var), expected)
+
+
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+def test_nearest(dtype):
+    x = sc.linspace(dim='xx', start=0, stop=1, num=5)
+    data = sc.array(dims=['xx'], values=[0, 1, 0, 2, 2], dtype=dtype)
+    da = sc.DataArray(data=data, coords={'xx': x})
+    var = sc.array(dims=['event'], values=[0.1, 0.4, 0.1, 0.6, 0.9, 1.1, 0.2])
+    expected = sc.array(dims=['event'], values=[0, 0, 0, 0, 2, 2, 1], dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode='nearest')(var), expected)

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -56,6 +56,18 @@ def outofbounds(dtype):
 
 
 @pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
+@pytest.mark.parametrize("mode", ['nearest', 'previous'])
+def test_no_value(mode, dtype):
+    x = sc.array(dims=['xx'], values=[])
+    data = sc.array(dims=['xx'], values=[], dtype=dtype)
+    da = sc.DataArray(data=data, coords={'xx': x})
+    var = sc.array(dims=['event'], values=[0.1, 0.5, 0.6])
+    bad = outofbounds(dtype)
+    expected = sc.array(dims=['event'], values=[bad, bad, bad], dtype=dtype)
+    assert sc.identical(sc.lookup(da, mode=mode)(var), expected, equal_nan=True)
+
+
+@pytest.mark.parametrize("dtype", ['bool', 'int32', 'int64', 'float32', 'float64'])
 def test_previous_single_value(dtype):
     x = sc.array(dims=['xx'], values=[0.5])
     data = sc.array(dims=['xx'], values=[11], dtype=dtype)
@@ -73,7 +85,5 @@ def test_nearest_single_value(dtype):
     data = sc.array(dims=['xx'], values=[11], dtype=dtype)
     da = sc.DataArray(data=data, coords={'xx': x})
     var = sc.array(dims=['event'], values=[0.1, 0.5, 0.6])
-    expected = sc.array(dims=['event'],
-                        values=[11, 11, 11],
-                        dtype=dtype)
+    expected = sc.array(dims=['event'], values=[11, 11, 11], dtype=dtype)
     assert sc.identical(sc.lookup(da, mode='nearest')(var), expected)


### PR DESCRIPTION
This got more complex than anticipated during our initial discussions (an indicator that it is probably important not to leave this to the user, since it is relatively easy to get wrong).

- Add `fill_value` argument.
- Change default `fill_value` to NaN (away from 0), if dtype supports it.
- Fix a bug that led to ignored masks, caused by a previously added optimization.
- Support non-histogram "functions", with modes `linear` and `previous`. 
- Add `__call__`, which does the same as `__getitem__`. Should we consider removing `__getitem__`?

Furthermore, when trying to use `sc.lookup` with `transform_coords`, I ran into two problems:

- Objects defining `__call__` include `self` in the argument list, which broke `transform_coords`. This is fixed (in an ugly and not entirely safe way, I did not find to detect this in a 100% safe manner).
- `__name__` is not defined for various callables, e.g., objects created by `functools.partial`. This is also fixed (bypassed).
- `sc.lookup` returns a callable, but to work with `transform_coords` we would need to have a `__call__` that expects a parameter with name matching the dimension of the lookup function. This is tricky. I chose to update `transform_coords` to use a custom property of the callable.

Fixes #2674.