### PR TITLE
Support kwargs in rename_dims

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -16,6 +16,7 @@ Features
 * Added keyword argument syntax to :func:`scipp.transform_coords` for more concise user experience in simple single-step transformations `#2670 <https://github.com/scipp/scipp/pull/2670>`_.
 * Generalized :func:`scipp.lookup` to also support non-histogram functions for value lookup, with supported modes "previous" and "nearest".
   Also adding support for custom fill values `#2681 <https://github.com/scipp/scipp/pull/2681>`_.
+* Added possibility to pass keyword arguments to ``rename_dims``, matching the signature of ``rename`` `#2689 <https://github.com/scipp/scipp/pull/2689>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/lib/core/include/scipp/core/element/event_operations.h
+++ b/lib/core/include/scipp/core/element/event_operations.h
@@ -89,7 +89,6 @@ constexpr auto map_linspace =
                        const auto &weights, const auto &fill) {
                  const auto [offset, nbin, factor] = linear_edge_params(edges);
                  const auto bin = (coord - offset) * factor;
-                 using T = std::decay_t<decltype(get(weights, 0))>;
                  return (bin < 0.0 || bin >= nbin) ? fill : get(weights, bin);
                }};
 
@@ -97,7 +96,6 @@ constexpr auto map_sorted_edges =
     overloaded{map, [](const auto &coord, const auto &edges,
                        const auto &weights, const auto &fill) {
                  auto it = std::upper_bound(edges.begin(), edges.end(), coord);
-                 using T = std::decay_t<decltype(get(weights, 0))>;
                  return (it == edges.end() || it == edges.begin())
                             ? fill
                             : get(weights, --it - edges.begin());
@@ -107,7 +105,6 @@ constexpr auto lookup_previous =
     overloaded{map, [](const auto &point, const auto &x, const auto &weights,
                        const auto &fill) {
                  auto it = std::upper_bound(x.begin(), x.end(), point);
-                 using T = std::decay_t<decltype(get(weights, 0))>;
                  return it == x.begin() ? fill : get(weights, --it - x.begin());
                }};
 

--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -255,10 +255,8 @@ Returned by :py:func:`DataArray.masks`)");
   bind_binary<DataArray>(dataset);
   bind_binary<Variable>(dataset);
 
-  dataArray.def("rename_dims", &rename_dims<DataArray>, py::arg("dims_dict"),
-                py::pos_only(), "Rename dimensions.");
-  dataset.def("rename_dims", &rename_dims<Dataset>, py::arg("dims_dict"),
-              py::pos_only(), "Rename dimensions.");
+  dataArray.def("_rename_dims", &rename_dims<DataArray>);
+  dataset.def("_rename_dims", &rename_dims<Dataset>);
 
   m.def(
       "merge",

--- a/lib/python/variable.cpp
+++ b/lib/python/variable.cpp
@@ -89,9 +89,7 @@ Array of values with dimension labels and a unit, optionally including an array
 of variances.)");
 
   bind_init(variable);
-  variable
-      .def("rename_dims", &rename_dims<Variable>, py::arg("dims_dict"),
-           py::pos_only(), "Rename dimensions.")
+  variable.def("_rename_dims", &rename_dims<Variable>)
       .def_property_readonly("dtype", &Variable::dtype)
       .def("__sizeof__",
            [](const Variable &self) {

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -93,7 +93,7 @@ def transform_coords(x: Union[DataArray, Dataset],
       >>> transformed = da.transform_coords('xy', graph={'xy': lambda x, y: x + y})
 
     Multiple new coordinates can be computed at once. Here ``z2`` is setup as an alias
-    of ``z`:
+    of ``z``:
 
       >>> da = sc.data.table_xyz(nrow=10)
       >>> transformed = da.transform_coords(xy=lambda x, y: x + y, z2='z')

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -20,11 +20,14 @@ from .cpp_classes import BinEdgeError, BinnedDataError, CoordError, \
 
 from .._scipp.core import get_slice_params
 
-from .dimensions import _rename_variable, _rename_data_array, _rename_dataset
+from .dimensions import _rename_dims, _rename_variable, _rename_data_array, _rename_dataset
 
+for cls in (Variable, DataArray, Dataset):
+    setattr(cls, 'rename_dims', _rename_dims)
 setattr(Variable, 'rename', _rename_variable)
 setattr(DataArray, 'rename', _rename_data_array)
 setattr(Dataset, 'rename', _rename_dataset)
+del _rename_dims, _rename_variable, _rename_data_array, _rename_dataset, cls
 
 from .bins import _bins, _set_bins
 

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -1,10 +1,55 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Dict
+from typing import Dict, Optional
 
 from .._scipp.core import Variable, DataArray, Dataset, CoordError
+from ..typing import VariableLikeType
 from .dataset import merge
+
+
+def _combine_dims(dims_dict: Optional[Dict[str, str]],
+                  names: Dict[str, str]) -> Dict[str, str]:
+    dims_dict = {} if dims_dict is None else dims_dict
+    if set(dims_dict).intersection(names):
+        raise ValueError(
+            'The names passed in the dict and as keyword arguments must be distinct.'
+            f'Got dims_dict={dims_dict} and kwargs={names}')
+    return {**dims_dict, **names}
+
+
+def _rename_dims(self: VariableLikeType,
+                 dims_dict: Optional[Dict[str, str]] = None,
+                 /,
+                 **names: str) -> VariableLikeType:
+    """Rename dimensions.
+
+    The renaming can be defined:
+
+    - using a dict mapping the old to new names, e.g.
+     ``rename_dims({'x': 'a', 'y': 'b'})``
+    - using keyword arguments, e.g. ``rename_dims(x='a', y='b')``
+
+    In both cases, x is renamed to a and y to b.
+
+    Dimensions not specified in either input are unchanged.
+
+    This function only renames dimensions.
+    See the ``rename`` method to also rename coordinates and attributes.
+
+    Parameters
+    ----------
+    dims_dict:
+        Dictionary mapping old to new names.
+    names:
+        Mapping of old to new names as keyword arguments.
+
+    Returns
+    -------
+    :
+        A new object with renamed dimensions.
+    """
+    return self._rename_dims(_combine_dims(dims_dict, names))
 
 
 def _rename_variable(var: Variable,
@@ -15,8 +60,8 @@ def _rename_variable(var: Variable,
 
     The renaming can be defined:
 
-    - using a dict mapping the old to new names, e.g. rename({'x': 'a', 'y': 'b'})
-    - using keyword arguments, e.g. rename(x='a', y='b')
+    - using a dict mapping the old to new names, e.g. ``rename({'x': 'a', 'y': 'b'})``
+    - using keyword arguments, e.g. ``rename(x='a', y='b')``
 
     In both cases, x is renamed to a and y to b.
 
@@ -33,8 +78,13 @@ def _rename_variable(var: Variable,
     -------
     :
         A new variable with renamed dimensions which shares a buffer with the input.
+
+    See Also
+    --------
+    scipp.Variable.rename_dims:
+        Equivalent for ``Variable`` but differs for ``DataArray`` and ``Dataset``.
     """
-    return var.rename_dims({**({} if dims_dict is None else dims_dict), **names})
+    return var.rename_dims(_combine_dims(dims_dict, names))
 
 
 def _rename_data_array(da: DataArray,
@@ -45,8 +95,8 @@ def _rename_data_array(da: DataArray,
 
     The renaming can be defined:
 
-    - using a dict mapping the old to new names, e.g. rename({'x': 'a', 'y': 'b'})
-    - using keyword arguments, e.g. rename(x='a', y='b')
+    - using a dict mapping the old to new names, e.g. ``rename({'x': 'a', 'y': 'b'})``
+    - using keyword arguments, e.g. ``rename(x='a', y='b')``
 
     In both cases, x is renamed to a and y to b.
 
@@ -64,8 +114,13 @@ def _rename_data_array(da: DataArray,
     :
         A new data array with renamed dimensions, coordinates, and attributes.
         Buffers are shared with the input.
+
+    See Also
+    --------
+    scipp.DataArray.rename_dims:
+        Only rename dimensions, not coordinates and attributes.
     """
-    renaming_dict = {**({} if dims_dict is None else dims_dict), **names}
+    renaming_dict = _combine_dims(dims_dict, names)
     out = da.rename_dims(renaming_dict)
     for old, new in renaming_dict.items():
         if new in out.meta:
@@ -86,8 +141,8 @@ def _rename_dataset(ds: Dataset,
 
     The renaming can be defined:
 
-    - using a dict mapping the old to new names, e.g. rename({'x': 'a', 'y': 'b'})
-    - using keyword arguments, e.g. rename(x='a', y='b')
+    - using a dict mapping the old to new names, e.g. ``rename({'x': 'a', 'y': 'b'})``
+    - using keyword arguments, e.g. ``rename(x='a', y='b')``
 
     In both cases, x is renamed to a and y to b.
 
@@ -105,8 +160,13 @@ def _rename_dataset(ds: Dataset,
     :
         A new dataset with renamed dimensions, coordinates, and attributes.
         Buffers are shared with the input.
+
+    See Also
+    --------
+    scipp.Dataset.rename_dims:
+        Only rename dimensions, not coordinates and attributes.
     """
-    renaming_dict = {**({} if dims_dict is None else dims_dict), **names}
+    renaming_dict = _combine_dims(dims_dict, names)
     ds_from_items = Dataset()
     for key, item in ds.items():
         dims_dict = {old: new for old, new in renaming_dict.items() if old in item.dims}

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -14,7 +14,7 @@ def _combine_dims(dims_dict: Optional[Dict[str, str]],
     if set(dims_dict).intersection(names):
         raise ValueError(
             'The names passed in the dict and as keyword arguments must be distinct.'
-            f'Got dims_dict={dims_dict} and kwargs={names}')
+            f'Got {dims_dict} and {names}')
     return {**dims_dict, **names}
 
 

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -346,6 +346,24 @@ def test_rename_dims():
     assert sc.identical(xy, original)
 
 
+def test_rename_dims_kwargs():
+    values = np.arange(6).reshape(2, 3)
+    xy = sc.Variable(dims=['x', 'y'], values=values)
+    original = xy.copy()
+    zy = sc.Variable(dims=['z', 'y'], values=values)
+    zw = sc.Variable(dims=['z', 'w'], values=values)
+    assert sc.identical(xy.rename_dims(x='z'), zy)
+    assert sc.identical(xy.rename_dims({'y': 'w'}, x='z'), zw)
+    assert sc.identical(xy, original)
+
+
+def test_rename_dims_dict_and_kwargs_must_be_distinct():
+    values = np.arange(6).reshape(2, 3)
+    xy = sc.Variable(dims=['x', 'y'], values=values)
+    with pytest.raises(ValueError):
+        xy.rename_dims({'x': 'w'}, x='z')
+
+
 def test_rename():
     values = np.arange(6).reshape(2, 3)
     xy = sc.Variable(dims=['x', 'y'], values=values)
@@ -358,8 +376,19 @@ def test_rename():
 def test_rename_kwargs():
     values = np.arange(6).reshape(2, 3)
     xy = sc.Variable(dims=['x', 'y'], values=values)
+    original = xy.copy()
     zy = sc.Variable(dims=['z', 'y'], values=values)
+    zw = sc.Variable(dims=['z', 'w'], values=values)
     assert sc.identical(xy.rename(x='z'), zy)
+    assert sc.identical(xy.rename({'y': 'w'}, x='z'), zw)
+    assert sc.identical(xy, original)
+
+
+def test_rename_dict_and_kwargs_must_be_distinct():
+    values = np.arange(6).reshape(2, 3)
+    xy = sc.Variable(dims=['x', 'y'], values=values)
+    with pytest.raises(ValueError):
+        xy.rename({'x': 'w'}, x='z')
 
 
 def test_rename_self_and_dims_dict_are_position_only():


### PR DESCRIPTION
Fixes #2688

Note that this breaks the behaviour of `rename` in that it is no longer allowed to have overlapping and `dims_dict` and `names` arguments. But I think it is unlikely that anyone used it.