### PR TITLE
More accurate sizeof

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -3,6 +3,36 @@
 Release Notes
 =============
 
+v0.16.0 (Unreleased)
+--------------------
+
+Features
+~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Bugfixes
+~~~~~~~~
+
+* Made ``__sizeof__`` and related functions more accurate `#2705 <https://github.com/scipp/scipp/pull/2705>`_.
+
+Documentation
+~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.15.0 (July 2022)
 -------------------
 

--- a/docs/visualization/representations-and-tables.ipynb
+++ b/docs/visualization/representations-and-tables.ipynb
@@ -76,6 +76,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The reported size is only an estimate.\n",
+    "It includes the actual arrays of values as well as (some of) the internal memory used by variables, etc.\n",
+    "See, e.g. [scipp.Variable.underlying_size](https://scipp.github.io/generated/classes/scipp.Variable.html#scipp.Variable.underlying_size)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Note that (as usual) Jupyter only shows the last variable mentioned in a cell:"
    ]
   },
@@ -260,7 +269,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/visualization/representations-and-tables.ipynb
+++ b/docs/visualization/representations-and-tables.ipynb
@@ -269,8 +269,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/lib/dataset/test/size_of_test.cpp
+++ b/lib/dataset/test/size_of_test.cpp
@@ -6,7 +6,10 @@
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/util.h"
 #include "scipp/variable/arithmetic.h"
+#include "scipp/variable/bin_array_model.h"
 #include "scipp/variable/bins.h"
+#include "scipp/variable/element_array_model.h"
+#include "scipp/variable/structure_array_model.h"
 
 using namespace scipp;
 using namespace scipp::dataset;
@@ -18,6 +21,9 @@ protected:
       dims, Values{std::pair{0, 2}, std::pair{2, 2}, std::pair{2, 4}});
   Variable buffer = makeVariable<double>(Dims{Dim::X}, Shape{4});
   Variable var = make_bins(indices, Dim::X, buffer);
+
+  const scipp::index object_size =
+      sizeof(Variable) + sizeof(variable::BinArrayModel<Variable>);
 };
 
 class BinnedDataArraySizeOfTest : public ::testing::Test {
@@ -28,6 +34,9 @@ protected:
   Variable data = makeVariable<double>(Dims{Dim::X}, Shape{4});
   DataArray buffer = DataArray(data, {{Dim::X, data + data}});
   Variable var = make_bins(indices, Dim::X, buffer);
+
+  const scipp::index object_size =
+      sizeof(Variable) + sizeof(variable::BinArrayModel<DataArray>);
 };
 
 class BinnedDatasetSizeOfTest : public ::testing::Test {
@@ -37,40 +46,73 @@ protected:
       dims, Values{std::pair{0, 2}, std::pair{2, 4}});
   Variable column = makeVariable<double>(Dims{Dim::X}, Shape{4});
   Dataset buffer;
+
+  const scipp::index object_size =
+      sizeof(Variable) + sizeof(variable::BinArrayModel<Dataset>);
 };
 
 TEST(SizeOf, variable) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<double>);
+
   auto var = makeVariable<double>(Shape{4}, Dims{Dim::X});
-  EXPECT_EQ(size_of(var, SizeofTag::ViewOnly), sizeof(double) * 4);
-  EXPECT_EQ(size_of(var, SizeofTag::Underlying), sizeof(double) * 4);
+  EXPECT_EQ(size_of(var, SizeofTag::ViewOnly),
+            sizeof(double) * 4 + object_size);
+  EXPECT_EQ(size_of(var, SizeofTag::Underlying),
+            sizeof(double) * 4 + object_size);
 
   auto var_with_variance = makeVariable<double>(
       Shape{1, 2}, Dims{Dim::X, Dim::Y}, Values{3, 4}, Variances{1, 2});
 
   EXPECT_EQ(size_of(var_with_variance, SizeofTag::ViewOnly),
-            sizeof(double) * 4);
+            sizeof(double) * 4 + object_size);
   EXPECT_EQ(size_of(var_with_variance, SizeofTag::Underlying),
-            sizeof(double) * 4);
+            sizeof(double) * 4 + object_size);
+}
+
+TEST(SizeOf, sliced_variable) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<Variable>);
+
+  auto var = makeVariable<double>(Shape{4}, Dims{Dim::X});
+  auto sliced_view = var.slice(Slice(Dim::X, 0, 2));
+  EXPECT_EQ(size_of(sliced_view, SizeofTag::ViewOnly),
+            2 * sizeof(double) + object_size);
+  EXPECT_EQ(size_of(sliced_view, SizeofTag::Underlying),
+            4 * sizeof(double) + object_size);
 }
 
 TEST(SizeOf, variable_of_vector3) {
+  const auto object_size =
+      sizeof(Variable) +
+      sizeof(variable::StructureArrayModel<Eigen::Vector3d, double>) +
+      sizeof(variable::ElementArrayModel<double>);
+
   auto var = makeVariable<Eigen::Vector3d>(Shape{1, 1}, Dims{Dim::X, Dim::Y});
-  EXPECT_EQ(size_of(var, SizeofTag::ViewOnly), sizeof(Eigen::Vector3d));
-  EXPECT_EQ(size_of(var, SizeofTag::Underlying), sizeof(Eigen::Vector3d));
+  EXPECT_EQ(size_of(var, SizeofTag::ViewOnly),
+            sizeof(Eigen::Vector3d) + object_size);
+  EXPECT_EQ(size_of(var, SizeofTag::Underlying),
+            sizeof(Eigen::Vector3d) + object_size);
 }
 
 TEST(SizeOf, variable_of_short_string) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<std::string>);
+
   const auto var =
       makeVariable<std::string>(Shape{1}, Dims{Dim::X}, Values{"short"});
-  const auto expected_size = sizeof(std::string);
+  const auto expected_size = sizeof(std::string) + object_size;
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly), expected_size);
   EXPECT_EQ(size_of(var, SizeofTag::Underlying), expected_size);
 }
 
 TEST(SizeOf, variable_of_long_string) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<std::string>);
+
   const std::string str = "A rather long string that is hopefully on the heap";
   ASSERT_GT(str.size(), sizeof(std::string));
-  const auto expected_size = sizeof(std::string) + str.size();
+  const auto expected_size = sizeof(std::string) + str.size() + object_size;
   const auto var =
       makeVariable<std::string>(Shape{1}, Dims{Dim::X}, Values{str});
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly), expected_size);
@@ -78,10 +120,14 @@ TEST(SizeOf, variable_of_long_string) {
 }
 
 TEST(SizeOf, variable_of_three_strings) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<std::string>);
+
   const std::string str0 = "A rather long string that is hopefully on the heap";
   const std::string str1;
   const std::string str2 = "short";
-  const auto expected_size = 3 * sizeof(std::string) + str0.size();
+  const auto expected_size =
+      3 * sizeof(std::string) + str0.size() + object_size;
   const auto var = makeVariable<std::string>(Shape{3}, Dims{Dim::X},
                                              Values{str0, str1, str2});
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly), expected_size);
@@ -89,6 +135,9 @@ TEST(SizeOf, variable_of_three_strings) {
 }
 
 TEST(SizeOf, variable_of_three_strings_slice) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<std::string>);
+
   const std::string str0 = "A rather long string that is hopefully on the heap";
   const std::string str1;
   const std::string str2 = "short";
@@ -96,30 +145,37 @@ TEST(SizeOf, variable_of_three_strings_slice) {
                                               Values{str0, str1, str2});
   const auto var1 = full.slice({Dim::X, 0, 2});
   EXPECT_EQ(size_of(var1, SizeofTag::ViewOnly),
-            2 * sizeof(std::string) + str0.size());
+            2 * sizeof(std::string) + str0.size() + object_size);
   EXPECT_EQ(size_of(var1, SizeofTag::Underlying),
-            3 * sizeof(std::string) + str0.size());
+            3 * sizeof(std::string) + str0.size() + object_size);
   const auto var2 = full.slice({Dim::X, 1, 3});
-  EXPECT_EQ(size_of(var2, SizeofTag::ViewOnly), 2 * sizeof(std::string));
+  EXPECT_EQ(size_of(var2, SizeofTag::ViewOnly),
+            2 * sizeof(std::string) + object_size);
   EXPECT_EQ(size_of(var2, SizeofTag::Underlying),
-            3 * sizeof(std::string) + str0.size());
+            3 * sizeof(std::string) + str0.size() + object_size);
   const auto var3 = full.slice({Dim::X, 1, 1});
-  EXPECT_EQ(size_of(var3, SizeofTag::ViewOnly), 0);
+  EXPECT_EQ(size_of(var3, SizeofTag::ViewOnly), object_size);
   EXPECT_EQ(size_of(var3, SizeofTag::Underlying),
-            3 * sizeof(std::string) + str0.size());
+            3 * sizeof(std::string) + str0.size() + object_size);
 }
 
 TEST(SizeOf, variable_of_variable) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<Variable>);
+
   const auto inner =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto outer = makeVariable<Variable>(Shape{}, Values{inner});
   EXPECT_EQ(size_of(outer, SizeofTag::ViewOnly),
-            size_of(inner, SizeofTag::ViewOnly));
+            size_of(inner, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(outer, SizeofTag::Underlying),
-            size_of(inner, SizeofTag::Underlying));
+            size_of(inner, SizeofTag::Underlying) + object_size);
 }
 
 TEST(SizeOf, slice_of_variable_of_variables) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<Variable>);
+
   const auto inner1 =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto inner2 =
@@ -128,12 +184,15 @@ TEST(SizeOf, slice_of_variable_of_variables) {
       makeVariable<Variable>(Dims{Dim::Y}, Shape{2}, Values{inner1, inner2});
   const auto sliced = outer.slice({Dim::Y, 1, 2});
   EXPECT_EQ(size_of(sliced, SizeofTag::ViewOnly),
-            size_of(inner2, SizeofTag::ViewOnly));
+            size_of(inner2, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(sliced, SizeofTag::Underlying),
             size_of(outer, SizeofTag::Underlying));
 }
 
 TEST(SizeOf, variable_of_sliced_variables) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<Variable>);
+
   const auto inner1 =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3});
   const auto sliced_inner1 = inner1.slice({Dim::X, 0, 2});
@@ -143,52 +202,64 @@ TEST(SizeOf, variable_of_sliced_variables) {
                                             Values{sliced_inner1, inner2});
   EXPECT_EQ(size_of(outer, SizeofTag::ViewOnly),
             size_of(sliced_inner1, SizeofTag::ViewOnly) +
-                size_of(inner2, SizeofTag::ViewOnly));
+                size_of(inner2, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(outer, SizeofTag::Underlying),
             size_of(inner1, SizeofTag::Underlying) +
-                size_of(inner2, SizeofTag::Underlying));
+                size_of(inner2, SizeofTag::Underlying) + object_size);
 }
 
 TEST(SizeOf, variable_of_data_array) {
+  const auto object_size =
+      sizeof(Variable) + sizeof(variable::ElementArrayModel<Variable>);
+
   const auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
   const auto coord =
       makeVariable<int64_t>(Dims{Dim::X}, Shape{3}, Values{0, 1, 2});
   const DataArray da(data, {{Dim::X, coord}});
   const auto outer = makeVariable<DataArray>(Shape{}, Values{da});
   EXPECT_EQ(size_of(outer, SizeofTag::ViewOnly),
-            size_of(da, SizeofTag::ViewOnly));
+            size_of(da, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(outer, SizeofTag::Underlying),
-            size_of(da, SizeofTag::Underlying));
+            size_of(da, SizeofTag::Underlying) + object_size);
 }
 
-TEST(SizeOf, sliced_variable) {
-  auto var = makeVariable<double>(Shape{4}, Dims{Dim::X});
-  auto sliced_view = var.slice(Slice(Dim::X, 0, 2));
-  EXPECT_EQ(size_of(sliced_view, SizeofTag::ViewOnly), 2 * sizeof(double));
-  EXPECT_EQ(size_of(sliced_view, SizeofTag::Underlying), 4 * sizeof(double));
+TEST(SizeOf, data_array) {
+  const auto object_size = sizeof(DataArray) + sizeof(dataset::Coords) +
+                           sizeof(dataset::Attrs) + sizeof(dataset::Masks);
+
+  const auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0, 1});
+  const auto coord =
+      makeVariable<int64_t>(Dims{Dim::X}, Shape{3}, Values{0, 1, 2});
+  const DataArray da(data, {{Dim::X, coord}});
+  EXPECT_EQ(size_of(da, SizeofTag::ViewOnly),
+            size_of(data, SizeofTag::ViewOnly) +
+                size_of(coord, SizeofTag::ViewOnly) + object_size);
+  EXPECT_EQ(size_of(da, SizeofTag::Underlying),
+            size_of(data, SizeofTag::Underlying) +
+                size_of(coord, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedVariableSizeOfTest, size_in_memory_of_bucketed_variable) {
+TEST_F(BinnedVariableSizeOfTest, full_variable) {
   const auto &[indices_, dim_, buffer_] = var.constituents<Variable>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(var, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedVariableSizeOfTest, size_in_memory_of_sliced_bucketed_variable) {
+TEST_F(BinnedVariableSizeOfTest, sliced_variable) {
   auto slice = var.slice(Slice(Dim::Y, 0, 1));
   const auto &[indices_, dim_, buffer_] = slice.constituents<Variable>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(slice, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) * 0.5 +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(slice, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
 TEST_F(BinnedVariableSizeOfTest, empty_buffer) {
@@ -196,49 +267,49 @@ TEST_F(BinnedVariableSizeOfTest, empty_buffer) {
   const auto &[indices_, dim_, buffer_] = empty.constituents<Variable>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(empty, SizeofTag::ViewOnly),
-            size_of(indices_, SizeofTag::ViewOnly));
+            size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(empty, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedDataArraySizeOfTest, size_in_memory_of_bucketed_variable) {
+TEST_F(BinnedDataArraySizeOfTest, full_variable) {
   const auto &[indices_, dim_, buffer_] = var.constituents<DataArray>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(var, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedDataArraySizeOfTest, size_in_memory_of_sliced_bucketed_variable) {
+TEST_F(BinnedDataArraySizeOfTest, sliced_variable) {
   auto slice = var.slice(Slice(Dim::Y, 0, 1));
   const auto &[indices_, dim_, buffer_] = slice.constituents<DataArray>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(slice, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) * 0.5 +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(slice, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedDatasetSizeOfTest, size_in_memory_of_bucketed_variable) {
+TEST_F(BinnedDatasetSizeOfTest, full_variable) {
   buffer.setCoord(Dim::X, column);
   Variable var = make_bins(indices, Dim::X, buffer);
   const auto &[indices_, dim_, buffer_] = var.constituents<Dataset>();
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(var, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(var, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }
 
-TEST_F(BinnedDatasetSizeOfTest, size_in_memory_of_sliced_bucketed_variable) {
+TEST_F(BinnedDatasetSizeOfTest, sliced_variable) {
   buffer.setCoord(Dim::X, column);
   Variable var = make_bins(indices, Dim::X, buffer);
   auto slice = var.slice(Slice(Dim::Y, 0, 1));
@@ -246,8 +317,8 @@ TEST_F(BinnedDatasetSizeOfTest, size_in_memory_of_sliced_bucketed_variable) {
   EXPECT_EQ(dim_, Dim::X);
   EXPECT_EQ(size_of(slice, SizeofTag::ViewOnly),
             size_of(buffer_, SizeofTag::ViewOnly) * 0.5 +
-                size_of(indices_, SizeofTag::ViewOnly));
+                size_of(indices_, SizeofTag::ViewOnly) + object_size);
   EXPECT_EQ(size_of(slice, SizeofTag::Underlying),
             size_of(buffer_, SizeofTag::Underlying) +
-                size_of(indices_, SizeofTag::Underlying));
+                size_of(indices_, SizeofTag::Underlying) + object_size);
 }

--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -7,7 +7,6 @@
 #include "scipp/dataset/map_view.h"
 #include "scipp/dataset/math.h"
 #include "scipp/dataset/rebin.h"
-#include "scipp/dataset/util.h"
 
 #include "bind_data_access.h"
 #include "bind_data_array.h"
@@ -172,14 +171,6 @@ Returned by :py:func:`DataArray.masks`)");
               Name of the data array.
           )doc");
   options.enable_function_signatures();
-  dataArray
-      .def("__sizeof__",
-           [](const DataArray &array) {
-             return size_of(array, SizeofTag::ViewOnly, true);
-           })
-      .def("underlying_size", [](const DataArray &self) {
-        return size_of(self, SizeofTag::Underlying);
-      });
 
   bind_data_array(dataArray);
 
@@ -227,14 +218,7 @@ Returned by :py:func:`DataArray.masks`)");
       .def("__delitem__", &Dataset::erase,
            py::call_guard<py::gil_scoped_release>())
       .def("clear", &Dataset::clear,
-           R"(Removes all data, preserving coordinates.)")
-      .def("__sizeof__",
-           [](const Dataset &self) {
-             return size_of(self, SizeofTag::ViewOnly);
-           })
-      .def("underlying_size", [](const Dataset &self) {
-        return size_of(self, SizeofTag::Underlying);
-      });
+           R"(Removes all data, preserving coordinates.)");
 
   bind_dataset_view_methods(dataset);
   bind_dict_update(dataset,

--- a/lib/python/variable.cpp
+++ b/lib/python/variable.cpp
@@ -18,7 +18,6 @@
 #include "scipp/variable/variable_factory.h"
 
 #include "scipp/dataset/dataset.h"
-#include "scipp/dataset/util.h"
 
 #include "bind_data_access.h"
 #include "bind_operators.h"
@@ -90,14 +89,7 @@ of variances.)");
 
   bind_init(variable);
   variable.def("_rename_dims", &rename_dims<Variable>)
-      .def_property_readonly("dtype", &Variable::dtype)
-      .def("__sizeof__",
-           [](const Variable &self) {
-             return size_of(self, SizeofTag::ViewOnly);
-           })
-      .def("underlying_size", [](const Variable &self) {
-        return size_of(self, SizeofTag::Underlying);
-      });
+      .def_property_readonly("dtype", &Variable::dtype);
 
   bind_common_operators(variable);
 

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -102,6 +102,7 @@ public:
   [[nodiscard]] scipp::index dtype_size() const override {
     return sizeof(scipp::index_pair);
   }
+  scipp::index object_size() const override { return sizeof(*this); }
 
   void setVariances(const Variable &) override {
     except::throw_cannot_have_variances(core::dtype<core::bin<T>>);

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -109,6 +109,7 @@ public:
   }
 
   scipp::index dtype_size() const override { return sizeof(T); }
+  scipp::index object_size() const override { return sizeof(*this); }
   const VariableConceptHandle &bin_indices() const override {
     throw except::TypeError("This data type does not have bin indices.");
   }

--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -84,6 +84,9 @@ public:
   VariableConceptHandle elements() const { return m_elements; }
 
   scipp::index dtype_size() const override { return sizeof(T); }
+  scipp::index object_size() const override {
+    return sizeof(*this) + m_elements->object_size();
+  }
   const VariableConceptHandle &bin_indices() const override {
     throw except::TypeError("This data type does not have bin indices.");
   }

--- a/lib/variable/include/scipp/variable/variable_concept.h
+++ b/lib/variable/include/scipp/variable/variable_concept.h
@@ -56,6 +56,7 @@ public:
   virtual void copy(const Variable &src, Variable &&dest) const = 0;
   virtual void assign(const VariableConcept &other) = 0;
   virtual scipp::index dtype_size() const = 0;
+  virtual scipp::index object_size() const = 0;
 
   virtual const VariableConceptHandle &bin_indices() const = 0;
 


### PR DESCRIPTION
Fixes #2677

Changes:
- recurses into variables, data arrays, datasets stored in variables
- calculates the actual length of strings
- includes the size of the object (e.g. variable) itself. This makes the display less intuitive but more accurate. Especially considering that `sys.getsizeof(var)` is closer to the actual used memory.