### PR TITLE
Fix `table` for a number of dtypes and other problems

### DIFF
--- a/src/scipp/html/table.py
+++ b/src/scipp/html/table.py
@@ -17,10 +17,13 @@ def _string_in_cell(v: Variable) -> str:
         return f'len={v.value.shape}'
     if v.dtype not in (DType.float32, DType.float64):
         return str(v.value)
-    if (v.variance is None) or (v.variance == 0):
+    if (v.variance is None):
         return str(round(v.value, 3))
     err = np.sqrt(v.variance)
-    prec = -int(np.floor(np.log10(err)))
+    if err == 0.0:
+        prec = 3
+    else:
+        prec = -int(np.floor(np.log10(err)))
     v_str = round(v.value, prec)
     e_str = round(err, prec)
     return f'{v_str}&plusmn;{e_str}'

--- a/src/scipp/html/table.py
+++ b/src/scipp/html/table.py
@@ -15,7 +15,7 @@ BOTTOM_BORDER = 'border-bottom:2px solid #a9a9a9;'
 def _string_in_cell(v: Variable) -> str:
     if v.bins is not None:
         return f'len={v.value.shape}'
-    if v.dtype in (DType.vector3, DType.string, DType.bool):
+    if v.dtype not in (DType.float32, DType.float64):
         return str(v.value)
     if (v.variance is None) or (v.variance == 0):
         return str(round(v.value, 3))

--- a/src/scipp/html/table.py
+++ b/src/scipp/html/table.py
@@ -18,15 +18,13 @@ def _string_in_cell(v: Variable) -> str:
     if v.dtype not in (DType.float32, DType.float64):
         return str(v.value)
     if (v.variance is None):
-        return str(round(v.value, 3))
+        return f'{v.value:.3f}'
     err = np.sqrt(v.variance)
     if err == 0.0:
         prec = 3
     else:
-        prec = -int(np.floor(np.log10(err)))
-    v_str = round(v.value, prec)
-    e_str = round(err, prec)
-    return f'{v_str}&plusmn;{e_str}'
+        prec = max(3, -int(np.floor(np.log10(err))))
+    return f'{v.value:.{prec}f}&plusmn;{err:.{prec}f}'
 
 
 def _var_name_with_unit(name: str, var: Variable) -> str:

--- a/tests/html/table_test.py
+++ b/tests/html/table_test.py
@@ -38,6 +38,11 @@ def test_table_variable_vector():
     sc.table(sc.vectors(dims=['x'], values=np.arange(30.).reshape(10, 3)))
 
 
+def test_table_variable_datetime():
+    col = sc.epoch(unit='s') + sc.arange('time', 4, unit='s')
+    sc.table(col)
+
+
 @pytest.mark.parametrize("with_all", [True, False])
 @pytest.mark.parametrize("dtype", [sc.DType.float64, sc.DType.int64])
 @pytest.mark.parametrize("unit", ['dimensionless', 'counts', 's'])

--- a/tests/html/table_test.py
+++ b/tests/html/table_test.py
@@ -30,6 +30,11 @@ def test_table_variable(variances, dtype, unit):
     sc.table(var['xx', 1:10])
 
 
+def test_column_with_zero_variance():
+    col = sc.zeros(dims=['row'], shape=(4,), with_variances=True)
+    sc.table(col)
+
+
 def test_table_variable_strings():
     sc.table(sc.array(dims=['x'], values=list(map(chr, range(97, 123)))))
 

--- a/tests/html/table_test.py
+++ b/tests/html/table_test.py
@@ -38,6 +38,12 @@ def test_table_variable_vector():
     sc.table(sc.vectors(dims=['x'], values=np.arange(30.).reshape(10, 3)))
 
 
+def test_table_variable_linear_transform():
+    col = sc.spatial.linear_transforms(dims=['x'],
+                                       values=np.arange(90.).reshape(10, 3, 3))
+    sc.table(col)
+
+
 def test_table_variable_datetime():
     col = sc.epoch(unit='s') + sc.arange('time', 4, unit='s')
     sc.table(col)

--- a/tests/html/table_test.py
+++ b/tests/html/table_test.py
@@ -31,7 +31,7 @@ def test_table_variable(variances, dtype, unit):
 
 
 def test_column_with_zero_variance():
-    col = sc.zeros(dims=['row'], shape=(4,), with_variances=True)
+    col = sc.zeros(dims=['row'], shape=(4, ), with_variances=True)
     sc.table(col)
 
 


### PR DESCRIPTION
Fixes #2706.

- Fixes for various non-float dtypes.
- Do not hide variance if it is exactly zero.
- Fix alignment issues by not dropping trailing zeros.

Alignment before:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/12912489/179904738-d108bdcd-74ee-48a9-9ccd-a43e8984b643.png">

Alignment after:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/12912489/179904801-bd6de88e-eb06-4ab6-b3ff-95e1ff673c17.png">
