### PR TITLE
Do not mention explicit variable size in docs

### DIFF
--- a/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
+++ b/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "Slices or other views of variables are also of type `Variable` and all views share ownership of the underlying data.\n",
     "\n",
-    "If a variable refers only to a section of the underlying data buffer this is indicated in the HTML view in the title line as part of the size, here *\"16 Bytes out of 96 Bytes\"*.\n",
+    "If a variable refers only to a section of the underlying data buffer this is indicated in the HTML view in the title line as part of the size (*\"x Bytes out of y Bytes\"*).\n",
     "This allows for identification of \"small\" variables that keep alive potentially large buffers:"
    ]
   },


### PR DESCRIPTION
Addresses https://github.com/scipp/scipp/pull/2705#issuecomment-1191057954

I removed the explicit number because they depend on the image the docs are built on and implementation details of `Variable`.