### PR TITLE
Overhaul docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,5 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
-        args: ["--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'",
-               "--strip-empty-cells"]
+        args: ["--strip-empty-cells",
+               "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'"]

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -4,24 +4,49 @@ What is Scipp?
 ==============
 
 Scipp is the result of a long evolution of packages for scientific computing in Python.
-`NumPy <https://numpy.org/>`_, the fundamental package for scientific computing in Python providing a multidimensional array object, sits at the core of this evolution.
-On top of this libraries such as `SciPy <https://scipy.org/>`_, `Pandas <https://pandas.pydata.org/>`, and `Xarray <https://docs.xarray.dev>`_ provide more advanced functionality and user convenience.
+`NumPy <https://numpy.org/>`_, the fundamental package for scientific computing in Python providing a multi-dimensional array object, sits at the core of this evolution.
+On top of this, libraries such as `SciPy <https://scipy.org/>`_, `Pandas <https://pandas.pydata.org/>`_, and `Xarray <https://docs.xarray.dev>`_ provide more advanced functionality and user convenience.
 
-Scipp's central ambition is to make scientific computing **safe** and **intuitive**.
-Safety, i.e., correctness of scientific results, is crucial given the rapidly growing complexity of scientific data and data analysis.
+Scipp's central ambition is to make scientific data analysis **safer** and **intuitive**.
+Safety, i.e., avoidance, detection, and prevention of mistakes, is crucial given the rapidly growing complexity of scientific data and data analysis.
 At the same time it has to be ensured that scientific results are reproducible.
-Open data alone is not sufficient if it is analysed using "black-box"-like applications that do not let the user, referee, or other scientists re-run the analysis or inspect and understand each processing step.
+For reproducible results, open data must be complemented by open and non-cryptic analysis scripts.
+This enables the user, the referee, or other scientists to re-run the analysis or to inspect and understand each processing step.
 
 Scipp aims to achieve its ambition in multiple ways:
 
-- A concise and intuitive "language" (programming interface) allows the user to clearly express their intent, and makes this intent apparent to future readers of the code.
+- A concise and intuitive "language" (programming interface) allows the user to clearly express their intent and makes this intent apparent to future readers of the code.
   For example, *named dimensions* remove the need for cryptic axis indices or explicit array transposition and broadcasting.
-- Coordinate arrays associated with an array of data ensure that no incompatible data is combined and allow for direct creation of meaningful plots with labelled axes.
+- Coordinate arrays associated with an array of data ensure that no incompatible data is combined and allow for direct creation of meaningful plots with labeled axes.
 - Physical units associated with all arrays as well as their coordinate arrays eliminate a whole set of potential errors.
   This includes the risk of combining data with different units (such as adding "meters" and "seconds") or unit scales (such as adding "meters" and "millimeters").
+- *Binned data* provides an efficient and powerful multi-dimensional view of tabular data.
+  This unifies the flexibility of working with such record-based data with the same concise, intuitive, and safe interface that Scipp provides for dense arrays.
 - Features targeting `Jupyter <https://jupyter.org/>`_, such as rich HTML visualizations of data, give the user the tools to understand their data at every step and share their work with collaborators.
 
-Scipp's core is written in C++ with multi-threading enabled by default, providing good out-of-the-box performance for many applications.
+Scipp comes multi-threading enabled by default, providing good out-of-the-box performance for many applications.
+
+
+What Scipp is not
+-----------------
+
+Scipp is not intended for simulations or HPC applications which often require highly specialized and performant code.
+Scipp also does not target machine learning applications.
+
+
+Comparison with other software
+------------------------------
+
+- `Pandas <https://pandas.pydata.org/>` is a mature and extremely powerful package if you are mainly working with tabular 1-D data.
+  Compared with Scipp it lacks support for multi-dimensional labeled data, binned data, and physical units.
+- `Xarray <https://docs.xarray.dev>`_ supports multi-dimensional labeled data similar to Scipp, but is considerably more mature.
+  Compared with Scipp it lacks support for binned data and physical units.
+  Experimental support for physical units using `Pint <https://pint.readthedocs.io>`_ is available with `pint-xarray <https://pint-xarray.readthedocs.io>`_.
+  Xarray comes with `Dask <https://www.dask.org/>`_ support for highly scalable parallel computing.
+- `Awkward Array <https://awkward-array.readthedocs.io>`_ is a powerful package for nested, variable-sized data.
+  Its support for records is similar to Scipp's binned data.
+  Compared with Scipp it lacks support for multi-dimensional labeled data and physical units.
+  It may be combined with Xarray (and Pint) to achieve this, but support for multi-dimensional binning operations may be lacking.
 
 
 The data array concept

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -16,7 +16,7 @@ Scipp aims to achieve its ambition in multiple ways:
 
 - A concise and intuitive "language" (programming interface) allows the user to clearly express their intent, and makes this intent apparent to future readers of the code.
   For example, *named dimensions* remove the need for cryptic axis indices or explicit array transposition and broadcasting.
-- Coordinate arrays associated with and array of data ensure that no incompatible data is combined and allow for direct creation of meaning plots with labelled axis tick marks.
+- Coordinate arrays associated with an array of data ensure that no incompatible data is combined and allow for direct creation of meaningful plots with labelled axes.
 - Physical units associated with all arrays as well as their coordinate arrays eliminate a whole set of potential errors.
   This includes the risk of combining data with different units (such as adding "meters" and "seconds") or unit scales (such as adding "meters" and "millimeters").
 - Features targeting `Jupyter <https://jupyter.org/>`_, such as rich HTML visualizations of data, give the user the tools to understand their data at every step and share their work with collaborators.

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -1,7 +1,7 @@
 .. _overview:
 
-Overview
-========
+What is Scipp?
+==============
 
 The data array concept
 ----------------------

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -3,10 +3,31 @@
 What is Scipp?
 ==============
 
+Scipp is the result of a long evolution of packages for scientific computing in Python.
+`NumPy <https://numpy.org/>`_, the fundamental package for scientific computing in Python providing a multidimensional array object, sits at the core of this evolution.
+On top of this libraries such as `SciPy <https://scipy.org/>`_, `Pandas <https://pandas.pydata.org/>`, and `Xarray <https://docs.xarray.dev>`_ provide more advanced functionality and user convenience.
+
+Scipp's central ambition is to make scientific computing **safe** and **intuitive**.
+Safety, i.e., correctness of scientific results, is crucial given the rapidly growing complexity of scientific data and data analysis.
+At the same time it has to be ensured that scientific results are reproducible.
+Open data alone is not sufficient if it is analysed using "black-box"-like applications that do not let the user, referee, or other scientists re-run the analysis or inspect and understand each processing step.
+
+Scipp aims to achieve its ambition in multiple ways:
+
+- A concise and intuitive "language" (programming interface) allows the user to clearly express their intent, and makes this intent apparent to future readers of the code.
+  For example, *named dimensions* remove the need for cryptic axis indices or explicit array transposition and broadcasting.
+- Coordinate arrays associated with and array of data ensure that no incompatible data is combined and allow for direct creation of meaning plots with labelled axis tick marks.
+- Physical units associated with all arrays as well as their coordinate arrays eliminate a whole set of potential errors.
+  This includes the risk of combining data with different units (such as adding "meters" and "seconds") or unit scales (such as adding "meters" and "millimeters").
+- Features targeting `Jupyter <https://jupyter.org/>`_, such as rich HTML visualizations of data, give the user the tools to understand their data at every step and share their work with collaborators.
+
+Scipp's core is written in C++ with multi-threading enabled by default, providing good out-of-the-box performance for many applications.
+
+
 The data array concept
 ----------------------
 
-The core data structure of scipp is :py:class:`scipp.DataArray`.
+The core data structure of Scipp is :py:class:`scipp.DataArray`.
 A data array is essentially a multi-dimensional array with associated dicts of coordinates, masks, and attributes.
 For a more detailed explanation we refer to the `documentation of DataArray <../user-guide/data-structures.rst#DataArray>`_.
 
@@ -24,27 +45,12 @@ A dataset is essentially a dict-like container of data arrays with common associ
 Physical units
 --------------
 
-Data in a data array as well as coordinates are associated with a physical unit.
-The unit is accessed using the ``unit`` property.
+Data in a data array as well as its coordinates are associated with physical units.
 All operations take the unit into account:
 
 - Operations fail if the units of coordinates do not match.
 - Operations such as addition fail if the units of the data items do not match.
-- Operations such as multiplication produce an output dataset with a new unit for each data item, e.g., :math:`m^{2}` results from multiplication of two data items with unit :math:`m`.
-
-
-Variances and propagation of uncertainties
-------------------------------------------
-
-Data in a data array as well as coordinates support optional variances in addition to their values.
-The variances are accessed using the ``variances`` property and have the same shape and dtype as the ``values`` array.
-All operations take the variances into account:
-
-- Operations fail if the variances of coordinates are not identical, element by element.
-  For the future, we are considering supporting inexact matching based on variances of coordinates but currently this is not implemented.
-- Operations such as addition or multiplication propagate the errors to the output.
-  An overview of the method can be found in `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty>`_.
-  The implemented mechanism assumes uncorrelated data.
+- Operations such as multiplication produce an output with a new unit, e.g., :math:`m^{2}` results from multiplication of two inputs with unit :math:`m`.
 
 
 Scattered data (event data)
@@ -76,3 +82,20 @@ Bin-edge coordinates are handled naturally by operations with datasets.
 Most operations on individual data elements are unaffected.
 Other operations such as ``concat`` take the edges into account and ensure that the resulting concatenated edge coordinate is well-defined.
 There are also a number of operations specific to data with bin-edges, such as ``rebin``.
+
+
+Variances and propagation of uncertainties
+------------------------------------------
+
+Scipp provides basic features for propagation of uncertainties through operations.
+Scipp has no way of tracking correlations so this feature has its limitations and may be effectively useless for certain applications.
+
+Data in a data array support optional variances in addition to their values.
+The variances are accessed using the ``variances`` property and have the same shape and dtype as the ``values`` array.
+All operations take the variances into account:
+
+- Operations fail if the variances of coordinates are not identical, element by element.
+  For the future, we are considering supporting inexact matching based on variances of coordinates but currently this is not implemented.
+- Operations such as addition or multiplication propagate the errors to the output.
+  An overview of the method can be found in `Wikipedia: Propagation of uncertainty <https://en.wikipedia.org/wiki/Propagation_of_uncertainty>`_.
+  The implemented mechanism assumes uncorrelated data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,7 +79,7 @@ Depending on your area of application you may be most interested in `Binned Data
 `GroupBy <user-guide/groupby.rst>`_, or
 `Masking <user-guide/masking.rst>`_.
 The combination of these features is what sets Scipp apart from other Python libraries.
-Make sure to also checkout `Representations and Tables <visualization/representations-and-tables.rst>`_ and `Plotting Overview <visualization/plotting-overview.rst>`_ for an overview of Scipp's powerful visualization features.
+Make sure to also check out `Representations and Tables <visualization/representations-and-tables.rst>`_ and `Plotting Overview <visualization/plotting-overview.rst>`_ for an overview of Scipp's powerful visualization features.
 
 The **Reference** documentation section provides a detailed listing of all functions and classes of Scipp, as well as some more technical documentation.
 If you are looking for something in particular, use the **Search the docs** function in the left navigation panel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,10 +75,8 @@ that are not answered by these documentation pages.
 This space can be used to both search through problems already met/solved in the community
 and open new discussions if none of the existing ones provide a satisfactory answer.
 
-Documentation
-=============
-
 .. toctree::
+   :hidden:
    :caption: Getting Started
    :maxdepth: 3
 
@@ -88,6 +86,7 @@ Documentation
    getting-started/faq
 
 .. toctree::
+   :hidden:
    :caption: User Guide
    :maxdepth: 3
 
@@ -103,6 +102,7 @@ Documentation
    user-guide/tips-tricks-and-anti-patterns
 
 .. toctree::
+   :hidden:
    :caption: Visualization
    :maxdepth: 3
 
@@ -111,6 +111,7 @@ Documentation
    visualization/plotting-in-depth
 
 .. toctree::
+   :hidden:
    :caption: Reference
    :maxdepth: 3
 
@@ -128,6 +129,7 @@ Documentation
    reference/developer-documentation
 
 .. toctree::
+   :hidden:
    :caption: Tutorials
    :maxdepth: 3
 
@@ -135,6 +137,7 @@ Documentation
    tutorials/solar_flares
 
 .. toctree::
+   :hidden:
    :caption: About
    :maxdepth: 3
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,8 +37,8 @@ scipp - Multi-dimensional data arrays with labeled dimensions
 **scipp** is heavily inspired by `xarray <https://xarray.pydata.org>`_.
 It enriches raw NumPy-like multi-dimensional arrays of data by adding named dimensions and associated coordinates.
 Multiple arrays can be combined into datasets.
-While for many applications xarray is certainly more suitable (and definitely much more matured) than scipp, there is a number of features missing in other situations.
-If your use case requires one or several of the items on the following list, using scipp may be worth considering:
+While for many applications xarray is certainly more suitable (and definitely much more matured) than Scipp, there is a number of features missing in other situations.
+If your use case requires one or several of the items on the following list, using Scipp may be worth considering:
 
 - **Physical units** are stored with each data or coord array and are handled in arithmetic operations.
 - **Propagation of uncertainties**.
@@ -48,9 +48,9 @@ If your use case requires one or several of the items on the following list, usi
 - Support for **masks stored with data**.
 - Internals written in C++ for better performance (for certain applications), in combination with Python bindings.
 
-Generic functionality of scipp is provided in the **scipp** Python package.
+Generic functionality of Scipp is provided in the **scipp** Python package.
 In addition, more specific functionality is made available in other packages.
-Examples for this are `scippneutron <https://scipp.github.io/scippneutron>`_ for handling data from neutron-scattering experiments,
+Examples for this are `scippnexus <https://scipp.github.io/scippnexus>`_ for loading NeXus files, `scippneutron <https://scipp.github.io/scippneutron>`_ for handling data from neutron-scattering experiments,
 and `ess <https://scipp.github.io/ess>`_ for dealing with the specifics of neutron instruments at ESS.
 
 News
@@ -58,11 +58,31 @@ News
 
 - [|SCIPP_RELEASE_MONTH|] scipp-|SCIPP_VERSION| `has been released <about/release-notes.rst>`_.
   Check out the `What's new <about/whats-new.rst>`_ notebook for an overview of recent highlights and major changes.
+- Is your data stored in NeXus files?
+  Checkout our new project `scippnexus <https://scipp.github.io/scippnexus>`_, a h5py-like utility for conveniently loading NeXus classes into Scipp data structures.
 - We now provide ``pip`` packages of ``scipp``, in addition to ``conda`` packages.
   See `installation <getting-started/installation.rst#Pip>`_ for details.
 - Scipp changed from GPLv3 to the more permissive BSD-3 license which fits better into the Python eco system.
 - Looking for ``scipp.neutron``?
   This submodule has been moved into its own package, `scippneutron <https://scipp.github.io/scippneutron>`_.
+
+Lost? New to Scipp? Start Here!
+-------------------------------
+
+The **Getting Started** section motivates Scipp in `What is Scipp? <getting-started/overview.rst>`_, provides installation instructions in `Installation <getting-started/installation>`_, and gives a brief overview in `Quick start <getting-started/quick-start>`_.
+
+The **User Guide** provides a high-level overview of the most important Scipp concepts and features.
+Read `Data Structures <user-guide/data-structures.html>`_, `Slicing <user-guide/slicing.html>`_, and `Computation <user-guide/computation.html>`_ (in this order) to develop an understanding of the core concepts of Scipp.
+
+Further sections of the User Guide are optional and can be studied in arbitrary order.
+Depending on your area of application you may be most interested in `Binned Data <user-guide/binned-data.rst>`_, `Coordinate Transformations <user-guide/coordinate-transformations.rst>`_,
+`GroupBy <user-guide/groupby.rst>`_, or
+`Masking <user-guide/masking.rst>`_.
+The combination of these features is what sets Scipp apart from other Python libraries.
+Make sure to also checkout `Representations and Tables <visualization/representations-and-tables.rst>`_ and `Plotting Overview <visualization/plotting-overview.rst>`_ for an overview of Scipp's powerful visualization features.
+
+The **Reference** documentation section provides a detailed listing of all functions and class of Scipp, as well as some more technical documentation.
+If you are looking for something in particular, use the **Search the docs** function in the left navigation panel.
 
 Where can I get help?
 ---------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,7 @@ Depending on your area of application you may be most interested in `Binned Data
 The combination of these features is what sets Scipp apart from other Python libraries.
 Make sure to also checkout `Representations and Tables <visualization/representations-and-tables.rst>`_ and `Plotting Overview <visualization/plotting-overview.rst>`_ for an overview of Scipp's powerful visualization features.
 
-The **Reference** documentation section provides a detailed listing of all functions and class of Scipp, as well as some more technical documentation.
+The **Reference** documentation section provides a detailed listing of all functions and classes of Scipp, as well as some more technical documentation.
 If you are looking for something in particular, use the **Search the docs** function in the left navigation panel.
 
 Where can I get help?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ News
 - Is your data stored in NeXus files?
   Checkout our new project `scippnexus <https://scipp.github.io/scippnexus>`_, a h5py-like utility for conveniently loading NeXus classes into Scipp data structures.
 - We now provide ``pip`` packages of ``scipp``, in addition to ``conda`` packages.
-  See `installation <getting-started/installation.rst#Pip>`_ for details.
+  See `Installation <getting-started/installation.rst#Pip>`_ for details.
 - Scipp changed from GPLv3 to the more permissive BSD-3 license which fits better into the Python eco system.
 - Looking for ``scipp.neutron``?
   This submodule has been moved into its own package, `scippneutron <https://scipp.github.io/scippneutron>`_.

--- a/docs/tutorials/from-tabular-data-to-binned-data.ipynb
+++ b/docs/tutorials/from-tabular-data-to-binned-data.ipynb
@@ -379,7 +379,7 @@
     "### Exercise 2\n",
     "\n",
     "- The detector assembly is cylindrical, aligned with the z-axis.\n",
-    "  Compute the distance from the z-axis (from `x` and `y` defined above) and store it as a new coordinate in `table`.\n",
+    "  Compute the distance from the z-axis (from the `x_pos` and `y_pos` coordinates) and store it as a new coordinate in `table`.\n",
     "  This is the radius in cylinder coordinates.\n",
     "- Define bin edges for the radius using `scipp.linspace`.\n",
     "- Bin `table` by `z_pos` and the radius.\n",
@@ -465,7 +465,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wire1234 = table.group(sc.array(dims=['wire'], values=[1,2,3,4], unit=None))\n",
+    "wire1234 = table.group(sc.array(dims=['wire'], values=[1, 2, 3, 4], unit=None))\n",
     "wire1234.hist().plot()"
    ]
   },
@@ -558,7 +558,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Extra dimensions sliced out for display purposed. sc.show can deal with 5-D data\n",
+    "# Extra dimensions sliced out for display purposes, sc.show cannot deal with 5-D data\n",
     "sc.show(binned_logical['strip', 0]['counter', 0]['segment', 0]['module', :5].transpose())"
    ]
   },

--- a/docs/user-guide/masking.ipynb
+++ b/docs/user-guide/masking.ipynb
@@ -253,8 +253,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/masking.ipynb
+++ b/docs/user-guide/masking.ipynb
@@ -253,7 +253,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/masking.ipynb
+++ b/docs/user-guide/masking.ipynb
@@ -4,7 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Masking"
+    "# Masking\n",
+    "\n",
+    "The purpose of masks in Scipp is to *exclude* regions of data from analysis, or to *select* regions of interest (ROIs).\n",
+    "For example, we may mask data from sensors we know to be broken, or we may mask everything outside our ROI in an image.\n",
+    "\n",
+    "In some cases direct *removal* of the bad data or data outside the ROI may be preferred.\n",
+    "Masking provides an alternative solution, which lets us, e.g., modify the mask or remove it later.\n",
+    "\n",
+    "NumPy provides support for masked arrays in the [numpy.ma](https://numpy.org/doc/stable/reference/maskedarray.html) module.\n",
+    "Scipp's masking feature is conceptually similar, but is based on a *dictionary* of masks.\n",
+    "Each mask is a `Variable`, i.e., comes with explicit dimensions.\n",
+    "Scipp can therefore store masks in a very space-efficient manner.\n",
+    "For example, given an image stack with dimensions `('image', 'pixel_y', 'pixel_x')` we may have a mask for \"images\" with dimensions `('image', )` and a second mask defining the ROI with dimensions `('pixel_y', 'pixel_x')`.\n",
+    "The support for multiple masks also enables Scipp to selectively apply or preserve masks.\n",
+    "For example, a sum over the 'image' dimension can preserve the ROI mask."
    ]
   },
   {
@@ -32,8 +46,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = sc.Variable(dims=['x'], values=[False, False, True])\n",
-    "sc.table(mask)"
+    "mask = sc.array(dims=['x'], values=[False, False, True])\n",
+    "mask"
    ]
   },
   {
@@ -68,8 +82,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var = sc.Variable(dims=['x'], values=np.random.random(5), unit=sc.units.m)\n",
-    "mask2 = var < 0.5 * sc.units.m\n",
+    "var = sc.array(dims=['x'], values=np.random.random(5), unit='m')\n",
+    "mask2 = var < 0.5 * sc.Unit('m')\n",
     "mask2"
    ]
   },
@@ -91,13 +105,10 @@
    "outputs": [],
    "source": [
     "a = sc.DataArray(\n",
-    "    data = sc.Variable(dims=['y', 'x'], values=np.arange(1.0, 7.0).reshape((2, 3))),\n",
-    "    coords={\n",
-    "        'y': sc.Variable(dims=['y'], values=np.arange(2.0), unit=sc.units.m),\n",
-    "        'x': sc.Variable(dims=['x'], values=np.arange(3.0), unit=sc.units.m)},\n",
-    "    masks={\n",
-    "        'x': sc.Variable(dims=['x'], values=[False, False, True])}\n",
-    "    )\n",
+    "    data=sc.array(dims=['y', 'x'], values=np.arange(1.0, 7.0).reshape((2, 3))),\n",
+    "    coords={'y': sc.arange('y', 2.0, unit='m'), 'x': sc.arange('x', 3.0, unit='m')},\n",
+    "    masks={'x': sc.array(dims=['x'], values=[False, False, True])},\n",
+    ")\n",
     "sc.show(a)"
    ]
   },
@@ -109,7 +120,7 @@
    "source": [
     "b = a.copy()\n",
     "b.masks['x'].values[1] = True\n",
-    "b.masks['y'] = sc.Variable(dims=['y'], values=[False, True])"
+    "b.masks['y'] = sc.array(dims=['y'], values=[False, True])"
    ]
   },
   {
@@ -170,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.sum(a, 'x')"
+    "a.sum('x')"
    ]
   },
   {
@@ -186,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.mean(a, 'x')"
+    "a.mean('x')"
    ]
   },
   {
@@ -205,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "sc.sum(b, 'x')"
+    "b.sum('x')"
    ]
   },
   {

--- a/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
+++ b/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
@@ -17,7 +17,7 @@
     "# Tips, tricks, and anti-patterns\n",
     "## Choose dimensions wisely\n",
     "\n",
-    "A good choice of dimension for representing data goes a long way in making working with scipp efficient.\n",
+    "A good choice of dimensions for representing data goes a long way in making working with Scipp efficient.\n",
     "Consider, e.g., data gathered from detector pixels at certain time intervals.\n",
     "We could represent it as"
    ]
@@ -62,7 +62,7 @@
     "\n",
     "## Choose dimension order wisely\n",
     "\n",
-    "In principle the order of dimension in scipp can be arbitrary since operations transpose automatically based on dimension labels.\n",
+    "In principle the order of dimensions in scipp can be arbitrary since operations transpose automatically based on dimension labels.\n",
     "In practice however a bad choice of dimension order can lead to performance bottlenecks.\n",
     "This is most obvious when slicing multi-dimensional variables or arrays, where slicing any but the outer dimension yields a slice with gaps between data values, i.e., a very inefficient memory layout.\n",
     "If an application requires slicing (directly or indirectly, e.g., in `groupby` operations) predominantly for a certain dimension, this dimension should be made the *outermost* dimension.\n",
@@ -101,13 +101,13 @@
    "metadata": {},
    "source": [
     "will then have data for all pixels in a contiguous chunk of memory.\n",
-    "Note that in scipp the first listed dimension in `dims` is always the *outermost* dimension (numpy's default).\n",
+    "Note that in Scipp the first listed dimension in `dims` is always the *outermost* dimension (NumPy's default).\n",
     "\n",
     "## Avoid loops\n",
     "\n",
-    "With scipp, just like with numpy or Matlab, loops such as `for`-loops should be avoided.\n",
-    "Loops typically lead to many small slices or many small array objects and very quickly lead to very inefficient code.\n",
-    "If we encounter the need for a loop in a workflow using scipp we should try and take a step back to understand how it can be avoided.\n",
+    "With Scipp, just like with NumPy or Matlab, loops such as `for`-loops should be avoided.\n",
+    "Loops typically lead to many small slices or many small array objects and rapidly lead to very inefficient code.\n",
+    "If we encounter the need for a loop in a workflow using Scipp we should try and take a step back to understand how it can be avoided.\n",
     "Some tips to do this include:\n",
     "\n",
     "### Use slicing with \"shifts\"\n",
@@ -145,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that a this point numpy provides more powerful functions such as [numpy.roll](https://numpy.org/doc/stable/reference/generated/numpy.roll.html).\n",
+    "Note that at this point NumPy provides more powerful functions such as [numpy.roll](https://numpy.org/doc/stable/reference/generated/numpy.roll.html).\n",
     "Scipp's toolset for such purposes is not fully developed yet."
    ]
   },
@@ -155,10 +155,10 @@
    "source": [
     "### Seek advice from numpy\n",
     "\n",
-    "There is a huge amount of information available for numpy, e.g., on [stackoverflow](https://stackoverflow.com/questions/tagged/numpy?tab=Votes).\n",
+    "There is a huge amount of information available for NumPy, e.g., on [stackoverflow](https://stackoverflow.com/questions/tagged/numpy?tab=Votes).\n",
     "We can profit in two ways from this.\n",
-    "In some cases, the same techniques can be applied to scipp variables or data arrays, since mechanisms such as slicing and basic operations are very similar.\n",
-    "In other cases, e.g., when functionality is not available in scipp yet, we can resort to processing the raw array accessible through the `values` property:"
+    "In some cases, the same techniques can be applied to Scipp variables or data arrays, since mechanisms such as slicing and basic operations are very similar.\n",
+    "In other cases, e.g., when functionality is not available in Scipp yet, we can resort to processing the raw array accessible through the `values` property:"
    ]
   },
   {
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `values` property can also be used as the `out` argument that many numpy functions support:"
+    "The `values` property can also be used as the `out` argument that many NumPy functions support:"
    ]
   },
   {
@@ -196,7 +196,7 @@
     "<div class=\"alert alert-warning\">\n",
     "    <b>WARNING</b>\n",
     "\n",
-    "When applying numpy functions to the `values` directly we lose handling of units and variances, so this should be used with care.\n",
+    "When applying NumPy functions to the `values` directly we lose handling of units and variances, so this should be used with care.\n",
     "</div>"
    ]
   },
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that `fold` returns a view, i.e., the operation is performance without making a copy of the underlying data buffers.\n",
+    "Note that `fold` returns a view, i.e., the operation is performed without making a copy of the underlying data buffers.\n",
     "The companion operation of `fold` is `flatten`, which provides the reverse operation.\n",
     "\n",
     "## Use in-place operations\n",
@@ -234,7 +234,7 @@
     "Allocating memory or copying data is an expensive process and may even be the dominant factor for overall application performance, apart from loading large amounts of data from disk.\n",
     "Therefore, it pays off the avoid copies where possible.\n",
     "\n",
-    "Scipp provides two mechanisms for this, in-place arithmetic operators such as `+=`, and `out`-arguments similar to what numpy provides.\n",
+    "Scipp provides two mechanisms for this, in-place arithmetic operators such as `+=`, and `out`-arguments similar to what NumPy provides.\n",
     "Examples:"
    ]
   },


### PR DESCRIPTION
Addresses a number of items from #2711.

Regarding the `What is Scipp?` page: I am tempted to remove all but the new intro part, i.e., all the subsections. It feels like a waste of effort to explain these things in multiple places. Thoughts?