### PR TITLE
Switch order of nbstripout args in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,5 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
-        args: ["--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'",
-               "--strip-empty-cells"]
+        args: ["--strip-empty-cells",
+               "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'"]


### PR DESCRIPTION
This fixes the hook. Don't know why but the old order caused it to fail with
```
nbstripout...............................................................Failed
- hook id: nbstripout
- exit code: 2

usage: nbstripout
       [-h]
       [--dry-run | --install | --uninstall | --is-installed | --status | --version]
       [--keep-count]
       [--keep-output]
       [--extra-keys EXTRA_KEYS]
       [--strip-empty-cells]
       [--attributes FILEPATH]
       [--global | --system]
       [--force]
       [--max-size SIZE]
       [--mode {jupyter,zeppelin}]
       [--textconv]
       [files [files ...]]
nbstripout: error: unrecognized arguments: docs/reference/ownership-mechanism-and-readonly-flags.ipynb
```