### PR TITLE
Remove bad ref in checkout action

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-python@v3
         with:
           python-version: 3.8


### PR DESCRIPTION
Fixes #2627.

It is unclear why this `ref` was added initially.