### PR TITLE
Treat m as meter in datetimes function

### DIFF
--- a/lib/python/bind_units.cpp
+++ b/lib/python/bind_units.cpp
@@ -66,5 +66,6 @@ void init_units(py::module &m) {
 
   units.attr("default_unit") = DefaultUnit{};
 
-  m.def("to_numpy_time_string", to_numpy_time_string);
+  m.def("to_numpy_time_string",
+        py::overload_cast<const ProtoUnit &>(to_numpy_time_string));
 }

--- a/lib/python/unit.cpp
+++ b/lib/python/unit.cpp
@@ -27,8 +27,8 @@ get_time_unit(const std::optional<scipp::units::Unit> value_unit,
               const std::optional<scipp::units::Unit> dtype_unit,
               const units::Unit sc_unit) {
   if (!temporal_or_dimensionless(sc_unit)) {
-    throw std::invalid_argument("Invalid unit for dtype=datetime64: " +
-                                to_string(sc_unit));
+    throw except::UnitError("Invalid unit for dtype=datetime64: " +
+                            to_string(sc_unit));
   }
   if (dtype_unit.value_or(units::one) != units::one &&
       (sc_unit != units::one && *dtype_unit != sc_unit)) {
@@ -70,8 +70,8 @@ std::tuple<scipp::units::Unit, scipp::units::Unit>
 common_unit<scipp::core::time_point>(const pybind11::object &values,
                                      const scipp::units::Unit unit) {
   if (!temporal_or_dimensionless(unit)) {
-    throw std::invalid_argument("Invalid unit for dtype=datetime64: " +
-                                to_string(unit));
+    throw except::UnitError("Invalid unit for dtype=datetime64: " +
+                            to_string(unit));
   }
 
   if (values.is_none() || !has_datetime_dtype(values)) {

--- a/lib/python/unit.cpp
+++ b/lib/python/unit.cpp
@@ -87,6 +87,11 @@ common_unit<scipp::core::time_point>(const pybind11::object &values,
 }
 
 std::string to_numpy_time_string(const scipp::units::Unit unit) {
+  if (unit == units::m) {
+    // Would be treated as minute otherwise.
+    throw except::UnitError("Invalid time unit, got 'm' which means meter. "
+                            "If you meant minute, use unit='min' instead.");
+  }
   return unit == units::us            ? std::string("us")
          : unit == units::Unit("min") ? std::string("m")
                                       : to_string(unit);

--- a/lib/python/unit.cpp
+++ b/lib/python/unit.cpp
@@ -92,6 +92,17 @@ std::string to_numpy_time_string(const scipp::units::Unit unit) {
                                       : to_string(unit);
 }
 
+std::string to_numpy_time_string(const ProtoUnit &unit) {
+  return std::visit(
+      overloaded{
+          [](const scipp::units::Unit &u) { return to_numpy_time_string(u); },
+          [](const std::string &u) {
+            return to_numpy_time_string(scipp::units::Unit(u));
+          },
+          [](const auto &) { return std::string(); }},
+      unit);
+}
+
 scipp::units::Unit unit_or_default(const ProtoUnit &unit, const DType type) {
   return std::visit(
       overloaded{[type](DefaultUnit) {
@@ -100,7 +111,7 @@ scipp::units::Unit unit_or_default(const ProtoUnit &unit, const DType type) {
                          "Default unit requested but dtype unknown.");
                    return variable::default_unit_for(type);
                  },
-                 [](py::none) { return units::none; },
+                 [](const py::none &) { return units::none; },
                  [](const std::string &u) { return units::Unit(u); },
                  [](const units::Unit &u) { return u; }},
       unit);

--- a/lib/python/unit.h
+++ b/lib/python/unit.h
@@ -40,7 +40,8 @@ common_unit<scipp::core::time_point>(const pybind11::object &values,
 /// Format a time unit as an ASCII string.
 /// Only time units are supported!
 // TODO Can be removed if / when the units library supports this.
-std::string to_numpy_time_string(scipp::units::Unit const unit);
+std::string to_numpy_time_string(scipp::units::Unit unit);
+std::string to_numpy_time_string(const ProtoUnit &unit);
 
 scipp::units::Unit
 unit_or_default(const ProtoUnit &unit,

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -861,10 +861,7 @@ def datetimes(*,
       >>> sc.datetimes(dims=['t'], values=[0, 1610288175], unit='s')
       <scipp.Variable> (t: 2)  datetime64              [s]  [1970-01-01T00:00:00, 2021-01-10T14:16:15]
     """
-    if unit is None or unit is default_unit:
-        np_unit_str = ''
-    else:
-        np_unit_str = f'[{_cpp.to_numpy_time_string(unit)}]'
+    np_unit_str = f'[{u}]' if (u := _cpp.to_numpy_time_string(unit)) else ''
     with _timezone_warning_as_error():
         return array(dims=dims,
                      values=_np.asarray(values, dtype=f'datetime64{np_unit_str}'))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -711,6 +711,12 @@ def test_datetimes_raises_if_given_unit_m():
                      unit='m')
 
 
+def test_datetime_raises_if_given_unit_m():
+    # This one is special because in NumPy, 'm' means minute.
+    with pytest.raises(sc.UnitError):
+        sc.datetime('2022-08-02T11:18', unit='m')
+
+
 def test_datetime_epoch():
     assert sc.identical(sc.epoch(unit='s'),
                         sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -703,6 +703,14 @@ def test_datetime_raises_if_given_invalid_unit_string():
         sc.datetime('2022-08-02T11:18', unit='not-a-valid-unit')
 
 
+def test_datetimes_raises_if_given_unit_m():
+    # This one is special because in NumPy, 'm' means minute.
+    with pytest.raises(sc.UnitError):
+        sc.datetimes(dims=['t'],
+                     values=['2022-08-02T11:18', '2022-08-02T11:33'],
+                     unit='m')
+
+
 def test_datetime_epoch():
     assert sc.identical(sc.epoch(unit='s'),
                         sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -691,6 +691,18 @@ def test_datetimes():
                  values=np.array([-723, 2**13, -3**5], dtype='datetime64[m]')))
 
 
+def test_datetimes_raises_if_given_invalid_unit_string():
+    with pytest.raises(sc.UnitError):
+        sc.datetimes(dims=['t'],
+                     values=['2022-08-02T11:18', '2022-08-02T11:33'],
+                     unit='not-a-valid-unit')
+
+
+def test_datetime_raises_if_given_invalid_unit_string():
+    with pytest.raises(sc.UnitError):
+        sc.datetime('2022-08-02T11:18', unit='not-a-valid-unit')
+
+
 def test_datetime_epoch():
     assert sc.identical(sc.epoch(unit='s'),
                         sc.scalar(np.datetime64('1970-01-01T00:00:00', 's')))


### PR DESCRIPTION
Fixes #2730 

Changes in the 1st commit produce a proper exception when calling `sc.datetimes(...,  unit='something-invalid')`. Previously, this made pybind11 raise a `TypeError`.