### PR TITLE
Bump boost to v1.79

### DIFF
--- a/conda/cmake-package-test/conanfile.txt
+++ b/conda/cmake-package-test/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 benchmark/1.6.1
-boost/1.76.0
+boost/1.79.0
 eigen/3.3.9
 gtest/1.11.0
 LLNL-Units/0.5.0.1

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 conan_cmake_configure(
   REQUIRES
   benchmark/1.6.1
-  boost/1.76.0
+  boost/1.79.0
   eigen/3.3.9
   gtest/1.11.0
   LLNL-Units/0.5.0.1

--- a/lib/cmake/scipp-config.cmake.in
+++ b/lib/cmake/scipp-config.cmake.in
@@ -9,7 +9,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/scipp-targets.cmake")
 check_required_components(scipp-targets)
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost 1.67)
+find_dependency(Boost 1.69)
 find_dependency(Eigen3)
 find_dependency(LLNL-Units)
 find_dependency(TBB)


### PR DESCRIPTION
Fixes a warning about reading too much memory (probably coming from `boost::small_vector`).