### PR TITLE
Fix setitem for value based slicing

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -53,6 +53,7 @@ Bugfixes
 * Binary arithmetic operations such as ``x + x`` of ``x * x``, i.e., with both operands the same, now handle correlations correctly and result in the correct variances in the output `#2709 <https://github.com/scipp/scipp/pull/2709>`_.
 * Made ``__sizeof__`` and related functions more accurate `#2705 <https://github.com/scipp/scipp/pull/2705>`_.
 * 1-D entries with identical dimensions but different coordinate units are no longer plotted on the same axes `#2728 <https://github.com/scipp/scipp/pull/2728>`_.
+* Fix a bug in the argument detection when using setitem in combination with value-based slicing `#2750 <https://github.com/scipp/scipp/pull/2750>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/lib/python/bind_slice_methods.h
+++ b/lib/python/bind_slice_methods.h
@@ -155,11 +155,13 @@ template <class T> struct slicer {
   }
 
   template <class Other>
-  static void set_by_value(T &self, const std::tuple<Dim, Variable> &value,
+  static void set_by_value(T &self,
+                           const std::tuple<std::string, Variable> &value,
                            const Other &data) {
     auto &[dim, val] = value;
-    self.setSlice(std::make_from_tuple<Slice>(get_slice_params(self, dim, val)),
-                  data);
+    self.setSlice(
+        std::make_from_tuple<Slice>(get_slice_params(self, Dim(dim), val)),
+        data);
   }
 
   // Manually dispatch based on the object we are assigning from in order to

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -80,3 +80,19 @@ def test_setitem_with_stride_2_sets_every_other_element():
     var = sc.array(dims=['x'], values=[1, 2, 3, 4, 5, 6])
     var['x', 1:5:2] = sc.array(dims=['x'], values=[11, 22])
     assert sc.identical(var, sc.array(dims=['x'], values=[1, 11, 3, 22, 5, 6]))
+
+
+def test_setitem_data_array_value_based_slice():
+    da = sc.data.table_xyz(10)
+    var = sc.scalar(44., unit='K')
+    da['x', da.coords['x'][0]] = var  # Assign a single variable
+    assert sc.identical(da[0].data, var)
+    da['x', da.coords['x'][0]] = da['x', da.coords['x'][1]]  # Assign data array slice
+    assert sc.identical(da[0].data, da[1].data)
+
+
+def test_setitem_dataset_value_based_slice():
+    ds = sc.Dataset({'a': sc.data.table_xyz(10), 'b': sc.data.table_xyz(10) * 1.123})
+    ds['x', ds.coords['x'][0]] = ds['x', ds.coords['x'][1]]
+    assert sc.identical(ds['a'][0].data, ds['a'][1].data)
+    assert sc.identical(ds['b'][0].data, ds['b'][1].data)

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -85,9 +85,9 @@ def test_setitem_with_stride_2_sets_every_other_element():
 def test_setitem_data_array_value_based_slice():
     da = sc.data.table_xyz(10)
     var = sc.scalar(44., unit='K')
-    da['x', da.coords['x'][0]] = var  # Assign a single variable
+    da['x', da.coords['x'][0]] = var
     assert sc.identical(da[0].data, var)
-    da['x', da.coords['x'][0]] = da['x', da.coords['x'][1]]  # Assign data array slice
+    da['x', da.coords['x'][0]] = da['x', da.coords['x'][1]]
     assert sc.identical(da[0].data, da[1].data)
 
 


### PR DESCRIPTION
Argument detection was not working because the bindings were expecting a `Dim` instead of a `std::string`.
See unit tests for the cases that were broken.