### PR TITLE
Support datasets w/o data in transform_coords

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -58,6 +58,7 @@ Bugfixes
 * Data arrays with missing coords can now be plotted using the experimental plotting `#2748 <https://github.com/scipp/scipp/pull/2748>`_.
 * Fix a bug in the argument detection when using setitem in combination with value-based slicing `#2750 <https://github.com/scipp/scipp/pull/2750>`_.
 * Fixed broken profile plot on 3-D data `#2746 <https://github.com/scipp/scipp/pull/2746>`_.
+* ``transform_coords`` now works with datasets with only coordinates but no data `#2755 <https://github.com/scipp/scipp/pull/2755>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/src/scipp/coords/rule.py
+++ b/src/scipp/coords/rule.py
@@ -41,7 +41,7 @@ class Rule(ABC):
         self.out_names = out_names
 
     @abstractmethod
-    def __call__(self, coords: _CoordProvider) -> Dict[str, Variable]:
+    def __call__(self, coords: _CoordProvider) -> Dict[str, Coord]:
         """Evaluate the rule."""
 
     @property

--- a/src/scipp/coords/transform_coords.py
+++ b/src/scipp/coords/transform_coords.py
@@ -214,11 +214,15 @@ def _transform_dataset(original: Dataset, targets: Set[str], graph: Graph, *,
 
     # Cannot keep attributes in output anyway.
     # So make sure they are removed as early as possible.
-    options = dataclasses.replace(options, keep_inputs=False,
-                                  keep_aliases=False, keep_intermediate=False)
+    options = dataclasses.replace(options,
+                                  keep_inputs=False,
+                                  keep_aliases=False,
+                                  keep_intermediate=False)
     dummy = DataArray(empty(sizes=original.sizes), coords=original.coords)
-    transformed = _transform_data_array(dummy, targets=targets,
-                                        graph=graph, options=options)
+    transformed = _transform_data_array(dummy,
+                                        targets=targets,
+                                        graph=graph,
+                                        options=options)
     return Dataset(coords=transformed.coords)
 
 

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -650,42 +650,46 @@ def test_dataset_coord_and_attr_clash_matching_value(a):
 
 def test_dataset_coord_and_attr_clash_mismatching_value(a):
     da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
-    da2 = sc.DataArray(data=a.copy(), attrs={'a': a+1})
+    da2 = sc.DataArray(data=a.copy(), attrs={'a': a + 1})
     ds = sc.Dataset({'item1': da1, 'item2': da2})
     with pytest.raises(sc.DataArrayError):
         ds.transform_coords('b', graph={'b': 'a'})
 
 
 def test_dataset_missing_attr_in_one_item_without_rule_to_make_it(a):
-    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a+1})
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a + 1})
     da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
     ds = sc.Dataset({'item1': da1, 'item2': da2})
     with pytest.raises(KeyError):
-        ds.transform_coords('b', graph={'b': lambda a, aa: a+aa})
+        ds.transform_coords('b', graph={'b': lambda a, aa: a + aa})
 
 
 def test_dataset_missing_attr_in_one_item_with_rule_to_make_it(a):
-    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a+1})
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a + 1})
     da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
     ds = sc.Dataset({'item1': da1, 'item2': da2})
     with pytest.raises(sc.DatasetError):
-        ds.transform_coords('b', graph={'b': lambda a, aa: a+aa, 'aa': lambda a: a+2})
+        ds.transform_coords('b',
+                            graph={
+                                'b': lambda a, aa: a + aa,
+                                'aa': lambda a: a + 2
+                            })
 
 
 def test_dataset_missing_coord_in_one_item_without_rule_to_make_it(a, b):
-    da1 = sc.DataArray(data=a+b, coords={'a': a.copy(), 'b': b.copy()})
+    da1 = sc.DataArray(data=a + b, coords={'a': a.copy(), 'b': b.copy()})
     da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
     ds = sc.Dataset({'item1': da1, 'item2': da2})
     with pytest.raises(KeyError):
-        ds.transform_coords('c', graph={'c': lambda a, b: a+b})
+        ds.transform_coords('c', graph={'c': lambda a, b: a + b})
 
 
 def test_dataset_missing_coord_in_one_item_with_rule_to_make_it(a, b):
-    da1 = sc.DataArray(data=a+b, coords={'a': a.copy(), 'b': b.copy()})
+    da1 = sc.DataArray(data=a + b, coords={'a': a.copy(), 'b': b.copy()})
     da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
     ds = sc.Dataset({'item1': da1, 'item2': da2})
     with pytest.raises(sc.DatasetError):
-        ds.transform_coords('c', graph={'c': lambda a, b: a+b, 'b': 'a'})
+        ds.transform_coords('c', graph={'c': lambda a, b: a + b, 'b': 'a'})
 
 
 def test_dataset_without_data(a):

--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -632,12 +632,68 @@ def test_inplace(c):
     assert sc.identical(da.attrs['a'], 2 * c + 3 * c)
 
 
-def test_dataset(a):
+def test_dataset_works_with_matching_coord(a):
     da = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
-    ds = sc.Dataset(data={'item1': da.copy(), 'item2': da + da})
+    ds = sc.Dataset({'item1': da.copy(), 'item2': da + da})
     transformed = ds.transform_coords('b', graph={'b': 'a'})
     assert sc.identical(transformed['item1'].attrs['a'], a.rename_dims({'a': 'b'}))
     assert sc.identical(transformed.coords['b'], a.rename_dims({'a': 'b'}))
+
+
+def test_dataset_coord_and_attr_clash_matching_value(a):
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    da2 = sc.DataArray(data=a.copy(), attrs={'a': a.copy()})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(sc.DataArrayError):
+        ds.transform_coords('b', graph={'b': 'a'})
+
+
+def test_dataset_coord_and_attr_clash_mismatching_value(a):
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    da2 = sc.DataArray(data=a.copy(), attrs={'a': a+1})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(sc.DataArrayError):
+        ds.transform_coords('b', graph={'b': 'a'})
+
+
+def test_dataset_missing_attr_in_one_item_without_rule_to_make_it(a):
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a+1})
+    da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(KeyError):
+        ds.transform_coords('b', graph={'b': lambda a, aa: a+aa})
+
+
+def test_dataset_missing_attr_in_one_item_with_rule_to_make_it(a):
+    da1 = sc.DataArray(data=a.copy(), coords={'a': a.copy()}, attrs={'aa': a+1})
+    da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(sc.DatasetError):
+        ds.transform_coords('b', graph={'b': lambda a, aa: a+aa, 'aa': lambda a: a+2})
+
+
+def test_dataset_missing_coord_in_one_item_without_rule_to_make_it(a, b):
+    da1 = sc.DataArray(data=a+b, coords={'a': a.copy(), 'b': b.copy()})
+    da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(KeyError):
+        ds.transform_coords('c', graph={'c': lambda a, b: a+b})
+
+
+def test_dataset_missing_coord_in_one_item_with_rule_to_make_it(a, b):
+    da1 = sc.DataArray(data=a+b, coords={'a': a.copy(), 'b': b.copy()})
+    da2 = sc.DataArray(data=a.copy(), coords={'a': a.copy()})
+    ds = sc.Dataset({'item1': da1, 'item2': da2})
+    with pytest.raises(sc.DatasetError):
+        ds.transform_coords('c', graph={'c': lambda a, b: a+b, 'b': 'a'})
+
+
+def test_dataset_without_data(a):
+    ds = sc.Dataset(coords={'a': a.copy()})
+    transformed = ds.transform_coords('b', graph={'b': 'a'})
+    assert sc.identical(transformed.coords['b'], a.rename(a='b'))
+    assert 'a' not in transformed.coords
+    assert len(transformed) == 0
 
 
 def test_binned_does_not_modify_inputs(binned_in_a_b):


### PR DESCRIPTION
Fixes #2751

Inputs and intermediates are not preserved because datasets cannot have attributes.

I tried to avoid the branch in `_transform_dataset` by always applying the transform to a dummy. But that got really complicated real quick.