### PR TITLE
Datetime `arange` fixes

### DIFF
--- a/docs/user-guide/data-structures/creating-arrays-and-datasets.ipynb
+++ b/docs/user-guide/data-structures/creating-arrays-and-datasets.ipynb
@@ -359,7 +359,7 @@
    "outputs": [],
    "source": [
     "sc.arange('time', '2022-08-04T14:00:00', '2022-08-04T14:04:00',\n",
-    "          step=30, dtype='datetime64')"
+    "          step=30 * sc.Unit('s'), dtype='datetime64')"
    ]
   },
   {

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -775,13 +775,13 @@ def arange(dim: str,
       >>> sc.arange('t', '2000-01-01T01:00:00', '2000-01-01T01:01:30', 30, dtype='datetime64')
       <scipp.Variable> (t: 3)  datetime64              [s]  [2000-01-01T01:00:00, 2000-01-01T01:00:30, 2000-01-01T01:01:00]
     """
+    if dtype == 'datetime64' and isinstance(start, str):
+        start = datetime(start)
+        stop = stop if stop is None else datetime(stop)
     range_args, unit = _normalize_range_args(unit=unit,
                                              start=start,
                                              stop=stop,
                                              step=step)
-    if dtype == 'datetime64' and isinstance(range_args['start'], str):
-        range_args['start'] = _np.datetime64(range_args['start'])
-        range_args['stop'] = _np.datetime64(range_args['stop'])
     return array(dims=[dim], values=_np.arange(**range_args), unit=unit, dtype=dtype)
 
 

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -772,7 +772,7 @@ def arange(dim: str,
 
     Datetimes are also supported:
 
-      >>> sc.arange('t', '2000-01-01T01:00:00', '2000-01-01T01:01:30', 30, dtype='datetime64')
+      >>> sc.arange('t', '2000-01-01T01:00:00', '2000-01-01T01:01:30', 30 * sc.Unit('s'), dtype='datetime64')
       <scipp.Variable> (t: 3)  datetime64              [s]  [2000-01-01T01:00:00, 2000-01-01T01:00:30, 2000-01-01T01:01:00]
     """
     if dtype == 'datetime64' and isinstance(start, str):

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -491,11 +491,29 @@ def test_arange_datetime_from_np_datetime64():
     assert sc.identical(var, expected)
 
 
+def test_arange_datetime_from_str_raises_if_step_has_no_unit():
+    with pytest.raises(TypeError):
+        sc.arange('t',
+                  '2022-08-02T06:42:45',
+                  '2022-08-02T06:43:33',
+                  16,
+                  dtype='datetime64')
+
+
+def test_arange_datetime_from_str_raises_given_string_with_timezone():
+    with pytest.raises(ValueError):
+        sc.arange('t',
+                  '2022-08-02T06:42:45Z',
+                  '2022-08-02T06:43:33Z',
+                  16 * sc.Unit('s'),
+                  dtype='datetime64')
+
+
 def test_arange_datetime_from_str():
     var = sc.arange('t',
                     '2022-08-02T06:42:45',
                     '2022-08-02T06:43:33',
-                    16,
+                    16 * sc.Unit('s'),
                     dtype='datetime64')
     expected = sc.datetimes(
         dims=['t'],


### PR DESCRIPTION
- Fixes #2756.
- Fixes bug in `arange` which failed to raise when given datetime strings with timezone info (unlike the `datetime(s)` functions).