### PR TITLE
Show different lambdas as distinct functions in graph

### DIFF
--- a/src/scipp/coords/graph.py
+++ b/src/scipp/coords/graph.py
@@ -89,8 +89,11 @@ class Graph:
                 dot.edge(rule.dependencies[0], output, style='dashed')
             elif isinstance(rule, ComputeRule):
                 if not simplified:
-                    name = f'{rule.func_name}(...)'
-                    dot.node(name, shape='ellipse', style='filled', color='lightgrey')
+                    # Get a unique name for every node,
+                    # works because str contains address of func.
+                    name = str(rule)
+                    label = f'{rule.func_name}(...)'
+                    dot.node(name, label=label, shape='ellipse', style='filled', color='lightgrey')
                     dot.edge(name, output)
                 else:
                     name = output

--- a/src/scipp/coords/graph.py
+++ b/src/scipp/coords/graph.py
@@ -93,7 +93,11 @@ class Graph:
                     # works because str contains address of func.
                     name = str(rule)
                     label = f'{rule.func_name}(...)'
-                    dot.node(name, label=label, shape='plain', style='filled', color='lightgrey')
+                    dot.node(name,
+                             label=label,
+                             shape='plain',
+                             style='filled',
+                             color='lightgrey')
                     dot.edge(name, output)
                 else:
                     name = output

--- a/src/scipp/coords/graph.py
+++ b/src/scipp/coords/graph.py
@@ -93,7 +93,7 @@ class Graph:
                     # works because str contains address of func.
                     name = str(rule)
                     label = f'{rule.func_name}(...)'
-                    dot.node(name, label=label, shape='ellipse', style='filled', color='lightgrey')
+                    dot.node(name, label=label, shape='plain', style='filled', color='lightgrey')
                     dot.edge(name, output)
                 else:
                     name = output


### PR DESCRIPTION
Fixes #2758 

Now we get
```.py
import scipp as sc
def foo(x, y): pass
def bar(theta): pass
def baz(Q): pass
baz.__name__ = 'foo'
g = {'theta': lambda x, y: x+y, 'Q': lambda wavelength, theta: 1, 'foo': foo, 'bar': bar, 'baz': baz}
sc.show_graph(g, simplified=False)
```
![graph](https://user-images.githubusercontent.com/11393224/185623497-e7b7ec95-2d49-4321-b5ea-c99b7fcf77c0.png)

This also avoids clashes between functions of the same name (even when the name is changed manually) as shown.

I also changed it to render functions with 'plain' nodes because ellipses waste a lot of space.