### PR TITLE
Expose LLNL::units User Defined units

### DIFF
--- a/lib/python/bind_units.cpp
+++ b/lib/python/bind_units.cpp
@@ -69,4 +69,7 @@ void init_units(py::module &m) {
 
   m.def("to_numpy_time_string",
         py::overload_cast<const ProtoUnit &>(to_numpy_time_string));
+
+  units.def("addUserDefinedUnit", &scipp::units::addUserDefinedUnit);
+  units.def("clearUserDefinedUnits", &scipp::units::clearUserDefinedUnits);
 }

--- a/lib/units/include/scipp/units/unit.h
+++ b/lib/units/include/scipp/units/unit.h
@@ -86,6 +86,9 @@ constexpr Unit meV{llnl::units::precise::milli *
 constexpr Unit c{
     {llnl::units::precise::m / llnl::units::precise::s, 299792458}};
 
+SCIPP_UNITS_EXPORT Unit addUserDefinedUnit(std::string, Unit);
+SCIPP_UNITS_EXPORT void clearUserDefinedUnits();
+
 } // namespace scipp::units
 
 namespace std {

--- a/lib/units/unit.cpp
+++ b/lib/units/unit.cpp
@@ -184,4 +184,11 @@ Unit atan2(const Unit &y, const Unit &x) {
       " b " + y.name() + ".");
 }
 
+Unit addUserDefinedUnit(std::string name, Unit u) {
+  llnl::units::addUserDefinedUnit(name, u.underlying());
+  return Unit(llnl::units::unit_from_string(name));
+}
+
+void clearUserDefinedUnits() { return llnl::units::clearUserDefinedUnits(); }
+
 } // namespace scipp::units

--- a/src/scipp/units/__init__.py
+++ b/src/scipp/units/__init__.py
@@ -34,7 +34,19 @@ Special:
 from .._scipp.core.units import (angstrom, counts, default_unit, deg, dimensionless, kg,
                                  K, meV, m, one, rad, s, us, ns, mm)
 
+from .._scipp.core.units import clearUserDefinedUnits
+from .._scipp.core import Unit as _Unit
+from typing import Union
+
+
+def addUserDefinedUnit(name: str, unit: Union[str, _Unit]) -> _Unit:
+    from .._scipp.core.units import addUserDefinedUnit as implementation
+    if isinstance(unit, str):
+        unit = _Unit(unit)
+    return implementation(name, unit)
+
+
 __all__ = [
     'angstrom', 'counts', 'default_unit', 'deg', 'dimensionless', 'kg', 'K', 'meV', 'm',
-    'one', 'rad', 's', 'us', 'ns', 'mm'
+    'one', 'rad', 's', 'us', 'ns', 'mm', 'addUserDefinedUnit', 'clearUserDefinedUnits'
 ]

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -50,3 +50,21 @@ def test_explicit_default_unit_for_string_gives_none():
 def test_default_unit_for_string_is_none():
     var = sc.scalar('abcdef')
     assert var.unit is None
+
+
+def test_user_defined_units():
+    # Test from LLNL units test_unit_string.cpp
+    from scipp import Unit
+    from scipp.units import addUserDefinedUnit, clearUserDefinedUnits
+    clucks = addUserDefinedUnit('clucks', '19.3 m*A')
+    assert Unit('clucks/A') == Unit('19.3 m')
+    assert repr(clucks) == 'clucks'
+    assert repr((1 / clucks).unit) == '1/clucks'
+    assert repr(clucks**2) == 'clucks^2'
+    assert repr(clucks * Unit('kg')) == 'clucks*kg'
+    assert repr(Unit('kg') / clucks**2) == 'kg/clucks^2'
+    speed = addUserDefinedUnit('speed', 'm/s')
+    assert repr(speed) == 'speed'
+    assert repr(speed * Unit('s')) == 'm'
+    clearUserDefinedUnits()
+    assert repr(speed) == 'm/s'


### PR DESCRIPTION
The LLNL units library support user defined units by adding new named units to those handled by `*_from_string` and `to_string`:
https://units.readthedocs.io/en/latest/user-guide/user_defined_units.html#defining-a-custom-unit

Access to this can be useful in certain situations, notably when using fractional units, e.g., `reciprocal lattice units`. In such a case a user may expect values in units of the reciprocal lattice vector lengths, e.g., `1/(3.9 angstrom)`, which at-present can be parsed and used as a unit but with an often cumbersome string representation like '2564102564.10256433/m' as in this case.

By providing users with the option to replace the string representation of such a unit, the `r.l.u.` units can be used in, e.g., plots.

This PR adds the functions `scipp.units.addUserDefinedUnit` and `scipp.units.clearUserDefinedUnits` which access the same-named LLNL library functions to define and clear user-defined units, respectively.

&hline;
With the new functionality one can create useful aliases to existing units,
```python
scipp.units.addUserDefinedUnit('speed', 'm/s')
scipp.units.addUserDefinedUnit('a_star', numpy.pi*2/sc.Unit('3.95 angstrom'))
```
