### PR TITLE
Fix `scipp.spatial.rotations` to not reject non-1-D inputs

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -42,6 +42,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fix missing support for comparison for spatial dtypes such as ``affine_transform3`` `#2821 <https://github.com/scipp/scipp/pull/2821>`_.
+* Fix :func:`scipp.spatial.rotations` to support creation of quaternion arrays with more than 1 dimension `#2822 <https://github.com/scipp/scipp/pull/2822>`_.
 
 v0.16.2 (August 2022)
 ---------------------

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,6 +35,14 @@ Release Notes
    and Jan-Lukas Wynen :sup:`a`
 
 
+v0.16.4 (September 2022)
+------------------------
+
+Bugfixes
+~~~~~~~~
+
+* Fix missing support for comparison for spatial dtypes such as ``affine_transform3`` `#2821 <https://github.com/scipp/scipp/pull/2821>`_.
+
 v0.16.2 (August 2022)
 ---------------------
 

--- a/lib/core/include/scipp/core/eigen.h
+++ b/lib/core/include/scipp/core/eigen.h
@@ -41,4 +41,14 @@ template <> inline bool isinf<Eigen::Vector3d>(const Eigen::Vector3d &x) {
   return !isfinite(x) && !isnan(x);
 }
 
+[[nodiscard]] inline bool operator==(const Eigen::Affine3d &a,
+                                     const Eigen::Affine3d &b) {
+  return a.matrix() == b.matrix();
+}
+
+[[nodiscard]] inline bool operator!=(const Eigen::Affine3d &a,
+                                     const Eigen::Affine3d &b) {
+  return a.matrix() != b.matrix();
+}
+
 } // namespace scipp::numeric

--- a/lib/core/include/scipp/core/element/comparison.h
+++ b/lib/core/include/scipp/core/element/comparison.h
@@ -100,10 +100,16 @@ constexpr auto greater_equal =
 
 constexpr auto equal = overloaded{
     equality,
-    [](const auto &x, const auto &y) { return x == y; },
+    [](const auto &x, const auto &y) {
+      using numeric::operator==;
+      return x == y;
+    },
 };
 constexpr auto not_equal =
-    overloaded{equality, [](const auto &x, const auto &y) { return x != y; }};
+    overloaded{equality, [](const auto &x, const auto &y) {
+                 using numeric::operator!=;
+                 return x != y;
+               }};
 
 constexpr auto max_equals =
     overloaded{arg_list<double, float, int64_t, int32_t, bool, time_point>,

--- a/lib/core/include/scipp/core/element/comparison.h
+++ b/lib/core/include/scipp/core/element/comparison.h
@@ -64,7 +64,9 @@ struct equality_types_t {
   constexpr void operator()() const noexcept;
   using types = decltype(std::tuple_cat(
       comparison_types_t::types{}, std::tuple<std::string>{},
-      std::tuple<Eigen::Vector3d>{}, std::tuple<Eigen::Matrix3d>{}));
+      std::tuple<Eigen::Vector3d>{}, std::tuple<Eigen::Matrix3d>{},
+      std::tuple<Eigen::Affine3d>{}, std::tuple<Quaternion>{},
+      std::tuple<Translation>{}));
 };
 
 constexpr auto comparison =

--- a/lib/core/include/scipp/core/spatial_transforms.h
+++ b/lib/core/include/scipp/core/spatial_transforms.h
@@ -31,6 +31,8 @@ public:
            m_quat.y() == other.m_quat.y() && m_quat.z() == other.m_quat.z();
   }
 
+  bool operator!=(const Quaternion &other) const { return !operator==(other); }
+
   double &operator()(const int i) {
     if (i == 0) {
       return m_quat.x();
@@ -59,6 +61,10 @@ public:
 
   bool operator==(const Translation &other) const {
     return m_vec == other.m_vec;
+  }
+
+  bool operator!=(const Translation &other) const {
+    return m_vec != other.m_vec;
   }
 
   double &operator()(const int i) { return m_vec(i); }

--- a/lib/core/test/element_comparison_test.cpp
+++ b/lib/core/test/element_comparison_test.cpp
@@ -228,3 +228,21 @@ TEST(ComparisonTest, min_equals) {
   check_inplace(min_equals, core::time_point(23), core::time_point(13),
                 core::time_point(13));
 }
+
+TEST(ElementSpatialEqualTest, quaternion) {
+  core::Quaternion x;
+  EXPECT_TRUE(equal(x, x));
+  EXPECT_FALSE(not_equal(x, x));
+}
+
+TEST(ElementSpatialEqualTest, translation) {
+  core::Translation x;
+  EXPECT_TRUE(equal(x, x));
+  EXPECT_FALSE(not_equal(x, x));
+}
+
+TEST(ElementSpatialEqualTest, affine) {
+  Eigen::Affine3d x(Eigen::Translation<double, 3>(Eigen::Vector3d(1, 2, 3)));
+  EXPECT_TRUE(equal(x, x));
+  EXPECT_FALSE(not_equal(x, x));
+}

--- a/src/scipp/spatial/__init__.py
+++ b/src/scipp/spatial/__init__.py
@@ -90,11 +90,11 @@ def rotations(*, dims: Sequence[str], values: Union[_np.ndarray, list]):
     :param values: a numpy array of numpy arrays corresponding to the quaternion
         coefficients (w, x*i, y*j, z*k)
     """
-    for val in values:
-        if hasattr(val, "__len__") and len(val) != 4:
-            raise ValueError("Inputs must be Quaternions to create a rotation. If you"
-                             "want to pass a rotation matrix, use "
-                             "sc.linear_transforms instead.")
+    values = np.asarray(values)
+    if values.shape[-1] != 4:
+        raise ValueError("Inputs must be Quaternions to create a rotation, i.e., have "
+                         "4 components. If you want to pass a rotation matrix, use "
+                         "sc.linear_transforms instead.")
     return _core_cpp.rotations(dims=dims, values=values)
 
 

--- a/tests/spatial/rotation_test.py
+++ b/tests/spatial/rotation_test.py
@@ -65,6 +65,20 @@ def test_from_quaternions():
         sc.vectors(dims=["x"], values=[[1, -2, -3], [-4, 5, -6]], unit=sc.units.m))
 
 
+def test_from_quaternions_2d():
+    quat1 = [1, 0, 0, 0]
+    quat2 = [0, 1, 0, 0]
+
+    transforms = rotations(dims=["y", "x"], values=[[quat1, quat2]])
+    vectors = sc.vectors(dims=["x"], values=[[1, 2, 3], [4, 5, 6]], unit=sc.units.m)
+
+    assert sc.allclose(
+        transforms * vectors,
+        sc.vectors(dims=["y", "x"],
+                   values=[[[1, -2, -3], [-4, 5, -6]]],
+                   unit=sc.units.m))
+
+
 def test_rotation_default_unit_is_dimensionless():
     var = rotation(value=np.ones(shape=(4, )))
     assert var.unit == sc.units.one


### PR DESCRIPTION
Fixes #2819.