### PR TITLE
Faster `obj.bins.concat`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,6 +35,37 @@ Release Notes
    and Jan-Lukas Wynen :sup:`a`
 
 
+v0.17.0 (Unreleased)
+--------------------
+
+Features
+~~~~~~~~
+
+* Much faster ``obj.bins.concat`` operations in presence of many bins `#2825 <https://github.com/scipp/scipp/pull/2825>`_.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Bugfixes
+~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
+
 v0.16.4 (September 2022)
 ------------------------
 

--- a/lib/python/bins.cpp
+++ b/lib/python/bins.cpp
@@ -184,18 +184,6 @@ void init_buckets(py::module &m) {
       },
       py::call_guard<py::gil_scoped_release>());
   buckets.def(
-      "concatenate",
-      [](const Variable &var, const std::string &dim) {
-        return dataset::buckets::concatenate(var, Dim{dim});
-      },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
-      "concatenate",
-      [](const DataArray &array, const std::string &dim) {
-        return dataset::buckets::concatenate(array, Dim{dim});
-      },
-      py::call_guard<py::gil_scoped_release>());
-  buckets.def(
       "append",
       [](Variable &a, const Variable &b) {
         return dataset::buckets::append(a, b);

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from typing import Callable, Dict, Literal, Optional, Union
+import uuid
+
+from .._scipp import core as _cpp
+from ._cpp_wrapper_util import call_func as _call_cpp_func
+from ..typing import VariableLike, MetaDataMap
+from .domains import merge_equal_adjacent
+from .operations import islinspace
+from .math import midpoints
+from .shape import concat
+
+from math import prod
+
+
+def _bin_index(obj):
+    nbin = prod(obj.shape)
+    return sc.arange('dummy', nbin).fold('dummy', sizes=obj.sizes)
+
+
+def _input_bin_index(obj, dim):
+    return _bin_index(obj, dim)
+
+
+def _output_bin_index(obj, dim):
+    sizes = dict(obj.sizes)
+    del sizes[dim]
+    return _bin_index(sc.empty(dims=sizes.keys(),
+                               shape=sizes.values())).broadcast(dims=obj.dims,
+                                                                shape=obj.shape)
+
+
+def concat_bins(da, dim):
+    start = time.time()
+    out_dims = {d: s for d, s in da.sizes.items() if d != dim}
+    # TODO masks
+    # output_bin_lut = sc.DataArray(sc.arange('param', len(edges)-1), coords={'param':edges})
+    # func = sc.lookup(output_bin_lut)
+    # output_bin = func(param)
+
+    # sizes = sc.DataArray(da.bins.size().data, coords={'output_bin':output_bin, 'input_bin':sc.arange('x', len(da))})
+
+    sizes = sc.DataArray(
+        da.bins.size().data,
+        coords={
+            'output_bin': output_bin_index(da, dim),
+            'input_bin': input_bin_index(da),
+        },
+    )
+    print(time.time() - start)
+    #sizes2 = sizes.flatten(to='dummy')
+    #sizes_sort_out2 = sc.sort(sizes2, 'output_bin')
+    sizes_sort_out = sizes.transpose(list(out_dims) + [dim])
+    print(time.time() - start)
+
+    # subbin sizes
+    out_end = sc.cumsum(sizes_sort_out.data)
+    out_begin = out_end - sizes_sort_out.data
+    sizes_sort_out.coords['out_begin'] = out_begin
+    sizes_sort_out.coords['out_end'] = out_end
+    #sizes_sort_in = sc.sort(sizes_sort_out, 'input_bin')
+    sizes_sort_in = sizes_sort_out.transpose(da.dims)
+    print(time.time() - start)
+    out = _cpp._bins_no_validate(
+        data=sc.empty_like(da.bins.constituents['data']),
+        dim=da.bins.constituents['dim'],
+        begin=sizes_sort_in.coords['out_begin'].transpose(da.dims),
+        end=sizes_sort_in.coords['out_end'].transpose(da.dims),
+    )
+    print(time.time() - start)
+
+    #out[...] = da.data.flatten(to='dummy')
+    out[...] = da.data
+    print(time.time() - start)
+
+    #TODO would drop empty bins, give groups explicitly!
+    #out_sizes = sizes_sort_out.groupby('output_bin').sum('dummy').fold('output_bin', sizes=out_dims)
+    out_sizes = sizes_sort_out.sum(dim)
+    out_end = sc.cumsum(out_sizes.data)
+    out_begin = out_end - out_sizes.data
+    out = sc.bins(
+        data=out.bins.constituents['data'],
+        dim=out.bins.constituents['dim'],
+        begin=out_begin,
+        end=out_end,
+    )
+    print(time.time() - start)
+    out = sc.DataArray(out,
+                       coords={
+                           name: coord
+                           for name, coord in da.coords.items() if dim not in coord.dims
+                       })
+    return out

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -1,34 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable, Dict, Literal, Optional, Union
-import uuid
-
 from .._scipp import core as _cpp
 from .cpp_classes import DataArray
-from .variable import empty, arange
 from .like import empty_like
 from .cumulative import cumsum
 
-from math import prod
 import time
-
-
-def _bin_index(obj):
-    nbin = prod(obj.shape)
-    return arange('dummy', nbin).fold('dummy', sizes=obj.sizes)
-
-
-def _input_bin_index(obj):
-    return _bin_index(obj)
-
-
-def _output_bin_index(obj, dim):
-    sizes = dict(obj.sizes)
-    del sizes[dim]
-    return _bin_index(empty(dims=list(sizes.keys()),
-                            shape=list(sizes.values()))).broadcast(dims=obj.dims,
-                                                                   shape=obj.shape)
 
 
 def concat_bins(da, dim):
@@ -36,18 +14,12 @@ def concat_bins(da, dim):
     out_dims = {d: s for d, s in da.sizes.items() if d != dim}
     # TODO masks
 
-    sizes = DataArray(
-        da.bins.size().data,
-        coords={
-            'output_bin': _output_bin_index(da, dim),
-            'input_bin': _input_bin_index(da),
-        },
-    )
+    sizes = da.bins.size().data
     print(time.time() - start)
-    sizes_sort_out = sizes.data.transpose(list(out_dims) + [dim])
-    print(time.time() - start)
-
     # subbin sizes
+    # cumsum performed with the remove dim as innermost, such that we map all merged
+    # bins into the same output bin
+    sizes_sort_out = sizes.transpose(list(out_dims) + [dim])
     out_end = cumsum(sizes_sort_out)
     out_begin = out_end - sizes_sort_out
     print(time.time() - start)
@@ -62,10 +34,10 @@ def concat_bins(da, dim):
     out[...] = da.data
     print(time.time() - start)
 
-    #TODO would drop empty bins, give groups explicitly!
+    # TODO would drop empty bins, give groups explicitly!
     out_sizes = sizes.sum(dim)
-    out_end = cumsum(out_sizes.data)
-    out_begin = out_end - out_sizes.data
+    out_end = cumsum(out_sizes)
+    out_begin = out_end - out_sizes
     out = _cpp._bins_no_validate(
         data=out.bins.constituents['data'],
         dim=out.bins.constituents['dim'],

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Dict, Union
+from typing import Dict
 from .._scipp import core as _cpp
 from .cpp_classes import DataArray, Variable, Dataset
 from .like import empty_like
@@ -26,11 +26,11 @@ def reduced_masks(da: DataArray, dim: str) -> Dict[str, Variable]:
     return {name: mask.copy() for name, mask in _reduced(da.masks, dim).items()}
 
 
-def _copy_dict_for_overwrite(mapping: Dict[str, Variable]):
+def _copy_dict_for_overwrite(mapping: Dict[str, Variable]) -> Dict[str, Variable]:
     return {name: copy_for_overwrite(var) for name, var in mapping.items()}
 
 
-def copy_for_overwrite(obj: Union[Variable, DataArray, Dataset]):
+def copy_for_overwrite(obj: VariableLikeType) -> VariableLikeType:
     """
     Copy a Scipp object for overwriting.
 
@@ -45,9 +45,15 @@ def copy_for_overwrite(obj: Union[Variable, DataArray, Dataset]):
                          coords=_copy_dict_for_overwrite(obj.coords),
                          masks=_copy_dict_for_overwrite(obj.masks),
                          attrs=_copy_dict_for_overwrite(obj.attrs))
+    ds = Dataset(coords=_copy_dict_for_overwrite(obj.coords))
+    for name, da in ds:
+        ds[name] = DataArray(copy_for_overwrite(obj.data),
+                             masks=_copy_dict_for_overwrite(obj.masks),
+                             attrs=_copy_dict_for_overwrite(obj.attrs))
+    return ds
 
 
-def hide_masked_and_reduce_meta(da: DataArray, dim: str):
+def hide_masked_and_reduce_meta(da: DataArray, dim: str) -> DataArray:
     if (mask := irreducible_mask(da.masks, dim)) is not None:
         # Avoid using boolean indexing since it would result in (partial) content
         # buffer copy. Instead index just begin/end and reuse content buffer.
@@ -68,10 +74,11 @@ def hide_masked_and_reduce_meta(da: DataArray, dim: str):
 
 
 def _concat_bins_variable(var: Variable, dim: str) -> Variable:
+    # We want to write data from all bins along dim to a contiguous chunk in the
+    # content buffer. This will then allow us to create new, larger bins covering the
+    # respective input bins. We use `cumsum` after moving `dim` to the innermost dim.
+    # This will allow us to setup offsets for the new contiguous layout.
     sizes = var.bins.size()
-    # subbin sizes
-    # cumsum performed with the remove dim as innermost, such that we map all merged
-    # bins into the same output bin
     out_dims = [d for d in var.dims if d != dim]
     out_end = cumsum(sizes.transpose(out_dims + [dim])).transpose(var.dims)
     out_begin = out_end - sizes
@@ -82,8 +89,11 @@ def _concat_bins_variable(var: Variable, dim: str) -> Variable:
         end=out_end,
     )
 
+    # Copy all bin contents, performing the actual reordering with the content buffer.
     out[...] = var
 
+    # Setup output indices. This will have the "merged" bins, referening the new
+    # contigous layout in the content buffer.
     out_sizes = sizes.sum(dim)
     out_end = cumsum(out_sizes)
     out_begin = out_end - out_sizes

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -5,91 +5,76 @@ from typing import Callable, Dict, Literal, Optional, Union
 import uuid
 
 from .._scipp import core as _cpp
-from ._cpp_wrapper_util import call_func as _call_cpp_func
-from ..typing import VariableLike, MetaDataMap
-from .domains import merge_equal_adjacent
-from .operations import islinspace
-from .math import midpoints
-from .shape import concat
+from .cpp_classes import DataArray
+from .variable import empty, arange
+from .like import empty_like
+from .cumulative import cumsum
 
 from math import prod
+import time
 
 
 def _bin_index(obj):
     nbin = prod(obj.shape)
-    return sc.arange('dummy', nbin).fold('dummy', sizes=obj.sizes)
+    return arange('dummy', nbin).fold('dummy', sizes=obj.sizes)
 
 
-def _input_bin_index(obj, dim):
-    return _bin_index(obj, dim)
+def _input_bin_index(obj):
+    return _bin_index(obj)
 
 
 def _output_bin_index(obj, dim):
     sizes = dict(obj.sizes)
     del sizes[dim]
-    return _bin_index(sc.empty(dims=sizes.keys(),
-                               shape=sizes.values())).broadcast(dims=obj.dims,
-                                                                shape=obj.shape)
+    return _bin_index(empty(dims=list(sizes.keys()),
+                            shape=list(sizes.values()))).broadcast(dims=obj.dims,
+                                                                   shape=obj.shape)
 
 
 def concat_bins(da, dim):
     start = time.time()
     out_dims = {d: s for d, s in da.sizes.items() if d != dim}
     # TODO masks
-    # output_bin_lut = sc.DataArray(sc.arange('param', len(edges)-1), coords={'param':edges})
-    # func = sc.lookup(output_bin_lut)
-    # output_bin = func(param)
 
-    # sizes = sc.DataArray(da.bins.size().data, coords={'output_bin':output_bin, 'input_bin':sc.arange('x', len(da))})
-
-    sizes = sc.DataArray(
+    sizes = DataArray(
         da.bins.size().data,
         coords={
-            'output_bin': output_bin_index(da, dim),
-            'input_bin': input_bin_index(da),
+            'output_bin': _output_bin_index(da, dim),
+            'input_bin': _input_bin_index(da),
         },
     )
     print(time.time() - start)
-    #sizes2 = sizes.flatten(to='dummy')
-    #sizes_sort_out2 = sc.sort(sizes2, 'output_bin')
-    sizes_sort_out = sizes.transpose(list(out_dims) + [dim])
+    sizes_sort_out = sizes.data.transpose(list(out_dims) + [dim])
     print(time.time() - start)
 
     # subbin sizes
-    out_end = sc.cumsum(sizes_sort_out.data)
-    out_begin = out_end - sizes_sort_out.data
-    sizes_sort_out.coords['out_begin'] = out_begin
-    sizes_sort_out.coords['out_end'] = out_end
-    #sizes_sort_in = sc.sort(sizes_sort_out, 'input_bin')
-    sizes_sort_in = sizes_sort_out.transpose(da.dims)
+    out_end = cumsum(sizes_sort_out)
+    out_begin = out_end - sizes_sort_out
     print(time.time() - start)
     out = _cpp._bins_no_validate(
-        data=sc.empty_like(da.bins.constituents['data']),
+        data=empty_like(da.bins.constituents['data']),
         dim=da.bins.constituents['dim'],
-        begin=sizes_sort_in.coords['out_begin'].transpose(da.dims),
-        end=sizes_sort_in.coords['out_end'].transpose(da.dims),
+        begin=out_begin.transpose(da.dims),
+        end=out_end.transpose(da.dims),
     )
     print(time.time() - start)
 
-    #out[...] = da.data.flatten(to='dummy')
     out[...] = da.data
     print(time.time() - start)
 
     #TODO would drop empty bins, give groups explicitly!
-    #out_sizes = sizes_sort_out.groupby('output_bin').sum('dummy').fold('output_bin', sizes=out_dims)
-    out_sizes = sizes_sort_out.sum(dim)
-    out_end = sc.cumsum(out_sizes.data)
+    out_sizes = sizes.sum(dim)
+    out_end = cumsum(out_sizes.data)
     out_begin = out_end - out_sizes.data
-    out = sc.bins(
+    out = _cpp._bins_no_validate(
         data=out.bins.constituents['data'],
         dim=out.bins.constituents['dim'],
         begin=out_begin,
         end=out_end,
     )
     print(time.time() - start)
-    out = sc.DataArray(out,
-                       coords={
-                           name: coord
-                           for name, coord in da.coords.items() if dim not in coord.dims
-                       })
-    return out
+    return DataArray(out,
+                     coords={
+                         name: coord
+                         for name, coord in da.coords.items() if dim not in coord.dims
+                     })

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -1,12 +1,29 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from typing import Dict
 from .._scipp import core as _cpp
-from .cpp_classes import DataArray
+from .cpp_classes import DataArray, Variable
 from .like import empty_like
 from .cumulative import cumsum
 
 import time
+
+
+def _reduced(obj: Dict[str, Variable], dim: str) -> Dict[str, Variable]:
+    return {name: var for name, var in obj.items() if dim not in var.dims}
+
+
+def reduced_coords(da: DataArray, dim: str) -> Dict[str, Variable]:
+    return _reduced(da.coords, dim)
+
+
+def reduced_attrs(da: DataArray, dim: str) -> Dict[str, Variable]:
+    return _reduced(da.attrs, dim)
+
+
+def reduced_masks(da: DataArray, dim: str) -> Dict[str, Variable]:
+    return _reduced(da.masks, dim)
 
 
 def concat_bins(da, dim):
@@ -44,7 +61,6 @@ def concat_bins(da, dim):
     )
     print(time.time() - start)
     return DataArray(out,
-                     coords={
-                         name: coord
-                         for name, coord in da.coords.items() if dim not in coord.dims
-                     })
+                     coords=reduced_coords(da, dim),
+                     masks=reduced_masks(da, dim),
+                     attrs=reduced_attrs(da, dim))

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -92,7 +92,7 @@ def _concat_bins_variable(var: Variable, dim: str) -> Variable:
     # Copy all bin contents, performing the actual reordering with the content buffer.
     out[...] = var
 
-    # Setup output indices. This will have the "merged" bins, referening the new
+    # Setup output indices. This will have the "merged" bins, referencing the new
     # contigous layout in the content buffer.
     out_sizes = sizes.sum(dim)
     out_end = cumsum(out_sizes)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -46,10 +46,10 @@ def copy_for_overwrite(obj: VariableLikeType) -> VariableLikeType:
                          masks=_copy_dict_for_overwrite(obj.masks),
                          attrs=_copy_dict_for_overwrite(obj.attrs))
     ds = Dataset(coords=_copy_dict_for_overwrite(obj.coords))
-    for name, da in ds:
-        ds[name] = DataArray(copy_for_overwrite(obj.data),
-                             masks=_copy_dict_for_overwrite(obj.masks),
-                             attrs=_copy_dict_for_overwrite(obj.attrs))
+    for name, da in obj.items():
+        ds[name] = DataArray(copy_for_overwrite(da.data),
+                             masks=_copy_dict_for_overwrite(da.masks),
+                             attrs=_copy_dict_for_overwrite(da.attrs))
     return ds
 
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -356,13 +356,9 @@ class Bins:
             All bins along `dim` concatenated into a single bin.
         """
         if dim is not None:
-            return _call_cpp_func(_cpp.buckets.concatenate, self._obj, dim)
+            return concat_bins(self._obj, dim)
         dim = uuid.uuid4().hex
         return self._obj.flatten(to=dim).bins.concat(dim)
-
-    def concat2(self,
-                dim: Optional[str] = None) -> Union[_cpp.Variable, _cpp.DataArray]:
-        return concat_bins(self._obj, dim)
 
     def concatenate(
             self,

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -360,9 +360,9 @@ class Bins:
         dim = uuid.uuid4().hex
         return self._obj.flatten(to=dim).bins.concat(dim)
 
-    def concat2(self, dim: Optional[str] = None) -> Union[_cpp.Variable, _cpp.DataArray]:
+    def concat2(self,
+                dim: Optional[str] = None) -> Union[_cpp.Variable, _cpp.DataArray]:
         return concat_bins(self._obj, dim)
-
 
     def concatenate(
             self,

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -11,6 +11,7 @@ from .domains import merge_equal_adjacent
 from .operations import islinspace
 from .math import midpoints
 from .shape import concat
+from .bin_remapping import concat_bins
 
 
 class Lookup:
@@ -358,6 +359,10 @@ class Bins:
             return _call_cpp_func(_cpp.buckets.concatenate, self._obj, dim)
         dim = uuid.uuid4().hex
         return self._obj.flatten(to=dim).bins.concat(dim)
+
+    def concat2(self, dim: Optional[str] = None) -> Union[_cpp.Variable, _cpp.DataArray]:
+        return concat_bins(self._obj, dim)
+
 
     def concatenate(
             self,

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -404,6 +404,24 @@ def test_bins_concat_variable():
     assert sc.identical(da.data.bins.concat('x'), da.bins.concat('x').data)
 
 
+def test_bins_concat_content_variable():
+    table = sc.data.table_xyz(nrow=100)
+    table.data = sc.arange('row', 100, dtype='float64')
+    da = table.bin(x=4, y=5)
+    assert sc.identical(da.bins.data.bins.concat('x'), da.bins.concat('x').bins.data)
+
+
+@pytest.mark.skip(reason="Need fix in Variable::setSlice")
+def test_bins_concat_content_dataset():
+    table = sc.data.table_xyz(nrow=100)
+    table.data = sc.arange('row', 100, dtype='float64')
+    da = table.bin(x=4, y=5)
+    constituents = table.bin(x=4, y=5).bins.constituents
+    constituents['data'] = sc.Dataset({'a': table, 'b': table + table})
+    binned = sc.bins(**constituents)
+    assert sc.identical(binned.bins.concat('x').bins['a'], da.bins.concat('x'))
+
+
 def test_bins_concat_along_outer_length_1_dim_equivalent_to_squeeze():
     table = sc.data.table_xyz(nrow=100)
     da = table.bin(x=1, y=5, z=7)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -395,3 +395,33 @@ def test_bins_concat():
     assert sc.identical(da.bins.concat('x').hist(), table.hist(y=5))
     assert sc.identical(da.bins.concat('y').hist(), table.hist(x=4))
     assert sc.identical(da.bins.concat().hist(), table.sum())
+
+
+def test_bins_concat_along_outer_length_1_dim_equivalent_to_squeeze():
+    table = sc.data.table_xyz(nrow=100)
+    da = table.bin(x=1, y=5, z=7)
+    expected = da.squeeze()
+    del expected.attrs['x']
+    assert sc.identical(da.bins.concat('x'), expected)
+
+
+def test_bins_concat_along_middle_length_1_dim_equivalent_to_squeeze():
+    table = sc.data.table_xyz(nrow=100)
+    da = table.bin(x=5, y=1, z=7)
+    expected = da.squeeze()
+    del expected.attrs['y']
+    assert sc.identical(da.bins.concat('y'), expected)
+
+
+def test_bins_concat_along_inner_length_1_dim_equivalent_to_squeeze():
+    table = sc.data.table_xyz(nrow=100)
+    da = table.bin(x=5, y=7, z=1)
+    expected = da.squeeze()
+    del expected.attrs['z']
+    assert sc.identical(da.bins.concat('z'), expected)
+
+
+def test_bins_concat_gives_same_result_on_transposed():
+    table = sc.data.table_xyz(nrow=100)
+    da = table.bin(x=5, y=13)
+    assert sc.identical(da.bins.concat('x'), da.transpose().bins.concat('x'))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -425,3 +425,11 @@ def test_bins_concat_gives_same_result_on_transposed():
     table = sc.data.table_xyz(nrow=100)
     da = table.bin(x=5, y=13)
     assert sc.identical(da.bins.concat('x'), da.transpose().bins.concat('x'))
+
+
+def test_bins_concat_preserves_unrelated_mask():
+    table = sc.data.table_xyz(nrow=100)
+    da = table.bin(x=5, y=13)
+    da.masks['masky'] = sc.zeros(dims=['y'], shape=[13], dtype=bool)
+    result = da.bins.concat('x')
+    assert 'masky' in result.masks

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -397,6 +397,13 @@ def test_bins_concat():
     assert sc.identical(da.bins.concat().hist(), table.sum())
 
 
+def test_bins_concat_variable():
+    table = sc.data.table_xyz(nrow=100)
+    table.data = sc.arange('row', 100, dtype='float64')
+    da = table.bin(x=4, y=5)
+    assert sc.identical(da.data.bins.concat('x'), da.bins.concat('x').data)
+
+
 def test_bins_concat_along_outer_length_1_dim_equivalent_to_squeeze():
     table = sc.data.table_xyz(nrow=100)
     da = table.bin(x=1, y=5, z=7)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -439,5 +439,4 @@ def test_bins_concat_applies_irreducible_masks():
     table = sc.data.table_xyz(nrow=10)
     da = table.bin(x=5, y=13)
     da.masks['maskx'] = sc.array(dims=['x'], values=[False, False, False, False, True])
-    print(da.bins.concat('x'), da['x', :4].bins.concat('x'))
     assert sc.identical(da.bins.concat('x'), da['x', :4].bins.concat('x'))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -433,3 +433,11 @@ def test_bins_concat_preserves_unrelated_mask():
     da.masks['masky'] = sc.zeros(dims=['y'], shape=[13], dtype=bool)
     result = da.bins.concat('x')
     assert 'masky' in result.masks
+
+
+def test_bins_concat_applies_irreducible_masks():
+    table = sc.data.table_xyz(nrow=10)
+    da = table.bin(x=5, y=13)
+    da.masks['maskx'] = sc.array(dims=['x'], values=[False, False, False, False, True])
+    print(da.bins.concat('x'), da['x', :4].bins.concat('x'))
+    assert sc.identical(da.bins.concat('x'), da['x', :4].bins.concat('x'))


### PR DESCRIPTION
This addresses parts of #2741.

This also starts development of a small toolbox one the Python side that may be used more in the future. I will also need this for the other part of #2741 and intend to move/test it better then, i.e., bear with me.

Improvements:

sizes | main | new
---|---|---
(x:400k) | 0.13 | 0.6
(x:4M) | 1.0 | 0.2
(x:400k, y:10) | 1.1 | 0.2
(x:400k, y:100) | 11.8 | 1.15
(x:400k, y:1000) | 135 | 10.5
(x:4M, y:100) | 139 | 10.4