### PR TITLE
Faster `bin` and `group` operations when mapping/combining entire existing bins.

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -46,6 +46,7 @@ Features
 * When mapping between many input and output bins:
   Avoid huge memory use and slow performance in use of :py:func:`scipp.bin` and :py:func:`scipp.group` when only entire bins are combined (rather than splitting bins based on bin content coordinates).
   This avoids a number of cases where Python kernel used to crash since Scipp ran out of memory `#2827 <https://github.com/scipp/scipp/pull/2827>`_.
+* :py:func:`scipp.sum` now also accepts a sequence of dimension labels `#2827 <https://github.com/scipp/scipp/pull/2827>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -43,6 +43,9 @@ Features
 
 * :class:`scipp.Bins` now supports `__getitem__`, providing a shorthand for extracting events based on a coord value or value interval. This is equivalent functionality to label-based indexing for dense data but considers the coordinates of the underlying bin content `#2831 <https://github.com/scipp/scipp/pull/2831>`_.
 * Much faster ``obj.bins.concat`` operations in presence of many bins `#2825 <https://github.com/scipp/scipp/pull/2825>`_.
+* When mapping between many input and output bins:
+  Avoid huge memory use and slow performance in use of :py:func:`scipp.bin` and :py:func:`scipp.group` when only entire bins are combined (rather than splitting bins based on bin content coordinates).
+  This avoids a number of cases where Python kernel used to crash since Scipp ran out of memory `#2827 <https://github.com/scipp/scipp/pull/2827>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -59,6 +59,8 @@ Documentation
 Deprecations
 ~~~~~~~~~~~~
 
+- The ``concat`` action of :py:func:`scipp.groupby` is deprecated. Use :py:func:`scipp.group` and :py:func:`scipp.bin` instead `#2827 <https://github.com/scipp/scipp/pull/2827>`_.
+
 Stability, Maintainability, and Testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user-guide/binned-data/computation.ipynb
+++ b/docs/user-guide/binned-data/computation.ipynb
@@ -38,9 +38,13 @@
     "`a += b` | `a.bins.concatenate(b, out=a)`         | if both `a` and `b` are event data\n",
     "`a -= b` | `a.bins.concatenate(-b, out=a)`        | if both `a` and `b` are event data\n",
     "`sc.sum(a, 'dim')` | `a.bins.concat('dim')`            |\n",
-    "`sc.mean(a, 'dim')` | not available                     | `min`, `max`, and other similar reductions are also not available\n",
+    "`sc.mean(a, 'dim')` | not available (but see comment below) | `min`, `max`, and other similar reductions are also not available\n",
     "`sc.rebin(a, {dim:edges})` | `sc.bin(a, {dim:edges})`        |\n",
-    "`groupby(...).sum('dim')` | `groupby(...).bins.concat('dim')` | `mean`, `max`, and other similar reductions are also available"
+    "`a.groupby('param').sum('dim')` | `a.group('param')` |\n",
+    "`a.groupby('param', bins=edges).sum('dim')` | `a.bin(param=edges)` |\n",
+    "\n",
+    "While above we list `mean`, `min`, `max`, and others as \"not available\", note that this refers to an equivalent function *preserving* data as binned data.\n",
+    "`sum`, `mean`, `min`, and `max` all *do* work on binned data, but return dense data."
    ]
   },
   {

--- a/lib/dataset/bins_util.h
+++ b/lib/dataset/bins_util.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "scipp/dataset/bins.h"
+#include "scipp/variable/shape.h"
 #include "scipp/variable/util.h"
 
 namespace scipp::dataset {
@@ -17,9 +18,11 @@ Variable hide_masked(const Variable &data, const Masks &masks,
   const auto &[begin_end, buffer_dim, buffer] = data.constituents<DataArray>();
   auto indices = begin_end;
   for (const auto dim : dims) {
-    const auto mask = irreducible_mask(masks, dim);
-    if (mask.is_valid())
+    auto mask = irreducible_mask(masks, dim);
+    if (mask.is_valid()) {
+      mask = transpose(mask, data.dims().labels());
       indices = where(mask, empty_range, indices);
+    }
   }
   return make_bins_no_validate(indices, buffer_dim, buffer);
 }

--- a/lib/dataset/bins_util.h
+++ b/lib/dataset/bins_util.h
@@ -20,7 +20,7 @@ Variable hide_masked(const Variable &data, const Masks &masks,
   for (const auto dim : dims) {
     auto mask = irreducible_mask(masks, dim);
     if (mask.is_valid()) {
-      mask = transpose(mask, data.dims().labels());
+      mask = transpose(mask, intersection(data.dims(), mask.dims()).labels());
       indices = where(mask, empty_range, indices);
     }
   }

--- a/lib/dataset/test/sum_test.cpp
+++ b/lib/dataset/test/sum_test.cpp
@@ -76,6 +76,28 @@ TEST(SumTest, masked_data_array_two_masks) {
   EXPECT_FALSE(sum(a, Dim::Y).masks().contains("y"));
 }
 
+TEST(SumTest, mask_dim_order_does_not_overrule_data_dim_order) {
+  Variable var =
+      makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{1, 1, 1});
+  DataArray da(var);
+  da.masks().set("mask", makeVariable<bool>(Dims{Dim::Y, Dim::X, Dim::Z},
+                                            Shape{1, 1, 1}, Values{true}));
+  EXPECT_EQ(sum(da, Dim::Z).dims(), da.slice({Dim::Z, 0}).dims());
+}
+
+TEST(SumTest, mask_order_does_not_overrule_data_dim_order) {
+  Variable var =
+      makeVariable<double>(Dims{Dim::X, Dim::Y, Dim::Z}, Shape{1, 1, 1});
+  DataArray da(var);
+  // Would pass with just one mask
+  da.masks().set("yz", makeVariable<bool>(Dims{Dim::Y, Dim::Z}, Shape{1, 1},
+                                          Values{true}));
+  // Mask dict keeps insertion order, masks merged in order "Y then X"
+  da.masks().set("xy", makeVariable<bool>(Dims{Dim::X, Dim::Z}, Shape{1, 1},
+                                          Values{true}));
+  EXPECT_EQ(sum(da, Dim::Z).dims(), da.slice({Dim::Z, 0}).dims());
+}
+
 class Sum2dCoordTest : public ::testing::Test {
 protected:
   Variable var{makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},

--- a/lib/dataset/variable_reduction.cpp
+++ b/lib/dataset/variable_reduction.cpp
@@ -21,7 +21,8 @@ template <class Op>
 Variable reduce_impl(const Variable &var, const Dim dim, const Masks &masks,
                      const FillValue fill, const Op &op) {
   if (auto mask_union = irreducible_mask(masks, dim); mask_union.is_valid()) {
-    mask_union = transpose(mask_union, var.dims().labels());
+    mask_union = transpose(
+        mask_union, intersection(var.dims(), mask_union.dims()).labels());
     return op(
         where(mask_union, dense_special_like(var, Dimensions{}, fill), var),
         dim);

--- a/lib/dataset/variable_reduction.cpp
+++ b/lib/dataset/variable_reduction.cpp
@@ -8,6 +8,7 @@
 #include "scipp/variable/arithmetic.h"
 #include "scipp/variable/creation.h"
 #include "scipp/variable/reduction.h"
+#include "scipp/variable/shape.h"
 #include "scipp/variable/special_values.h"
 #include "scipp/variable/util.h"
 
@@ -19,8 +20,8 @@ namespace {
 template <class Op>
 Variable reduce_impl(const Variable &var, const Dim dim, const Masks &masks,
                      const FillValue fill, const Op &op) {
-  if (const auto mask_union = irreducible_mask(masks, dim);
-      mask_union.is_valid()) {
+  if (auto mask_union = irreducible_mask(masks, dim); mask_union.is_valid()) {
+    mask_union = transpose(mask_union, var.dims().labels());
     return op(
         where(mask_union, dense_special_like(var, Dimensions{}, fill), var),
         dim);

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -38,12 +38,6 @@ def _with_bin_sizes(var: Variable, sizes: Variable) -> Variable:
     return _cpp._bins_no_validate(data=data, dim=dim, begin=begin, end=end)
 
 
-def _sum(var: Variable, dims: List[str]) -> Variable:
-    for dim in dims:
-        var = var.sum(dim)
-    return var
-
-
 def _concat_bins(var: Variable, dim: List[str]) -> Variable:
     # To concat bins, two things need to happen:
     # 1. Data needs to be written to a contiguous chunk.
@@ -57,7 +51,7 @@ def _concat_bins(var: Variable, dim: List[str]) -> Variable:
     # TODO It would be possible to support a copy=False parameter, to skip the copy if
     # the copy would not result in any moving or reordering.
     out = var.transpose(unchanged_dims + changed_dims).copy()
-    sizes = _sum(out.bins.size(), changed_dims)
+    sizes = out.bins.size().sum(changed_dims)
     return _with_bin_sizes(out, sizes)
 
 

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -122,11 +122,10 @@ def _combine_bins_by_binning_variable(var: Variable, param: Variable,
     index_range = arange(dim, len(param), unit=None)
     input_bin = DataArray(index_range, coords={edges.dim: param})
     sizes.coords['input_bin'] = index_range
-    sizes.coords[edges.dim] = param
 
-    unchanged_dims = [d for d in var.dims if d != dim]
     # To merge bins we need to ensure their content is placed in adjacent memory.
     # We thus move the grouping/binning dim to innermost.
+    unchanged_dims = [d for d in var.dims if d != dim]
     sizes = sizes.transpose(unchanged_dims + [dim])
 
     # Setup shuffle indices for reordering input sizes such that we can use cumsum for
@@ -144,9 +143,6 @@ def _combine_bins_by_binning_variable(var: Variable, param: Variable,
     out_end = cumsum(sizes_sort_out.data)[dim, reverse_shuffle]
     out_begin = out_end - sizes.data
     out_sizes = sizes.groupby(param, bins=edges).sum(dim).data
-    print(f'{out_begin=}')
-    print(f'{out_end=}')
-    print(f'{out_sizes=}')
     return _remap_bins(var, out_begin, out_end, out_sizes)
 
 

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -122,10 +122,7 @@ def _combine_bins(var: Variable, coords: Dict[str, Variable], edges: List[Variab
 
 def combine_bins(da: DataArray, edges: List[Variable], groups: List[Variable],
                  erase: List[str]) -> DataArray:
-    coords = {
-        d: coord
-        for d, coord in da.coords.items() if set(coord.dims).issubset(erase)
-    }
+    coords = {d: var for d, var in da.meta.items() if set(var.dims).issubset(erase)}
     da = hide_masked_and_reduce_meta(da, erase)
     if len(edges) == 0 and len(groups) == 0:
         data = _concat_bins(da.data, erase)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -10,7 +10,8 @@ from .cumulative import cumsum
 from ..typing import Dims, VariableLikeType
 from .variable import index
 from .operations import where
-from .concepts import reduced_coords, reduced_attrs, reduced_masks, irreducible_mask
+from .concepts import (concrete_dims, reduced_coords, reduced_attrs, reduced_masks,
+                       irreducible_mask)
 
 
 def hide_masked_and_reduce_meta(da: DataArray, dim: Dims) -> DataArray:
@@ -134,7 +135,8 @@ def combine_bins(da: DataArray, edges: List[Variable], groups: List[Variable],
     return out
 
 
-def concat_bins(obj: VariableLikeType, dim: str) -> VariableLikeType:
+def concat_bins(obj: VariableLikeType, dim: Dims = None) -> VariableLikeType:
+    erase = list(concrete_dims(obj, dim))
     da = obj if isinstance(obj, DataArray) else DataArray(obj)
-    out = combine_bins(da, edges=[], groups=[], erase=[dim])
+    out = combine_bins(da, edges=[], groups=[], erase=erase)
     return out if isinstance(obj, DataArray) else out.data

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -129,25 +129,20 @@ def _combine_bins_by_binning_variable(var: Variable, param: Variable,
     meta_sizes = full(dims=unchanged_dims,
                       shape=[var.sizes[dim] for dim in unchanged_dims],
                       value=var.sizes[dim])
-    print(f'{meta_sizes=}')
     meta_end = cumsum(meta_sizes)
     meta_begin = meta_end - meta_sizes
     tmp = _cpp._bins_no_validate(data=sizes2.flatten(to='dummy'),
                                  dim='dummy',
                                  begin=meta_begin,
                                  end=meta_end)
-    print(tmp)
-    out_dims = [d if d != dim else edges.dim for d in var.dims]
     # TODO This is some duplicate work, as all target indices are the same
-    tmp = DataArray(tmp).bin({edges.dim: edges}).transpose(out_dims)
-    print(tmp.bins.sum())
+    tmp = DataArray(tmp).bin({edges.dim: edges})
 
     # Setup shuffle indices for reordering input sizes such that we can use cumsum for
     # computing output bin sizes and offsets.
     # We bin only the indices and not the sizes since the latter might not be 1-D
     grouped_input_bin = input_bin.bin({edges.dim: edges})
     shuffle = grouped_input_bin.bins.concat(edges.dim).value.values
-    print(f'{shuffle=}')
     sizes_sort_out = sizes2[param.dim, shuffle]
 
     # Indices for reverting shuffle
@@ -158,11 +153,8 @@ def _combine_bins_by_binning_variable(var: Variable, param: Variable,
     out_end = cumsum(sizes_sort_out.data)[param.dim, reverse_shuffle]
     out_begin = out_end - sizes2.data
     out_sizes = tmp.data.bins.sum()
-    print(f'{param=}')
-    print(f'{var.bins.size().values=}')
-    print(f'{out_begin.values=}')
-    print(f'{out_end.values=}')
-    print(f'{(out_end-out_begin).values=}')
+    print(f'{out_begin=}')
+    print(f'{out_end=}')
     print(f'{out_sizes=}')
     return _remap_bins(var, out_begin, out_end, out_sizes)
 

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -24,9 +24,7 @@ def hide_masked_and_reduce_meta(da: DataArray, dim: Dims) -> DataArray:
             comps['begin'] = comps['begin'][select]
             comps['end'] = comps['end'][select]
         else:
-            zero = index(0, dtype='int64')
-            comps['begin'] = where(mask, zero, comps['begin'])
-            comps['end'] = where(mask, zero, comps['end'])
+            comps['end'] = where(mask, comps['begin'], comps['end'])
         data = _cpp._bins_no_validate(**comps)
     else:
         data = da.data

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -61,7 +61,7 @@ def _concat_bins(var: Variable, dims: List[str]) -> Variable:
     changed_dims = dims
     unchanged_dims = [d for d in var.dims if d not in changed_dims]
     # TODO It would be possible to support a copy=False parameter, to skip the copy if
-    # the copy would not result in an moving or reordering.
+    # the copy would not result in any moving or reordering.
     out = var.transpose(unchanged_dims + changed_dims).copy()
     sizes = _sum(out.bins.size(), dims)
     return _with_bin_sizes(out, sizes)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import uuid
 from typing import Dict
 from .._scipp import core as _cpp
 from .cpp_classes import DataArray, Variable, Dataset
@@ -115,8 +116,15 @@ def _concat_bins_variable(var: Variable, dim: str) -> Variable:
     return _remap_bins(var, out_begin, out_end, out_sizes)
 
 
+def _flatten_param_dims(var: Variable, param: Variable):
+    dim = uuid.uuid4().hex
+    dims = [d for d in var.dims if d in param.dims]
+    return var.flatten(dims=dims, to=dim), param.transpose(dims).flatten(to=dim)
+
+
 def _combine_bins_by_binning_variable(var: Variable, param: Variable,
                                       edges: Variable) -> Variable:
+    var, param = _flatten_param_dims(var, param)
     dim = param.dim
     sizes = DataArray(var.bins.size())
     index_range = arange(dim, len(param), unit=None)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -182,20 +182,17 @@ def func(var: Variable, coords, edges, groups, erase):
     return {'begin': out_begin, 'end': out_end, 'sizes': tmp.data.bins.sum()}
 
 
-def remap_bins_by_binning(da: DataArray, edges: List[Variable]) -> DataArray:
-    erase = []
-    for x in edges:
-        dim = x.dim
-        for d in da.meta[dim].dims:
-            if d not in erase:
-                erase.append(d)
+def remap_bins_by_binning(da: DataArray, edges: List[Variable], groups: List[Variable],
+                          erase: List[str]) -> DataArray:
     coords = da.coords
     da = hide_masked_and_reduce_meta(da, erase)
-    params = func(da.data, coords=coords, edges=edges, groups=[], erase=erase)
+    params = func(da.data, coords=coords, edges=edges, groups=groups, erase=erase)
     data = _remap_bins(da.data, **params)
     out = DataArray(data, coords=da.coords, masks=da.masks, attrs=da.attrs)
     for edge in edges:
         out.coords[edge.dim] = edge
+    for group in groups:
+        out.coords[group.dim] = group
     return out
 
 

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -149,13 +149,13 @@ def _setup_combine_bins_params(var: Variable, coords: Dict[str, Variable],
 
     # Preserve subspace dim order of input data, instead of the one given by `erase`
     changed_dims = [dim for dim in var.dims if dim in erase]
-    unchanged_dims = [d for d in var.dims if d not in changed_dims]
+    unchanged_dims = [dim for dim in var.dims if dim not in changed_dims]
     sizes = DataArray(var.bins.size(), coords=coords)
     input_bin = uuid.uuid4().hex
     changed_shape = [var.sizes[dim] for dim in changed_dims]
     unchanged_shape = [var.sizes[dim] for dim in unchanged_dims]
     changed_volume = prod(changed_shape)
-    # Move modified dims to innermost to ensure data is writen in contiguous memory.
+    # Move modified dims to innermost to ensure data is written in contiguous memory.
     sizes = sizes.transpose(unchanged_dims + changed_dims)
     # Flatten modified subspace for next steps. This is mainly necessary so we can
     # `sort` later to reshuffle back to input bin order, using the added `input_bin`

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -72,11 +72,11 @@ def _combine_bins(var: Variable, coords: Dict[str, Variable], edges: List[Variab
     # --------
     # The purpose of this code is to combine existing bins, but in a more general
     # manner than `concat`, which combines all bins along a dimension. Here we operate
-    # more like `groupby`, which combines selected subset and creates a new output dim.
+    # more like `groupby`, which combines selected subsets and creates a new output dim.
     #
     # Approach
     # --------
-    # The algorithm works concetually similar to `_concat_bins`, but with an additional
+    # The algorithm works conceptually similar to `_concat_bins`, but with an additional
     # step, calling `make_binned` for grouping within the erased dims. For the final
     # output binning, instead of summing the input bin sizes over all erased dims, we
     # sum only within the groups created by `make_binned`.

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -19,7 +19,7 @@ def hide_masked(da: DataArray, dim: Dims) -> DataArray:
         # Avoid using boolean indexing since it would result in (partial) content
         # buffer copy. Instead index just begin/end and reuse content buffer.
         comps = da.bins.constituents
-        # The the mask is 1-D we can drop entire "rows" or "columns". This can
+        # If the mask is 1-D we can drop entire "rows" or "columns". This can
         # drastically reduce the number of bins to handle in some cases for better
         # performance. For 2-D or higher masks we fall back to making bins "empty" by
         # setting end=begin.

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -87,9 +87,10 @@ def _setup_concat_bins_params(var: Variable, dim: str) -> Variable:
     # content buffer. This will then allow us to create new, larger bins covering the
     # respective input bins. We use `cumsum` after moving `dim` to the innermost dim.
     # This will allow us to setup offsets for the new contiguous layout.
+    changed_dims = [dim]
+    unchanged_dims = [d for d in var.dims if d != dim]
     sizes = var.bins.size()
-    out_dims = [d for d in var.dims if d != dim]
-    end = cumsum(sizes.transpose(out_dims + [dim])).transpose(var.dims)
+    end = cumsum(sizes.transpose(unchanged_dims + changed_dims)).transpose(var.dims)
     begin = end - sizes
     return {'begin': begin, 'end': end, 'sizes': sizes.sum(dim)}
 
@@ -140,7 +141,7 @@ def _setup_combine_bins_params(var: Variable, coords: Dict[str, Variable],
     #       output content buffer.
     # 7. The result of 6.b is converted back to the input order, undoing the binning.
 
-    # Preserve subspace dim order of input data, instead of using that given by `erase`
+    # Preserve subspace dim order of input data, instead of the one given by `erase`
     changed_dims = [dim for dim in var.dims if dim in erase]
     unchanged_dims = [d for d in var.dims if d not in changed_dims]
     sizes = DataArray(var.bins.size(), coords=coords)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -8,7 +8,7 @@ from .like import empty_like
 from .cumulative import cumsum
 from .dataset import irreducible_mask
 from ..typing import VariableLikeType
-from .variable import arange, full
+from .variable import arange
 from .operations import sort
 
 
@@ -117,42 +117,33 @@ def _concat_bins_variable(var: Variable, dim: str) -> Variable:
 
 def _combine_bins_by_binning_variable(var: Variable, param: Variable,
                                       edges: Variable) -> Variable:
+    dim = param.dim
     sizes = DataArray(var.bins.size())
-    index_range = arange(param.dim, len(param), unit=None)
+    index_range = arange(dim, len(param), unit=None)
     input_bin = DataArray(index_range, coords={edges.dim: param})
     sizes.coords['input_bin'] = index_range
     sizes.coords[edges.dim] = param
 
-    dim = param.dim
     unchanged_dims = [d for d in var.dims if d != dim]
-    sizes2 = sizes.transpose(unchanged_dims + [dim])
-    meta_sizes = full(dims=unchanged_dims,
-                      shape=[var.sizes[dim] for dim in unchanged_dims],
-                      value=var.sizes[dim])
-    meta_end = cumsum(meta_sizes)
-    meta_begin = meta_end - meta_sizes
-    tmp = _cpp._bins_no_validate(data=sizes2.flatten(to='dummy'),
-                                 dim='dummy',
-                                 begin=meta_begin,
-                                 end=meta_end)
-    # TODO This is some duplicate work, as all target indices are the same
-    tmp = DataArray(tmp).bin({edges.dim: edges})
+    # To merge bins we need to ensure their content is placed in adjacent memory.
+    # We thus move the grouping/binning dim to innermost.
+    sizes = sizes.transpose(unchanged_dims + [dim])
 
     # Setup shuffle indices for reordering input sizes such that we can use cumsum for
     # computing output bin sizes and offsets.
     # We bin only the indices and not the sizes since the latter might not be 1-D
     grouped_input_bin = input_bin.bin({edges.dim: edges})
     shuffle = grouped_input_bin.bins.concat(edges.dim).value.values
-    sizes_sort_out = sizes2[param.dim, shuffle]
+    sizes_sort_out = sizes[dim, shuffle]
 
     # Indices for reverting shuffle
     reverse_shuffle = DataArray(index_range,
                                 coords={'order': sizes_sort_out.coords['input_bin']})
     reverse_shuffle = sort(reverse_shuffle, 'order').values
 
-    out_end = cumsum(sizes_sort_out.data)[param.dim, reverse_shuffle]
-    out_begin = out_end - sizes2.data
-    out_sizes = tmp.data.bins.sum()
+    out_end = cumsum(sizes_sort_out.data)[dim, reverse_shuffle]
+    out_begin = out_end - sizes.data
+    out_sizes = sizes.groupby(param, bins=edges).sum(dim).data
     print(f'{out_begin=}')
     print(f'{out_end=}')
     print(f'{out_sizes=}')

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -182,8 +182,8 @@ def func(var: Variable, coords, edges, groups, erase):
     return {'begin': out_begin, 'end': out_end, 'sizes': tmp.data.bins.sum()}
 
 
-def remap_bins_by_binning(da: DataArray, edges: List[Variable], groups: List[Variable],
-                          erase: List[str]) -> DataArray:
+def remap_bins(da: DataArray, edges: List[Variable], groups: List[Variable],
+               erase: List[str]) -> DataArray:
     coords = da.coords
     da = hide_masked_and_reduce_meta(da, erase)
     params = func(da.data, coords=coords, edges=edges, groups=groups, erase=erase)

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -12,7 +12,7 @@ from ..typing import VariableLikeType
 from .variable import arange, full
 from .operations import sort
 from .comparison import identical
-from .concepts import copy_for_overwrite
+from .util import copy_for_overwrite
 
 
 def _reduced(obj: Dict[str, Variable], dim: str) -> Dict[str, Variable]:

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -13,22 +13,7 @@ from .variable import arange, full, index
 from .operations import sort, where
 from .comparison import identical
 from .util import copy_for_overwrite
-
-
-def _reduced(obj: Dict[str, Variable], dim: str) -> Dict[str, Variable]:
-    return {name: var for name, var in obj.items() if dim not in var.dims}
-
-
-def reduced_coords(da: DataArray, dim: str) -> Dict[str, Variable]:
-    return _reduced(da.coords, dim)
-
-
-def reduced_attrs(da: DataArray, dim: str) -> Dict[str, Variable]:
-    return _reduced(da.attrs, dim)
-
-
-def reduced_masks(da: DataArray, dim: str) -> Dict[str, Variable]:
-    return {name: mask.copy() for name, mask in _reduced(da.masks, dim).items()}
+from .concepts import reduced_coords, reduced_attrs, reduced_masks
 
 
 def hide_masked_and_reduce_meta(da: DataArray, dims: List[str]) -> DataArray:

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -111,18 +111,16 @@ def _combine_bins(var: Variable, coords: Dict[str, Variable], edges: List[Variab
 
 def combine_bins(da: DataArray, edges: List[Variable], groups: List[Variable],
                  dim: Dims) -> DataArray:
-    data = hide_masked(da, dim)
+    masked = hide_masked(da, dim)
     if len(edges) == 0 and len(groups) == 0:
-        data = _concat_bins(data, dim=dim)
+        data = _concat_bins(masked, dim=dim)
     else:
         names = [coord.dim for coord in itertools.chain(edges, groups)]
         coords = {name: da.meta[name] for name in names}
-        data = _combine_bins(data, coords=coords, edges=edges, groups=groups, dim=dim)
+        data = _combine_bins(masked, coords=coords, edges=edges, groups=groups, dim=dim)
     out = rewrap_reduced_data(da, data, dim=dim)
-    for edge in edges:
-        out.coords[edge.dim] = edge
-    for group in groups:
-        out.coords[group.dim] = group
+    for coord in itertools.chain(edges, groups):
+        out.coords[coord.dim] = coord
     return out
 
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Union, Sequence
 from .._scipp import core as _cpp
 from .variable import array, Variable, linspace, arange, epoch, scalar
 from .math import round as round_
-from .bin_remapping import remap_bins
+from .bin_remapping import combine_bins
 
 
 def make_histogrammed(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset], *,
@@ -107,12 +107,12 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
                              "binning or histogramming a variable.")
         data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes).copy()
         x = _cpp.DataArray(data, coords={coords[0].dim: x})
-    if _can_remap_bins_by_binning(x, edges, groups, erase):
-        return remap_bins(x, edges=edges, groups=groups, erase=erase)
+    if _can_combine_bins_by_binning(x, edges, groups, erase):
+        return combine_bins(x, edges=edges, groups=groups, erase=erase)
     return _cpp.bin(x, edges, groups, erase)
 
 
-def _can_remap_bins_by_binning(x, edges, groups, erase):
+def _can_combine_bins_by_binning(x, edges, groups, erase):
     if x.bins is None:
         return False
     dims = []

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -108,7 +108,7 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
         data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes).copy()
         x = _cpp.DataArray(data, coords={coords[0].dim: x})
     if _can_remap_bins_by_binning(x, edges, groups, erase):
-        return remap_bins_by_binning(x, edges)
+        return remap_bins_by_binning(x, edges=edges, groups=groups, erase=erase)
     return _cpp.bin(x, edges, groups, erase)
 
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -125,6 +125,8 @@ def _can_remap_bins_by_binning(x, edges, groups, erase):
             return False
         if edge.dim in x.bins.meta:
             return False
+        if edge.dim not in x.meta:
+            return False
         dims += x.meta[edge.dim].dims
     return set(dims) == set(erase) and len(dims) == len(erase)
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -127,7 +127,7 @@ def _can_operate_on_bins(x, edges, groups, erase) -> bool:
         if coord.dim not in x.meta:
             return False
         dims += x.meta[coord.dim].dims
-    return set(dims) <= set(erase) and len(dims) <= len(erase)
+    return set(dims) <= set(erase)
 
 
 def _require_coord(name, coord):

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import itertools
 import warnings
 from numbers import Integral
 from typing import Dict, List, Optional, Union, Sequence
@@ -118,15 +119,14 @@ def _can_operate_on_bins(x, edges, groups, erase) -> bool:
     if x.bins is None:
         return False
     dims = []
-    for coords in [edges, groups]:
-        for coord in coords:
-            if coord.ndim != 1:
-                return False
-            if coord.dim in x.bins.meta:
-                return False
-            if coord.dim not in x.meta:
-                return False
-            dims += x.meta[coord.dim].dims
+    for coord in itertools.chain(edges, groups):
+        if coord.ndim != 1:
+            return False
+        if coord.dim in x.bins.meta:
+            return False
+        if coord.dim not in x.meta:
+            return False
+        dims += x.meta[coord.dim].dims
     return set(dims) <= set(erase) and len(dims) <= len(erase)
 
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -111,7 +111,7 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
         data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes).copy()
         x = _cpp.DataArray(data, coords={coords[0].dim: x})
     if _can_operate_on_bins(x, edges, groups, erase):
-        return combine_bins(x, edges=edges, groups=groups, erase=erase)
+        return combine_bins(x, edges=edges, groups=groups, dim=erase)
     return _cpp.bin(x, edges, groups, erase)
 
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -100,7 +100,9 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
         groups = []
     if edges is None:
         edges = []
-    if isinstance(x, Variable):
+    if isinstance(x, Variable) and x.bins is not None:
+        x = _cpp.DataArray(x)
+    elif isinstance(x, Variable):
         coords = [*edges, *groups]
         if len(coords) != 1:
             raise ValueError("Edges for exactly one dimension must be specified when "

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -109,12 +109,12 @@ def make_binned(x: Union[_cpp.Variable, _cpp.DataArray],
                              "binning or histogramming a variable.")
         data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes).copy()
         x = _cpp.DataArray(data, coords={coords[0].dim: x})
-    if _can_combine_bins_by_binning(x, edges, groups, erase):
+    if _can_operate_on_bins(x, edges, groups, erase):
         return combine_bins(x, edges=edges, groups=groups, erase=erase)
     return _cpp.bin(x, edges, groups, erase)
 
 
-def _can_combine_bins_by_binning(x, edges, groups, erase):
+def _can_operate_on_bins(x, edges, groups, erase) -> bool:
     if x.bins is None:
         return False
     dims = []

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -127,7 +127,7 @@ def _can_combine_bins_by_binning(x, edges, groups, erase):
             if coord.dim not in x.meta:
                 return False
             dims += x.meta[coord.dim].dims
-    return set(dims) == set(erase) and len(dims) == len(erase)
+    return set(dims) <= set(erase) and len(dims) <= len(erase)
 
 
 def _require_coord(name, coord):

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -118,7 +118,7 @@ def _can_remap_bins_by_binning(x, edges, groups, erase):
     if len(groups) != 0:
         return False
     if len(edges) != 1:
-        return False  # Not implemented currently
+        return False  # Not implemented currently, but possible
     dims = []
     for edge in edges:
         if edge.ndim != 1:

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -430,7 +430,7 @@ class GroupbyBins:
 
     def concat(self, dim):
         warnings.warn(
-            "groupby(...).bins.concat(dim) deprecated. `group` or `bin` instead",
+            "groupby(...).bins.concat(dim) is deprecated. Use `group` or `bin` instead",
             UserWarning)
         return self._obj.concat(dim)
 

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -2,12 +2,11 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from typing import Callable, Dict, Literal, Optional, Union, Tuple
-import uuid
 import warnings
 
 from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from ..typing import VariableLike, MetaDataMap
+from ..typing import Dims, VariableLike, MetaDataMap
 from .domains import merge_equal_adjacent
 from .operations import islinspace
 from .math import midpoints
@@ -366,7 +365,7 @@ class Bins:
         """
         return _call_cpp_func(_cpp.bin_sizes, self._obj)
 
-    def concat(self, dim: Optional[str] = None) -> Union[_cpp.Variable, _cpp.DataArray]:
+    def concat(self, dim: Dims = None) -> Union[_cpp.Variable, _cpp.DataArray]:
         """Concatenate bins element-wise by concatenating bin contents along
         their internal bin dimension.
 
@@ -383,10 +382,7 @@ class Bins:
         :
             All bins along `dim` concatenated into a single bin.
         """
-        if dim is not None:
-            return concat_bins(self._obj, dim)
-        dim = uuid.uuid4().hex
-        return self._obj.flatten(to=dim).bins.concat(dim)
+        return concat_bins(self._obj, dim)
 
     def concatenate(
             self,

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -3,6 +3,7 @@
 # @author Simon Heybrock
 from typing import Callable, Dict, Literal, Optional, Union, Tuple
 import uuid
+import warnings
 
 from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
@@ -432,6 +433,9 @@ class GroupbyBins:
         self._obj = obj
 
     def concat(self, dim):
+        warnings.warn(
+            "groupby(...).bins.concat(dim) deprecated. `group` or `bin` instead",
+            UserWarning)
         return self._obj.concat(dim)
 
 

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable, Dict, Sequence, Union
+from functools import reduce
+from typing import Callable, Dict, List, Tuple, Union
 from .cpp_classes import DataArray, Variable
-from ..typing import VariableLikeType
+from ..typing import Dims, VariableLikeType
+from .logical import logical_or
 
 
 def rewrap_output_data(prototype: VariableLikeType, data) -> VariableLikeType:
@@ -28,21 +30,47 @@ def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
         raise TypeError(f"{func} only supports Variable and DataArray as inputs.")
 
 
-Dims = Union[str, Sequence[str]]
+def concrete_dims(obj: VariableLikeType, dim: Dims) -> Tuple[str]:
+    """Convert a dimension specification into a concrete tuple of dimension labels.
+
+    This does *not* validate that the dimension labels are valid for the given object.
+    """
+    if dim is None:
+        return obj.dims
+    return (dim, ) if isinstance(dim, str) else tuple(dim)
 
 
-def _reduced(obj: Dict[str, Variable], dim: Dims) -> Dict[str, Variable]:
-    dims = set([dim] if isinstance(dim, str) else dim)
+def _reduced(obj: Dict[str, Variable], dims: List[str]) -> Dict[str, Variable]:
+    dims = set(dims)
     return {name: var for name, var in obj.items() if dims.isdisjoint(var.dims)}
 
 
 def reduced_coords(da: DataArray, dim: Dims) -> Dict[str, Variable]:
-    return _reduced(da.coords, dim)
+    return _reduced(da.coords, concrete_dims(da, dim))
 
 
 def reduced_attrs(da: DataArray, dim: Dims) -> Dict[str, Variable]:
-    return _reduced(da.attrs, dim)
+    return _reduced(da.attrs, concrete_dims(da, dim))
 
 
 def reduced_masks(da: DataArray, dim: Dims) -> Dict[str, Variable]:
-    return {name: mask.copy() for name, mask in _reduced(da.masks, dim).items()}
+    return {
+        name: mask.copy()
+        for name, mask in _reduced(da.masks, concrete_dims(da, dim)).items()
+    }
+
+
+def irreducible_mask(da: DataArray, dim: Dims) -> Union[None, Variable]:
+    """
+    The union of masks that would need to be applied in a reduction op over dim.
+
+    Irreducible means that a reduction operation must apply these masks since they
+    depend on the reduction dimensions. Returns None if there is no irreducible mask.
+    """
+    dims = set(concrete_dims(da, dim))
+    irreducible = [mask for mask in da.masks.values() if not dims.isdisjoint(mask.dims)]
+    if len(irreducible) == 0:
+        return None
+    if len(irreducible) == 1:
+        return irreducible[0].copy()
+    return reduce(logical_or, irreducible)

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -27,6 +27,14 @@ def rewrap_output_data(prototype: VariableLikeType, data) -> VariableLikeType:
         return data
 
 
+def rewrap_reduced_data(prototype: VariableLikeType, data,
+                        dim: Dims) -> VariableLikeType:
+    return DataArray(data,
+                     coords=reduced_coords(prototype, dim),
+                     masks=reduced_masks(prototype, dim),
+                     attrs=reduced_attrs(prototype, dim))
+
+
 def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
     if isinstance(obj, Variable):
         return func(obj)

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable, Dict
-from .cpp_classes import DataArray, Variable, Dataset
+from typing import Callable
+from .cpp_classes import DataArray, Variable
 from ..typing import VariableLikeType
 
 
@@ -26,31 +26,3 @@ def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
         return rewrap_output_data(obj, func(obj.data))
     else:
         raise TypeError(f"{func} only supports Variable and DataArray as inputs.")
-
-
-def _copy_dict_for_overwrite(mapping: Dict[str, Variable]) -> Dict[str, Variable]:
-    return {name: copy_for_overwrite(var) for name, var in mapping.items()}
-
-
-def copy_for_overwrite(obj: VariableLikeType) -> VariableLikeType:
-    """
-    Copy a Scipp object for overwriting.
-
-    Unlike :py:func:`scipp.empty_like` this does not preserve (and share) coord,
-    mask, and attr values. Instead, those values are not initialized, just like the
-    data values.
-    """
-    from .like import empty_like
-    if isinstance(obj, Variable):
-        return empty_like(obj)
-    if isinstance(obj, DataArray):
-        return DataArray(copy_for_overwrite(obj.data),
-                         coords=_copy_dict_for_overwrite(obj.coords),
-                         masks=_copy_dict_for_overwrite(obj.masks),
-                         attrs=_copy_dict_for_overwrite(obj.attrs))
-    ds = Dataset(coords=_copy_dict_for_overwrite(obj.coords))
-    for name, da in obj.items():
-        ds[name] = DataArray(copy_for_overwrite(da.data),
-                             masks=_copy_dict_for_overwrite(da.masks),
-                             attrs=_copy_dict_for_overwrite(da.attrs))
-    return ds

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -2,17 +2,17 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from functools import reduce
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Mapping, Tuple, Union
 from .cpp_classes import DataArray, Variable
 from ..typing import Dims, VariableLikeType
 from .logical import logical_or
 
 
-def _copied(obj: Dict[str, Variable]) -> Dict[str, Variable]:
+def _copied(obj: Mapping[str, Variable]) -> Dict[str, Variable]:
     return {name: var.copy() for name, var in obj.items()}
 
 
-def _reduced(obj: Dict[str, Variable], dims: List[str]) -> Dict[str, Variable]:
+def _reduced(obj: Mapping[str, Variable], dims: List[str]) -> Dict[str, Variable]:
     dims = set(dims)
     return {name: var for name, var in obj.items() if dims.isdisjoint(var.dims)}
 

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable
+from typing import Callable, Dict, Sequence, Union
 from .cpp_classes import DataArray, Variable
 from ..typing import VariableLikeType
 
@@ -26,3 +26,23 @@ def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
         return rewrap_output_data(obj, func(obj.data))
     else:
         raise TypeError(f"{func} only supports Variable and DataArray as inputs.")
+
+
+Dims = Union[str, Sequence[str]]
+
+
+def _reduced(obj: Dict[str, Variable], dim: Dims) -> Dict[str, Variable]:
+    dims = set([dim] if isinstance(dim, str) else dim)
+    return {name: var for name, var in obj.items() if dims.isdisjoint(var.dims)}
+
+
+def reduced_coords(da: DataArray, dim: Dims) -> Dict[str, Variable]:
+    return _reduced(da.coords, dim)
+
+
+def reduced_attrs(da: DataArray, dim: Dims) -> Dict[str, Variable]:
+    return _reduced(da.attrs, dim)
+
+
+def reduced_masks(da: DataArray, dim: Dims) -> Dict[str, Variable]:
+    return {name: mask.copy() for name, mask in _reduced(da.masks, dim).items()}

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable
-from .cpp_classes import DataArray, Variable
+from typing import Callable, Dict
+from .cpp_classes import DataArray, Variable, Dataset
 from ..typing import VariableLikeType
 
 
@@ -26,3 +26,31 @@ def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
         return rewrap_output_data(obj, func(obj.data))
     else:
         raise TypeError(f"{func} only supports Variable and DataArray as inputs.")
+
+
+def _copy_dict_for_overwrite(mapping: Dict[str, Variable]) -> Dict[str, Variable]:
+    return {name: copy_for_overwrite(var) for name, var in mapping.items()}
+
+
+def copy_for_overwrite(obj: VariableLikeType) -> VariableLikeType:
+    """
+    Copy a Scipp object for overwriting.
+
+    Unlike :py:func:`scipp.empty_like` this does not preserve (and share) coord,
+    mask, and attr values. Instead, those values are not initialized, just like the
+    data values.
+    """
+    from .like import empty_like
+    if isinstance(obj, Variable):
+        return empty_like(obj)
+    if isinstance(obj, DataArray):
+        return DataArray(copy_for_overwrite(obj.data),
+                         coords=_copy_dict_for_overwrite(obj.coords),
+                         masks=_copy_dict_for_overwrite(obj.masks),
+                         attrs=_copy_dict_for_overwrite(obj.attrs))
+    ds = Dataset(coords=_copy_dict_for_overwrite(obj.coords))
+    for name, da in obj.items():
+        ds[name] = DataArray(copy_for_overwrite(da.data),
+                             masks=_copy_dict_for_overwrite(da.masks),
+                             attrs=_copy_dict_for_overwrite(da.attrs))
+    return ds

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -24,4 +24,5 @@ def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
         return func(obj)
     if isinstance(obj, DataArray):
         return rewrap_output_data(obj, func(obj.data))
-    # TODO Dataset
+    else:
+        raise TypeError(f"{func} only supports Variable and DataArray as inputs.")

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from typing import Callable
+from .cpp_classes import DataArray, Variable
+from ..typing import VariableLikeType
+
+
+def rewrap_output_data(prototype: VariableLikeType, data) -> VariableLikeType:
+    if isinstance(prototype, DataArray):
+        return DataArray(data=data,
+                         coords={c: coord
+                                 for c, coord in prototype.coords.items()},
+                         attrs={a: attr
+                                for a, attr in prototype.attrs.items()},
+                         masks={m: mask.copy()
+                                for m, mask in prototype.masks.items()})
+    else:
+        return data
+
+
+def transform_data(obj: VariableLikeType, func: Callable) -> VariableLikeType:
+    if isinstance(obj, Variable):
+        return func(obj)
+    if isinstance(obj, DataArray):
+        return rewrap_output_data(obj, func(obj.data))
+    # TODO Dataset

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -77,6 +77,10 @@ def irreducible_mask(da: DataArray, dim: Dims) -> Union[None, Variable]:
     irreducible = [mask for mask in da.masks.values() if not dims.isdisjoint(mask.dims)]
     if len(irreducible) == 0:
         return None
+
+    def _transposed_like_data(x):
+        return x.transpose([dim for dim in da.dims if dim in x.dims])
+
     if len(irreducible) == 1:
-        return irreducible[0].copy()
-    return reduce(logical_or, irreducible)
+        return _transposed_like_data(irreducible[0]).copy()
+    return _transposed_like_data(reduce(logical_or, irreducible))

--- a/src/scipp/core/cumulative.py
+++ b/src/scipp/core/cumulative.py
@@ -5,12 +5,14 @@
 from typing import Literal, Optional
 
 from .._scipp import core as _cpp
+from ..typing import VariableLikeType
 from ._cpp_wrapper_util import call_func as _call_cpp_func
+from .concepts import transform_data
 
 
-def cumsum(a: _cpp.Variable,
+def cumsum(a: VariableLikeType,
            dim: Optional[str] = None,
-           mode: Literal['exclusive', 'inclusive'] = 'inclusive') -> _cpp.Variable:
+           mode: Literal['exclusive', 'inclusive'] = 'inclusive') -> VariableLikeType:
     """Return the cumulative sum along the specified dimension.
 
     See :py:func:`scipp.sum` on how rounding errors for float32 inputs are handled.
@@ -31,7 +33,11 @@ def cumsum(a: _cpp.Variable,
     :
         The cumulative sum of the input values.
     """
-    if dim is None:
-        return _call_cpp_func(_cpp.cumsum, a, mode=mode)
-    else:
-        return _call_cpp_func(_cpp.cumsum, a, dim, mode=mode)
+
+    def _cumsum(data):
+        if dim is None:
+            return _call_cpp_func(_cpp.cumsum, data, mode=mode)
+        else:
+            return _call_cpp_func(_cpp.cumsum, data, dim, mode=mode)
+
+    return transform_data(a, _cumsum)

--- a/src/scipp/core/cumulative.py
+++ b/src/scipp/core/cumulative.py
@@ -19,7 +19,7 @@ def cumsum(a: VariableLikeType,
 
     Parameters
     ----------
-    a:
+    a: scipp.typing.VariableLike
         Input data.
     dim:
         Optional dimension along which to calculate the sum. If not
@@ -30,7 +30,7 @@ def cumsum(a: VariableLikeType,
 
     Returns
     -------
-    :
+    : Same type as input
         The cumulative sum of the input values.
     """
 

--- a/src/scipp/core/like.py
+++ b/src/scipp/core/like.py
@@ -2,22 +2,9 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 
 from typing import Any
-from .._scipp import core as _cpp
 from .variable import ones, zeros, empty, full
 from ..typing import VariableLikeType
-
-
-def _to_variable_or_data_array(var, new_values):
-    if isinstance(var, _cpp.DataArray):
-        return _cpp.DataArray(data=new_values,
-                              coords={c: coord
-                                      for c, coord in var.coords.items()},
-                              attrs={a: attr
-                                     for a, attr in var.attrs.items()},
-                              masks={m: mask.copy()
-                                     for m, mask in var.masks.items()})
-    else:
-        return new_values
+from .concepts import rewrap_output_data
 
 
 def zeros_like(obj: VariableLikeType, /) -> VariableLikeType:
@@ -54,7 +41,7 @@ def zeros_like(obj: VariableLikeType, /) -> VariableLikeType:
                        unit=obj.unit,
                        dtype=obj.dtype,
                        with_variances=obj.variances is not None)
-    return _to_variable_or_data_array(obj, new_values)
+    return rewrap_output_data(obj, new_values)
 
 
 def ones_like(obj: VariableLikeType, /) -> VariableLikeType:
@@ -91,7 +78,7 @@ def ones_like(obj: VariableLikeType, /) -> VariableLikeType:
                       unit=obj.unit,
                       dtype=obj.dtype,
                       with_variances=obj.variances is not None)
-    return _to_variable_or_data_array(obj, new_values)
+    return rewrap_output_data(obj, new_values)
 
 
 def empty_like(obj: VariableLikeType, /) -> VariableLikeType:
@@ -132,7 +119,7 @@ def empty_like(obj: VariableLikeType, /) -> VariableLikeType:
                        unit=obj.unit,
                        dtype=obj.dtype,
                        with_variances=obj.variances is not None)
-    return _to_variable_or_data_array(obj, new_values)
+    return rewrap_output_data(obj, new_values)
 
 
 def full_like(obj: VariableLikeType,
@@ -178,4 +165,4 @@ def full_like(obj: VariableLikeType,
                       dtype=obj.dtype,
                       value=value,
                       variance=variance)
-    return _to_variable_or_data_array(obj, new_values)
+    return rewrap_output_data(obj, new_values)

--- a/src/scipp/core/reduction.py
+++ b/src/scipp/core/reduction.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .._scipp import core as _cpp
-from ..typing import VariableLikeType
+from ..typing import Dims, VariableLikeType
 
 
 def mean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
@@ -81,7 +81,7 @@ def nanmean(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
         return _cpp.nanmean(x, dim=dim)
 
 
-def sum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
+def sum(x: VariableLikeType, dim: Dims = None) -> VariableLikeType:
     """Sum of elements in the input.
 
     If the input data is in single precision (dtype='float32') this internally uses
@@ -110,8 +110,11 @@ def sum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:
     """
     if dim is None:
         return _cpp.sum(x)
-    else:
+    elif isinstance(dim, str):
         return _cpp.sum(x, dim=dim)
+    for d in dim:
+        x = _cpp.sum(x, d)
+    return x
 
 
 def nansum(x: VariableLikeType, dim: Optional[str] = None) -> VariableLikeType:

--- a/src/scipp/core/shape.py
+++ b/src/scipp/core/shape.py
@@ -10,6 +10,7 @@ from .._scipp import core as _cpp
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from ._sizes import _parse_dims_shape_sizes
 from ..typing import VariableLikeType
+from .concepts import transform_data
 
 
 def broadcast(
@@ -48,19 +49,11 @@ def broadcast(
         New Variable or DataArray with requested dimension labels and shape.
     """
     sizes = _parse_dims_shape_sizes(dims=dims, shape=shape, sizes=sizes)
-    if isinstance(x, _cpp.Variable):
+
+    def _broadcast(x):
         return _call_cpp_func(_cpp.broadcast, x, sizes["dims"], sizes["shape"])
-    elif isinstance(x, _cpp.DataArray):
-        return _cpp.DataArray(data=_call_cpp_func(_cpp.broadcast, x.data, sizes["dims"],
-                                                  sizes["shape"]),
-                              coords={c: coord
-                                      for c, coord in x.coords.items()},
-                              attrs={a: attr
-                                     for a, attr in x.attrs.items()},
-                              masks={m: mask.copy()
-                                     for m, mask in x.masks.items()})
-    else:
-        raise TypeError("Broadcast only supports Variable and DataArray as inputs.")
+
+    return transform_data(x, _broadcast)
 
 
 def concat(x: Sequence[VariableLikeType], dim: str) -> VariableLikeType:

--- a/src/scipp/core/util.py
+++ b/src/scipp/core/util.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from typing import Dict
+from .cpp_classes import DataArray, Variable, Dataset
+from ..typing import VariableLikeType
+from .like import empty_like
+
+
+def _copy_dict_for_overwrite(mapping: Dict[str, Variable]) -> Dict[str, Variable]:
+    return {name: copy_for_overwrite(var) for name, var in mapping.items()}
+
+
+def copy_for_overwrite(obj: VariableLikeType) -> VariableLikeType:
+    """
+    Copy a Scipp object for overwriting.
+
+    Unlike :py:func:`scipp.empty_like` this does not preserve (and share) coord,
+    mask, and attr values. Instead, those values are not initialized, just like the
+    data values.
+    """
+    if isinstance(obj, Variable):
+        return empty_like(obj)
+    if isinstance(obj, DataArray):
+        return DataArray(copy_for_overwrite(obj.data),
+                         coords=_copy_dict_for_overwrite(obj.coords),
+                         masks=_copy_dict_for_overwrite(obj.masks),
+                         attrs=_copy_dict_for_overwrite(obj.attrs))
+    ds = Dataset(coords=_copy_dict_for_overwrite(obj.coords))
+    for name, da in obj.items():
+        ds[name] = DataArray(copy_for_overwrite(da.data),
+                             masks=_copy_dict_for_overwrite(da.masks),
+                             attrs=_copy_dict_for_overwrite(da.attrs))
+    return ds

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -51,7 +51,7 @@ Dims = _std_typing.Union[None, str, _std_typing.Sequence[str]]
 Describes dimensions to operate on.
 
 Can be a string (for a single dimension) or a sequence of strings (multiple dimensions).
-A value of ``None`` indicated "all dimensions."
+A value of ``None`` indicates "all dimensions."
 """
 
 VariableLike = _std_typing.Union[Variable, DataArray, Dataset]

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -46,6 +46,14 @@ def has_numeric_type(obj: _std_typing.Any) -> bool:
     return (not has_vector_type(obj)) and (not has_string_type(obj))
 
 
+Dims = _std_typing.Union[None, str, _std_typing.Sequence[str]]
+"""
+Describes dimensions to operate on.
+
+Can be a string (for a single dimension) or a sequence of strings (multiple dimensions).
+A value of ``None`` indicated "all dimensions."
+"""
+
 VariableLike = _std_typing.Union[Variable, DataArray, Dataset]
 """Any object that behaves like a :class:`scipp.Variable`.
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -598,8 +598,9 @@ def test_group_many_and_erase():
     ycoarse = sc.arange('y', size) // 2
     da.coords['xcoarse'] = xcoarse
     da.coords['ycoarse'] = ycoarse
-    result = binning.make_binned(da,
-                                 edges=[],
-                                 groups=[sc.arange('xcoarse', size // 2)],
-                                 erase=['x', 'y'])
+    result = binning.make_binned(
+        da,
+        edges=[],
+        groups=[sc.arange('xcoarse', size // 2, dtype=xcoarse.dtype)],
+        erase=['x', 'y'])
     assert result.dims == ('z', 'xcoarse')

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -586,3 +586,20 @@ def test_group_many_to_many_with_extra_outer_dim_uses_optimized_codepath():
     # The old "standard" implementation uses a massive amount of memory, crashing even
     # with 256 GByte of RAM.
     assert da.group('xcoarse', 'ycoarse').dims == ('z', 'xcoarse', 'ycoarse')
+
+
+def test_group_many_and_erase():
+    from scipp import binning
+    binning.make_binned
+    size = 512
+    table = sc.data.table_xyz(int(1e3))
+    da = table.bin(z=3, x=size, y=size)
+    xcoarse = sc.arange('x', size) // 2
+    ycoarse = sc.arange('y', size) // 2
+    da.coords['xcoarse'] = xcoarse
+    da.coords['ycoarse'] = ycoarse
+    result = binning.make_binned(da,
+                                 edges=[],
+                                 groups=[sc.arange('xcoarse', size // 2)],
+                                 erase=['x', 'y'])
+    assert result.dims == ('z', 'xcoarse')

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -604,3 +604,12 @@ def test_group_many_and_erase():
         groups=[sc.arange('xcoarse', size // 2, dtype=xcoarse.dtype)],
         erase=['x', 'y'])
     assert result.dims == ('z', 'xcoarse')
+
+
+def test_erase_multiple():
+    from scipp import binning
+    binning.make_binned
+    table = sc.data.table_xyz(int(1e3))
+    da = table.bin(x=13, y=7)
+    result = binning.make_binned(da, edges=[], groups=[], erase=['x', 'y'])
+    assert sc.identical(result.value, da.bins.constituents['data'])

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -588,6 +588,19 @@ def test_group_many_to_many_with_extra_outer_dim_uses_optimized_codepath():
     assert da.group('xcoarse', 'ycoarse').dims == ('z', 'xcoarse', 'ycoarse')
 
 
+def test_group_many_to_many_by_two_coords_along_same_dim_uses_optimized_codepath():
+    size = 512
+    table = sc.data.table_xyz(int(1e3))
+    da = table.bin(x=size * size)
+    x1 = sc.arange('x', size * size) // size
+    x2 = sc.arange('x', size * size) % size
+    da.coords['x1'] = x1
+    da.coords['x2'] = x2
+    # The old "standard" implementation uses a massive amount of memory, crashing even
+    # with 256 GByte of RAM.
+    assert da.group('x1', 'x2').dims == ('x1', 'x2')
+
+
 def test_group_many_and_erase():
     from scipp import binning
     binning.make_binned

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -626,3 +626,17 @@ def test_erase_2d_mask():
     result = binning.make_binned(da, edges=[], groups=[], erase=['x', 'y'])
     assert not sc.identical(result.sum(), table.sum())
     assert sc.identical(result.sum(), da.sum())
+
+
+def test_erase_multiple_masks():
+    from scipp import binning
+    binning.make_binned
+    table = sc.data.table_xyz(100)
+    table.data = sc.arange('row', 100)
+    da = table.bin(x=2, y=2)
+    da.masks['xy'] = sc.zeros(dims=da.dims, shape=da.shape, dtype=bool)
+    da.masks['xy'].values[1, 1] = True
+    da.masks['x'] = sc.array(dims=['x'], values=[False, True])
+    result = binning.make_binned(da, edges=[], groups=[], erase=['x', 'y'])
+    assert not sc.identical(result.sum(), table.sum())
+    assert sc.identical(result.sum(), da.sum())

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -613,3 +613,16 @@ def test_erase_multiple():
     da = table.bin(x=13, y=7)
     result = binning.make_binned(da, edges=[], groups=[], erase=['x', 'y'])
     assert sc.identical(result.value, da.bins.constituents['data'])
+
+
+def test_erase_2d_mask():
+    from scipp import binning
+    binning.make_binned
+    table = sc.data.table_xyz(100)
+    table.data = sc.arange('row', 100)
+    da = table.bin(x=2, y=2)
+    da.masks['mask'] = sc.zeros(dims=da.dims, shape=da.shape, dtype=bool)
+    da.masks['mask'].values[1, 1] = True
+    result = binning.make_binned(da, edges=[], groups=[], erase=['x', 'y'])
+    assert not sc.identical(result.sum(), table.sum())
+    assert sc.identical(result.sum(), da.sum())

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -476,7 +476,7 @@ def test_bin_1d_without_event_coord():
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=13)
     from scipp.core.bin_remapping import remap_bins_by_binning
-    result = remap_bins_by_binning(da, [edges])
+    result = remap_bins_by_binning(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected)
 
@@ -490,7 +490,7 @@ def test_bin_outer_of_2d_without_event_coord():
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=5)
     from scipp.core.bin_remapping import remap_bins_by_binning
-    result = remap_bins_by_binning(da, [edges])
+    result = remap_bins_by_binning(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected.transpose(result.dims))
 
@@ -504,9 +504,9 @@ def test_bin_combined_outer_and_inner_of_2d_without_event_coord():
     edges = sc.linspace('param', 0.0, 1.0, num=5)
     from scipp.core.bin_remapping import remap_bins_by_binning
     da.coords['param'] = param
-    result_xy = remap_bins_by_binning(da, [edges])
+    result_xy = remap_bins_by_binning(da, [edges], [], ['x', 'y'])
     da.coords['param'] = param.transpose()
-    result_yx = remap_bins_by_binning(da, [edges])
+    result_yx = remap_bins_by_binning(da, [edges], [], ['x', 'y'])
     assert sc.identical(result_xy, result_yx)
     expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
     assert sc.identical(result_xy, expected.transpose(result_xy.dims))
@@ -524,7 +524,7 @@ def test_bin_outer_and_inner_of_2d_without_event_coord():
     from scipp.core.bin_remapping import remap_bins_by_binning
     da.coords['xnew'] = x
     da.coords['ynew'] = y
-    result = remap_bins_by_binning(da, [xnew, ynew])
+    result = remap_bins_by_binning(da, [xnew, ynew], [], ['x', 'y'])
     expected = da.groupby('ynew', bins=ynew).bins.concat('y') \
                  .groupby('xnew', bins=xnew).bins.concat('x')
     assert sc.identical(result, expected)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -478,5 +478,4 @@ def test_bin_without_event_coord():
     from scipp.core.bin_remapping import _combine_bins_by_binning_variable
     result = _combine_bins_by_binning_variable(da.data, param, edges)
     expected = da.groupby('param', bins=edges).bins.concat(da.dim)
-    print(result, expected.data)
     assert sc.identical(result, expected.data)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -468,12 +468,27 @@ def test_bins_concat_applies_irreducible_masks():
     assert sc.identical(da.bins.concat('x'), da['x', :4].bins.concat('x'))
 
 
-def test_bin_1d_without_event_coord():
+def test_bin_1d_by_coord_without_event_coord():
     table = sc.data.table_xyz(nrow=1000)
     da = table.bin(x=100)
     rng = default_rng(seed=1234)
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
+    edges = sc.linspace('param', 0.0, 1.0, num=13)
+    from scipp.core.bin_remapping import combine_bins
+    result = combine_bins(da, [edges], [], ['x'])
+    # Setup flat table with param for computing expected result
+    da.bins.coords['param'] = sc.bins_like(da, param)
+    table = da.bins.constituents['data']
+    assert sc.identical(result.hist(), table.hist(param=edges))
+
+
+def test_bin_1d_by_attr_without_event_coord():
+    table = sc.data.table_xyz(nrow=1000)
+    da = table.bin(x=100)
+    rng = default_rng(seed=1234)
+    param = sc.array(dims='x', values=rng.random(da.sizes['x']))
+    da.attrs['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=13)
     from scipp.core.bin_remapping import combine_bins
     result = combine_bins(da, [edges], [], ['x'])

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -475,8 +475,8 @@ def test_bin_1d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=13)
-    from scipp.core.bin_remapping import remap_bins_by_binning
-    result = remap_bins_by_binning(da, [edges], [], ['x'])
+    from scipp.core.bin_remapping import remap_bins
+    result = remap_bins(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected)
 
@@ -489,8 +489,8 @@ def test_bin_outer_of_2d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import remap_bins_by_binning
-    result = remap_bins_by_binning(da, [edges], [], ['x'])
+    from scipp.core.bin_remapping import remap_bins
+    result = remap_bins(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected.transpose(result.dims))
 
@@ -502,11 +502,11 @@ def test_bin_combined_outer_and_inner_of_2d_without_event_coord():
     rng = default_rng(seed=1234)
     param = sc.array(dims=['x', 'y'], values=rng.random(da.shape))
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import remap_bins_by_binning
+    from scipp.core.bin_remapping import remap_bins
     da.coords['param'] = param
-    result_xy = remap_bins_by_binning(da, [edges], [], ['x', 'y'])
+    result_xy = remap_bins(da, [edges], [], ['x', 'y'])
     da.coords['param'] = param.transpose()
-    result_yx = remap_bins_by_binning(da, [edges], [], ['x', 'y'])
+    result_yx = remap_bins(da, [edges], [], ['x', 'y'])
     assert sc.identical(result_xy, result_yx)
     expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
     assert sc.identical(result_xy, expected.transpose(result_xy.dims))
@@ -521,10 +521,10 @@ def test_bin_outer_and_inner_of_2d_without_event_coord():
     y = sc.array(dims=['y'], values=rng.random(da.sizes['y']))
     xnew = sc.linspace('xnew', 0.0, 1.0, num=5)
     ynew = sc.linspace('ynew', 0.0, 1.0, num=4)
-    from scipp.core.bin_remapping import remap_bins_by_binning
+    from scipp.core.bin_remapping import remap_bins
     da.coords['xnew'] = x
     da.coords['ynew'] = y
-    result = remap_bins_by_binning(da, [xnew, ynew], [], ['x', 'y'])
+    result = remap_bins(da, [xnew, ynew], [], ['x', 'y'])
     expected = da.groupby('ynew', bins=ynew).bins.concat('y') \
                  .groupby('xnew', bins=xnew).bins.concat('x')
     assert sc.identical(result, expected)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -481,7 +481,7 @@ def test_bin_1d_without_event_coord():
     assert sc.identical(result, expected.data)
 
 
-def test_bin_2d_without_event_coord():
+def test_bin_outer_of_2d_without_event_coord():
     table = sc.data.table_xyz(nrow=100)
     table.data = sc.arange('row', 100, dtype='float64')
     da = table.bin(x=7, y=3)
@@ -493,3 +493,19 @@ def test_bin_2d_without_event_coord():
     result = _combine_bins_by_binning_variable(da.data, param, edges)
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected.data.transpose(result.dims))
+
+
+def test_bin_outer_and_inner_of_2d_without_event_coord():
+    table = sc.data.table_xyz(nrow=100)
+    table.data = sc.arange('row', 100, dtype='float64')
+    da = table.bin(x=7, y=3)
+    rng = default_rng(seed=1234)
+    param = sc.array(dims=['x', 'y'], values=rng.random(da.shape))
+    da.coords['param'] = param
+    edges = sc.linspace('param', 0.0, 1.0, num=5)
+    from scipp.core.bin_remapping import _combine_bins_by_binning_variable
+    result_xy = _combine_bins_by_binning_variable(da.data, param, edges)
+    result_yx = _combine_bins_by_binning_variable(da.data, param.transpose(), edges)
+    assert sc.identical(result_xy, result_yx)
+    expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
+    assert sc.identical(result_xy, expected.data.transpose(result_xy.dims))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -475,10 +475,10 @@ def test_bin_1d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=13)
-    from scipp.core.bin_remapping import _combine_bins_by_binning_variable
-    result = _combine_bins_by_binning_variable(da.data, param, edges)
+    from scipp.core.bin_remapping import remap_bins_by_binning
+    result = remap_bins_by_binning(da, [edges])
     expected = da.groupby('param', bins=edges).bins.concat('x')
-    assert sc.identical(result, expected.data)
+    assert sc.identical(result, expected)
 
 
 def test_bin_outer_of_2d_without_event_coord():
@@ -489,10 +489,10 @@ def test_bin_outer_of_2d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import _combine_bins_by_binning_variable
-    result = _combine_bins_by_binning_variable(da.data, param, edges)
+    from scipp.core.bin_remapping import remap_bins_by_binning
+    result = remap_bins_by_binning(da, [edges])
     expected = da.groupby('param', bins=edges).bins.concat('x')
-    assert sc.identical(result, expected.data.transpose(result.dims))
+    assert sc.identical(result, expected.transpose(result.dims))
 
 
 def test_bin_outer_and_inner_of_2d_without_event_coord():
@@ -501,11 +501,12 @@ def test_bin_outer_and_inner_of_2d_without_event_coord():
     da = table.bin(x=7, y=3)
     rng = default_rng(seed=1234)
     param = sc.array(dims=['x', 'y'], values=rng.random(da.shape))
-    da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import _combine_bins_by_binning_variable
-    result_xy = _combine_bins_by_binning_variable(da.data, param, edges)
-    result_yx = _combine_bins_by_binning_variable(da.data, param.transpose(), edges)
+    from scipp.core.bin_remapping import remap_bins_by_binning
+    da.coords['param'] = param
+    result_xy = remap_bins_by_binning(da, [edges])
+    da.coords['param'] = param.transpose()
+    result_yx = remap_bins_by_binning(da, [edges])
     assert sc.identical(result_xy, result_yx)
     expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
-    assert sc.identical(result_xy, expected.data.transpose(result_xy.dims))
+    assert sc.identical(result_xy, expected.transpose(result_xy.dims))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -475,8 +475,8 @@ def test_bin_1d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=13)
-    from scipp.core.bin_remapping import remap_bins
-    result = remap_bins(da, [edges], [], ['x'])
+    from scipp.core.bin_remapping import combine_bins
+    result = combine_bins(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected)
 
@@ -489,8 +489,8 @@ def test_bin_outer_of_2d_without_event_coord():
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import remap_bins
-    result = remap_bins(da, [edges], [], ['x'])
+    from scipp.core.bin_remapping import combine_bins
+    result = combine_bins(da, [edges], [], ['x'])
     expected = da.groupby('param', bins=edges).bins.concat('x')
     assert sc.identical(result, expected.transpose(result.dims))
 
@@ -502,11 +502,11 @@ def test_bin_combined_outer_and_inner_of_2d_without_event_coord():
     rng = default_rng(seed=1234)
     param = sc.array(dims=['x', 'y'], values=rng.random(da.shape))
     edges = sc.linspace('param', 0.0, 1.0, num=5)
-    from scipp.core.bin_remapping import remap_bins
+    from scipp.core.bin_remapping import combine_bins
     da.coords['param'] = param
-    result_xy = remap_bins(da, [edges], [], ['x', 'y'])
+    result_xy = combine_bins(da, [edges], [], ['x', 'y'])
     da.coords['param'] = param.transpose()
-    result_yx = remap_bins(da, [edges], [], ['x', 'y'])
+    result_yx = combine_bins(da, [edges], [], ['x', 'y'])
     assert sc.identical(result_xy, result_yx)
     expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
     assert sc.identical(result_xy, expected.transpose(result_xy.dims))
@@ -521,10 +521,10 @@ def test_bin_outer_and_inner_of_2d_without_event_coord():
     y = sc.array(dims=['y'], values=rng.random(da.sizes['y']))
     xnew = sc.linspace('xnew', 0.0, 1.0, num=5)
     ynew = sc.linspace('ynew', 0.0, 1.0, num=4)
-    from scipp.core.bin_remapping import remap_bins
+    from scipp.core.bin_remapping import combine_bins
     da.coords['xnew'] = x
     da.coords['ynew'] = y
-    result = remap_bins(da, [xnew, ynew], [], ['x', 'y'])
+    result = combine_bins(da, [xnew, ynew], [], ['x', 'y'])
     expected = da.groupby('ynew', bins=ynew).bins.concat('y') \
                  .groupby('xnew', bins=xnew).bins.concat('x')
     assert sc.identical(result, expected)

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -477,13 +477,15 @@ def test_bin_1d_without_event_coord():
     edges = sc.linspace('param', 0.0, 1.0, num=13)
     from scipp.core.bin_remapping import combine_bins
     result = combine_bins(da, [edges], [], ['x'])
-    expected = da.groupby('param', bins=edges).bins.concat('x')
-    assert sc.identical(result, expected)
+    # Setup flat table with param for computing expected result
+    da.bins.coords['param'] = sc.bins_like(da, param)
+    table = da.bins.constituents['data']
+    assert sc.identical(result.hist(), table.hist(param=edges))
 
 
 def test_bin_outer_of_2d_without_event_coord():
-    table = sc.data.table_xyz(nrow=100)
-    table.data = sc.arange('row', 100, dtype='float64')
+    table = sc.data.table_xyz(nrow=1000)
+    table.data = sc.arange('row', 1000, dtype='float64')
     da = table.bin(x=7, y=3)
     rng = default_rng(seed=1234)
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
@@ -491,13 +493,15 @@ def test_bin_outer_of_2d_without_event_coord():
     edges = sc.linspace('param', 0.0, 1.0, num=5)
     from scipp.core.bin_remapping import combine_bins
     result = combine_bins(da, [edges], [], ['x'])
-    expected = da.groupby('param', bins=edges).bins.concat('x')
-    assert sc.identical(result, expected.transpose(result.dims))
+    # Setup flat table with param for computing expected result
+    da.bins.coords['param'] = sc.bins_like(da, param)
+    table = da.bins.constituents['data']
+    assert sc.identical(result.hist(), table.hist(y=3, param=edges))
 
 
 def test_bin_combined_outer_and_inner_of_2d_without_event_coord():
-    table = sc.data.table_xyz(nrow=100)
-    table.data = sc.arange('row', 100, dtype='float64')
+    table = sc.data.table_xyz(nrow=1000)
+    table.data = sc.arange('row', 1000, dtype='float64')
     da = table.bin(x=7, y=3)
     rng = default_rng(seed=1234)
     param = sc.array(dims=['x', 'y'], values=rng.random(da.shape))
@@ -508,13 +512,15 @@ def test_bin_combined_outer_and_inner_of_2d_without_event_coord():
     da.coords['param'] = param.transpose()
     result_yx = combine_bins(da, [edges], [], ['x', 'y'])
     assert sc.identical(result_xy, result_yx)
-    expected = da.flatten(to='dummy').groupby('param', bins=edges).bins.concat('dummy')
-    assert sc.identical(result_xy, expected.transpose(result_xy.dims))
+    # Setup flat table with param for computing expected result
+    da.bins.coords['param'] = sc.bins_like(da, param)
+    table = da.bins.constituents['data']
+    assert sc.identical(result_xy.hist(), table.hist(param=edges))
 
 
 def test_bin_outer_and_inner_of_2d_without_event_coord():
-    table = sc.data.table_xyz(nrow=100)
-    table.data = sc.arange('row', 100, dtype='float64')
+    table = sc.data.table_xyz(nrow=1000)
+    table.data = sc.arange('row', 1000, dtype='float64')
     da = table.bin(x=7, y=3)
     rng = default_rng(seed=1234)
     x = sc.array(dims=['x'], values=rng.random(da.sizes['x']))
@@ -525,6 +531,8 @@ def test_bin_outer_and_inner_of_2d_without_event_coord():
     da.coords['xnew'] = x
     da.coords['ynew'] = y
     result = combine_bins(da, [xnew, ynew], [], ['x', 'y'])
-    expected = da.groupby('ynew', bins=ynew).bins.concat('y') \
-                 .groupby('xnew', bins=xnew).bins.concat('x')
-    assert sc.identical(result, expected)
+    # Setup flat table with param for computing expected result
+    da.bins.coords['xnew'] = sc.bins_like(da, x)
+    da.bins.coords['ynew'] = sc.bins_like(da, y)
+    table = da.bins.constituents['data']
+    assert sc.identical(result.hist(), table.hist(xnew=xnew, ynew=ynew))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -484,10 +484,7 @@ def test_bin_1d_without_event_coord():
 def test_bin_2d_without_event_coord():
     table = sc.data.table_xyz(nrow=100)
     table.data = sc.arange('row', 100, dtype='float64')
-    del table.coords['z']
     da = table.bin(x=7, y=3)
-    del da.bins.coords['x']
-    del da.bins.coords['y']
     rng = default_rng(seed=1234)
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -492,7 +492,4 @@ def test_bin_2d_without_event_coord():
     from scipp.core.bin_remapping import _combine_bins_by_binning_variable
     result = _combine_bins_by_binning_variable(da.data, param, edges)
     expected = da.groupby('param', bins=edges).bins.concat('x')
-    print(result)
-    print(expected.data)
-    print(expected.data.bins.size())
     assert sc.identical(result, expected.data.transpose(result.dims))

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -482,14 +482,16 @@ def test_bin_1d_without_event_coord():
 
 
 def test_bin_2d_without_event_coord():
-    table = sc.data.table_xyz(nrow=10)
-    table.data = sc.arange('row', 10, dtype='float64')
+    table = sc.data.table_xyz(nrow=100)
+    table.data = sc.arange('row', 100, dtype='float64')
     del table.coords['z']
-    da = table.bin(x=3, y=2)
+    da = table.bin(x=7, y=3)
+    del da.bins.coords['x']
+    del da.bins.coords['y']
     rng = default_rng(seed=1234)
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
-    edges = sc.linspace('param', 0.0, 1.0, num=3)
+    edges = sc.linspace('param', 0.0, 1.0, num=5)
     from scipp.core.bin_remapping import _combine_bins_by_binning_variable
     result = _combine_bins_by_binning_variable(da.data, param, edges)
     expected = da.groupby('param', bins=edges).bins.concat('x')

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -18,3 +18,40 @@ def test_concrete_dims_given_dim_list_returns_dim_tuple():
 def test_concrete_dims_given_none_returns_obj_dims():
     var = sc.empty(dims=('xx', 'yy'), shape=(2, 2))
     assert concepts.concrete_dims(var, None) == ('xx', 'yy')
+
+
+def test_irreducible_mask_returns_union_of_relevant_masks():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['x'] = sc.array(dims=['xx'], values=[False, True])
+    da.masks['y'] = sc.array(dims=['yy'], values=[False, True, False])
+    da.masks['xy'] = sc.array(dims=['xx', 'yy'],
+                              values=[[False, False, False], [False, False, True]])
+    assert sc.identical(concepts.irreducible_mask(da, 'xx'),
+                        da.masks['x'] | da.masks['xy'])
+    assert sc.identical(concepts.irreducible_mask(da, 'yy'),
+                        da.masks['y'] | da.masks['xy'])
+    assert sc.identical(concepts.irreducible_mask(da, ('xx', 'yy')),
+                        da.masks['x'] | da.masks['y'] | da.masks['xy'])
+
+
+def test_irreducible_mask_returns_None_if_all_masks_unrelated():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['x'] = sc.array(dims=['xx'], values=[False, True])
+    assert concepts.irreducible_mask(da, 'yy') is None
+
+
+def test_irreducible_mask_returns_copy_if_single_mask_matches():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['x'] = sc.array(dims=['xx'], values=[False, True])
+    mask = concepts.irreducible_mask(da, 'xx')
+    mask.values[0] = True
+    assert not da.masks['x'].values[0]
+
+
+def test_irreducible_mask_does_not_include_0d_mask():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['0d'] = sc.scalar(True)
+    assert concepts.irreducible_mask(da, 'xx') is None
+    assert concepts.irreducible_mask(da, 'yy') is None
+    assert concepts.irreducible_mask(da, ('xx', 'yy')) is None
+    assert concepts.irreducible_mask(da, None) is None

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -55,3 +55,12 @@ def test_irreducible_mask_does_not_include_0d_mask():
     assert concepts.irreducible_mask(da, 'yy') is None
     assert concepts.irreducible_mask(da, ('xx', 'yy')) is None
     assert concepts.irreducible_mask(da, None) is None
+
+
+def test_reduced_masks_copies_preserved_masks():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['x'] = sc.array(dims=['xx'], values=[False, True])
+    da.masks['y'] = sc.array(dims=['yy'], values=[False, True, False])
+    masks = concepts.reduced_masks(da, 'xx')
+    masks['y'].values[0] = True
+    assert not da.masks['y'].values[0]

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -57,6 +57,19 @@ def test_irreducible_mask_does_not_include_0d_mask():
     assert concepts.irreducible_mask(da, None) is None
 
 
+def test_irreducible_mask_returns_mask_with_dim_order_matching_data():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['x'] = sc.ones(dims=['yy', 'xx'], shape=(3, 2), dtype=bool)
+    assert concepts.irreducible_mask(da, 'yy').dims == ('xx', 'yy')
+
+
+def test_irreducible_mask_returns_multiple_masks_with_dim_order_matching_data():
+    da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
+    da.masks['m1'] = sc.ones(dims=['yy', 'xx'], shape=(3, 2), dtype=bool)
+    da.masks['m2'] = sc.ones(dims=['yy', 'xx'], shape=(3, 2), dtype=bool)
+    assert concepts.irreducible_mask(da, 'yy').dims == ('xx', 'yy')
+
+
 def test_reduced_masks_copies_preserved_masks():
     da = sc.DataArray(sc.empty(dims=('xx', 'yy'), shape=(2, 3)))
     da.masks['x'] = sc.array(dims=['xx'], values=[False, True])

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import scipp as sc
+from scipp.core import concepts
+
+
+def test_concrete_dims_given_single_dim_returns_dim_as_tuple():
+    var = sc.empty(dims=('xx', 'yy'), shape=(2, 2))
+    assert concepts.concrete_dims(var, 'xx') == ('xx', )
+
+
+def test_concrete_dims_given_dim_list_returns_dim_tuple():
+    var = sc.empty(dims=('xx', 'yy'), shape=(2, 2))
+    assert concepts.concrete_dims(var, ['yy', 'xx']) == ('yy', 'xx')
+
+
+def test_concrete_dims_given_none_returns_obj_dims():
+    var = sc.empty(dims=('xx', 'yy'), shape=(2, 2))
+    assert concepts.concrete_dims(var, None) == ('xx', 'yy')

--- a/tests/hypothesis/bin_test.py
+++ b/tests/hypothesis/bin_test.py
@@ -63,7 +63,9 @@ def test_bins_concat_masking(nevent, mask):
                 if dim not in dims:
                     m = m[dim, 0]
             da.masks["".join(dims)] = m
-    for n in range(1, mask.ndim + 1):
-        for dims in itertools.permutations(mask.dims, n):
+    for n in range(1, da.ndim + 1):
+        for dims in itertools.permutations(da.dims, n):
             assert sc.identical(da.bins.concat(dims).hist(), da.hist().sum(dims))
+            assert sc.identical(da.transpose().bins.concat(dims).hist(),
+                                da.transpose().hist().sum(dims))
     assert sc.identical(da.bins.concat(None).hist(), da.hist().sum(None))

--- a/tests/hypothesis/bin_test.py
+++ b/tests/hypothesis/bin_test.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import itertools
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from scipp.testing import strategies as scst
 
 import scipp as sc
 import numpy as np
@@ -41,3 +43,27 @@ def test_automatic_grouping_optimization(nrow, i, j):
     assert sc.identical(
         table.group('label').coords['label'],
         sc.array(dims=['label'], values=np.unique(table.coords['label'].values)))
+
+
+@settings(max_examples=100, deadline=1000)
+@given(st.integers(min_value=1, max_value=12345),
+       scst.variables(dtype=bool, ndim=st.integers(min_value=1, max_value=3)))
+def test_bins_concat_masking(nevent, mask):
+    from numpy.random import default_rng
+    rng = default_rng(seed=1234)
+    mask.unit = None
+    table = sc.DataArray(sc.arange('row', nevent))
+    for dim in mask.dims:
+        table.coords[dim] = sc.array(dims=['row'], values=rng.random((nevent, )))
+    da = table.bin(mask.sizes)
+    for n in range(1, mask.ndim + 1):
+        for dims in itertools.permutations(mask.dims, n):
+            m = mask
+            for dim in mask.dims:
+                if dim not in dims:
+                    m = m[dim, 0]
+            da.masks["".join(dims)] = m
+    for n in range(1, mask.ndim + 1):
+        for dims in itertools.permutations(mask.dims, n):
+            assert sc.identical(da.bins.concat(dims).hist(), da.hist().sum(dims))
+    assert sc.identical(da.bins.concat(None).hist(), da.hist().sum(None))

--- a/tests/hypothesis/to_unit_test.py
+++ b/tests/hypothesis/to_unit_test.py
@@ -14,7 +14,7 @@ import scipp as sc
 _max_examples = 1000
 
 
-@settings(max_examples=_max_examples)
+@settings(max_examples=_max_examples, deadline=None)
 def _to_unit_value_one(x):
     unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(x, unit='')
@@ -35,7 +35,7 @@ test_to_unit_value_one_3 = given(st.floats(min_value=1e-300,
                                            max_value=1e300))(_to_unit_value_one)
 
 
-@settings(max_examples=_max_examples)
+@settings(max_examples=_max_examples, deadline=None)
 def _to_unit_small_value(x):
     unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(1.2345e-6 * x, unit='')
@@ -52,7 +52,7 @@ test_to_unit_small_value_3 = given(st.floats(min_value=1e-300,
                                              max_value=1e300))(_to_unit_small_value)
 
 
-@settings(max_examples=_max_examples)
+@settings(max_examples=_max_examples, deadline=None)
 def _to_unit_large_value(x):
     unit = sc.Unit(f'{x:.14E}')
     var = sc.scalar(1.2345e6 * x, unit='')

--- a/tests/variable_reduction_test.py
+++ b/tests/variable_reduction_test.py
@@ -70,3 +70,17 @@ def test_nanmean():
     var = sc.array(dims=['x', 'y'], values=[[1.0, 1.0], [1.0, 1.0]])
     assert sc.identical(sc.nanmean(var), sc.scalar(3.0 / 3))
     assert sc.identical(sc.nanmean(var, 'x'), sc.array(dims=['y'], values=[1.0, 1.0]))
+
+
+def test_sum_multiple_dims():
+    values = np.arange(24).reshape(2, 3, 4)
+    var = sc.array(dims=['x', 'y', 'z'], values=values)
+    assert sc.identical(var.sum(('x', 'y')),
+                        sc.array(dims=['z'], values=values.sum(axis=(0, 1))))
+    assert sc.identical(var.sum(('x', 'z')),
+                        sc.array(dims=['y'], values=values.sum(axis=(0, 2))))
+    assert sc.identical(var.sum(('z', 'x')),
+                        sc.array(dims=['y'], values=values.sum(axis=(0, 2))))
+    assert sc.identical(var.sum(()), var)
+    assert sc.identical(var.sum(('x', )), var.sum('x'))
+    assert sc.identical(var.sum(('x', 'y', 'z')), var.sum())


### PR DESCRIPTION
Fixes #2741.

To do:

- [x] I think we should deprecate `groupby.bins.concat()` and point users to `bin` and `group` instead. I *think* this can now cover all possible input data, but I am far from certain. Can you think of a counterexample?
- [ ] Find more relevant points input param "space". Are we detecting and supporting all relevant cases?
- [ ] Should we add additional branching for a two-step approach, when erasing dims is combined with other binning? It may be faster to first operate on the bins, and then on the events, even though it results in an extra intermediate copy of all the events.