### PR TITLE
Fix segfault in flatten with empty dims

### DIFF
--- a/lib/dataset/shape.cpp
+++ b/lib/dataset/shape.cpp
@@ -301,7 +301,7 @@ DataArray flatten(const DataArray &a, const scipp::span<const Dim> &from_labels,
       return flatten_bin_edge(var, from_labels, to_dim, bin_edge_dim);
     } else if (var.dims().contains(from_labels.front())) {
       // maybe_broadcast ensures that all variables contain
-      // all dims in from_labels, se only need to check the first.
+      // all dims in from_labels, so only need to check from_labels.front().
       return flatten(var, from_labels, to_dim);
     } else {
       // This only happens for metadata.

--- a/lib/dataset/test/shape_test.cpp
+++ b/lib/dataset/test/shape_test.cpp
@@ -663,6 +663,12 @@ TEST_F(SqueezeTest, data_array_3d_all) {
             squeeze(a, std::vector<Dim>{Dim::X, Dim::Y}));
 }
 
+TEST_F(SqueezeTest, data_array_3d_no_dims) {
+  const auto dims = std::vector<Dim>{};
+  const auto squeezed = squeeze(a, dims);
+  EXPECT_EQ(squeezed, a);
+}
+
 TEST_F(SqueezeTest, data_array_3d_wrong_length_throws) {
   EXPECT_THROW_DISCARD(squeeze(a, std::vector<Dim>{Dim::Z}),
                        except::DimensionError);
@@ -726,6 +732,12 @@ TEST_F(SqueezeDatasetTest, dataset_3d_all) {
   EXPECT_EQ(squeezed["a"], squeeze(a, dims));
   EXPECT_EQ(squeezed["b"], squeeze(b, std::vector<Dim>({Dim::Y})));
   EXPECT_EQ(squeezed["c"], squeeze(c, std::vector<Dim>({Dim::X})));
+}
+
+TEST_F(SqueezeDatasetTest, dataset_3d_no_dims) {
+  const std::vector<Dim> dims{};
+  const auto squeezed = squeeze(dset, dims);
+  EXPECT_EQ(squeezed, dset);
 }
 
 TEST_F(SqueezeDatasetTest, dataset_output_is_not_readonly) {


### PR DESCRIPTION
Fixes #2828

Also fixes detection of bad dim labels, see `ReshapeTest.flatten_dim_not_in_input`.