### PR TITLE
Support `__getitem__` on the `bins` property for more concise value/interval extraction

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -41,6 +41,7 @@ v0.17.0 (Unreleased)
 Features
 ~~~~~~~~
 
+* :class:`scipp.Bins` now supports `__getitem__`, providing a shorthand for extracting events based on a coord value or value interval. This is equivalent functionality to label-based indexing for dense data but considers the coordinates of the underlying bin content `#2830 <https://github.com/scipp/scipp/pull/2830>`_.
 * Much faster ``obj.bins.concat`` operations in presence of many bins `#2825 <https://github.com/scipp/scipp/pull/2825>`_.
 
 Breaking changes

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -41,7 +41,7 @@ v0.17.0 (Unreleased)
 Features
 ~~~~~~~~
 
-* :class:`scipp.Bins` now supports `__getitem__`, providing a shorthand for extracting events based on a coord value or value interval. This is equivalent functionality to label-based indexing for dense data but considers the coordinates of the underlying bin content `#2830 <https://github.com/scipp/scipp/pull/2830>`_.
+* :class:`scipp.Bins` now supports `__getitem__`, providing a shorthand for extracting events based on a coord value or value interval. This is equivalent functionality to label-based indexing for dense data but considers the coordinates of the underlying bin content `#2831 <https://github.com/scipp/scipp/pull/2831>`_.
 * Much faster ``obj.bins.concat`` operations in presence of many bins `#2825 <https://github.com/scipp/scipp/pull/2825>`_.
 
 Breaking changes

--- a/lib/variable/shape.cpp
+++ b/lib/variable/shape.cpp
@@ -101,8 +101,12 @@ Variable fold(const Variable &view, const Dim from_dim,
 
 Variable flatten(const Variable &view,
                  const scipp::span<const Dim> &from_labels, const Dim to_dim) {
-  if (from_labels.empty())
-    return broadcast(view, merge(view.dims(), Dimensions(to_dim, 1)));
+  if (from_labels.empty()) {
+    auto out(view);
+    out.unchecked_dims().addInner(to_dim, 1);
+    out.unchecked_strides().push_back(1);
+    return out;
+  }
   const auto &labels = view.dims().labels();
   auto it = std::search(labels.begin(), labels.end(), from_labels.begin(),
                         from_labels.end());

--- a/lib/variable/test/shape_test.cpp
+++ b/lib/variable/test/shape_test.cpp
@@ -222,6 +222,14 @@ TEST(ShapeTest, flatten_non_contiguous) {
       "Can only flatten a contiguous set of dimensions in the correct order");
 }
 
+TEST(ShapeTest, flatten_0d) {
+  const auto var = makeVariable<double>(Values{1});
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{1});
+  const auto flat = flatten(var, std::vector<Dim>{}, Dim::X);
+  EXPECT_EQ(flat, expected);
+  EXPECT_EQ(flat.strides()[0], 1);
+}
+
 TEST(ShapeTest, round_trip) {
   const auto var = cumsum(
       variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -133,6 +133,20 @@ class Bins:
         _cpp.buckets.scale(self._obj, _cpp.reciprocal(lut.func), lut.dim)
         return self
 
+    def __getitem__(self, key):
+        dim, index = key
+        if isinstance(index, _cpp.Variable):
+            if index.ndim == 0:
+                return self._obj.group(concat([index], dim)).squeeze(dim)
+        elif isinstance(index, slice):
+            start = index.start
+            stop = index.stop
+            step = index.step
+            assert step is None  # TODO raise
+            # TODO support start=None and stop=None
+            return self._obj.bin({dim: concat([start, stop], dim)}).squeeze(dim)
+        # TODO raise
+
     @property
     def coords(self) -> MetaDataMap:
         """Coords of the bins"""

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-from typing import Callable, Dict, Literal, Optional, Union
+from typing import Callable, Dict, Literal, Optional, Union, Tuple
 import uuid
 
 from .._scipp import core as _cpp
@@ -133,7 +133,7 @@ class Bins:
         _cpp.buckets.scale(self._obj, _cpp.reciprocal(lut.func), lut.dim)
         return self
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Tuple[str, Union[_cpp.Variable, slice]]):
         dim, index = key
         if isinstance(index, _cpp.Variable):
             if index.ndim == 0:

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -137,7 +137,7 @@ class Bins:
         dim, index = key
         if isinstance(index, _cpp.Variable):
             if index.ndim == 0:
-                return self._obj.group(concat([index], dim)).squeeze(dim)
+                return self._obj.group(index.flatten(to=dim)).squeeze(dim)
         elif isinstance(index, slice):
             from .binning import _upper_bound
             if index.step is not None:

--- a/tests/slice_bins_test.py
+++ b/tests/slice_bins_test.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import pytest
+import scipp as sc
+
+
+def test_slice_bins_by_int_label():
+    table = sc.data.table_xyz(100)
+    table.coords['param'] = (table.coords.pop('y') * 10).to(dtype='int64')
+    da = table.bin(x=10)
+    param = sc.scalar(4, unit='m')
+    result = da.bins['param', param]
+    assert result.dims == da.dims
+    assert sc.identical(result.attrs['param'], param)
+    assert sc.identical(
+        result,
+        da.group(sc.array(dims=['param'], values=[4], dtype='int64',
+                          unit='m')).squeeze())
+
+
+def test_slice_bins_by_int_label_range():
+    table = sc.data.table_xyz(100)
+    table.coords['param'] = sc.arange(dim='row', start=0, stop=100, unit='s') // 10
+    da = table.bin(x=10)
+    start = sc.scalar(4, unit='s')
+    stop = sc.scalar(6, unit='s')
+    result = da.bins['param', start:stop]
+    assert result.dims == da.dims
+    assert sc.identical(
+        result.attrs['param'],
+        sc.array(dims=['param'], values=[4, 6], unit='s', dtype='int64'))
+    assert result.bins.size().sum().value == 20  # 2x10 events
+    assert sc.identical(
+        result,
+        da.bin(param=sc.array(dims=['param'], values=[4, 6], unit='s',
+                              dtype='int64')).squeeze())
+
+
+def test_slice_bins_by_float_label_range():
+    table = sc.data.table_xyz(100)
+    da = table.bin(x=10)
+    start = sc.scalar(0.1, unit='m')
+    stop = sc.scalar(0.2, unit='m')
+    result = da.bins['z', start:stop]
+    assert result.dims == da.dims
+    assert sc.identical(result.attrs['z'],
+                        sc.array(dims=['z'], values=[0.1, 0.2], unit='m'))
+    assert sc.identical(
+        result,
+        da.bin(z=sc.array(dims=['z'], values=[0.1, 0.2], unit='m')).squeeze())
+
+
+def test_slice_bins_by_open_range_includes_everything():
+    table = sc.data.table_xyz(100)
+    da = table.bin(x=10)
+    result = da.bins['z', :]
+    assert result.bins.size().sum().value == 100
+
+
+def test_slice_bins_by_half_open_int_range_splits_without_duplication():
+    table = sc.data.table_xyz(100)
+    da = table.bin(x=10)
+    split = sc.scalar(0.4, unit='m')
+    left = da.bins['z', :split]
+    right = da.bins['z', split:]
+    assert left.bins.size().sum().value + right.bins.size().sum().value == 100
+
+
+def test_slice_bins_by_half_open_float_range_splits_without_duplication():
+    table = sc.data.table_xyz(100)
+    table.coords['param'] = sc.arange(dim='row', start=0, stop=100, unit='s') // 10
+    da = table.bin(x=10)
+    split = sc.scalar(4, unit='s')
+    left = da.bins['param', :split]
+    right = da.bins['param', split:]
+    assert left.bins.size().sum().value + right.bins.size().sum().value == 100
+
+
+def test_slice_bins_with_step_raises():
+    da = sc.data.table_xyz(100).bin(x=10)
+    start = sc.scalar(0.1, unit='m')
+    stop = sc.scalar(0.4, unit='m')
+    step = sc.scalar(0.1, unit='m')
+    with pytest.raises(ValueError):
+        da.bins['z', start:stop:step]
+
+
+def test_slice_bins_with_int_index_raises():
+    da = sc.data.table_xyz(100).bin(x=10)
+    with pytest.raises(ValueError):
+        da.bins['z', 1:4]
+    with pytest.raises(ValueError):
+        da.bins['z', 1]


### PR DESCRIPTION
This addresses an aspect of the long standing issue https://github.com/scipp/scippneutron/issues/237#issuecomment-1174871318, in particular cases a) and c). After this change, I believe we are in a position to update/rewrite the [filtering documentation](https://scipp.github.io/user-guide/binned-data/filtering.html) and finally close that issue.