### PR TITLE
Use different method to set cbar opacity to 1 after draw_all was deprecated

### DIFF
--- a/src/scipp/plotting/figure2d.py
+++ b/src/scipp/plotting/figure2d.py
@@ -105,8 +105,8 @@ class PlotFigure2d(PlotFigure):
         self.draw()
 
     def opacify_colorbar(self):
-        self.cbar.set_alpha(1.0)
-        self.cbar.draw_all()
+        # From comment in https://stackoverflow.com/a/4480124/13086629
+        self.cbar.solids.set(alpha=1)
 
     def toggle_mask(self, *args, **kwargs):
         """


### PR DESCRIPTION
`cbar.draw_all()` was deprecated in in mpl 3.6.
Use alternative method.

Fixes warnings in python tests.