### PR TITLE
Move SciPy wrappers

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,6 +35,36 @@ Release Notes
    and Jan-Lukas Wynen :sup:`a`
 
 
+v0.xy.0 (Unreleased)
+--------------------
+
+Features
+~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* The SciPy wrappers ``integrate``, ``interpolate``, ``ndimage``, ``optimize``, and ``signal`` were moved into the :py:module:`scipp.scipy` submodule `#2881 <https://github.com/scipp/scipp/pull/2881>`_.
+
+Bugfixes
+~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.17.0 (October 2022)
 ----------------------
 

--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -1056,48 +1056,6 @@
     "tags": []
    },
    "source": [
-    "## SciPy compatibility layer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.11**\n",
-    "    \n",
-    "A number of subpackages providing wrappers for a *subset* of functions from the corresponding packages in SciPy was added:\n",
-    "    \n",
-    "- [scipp.scipy.integrate](../generated/modules/scipp.scipy.integrate.rst) providing `simpson` and `trapezoid`.\n",
-    "- [scipp.scipy.interpolate](../generated/modules/scipp.scipy.interpolate.rst) providing `interp1d`.\n",
-    "- [scipp.scipy.optimize](../generated/modules/scipp.scipy.optimize.rst) providing `curve_fit`.\n",
-    "- [scipp.scipy.signal](../generated/modules/scipp.scipy.signal.rst) providing `butter` and `sosfiltfilt`.\n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "Please refer to the function documentation for working examples."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**New in 0.14**\n",
-    "    \n",
-    "- [scipp.scipy.ndimage](../generated/modules/scipp.scipy.ndimage.rst) providing `gaussian_filter`, `median_filter`, and more.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
     "## Python ecosystem compatibility"
    ]
   },

--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -1069,10 +1069,10 @@
     "    \n",
     "A number of subpackages providing wrappers for a *subset* of functions from the corresponding packages in SciPy was added:\n",
     "    \n",
-    "- [scipp.integrate](../generated/modules/scipp.integrate.rst) providing `simpson` and `trapezoid`.\n",
-    "- [scipp.interpolate](../generated/modules/scipp.interpolate.rst) providing `interp1d`.\n",
-    "- [scipp.optimize](../generated/modules/scipp.optimize.rst) providing `curve_fit`.\n",
-    "- [scipp.signal](../generated/modules/scipp.signal.rst) providing `butter` and `sosfiltfilt`.\n",
+    "- [scipp.scipy.integrate](../generated/modules/scipp.scipy.integrate.rst) providing `simpson` and `trapezoid`.\n",
+    "- [scipp.scipy.interpolate](../generated/modules/scipp.scipy.interpolate.rst) providing `interp1d`.\n",
+    "- [scipp.scipy.optimize](../generated/modules/scipp.scipy.optimize.rst) providing `curve_fit`.\n",
+    "- [scipp.scipy.signal](../generated/modules/scipp.scipy.signal.rst) providing `butter` and `sosfiltfilt`.\n",
     "\n",
     "</div>\n",
     "\n",
@@ -1087,7 +1087,7 @@
     "\n",
     "**New in 0.14**\n",
     "    \n",
-    "- [scipp.ndimage](../generated/modules/scipp.ndimage.rst) providing `gaussian_filter`, `median_filter`, and more.\n",
+    "- [scipp.scipy.ndimage](../generated/modules/scipp.scipy.ndimage.rst) providing `gaussian_filter`, `median_filter`, and more.\n",
     "\n",
     "</div>"
    ]

--- a/docs/reference/modules.rst
+++ b/docs/reference/modules.rst
@@ -13,13 +13,18 @@ Core Functionality
 
    binning
    constants
-   integrate
-   interpolate
-   ndimage
-   optimize
-   signal
    spatial
    units
+
+Wrappers
+--------
+
+.. autosummary::
+   :toctree: ../generated/modules/scipy
+   :template: scipp-module-template.rst
+   :recursive:
+
+   scipy
 
 Utilities
 ---------

--- a/src/scipp/scipy/integrate/__init__.py
+++ b/src/scipp/scipy/integrate/__init__.py
@@ -7,8 +7,8 @@ This subpackage provides wrappers for a subset of functions from
 :py:mod:`scipy.integrate`.
 """
 
-from ..core import array, DataArray
-from ..compat.wrapping import wrap1d
+from ...core import array, DataArray
+from ...compat.wrapping import wrap1d
 
 from typing import Callable
 

--- a/src/scipp/scipy/integrate/__init__.py
+++ b/src/scipp/scipy/integrate/__init__.py
@@ -34,7 +34,7 @@ def trapezoid(da: DataArray, dim: str, **kwargs) -> DataArray:
 
       >>> x = sc.geomspace(dim='x', start=0.1, stop=0.4, num=4, unit='m')
       >>> da = sc.DataArray(x*x, coords={'x': x})
-      >>> from scipp.integrate import trapezoid
+      >>> from scipp.scipy.integrate import trapezoid
       >>> trapezoid(da, 'x')
       <scipp.DataArray>
       Dimensions: Sizes[]
@@ -55,7 +55,7 @@ def simpson(da: DataArray, dim: str, **kwargs) -> DataArray:
 
       >>> x = sc.geomspace(dim='x', start=0.1, stop=0.4, num=4, unit='m')
       >>> da = sc.DataArray(x*x, coords={'x': x})
-      >>> from scipp.integrate import simpson
+      >>> from scipp.scipy.integrate import simpson
       >>> simpson(da, 'x')
       <scipp.DataArray>
       Dimensions: Sizes[]

--- a/src/scipp/scipy/interpolate/__init__.py
+++ b/src/scipp/scipy/interpolate/__init__.py
@@ -7,9 +7,9 @@ This subpackage provides wrappers for a subset of functions from
 :py:mod:`scipy.interpolate`.
 """
 
-from ..core import empty, epoch, Variable, DataArray, DimensionError, UnitError
-from ..core import DType, irreducible_mask
-from ..compat.wrapping import wrap1d
+from ...core import empty, epoch, Variable, DataArray, DimensionError, UnitError
+from ...core import DType, irreducible_mask
+from ...compat.wrapping import wrap1d
 
 from typing import Any, Callable, Literal, Union
 

--- a/src/scipp/scipy/interpolate/__init__.py
+++ b/src/scipp/scipy/interpolate/__init__.py
@@ -116,7 +116,7 @@ def interp1d(da: DataArray,
       >>> x = sc.linspace(dim='x', start=0.1, stop=1.4, num=4, unit='rad')
       >>> da = sc.DataArray(sc.sin(x), coords={'x': x})
 
-      >>> from scipp.interpolate import interp1d
+      >>> from scipp.scipy.interpolate import interp1d
       >>> f = interp1d(da, 'x')
 
       >>> xnew = sc.linspace(dim='x', start=0.1, stop=1.4, num=12, unit='rad')

--- a/src/scipp/scipy/ndimage/__init__.py
+++ b/src/scipp/scipy/ndimage/__init__.py
@@ -11,10 +11,10 @@ from typing import Callable, Dict, Optional, Union
 
 import scipy.ndimage
 
-from ..core import Variable, DataArray
-from ..core import CoordError, DimensionError, VariancesError
-from ..core import empty_like, islinspace, ones
-from ..typing import VariableLike, VariableLikeType
+from ...core import Variable, DataArray
+from ...core import CoordError, DimensionError, VariancesError
+from ...core import empty_like, islinspace, ones
+from ...typing import VariableLike, VariableLikeType
 
 
 def _ndfilter(func: Callable) -> Callable:

--- a/src/scipp/scipy/ndimage/__init__.py
+++ b/src/scipp/scipy/ndimage/__init__.py
@@ -115,7 +115,7 @@ def gaussian_filter(x: VariableLikeType,
 
     .. plot:: :context: close-figs
 
-      >>> from scipp.ndimage import gaussian_filter
+      >>> from scipp.scipy.ndimage import gaussian_filter
       >>> da = sc.data.data_xy()
       >>> da.plot()
 
@@ -241,7 +241,7 @@ def _make_footprint_filter(name, example=True, extra_args=''):
 
     .. plot:: :context: close-figs
 
-      >>> from scipp.ndimage import {name}
+      >>> from scipp.scipy.ndimage import {name}
       >>> da = sc.data.data_xy()
       >>> da.plot()
 

--- a/src/scipp/scipy/optimize/__init__.py
+++ b/src/scipp/scipy/optimize/__init__.py
@@ -177,7 +177,7 @@ def curve_fit(
       >>> y.values += 0.01 * np.random.default_rng().normal(size=50)
       >>> da = sc.DataArray(y, coords={'x': x})
 
-      >>> from scipp.optimize import curve_fit
+      >>> from scipp.scipy.optimize import curve_fit
       >>> popt, _ = curve_fit(func, da, p0 = {'b': 1.0 / sc.Unit('m')})
       >>> sc.round(sc.values(popt['a']))
       <scipp.Variable> ()    float64            [dimensionless]  [5]

--- a/src/scipp/scipy/optimize/__init__.py
+++ b/src/scipp/scipy/optimize/__init__.py
@@ -7,9 +7,9 @@ This subpackage provides wrappers for a subset of functions from
 :py:mod:`scipy.optimize`.
 """
 
-from ..core import scalar, stddevs, Variable, DataArray
-from ..core import BinEdgeError
-from ..units import default_unit, dimensionless
+from ...core import scalar, stddevs, Variable, DataArray
+from ...core import BinEdgeError
+from ...units import default_unit, dimensionless
 from ..interpolate import _drop_masked
 
 import numpy as np

--- a/src/scipp/scipy/signal/__init__.py
+++ b/src/scipp/scipy/signal/__init__.py
@@ -10,10 +10,10 @@ from dataclasses import dataclass
 from numpy import ndarray
 from typing import Union
 
-from ..core import array, identical, islinspace, to_unit, DataArray, Variable
-from ..core import UnitError, CoordError
-from ..units import one
-from ..compat.wrapping import wrap1d
+from ...core import array, identical, islinspace, to_unit, DataArray, Variable
+from ...core import UnitError, CoordError
+from ...units import one
+from ...compat.wrapping import wrap1d
 
 
 @dataclass

--- a/src/scipp/scipy/signal/__init__.py
+++ b/src/scipp/scipy/signal/__init__.py
@@ -48,8 +48,8 @@ def butter(coord: Variable, *, N: int, Wn: Variable, **kwargs) -> SOS:
     Design an Nth-order digital or analog Butterworth filter and return the filter
     coefficients.
 
-    This is intended for use with :py:func:`scipp.signal.sosfiltfilt`. See there for
-    an example.
+    This is intended for use with :py:func:`scipp.scipy.signal.sosfiltfilt`. See there
+    for an example.
 
     This is a wrapper around :py:func:`scipy.signal.butter`. See there for a
     complete description of parameters. The differences are:
@@ -61,7 +61,7 @@ def butter(coord: Variable, *, N: int, Wn: Variable, **kwargs) -> SOS:
       unit.
     - Only 'sos' output is supported.
 
-    :seealso: :py:func:`scipp.signal.sosfiltfilt`
+    :seealso: :py:func:`scipp.scipy.signal.sosfiltfilt`
     """
     fs = _frequency(coord).value
     try:
@@ -81,7 +81,8 @@ def _sosfiltfilt(da: DataArray, dim: str, *, sos: SOS, **kwargs) -> DataArray:
     if not identical(da.coords[dim], sos.coord):
         raise CoordError(f"Coord\n{da.coords[dim]}\nof filter dimension '{dim}' does "
                          f"not match coord\n{sos.coord}\nused for creating the "
-                         "second-order sections representation by scipp.signal.butter.")
+                         "second-order sections representation by "
+                         "scipp.scipy.signal.butter.")
     import scipy.signal
     data = array(dims=da.dims,
                  unit=da.unit,
@@ -109,7 +110,7 @@ def sosfiltfilt(obj: Union[Variable, DataArray], dim: str, *, sos: SOS,
 
     .. plot:: :context: close-figs
 
-      >>> from scipp.signal import butter, sosfiltfilt
+      >>> from scipp.scipy.signal import butter, sosfiltfilt
       >>> x = sc.linspace(dim='x', start=1.1, stop=4.0, num=1000, unit='m')
       >>> y = sc.sin(x * sc.scalar(1.0, unit='rad/m'))
       >>> y += sc.sin(x * sc.scalar(400.0, unit='rad/m'))
@@ -119,7 +120,7 @@ def sosfiltfilt(obj: Union[Variable, DataArray], dim: str, *, sos: SOS,
       >>> sc.plot({'input':da, 'sosfiltfilt':out})
 
     Instead of calling sosfiltfilt the more convenient filtfilt method of
-    :py:class:`scipp.signal.SOS` can be used:
+    :py:class:`scipp.scipy.signal.SOS` can be used:
 
       >>> out = butter(da.coords['x'], N=4, Wn=20 / x.unit).filtfilt(da, 'x')
     """

--- a/tests/scipy/integrate_test.py
+++ b/tests/scipy/integrate_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import scipp as sc
-from scipp.integrate import trapezoid, simpson
+from scipp.scipy.integrate import trapezoid, simpson
 
 import pytest
 

--- a/tests/scipy/interpolate/interp1d_test.py
+++ b/tests/scipy/interpolate/interp1d_test.py
@@ -3,7 +3,7 @@
 import numpy as np
 import scipp as sc
 import scipy.interpolate as theirs
-from scipp.interpolate import interp1d
+from scipp.scipy.interpolate import interp1d
 
 import pytest
 

--- a/tests/scipy/ndimage/footprint_filter_test.py
+++ b/tests/scipy/ndimage/footprint_filter_test.py
@@ -3,8 +3,8 @@
 import numpy as np
 import scipp as sc
 import scipy.ndimage
-from scipp.ndimage import (generic_filter, maximum_filter, median_filter,
-                           minimum_filter, percentile_filter, rank_filter)
+from scipp.scipy.ndimage import (generic_filter, maximum_filter, median_filter,
+                                 minimum_filter, percentile_filter, rank_filter)
 import pytest
 
 filters = (generic_filter, maximum_filter, median_filter, minimum_filter,

--- a/tests/scipy/ndimage/gaussian_filter_test.py
+++ b/tests/scipy/ndimage/gaussian_filter_test.py
@@ -3,7 +3,7 @@
 import numpy as np
 import scipp as sc
 import scipy.ndimage
-from scipp.ndimage import gaussian_filter
+from scipp.scipy.ndimage import gaussian_filter
 
 import pytest
 

--- a/tests/scipy/optimize/curve_fit_test.py
+++ b/tests/scipy/optimize/curve_fit_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import scipp as sc
-from scipp.optimize import curve_fit
+from scipp.scipy.optimize import curve_fit
 
 import pytest
 from functools import partial

--- a/tests/scipy/signal/butter_test.py
+++ b/tests/scipy/signal/butter_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import scipp as sc
-from scipp.signal import butter
+from scipp.scipy.signal import butter
 
 import pytest
 

--- a/tests/scipy/signal/sosfiltfilt_test.py
+++ b/tests/scipy/signal/sosfiltfilt_test.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import scipp as sc
-from scipp.signal import butter, sosfiltfilt
+from scipp.scipy.signal import butter, sosfiltfilt
 
 import pytest
 


### PR DESCRIPTION
Addresses on item in #2711: Move all SciPy wrappers into `scipp.scipy`. `scipp.constants` is an exception, as we consider it "core" functionality that we want to support in the same manner regardless of the underlying library used.

For now at least, I have *not* kept the old packages with a deprecation warning, i.e., this would be a direct breaking change. Do we need to keep support for the old imports and add a migration notice?