### PR TITLE
Workaround so that mpl figures are visible in docs

### DIFF
--- a/docs/user-guide/binned-data/binned-data.ipynb
+++ b/docs/user-guide/binned-data/binned-data.ipynb
@@ -45,6 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import scipp as sc\n",


### PR DESCRIPTION
Most probably related to https://github.com/ipython/matplotlib-inline/issues/22