### PR TITLE
Update deprecated set-output syntax

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Cache conan setup
         id: conan-cache-key
         run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%m%d")"
-          echo "::set-output name=path::$(conan config home)"
+          echo "key=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+          echo "path=$(conan config home)" >> $GITHUB_OUTPUT
       - name: Cache conan
         uses: actions/cache@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,8 @@ jobs:
       - name: Set outputs
         id: version
         run: |
-          echo "::set-output name=new::$(python docs/version.py --repo=scipp --version=${GITHUB_REF_NAME} --action=is-new)"
-          echo "::set-output name=replaced::$(python docs/version.py --repo=scipp --version=${GITHUB_REF_NAME} --action=get-replaced)"
+          echo "new=$(python docs/version.py --repo=scipp --version=${GITHUB_REF_NAME} --action=is-new)" >> $GITHUB_OUTPUT
+          echo "replaced=$(python docs/version.py --repo=scipp --version=${GITHUB_REF_NAME} --action=get-replaced)" >> $GITHUB_OUTPUT
 
   docs:
     needs: [upload_conda, upload_pypi, manage-versions]


### PR DESCRIPTION
Fixing some warnings in our workflows. See
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details.