### PR TITLE
Fix test for numpy 1.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ filterwarnings = [
   'ignore:You are running a "Debug" build of scipp:',
   'ignore:sc.matrix\(\) has been deprecated:DeprecationWarning',
   'ignore:sc.matrices\(\) has been deprecated:DeprecationWarning',
-  # Explained in variable_init_test.py. TODO Address this!
-  'ignore:Creating an ndarray from ragged nested sequences:DeprecationWarning',
-  'ignore:Creating an ndarray from ragged nested sequences:numpy.VisibleDeprecationWarning',
   # Comes from pytest_asyncio and is not our fault.
   "ignore:The 'asyncio_mode' default value will change to 'strict' in future:DeprecationWarning",
   'ignore::scipy.optimize._optimize.OptimizeWarning',

--- a/tests/variable_init_test.py
+++ b/tests/variable_init_test.py
@@ -331,22 +331,7 @@ def test_create_1d_values_and_variances_array_like(values_type, variances_type):
     np.testing.assert_array_equal(var.variances, variances)
 
 
-# The constructors in this test trigger deprecation warnings in numpy:
-#
-# Creating an ndarray from ragged nested sequences (which is a list-or-tuple
-# of lists-or-tuples-or ndarrays with different lengths or shapes)
-# is deprecated. If you meant to do this, you must specify 'dtype=object'
-# when creating the ndarray.
-#
-# This is because the array-variable constructor uses py::array(values).
-# Unfortunately, py::array_t<py::object> is not implemented.
-# This test will fail when numpy changes the current behavior.
-# Until then, we are fine.
-#
-# Users can avoid the issue by using numpy.ndarray for the 'values'.
-@pytest.mark.parametrize('values_type',
-                         (tuple, list, lambda x: np.array(x, dtype=object)))
-def test_create_1d_dtype_object(values_type):
+def test_create_1d_dtype_object():
 
     def check(v):
         assert v.dtype == sc.DType.PyObject
@@ -354,7 +339,7 @@ def test_create_1d_dtype_object(values_type):
         assert v['x', 0].value == values[0]
         assert v['x', 1].value == values[1]
 
-    values = values_type([{1, 2}, {3, 4}])
+    values = np.array([{1, 2}, (3, 4)], dtype=object)
     var = sc.Variable(dims=['x'], values=values)
     check(var)
     var = sc.Variable(dims=['x'], values=values, dtype=sc.DType.PyObject)

--- a/tests/variable_init_test.py
+++ b/tests/variable_init_test.py
@@ -354,7 +354,7 @@ def test_create_1d_dtype_object(values_type):
         assert v['x', 0].value == values[0]
         assert v['x', 1].value == values[1]
 
-    values = values_type([{1, 2}, (3, 4)])
+    values = values_type([{1, 2}, {3, 4}])
     var = sc.Variable(dims=['x'], values=values)
     check(var)
     var = sc.Variable(dims=['x'], values=values, dtype=sc.DType.PyObject)


### PR DESCRIPTION
Numpy 1.24 can no longer handle inhomogeneous inputs like in the old test.

Note that specifying `dtype=object` or `dtype=sc.DType.PyObject` doesn't work either. This is because `Variable.__init__` converts the `values` param to a numpy array except for a few special types. We could change it to handle `dtype=object` explicitly. But I don't think this is important enough at this point.