### PR TITLE
Begin collecting list of services our builds depend on

### DIFF
--- a/docs/reference/developer/dependencies.rst
+++ b/docs/reference/developer/dependencies.rst
@@ -55,6 +55,22 @@ This list is incomplete, but attempts to aid in better understanding how many th
      - PR
      - Release
      - Comment
+   * - `<http://github.com>`_
+     - x
+     - x
+     -
+   * - `<http://conan.io>`_
+     - x
+     - x
+     -
+   * - `<http://pypi.org>`_
+     - x
+     - x
+     -
+   * - `<http://anaconda.org/conda-forge>`_
+     - x
+     - x
+     -
    * - `<https://public.esss.dk>`_
      - x
      - x

--- a/docs/reference/developer/dependencies.rst
+++ b/docs/reference/developer/dependencies.rst
@@ -55,7 +55,7 @@ This list is incomplete, but attempts to aid in better understanding how many th
      - PR
      - Release
      - Comment
-   * - `<https://public.esss.dkii>`_
+   * - `<https://public.esss.dk>`_
      - x
      - x
      - ``pooch`` files, accessed during ``docs`` build

--- a/docs/reference/developer/dependencies.rst
+++ b/docs/reference/developer/dependencies.rst
@@ -41,3 +41,25 @@ Places that define dependencies
   The goal is to move to the global conda-forge pin once they move to ``numpy-1.20``. See `#2571 <https://github.com/scipp/scipp/issues/2571>`_.
 - Environment files in `docs/environments/ <https://github.com/scipp/scipp/tree/main/docs/environments>`_ list optional requirements.
   These environments are not used for builds but for users.
+
+Services / Servers we depend on
+###############################
+
+This list is incomplete, but attempts to aid in better understanding how many things we depend on for making PR (including ``main``) and Release builds.
+
+.. list-table:: Services
+   :header-rows: 1
+   :widths: 40 5 5 60
+
+   * - Service
+     - PR
+     - Release
+     - Comment
+   * - `<https://public.esss.dkii>`_
+     - x
+     - x
+     - ``pooch`` files, accessed during ``docs`` build
+   * - `<http://azure.archive.ubuntu.com>`_
+     - x
+     -
+     - ccache-action gets Ubuntu ``ccache`` from here


### PR DESCRIPTION
This morning `main` workflow failed, since http://azure.archive.ubuntu.com was temporarily inaccessible. I thought it would be good to at least begin collecting a list of things we depend on.