### PR TITLE
Add `versionadded` Sphinx directive

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -50,6 +50,8 @@ class DataGroup(MutableMapping):
     such as positional- and label-based indexing and Scipp operations by mapping them
     to the values in the dict. This may happen recursively to support tree-like data
     structures.
+
+    .. versionadded:: 23.01.0
     """
 
     def __init__(self, /, *args, **kwargs):


### PR DESCRIPTION
Related to #2957. The main question is whether it is good enough to "guess" which will be the next release, or whether we should use a placeholder in PRs and a script run as part of the release process to substitute for the actual release?