### PR TITLE
Add HDF5 methods for DataGroup

### DIFF
--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -47,6 +47,7 @@ from .io.hdf5 import to_hdf5 as _to_hdf5
 setattr(Variable, 'to_hdf5', _to_hdf5)
 setattr(DataArray, 'to_hdf5', _to_hdf5)
 setattr(Dataset, 'to_hdf5', _to_hdf5)
+setattr(DataGroup, 'to_hdf5', _to_hdf5)
 del _to_hdf5
 
 from .format import format_variable as _format_variable

--- a/src/scipp/io/hdf5.py
+++ b/src/scipp/io/hdf5.py
@@ -366,7 +366,13 @@ class HDF5IO:
     @classmethod
     def write(cls, group, data, **kwargs):
         name = data.__class__.__name__.replace('View', '')
-        return cls._handlers[name].write(group, data, **kwargs)
+        try:
+            handler = cls._handlers[name]
+        except KeyError:
+            get_logger().warning("Writing type '%s' to HDF5 not implemented, skipping.",
+                                 type(data))
+            return None
+        return handler.write(group, data, **kwargs)
 
     @classmethod
     def read(cls, group, **kwargs):

--- a/src/scipp/io/hdf5.py
+++ b/src/scipp/io/hdf5.py
@@ -263,8 +263,8 @@ def _write_mapping(parent, mapping, override=None):
         if (g := override.get(name)) is not None:
             parent[var_group_name] = g
         else:
-            g = VariableIO.write(group=parent.create_group(var_group_name),
-                                 var=mapping[name])
+            g = HDF5IO.write(group=parent.create_group(var_group_name),
+                             data=mapping[name])
             if g is None:
                 del parent[var_group_name]
             else:
@@ -289,7 +289,8 @@ class DataArrayIO:
             override = {}
         _write_scipp_header(group, 'DataArray')
         group.attrs['name'] = data.name
-        VariableIO.write(group.create_group('data'), var=data.data)
+        if VariableIO.write(group.create_group('data'), var=data.data) is None:
+            return None
         views = [data.coords, data.masks, data.attrs]
         # Note that we write aligned and unaligned coords into the same group.
         # Distinction is via an attribute, which is more natural than having
@@ -297,6 +298,7 @@ class DataArrayIO:
         for view_name, view in zip(['coords', 'masks', 'attrs'], views):
             subgroup = group.create_group(view_name)
             _write_mapping(subgroup, view, override.get(view_name))
+        return group
 
     @staticmethod
     def read(group, override=None):
@@ -328,6 +330,7 @@ class DatasetIO:
             HDF5IO.write(entries.create_group(collection_element_name(name, i)),
                          da,
                          override={'coords': coords})
+        return group
 
     @staticmethod
     def read(group):
@@ -339,9 +342,26 @@ class DatasetIO:
                                                                       coords}))
 
 
+class DataGroupIO:
+
+    @staticmethod
+    def write(group, data):
+        _write_scipp_header(group, 'DataGroup')
+        entries = group.create_group('entries')
+        _write_mapping(entries, data)
+        return group
+
+    @staticmethod
+    def read(group):
+        _check_scipp_header(group, 'DataGroup')
+        from ..core import DataGroup
+        return DataGroup(_read_mapping(group['entries']))
+
+
 class HDF5IO:
     _handlers = dict(
-        zip(['Variable', 'DataArray', 'Dataset'], [VariableIO, DataArrayIO, DatasetIO]))
+        zip(['Variable', 'DataArray', 'Dataset', 'DataGroup'],
+            [VariableIO, DataArrayIO, DatasetIO, DataGroupIO]))
 
     @classmethod
     def write(cls, group, data, **kwargs):

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -23,6 +23,9 @@ def roundtrip(obj):
 
 def check_roundtrip(obj):
     result = roundtrip(obj)
+    print(obj)
+    print('----')
+    print(result)
     assert sc.identical(result, obj)
     return result  # for optional addition tests
 
@@ -274,6 +277,26 @@ def test_dataset_with_many_coords():
         # depend on the number of rows.
         extra = 75000
         assert size1 < (len(ds1.coords) + 1) * rows * 8 + extra
+
+
+def test_data_group():
+    dg = sc.DataGroup({
+        'vector':
+        vector,
+        'data_array':
+        array_2d,
+        'dataset':
+        sc.Dataset({
+            'a': array_1d,
+            'b': array_2d
+        }),
+        'data group':
+        sc.DataGroup({
+            'v.same': vector,
+            'm/copy': matrix.copy()
+        })
+    })
+    check_roundtrip(dg)
 
 
 def test_variable_with_zero_length_dimension():

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -296,6 +296,18 @@ def test_data_group():
     check_roundtrip(dg)
 
 
+def test_data_group_empty():
+    dg = sc.DataGroup()
+    check_roundtrip(dg)
+
+
+def test_data_group_unsupported_PyObject():
+    dg = sc.DataGroup({'a': x, 'b': sc.scalar([1, 2], dtype=object)})
+    res = roundtrip(dg)
+    assert sc.identical(res['a'], dg['a'])
+    assert 'b' not in res
+
+
 def test_variable_with_zero_length_dimension():
     v = sc.Variable(dims=["x"], values=[])
     check_roundtrip(v)

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -23,9 +23,6 @@ def roundtrip(obj):
 
 def check_roundtrip(obj):
     result = roundtrip(obj)
-    print(obj)
-    print('----')
-    print(result)
     assert sc.identical(result, obj)
     return result  # for optional addition tests
 

--- a/tests/io/hdf5_test.py
+++ b/tests/io/hdf5_test.py
@@ -278,7 +278,7 @@ def test_dataset_with_many_coords():
 
 def test_data_group():
     dg = sc.DataGroup({
-        'vector':
+        'variable':
         vector,
         'data_array':
         array_2d,
@@ -306,6 +306,13 @@ def test_data_group_unsupported_PyObject():
     res = roundtrip(dg)
     assert sc.identical(res['a'], dg['a'])
     assert 'b' not in res
+
+
+def test_data_group_unsupported_type():
+    dg = sc.DataGroup({'a': 2, 'b': sc.scalar(3)})
+    res = roundtrip(dg)
+    assert 'a' not in res
+    assert sc.identical(res['b'], dg['b'])
 
 
 def test_variable_with_zero_length_dimension():


### PR DESCRIPTION
Fixes #2948

I did not address the issues with unsupported dtypes in `DataArrayIO` and `DatasetIO`. I am unsure if this is worth the effort given that the resulting HDF5 file likely is useless anyway.