### PR TITLE
Update DataGroup __str__ and __repr__

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -199,11 +199,14 @@ class DataGroup(MutableMapping):
         return out
 
     def __repr__(self):
-        r = 'DataGroup(\n'
+        r = f'DataGroup(sizes={self.sizes}, keys=[\n'
         for name, var in self.items():
-            r += f'    {name}: {_summarize(var)}\n'
-        r += ')'
+            r += f'    {name}: {type(var).__name__},\n'
+        r += '])'
         return r
+
+    def __str__(self):
+        return f'DataGroup(sizes={self.sizes}, keys={list(self.keys())})'
 
     @property
     def bins(self):

--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -201,7 +201,7 @@ class DataGroup(MutableMapping):
     def __repr__(self):
         r = f'DataGroup(sizes={self.sizes}, keys=[\n'
         for name, var in self.items():
-            r += f'    {name}: {type(var).__name__},\n'
+            r += f'    {name}: {_summarize(var)[:-1]},\n'
         r += '])'
         return r
 


### PR DESCRIPTION
I am not really happy with this, but I do not have a better idea. `__repr__` is menat to be "unambiguous", but that is not really feasible for the large data structures we are dealing with.

Is it useful like this? Example:

![image](https://user-images.githubusercontent.com/12912489/212908205-94fbcd2f-5ffb-4d18-898a-fb7b083c04c6.png)
