### PR TITLE
Fix bounds check in integer-array indexing

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -65,6 +65,7 @@ Bugfixes
 * Fix issue with events close to upper or lower bin bounds getting dropped by :func:`scipp.lookup` with edges that form a "linspace" `#2942 <https://github.com/scipp/scipp/pull/2942>`_.
 * Fix minor issue with events close to bin bounds getting assigned to the wrong bin by :func:`scipp.lookup` with edges that form a "linspace" `#2942 <https://github.com/scipp/scipp/pull/2942>`_.
 * Fix two memory usage and performance issue that affected certain cases of :py:func:`scipp.hist` `#2977 <https://github.com/scipp/scipp/pull/2977>`_.
+* Fix bounds check in integer-array indexing, which previously silently skipped out-of-range indices `#2986 <https://github.com/scipp/scipp/pull/2986>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/tests/slice_by_index_list_test.py
+++ b/tests/slice_by_index_list_test.py
@@ -112,4 +112,4 @@ def test_2d_list_raises_TypeError():
 def test_out_of_range_index_raises_IndexError(pos):
     var = sc.arange('xx', 4)
     with pytest.raises(IndexError):
-        var['xx', pos]
+        var['xx', [pos]]


### PR DESCRIPTION
Fixes #2984.

There actually *was* a unit test for this, but the test had a bug...