### PR TITLE
Minor fix so DataGroup.bins is usable.

### DIFF
--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -109,18 +109,6 @@ class Bins:
     def __init__(self, obj):
         self._obj = obj
 
-    @property
-    def dims(self):
-        return self._obj.dims
-
-    @property
-    def shape(self):
-        return self._obj.shape
-
-    @property
-    def sizes(self):
-        return self._obj.sizes
-
     def _data(self):
         try:
             return self._obj.data

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -109,6 +109,18 @@ class Bins:
     def __init__(self, obj):
         self._obj = obj
 
+    @property
+    def dims(self):
+        return self._obj.dims
+
+    @property
+    def shape(self):
+        return self._obj.shape
+
+    @property
+    def sizes(self):
+        return self._obj.sizes
+
     def _data(self):
         try:
             return self._obj.data

--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -107,6 +107,7 @@ class DataGroup(MutableMapping):
         is only possible when the shape of all items is compatible with the boolean
         variable.
         """
+        from .bins import Bins
         if isinstance(name, str):
             return self._items[name]
         if isinstance(name, tuple) and name == ():
@@ -128,7 +129,8 @@ class DataGroup(MutableMapping):
                 f"Positional indexing dim '{dim}' not possible as the length is not "
                 "unique.")
         return DataGroup({
-            key: var[dim, index] if dim in _item_dims(var) else var
+            key: var[dim, index] if
+            (isinstance(var, Bins) or dim in _item_dims(var)) else var
             for key, var in self.items()
         })
 

--- a/tests/data_group_test.py
+++ b/tests/data_group_test.py
@@ -606,3 +606,11 @@ def test_methods_work_with_any_value_type_that_supports_it():
     result = dg.max()
     assert sc.identical(result['a'], sc.arange('x', 4).max())
     assert np.array_equal(result['b'], np.arange(5).max())
+
+
+def test_bins_property_indexing():
+    table = sc.data.table_xyz(10)
+    dg = sc.DataGroup(a=table)
+    dg = dg.bin(x=10)
+    result = dg.bins['x', sc.scalar(0.5, unit='m'):]
+    assert sc.identical(result['a'], dg['a'].bins['x', sc.scalar(0.5, unit='m'):])


### PR DESCRIPTION
Initially I thought that the solution would be to add a `dims` property to `Bins` such as `_item_dims` does not give `()`. However, slicing via the `bins` property works differently, namely it considers the event-coords, regardless of the dims of the surrounding object. Therefore, we are no checking if items are instances of `Bins`.