### PR TITLE
Improve performance of `DataGroup.shape`

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -165,9 +165,10 @@ class DataGroup(MutableMapping):
     @property
     def shape(self):
         """Union of shape of all items. Non-Scipp items are handled as shape=()."""
+        itemsizes = [getattr(x, 'sizes', {}) for x in self.values()]
 
         def dim_size(dim):
-            sizes = {var.sizes[dim] for var in self.values() if dim in _item_dims(var)}
+            sizes = {sizes[dim] for sizes in itemsizes if dim in sizes}
             if len(sizes) == 1:
                 return next(iter(sizes))
             return None


### PR DESCRIPTION
`DataGroup.shape` was relatively slow, since it has to dynamically iterate over all items, and determine consistent or inconsistent shapes.

One alternative I have considered to use caching. However I feared that solution would be to complex since we would need to be absolutely sure that the cache can be invalidated on item updates... but given that data groups can be nested I believe this is impossible to guarantee without a very complex mechanism.

Instead I just rewrote it slightly:

Timings:

```python
import scipp as sc

# timings are:
# dg.dims, dg.shape [-> dg.shape (improved)]
dg = sc.DataGroup({f'{i}':sc.scalar(i) for i in range(1000)})  # 1.4 ms, 1.3 ms
dg = sc.DataGroup({f'{i}':sc.array(dims=['x'], values=[i]) for i in range(1000)})  # 1.4 ms, 3.2 ms -> 2.8 ms
dg = sc.DataGroup({f'{i}':sc.array(dims=['x', 'y'], values=[[i]]) for i in range(1000)})  # 1.4 ms, 5.1 ms
dg = sc.DataGroup({f'{i}':sc.array(dims=[f'{i//300}'], values=[i]) for i in range(1000)})  # 1.4 ms, 7.5 ms
dg = sc.DataGroup({f'{i}':sc.array(dims=[f'{i//100}'], values=[i]) for i in range(1000)})  # 1.5 ms, 15.9 ms -> 3.1 ms
dg = sc.DataGroup()  # 2.8 ms, 30.4 ms -> 5.8 ms
for i in range(1000):
    dg[f'{i}'] = sc.array(dims=[f'{i//100}'], values=[i])
    dg[f'{i}x'] = sc.scalar(i)
```