### PR TITLE
Check stepsize to avoid inconsistent errors/warnings from numpy

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -192,6 +192,8 @@ def _parse_coords_arg(x: Union[_cpp.Variable, _cpp.DataArray, _cpp.Dataset], nam
         return linspace(name, start, stop, num=arg + 1).to(dtype=start.dtype,
                                                            copy=False)
     step = arg.to(dtype=start.dtype, unit=start.unit)
+    if step.value == 0:
+        raise ValueError("Step size cannot be 0.")
     return arange(name, start, stop + step, step=step)
 
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -178,7 +178,7 @@ def test_bin_integer_coord_by_float_stepsize(dtype):
 def test_bin_integer_coord_by_fractional_stepsize_raises(dtype):
     table = sc.data.table_xyz(100)
     table.coords['label'] = (table.coords['x'] * 10).to(dtype=dtype)
-    with pytest.raises(ValueError, "Step size cannot be 0."):
+    with pytest.raises(ValueError):
         table.bin(label=sc.scalar(0.5, unit='m'))
 
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -178,7 +178,7 @@ def test_bin_integer_coord_by_float_stepsize(dtype):
 def test_bin_integer_coord_by_fractional_stepsize_raises(dtype):
     table = sc.data.table_xyz(100)
     table.coords['label'] = (table.coords['x'] * 10).to(dtype=dtype)
-    with pytest.raises(RuntimeWarning, match='divide by zero'):
+    with pytest.raises(ValueError, "Step size cannot be 0."):
         table.bin(label=sc.scalar(0.5, unit='m'))
 
 


### PR DESCRIPTION
We had a random test fail in a (test) release build. The unit test checked for `RuntimeWarning: divide by zero encountered in long_scalars`. However, it suddenly raises `ValueError: Maximum allowed size exceeded`. I managed to reproduce this locally, but not consistently, I have no real idea what is going on.

As a fix, I check for a zero step size instead.