### PR TITLE
Conditionally import ScippIndex instead of DataGroup

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -9,14 +9,18 @@ import itertools
 import numbers
 import operator
 from collections.abc import MutableMapping
-from typing import Any, Callable, Dict, Iterable, NoReturn, Optional, Tuple, Union, \
-    overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, NoReturn, Optional, \
+    Tuple, Union, overload
 
 import numpy as np
 
 from .. import _binding
-from ..typing import ScippIndex
 from .cpp_classes import DataArray, Dataset, DimensionError, Variable
+
+if TYPE_CHECKING:
+    # typing imports data_group.
+    # So the following import would create a cycle at runtime.
+    from ..typing import ScippIndex
 
 
 def _item_dims(item):

--- a/src/scipp/typing.py
+++ b/src/scipp/typing.py
@@ -10,11 +10,7 @@ import numpy.typing
 
 from ._scipp import core as sc
 from .core.cpp_classes import DataArray, Dataset, DType, Variable
-
-if _std_typing.TYPE_CHECKING:
-    # data_group import typing.
-    # So this would create a cycle at runtime.
-    from .core.data_group import DataGroup
+from .core.data_group import DataGroup
 
 
 def is_scalar(obj: _std_typing.Any) -> bool:
@@ -60,12 +56,14 @@ Can be a string (for a single dimension) or a sequence of strings (multiple dime
 A value of ``None`` indicates "all dimensions."
 """
 
-VariableLike = _std_typing.Union[Variable, DataArray, Dataset, 'DataGroup']
+VariableLike = _std_typing.Union[Variable, DataArray, Dataset, DataGroup]
 """Any object that behaves like a :class:`scipp.Variable`.
 
-More concretely, an array with labeled dimensions:
+More concretely, an array with labeled dimensions which supports slicing and
+arithmetic:
 
 - :class:`scipp.DataArray`
+- :class:`scipp.DataGroup`
 - :class:`scipp.Dataset`
 - :class:`scipp.Variable`
 """
@@ -74,7 +72,7 @@ MetaDataMap = _std_typing.MutableMapping[str, Variable]
 """dict-like object mapping dimension labels to Variables."""
 
 VariableLikeType = _std_typing.TypeVar('VariableLikeType', Variable, DataArray, Dataset,
-                                       'DataGroup')
+                                       DataGroup)
 """TypeVar for use in annotations.
 
 Should be hidden in rendered documentation in favor of VariableLike.


### PR DESCRIPTION
Fixes the part of #3000 related to data groups. But the logo still doesn't show up on generated apges.