### PR TITLE
Fix new segfault from `_repr_html_` with binned data

### DIFF
--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -55,18 +55,19 @@ dict_to_compact_string(const scipp::dataset::SizedDict<Key, Value> &dict,
 
 template <>
 std::string Formatter<core::bin<DataArray>>::format(const Variable &var) const {
-  const auto &buffer = var.bin_buffer<DataArray>();
+  const auto &[indices, dim, buffer] = var.constituents<DataArray>();
   std::string margin(8, ' ');
   std::stringstream s;
-  s << "\n" << margin << "dims=" << labels_to_string(buffer.data().dims());
+  s << "binned data: dim='" + to_string(dim) + "', content=DataArray(";
+  s << "\n" << margin << "dims=" << to_string(buffer.dims()) << ',';
   s << "\n" << margin << "data=" << format_variable_compact(buffer.data());
   if (!buffer.coords().empty())
-    s << "\n" << dict_to_compact_string(buffer.coords(), "coords", margin);
+    s << ",\n" << dict_to_compact_string(buffer.coords(), "coords", margin);
   if (!buffer.masks().empty())
-    s << "\n" << dict_to_compact_string(buffer.masks(), "masks", margin);
+    s << ",\n" << dict_to_compact_string(buffer.masks(), "masks", margin);
   if (!buffer.attrs().empty())
-    s << "\n" << dict_to_compact_string(buffer.attrs(), "attrs", margin);
-  return s.str();
+    s << ",\n" << dict_to_compact_string(buffer.attrs(), "attrs", margin);
+  return s.str() + ')';
 }
 
 INSTANTIATE_BIN_ARRAY_VARIABLE(DatasetView, Dataset)

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -26,7 +26,7 @@ dict_to_compact_string(const scipp::dataset::SizedDict<Key, Value> &dict,
                        const std::string &description,
                        const std::string &margin) {
   std::stringstream s;
-  const scipp::index max_length = 92;
+  const scipp::index max_length = 70;
   const auto indent = margin.size() + description.size() + 2;
   s << margin << description << "={";
   bool first_iter = true;

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -56,7 +56,7 @@ dict_to_compact_string(const scipp::dataset::SizedDict<Key, Value> &dict,
 template <>
 std::string Formatter<core::bin<DataArray>>::format(const Variable &var) const {
   const auto &[indices, dim, buffer] = var.constituents<DataArray>();
-  std::string margin(8, ' ');
+  std::string margin(10, ' ');
   std::stringstream s;
   s << "binned data: dim='" + to_string(dim) + "', content=DataArray(";
   s << "\n" << margin << "dims=" << to_string(buffer.dims()) << ',';

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -11,9 +11,13 @@ namespace scipp::variable {
 
 template <>
 std::string Formatter<core::bin<Variable>>::format(const Variable &var) const {
-  const auto &buffer = var.bin_buffer<Variable>();
-  return "[binned data: dims=" + labels_to_string(buffer.dims()) + " " +
-         format_variable_compact(buffer) + "]";
+  const auto &[indices, dim, content] = var.constituents<Variable>();
+  auto str = "binned data: dim='" + to_string(dim) +
+             "', content=Variable(dims=" + to_string(content.dims()) +
+             ", dtype=" + to_string(content.dtype());
+  if (content.unit() != units::none)
+    str += ", unit=" + to_string(content.unit());
+  return str + ')';
 }
 
 INSTANTIATE_BIN_ARRAY_VARIABLE(VariableView, Variable)

--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -130,15 +130,11 @@ def _short_data_repr_html_events(var):
         return str(var)
     underlying = var.bins.constituents['data']
     string = str(var.data) if isinstance(var, sc.DataArray) else str(var)
-    if isinstance(underlying, sc.DataArray):
-        lines = string.splitlines()
-        ind = lines[1].find('dims=')
-        return '\n'.join([line[ind:] for line in lines[1:]])
-    elif isinstance(underlying, sc.Variable):
-        ind = string.find('[binned data: dims=')
-        return string[ind:]
-    else:
+    if isinstance(underlying, sc.Dataset):
         return string
+    start = 'binned data: '
+    ind = string.find(start) + len(start)
+    return string[ind:].replace(', content=', ',\ncontent=')
 
 
 def short_data_repr_html(var, variances=False):

--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -126,11 +126,8 @@ def _short_data_repr_html_non_events(var, variances=False):
 
 
 def _short_data_repr_html_events(var):
-    if isinstance(var, sc.Dataset):
-        return str(var)
-    underlying = var.bins.constituents['data']
     string = str(var.data) if isinstance(var, sc.DataArray) else str(var)
-    if isinstance(underlying, sc.Dataset):
+    if isinstance(var.bins.constituents['data'], sc.Dataset):
         return string
     start = 'binned data: '
     ind = string.find(start) + len(start)

--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -128,7 +128,7 @@ def _short_data_repr_html_non_events(var, variances=False):
 def _short_data_repr_html_events(var):
     if isinstance(var, sc.Dataset):
         return str(var)
-    underlying = var.values[0]
+    underlying = var.bins.constituents['data']
     string = str(var.data) if isinstance(var, sc.DataArray) else str(var)
     if isinstance(underlying, sc.DataArray):
         lines = string.splitlines()


### PR DESCRIPTION
- Fixes #3009.
- Fix inconsistent "binned data:" prefix.
- Fix inconsistent `[...]`.
- Add `dim` and `content` to improve clarity.