### PR TITLE
Use briefer format when printing dtype=Variable and dtype=DataArray

### DIFF
--- a/lib/dataset/variable_instantiate_dataset.cpp
+++ b/lib/dataset/variable_instantiate_dataset.cpp
@@ -9,16 +9,6 @@
 
 namespace scipp::variable {
 
-namespace {
-std::string format_data_array(const DataArray &da) {
-  auto s = "DataArray(dims=" + to_string(da.dims()) +
-           ", dtype=" + to_string(da.dtype());
-  if (da.unit() != units::none)
-    s += ", unit=" + to_string(da.unit());
-  return s + ')';
-}
-} // namespace
-
 template <>
 std::string Formatter<DataArray>::format(const Variable &var) const {
   if (var.dims().volume() == 1)

--- a/lib/dataset/variable_instantiate_dataset.cpp
+++ b/lib/dataset/variable_instantiate_dataset.cpp
@@ -9,6 +9,23 @@
 
 namespace scipp::variable {
 
+namespace {
+std::string format_data_array(const DataArray &da) {
+  auto s = "DataArray(dims=" + to_string(da.dims()) +
+           ", dtype=" + to_string(da.dtype());
+  if (da.unit() != units::none)
+    s += ", unit=" + to_string(da.unit());
+  return s + ')';
+}
+} // namespace
+
+template <>
+std::string Formatter<DataArray>::format(const Variable &var) const {
+  if (var.dims().volume() == 1)
+    return "DataArray" + format_variable_like(var.value<DataArray>());
+  return "[multiple data arrays]";
+}
+
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(Dataset, scipp::dataset::Dataset)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(DataArray, scipp::dataset::DataArray)
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/string.h
+++ b/lib/variable/include/scipp/variable/string.h
@@ -13,6 +13,14 @@
 
 namespace scipp::variable {
 
+template <class T> std::string format_variable_like(const T &obj) {
+  auto s =
+      "(dims=" + to_string(obj.dims()) + ", dtype=" + to_string(obj.dtype());
+  if (obj.unit() != units::none)
+    s += ", unit=" + to_string(obj.unit());
+  return s + ')';
+}
+
 SCIPP_VARIABLE_EXPORT std::ostream &operator<<(std::ostream &os,
                                                const Variable &variable);
 

--- a/lib/variable/variable_instantiate_basic.cpp
+++ b/lib/variable/variable_instantiate_basic.cpp
@@ -9,6 +9,12 @@
 
 namespace scipp::variable {
 
+template <> std::string Formatter<Variable>::format(const Variable &var) const {
+  if (var.dims().volume() == 1)
+    return "Variable" + format_variable_like(var.value<Variable>());
+  return "[multiple variables]";
+}
+
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(string, std::string)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(float64, double)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(float32, float)
@@ -17,5 +23,7 @@ INSTANTIATE_ELEMENT_ARRAY_VARIABLE(int32, int32_t)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(bool, bool)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(datetime64, scipp::core::time_point)
 INSTANTIATE_ELEMENT_ARRAY_VARIABLE(Variable, Variable)
+
+REGISTER_FORMATTER(Variable, Variable)
 
 } // namespace scipp::variable

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -12,12 +12,8 @@ namespace scipp::variable {
 template <>
 std::string Formatter<core::bin<Variable>>::format(const Variable &var) const {
   const auto &[indices, dim, content] = var.constituents<Variable>();
-  auto str = "binned data: dim='" + to_string(dim) +
-             "', content=Variable(dims=" + to_string(content.dims()) +
-             ", dtype=" + to_string(content.dtype());
-  if (content.unit() != units::none)
-    str += ", unit=" + to_string(content.unit());
-  return str + ')';
+  return "binned data: dim='" + to_string(dim) + "', content=Variable" +
+         format_variable_like(content);
 }
 
 INSTANTIATE_BIN_ARRAY_VARIABLE(VariableView, Variable)


### PR DESCRIPTION
Fixes #2908.

Before:
```
<scipp.DataArray>
Dimensions: Sizes[x:10, ]
Coordinates:
  x                         float64              [m]  (x [bin-edge])  [4.61286e-05, 0.099955, ..., 0.899226, 0.999135]
Data:
                            float64              [K]  (x)  [112.397, 109.431, ..., 111.287, 101.792]
Attributes:
  attr1                   DataArray        <no unit>  ()  [<scipp.DataArray>
Dimensions: Sizes[]
Data:
                            float64  [dimensionless]  ()  [1.2]

]
  attr2                   DataArray        <no unit>  ()  [<scipp.DataArray>
Dimensions: Sizes[]
Coordinates:
  x                           int64  [dimensionless]  ()  [4]
Data:
                            float64              [m]  ()  [1.2]

]
  attr3                   DataArray        <no unit>  ()  [<scipp.DataArray>
Dimensions: Sizes[]
Data:
                            float64        <no unit>  ()  [1.2]

]
  attr4                    Variable        <no unit>  ()  [<scipp.Variable> ()    float64              [m]  [1.2]]
```

After:
```
<scipp.DataArray>
Dimensions: Sizes[x:10, ]
Coordinates:
  x                         float64              [m]  (x [bin-edge])  [4.61286e-05, 0.099955, ..., 0.899226, 0.999135]
Data:
                            float64              [K]  (x)  [112.397, 109.431, ..., 111.287, 101.792]
Attributes:
  attr1                   DataArray        <no unit>  ()  DataArray(dims=(), dtype=float64, unit=dimensionless)
  attr2                   DataArray        <no unit>  ()  DataArray(dims=(), dtype=float64, unit=m)
  attr3                   DataArray        <no unit>  ()  DataArray(dims=(), dtype=float64)
  attr4                    Variable        <no unit>  ()  Variable(dims=(), dtype=float64, unit=m)
```
