### PR TITLE
Implement custom formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: [ --markdown-linebreak-ext=md ]
         exclude: '\.svg'
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -6,7 +6,7 @@ Release Notes
 
 .. Template, copy this to create a new section after a release:
 
-   Version RELEASE_PLACEHOLDER
+   vRELEASE_PLACEHOLDER
    --------
 
    Features
@@ -36,7 +36,7 @@ Release Notes
    and Sunyoung Yoo :sup:`a`
 
 
-Version RELEASE_PLACEHOLDER
+vRELEASE_PLACEHOLDER
 --------
 
 Features

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -6,7 +6,7 @@ Release Notes
 
 .. Template, copy this to create a new section after a release:
 
-   v23.01.0
+   Version RELEASE_PLACEHOLDER
    --------
 
    Features
@@ -34,6 +34,38 @@ Release Notes
    Neil Vaytet :sup:`a`\ ,
    Jan-Lukas Wynen :sup:`a`\ ,
    and Sunyoung Yoo :sup:`a`
+
+
+Version RELEASE_PLACEHOLDER
+--------
+
+Features
+~~~~~~~~
+
+* Added new string-formatting options `#3017 <https://github.com/scipp/scipp/pull/3017>`_.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Bugfixes
+~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+Jan-Lukas Wynen :sup:`a`\ ,
+and Sunyoung Yoo :sup:`a`
 
 
 v23.01.0

--- a/src/scipp/format/_parse.py
+++ b/src/scipp/format/_parse.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# @author Jan-Lukas Wynen
+
+import dataclasses
+import enum
+
+
+def _dataclass_with_slots(**kwargs):
+    try:
+        return dataclasses.dataclass(slots=True, **kwargs)
+    except TypeError:
+        # Fallback for Python < 3.10
+        return dataclasses.dataclass(**kwargs)
+
+
+class FormatType(enum.Enum):
+    default = enum.auto()
+    compact = enum.auto()
+
+
+@_dataclass_with_slots(frozen=True)
+class FormatSpec:
+    format_type: FormatType
+    nested: str
+
+
+def parse(raw_spec: str, cls: type) -> FormatSpec:
+    pieces = raw_spec.split(':', 1)
+    raw_scipp_spec = pieces[0]
+    nested = pieces[1] if len(pieces) == 2 else ''
+
+    if raw_scipp_spec not in ('', 'c'):
+        raise ValueError(f"Unknown format spec '{raw_spec}' for type '{cls}'")
+
+    format_type = FormatType.default if raw_scipp_spec == '' else FormatType.compact
+
+    return FormatSpec(format_type=format_type, nested=nested)

--- a/src/scipp/format/formatter.py
+++ b/src/scipp/format/formatter.py
@@ -104,8 +104,7 @@ def _format_variable_default(var: Variable, spec: FormatSpec) -> str:
 
 def _format_variable_compact(var: Variable, spec: FormatSpec) -> str:
     if spec.nested:
-        raise NotImplementedError("Nested specs not supported for compact formatting")
-
+        raise ValueError("Compact formatting does not support nested format specs")
     if not _is_numeric(var.dtype):
         raise ValueError(f"Compact formatting is not supported for dtype {var.dtype}")
 

--- a/src/scipp/format/formatter.py
+++ b/src/scipp/format/formatter.py
@@ -104,7 +104,7 @@ def _format_variable_default(var: Variable, spec: FormatSpec) -> str:
 
 def _format_variable_compact(var: Variable, spec: FormatSpec) -> str:
     if spec.nested:
-        raise NotImplementedError("Nested spec is not implemented")
+        raise NotImplementedError("Nested specs not supported for compact formatting")
 
     if not _is_numeric(var.dtype):
         raise ValueError(f"Compact formatting is not supported for dtype {var.dtype}")
@@ -115,9 +115,11 @@ def _format_variable_compact(var: Variable, spec: FormatSpec) -> str:
 
     # Iterate over array values to handle no- and infinite-precision cases
     if variances is None:
-        formatted = [_format(v) for v in values]
+        formatted = [_format_element_compact(v) for v in values]
     else:
-        formatted = [_format(*_round(v, e)) for v, e in zip(values, variances)]
+        formatted = [
+            _format_element_compact(*_round(v, e)) for v, e in zip(values, variances)
+        ]
     return f"{', '.join(formatted)}{unt}"
 
 
@@ -162,7 +164,7 @@ def _round(value, variance):
     return value, error, precision
 
 
-def _format(value, error=None, precision=None):
+def _format_element_compact(value, error=None, precision=None):
     # Build the appropriate format string:
     # No variance (or infinite precision) values take no formatting string
     # Positive precision implies no decimals, with format '0.0f'

--- a/tests/format/format_test.py
+++ b/tests/format/format_test.py
@@ -8,13 +8,14 @@ import pytest
 import scipp as sc
 
 
-@pytest.mark.parametrize('var',
-                         (sc.scalar(1), sc.scalar(3.1, variance=0.1, unit='m'),
-                          sc.array(dims=['x', 't'], values=np.ones(
-                              (3, 4)), unit='kg/s'), sc.scalar('some string'),
-                          sc.array(dims=['s'], values=['str', '2']),
-                          sc.scalar(6134, dtype='datetime64', unit='s'),
-                          sc.array(dims=['e'], values=[512, 1662], unit='s')))
+@pytest.mark.parametrize(
+    'var',
+    (sc.scalar(1), sc.scalar(-4, dtype='int32'), sc.scalar(
+        3.1, variance=0.1, unit='m'), sc.scalar(2.1, variance=0.1, dtype='float32'),
+     sc.array(dims=['x', 't'], values=np.ones((3, 4)), unit='kg/s'),
+     sc.scalar('some string'), sc.array(dims=['s'], values=['str', '2']),
+     sc.scalar(6134, dtype='datetime64',
+               unit='s'), sc.array(dims=['e'], values=[512, 1662], unit='s')))
 def test_variable_default(var):
     assert f'{var}' == str(var)
     assert f'{var:}' == str(var)

--- a/tests/format/format_test.py
+++ b/tests/format/format_test.py
@@ -8,35 +8,45 @@ import pytest
 import scipp as sc
 
 
-@pytest.mark.parametrize(
-    'var', (sc.scalar(1), sc.scalar(3.1, variance=0.1, unit='m'),
-            sc.array(dims=['x', 't'], values=np.ones(
-                (3, 4)), unit='kg/s'), sc.array(dims=['s'], values=['str', '2'])))
+@pytest.mark.parametrize('var',
+                         (sc.scalar(1), sc.scalar(3.1, variance=0.1, unit='m'),
+                          sc.array(dims=['x', 't'], values=np.ones(
+                              (3, 4)), unit='kg/s'), sc.scalar('some string'),
+                          sc.array(dims=['s'], values=['str', '2']),
+                          sc.scalar(6134, dtype='datetime64', unit='s'),
+                          sc.array(dims=['e'], values=[512, 1662], unit='s')))
 def test_variable_default(var):
     assert f'{var}' == str(var)
     assert f'{var:}' == str(var)
+    assert f'{var::}' == str(var)
     assert '{:}'.format(var) == str(var)
 
 
-def scalar_string(value, error, unit):
-    if error is None:
-        scalar = sc.scalar(value=value, unit=unit)
-    else:
-        scalar = sc.scalar(value=value, variance=error**2, unit=unit)
-    return f"{scalar:c}"
+def test_variable_default_nested_exponential():
+    var = sc.array(dims=['ys'], values=[1.2345, 654.98], unit='kg')
+    res = f'{var::.2e}'
+    assert f'{1.2345:.2e}' in res
+    assert f'{654.98:.2e}' in res
 
 
-def array_string(value, error, unit):
-    if error is None:
-        array = sc.array(values=value, unit=unit, dims=['x'])
-    else:
-        array = sc.array(values=value, variances=error**2, unit=unit, dims=['x'])
-    return f"{array:c}"
+def test_variable_default_forwards_to_nested_scalar():
+
+    class C:
+
+        def __format__(self, format_spec: str) -> str:
+            return f'NESTED-{format_spec}'
+
+    var = sc.scalar(C())
+    assert 'NESTED-abcd#0' in f'{var::abcd#0}'
 
 
-def test_scalar_variables():
+def test_variable_compact_scalar_no_variance():
+    var = sc.scalar(100, unit='s')
+    assert f'{var:c}' == '100 s'
+
+
+def test_variable_compact_scalar_with_variance():
     scalar_variables = [
-        (100, None, 's', '100 s'),
         (100., 1., 'm', '100.0(10) m'),
         (100., 2., '1', '100(2)'),
         (100., 10., 'counts', '100(10) counts'),
@@ -54,17 +64,24 @@ def test_scalar_variables():
         (100., 0., 'C', '100.0 C'),
     ]
     for value, error, unit, expected in scalar_variables:
-        assert scalar_string(value, error, unit) == expected
+        var = sc.scalar(value, variance=error**2, unit=unit)
+        assert f'{var:c}' == expected
 
 
-def test_array_variables():
-    from numpy import array
-    array_variables = [(array([100, 20, 3]), None, 's', '100, 20, 3 s'),
-                       (array([100., 20.]), array([1., 2.]), 'm', '100.0(10), 20(2) m'),
-                       (array([9000., 800., 70., 6.]), array([100., 20., 3., 0.4]), '1',
-                        '9000(100), 800(20), 70(3), 6.0(4)'),
-                       (array([1., 2.,
-                               3.]), array([0., 1.,
-                                            0.2]), 'C', '1.0, 2.0(10), 3.0(2) C')]
-    for value, error, unit, expected in array_variables:
-        assert array_string(value, error, unit) == expected
+def test_variable_compact_array_no_variance():
+    var = sc.array(dims=['fg'], values=[100, 20, 3], unit='s')
+    assert f'{var:c}' == '100, 20, 3 s'
+
+
+def test_variable_compact_array_with_variance():
+    array_variables = [([100., 20.], [1., 2.], 'm', '100.0(10), 20(2) m'),
+                       ([9000., 800., 70.,
+                         6.], [100., 20., 3.,
+                               0.4], '1', '9000(100), 800(20), 70(3), 6.0(4)'),
+                       ([1., 2., 3.], [0., 1., 0.2], 'C', '1.0, 2.0(10), 3.0(2) C')]
+    for values, errors, unit, expected in array_variables:
+        var = sc.array(dims=['ga'],
+                       values=values,
+                       variances=np.array(errors)**2,
+                       unit=unit)
+        assert f'{var:c}' == expected

--- a/tests/format/format_test.py
+++ b/tests/format/format_test.py
@@ -85,3 +85,15 @@ def test_variable_compact_array_with_variance():
                        variances=np.array(errors)**2,
                        unit=unit)
         assert f'{var:c}' == expected
+
+
+def test_variable_compact_raises_for_nested():
+    var = sc.scalar(2)
+    with pytest.raises(ValueError):
+        f'{var:c:f}'
+
+
+def test_variable_compact_only_supports_numeric_dtype():
+    var = sc.scalar('a string')
+    with pytest.raises(ValueError):
+        f'{var:c}'

--- a/tests/format/format_test.py
+++ b/tests/format/format_test.py
@@ -1,6 +1,21 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# @author Gregory Tucker, Jan-Lukas Wynen
+
 import numpy as np
+import pytest
 
 import scipp as sc
+
+
+@pytest.mark.parametrize(
+    'var', (sc.scalar(1), sc.scalar(3.1, variance=0.1, unit='m'),
+            sc.array(dims=['x', 't'], values=np.ones(
+                (3, 4)), unit='kg/s'), sc.array(dims=['s'], values=['str', '2'])))
+def test_variable_default(var):
+    assert f'{var}' == str(var)
+    assert f'{var:}' == str(var)
+    assert '{:}'.format(var) == str(var)
 
 
 def scalar_string(value, error, unit):

--- a/tests/html/html_repr_test.py
+++ b/tests/html/html_repr_test.py
@@ -4,10 +4,12 @@
 # @author Neil Vaytet
 
 import numpy as np
-import scipp as sc
 import pytest
-from ..factory import make_dense_data_array, make_dense_dataset, \
-    make_binned_data_array, make_scalar, make_variable, make_scalar_array
+
+import scipp as sc
+
+from ..factory import make_binned_data_array, make_dense_data_array, \
+    make_dense_dataset, make_scalar, make_scalar_array, make_variable
 
 # TODO:
 # For now, we are just checking that creating the repr does not throw.

--- a/tests/html/table_test.py
+++ b/tests/html/table_test.py
@@ -2,10 +2,12 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 import numpy as np
-import scipp as sc
 import pytest
-from ..factory import make_dense_data_array, make_dense_dataset, \
-    make_binned_data_array, make_variable
+
+import scipp as sc
+
+from ..factory import make_binned_data_array, make_dense_data_array, \
+    make_dense_dataset, make_variable
 
 # TODO:
 # For now,  we are just checking that creating the repr does not throw.


### PR DESCRIPTION
Ready for review now.

This implements nested format specs as proposed in #1472 but only for variables.
For the outer level, it keeps the behaviour of the compact formatter of #3012. And the default case formats the variable the same as `str(var)` except for nested scipp objects. Using `f'{var}'` uses the old, long form output instead of the new, brief one.

We can add more options later. But this one is useful on its own.