### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: |
-          sleep 60  # PyPI upload have a small delay until visible, avoid workflow fails in release builds
+          sleep 120  # PyPI upload have a small delay until visible, avoid workflow fails in release builds
           tox --skip-pkg-install -e docs -- scipp==${VERSION}
           echo "target=$(python docs/version.py --repo=scipp --version=${VERSION} --action=get-target)" >> $GITHUB_ENV
         if: ${{ inputs.publish }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
         required: false
         type: string
       branch:
+        description: 'Branch/tag with documentation source. If not set, the current branch will be used.'
         default: ''
         required: false
         type: string
@@ -24,6 +25,7 @@ on:
         required: false
         type: string
       branch:
+        description: 'Branch/tag with documentation source. If not set, the current branch will be used.'
         default: ''
         required: false
         type: string

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
         default: ''
         required: false
         type: string
+      branch:
+        default: ${{ github.ref_name }}
+        required: false
+        type: string
   workflow_call:
     inputs:
       publish:
@@ -17,6 +21,10 @@ on:
         type: boolean
       version:
         default: ''
+        required: false
+        type: string
+      branch:
+        default: ${{ github.ref_name }}
         required: false
         type: string
 
@@ -31,7 +39,8 @@ jobs:
       - run: sudo apt install --yes graphviz pandoc
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:
           python-version: 3.8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
       branch:
-        default: ${{ github.ref_name }}
+        default: ''
         required: false
         type: string
   workflow_call:
@@ -24,7 +24,7 @@ on:
         required: false
         type: string
       branch:
-        default: ${{ github.ref_name }}
+        default: ''
         required: false
         type: string
 
@@ -39,7 +39,7 @@ jobs:
       - run: sudo apt install --yes graphviz pandoc
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch == '' && github.ref_name || inputs.branch }}
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,4 +163,5 @@ jobs:
     with:
       publish: true
       version: ${{ needs.manage-versions.outputs.version-replaced }}
+      branch: ${{ needs.manage-versions.outputs.version-replaced }}
     secrets: inherit


### PR DESCRIPTION
- Set proper fetch-depth, since we are back to getting versions from tags.
- Implement changes so we can manually publish docs for a branch that is *different* from the version tag. This is not strictly necessary in this case (since only the workflow needed fixing), but in the past it was impossible to fix a problem in the docs build without making a new patch release.
  - I wasn't sure if this should default to `inputs.version` instead of `github.ref_name`?