### PR TITLE
Fix access to value of 0-D variable with spatial transform dtype

### DIFF
--- a/tests/spatial/affine_test.py
+++ b/tests/spatial/affine_test.py
@@ -50,3 +50,18 @@ def test_affine_transform_default_unit_is_dimensionless():
 def test_affine_transforms_default_unit_is_dimensionless():
     var = affine_transforms(dims=['x'], values=np.ones(shape=(3, 4, 4)))
     assert var.unit == sc.units.one
+
+
+def test_can_get_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((4, 4))
+    var = affine_transform(value=value)
+    assert np.array_equal(var.value, value)
+
+
+def test_can_set_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((4, 4))
+    var = affine_transform(value=value)
+    var.value += value
+    assert np.array_equal(var.value, value + value)

--- a/tests/spatial/rotation_test.py
+++ b/tests/spatial/rotation_test.py
@@ -88,3 +88,18 @@ def test_rotation_default_unit_is_dimensionless():
 def test_rotations_default_unit_is_dimensionless():
     var = rotations(dims=['x'], values=np.ones(shape=(3, 4)))
     assert var.unit == sc.units.one
+
+
+def test_can_get_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((4, ))
+    var = rotation(value=value)
+    assert np.array_equal(var.value, value)
+
+
+def test_can_set_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((4, ))
+    var = rotation(value=value)
+    var.value += value
+    assert np.array_equal(var.value, value + value)

--- a/tests/spatial/translation_test.py
+++ b/tests/spatial/translation_test.py
@@ -30,3 +30,18 @@ def test_translation_default_unit_is_dimensionless():
 def test_translations_default_unit_is_dimensionless():
     var = translations(dims=['x'], values=np.ones(shape=(2, 3)))
     assert var.unit == sc.units.one
+
+
+def test_can_get_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((3, ))
+    var = translation(value=value)
+    assert np.array_equal(var.value, value)
+
+
+def test_can_set_value_of_0d_variable():
+    rng = np.random.default_rng()
+    value = rng.random((3, ))
+    var = translation(value=value)
+    var.value += value
+    assert np.array_equal(var.value, value + value)


### PR DESCRIPTION
Fixes #3032 