### PR TITLE
Bug fix - lagging in ``DataGroup`` html wrapper

### DIFF
--- a/src/scipp/html/formatting_datagroup_html.py
+++ b/src/scipp/html/formatting_datagroup_html.py
@@ -16,7 +16,7 @@ from .resources import load_atomic_row_tpl, load_collapsible_row_tpl, \
 
 
 def _format_shape(var: Union[Variable, DataArray, Dataset, DataGroup], br_at=15) -> str:
-    """Returns HTML Component that represents the shape of ``var``"""
+    """Return HTML Component that represents the shape of ``var``"""
     shape_list = [f"{escape(str(dim))}: {size}" for dim, size in var.sizes.items()]
     if sum([len(line) - line.count('\\') for line in shape_list]) < br_at:
         return f"({', '.join(shape_list)})"
@@ -25,6 +25,7 @@ def _format_shape(var: Union[Variable, DataArray, Dataset, DataGroup], br_at=15)
 
 
 def _format_atomic_value(value, maxidx: int = 5) -> str:
+    """Inline preview of single value"""
     value_repr = str(value)[:maxidx]
     if len(value_repr) < len(str(value)):
         value_repr += "..."
@@ -32,14 +33,15 @@ def _format_atomic_value(value, maxidx: int = 5) -> str:
 
 
 def _format_dictionary_item(name_item: tuple, maxidx: int = 10) -> str:
+    """Inline preview of a dictionary"""
     name, item = name_item
     name = _format_atomic_value(name, maxidx=maxidx)
     type_repr = _format_atomic_value(type(item).__name__, maxidx=maxidx)
     return "(" + ": ".join((name, type_repr)) + ")"
 
 
-def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray],
-                           max_item_number: int = 2) -> str:
+def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray]) -> str:
+    """Inline preview of single or multi-dimensional data"""
     if isinstance(var, Variable):
         if var.ndim != var.values.ndim:
             return _format_atomic_value(var.values, maxidx=None)
@@ -76,7 +78,7 @@ def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray],
 
 
 def _summarize_atomic_variable(var, name: str, depth: int = 0) -> str:
-    """Returns HTML Component that contains summary of ``var``"""
+    """Return HTML Component that contains summary of ``var``"""
     shape_repr = escape("()")
     unit = ''
     dtype_str = ''

--- a/src/scipp/html/formatting_datagroup_html.py
+++ b/src/scipp/html/formatting_datagroup_html.py
@@ -43,7 +43,7 @@ def _format_dictionary_item(name_item: tuple, maxidx: int = 10) -> str:
 def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray]) -> str:
     """Inline preview of single or multi-dimensional data"""
     if isinstance(var, (Variable, DataArray)):
-        return inline_variable_repr(var)[5:-6]
+        return inline_variable_repr(var)
     elif isinstance(var, Dataset):
         view_iterable = list(var.items())
         var_len = len(var)

--- a/src/scipp/html/formatting_datagroup_html.py
+++ b/src/scipp/html/formatting_datagroup_html.py
@@ -43,7 +43,7 @@ def _format_dictionary_item(name_item: tuple, maxidx: int = 10) -> str:
 def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray]) -> str:
     """Inline preview of single or multi-dimensional data"""
     if isinstance(var, (Variable, DataArray)):
-        return inline_variable_repr(var).replace("<div>", '').replace("</div>", '')
+        return inline_variable_repr(var)[5:-6]
     elif isinstance(var, Dataset):
         view_iterable = list(var.items())
         var_len = len(var)

--- a/src/scipp/html/formatting_datagroup_html.py
+++ b/src/scipp/html/formatting_datagroup_html.py
@@ -47,7 +47,7 @@ def _format_multi_dim_data(var: Union[Variable, DataArray, Dataset, np.ndarray],
             return _format_atomic_value(var.value, maxidx=30)
 
     if isinstance(var, Dataset):
-        view_iterable = list(var.items())[0]
+        view_iterable = list(var.items())
         var_len = len(var)
         first_idx, last_idx = 0, -1
         format_item = _format_dictionary_item

--- a/src/scipp/html/formatting_html.py
+++ b/src/scipp/html/formatting_html.py
@@ -70,7 +70,7 @@ def _format_non_events(var, has_variances):
     s = _format_array(data, size, ellipsis_after=2)
     if has_variances:
         s = f'{STDDEV_PREFIX}{s}'
-    return _make_row(s)
+    return s
 
 
 def _repr_item(bin_dim, item):
@@ -105,7 +105,7 @@ def _get_events(var, variances, ellipsis_after):
 
 def _format_events(var, has_variances):
     s = _get_events(var, has_variances, ellipsis_after=2)
-    return _make_row(f'binned data [{", ".join([row for row in s])}]')
+    return f'binned data [{", ".join([row for row in s])}]'
 
 
 def _ordered_dict(data):
@@ -307,13 +307,13 @@ def summarize_variable(name,
 
     disabled, attrs_ul = _make_inline_attributes(var, has_attrs, embedded_in)
 
-    preview = inline_variable_repr(var)
+    preview = _make_row(inline_variable_repr(var))
     data_repr = short_data_repr_html(var)
     if var.bins is None:
         data_repr = "Values:<br>" + data_repr
     variances_preview = None
     if var.variances is not None:
-        variances_preview = inline_variable_repr(var, has_variances=True)
+        variances_preview = _make_row(inline_variable_repr(var, has_variances=True))
         data_repr += f"<br><br>Variances ({VARIANCES_SYMBOL}):<br>\
 {short_data_repr_html(var, variances=True)}"
 

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -157,6 +157,14 @@ def make_simple_datagroup(child=None, maxdepth=1, cur_depth=1):
     dg['np-' + id_suffix] = np.random.sample((3, 2, 10))
     dg['scalar-' + id_suffix] = make_scalar()
     dg['str-' + id_suffix] = id_suffix
+    binning = sc.array(dims=['k'], values=[0, 30], unit=None)
+    binned = sc.bins(begin=binning, dim='x', data=dg['var-' + id_suffix])
+    dg['binned-' + id_suffix] = binned
+    dg['nonnum-da-' + id_suffix] = sc.array(dims=['row'], values=['a', 'b'])
+    trans3 = sc.spatial.translations(dims=['x'],
+                                     values=[[1, 2, 3], [1, 2, 3], [1, 2, 3]])
+    dg['trans3-' + id_suffix] = trans3
+    dg['matrix-' + id_suffix] = sc.matrix(value=[[1, 2.5, 3.75], [1, 2, 3], [1, 2, 3]])
     if cur_depth > 1:
         dg['dg-' + id_suffix] = child
 

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -157,7 +157,7 @@ def make_simple_datagroup(child=None, maxdepth=1, cur_depth=1):
     dg['np-' + id_suffix] = np.random.sample((3, 2, 10))
     dg['scalar-' + id_suffix] = make_scalar()
     dg['str-' + id_suffix] = id_suffix
-    binning = sc.array(dims=['k'], values=[0, 30], unit=None)
+    binning = sc.array(dims=['k'], values=[0, 30], unit=None, dtype=sc.DType('int64'))
     binned = sc.bins(begin=binning, dim='x', data=dg['var-' + id_suffix])
     dg['binned-' + id_suffix] = binned
     dg['nonnum-da-' + id_suffix] = sc.array(dims=['row'], values=['a', 'b'])


### PR DESCRIPTION
Fixes #3041 
Fixes #3059
Fixes #3045 

- Removed `dequeue` to retrieve the last element in inline preview

Here is the `timeit` result below.
The same wrapping that took 50.7 s now takes 586 ms with this update.

![lagging_meas](https://user-images.githubusercontent.com/17974113/218791865-9a2ed65f-497c-4a73-80e7-e4f3c923467d.png)
