### PR TITLE
Fix upper binning bound for float32

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -190,7 +190,8 @@ def _upper_bound(x: Variable) -> Variable:
     if bound.dtype in ('int32', 'int64', 'datetime64'):
         bound.value += 1
     else:
-        bound.value = np.nextafter(bound.value, bound.value + 1)
+        bound.value = np.nextafter(
+            bound.value, (bound + scalar(1, unit=bound.unit, dtype=bound.dtype)).value)
     return bound
 
 

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -190,7 +190,7 @@ def _upper_bound(x: Variable) -> Variable:
     if bound.dtype in ('int32', 'int64', 'datetime64'):
         bound.value += 1
     else:
-        bound.value = np.nextafter(bound.value, np.inf)
+        bound.value = np.nextafter(bound.value, bound.value + 1)
     return bound
 
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -47,8 +47,11 @@ def test_many_combinations():
     }
 
 
-def test_hist_table_define_edges_from_bin_count():
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+def test_hist_table_define_edges_from_bin_count(dtype):
     da = sc.data.table_xyz(100)
+    for c in list(da.coords.keys()):
+        da.coords[c] = da.coords[c].to(dtype=dtype)
     histogrammed = da.hist(y=4)
     edges = histogrammed.coords['y']
     assert len(edges) == 5
@@ -58,24 +61,6 @@ def test_hist_table_define_edges_from_bin_count():
     ymax = da.coords['y'].max()
     assert edges.max().value == np.nextafter(
         ymax.value, (ymax + sc.scalar(1.0, unit=ymax.unit, dtype=ymax.dtype)).value)
-
-
-def test_hist_table_define_edges_from_bin_count_float32():
-    da = sc.data.table_xyz(100)
-    for c in list(da.coords.keys()):
-        da.coords[c] = da.coords[c].to(dtype='float32')
-    # Make the last y value larger, so we end up with only one element in the last bin
-    da.coords['y'].values[-1] = 5.0
-    histogrammed = da.hist(y=10)
-    edges = histogrammed.coords['y']
-    assert len(edges) == 11
-    assert histogrammed.sizes['y'] == 10
-    assert edges.min().value == da.coords['y'].min().value
-    assert edges.max().value > da.coords['y'].max().value
-    ymax = da.coords['y'].max()
-    assert edges.max().value == np.nextafter(
-        ymax.value, (ymax + sc.scalar(1, unit=ymax.unit, dtype=ymax.dtype)).value)
-    assert histogrammed.values[-1] == da.values[-1]
 
 
 def test_hist_binned_define_edges_from_bin_count():


### PR DESCRIPTION
Doing
```Py
da = sc.data.table_xyz(100)
for c in list(da.coords.keys()):
    da.coords[c] = da.coords[c].to(dtype='float32')
da.coords['y'].values[-1] = 5.0
da.hist(y=10)
```
would miss the last event at y=5 because `nextafter` would make a flaot64 epsilon because of the `np.inf` which is a float and gets converted to float64.