### PR TITLE
Pin conan to 1.59

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan=1.57.0
+  - conan=1.59.0
   - cppcheck=2.6.2
   - graphviz=3.0.0
   - gxx_linux-64=11.1.*

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan=1.57.0
+  - conan=1.59.0
   - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
-  - conan=1.57.0
+  - conan=1.59.0
   - ninja=1.11.0
   - tbb=2020.2.*
   - tbb-devel=2020.2.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - cmake
-    - conan>=1.45.0
+    - conan==1.59.0
     - cppcheck [linux64]
     - git
     - ninja
@@ -54,7 +54,7 @@ test:
   requires:
     - {{ compiler('cxx') }}
     - cmake
-    - conan>=1.45.0
+    - conan==1.59.0
     - h5py
     - hypothesis
     - ipympl

--- a/docs/environments/developer.yml
+++ b/docs/environments/developer.yml
@@ -8,7 +8,7 @@ channels:
 
 dependencies:
   - cmake>=3.21
-  - conan>=1.45.0
+  - conan==1.59.0
   - conda-build
   - confuse
   - graphlib-backport # for python < 3.9

--- a/requirements/build.in
+++ b/requirements/build.in
@@ -1,3 +1,3 @@
 cmake>=3.21
-conan>=1.45.0
+conan==1.59.0
 ninja


### PR DESCRIPTION
This is the last version before 2.0 and we need to update a few things to make 2.0 work. In particular, cmake-conan does not yet work with 2.0.

See branch `conan-2` for a start of an update.