### PR TITLE
Ignore link to nist constants

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -309,4 +309,6 @@ linkcheck_ignore = [
     'https://apt.kitware.com+',
     # Flaky pooch fatiando website
     'https://www.fatiando.org/pooch+',
+    # Fails to validate SSL certificate but Firefox is happy with the URL.
+    'https://physics.nist.gov/cuu/Constants/',
 ]


### PR DESCRIPTION
linkcheck keeps failing because of this. But accessing the page with Firefox works perfectly fine.