### PR TITLE
Depend on numba in wheel tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
             "pandas",
             "pythreejs",
             "bs4",
-            "numba",
+            "numba;python_version<'3.11'",  # numba does not support 3.11 yet
         ],
         'all': ['h5py', 'scipy>=1.7.0', 'graphviz', 'pooch', 'plopp', 'matplotlib'],
         'interactive': [

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,15 @@ setup(
     python_requires='>=3.8',
     install_requires=['confuse', 'graphlib-backport', 'numpy>=1.20'],
     extras_require={
-        "test": ["pytest", "matplotlib", "xarray", "pandas", "pythreejs", "bs4"],
+        "test": [
+            "pytest",
+            "matplotlib",
+            "xarray",
+            "pandas",
+            "pythreejs",
+            "bs4",
+            "numba",
+        ],
         'all': ['h5py', 'scipy>=1.7.0', 'graphviz', 'pooch', 'plopp', 'matplotlib'],
         'interactive': [
             'ipympl',

--- a/tests/elemwise_func_test.py
+++ b/tests/elemwise_func_test.py
@@ -7,7 +7,9 @@ import pytest
 import scipp as sc
 
 # numba is not supported for these versions
-pytestmark = pytest.mark.skipif(sys.version_info >= (3, 11))
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason='numba does not support this Python version'
+)
 
 
 def test_unary():

--- a/tests/elemwise_func_test.py
+++ b/tests/elemwise_func_test.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import sys
+
 import pytest
 
 import scipp as sc
+
+# numba is not supported for these versions
+pytestmark = pytest.mark.skipif(sys.version_info >= (3, 11))
 
 
 def test_unary():


### PR DESCRIPTION
Release builds are failing because numba is not installed.