### PR TITLE
Protect against sorting with a bin-edge coordinate

### DIFF
--- a/lib/dataset/sort.cpp
+++ b/lib/dataset/sort.cpp
@@ -59,16 +59,25 @@ Variable indices_for_sorting(const Variable &key, const SortOrder order) {
       core::time_point>::apply<IndicesForSorting>(key.dtype(), key, order);
 }
 
+void require_same_shape(const Dimensions &a, const Dimensions &b,
+                        const Dim dim) {
+  if (a[dim] != b[dim])
+    throw except::DimensionError(
+        "Cannot sort based on key with different shape.");
+}
+
 } // namespace
 
 /// Return a Variable sorted based on key.
 Variable sort(const Variable &var, const Variable &key, const SortOrder order) {
+  require_same_shape(var.dims(), key.dims(), key.dim());
   return extract_ranges(indices_for_sorting(key, order), var, key.dim());
 }
 
 /// Return a DataArray sorted based on key.
 DataArray sort(const DataArray &array, const Variable &key,
                const SortOrder order) {
+  require_same_shape(array.dims(), key.dims(), key.dim());
   return extract_ranges(indices_for_sorting(key, order), array, key.dim());
 }
 

--- a/lib/dataset/sort.cpp
+++ b/lib/dataset/sort.cpp
@@ -59,11 +59,13 @@ Variable indices_for_sorting(const Variable &key, const SortOrder order) {
       core::time_point>::apply<IndicesForSorting>(key.dtype(), key, order);
 }
 
-void require_same_shape(const Dimensions &a, const Dimensions &b,
+void require_same_shape(const Dimensions &var_dims, const Dimensions &key_dims,
                         const Dim dim) {
-  if (a[dim] != b[dim])
+  if (var_dims[dim] != key_dims[dim])
     throw except::DimensionError(
-        "Cannot sort based on key with different shape.");
+        "Cannot sort: key for dimension " + to_string(dim) + " has length " +
+        std::to_string(key_dims[dim]) + " while variable has length " +
+        std::to_string(var_dims[dim]) + ". Lengths must agree.");
 }
 
 } // namespace

--- a/lib/dataset/test/sort_test.cpp
+++ b/lib/dataset/test/sort_test.cpp
@@ -34,7 +34,7 @@ TEST(SortTest, variable_1d_bad_key_shape_throws) {
   const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6});
   const auto key =
-      makeVariable<int>(Dims{Dim::X}, Shape{4}, Values{10, 20, -1, 5});
+      makeVariable<int>(Dims{Dim::X}, Shape{5}, Values{10, 20, -1, 5, 3});
   EXPECT_THROW(sort(var, key), except::DimensionError);
 }
 

--- a/lib/dataset/test/sort_test.cpp
+++ b/lib/dataset/test/sort_test.cpp
@@ -30,6 +30,14 @@ TEST(SortTest, variable_1d_descending) {
   EXPECT_EQ(sort(var, key, SortOrder::Descending), expected);
 }
 
+TEST(SortTest, variable_1d_bad_key_shape_throws) {
+  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+                                       Values{1, 2, 3}, Variances{4, 5, 6});
+  const auto key =
+      makeVariable<int>(Dims{Dim::X}, Shape{4}, Values{10, 20, -1, 5});
+  EXPECT_THROW(sort(var, key), except::DimensionError);
+}
+
 TEST(SortTest, variable_2d) {
   const auto var = makeVariable<int>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
                                      units::m, Values{1, 2, 3, 4, 5, 6});
@@ -126,6 +134,15 @@ TEST(SortTest, data_array_1d_descending) {
       DataArray(sorted_data, {{Dim::X, sorted_x}, {Dim("scalar"), scalar}},
                 {{"mask", sorted_mask}});
   EXPECT_EQ(sort(table, Dim::X, SortOrder::Descending), sorted_table);
+}
+
+TEST(SortTest, data_array_bin_edge_coord_throws) {
+  Variable data = makeVariable<double>(
+      Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4}, Variances{1, 3, 2, 4});
+  Variable x =
+      makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{5, 3, 2, 4, 1});
+  DataArray table = DataArray(data, {{Dim::X, x}});
+  EXPECT_THROW(sort(table, Dim::X), except::DimensionError);
 }
 
 TEST(SortTest, dataset_1d) {


### PR DESCRIPTION
We throw an error in `sc.sort` when the key for sorting does not have the same shape as the input Variable to be sorted.

Fix #3086 