### PR TITLE
Fix conda build

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -6,6 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
+  - comm=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
   - conan=1.59.0
   - cppcheck=2.6.2
   - graphviz=3.0.0

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -6,6 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
+  - comm=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
   - conan=1.59.0
   - ninja=1.11.0
   - scipp::plopp=23.03.0

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -6,6 +6,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake=3.23.2
+  - comm=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
   - conan=1.59.0
   - ninja=1.11.0
   - scipp::plopp=23.03.0

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ CMakeSettings.json
 .mypy_cache
 src/scipp.egg-info
 .tox
+conda/package
 
 ### VisualStudioCode ###
 .vscode/*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -55,9 +55,11 @@ test:
     - {{ compiler('cxx') }}
     - bs4
     - cmake
+    - comm>=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
     - conan==1.59.0
     - h5py
     - hypothesis
+    - ipykernel
     - ipympl
     - ipywidgets
     - matplotlib-base

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,14 +35,14 @@ requirements:
     - python
   host:
     - python
-    - tbb-devel=2020.2.*
+    - tbb-devel {{ tbb_devel }}
   run:
     - confuse
     - graphlib-backport # for python < 3.9
     - numpy
     - python
     - pyyaml
-    - tbb=2020.2.*
+    - tbb {{ tbb }}
 
 # Only the cmake-package-test works when cross compiling.
 # But it is not very important at the moment and
@@ -64,12 +64,13 @@ test:
     - ipywidgets
     - matplotlib-base
     - numba
+    - numpy
     - pandas
     - pytest
     - pythreejs
     - python-graphviz
     - scipy>=1.7.0
-    - tbb-devel=2020.2.*
+    - tbb-devel {{ tbb_devel }}
     - xarray
   files:
     - cmake-package-test/

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -61,6 +61,7 @@ test:
     - ipympl
     - ipywidgets
     - matplotlib-base
+    - numba
     - pandas
     - pytest
     - pythreejs

--- a/conda/variants/linux_64.yaml
+++ b/conda/variants/linux_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.20'
+  - '1.21'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/osx_64.yaml
+++ b/conda/variants/osx_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.20'
+  - '1.21'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/osx_arm64.yaml
+++ b/conda/variants/osx_arm64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.20'
+  - '1.21'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/win_64.yaml
+++ b/conda/variants/win_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.20'
+  - '1.21'
 python_impl:
   - cpython
 target_platform:

--- a/docs/environments/developer.yml
+++ b/docs/environments/developer.yml
@@ -33,7 +33,7 @@ dependencies:
   - pyyaml
   - scipp::plopp
   - scipy>=1.7.0
-  - tbb=2020.2.*
-  - tbb-devel=2020.2.*
+  - tbb=2021.8.*
+  - tbb-devel=2021.8.*
   - tox
   - xarray

--- a/lib/cmake/scipp-conan.cmake
+++ b/lib/cmake/scipp-conan.cmake
@@ -36,7 +36,7 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR})
 option(CONAN_TBB "Use TBB from conan" OFF)
 if(SKBUILD OR CONAN_TBB)
   # Conda builds install tbb via conda, not conan
-  set(CONAN_ONETBB onetbb/2021.3.0)
+  set(CONAN_ONETBB onetbb/2021.7.0)
   # The deploy generator is used to install dependencies into a know location.
   # The RUNTIME_DEPENDENCIES DIRECTORIES install option is then used to find the
   # dependencies. This is actually required only for Windows, since on Linux and

--- a/tests/elemwise_func_test.py
+++ b/tests/elemwise_func_test.py
@@ -10,11 +10,6 @@ import scipp as sc
 pytestmark = pytest.mark.skipif(
     sys.version_info >= (3, 11), reason='numba does not support this Python version'
 )
-try:
-    import numba  # noqa: F401
-except ImportError:
-    # Fallback for conda build. Remove this once conda build is fixed.
-    pytest.skip("numba is not available", allow_module_level=True)
 
 
 def test_unary():


### PR DESCRIPTION
Two things here:

# Update numpy version

conda-forge has dropped numpy 1.20. So we need to update the dependency in conda build.

Should we also add a lower version bound for 1.21 because we no longer test with 1.20?

# Fix #3085

The culprit was tbb. conda-forge now uses 2021 and numba requires that for the latest version. It seems that conda could resolve the env for python 3.8 adn 3.9 by using an older version of numba but not for 3.10.