### PR TITLE
Do not cache import of numpy in C++

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -50,6 +50,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fix bug that caused ``scipp.testing.strategies.variables`` to produce negative variances `#3100 <https://github.com/scipp/scipp/pull/3100>`_.
+* Fix the source of segmentation faults coming from caching the NumPy module in ``Variable.value`` `#3105 <https://github.com/scipp/scipp/pull/3105>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -304,8 +304,7 @@ public:
 
 private:
   static auto numpy_attr(const char *const name) {
-    static const auto np = py::module_::import("numpy");
-    return np.attr(name);
+    return py::module_::import("numpy").attr(name);
   }
 
   template <class Scalar, class View>


### PR DESCRIPTION
The old code triggered a segfault in ScippNeXus with Python 3.10. I don't know exactly why, this is hard to reproduce. But I suspect it has to do with the tear down order. Numpy might be deallocated before scipp which creates a dangling reference with the `static` variable.

I benchmarked this and got
```
old: 0.008s
new: 0.011s
```
with 
```python
import scipp as sc
from timeit import repeat
ts = repeat("var.value",
            setup="var=sc.scalar(123)",
            globals={"sc": sc},
            number=10_000,
            repeat=1_000)
print(min(ts))
```