### PR TITLE
String type item preview length limit

### DIFF
--- a/lib/core/include/scipp/core/array_to_string.h
+++ b/lib/core/include/scipp/core/array_to_string.h
@@ -28,9 +28,12 @@ element_to_string(const T &item,
                   const std::optional<units::Unit> &unit = std::nullopt) {
   using core::to_string;
   using std::to_string;
-  if constexpr (std::is_same_v<T, std::string>)
+  if constexpr (std::is_same_v<T, std::string>) {
+    if (item.length() > 80) {
+      return {'"' + item.substr(0, 77) + "...\", "};
+    }
     return {'"' + item + "\", "};
-  else if constexpr (std::is_same_v<T, bool>)
+  } else if constexpr (std::is_same_v<T, bool>)
     return core::to_string(item) + ", ";
   else if constexpr (std::is_same_v<T, scipp::core::time_point>) {
     return core::to_string(to_iso_date(item, unit.value())) + ", ";

--- a/src/scipp/html/formatting_datagroup_html.py
+++ b/src/scipp/html/formatting_datagroup_html.py
@@ -94,7 +94,7 @@ def _summarize_atomic_variable(var, name: str, depth: int = 0) -> str:
         preview += escape(_format_multi_dim_data(var))
 
     elif preview == '' and hasattr(var, "__str__"):
-        preview = escape(_format_atomic_value(var, maxidx=30))
+        preview = escape(_format_atomic_value(var, maxidx=80))
 
     html_tpl = load_atomic_row_tpl()
     return Template(html_tpl).substitute(

--- a/src/scipp/utils/to_string.py
+++ b/src/scipp/utils/to_string.py
@@ -23,12 +23,17 @@ def name_with_unit(var=None, name=None, log=False):
     return text
 
 
-def value_to_string(val, precision=3):
+def value_to_string(val, precision=3, max_str_len=133):
     """
     Convert a number to a human readable string.
     """
     if (not isinstance(val, float)) or (val == 0):
-        text = str(val)
+        raw_text = str(val)
+        if len(raw_text) > max_str_len:
+            preview_len = int((max_str_len - 5) / 2)
+            text = f"{raw_text[:preview_len]} ... {raw_text[-preview_len:]}"
+        else:
+            text = raw_text
     elif (abs(val) >= 10.0 ** (precision + 1)) or (
         abs(val) <= 10.0 ** (-precision - 1)
     ):

--- a/src/scipp/utils/to_string.py
+++ b/src/scipp/utils/to_string.py
@@ -23,15 +23,15 @@ def name_with_unit(var=None, name=None, log=False):
     return text
 
 
-def value_to_string(val, precision=3, max_str_len=133):
+def value_to_string(val, precision=3, max_str_len=80):
     """
     Convert a number to a human readable string.
     """
     if (not isinstance(val, float)) or (val == 0):
         raw_text = str(val)
         if len(raw_text) > max_str_len:
-            preview_len = int((max_str_len - 5) / 2)
-            text = f"{raw_text[:preview_len]} ... {raw_text[-preview_len:]}"
+            preview_len = max_str_len - 3
+            text = f"{raw_text[:preview_len]}..."
         else:
             text = raw_text
     elif (abs(val) >= 10.0 ** (precision + 1)) or (

--- a/src/scipp/utils/to_string.py
+++ b/src/scipp/utils/to_string.py
@@ -30,8 +30,7 @@ def value_to_string(val, precision=3, max_str_len=80):
     if (not isinstance(val, float)) or (val == 0):
         raw_text = str(val)
         if len(raw_text) > max_str_len:
-            preview_len = max_str_len - 3
-            text = f"{raw_text[:preview_len]}..."
+            text = f"{raw_text[:max_str_len-3]}..."
         else:
             text = raw_text
     elif (abs(val) >= 10.0 ** (precision + 1)) or (


### PR DESCRIPTION
Applied maximum length of 80 for printed preview of string type values.

![image](https://user-images.githubusercontent.com/17974113/233314150-c34df218-875c-4e0d-a236-3d1cad276b3d.png)

