### PR TITLE
Fix performance bug with datetime64 operations

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -43,6 +43,7 @@ Features
 
 * :class:`scipp.Dataset` now supports ``assign_coords``, which updates or inserts the given coordinates to the :class:`scipp.Dataset` `#3110 <https://github.com/scipp/scipp/pull/3110/>`_.
 * :class:`scipp.DataArray` now supports ``assign_coords``/ ``assign_masks``/ ``assign_attrs``, which updates or inserts the given coordinates/masks/attributes to the :class:`scipp.DataArray` `#3110 <https://github.com/scipp/scipp/pull/3110/>`_.
+* Fixed performance issues for ``datetime64`` operations `#3123 <https://github.com/scipp/scipp/pull/3123/>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/lib/core/include/scipp/core/time_point.h
+++ b/lib/core/include/scipp/core/time_point.h
@@ -14,7 +14,7 @@ namespace scipp::core {
 class time_point {
 public:
   time_point() = default;
-  explicit time_point(int64_t duration) : m_duration{duration} {}
+  explicit time_point(int64_t duration) noexcept : m_duration{duration} {}
 
   [[nodiscard]] int64_t time_since_epoch() const noexcept {
     return m_duration;
@@ -64,7 +64,7 @@ public:
   }
 
 private:
-  int64_t m_duration = 0;
+  int64_t m_duration;
 };
 
 } // namespace scipp::core

--- a/lib/core/test/time_point_test.cpp
+++ b/lib/core/test/time_point_test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 #include <gtest/gtest.h>
+#include <type_traits>
 
 #include "scipp/core/time_point.h"
 #include "scipp/units/except.h"
@@ -43,4 +44,12 @@ TEST_F(TimePointTest, inplace_arithmetics) {
   time_point aux = t2;
   EXPECT_EQ(aux -= 1, t1);
   EXPECT_EQ(aux += 1, t2);
+}
+
+TEST(TimePointTypeTest, is_pod) {
+  // It is essential that time_point is a POD-type, to ensure that operations
+  // such as sc.empty are fast and do not call constructors and initialize
+  // memory --- in particular since this is also used internally for
+  // initialization the output in the implementation of many operations.
+  ASSERT_TRUE(std::is_pod_v<time_point>);
 }


### PR DESCRIPTION
Many operations create "empties" as their output, which are then overwritten with the results of the operations. It is generally assumed that creating an empty is fast, since no initialization (not even zeroing) is done.

It was observed that even simple operations such as `copy` were significantly slower for datetime64. It turned out that a member-initialization of the duration field to 0 was the culprit. time_point was thus not a POD type, and C++ called the init code, even when creating an "empty".

The result were 1000x slower "empty" calls, and 5x slower "copy" calls, for example.