### PR TITLE
Improve performance for binning few events into many bins

### DIFF
--- a/lib/core/include/scipp/core/element/bin_detail.h
+++ b/lib/core/include/scipp/core/element/bin_detail.h
@@ -38,12 +38,8 @@ static constexpr auto end_edge =
                  index = bin + 2;
                }};
 
-constexpr auto subbin_sizes_exclusive_scan =
-    overloaded{arg_list<SubbinSizes>, [](auto &sum, auto &x) {
-                 sum.trim_to(x);
-                 sum += x;
-                 x = sum - x;
-               }};
+constexpr auto subbin_sizes_exclusive_scan = overloaded{
+    arg_list<SubbinSizes>, [](auto &sum, auto &x) { sum.exclusive_scan(x); }};
 
 constexpr auto subbin_sizes_add_intersection =
     overloaded{arg_list<SubbinSizes>,

--- a/lib/core/include/scipp/core/subbin_sizes.h
+++ b/lib/core/include/scipp/core/subbin_sizes.h
@@ -27,8 +27,8 @@ public:
 
   SubbinSizes cumsum_exclusive() const;
   scipp::index sum() const;
-  void trim_to(const SubbinSizes &other);
   SubbinSizes &add_intersection(const SubbinSizes &other);
+  void exclusive_scan(SubbinSizes &x);
 
 private:
   scipp::index m_offset{0};

--- a/lib/core/test/subbin_sizes_test.cpp
+++ b/lib/core/test/subbin_sizes_test.cpp
@@ -70,6 +70,22 @@ TEST_F(SubbinSizesTest, exclusive_scan) {
   EXPECT_EQ(x, SubbinSizes(2, {2, 3, 0}));
 }
 
+TEST_F(SubbinSizesTest, exclusive_scan_empty_accum) {
+  SubbinSizes accum(1, {});
+  SubbinSizes x(2, {2, 0, 3});
+  accum.exclusive_scan(x);
+  EXPECT_EQ(accum, SubbinSizes(2, {2, 0, 3}));
+  EXPECT_EQ(x, SubbinSizes(2, {0, 0, 0}));
+}
+
+TEST_F(SubbinSizesTest, exclusive_scan_empty_value) {
+  SubbinSizes accum(1, {1, 2, 3});
+  SubbinSizes x(2, {});
+  accum.exclusive_scan(x);
+  EXPECT_EQ(accum, SubbinSizes(2, {}));
+  EXPECT_EQ(x, SubbinSizes(2, {}));
+}
+
 TEST_F(SubbinSizesTest, add_intersection) {
   SubbinSizes x(2, {1, 2, 3});
   // no overlap

--- a/lib/core/test/subbin_sizes_test.cpp
+++ b/lib/core/test/subbin_sizes_test.cpp
@@ -62,16 +62,12 @@ TEST_F(SubbinSizesTest, sum) {
   EXPECT_EQ(x.sum(), 6);
 }
 
-TEST_F(SubbinSizesTest, trim_to) {
-  SubbinSizes x(2, {1, 2, 3});
-  x.trim_to({2, {6, 6, 6}});
-  EXPECT_EQ(x, SubbinSizes(2, {1, 2, 3}));
-  x.trim_to({3, {6, 6, 6}});
-  EXPECT_EQ(x, SubbinSizes(3, {2, 3, 0}));
-  x.trim_to({1, {6, 6, 6, 6, 6}});
-  EXPECT_EQ(x, SubbinSizes(1, {0, 0, 2, 3, 0}));
-  x.trim_to({2, {6, 6, 6}});
-  EXPECT_EQ(x, SubbinSizes(2, {0, 2, 3}));
+TEST_F(SubbinSizesTest, exclusive_scan) {
+  SubbinSizes accum(1, {1, 2, 3});
+  SubbinSizes x(2, {2, 0, 3});
+  accum.exclusive_scan(x);
+  EXPECT_EQ(accum, SubbinSizes(2, {2 + 2, 3 + 0, 0 + 3}));
+  EXPECT_EQ(x, SubbinSizes(2, {2, 3, 0}));
 }
 
 TEST_F(SubbinSizesTest, add_intersection) {

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -156,9 +156,10 @@ DataArray add_metadata(std::tuple<DataArray, Variable> &&proto,
   for (const auto &[dim_, coord] : attrs)
     if (!rebinned(coord) && !out_coords.contains(dim_))
       out_attrs.insert_or_assign(dim_, copy(coord));
-  return DataArray{
-      make_bins(zip(end - bin_sizes, end), buffer_dim, std::move(buffer)),
-      std::move(out_coords), std::move(out_masks), std::move(out_attrs)};
+  return DataArray{make_bins_no_validate(zip(end - bin_sizes, end), buffer_dim,
+                                         std::move(buffer)),
+                   std::move(out_coords), std::move(out_masks),
+                   std::move(out_attrs)};
 }
 
 class TargetBinBuilder {

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -215,8 +215,12 @@ Variable lookup_previous(const DataArray &function, const Variable &x, Dim dim,
 Variable pretend_bins_for_threading(const DataArray &da, Dim bin_dim) {
   const auto dim = da.dims().inner();
   const auto size = std::max(scipp::index(1), da.dims()[dim]);
-  // TODO automatic setup with reasonable bin count
-  const auto stride = std::max(scipp::index(1), size / 24);
+  const auto nthread = size > 10000000  ? 24
+                       : size > 1000000 ? 4
+                       : size > 100000  ? 2
+                                        : 1;
+
+  const auto stride = std::max(scipp::index(1), size / nthread);
   auto begin = bin_detail::make_range(0, size, stride, bin_dim);
   auto end = begin + stride * units::none;
   end.values<scipp::index>().as_span().back() = da.dims()[dim];


### PR DESCRIPTION
Fixes #3130 (there are definitely more potential gains to be made, but for now this seems decent).

There are three independent changes which together result in the following speedup:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/12912489/233974723-b1ea42fd-c733-4c27-9923-88ef6dfb2de8.png">

We can see a significant speedup in all relevant cases. There are some minor slowdowns for few detectors, but thus may be due to noise, and should be irrelevant on practice, especially when considering the absolute timings after this change:

<img width="864" alt="image" src="https://user-images.githubusercontent.com/12912489/233974859-9ca2b8b2-66a3-424c-813e-9cd71cfc9220.png">
