### PR TITLE
Add aligned flag to coords

### DIFF
--- a/lib/core/include/scipp/core/dict.h
+++ b/lib/core/include/scipp/core/dict.h
@@ -163,6 +163,19 @@ public:
     return Result(**this);
   }
 
+  template <class F> auto transform(F &&func) const & {
+    // Need explicit template params here because `TransformIterator` refers to
+    // the type of `*this`, i.e., with the same `BaseIterator` and `Func` and
+    // not the new ones.
+    return TransformIterator<std::decay_t<decltype(*this)>, std::decay_t<F>>{
+        *this, std::forward<F>(func)};
+  }
+
+  template <class F> auto transform(F &&func) && {
+    return TransformIterator<std::decay_t<decltype(*this)>, std::decay_t<F>>{
+        std::move(*this), std::forward<F>(func)};
+  }
+
 private:
   std::decay_t<Func> m_func;
 };

--- a/lib/core/include/scipp/core/dict.h
+++ b/lib/core/include/scipp/core/dict.h
@@ -267,6 +267,10 @@ public:
     }
   }
 
+  template <class V> void set(const key_type &key, V &&value) {
+    insert_or_assign(key, std::forward<V>(value));
+  }
+
   void erase(const key_type &key) { static_cast<void>(extract(key)); }
 
   mapped_type extract(const key_type &key) {

--- a/lib/core/test/dict_test.cpp
+++ b/lib/core/test/dict_test.cpp
@@ -559,6 +559,29 @@ TEST(Dict, transform_iterator_struct) {
   EXPECT_EQ(it, dict.end());
 }
 
+TEST(Dict, double_transform_iterator) {
+  DimDict dict{{Dim::Y, 773}, {Dim::Time, -9}};
+
+  struct Wrapper {
+    int i;
+  };
+
+  auto it = dict.begin()
+                .transform([](std::pair<Dim, Int> p) {
+                  return std::pair{p.first, Wrapper{p.second}};
+                })
+                .transform([](std::pair<Dim, Wrapper> p) {
+                  return std::pair{p.first, Wrapper{p.second.i * 2}};
+                });
+  EXPECT_EQ(it->first, Dim::Y);
+  EXPECT_EQ(it->second.i, 2 * 773);
+  ++it;
+  EXPECT_EQ(it->first, Dim::Time);
+  EXPECT_EQ(it->second.i, 2 * -9);
+  ++it;
+  EXPECT_EQ(it, dict.end());
+}
+
 TEST(Dict, transform_iterator_compare_with_end_with_transform) {
   DimDict dict{{Dim::Time, 72}, {Dim::Y, 41}};
 

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -121,7 +121,7 @@ const std::string &DataArray::name() const { return m_name; }
 void DataArray::setName(const std::string_view name) { m_name = name; }
 
 Coords DataArray::meta() const {
-  auto out = attrs().merge_from(coords());
+  auto out = coords().merge_from(attrs());
   out.set_readonly();
   return out;
 }
@@ -170,13 +170,12 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   DataArray out;
   out.m_data = m_data; // share data
   const Sizes sizes(dims());
-  typename Coords::holder_type selected;
+  Coords selected(coords.sizes(), {});
   for (const auto &[dim, coord] : coords)
     if (coords.item_applies_to(dim, dims()))
-      selected.insert_or_assign(dim, coord.as_const());
+      selected.set(dim, coord.as_const());
   const bool readonly_coords = true;
-  out.m_coords =
-      std::make_shared<Coords>(sizes, std::move(selected), readonly_coords);
+  out.m_coords = std::make_shared<Coords>(std::move(selected));
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs
   out.m_name = name;

--- a/lib/dataset/data_array.cpp
+++ b/lib/dataset/data_array.cpp
@@ -170,11 +170,11 @@ DataArray DataArray::view_with_coords(const Coords &coords,
   DataArray out;
   out.m_data = m_data; // share data
   const Sizes sizes(dims());
-  Coords selected(coords.sizes(), {});
+  Coords selected(out.dims(), {});
   for (const auto &[dim, coord] : coords)
     if (coords.item_applies_to(dim, dims()))
       selected.set(dim, coord.as_const());
-  const bool readonly_coords = true;
+  selected.set_readonly();
   out.m_coords = std::make_shared<Coords>(std::move(selected));
   out.m_masks = m_masks; // share masks
   out.m_attrs = m_attrs; // share attrs

--- a/lib/dataset/dataset_operations_common.h
+++ b/lib/dataset/dataset_operations_common.h
@@ -13,13 +13,15 @@ namespace scipp::dataset {
 template <bool ApplyToData, class Func, class... Args>
 DataArray apply_or_copy_dim_impl(const DataArray &da, Func func, const Dim dim,
                                  Args &&...args) {
-  auto data_result = [&]() {
-    if constexpr (ApplyToData) {
-      return func(da.data(), dim, std::forward<Args>(args)...);
-    } else {
-      return func(da, dim, std::forward<Args>(args)...);
-    }
-  }();
+  auto data_result = func(
+      [&]() {
+        if constexpr (ApplyToData) {
+          return da.data();
+        } else {
+          return da;
+        }
+      }(),
+      dim, std::forward<Args>(args)...);
   const Sizes out_sizes = data_result.dims();
 
   const auto copy_independent = [&](const auto &mapping, const bool share) {

--- a/lib/dataset/include/scipp/dataset/dataset.h
+++ b/lib/dataset/include/scipp/dataset/dataset.h
@@ -257,8 +257,7 @@ SCIPP_DATASET_EXPORT Dataset operator/(const Variable &lhs, const Dataset &rhs);
 /// If any of the masks repeat they are OR'ed.
 /// The result is stored in a new map
 SCIPP_DATASET_EXPORT
-typename Masks::holder_type union_or(const Masks &currentMasks,
-                                     const Masks &otherMasks);
+Masks union_or(const Masks &currentMasks, const Masks &otherMasks);
 
 /// Union the masks of the two proxies.
 /// If any of the masks repeat they are OR'ed.

--- a/lib/dataset/include/scipp/dataset/dataset_util.h
+++ b/lib/dataset/include/scipp/dataset/dataset_util.h
@@ -43,6 +43,13 @@ void check_nested_in_assign(const T &lhs, const SizedDict<Key, Value> &rhs) {
   }
 }
 
+template <class T, class Key, class Value>
+void check_nested_in_assign(const T &lhs, const AlignedDict<Key, Value> &rhs) {
+  for (const auto &[_, var] : rhs) {
+    check_nested_in_assign(lhs, var);
+  }
+}
+
 template <class L, class R>
 void check_nested_in_assign(const L &lhs, const R &rhs) {
   if constexpr (std::is_same_v<L, R>) {

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -20,7 +20,7 @@ Mapping slice_map(const Sizes &sizes, const Mapping &map, const Slice &params) {
   for (const auto &[key, value] : map) {
     if (value.dims().contains(params.dim())) {
       if (value.dims()[params.dim()] == sizes[params.dim()]) {
-        out.insert_or_assign(key, value.slice(params));
+        out.set(key, value.slice(params));
       } else { // bin edge
         if (params.stride() != 1)
           throw except::SliceError(
@@ -30,13 +30,12 @@ Mapping slice_map(const Sizes &sizes, const Mapping &map, const Slice &params) {
         const auto end = params.end() == -1               ? params.begin() + 2
                          : params.begin() == params.end() ? params.end()
                                                           : params.end() + 1;
-        out.insert_or_assign(
-            key, value.slice(Slice{params.dim(), params.begin(), end}));
+        out.set(key, value.slice(Slice{params.dim(), params.begin(), end}));
       }
     } else if (params == Slice{}) {
-      out.insert_or_assign(key, value);
+      out.set(key, value);
     } else {
-      out.insert_or_assign(key, value.as_const());
+      out.set(key, value.as_const());
     }
   }
   return out;
@@ -47,11 +46,17 @@ Mapping slice_map(const Sizes &sizes, const Mapping &map, const Slice &params) {
 /// Values must have dimensions and those dimensions must be a subset
 /// of the sizes stored in SizedDict. This is used, e.g., to ensure
 /// that coords are valid for a data array.
-template <class Key, class Value> class SizedDict {
+///
+/// Template parameter Impl is used to specify return types of member functions
+/// that return new instances of SizedDict. It can override the type to one
+/// that can be constructed as Impl{SizedDict{...}}.
+template <class Key, class Value, class Impl> class SizedDict {
 public:
   using key_type = Key;
   using mapped_type = Value;
   using holder_type = core::Dict<key_type, mapped_type>;
+  using impl =
+      std::conditional_t<std::is_void_v<Impl>, SizedDict<Key, Value>, Impl>;
 
   SizedDict() = default;
   SizedDict(const Sizes &sizes,
@@ -126,18 +131,16 @@ public:
   mapped_type extract(const key_type &key);
   mapped_type extract(const key_type &key, const mapped_type &default_value);
 
-  SizedDict slice(const Slice &params) const;
-  std::tuple<SizedDict, SizedDict> slice_coords(const Slice &params) const;
+  impl slice(const Slice &params) const;
   void validateSlice(const Slice &s, const SizedDict &dict) const;
-  [[maybe_unused]] SizedDict &setSlice(const Slice &s, const SizedDict &dict);
+  [[maybe_unused]] impl &setSlice(const Slice &s, const SizedDict &dict);
 
-  [[nodiscard]] SizedDict
-  rename_dims(const std::vector<std::pair<Dim, Dim>> &names,
-              const bool fail_on_unknown = true) const;
+  [[nodiscard]] impl rename_dims(const std::vector<std::pair<Dim, Dim>> &names,
+                                 const bool fail_on_unknown = true) const;
 
   void set_readonly() noexcept;
   [[nodiscard]] bool is_readonly() const noexcept;
-  [[nodiscard]] SizedDict as_const() const;
+  [[nodiscard]] impl as_const() const;
   [[nodiscard]] SizedDict merge_from(const SizedDict &other) const;
 
   bool item_applies_to(const Key &key, const Dimensions &dims) const;
@@ -169,6 +172,19 @@ template <class Value> struct AlignedValue {
     return value.dims();
   }
 
+  [[nodiscard]] AlignedValue slice(const Slice &params) const {
+    return {value.slice(params), aligned};
+  }
+
+  [[nodiscard]] AlignedValue
+  rename_dims(const std::vector<std::pair<Dim, Dim>> &names) {
+    return value.rename_dims(names);
+  }
+
+  [[nodiscard]] AlignedValue as_const() const noexcept {
+    return {value.as_const(), aligned};
+  }
+
   friend std::string to_string(const AlignedValue &x) {
     return to_string(x.value);
   }
@@ -176,7 +192,8 @@ template <class Value> struct AlignedValue {
 
 /// Dict with fixed dimensions and alignment flag.
 template <class Key, class Value>
-class AlignedDict : public SizedDict<Key, AlignedValue<Value>> {
+class AlignedDict
+    : public SizedDict<Key, AlignedValue<Value>, AlignedDict<Key, Value>> {
 public:
   using key_type = Key;
   using mapped_type = Value;
@@ -190,6 +207,10 @@ public:
               bool readonly = false);
   AlignedDict(Sizes sizes, raw_holder_type items, bool readonly = false);
   AlignedDict(Sizes sizes, holder_type items, bool readonly = false);
+  AlignedDict(const SizedDict<Key, AlignedValue<Value>, AlignedDict<Key, Value>>
+                  &other);
+  AlignedDict(SizedDict<Key, AlignedValue<Value>, AlignedDict<Key, Value>>
+                  &&other) noexcept;
   AlignedDict(const AlignedDict &other);
   AlignedDict(AlignedDict &&other) noexcept;
   AlignedDict &operator=(const AlignedDict &other);
@@ -246,11 +267,19 @@ public:
     return this->m_items.values_end().transform(GetValue{});
   }
 
+  using SizedDict<Key, AlignedValue<Value>, AlignedDict<Key, Value>>::set;
   void set(const key_type &key, mapped_type coord, bool aligned = true);
   mapped_type extract(const key_type &key);
   mapped_type extract(const key_type &key, const mapped_type &default_value);
 
+  std::tuple<AlignedDict, SizedDict<Key, Value>>
+  slice_coords(const Slice &params) const;
+
   [[nodiscard]] AlignedDict merge_from(const AlignedDict &other) const;
+  // TODO This is only used to merge attrs into coords in meta.
+  //  Remove when we remove meta.
+  [[nodiscard]] AlignedDict
+  merge_from(const SizedDict<Key, Value> &other) const;
 
   [[nodiscard]] bool is_aligned(const Key &key) const noexcept;
 
@@ -287,9 +316,13 @@ template <class Key, class Value>
 bool equals_nan(const SizedDict<Key, Value> &a, const SizedDict<Key, Value> &b);
 
 template <class Key, class Value>
-SizedDict<Key, Value> union_(const SizedDict<Key, Value> &a,
-                             const SizedDict<Key, Value> &b,
-                             std::string_view opname);
+bool equals_nan(const AlignedDict<Key, Value> &a,
+                const AlignedDict<Key, Value> &b);
+
+template <class Key, class Value>
+AlignedDict<Key, Value> union_(const AlignedDict<Key, Value> &a,
+                               const AlignedDict<Key, Value> &b,
+                               std::string_view opname);
 
 /// Return intersection of dicts, i.e., all items with matching names that
 /// have matching content.

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -167,15 +167,15 @@ template <class Key, class Value>
 bool equals_nan(const SizedDict<Key, Value> &a, const SizedDict<Key, Value> &b);
 
 template <class Key, class Value>
-core::Dict<Key, Value> union_(const SizedDict<Key, Value> &a,
-                              const SizedDict<Key, Value> &b,
-                              std::string_view opname);
+SizedDict<Key, Value> union_(const SizedDict<Key, Value> &a,
+                             const SizedDict<Key, Value> &b,
+                             std::string_view opname);
 
 /// Return intersection of dicts, i.e., all items with matching names that
 /// have matching content.
 template <class Key, class Value>
-core::Dict<Key, Value> intersection(const SizedDict<Key, Value> &a,
-                                    const SizedDict<Key, Value> &b);
+SizedDict<Key, Value> intersection(const SizedDict<Key, Value> &a,
+                                   const SizedDict<Key, Value> &b);
 
 constexpr auto get_data = [](auto &&a) -> decltype(auto) { return a.data(); };
 constexpr auto get_sizes = [](auto &&a) -> decltype(auto) { return a.sizes(); };

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -67,8 +67,15 @@ Mapping slice_map(const Sizes &sizes, const Mapping &map, const Slice &params) {
 /// that coords are valid for a data array.
 ///
 /// Template parameter Impl is used to specify return types of member functions
-/// that return new instances of SizedDict. It can override the type to one
-/// that can be constructed as Impl{SizedDict{...}}.
+/// that return new instances of SizedDict. Instances of Impl must be
+/// constructible from rvalues of SizedDict, e.g. this must be valid:
+/// Impl{SizedDict{...}}. See for example `slice` which uses
+///   SizedDict sliced =...
+///   // ...
+///   return Impl{std::move(sliced)};
+/// That is, it builds a new instance of SizedDict but converts it to Impl
+/// before return. This means that, e.g., AlignedDict does not need to
+/// reimplement this method.
 template <class Key, class Value, class Impl> class SizedDict {
 public:
   using key_type = Key;
@@ -149,7 +156,7 @@ public:
   void erase(const key_type &key);
   mapped_type extract(const key_type &key);
   mapped_type extract(const key_type &key, const mapped_type &default_value);
-  // Like extract but without conversion in AlignedDict.
+  /// Like extract but without conversion in AlignedDict.
   mapped_type extract_raw(const key_type &key) { return extract(key); }
 
   impl slice(const Slice &params) const;

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -286,10 +286,10 @@ public:
 
   auto items_begin() const && = delete;
   /// Return const iterator to the beginning of all items.
-  auto items_begin() const &noexcept { return begin().transform(GetValue{}); }
+  auto items_begin() const &noexcept { return begin(); }
   auto items_end() const && = delete;
   /// Return const iterator to the end of all items.
-  auto items_end() const &noexcept { return end().transform(GetValue{}); }
+  auto items_end() const &noexcept { return end(); }
 
   auto keys_begin() const && = delete;
   /// Return const iterator to the beginning of all keys.

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -188,7 +188,8 @@ template <class Value> struct AlignedValue {
   AlignedValue(Value val, const bool a) noexcept
       : value(std::move(val)), aligned(a) {}
 
-  operator Value() const { return value; }
+  operator const Value &() const & { return value; }
+  operator Value &() & { return value; }
 
   bool operator==(const AlignedValue &other) const noexcept {
     return value == other.value && aligned == other.aligned;

--- a/lib/dataset/include/scipp/dataset/sized_dict.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict.h
@@ -314,14 +314,10 @@ public:
   mapped_type extract(const key_type &key);
   mapped_type extract(const key_type &key, const mapped_type &default_value);
 
-  std::tuple<AlignedDict, SizedDict<Key, Value>>
+  std::tuple<AlignedDict, AlignedDict<Key, Value>>
   slice_coords(const Slice &params) const;
 
   [[nodiscard]] AlignedDict merge_from(const AlignedDict &other) const;
-  // TODO This is only used to merge attrs into coords in meta.
-  //  Remove when we remove meta.
-  [[nodiscard]] AlignedDict
-  merge_from(const SizedDict<Key, Value> &other) const;
 
   [[nodiscard]] bool is_aligned(const Key &key) const noexcept;
 
@@ -369,8 +365,8 @@ AlignedDict<Key, Value> union_(const AlignedDict<Key, Value> &a,
 /// Return intersection of dicts, i.e., all items with matching names that
 /// have matching content.
 template <class Key, class Value>
-SizedDict<Key, Value> intersection(const SizedDict<Key, Value> &a,
-                                   const SizedDict<Key, Value> &b);
+AlignedDict<Key, Value> intersection(const AlignedDict<Key, Value> &a,
+                                     const AlignedDict<Key, Value> &b);
 
 constexpr auto get_data = [](auto &&a) -> decltype(auto) { return a.data(); };
 constexpr auto get_sizes = [](auto &&a) -> decltype(auto) { return a.sizes(); };

--- a/lib/dataset/include/scipp/dataset/sized_dict_forward.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict_forward.h
@@ -13,10 +13,12 @@ class Variable;
 
 namespace scipp::dataset {
 
-template <class Key, class Value> class SizedDict;
+template <class Key, class Value, class Impl = void> class SizedDict;
+template <class Key, class Value> class AlignedDict;
+template <class Value> struct AlignedValue;
 
 /// Dict of coordinates of DataArray and Dataset.
-using Coords = SizedDict<Dim, variable::Variable>;
+using Coords = AlignedDict<Dim, variable::Variable>;
 /// Dict of masks of DataArray and Dataset.
 using Masks = SizedDict<std::string, variable::Variable>;
 /// Dict of attributes of DataArray and Dataset.
@@ -24,5 +26,6 @@ using Attrs = SizedDict<Dim, variable::Variable>;
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Coords copy(const Coords &coords);
 [[nodiscard]] SCIPP_DATASET_EXPORT Masks copy(const Masks &masks);
+[[nodiscard]] SCIPP_DATASET_EXPORT Attrs copy(const Attrs &attrs);
 
 } // namespace scipp::dataset

--- a/lib/dataset/include/scipp/dataset/sized_dict_forward.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict_forward.h
@@ -23,6 +23,10 @@ using Coords = AlignedDict<Dim, variable::Variable>;
 using Masks = SizedDict<std::string, variable::Variable>;
 /// Dict of attributes of DataArray and Dataset.
 using Attrs = SizedDict<Dim, variable::Variable>;
+/// Underlying dict of coordinates.
+/// This alias is needed because Coords::holder_type cannot be accessed when
+/// only the forward declaration is visible.
+using CoordsHolder = SizedDict<Dim, AlignedValue<variable::Variable>>;
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Coords copy(const Coords &coords);
 [[nodiscard]] SCIPP_DATASET_EXPORT Masks copy(const Masks &masks);

--- a/lib/dataset/include/scipp/dataset/sized_dict_forward.h
+++ b/lib/dataset/include/scipp/dataset/sized_dict_forward.h
@@ -22,7 +22,7 @@ using Coords = AlignedDict<Dim, variable::Variable>;
 /// Dict of masks of DataArray and Dataset.
 using Masks = SizedDict<std::string, variable::Variable>;
 /// Dict of attributes of DataArray and Dataset.
-using Attrs = SizedDict<Dim, variable::Variable>;
+using Attrs = AlignedDict<Dim, variable::Variable>;
 /// Underlying dict of coordinates.
 /// This alias is needed because Coords::holder_type cannot be accessed when
 /// only the forward declaration is visible.
@@ -30,6 +30,5 @@ using CoordsHolder = SizedDict<Dim, AlignedValue<variable::Variable>>;
 
 [[nodiscard]] SCIPP_DATASET_EXPORT Coords copy(const Coords &coords);
 [[nodiscard]] SCIPP_DATASET_EXPORT Masks copy(const Masks &masks);
-[[nodiscard]] SCIPP_DATASET_EXPORT Attrs copy(const Attrs &attrs);
 
 } // namespace scipp::dataset

--- a/lib/dataset/include/scipp/dataset/string.h
+++ b/lib/dataset/include/scipp/dataset/string.h
@@ -23,10 +23,13 @@ SCIPP_DATASET_EXPORT std::ostream &operator<<(std::ostream &os,
 
 SCIPP_DATASET_EXPORT std::string to_string(const DataArray &data);
 SCIPP_DATASET_EXPORT std::string to_string(const Dataset &dataset);
+
 SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
+SCIPP_DATASET_EXPORT std::string to_string(const Attrs &attrs);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Masks &masks);
+SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Attrs &attrs);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Dataset &dataset);
 
 } // namespace scipp::dataset

--- a/lib/dataset/include/scipp/dataset/string.h
+++ b/lib/dataset/include/scipp/dataset/string.h
@@ -27,7 +27,8 @@ SCIPP_DATASET_EXPORT std::string to_string(const Dataset &dataset);
 SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
 SCIPP_DATASET_EXPORT std::string to_string(const Attrs &attrs);
-SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Coords &coords);
+SCIPP_DATASET_EXPORT std::string
+dict_keys_to_string(const CoordsHolder &coords);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Masks &masks);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Attrs &attrs);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Dataset &dataset);

--- a/lib/dataset/include/scipp/dataset/string.h
+++ b/lib/dataset/include/scipp/dataset/string.h
@@ -26,11 +26,10 @@ SCIPP_DATASET_EXPORT std::string to_string(const Dataset &dataset);
 
 SCIPP_DATASET_EXPORT std::string to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string to_string(const Masks &masks);
-SCIPP_DATASET_EXPORT std::string to_string(const Attrs &attrs);
 SCIPP_DATASET_EXPORT std::string
 dict_keys_to_string(const CoordsHolder &coords);
+SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Coords &coords);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Masks &masks);
-SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Attrs &attrs);
 SCIPP_DATASET_EXPORT std::string dict_keys_to_string(const Dataset &dataset);
 
 } // namespace scipp::dataset

--- a/lib/dataset/operations.cpp
+++ b/lib/dataset/operations.cpp
@@ -50,7 +50,6 @@ template <class Mapping> auto copy_map(const Mapping &map) {
 
 Coords copy(const Coords &coords) { return copy_map(coords); }
 Masks copy(const Masks &masks) { return copy_map(masks); }
-Attrs copy(const Attrs &attrs) { return copy_map(attrs); }
 
 /// Return a deep copy of a DataArray.
 DataArray copy(const DataArray &array, const AttrPolicy attrPolicy) {

--- a/lib/dataset/sized_dict.cpp
+++ b/lib/dataset/sized_dict.cpp
@@ -365,30 +365,30 @@ bool SizedDict<Key, Value>::is_edges(const Key &key,
 }
 
 template <class Key, class Value>
-core::Dict<Key, Value> union_(const SizedDict<Key, Value> &a,
-                              const SizedDict<Key, Value> &b,
-                              std::string_view opname) {
-  core::Dict<Key, Value> out;
+SizedDict<Key, Value> union_(const SizedDict<Key, Value> &a,
+                             const SizedDict<Key, Value> &b,
+                             std::string_view opname) {
+  SizedDict<Key, Value> out(merge(a.sizes(), b.sizes()), {});
   out.reserve(out.size() + b.size());
   for (const auto &[key, val] : a)
-    out.insert_or_assign(key, val);
+    out.set(key, val);
   for (const auto &[key, val] : b) {
     if (const auto it = a.find(key); it != a.end()) {
       expect::matching_coord(it->first, it->second, val, opname);
     } else
-      out.insert_or_assign(key, val);
+      out.set(key, val);
   }
   return out;
 }
 
 template <class Key, class Value>
-core::Dict<Key, Value> intersection(const SizedDict<Key, Value> &a,
-                                    const SizedDict<Key, Value> &b) {
-  core::Dict<Key, Value> out;
+SizedDict<Key, Value> intersection(const SizedDict<Key, Value> &a,
+                                   const SizedDict<Key, Value> &b) {
+  SizedDict<Key, Value> out(merge(a.sizes(), b.sizes()), {});
   for (const auto &[key, item] : a)
     if (const auto it = b.find(key);
         it != b.end() && equals_nan(it->second, item))
-      out.insert_or_assign(key, item);
+      out.set(key, item);
   return out;
 }
 
@@ -396,8 +396,8 @@ template class SCIPP_DATASET_EXPORT SizedDict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT SizedDict<std::string, Variable>;
 template SCIPP_DATASET_EXPORT bool equals_nan(const Coords &a, const Coords &b);
 template SCIPP_DATASET_EXPORT bool equals_nan(const Masks &a, const Masks &b);
-template SCIPP_DATASET_EXPORT typename Coords::holder_type
-union_(const Coords &, const Coords &, std::string_view opname);
-template SCIPP_DATASET_EXPORT typename Coords::holder_type
-intersection(const Coords &, const Coords &);
+template SCIPP_DATASET_EXPORT Coords union_(const Coords &, const Coords &,
+                                            std::string_view opname);
+template SCIPP_DATASET_EXPORT Coords intersection(const Coords &,
+                                                  const Coords &);
 } // namespace scipp::dataset

--- a/lib/dataset/sized_dict.cpp
+++ b/lib/dataset/sized_dict.cpp
@@ -240,8 +240,8 @@ void SizedDict<Key, Value, Impl>::validateSlice(const Slice &s,
 }
 
 template <class Key, class Value, class Impl>
-typename SizedDict<Key, Value, Impl>::impl &
-SizedDict<Key, Value, Impl>::setSlice(const Slice &s, const SizedDict &dict) {
+void SizedDict<Key, Value, Impl>::setSlice(const Slice &s,
+                                           const SizedDict &dict) {
   validateSlice(s, dict);
   for (const auto &[key, item] : dict) {
     const auto it = find(key);
@@ -249,7 +249,6 @@ SizedDict<Key, Value, Impl>::setSlice(const Slice &s, const SizedDict &dict) {
         it->second.dims().contains(s.dim()))
       it->second.setSlice(s, item);
   }
-  return *this;
 }
 
 template <class Key, class Value, class Impl>
@@ -400,7 +399,7 @@ const Value &AlignedDict<Key, Value>::operator[](const Key &key) const {
 /// Const reference to the coordinate for given dimension.
 template <class Key, class Value>
 const Value &AlignedDict<Key, Value>::at(const Key &key) const {
-  return item_at(key).value;
+  return raw_at(key).value;
 }
 
 /// The coordinate for given dimension.
@@ -411,7 +410,7 @@ Value AlignedDict<Key, Value>::operator[](const Key &key) {
 
 template <class Key, class Value>
 const AlignedValue<Value> &
-AlignedDict<Key, Value>::item_at(const Key &key) const {
+AlignedDict<Key, Value>::raw_at(const Key &key) const {
   scipp::expect::contains(*this, key);
   return this->m_items.at(key);
 }
@@ -567,9 +566,12 @@ SizedDict<Key, Value> intersection(const SizedDict<Key, Value> &a,
 
 template class SCIPP_DATASET_EXPORT SizedDict<Dim, Variable>;
 template class SCIPP_DATASET_EXPORT SizedDict<std::string, Variable>;
+template class SCIPP_DATASET_EXPORT
+    SizedDict<Dim, AlignedValue<Variable>, AlignedDict<Dim, Variable>>;
 template class SCIPP_DATASET_EXPORT AlignedDict<Dim, Variable>;
 template SCIPP_DATASET_EXPORT bool equals_nan(const Coords &a, const Coords &b);
 template SCIPP_DATASET_EXPORT bool equals_nan(const Masks &a, const Masks &b);
+template SCIPP_DATASET_EXPORT bool equals_nan(const Attrs &a, const Attrs &b);
 template SCIPP_DATASET_EXPORT Coords union_(const Coords &, const Coords &,
                                             std::string_view opname);
 template SCIPP_DATASET_EXPORT Attrs intersection(const Attrs &, const Attrs &);

--- a/lib/dataset/sized_dict.cpp
+++ b/lib/dataset/sized_dict.cpp
@@ -88,8 +88,13 @@ const Value &SizedDict<Key, Value, Impl>::operator[](const Key &key) const {
 /// Const reference to the coordinate for given dimension.
 template <class Key, class Value, class Impl>
 const Value &SizedDict<Key, Value, Impl>::at(const Key &key) const {
-  scipp::expect::contains(*this, key);
-  return m_items.at(key);
+  if (const auto it = m_items.find(key); it == m_items.end()) {
+    using core::to_string;
+    throw except::NotFoundError("Expected " + to_string(*this) +
+                                " to contain " + to_string(key) + ".");
+  } else {
+    return it->second;
+  }
 }
 
 /// The coordinate for given dimension.
@@ -411,8 +416,7 @@ Value AlignedDict<Key, Value>::operator[](const Key &key) {
 template <class Key, class Value>
 const AlignedValue<Value> &
 AlignedDict<Key, Value>::raw_at(const Key &key) const {
-  scipp::expect::contains(*this, key);
-  return this->m_items.at(key);
+  return SizedDict<Key, AlignedValue<Value>, AlignedDict<Key, Value>>::at(key);
 }
 
 /// The coordinate for given dimension.

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -121,7 +121,7 @@ std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }
 std::string to_string(const Attrs &attrs) { return dict_to_string(attrs); }
 
-std::string dict_keys_to_string(const Coords &coords) {
+std::string dict_keys_to_string(const CoordsHolder &coords) {
   return core::dict_keys_to_string(coords.keys_begin(), coords.keys_end(),
                                    "scipp.Dict.keys");
 }

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -119,20 +119,19 @@ std::string dict_to_string(const SizedDict<Key, Value, Impl> &view) {
 
 std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }
-std::string to_string(const Attrs &attrs) { return dict_to_string(attrs); }
 
 std::string dict_keys_to_string(const CoordsHolder &coords) {
   return core::dict_keys_to_string(coords.keys_begin(), coords.keys_end(),
                                    "scipp.Dict.keys");
 }
 
-std::string dict_keys_to_string(const Masks &masks) {
-  return core::dict_keys_to_string(masks.keys_begin(), masks.keys_end(),
+std::string dict_keys_to_string(const Coords &coords) {
+  return core::dict_keys_to_string(coords.keys_begin(), coords.keys_end(),
                                    "scipp.Dict.keys");
 }
 
-std::string dict_keys_to_string(const Attrs &attrs) {
-  return core::dict_keys_to_string(attrs.keys_begin(), attrs.keys_end(),
+std::string dict_keys_to_string(const Masks &masks) {
+  return core::dict_keys_to_string(masks.keys_begin(), masks.keys_end(),
                                    "scipp.Dict.keys");
 }
 

--- a/lib/dataset/string.cpp
+++ b/lib/dataset/string.cpp
@@ -107,8 +107,8 @@ std::string to_string(const Dataset &dataset) {
 }
 
 namespace {
-template <class Key, class Value>
-std::string dict_to_string(const SizedDict<Key, Value> &view) {
+template <class Key, class Value, class Impl>
+std::string dict_to_string(const SizedDict<Key, Value, Impl> &view) {
   std::stringstream ss;
   ss << "<scipp.Dict>\n";
   for (const auto &[key, item] : view)
@@ -119,6 +119,7 @@ std::string dict_to_string(const SizedDict<Key, Value> &view) {
 
 std::string to_string(const Coords &coords) { return dict_to_string(coords); }
 std::string to_string(const Masks &masks) { return dict_to_string(masks); }
+std::string to_string(const Attrs &attrs) { return dict_to_string(attrs); }
 
 std::string dict_keys_to_string(const Coords &coords) {
   return core::dict_keys_to_string(coords.keys_begin(), coords.keys_end(),
@@ -127,6 +128,11 @@ std::string dict_keys_to_string(const Coords &coords) {
 
 std::string dict_keys_to_string(const Masks &masks) {
   return core::dict_keys_to_string(masks.keys_begin(), masks.keys_end(),
+                                   "scipp.Dict.keys");
+}
+
+std::string dict_keys_to_string(const Attrs &attrs) {
+  return core::dict_keys_to_string(attrs.keys_begin(), attrs.keys_end(),
                                    "scipp.Dict.keys");
 }
 

--- a/lib/dataset/test/dataset_arithmetic_test.cpp
+++ b/lib/dataset/test/dataset_arithmetic_test.cpp
@@ -586,8 +586,16 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_dataset_rhs) {
 
   /* Expect coordinates to be copied to the result dataset */
   EXPECT_EQ(res.coords(), dataset_a.coords());
-  for (const auto &item : res)
+  for (const auto &item : res) {
+    for (const auto &[k, v] : item.masks()) {
+      std::cout << k << " : " << v << '\n';
+    }
+    std::cout << "-----\n";
+    for (const auto &[k, v] : dataset_b[item.name()].masks()) {
+      std::cout << k << " : " << v << '\n';
+    }
     EXPECT_EQ(item.masks(), dataset_b[item.name()].masks());
+  }
 }
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_variableconstview_rhs) {

--- a/lib/dataset/test/dataset_arithmetic_test.cpp
+++ b/lib/dataset/test/dataset_arithmetic_test.cpp
@@ -587,13 +587,6 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_dataset_rhs) {
   /* Expect coordinates to be copied to the result dataset */
   EXPECT_EQ(res.coords(), dataset_a.coords());
   for (const auto &item : res) {
-    for (const auto &[k, v] : item.masks()) {
-      std::cout << k << " : " << v << '\n';
-    }
-    std::cout << "-----\n";
-    for (const auto &[k, v] : dataset_b[item.name()].masks()) {
-      std::cout << k << " : " << v << '\n';
-    }
     EXPECT_EQ(item.masks(), dataset_b[item.name()].masks());
   }
 }

--- a/lib/dataset/test/dataset_test.cpp
+++ b/lib/dataset/test/dataset_test.cpp
@@ -540,7 +540,8 @@ protected:
 };
 
 TEST_F(DatasetRenameTest, fail_duplicate_dim) {
-  ASSERT_THROW(d.rename_dims({{Dim::X, Dim::Y}}), except::DimensionError);
+  ASSERT_THROW_DISCARD(d.rename_dims({{Dim::X, Dim::Y}}),
+                       except::DimensionError);
   ASSERT_EQ(d, original);
 }
 
@@ -548,28 +549,28 @@ TEST_F(DatasetRenameTest, fail_duplicate_in_edge_dim_of_coord) {
   auto ds = copy(d);
   const Dim dim{"edge"};
   ds.setCoord(dim, makeVariable<double>(Dims{dim}, Shape{2}));
-  ASSERT_THROW(ds.rename_dims({{Dim::X, dim}}), except::DimensionError);
+  ASSERT_THROW_DISCARD(ds.rename_dims({{Dim::X, dim}}), except::DimensionError);
 }
 
 TEST_F(DatasetRenameTest, fail_duplicate_in_edge_dim_of_item_attr) {
   auto ds = copy(d);
   const Dim dim{"edge"};
   ds["data_xy"].attrs().set(dim, makeVariable<double>(Dims{dim}, Shape{2}));
-  ASSERT_THROW(ds.rename_dims({{Dim::X, dim}}), except::DimensionError);
+  ASSERT_THROW_DISCARD(ds.rename_dims({{Dim::X, dim}}), except::DimensionError);
 }
 
 TEST_F(DatasetRenameTest, fail_duplicate_in_edge_dim_in_data_array_coord) {
   auto da = copy(d["data_xy"]);
   const Dim dim{"edge"};
   da.coords().set(dim, makeVariable<double>(Dims{dim}, Shape{2}));
-  ASSERT_THROW(da.rename_dims({{Dim::X, dim}}), except::DimensionError);
+  ASSERT_THROW_DISCARD(da.rename_dims({{Dim::X, dim}}), except::DimensionError);
 }
 
 TEST_F(DatasetRenameTest, fail_duplicate_in_edge_dim_in_data_array_attr) {
   auto da = copy(d["data_xy"]);
   const Dim dim{"edge"};
   da.attrs().set(dim, makeVariable<double>(Dims{dim}, Shape{2}));
-  ASSERT_THROW(da.rename_dims({{Dim::X, dim}}), except::DimensionError);
+  ASSERT_THROW_DISCARD(da.rename_dims({{Dim::X, dim}}), except::DimensionError);
 }
 
 TEST_F(DatasetRenameTest, existing) {

--- a/lib/dataset/test/equals_nan_test.cpp
+++ b/lib/dataset/test/equals_nan_test.cpp
@@ -5,6 +5,8 @@
 #include "scipp/dataset/bins.h"
 #include "scipp/dataset/shape.h"
 
+#include "test_macros.h"
+
 using namespace scipp;
 
 template <class T> void check_equal(const T &var) {
@@ -38,12 +40,12 @@ protected:
     check_equal(make_bins(indices, Dim::X, ds));
     da.masks().erase("mask");
     ds["a"].masks().erase("mask");
-    ASSERT_NO_THROW(da + da);
-    ASSERT_NO_THROW(da + copy(da));
-    ASSERT_NO_THROW(ds + ds);
-    ASSERT_NO_THROW(ds + copy(ds));
-    ASSERT_NO_THROW(ds.setData("b", da));
-    ASSERT_NO_THROW(ds.setData("b", copy(da)));
+    ASSERT_NO_THROW_DISCARD(da + da);
+    ASSERT_NO_THROW_DISCARD(da + copy(da));
+    ASSERT_NO_THROW_DISCARD(ds + ds);
+    ASSERT_NO_THROW_DISCARD(ds + copy(ds));
+    ASSERT_NO_THROW_DISCARD(ds.setData("b", da));
+    ASSERT_NO_THROW_DISCARD(ds.setData("b", copy(da)));
   }
 };
 

--- a/lib/dataset/test/generated_test.cpp
+++ b/lib/dataset/test/generated_test.cpp
@@ -9,6 +9,7 @@
 #include "scipp/variable/reciprocal.h"
 
 #include "test_data_arrays.h"
+#include "test_macros.h"
 
 using namespace scipp;
 
@@ -120,6 +121,6 @@ TEST_F(GeneratedBinaryDataArrayTest, non_bool_masks_with_same_names) {
       makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
   auto mask = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.1, 0.1});
   a = DataArray(data, {{Dim::X, coord}}, {{"mask", mask}});
-  ASSERT_THROW(less(a, a), except::TypeError);
+  ASSERT_THROW_DISCARD(less(a, a), except::TypeError);
   ASSERT_THROW(a += a, except::TypeError);
 }

--- a/lib/dataset/test/histogram_test.cpp
+++ b/lib/dataset/test/histogram_test.cpp
@@ -116,7 +116,7 @@ auto make_single_events() {
 
 DataArray make_expected(const Variable &var, const Variable &edges) {
   auto dim = var.dims().inner();
-  core::Dict<Dim, Variable> coords = {{dim, edges}};
+  Coords coords(var.dims(), {{dim, edges}});
   auto expected = DataArray(var, coords, {}, {}, "events");
   return expected;
 }

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -20,11 +20,10 @@ std::string compact_dict_entry(const Key &key, const Value &var) {
   return s.str();
 }
 
-template <class Key, class Value>
-std::string
-dict_to_compact_string(const scipp::dataset::SizedDict<Key, Value> &dict,
-                       const std::string &description,
-                       const std::string &margin) {
+template <class Mapping>
+std::string dict_to_compact_string(const Mapping &dict,
+                                   const std::string &description,
+                                   const std::string &margin) {
   std::stringstream s;
   const scipp::index max_length = 70;
   const auto indent = margin.size() + description.size() + 2;

--- a/lib/python/bind_data_array.h
+++ b/lib/python/bind_data_array.h
@@ -45,7 +45,7 @@ void bind_helper_view(py::module &m, const std::string &name) {
 
 template <class T, class... Ignored>
 void bind_common_mutable_view_operators(pybind11::class_<T, Ignored...> &view) {
-  view.def("__len__", &T::size)
+  view.def("__len__", [](const T &self) { return self.size(); })
       .def(
           "__getitem__",
           [](const T &self, const std::string &key) {


### PR DESCRIPTION
First step towards moving away from the coords/attrs split. See #3109

This only adds the ability to store an alignment flag but doesn't use it in any way. I am not even sure if it is propagated correctly in all operations (there are no tests yet). I can take a closer looks as part of this PR or we do  it separately to get the big changes out of the way.