### PR TITLE
Fix potential whitespace issue in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,9 @@ deps = -r requirements/base.txt
 commands = python -c 'import scipp'
 
 [testenv:docs]
-deps = {posargs:}
-       -r requirements/docs.txt
+deps =
+  {posargs:}
+  -r requirements/docs.txt
 allowlist_externals = find
 setenv =
   {[testenv]setenv}


### PR DESCRIPTION
This caused issues in a ScippNexus release build (building the outdated docs). I am not sure what is going on, as this worked previously. I could not find any recent `tox` changes linked to this.