### PR TITLE
Enable warning about default encoding

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps = -r requirements/test.txt
 setenv =
   PYTHONPATH = {toxinidir}{/}install
   JUPYTER_PLATFORM_DIRS = 1
+  PYTHONWARNDEFAULTENCODING = 1
 commands = python -m pytest -n auto -v tests
 
 [testenv:import-minimal]


### PR DESCRIPTION
As mentioned in the seminar earlier. See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONWARNDEFAULTENCODING