### PR TITLE
Python versions as strings in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: |

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e check-release
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/download-artifact@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.10
+          python-version: '3.8'
       - run: conda install -c conda-forge --yes anaconda-client
       - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-*/*/*.tar.bz2)
 
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - name: Set outputs


### PR DESCRIPTION
[Release build](https://github.com/scipp/scipp/actions/runs/5131662132) failed because if `python-version` is set to `3.10` it parses it as `3.1`.
So we need to set it as `'3.10'` instead.
In this PR, I changed `3.10` to `'3.8'` because it was 3.8 everywhere else.
I also changed all the other occurences to strings, so that this doesn't happen again in the future.