### PR TITLE
Structured var init

### DIFF
--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -211,7 +211,7 @@ Variable make_variable(const py::object &dim_labels, const py::object &values,
   const auto unit = unit_.value_or(variable::default_unit_for(dtype));
   return core::CallDType<double, float, int64_t, int32_t, bool,
                          scipp::core::time_point, std::string, Variable,
-                         DataArray, Dataset, Eigen::Vector3d, Eigen::Matrix3d,
+                         DataArray, Dataset,
                          python::PyObject>::apply<MakeVariable>(dtype, dims,
                                                                 values,
                                                                 variances,

--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -10,6 +10,7 @@
 #include "scipp/core/tag_util.h"
 #include "scipp/dataset/dataset.h"
 #include "scipp/units/string.h"
+#include "scipp/variable/structures.h"
 #include "scipp/variable/to_unit.h"
 #include "scipp/variable/variable.h"
 
@@ -81,7 +82,18 @@ void ensure_same_shape(const py::object &values, const py::object &variances) {
 }
 
 namespace detail {
+void consume_extra_dims(py::iterator &shape_it,
+                        const scipp::index n_extra_dims) {
+  for (scipp::index i = 0; i < n_extra_dims; ++i) {
+    if (shape_it == shape_it.end())
+      throw std::invalid_argument(
+          "Data has too few dimensions for given dimension labels.");
+    ++shape_it;
+  }
+}
+
 Dimensions build_dimensions(py::iterator &&label_it, py::iterator &&shape_it,
+                            const scipp::index n_extra_dims,
                             const std::string_view shape_name) {
   Dimensions dims;
   scipp::index dim = 0;
@@ -90,6 +102,7 @@ Dimensions build_dimensions(py::iterator &&label_it, py::iterator &&shape_it,
     dims.addInner(Dim{label_it->cast<std::string>()},
                   shape_it->cast<scipp::index>());
   }
+  consume_extra_dims(shape_it, n_extra_dims);
   if (label_it != label_it.end() || shape_it != shape_it.end()) {
     throw_ndim_mismatch_error(dim + n_remaining(label_it), "dims",
                               dim + n_remaining(shape_it), shape_name);
@@ -100,17 +113,18 @@ Dimensions build_dimensions(py::iterator &&label_it, py::iterator &&shape_it,
 
 Dimensions build_dimensions(const py::object &dim_labels,
                             const py::object &values,
-                            const py::object &variances) {
+                            const py::object &variances,
+                            const scipp::index n_extra_dims = 0) {
   if (is_empty(dim_labels)) {
     return Dimensions{};
   } else {
     if (!values.is_none()) {
       ensure_same_shape(values, variances);
       return detail::build_dimensions(py::iter(dim_labels), shape_of(values),
-                                      "values");
+                                      n_extra_dims, "values");
     } else {
       return detail::build_dimensions(py::iter(dim_labels), shape_of(variances),
-                                      "variances");
+                                      n_extra_dims, "variances");
     }
   }
 }
@@ -217,6 +231,37 @@ Variable make_variable(const py::object &dim_labels, const py::object &values,
                                                                 variances,
                                                                 unit);
 }
+
+template <int N> Dimensions pad_structure_dimensions(Dimensions dims) {
+  dims.addInner(Dim::InternalStructureComponent, N);
+  return dims;
+}
+
+template <int M, int N> Dimensions pad_structure_dimensions(Dimensions dims) {
+  dims.addInner(Dim::InternalStructureRow, M);
+  dims.addInner(Dim::InternalStructureColumn, N);
+  return dims;
+}
+
+template <class T, class Elem, int... N>
+Variable make_structured_variable(const py::object &dim_labels,
+                                  const py::object &values_,
+                                  const py::object &variances,
+                                  const std::optional<units::Unit> &unit_) {
+  if (!variances.is_none())
+    throw except::VariancesError("Variances not supported for dtype " +
+                                 to_string(dtype<Elem>));
+
+  const auto values = py::array(values_);
+  const auto unit = unit_.value_or(variable::default_unit_for(dtype<Elem>));
+  const auto dims =
+      build_dimensions(dim_labels, values, py::none(), sizeof...(N));
+  const auto padded_dims = pad_structure_dimensions<N...>(dims);
+
+  auto var = variable::make_structures<T, Elem>(
+      dims, unit, make_element_array<Elem>(padded_dims, values, unit));
+  return var;
+}
 } // namespace
 
 /*
@@ -234,6 +279,23 @@ void bind_init(py::class_<Variable> &cls) {
         }
         const auto [scipp_dtype, actual_unit] =
             cast_dtype_and_unit(dtype, unit);
+
+        if (scipp_dtype == ::dtype<Eigen::Vector3d>)
+          return make_structured_variable<Eigen::Vector3d, double, 3>(
+              dim_labels, values, variances, actual_unit);
+        if (scipp_dtype == ::dtype<Eigen::Matrix3d>)
+          return make_structured_variable<Eigen::Matrix3d, double, 3, 3>(
+              dim_labels, values, variances, actual_unit);
+        if (scipp_dtype == ::dtype<Eigen::Affine3d>)
+          return make_structured_variable<Eigen::Affine3d, double, 4, 4>(
+              dim_labels, values, variances, actual_unit);
+        if (scipp_dtype == ::dtype<core::Quaternion>)
+          return make_structured_variable<core::Quaternion, double, 4>(
+              dim_labels, values, variances, actual_unit);
+        if (scipp_dtype == ::dtype<core::Translation>)
+          return make_structured_variable<core::Translation, double, 3>(
+              dim_labels, values, variances, actual_unit);
+
         return make_variable(dim_labels, values, variances, actual_unit,
                              scipp_dtype);
       }),

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -394,7 +394,7 @@ def vector(
       >>> sc.vector(value=[4, 5, 6], unit='m')
       <scipp.Variable> ()    vector3              [m]  (4, 5, 6)
     """
-    return _cpp.Variable(dims=(), values=value, unit=unit, dtype=DType.vector3)
+    return vectors(dims=(), values=value, unit=unit)
 
 
 def vectors(

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -394,7 +394,7 @@ def vector(
       >>> sc.vector(value=[4, 5, 6], unit='m')
       <scipp.Variable> ()    vector3              [m]  (4, 5, 6)
     """
-    return _cpp.vectors(dims=[], unit=unit, values=value)
+    return _cpp.Variable(dims=(), values=value, unit=unit, dtype=DType.vector3)
 
 
 def vectors(
@@ -443,7 +443,7 @@ def vectors(
       >>> sc.vectors(dims=['x'], values=[[1, 2, 3], [4, 5, 6]], unit='mm')
       <scipp.Variable> (x: 2)    vector3             [mm]  [(1, 2, 3), (4, 5, 6)]
     """
-    return _cpp.vectors(dims=dims, unit=unit, values=values)
+    return _cpp.Variable(dims=dims, values=values, unit=unit, dtype=DType.vector3)
 
 
 def array(

--- a/src/scipp/spatial/__init__.py
+++ b/src/scipp/spatial/__init__.py
@@ -91,9 +91,7 @@ def translation(
     :
         A scalar variable of dtype ``translation3``.
     """
-    return _core_cpp.Variable(
-        dims=(), unit=unit, values=value, dtype=DType.translation3
-    )
+    return translations(dims=(), unit=unit, values=value)
 
 
 def translations(
@@ -198,7 +196,7 @@ def rotation(*, value: Union[_np.ndarray, list]):
     :
         A scalar variable of dtype ``rotation3``.
     """
-    return _core_cpp.Variable(dims=(), values=value, dtype=DType.rotation3)
+    return rotations(dims=(), values=value)
 
 
 def rotations(*, dims: Sequence[str], values: Union[_np.ndarray, list]):
@@ -387,11 +385,10 @@ def linear_transform(
     :
         A scalar variable of dtype ``linear_transform3``.
     """
-    return _core_cpp.Variable(
+    return linear_transforms(
         dims=(),
         unit=unit,
-        values=_to_eigen_layout(value),
-        dtype=DType.linear_transform3,
+        values=value,
     )
 
 

--- a/src/scipp/spatial/__init__.py
+++ b/src/scipp/spatial/__init__.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from .. import units
 from .._scipp import core as _core_cpp
-from ..core import Unit, UnitError, Variable, vectors
+from ..core import DType, Unit, UnitError, Variable, vectors
 from ..core._cpp_wrapper_util import call_func as _call_cpp_func
 
 
@@ -91,7 +91,9 @@ def translation(
     :
         A scalar variable of dtype ``translation3``.
     """
-    return _call_cpp_func(_core_cpp.translations, dims=[], unit=unit, values=value)
+    return _core_cpp.Variable(
+        dims=(), unit=unit, values=value, dtype=DType.translation3
+    )
 
 
 def translations(
@@ -117,7 +119,9 @@ def translations(
     :
         An array variable of dtype ``translation3``.
     """
-    return _call_cpp_func(_core_cpp.translations, dims=dims, unit=unit, values=values)
+    return _core_cpp.Variable(
+        dims=dims, unit=unit, values=values, dtype=DType.translation3
+    )
 
 
 def scaling_from_vector(*, value: Union[_np.ndarray, list]):
@@ -194,7 +198,7 @@ def rotation(*, value: Union[_np.ndarray, list]):
     :
         A scalar variable of dtype ``rotation3``.
     """
-    return _call_cpp_func(_core_cpp.rotations, dims=[], values=value)
+    return _core_cpp.Variable(dims=(), values=value, dtype=DType.rotation3)
 
 
 def rotations(*, dims: Sequence[str], values: Union[_np.ndarray, list]):
@@ -238,7 +242,7 @@ def rotations(*, dims: Sequence[str], values: Union[_np.ndarray, list]):
             "4 components. If you want to pass a rotation matrix, use "
             "sc.linear_transforms instead."
         )
-    return _call_cpp_func(_core_cpp.rotations, dims=dims, values=values)
+    return _core_cpp.Variable(dims=dims, values=values, dtype=DType.rotation3)
 
 
 def rotations_from_rotvecs(rotation_vectors: Variable) -> Variable:
@@ -355,11 +359,11 @@ def affine_transforms(
     :
         An array variable of dtype ``affine_transform3``.
     """
-    return _call_cpp_func(
-        _core_cpp.affine_transforms,
+    return _core_cpp.Variable(
         dims=dims,
         unit=unit,
         values=_to_eigen_layout(values),
+        dtype=DType.affine_transform3,
     )
 
 
@@ -383,8 +387,11 @@ def linear_transform(
     :
         A scalar variable of dtype ``linear_transform3``.
     """
-    return _call_cpp_func(
-        _core_cpp.matrices, dims=[], unit=unit, values=_to_eigen_layout(value)
+    return _core_cpp.Variable(
+        dims=(),
+        unit=unit,
+        values=_to_eigen_layout(value),
+        dtype=DType.linear_transform3,
     )
 
 
@@ -411,8 +418,11 @@ def linear_transforms(
     :
         An array variable of dtype ``linear_transform3``.
     """
-    return _call_cpp_func(
-        _core_cpp.matrices, dims=dims, unit=unit, values=_to_eigen_layout(values)
+    return _core_cpp.Variable(
+        dims=dims,
+        unit=unit,
+        values=_to_eigen_layout(values),
+        dtype=DType.linear_transform3,
     )
 
 


### PR DESCRIPTION
This adds support for structured dtypes to `Variable.__init__`.

It was sparked by https://github.com/scipp/scipp/pull/3164#discussion_r1218898349 and allows for a more uniform way of creating variables in generic contexts (like HDF5 I/O).

There should be no user-facing changes as long as they avoid `Variable.__init__` as recommended.