### PR TITLE
Fix `sc.show` when bin-edge coords have been sliced

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -54,6 +54,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fixed label based indexing for arrays with a single element in the sliced dimension `#3171 <https://github.com/scipp/scipp/pull/3171>`_.
+* Fixed ``scipp.show`` in the presence of bin-edge coords that have been sliced out `#3178 <https://github.com/scipp/scipp/pull/3178>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/src/scipp/show.py
+++ b/src/scipp/show.py
@@ -378,7 +378,7 @@ class DatasetDrawer:
             for item in self._dataset.meta.values():
                 for dim in item.dims:
                     if dim not in dims:
-                        dims = [dim] + dims
+                        dims = (dim, ) + dims
         if len(dims) > 3:
             raise RuntimeError("Cannot visualize {}-D data".format(len(dims)))
         return dims

--- a/src/scipp/show.py
+++ b/src/scipp/show.py
@@ -378,7 +378,7 @@ class DatasetDrawer:
             for item in self._dataset.meta.values():
                 for dim in item.dims:
                     if dim not in dims:
-                        dims = (dim, ) + dims
+                        dims = (dim,) + dims
         if len(dims) > 3:
             raise RuntimeError("Cannot visualize {}-D data".format(len(dims)))
         return dims

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @file
 # @author Simon Heybrock
+import numpy as np
 import pytest
 
 import scipp as sc
@@ -28,3 +29,15 @@ def test_too_many_dataset_dimensions():
     )
     with pytest.raises(RuntimeError):
         sc.make_svg(d)
+
+
+def test_with_sliced_bin_edge_coords():
+    da = sc.DataArray(
+        data=sc.array(dims=['z', 'y', 'x'], values=np.random.random((5, 6, 7))),
+        coords={
+            'x': sc.arange('x', 8.0),
+            'y': sc.arange('y', 7.0),
+            'z': sc.arange('z', 6.0),
+        },
+    )
+    sc.make_svg(da['z', 0])


### PR DESCRIPTION
Fixes #3177 