### PR TITLE
fix: implement 'mod_equals' for the same set of types as 'mod'

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -98,6 +98,7 @@ Bugfixes
 
 * Fixed label based indexing for arrays with a single element in the sliced dimension `#3171 <https://github.com/scipp/scipp/pull/3171>`_.
 * Fixed ``scipp.show`` in the presence of bin-edge coords that have been sliced out `#3178 <https://github.com/scipp/scipp/pull/3178>`_.
+* Fixed in-place mod function for float `#3179 <https://github.com/scipp/scipp/pull/3179>`_.
 
 v23.05.0
 --------

--- a/lib/core/include/scipp/core/element/arithmetic.h
+++ b/lib/core/include/scipp/core/element/arithmetic.h
@@ -192,10 +192,18 @@ constexpr auto mod = overloaded{
     [](const auto a, const auto b) { return numeric::remainder(a, b); },
     [](const units::Unit &a, const units::Unit &b) { return a % b; }};
 
-constexpr auto mod_equals =
-    overloaded{arg_list<int64_t, int32_t, std::tuple<int64_t, int32_t>>,
-               [](units::Unit &a, const units::Unit &b) { a %= b; },
-               [](auto &&a, const auto &b) { a = mod(a, b); }};
+constexpr auto remainder_inplace_types =
+    arg_list<double, float, int64_t, int32_t, std::tuple<double, float>,
+             std::tuple<float, double>, std::tuple<double, int64_t>,
+             std::tuple<double, int32_t>, std::tuple<float, int64_t>,
+             std::tuple<float, int32_t>, std::tuple<int32_t, int64_t>,
+             std::tuple<int64_t, int32_t>>;
+
+constexpr auto mod_equals = overloaded{
+    remainder_inplace_types, transform_flags::expect_no_variance_arg<0>,
+    transform_flags::expect_no_variance_arg<1>,
+    [](units::Unit &a, const units::Unit &b) { a %= b; },
+    [](auto &&a, const auto &b) { a = mod(a, b); }};
 
 constexpr auto negative =
     overloaded{arg_list<double, float, int64_t, int32_t, Eigen::Vector3d>,

--- a/lib/core/test/element_arithmetic_test.cpp
+++ b/lib/core/test/element_arithmetic_test.cpp
@@ -49,6 +49,11 @@ TEST_F(ElementArithmeticTest, floor_divide_equals) {
   EXPECT_EQ(val, numeric::floor_divide(a, b));
 }
 
+TEST_F(ElementArithmeticTest, mod_equals) {
+  mod_equals(val, b);
+  EXPECT_EQ(val, mod(a, b));
+}
+
 TEST_F(ElementArithmeticTest, non_in_place) {
   EXPECT_EQ(add(a, b), a + b);
   EXPECT_EQ(subtract(a, b), a - b);


### PR DESCRIPTION
Closes #3074 

Not familiar with the code base so there might be issues with this fix, specifically with regards to `transform_flags::expect_no_variance_arg`.

// Johannes (I interviewed with @nvaytet earlier today).