### PR TITLE
Experiment: Support only contiguous bin content

### DIFF
--- a/lib/core/include/scipp/core/multi_index.h
+++ b/lib/core/include/scipp/core/multi_index.h
@@ -60,16 +60,8 @@ public:
           return this->m_data_index[data];
         },
         0, m_ndim - 1);
-    // Nested dims incremented, move on to bins.
-    // Note that we do not check whether there are any bins, instead whether
-    // the outer Variable is scalar because the loop above is enough to set up
-    // the coord in that case.
-    // if (has_bins() && dim_at_end(m_inner_ndim - 1))
-    //  seek_bin();
   }
 
-  // NOTE only used internally for bin index validation
-  // ... but calls increment_outer, which does bin increments
   void increment() noexcept {
     for (scipp::index data = 0; data < N; ++data)
       m_data_index[data] += m_stride[0][data];
@@ -79,10 +71,6 @@ public:
   }
 
   void increment_by(const scipp::index inner_distance) noexcept {
-    // NOTE
-    // If binned data, we know that this always increments exactly to the end
-    // of the bin (for binned operands), or not at all (other operands).
-    // We should simply call increment_outer() instead?
     for (scipp::index data = 0; data < N; ++data) {
       m_data_index[data] += inner_distance * m_stride[0][data];
     }
@@ -246,12 +234,15 @@ private:
   std::array<scipp::index, NDIM_OP_MAX + 1> m_shape = {};
   /// Total number of dimensions.
   scipp::index m_ndim{0};
+  /// Scale factor for bin size (1 unless bins are multi-dim).
   scipp::index m_bin_size_scale{-1};
+  /// Start/stop indices for binned args, used for translating m_data_index to
+  /// index for the bin content.
   std::array<const std::pair<scipp::index, scipp::index> *, N> m_indices = {};
+  /// Inner strides in case of iteration with bins
   std::array<scipp::index, N> m_inner_strides = {};
+  /// Index of an argument with bins
   scipp::index m_binned_arg{-1};
-  /// Parameters of the currently loaded bins.
-  /// std::array<BinIterator, N> m_bin = {};
 };
 
 template <class... StridesArgs>

--- a/lib/core/multi_index.cpp
+++ b/lib/core/multi_index.cpp
@@ -136,10 +136,14 @@ MultiIndex<N>::MultiIndex(binned_tag, const Dimensions &inner_dims,
     : MultiIndex(bin_dims, params.strides()...) {
   // TODO Where is the check for matching bin dims and shape?
   validate_bin_indices(params...);
-  // TODO init from bin volume
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   const auto bin_dim = get_slice_dim(params.bucketParams()...);
-  m_bin_size_scale = inner_dims.volume() / inner_dims[bin_dim];
+  m_bin_size_scale = 1;
+  for (const auto dim : inner_dims) {
+    if (dim == bin_dim)
+      continue;
+    m_bin_size_scale *= inner_dims[dim];
+  }
   m_indices = {params.bucketParams().indices...};
   m_inner_strides = {(params.bucketParams().indices == nullptr ? 0 : 1)...};
   // get index of first 1 in m_inner_strides

--- a/lib/variable/include/scipp/variable/transform.h
+++ b/lib/variable/include/scipp/variable/transform.h
@@ -263,10 +263,10 @@ static void transform_elements(Op op, Out &&out, Ts &&...other) {
     // 3. MultiIndex provides special method for getting dereferenced index
     // 4. transform has explicit branching to call correct methods
     if (!indices.has_bins()) {
-      const auto inner_size = indices.in_same_chunk(end, 1)
-                                  ? indices.inner_distance_to(end)
-                                  : indices.inner_distance_to_end();
       while (indices != end) {
+        const auto inner_size = indices.in_same_chunk(end, 1)
+                                    ? indices.inner_distance_to(end)
+                                    : indices.inner_distance_to_end();
         dispatch_inner_loop<false>(op, indices.get(), inner_strides, inner_size,
                                    std::forward<Out>(out),
                                    std::forward<Ts>(other)...);
@@ -518,10 +518,10 @@ template <bool dry_run> struct in_place {
     auto run = [&](auto &indices, const auto &end) {
       const auto inner_strides = indices.inner_strides();
       if (!indices.has_bins()) {
-        const auto inner_size = indices.in_same_chunk(end, 1)
-                                    ? indices.inner_distance_to(end)
-                                    : indices.inner_distance_to_end();
         while (indices != end) {
+          const auto inner_size = indices.in_same_chunk(end, 1)
+                                      ? indices.inner_distance_to(end)
+                                      : indices.inner_distance_to_end();
           detail::dispatch_inner_loop<true>(op, indices.get(), inner_strides,
                                             inner_size, std::forward<T>(arg),
                                             std::forward<Ts>(other)...);


### PR DESCRIPTION
This is an experiment for #3138, not intended for merge.

The essence of this change is to drop most of the iteration-with-bins code from `MultiIndex`. Instead, `transform` uses a different branch, calling a few dedicated methods (which might ultimately not make sense within `MultiIndex`, for for the time being this was the simplest).

Notes:

- I did not put any higher-level consistency checks in place for this experiment. That is, we simply get nonsense if bin-content is not contiguous (and consequently a number of tests are failing).
- In a quick test, I could not see any performance improvements (neither dense nor binned), at least not for a multi-threaded build.
- Code seems much simpler and easier to follow, which might allow for, e.g., support of negative strides.
- Binary size did not shrink (if anything it grew slightly), most likely because of the additional branch in `transform`.
- There may be room for more simplifications, or optimizations. With the reduced complexity this is at least something we can think and reason about (in contrast to the old implementation).

@jl-wynen please have a look. Can you simplify more?