### PR TITLE
Fix and cleanup scipp.yml

### DIFF
--- a/docs/environments/scipp.yml
+++ b/docs/environments/scipp.yml
@@ -9,12 +9,7 @@ dependencies:
   - ipython
   - ipywidgets
   - jupyterlab
-  - jupyterlab_widgets
-  - jupyter_nbextensions_configurator
-  - matplotlib-base
-  - nodejs
-  - pythreejs
+  - python-graphviz
+  - scipp::plopp
   - scipp::scipp
   - scipy
-  - scipp::plopp
-  - python-graphviz


### PR DESCRIPTION
Fixes #3196.

Removed because no longer necessary:

  - jupyterlab_widgets
  - jupyter_nbextensions_configurator
  - nodejs

Removed because `scipp::plopp` depends on it:

 - matplotlib-base

Removed because it is an optional requirement of `scipp::plopp` for 3-D scatter plats, which few users will need:

 - pythreejs