### PR TITLE
Add weekly workflow to ensure package builds don't break

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,53 @@
+name: Conda build
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system: ubuntu-20.04, macos-11, or windows-2019'
+        required: true
+        type: string
+      target:
+        description: 'Conda target: linux_64, osx_64, osx_arm64, or win_64'
+        required: true
+        type: string
+      python-version:
+        description: 'Python version such as 3.8, 3.9, or 3.10'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
+jobs:
+  build_conda:
+    name: Package build (${{ inputs.target }}, py${{ inputs.python-version }})
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0  # history required so cmake can determine version
+
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: >
+          conda install
+          --channel conda-forge
+          --channel nodefaults
+          --yes
+          conda-build conda-forge-pinning
+      - run: >
+          conda build
+          --channel conda-forge
+          --variant-config-files=${CONDA_PREFIX}/conda_build_config.yaml
+          --variant-config-files=${GITHUB_WORKSPACE}/conda/variants/${{ inputs.target }}.yaml
+          --python="${{ inputs.python-version }}.* *_cpython"
+          --no-anaconda-upload
+          --override-channels
+          --output-folder conda/package conda
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: conda-package-${{ inputs.os }}-py${{ inputs.python-version }}
+          path: conda/package/*/scipp*.tar.bz2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -22,6 +22,7 @@ defaults:
 
 jobs:
   build_conda:
+    name: Package build (${{ inputs.target }}, py${{ inputs.python-version }})
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -22,7 +22,6 @@ defaults:
 
 jobs:
   build_conda:
-    name: Package build (${{ inputs.target }}, py${{ inputs.python-version }})
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,8 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published'
 
   build_conda:
-    name: Package build (${{ matrix.variant.target }}, py${{ matrix.python-version }})
+    name: Conda
     needs: check_release
-    runs-on: ${{ matrix.variant.os }}
     strategy:
       matrix:
         variant:
@@ -35,34 +34,11 @@ jobs:
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
         python-version: ["3.8", "3.9", "3.10"]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0  # history required so cmake can determine version
-
-      - uses: conda-incubator/setup-miniconda@v2
-      - run: >
-          conda install
-          --channel conda-forge
-          --channel nodefaults
-          --yes
-          conda-build conda-forge-pinning
-      - run: >
-          conda build
-          --channel conda-forge
-          --variant-config-files=${CONDA_PREFIX}/conda_build_config.yaml
-          --variant-config-files=${GITHUB_WORKSPACE}/conda/variants/${{ matrix.variant.target }}.yaml
-          --python="${{ matrix.python-version }}.* *_cpython"
-          --no-anaconda-upload
-          --override-channels
-          --output-folder conda/package conda
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: conda-package-${{ matrix.variant.os }}-py${{ matrix.python-version }}
-          path: conda/package/*/scipp*.tar.bz2
+    uses: ./.github/workflows/conda.yml
+    with:
+      os: ${{ matrix.variant.os }}
+      target: ${{ matrix.variant.target }}
+      python-version: ${{ matrix.python-version }}
 
   build_sdist:
     name: Build SDist
@@ -86,35 +62,17 @@ jobs:
         path: dist/*.tar.gz
 
   build_wheels:
-    name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
+    name: Wheels
     needs: check_release
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
         build: [cp38, cp39, cp310, cp311]
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-        fetch-depth: 0  # history required so cmake can determine version
-
-    - uses: pypa/cibuildwheel@v2.15.0
-      env:
-        CIBW_BUILD: ${{ matrix.build }}-*
-        MACOSX_DEPLOYMENT_TARGET: "10.15"
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: wheelhouse/*.whl
+    uses: ./.github/workflows/wheel.yml
+    with:
+      os: ${{ matrix.os }}
+      build: ${{ matrix.build }}
 
   upload_pypi:
     name: Deploy PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - {os: macos-11, target: osx_64}
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - {os: macos-11, target: osx_64}
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.10"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,32 +21,11 @@ jobs:
         python-version: ["3.8", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0  # history required so cmake can determine version
-
-      - uses: conda-incubator/setup-miniconda@v2
-      - run: >
-          conda install
-          --channel conda-forge
-          --channel nodefaults
-          --yes
-          conda-build conda-forge-pinning
-      - run: >
-          conda build
-          --channel conda-forge
-          --variant-config-files=${CONDA_PREFIX}/conda_build_config.yaml
-          --variant-config-files=${GITHUB_WORKSPACE}/conda/variants/${{ matrix.variant.target }}.yaml
-          --python="${{ matrix.python-version }}.* *_cpython"
-          --no-anaconda-upload
-          --override-channels
-          --output-folder conda/package conda
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: conda-package-${{ matrix.variant.os }}-py${{ matrix.python-version }}
-          path: conda/package/*/scipp*.tar.bz2
+    - uses: ./.github/workflows/conda.yml
+      with:
+        os: ${{ matrix.variant.os }}
+        target: ${{ matrix.variant.target }}
+        python-version: ${{ matrix.python-version }}
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
@@ -57,22 +36,7 @@ jobs:
         build: [cp38, cp311]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: ./.github/workflows/wheel.yml
       with:
-        submodules: true
-        fetch-depth: 0  # history required so cmake can determine version
-
-    - uses: pypa/cibuildwheel@v2.15.0
-      env:
-        CIBW_BUILD: ${{ matrix.build }}-*
-        MACOSX_DEPLOYMENT_TARGET: "10.15"
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: wheelhouse/*.whl
+        os: ${{ matrix.os }}
+        build: ${{ matrix.build }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,7 +13,6 @@ defaults:
 jobs:
   build_conda:
     name: Package build (${{ matrix.variant.target }}, py${{ matrix.python-version }})
-    runs-on: ${{ matrix.variant.os }}
     strategy:
       matrix:
         variant:
@@ -27,7 +26,6 @@ jobs:
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,6 +1,7 @@
 name: Weekly package builds
 
 on:
+  pull_request:  # temp for testing
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 6" # every Saturday at midnight

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,6 +2,9 @@ name: Weekly package builds
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/weekly.yml'
   schedule:
     - cron: "0 0 * * 6" # every Saturday at midnight
 
@@ -15,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,13 +19,11 @@ jobs:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
         python-version: ["3.8", "3.10"]
-
-    steps:
-    - uses: ./.github/workflows/conda.yml
-      with:
-        os: ${{ matrix.variant.os }}
-        target: ${{ matrix.variant.target }}
-        python-version: ${{ matrix.python-version }}
+    uses: ./.github/workflows/conda.yml
+    with:
+      os: ${{ matrix.variant.os }}
+      target: ${{ matrix.variant.target }}
+      python-version: ${{ matrix.python-version }}
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
@@ -34,9 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         build: [cp38, cp311]
-
-    steps:
-    - uses: ./.github/workflows/wheel.yml
-      with:
-        os: ${{ matrix.os }}
-        build: ${{ matrix.build }}
+    uses: ./.github/workflows/wheel.yml
+    with:
+      os: ${{ matrix.os }}
+      build: ${{ matrix.build }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,77 @@
+name: Weekly package builds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 6" # every Saturday at midnight
+
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
+jobs:
+  build_conda:
+    name: Package build (${{ matrix.variant.target }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.variant.os }}
+    strategy:
+      matrix:
+        variant:
+          - {os: ubuntu-20.04, target: linux_64}
+        python-version: ["3.8", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0  # history required so cmake can determine version
+
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: >
+          conda install
+          --channel conda-forge
+          --channel nodefaults
+          --yes
+          conda-build conda-forge-pinning
+      - run: >
+          conda build
+          --channel conda-forge
+          --variant-config-files=${CONDA_PREFIX}/conda_build_config.yaml
+          --variant-config-files=${GITHUB_WORKSPACE}/conda/variants/${{ matrix.variant.target }}.yaml
+          --python="${{ matrix.python-version }}.* *_cpython"
+          --no-anaconda-upload
+          --override-channels
+          --output-folder conda/package conda
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: conda-package-${{ matrix.variant.os }}-py${{ matrix.python-version }}
+          path: conda/package/*/scipp*.tar.bz2
+
+  build_wheels:
+    name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        build: [cp38, cp311]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0  # history required so cmake can determine version
+
+    - uses: pypa/cibuildwheel@v2.15.0
+      env:
+        CIBW_BUILD: ${{ matrix.build }}-*
+        MACOSX_DEPLOYMENT_TARGET: "10.15"
+
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: wheelhouse/*.whl

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,7 +1,6 @@
 name: Weekly package builds
 
 on:
-  pull_request:  # temp for testing
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 6" # every Saturday at midnight

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,7 +12,6 @@ defaults:
 
 jobs:
   build_conda:
-    name: Package build (${{ matrix.variant.target }}, py${{ matrix.python-version }})
     strategy:
       matrix:
         variant:
@@ -25,7 +24,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   build_wheels:
-    name: Wheels on ${{ matrix.os }}-${{ matrix.build }}
     strategy:
       matrix:
         os: [ubuntu-20.04]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build_wheels:
+    name: Wheels on ${{ inputs.os }}-${{ inputs.build }}
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,39 @@
+name: Wheel build
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system: ubuntu-20.04, macos-11, or windows-2019'
+        required: true
+        type: string
+      build:
+        description: "Wheel build variant such as cp38"
+        required: true
+        type: string
+
+jobs:
+  build_wheels:
+    name: Wheels on ${{ inputs.os }}-${{ inputs.build }}
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0  # history required so cmake can determine version
+
+    - uses: pypa/cibuildwheel@v2.15.0
+      env:
+        CIBW_BUILD: ${{ inputs.build }}-*
+        MACOSX_DEPLOYMENT_TARGET: "10.15"
+
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: wheelhouse/*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   build_wheels:
-    name: Wheels on ${{ inputs.os }}-${{ inputs.build }}
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/conda/variants/linux_64.yaml
+++ b/conda/variants/linux_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.21'
+  - '1.22'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/osx_64.yaml
+++ b/conda/variants/osx_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.21'
+  - '1.22'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/osx_arm64.yaml
+++ b/conda/variants/osx_arm64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.21'
+  - '1.22'
 python_impl:
   - cpython
 target_platform:

--- a/conda/variants/win_64.yaml
+++ b/conda/variants/win_64.yaml
@@ -1,5 +1,5 @@
 numpy:
-  - '1.21'
+  - '1.22'
 python_impl:
   - cpython
 target_platform:


### PR DESCRIPTION
Fixes #3187.

I have considered making all or parts of the actual release workflow reusable. However, after a closer look this seemed to be more complicated and error prone than just replicating the relevant part. Since this is not about checking that the *workflow* does not break, but that the *package builds* (conda or wheel) do not break I think this is acceptable.