### PR TITLE
Deprecate `DataArray.attrs`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -27,6 +27,14 @@ Release Notes
    Stability, Maintainability, and Testing
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+v23.09.0
+--------
+
+Deprecations
+~~~~~~~~~~~~
+
+* ``scipp.DataArray.attrs`` and all related methods and properties have been deprecated `#3227 <https://github.com/scipp/scipp/pull/3227>`_.
+
 v23.08.0
 --------
 

--- a/lib/python/bind_data_array.h
+++ b/lib/python/bind_data_array.h
@@ -305,10 +305,11 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
       "coords", [](T &self) -> decltype(auto) { return self.coords(); },
       R"(Dict of aligned coords.)");
   c.def_property_readonly(
-      "meta", [](T &self) -> decltype(auto) { return self.meta(); },
+      "deprecated_meta", [](T &self) -> decltype(auto) { return self.meta(); },
       R"(Dict of coords and attrs.)");
   c.def_property_readonly(
-      "attrs", [](T &self) -> decltype(auto) { return self.attrs(); },
+      "deprecated_attrs",
+      [](T &self) -> decltype(auto) { return self.attrs(); },
       R"(Dict of attrs.)");
   c.def_property_readonly(
       "masks", [](T &self) -> decltype(auto) { return self.masks(); },
@@ -331,15 +332,16 @@ void bind_data_array_properties(py::class_<T, Ignored...> &c) {
   c.def("drop_masks", [](T &self, std::vector<std::string> &mask_names) {
     return self.drop_masks(mask_names);
   });
-  c.def("drop_attrs", [](T &self, std::string &attr_name) {
+  c.def("deprecated_drop_attrs", [](T &self, std::string &attr_name) {
     std::vector<scipp::Dim> attr_names_c = {scipp::Dim{attr_name}};
     return self.drop_attrs(attr_names_c);
   });
-  c.def("drop_attrs", [](T &self, std::vector<std::string> &attr_names) {
-    std::vector<scipp::Dim> attr_names_c;
-    std::transform(attr_names.begin(), attr_names.end(),
-                   std::back_inserter(attr_names_c),
-                   [](const auto &name) { return scipp::Dim{name}; });
-    return self.drop_attrs(attr_names_c);
-  });
+  c.def("deprecated_drop_attrs",
+        [](T &self, std::vector<std::string> &attr_names) {
+          std::vector<scipp::Dim> attr_names_c;
+          std::transform(attr_names.begin(), attr_names.end(),
+                         std::back_inserter(attr_names_c),
+                         [](const auto &name) { return scipp::Dim{name}; });
+          return self.drop_attrs(attr_names_c);
+        });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,4 +68,5 @@ filterwarnings = [
   "ignore:The 'asyncio_mode' default value will change to 'strict' in future:DeprecationWarning",
   'ignore::scipy.optimize._optimize.OptimizeWarning',
   'ignore:Support for mapping types has been deprecated and will be dropped in a future release.:DeprecationWarning',
+  'ignore:sc.DataArray.attrs has been deprecated:scipp.VisibleDeprecationWarning',
 ]

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -51,6 +51,14 @@ from .dimensions import (
     _rename_dataset,
 )
 
+
+from .deprecation import _deprecated_attrs, _deprecated_meta, _deprecated_drop_attrs
+
+setattr(DataArray, 'attrs', property(_deprecated_attrs))
+setattr(DataArray, 'meta', property(_deprecated_meta))
+setattr(DataArray, 'drop_attrs', _deprecated_drop_attrs)
+del _deprecated_attrs, _deprecated_meta, _deprecated_drop_attrs
+
 for cls in (Variable, DataArray, Dataset):
     setattr(cls, 'rename_dims', _rename_dims)
 setattr(Variable, 'rename', _rename_variable)

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -9,6 +9,7 @@ from ..typing import Dims, MetaDataMap, VariableLike
 from ._cpp_wrapper_util import call_func as _call_cpp_func
 from .bin_remapping import concat_bins
 from .data_group import DataGroup
+from .deprecation import _warn_attr_removal
 from .domains import merge_equal_adjacent
 from .math import midpoints
 from .operations import islinspace
@@ -195,13 +196,25 @@ class Bins:
 
     @property
     def meta(self) -> MetaDataMap:
-        """Coords and attrs of the bins"""
-        return _cpp._bins_view(self._data()).meta
+        """Coords and attrs of the bins
+
+        .. deprecated:: 23.9.0
+           Use :py:attr:`coords` with unset alignment flag instead, or
+           store attributes in higher-level data structures.
+        """
+        _warn_attr_removal()
+        return _cpp._bins_view(self._data()).deprecated_meta
 
     @property
     def attrs(self) -> MetaDataMap:
-        """Coords of the bins"""
-        return _cpp._bins_view(self._data()).attrs
+        """Attrs of the bins
+
+        .. deprecated:: 23.9.0
+           Use :py:attr:`coords` with unset alignment flag instead, or
+           store attributes in higher-level data structures.
+        """
+        _warn_attr_removal()
+        return _cpp._bins_view(self._data()).deprecated_attrs
 
     @property
     def masks(self) -> MetaDataMap:

--- a/src/scipp/core/deprecation.py
+++ b/src/scipp/core/deprecation.py
@@ -1,0 +1,49 @@
+import warnings
+
+from .util import VisibleDeprecationWarning
+
+
+def _warn_attr_removal():
+    warnings.warn(
+        "sc.DataArray.attrs has been deprecated and will be removed in Scipp v24.12.0. "
+        "The deprecation includes sc.DataArray.meta and sc.DataArray.drop_attrs. "
+        "For unaligned coords, use sc.DataArray.coords and unset the alignment flag. "
+        "For other attributes, use a higher-level data structure.",
+        VisibleDeprecationWarning,
+    )
+
+
+def _deprecated_attrs(cls):
+    """
+    Dict of attrs.
+
+    .. deprecated:: 23.9.0
+       Use :py:attr:`coords` with unset alignment flag instead, or
+       store attributes in higher-level data structures.
+    """
+    _warn_attr_removal()
+    return cls.deprecated_attrs
+
+
+def _deprecated_meta(cls):
+    """
+    Dict of coords and attrs.
+
+    .. deprecated:: 23.9.0
+       Use :py:attr:`coords` with unset alignment flag instead, or
+       store attributes in higher-level data structures.
+    """
+    _warn_attr_removal()
+    return cls.deprecated_meta
+
+
+def _deprecated_drop_attrs(cls, *args, **kwargs):
+    """
+    Drop attrs.
+
+    .. deprecated:: 23.9.0
+       Use :py:attr:`coords` with unset alignment flag instead, or
+       store attributes in higher-level data structures.
+    """
+    _warn_attr_removal()
+    return cls.deprecated_drop_attrs(*args, **kwargs)

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -622,3 +622,27 @@ def test_assign_update_attrs():
     assert sc.identical(
         da_n, sc.DataArray(data, attrs={'attr0': attr0_n, 'attr1': attr1_n})
     )
+
+
+def test_accessing_attrs_property_warns_about_deprecation():
+    da = sc.DataArray(sc.arange('x', 4))
+    with pytest.warns(sc.VisibleDeprecationWarning):
+        da.attrs
+
+
+def test_accessing_meta_property_warns_about_deprecation():
+    da = sc.DataArray(sc.arange('x', 4))
+    with pytest.warns(sc.VisibleDeprecationWarning):
+        da.meta
+
+
+def test_accessing_attrs_property_of_bins_warns_about_deprecation():
+    da = sc.data.binned_x(1, 1)
+    with pytest.warns(sc.VisibleDeprecationWarning):
+        da.bins.attrs
+
+
+def test_accessing_meta_property_of_bins_warns_about_deprecation():
+    da = sc.data.binned_x(1, 1)
+    with pytest.warns(sc.VisibleDeprecationWarning):
+        da.bins.meta


### PR DESCRIPTION
For simplicity this omits adding warnings to construction of `DataArray` with an `attrs` argument. Part of #3166.