### PR TITLE
Fix empty bin confusing error

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -213,6 +213,13 @@ def _parse_coords_arg(
         stop = coord.max()  # existing bin-edges, do not extend
     else:
         stop = _upper_bound(coord)
+    if start > stop:
+        raise ValueError(
+            (
+                'Empty data range, cannot automatically determine bounds. '
+                'Must provide concrete bin edges.'
+            )
+        )
     if isinstance(arg, Integral):
         if start.dtype == DType.datetime64:
             base = epoch(unit=start.unit)

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -231,6 +231,17 @@ def test_bin_integer_coord_by_fractional_stepsize_raises(dtype):
         table.bin(label=sc.scalar(0.5, unit='m'))
 
 
+def test_bin_with_automatic_bin_bounds_raises_if_no_events():
+    table = sc.data.table_xyz(0)
+    with pytest.raises(ValueError):
+        table.bin(x=4)
+
+
+def test_bin_with_manual_bin_bounds_not_raises_if_no_events():
+    table = sc.data.table_xyz(0)
+    table.bin(x=sc.linspace('x', 0, 1, 4, unit=table.coords['x'].unit))
+
+
 def test_group_after_bin_considers_event_value():
     table = sc.data.table_xyz(100)
     table.coords['label'] = (table.coords['x'] * 10).to(dtype='int64')


### PR DESCRIPTION
This pr fixes #3209 by raising an error if
* the selected data contains no entries and
* automatic binning was requested.

The data set can be either a `DataArray` or a `Dataset`, this makes the test a bit more cumbersome.
The binning should be fine if any of the `DataArrays` in the data set contains events.

I'm using `bins.constituents` to figure out the total number of events in a binned `DataArray`, is there a better way?