### PR TITLE
Prevent non str keys

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -177,7 +177,10 @@ class DataGroup(MutableMapping):
 
     def __setitem__(self, name, value):
         """Set self[key] to value."""
-        self._items[name] = value
+        if isinstance(name, str):
+            self._items[name] = value
+        else:
+            raise TypeError('Keys must be strings')
 
     def __delitem__(self, name: str):
         """Delete self[key]."""

--- a/tests/data_group_test.py
+++ b/tests/data_group_test.py
@@ -124,6 +124,12 @@ def test_setitem_str_key_replace():
     assert sc.identical(dg['a'], sc.scalar(2))
 
 
+def test_setitem_nonstr_key_fails():
+    dg = sc.DataGroup(a=sc.arange('x', 2))
+    with pytest.raises(TypeError):
+        dg[0] = sc.scalar(1)
+
+
 def test_delitem_removes_item():
     dg = sc.DataGroup({'a': sc.scalar(1)})
     del dg['a']


### PR DESCRIPTION
Fixes #3182.

Is there any case when non str slices are allowed in the `DataGroup.__setitem__` method?



