### PR TITLE
fix: add appropriate type combinations

### DIFF
--- a/lib/core/include/scipp/core/element/bin_detail.h
+++ b/lib/core/include/scipp/core/element/bin_detail.h
@@ -16,9 +16,14 @@ using bin_range_arg =
     std::tuple<scipp::index, scipp::index, Coord, scipp::span<const Edge>>;
 
 static constexpr auto bin_range_common = overloaded{
-    arg_list<bin_range_arg<double, double>, bin_range_arg<int64_t, double>,
-             bin_range_arg<int64_t, int64_t>, bin_range_arg<int32_t, int32_t>,
-             bin_range_arg<int32_t, double>,
+    arg_list<bin_range_arg<double, double>, bin_range_arg<double, float>,
+             bin_range_arg<double, int32_t>, bin_range_arg<double, int64_t>,
+             bin_range_arg<float, double>, bin_range_arg<float, float>,
+             bin_range_arg<float, int32_t>, bin_range_arg<float, int64_t>,
+             bin_range_arg<int32_t, double>, bin_range_arg<int32_t, float>,
+             bin_range_arg<int32_t, int32_t>, bin_range_arg<int32_t, int64_t>,
+             bin_range_arg<int64_t, double>, bin_range_arg<int64_t, float>,
+             bin_range_arg<int64_t, int32_t>, bin_range_arg<int64_t, int64_t>,
              bin_range_arg<time_point, time_point>>,
     transform_flags::expect_no_variance_arg<2>};
 

--- a/lib/core/test/element_bin_detail_test.cpp
+++ b/lib/core/test/element_bin_detail_test.cpp
@@ -9,9 +9,20 @@
 using namespace scipp;
 using namespace scipp::core::element;
 
-TEST(ElementBinUtilTest, begin_edge) {
-  constexpr auto check = [](const double coord, const scipp::index expected) {
-    const std::vector<double> edges{0, 1, 2, 3};
+template <typename T> class ElementBinUtilTest : public ::testing::Test {};
+using CoordEdgeTypePairs =
+    ::testing::Types<std::pair<double, double>, std::pair<double, float>,
+                     std::pair<double, int32_t>, std::pair<double, int64_t>,
+                     std::pair<float, double>, std::pair<float, float>,
+                     std::pair<float, int32_t>, std::pair<float, int64_t>>;
+TYPED_TEST_SUITE(ElementBinUtilTest, CoordEdgeTypePairs);
+
+TYPED_TEST(ElementBinUtilTest, begin_edge) {
+  typedef typename TypeParam::first_type CoordType;
+  typedef typename TypeParam::second_type EdgeType;
+  constexpr auto check = [](const CoordType coord,
+                            const scipp::index expected) {
+    const std::vector<EdgeType> edges{0, 1, 2, 3};
     scipp::index bin{0};
     scipp::index index;
     begin_edge(bin, index, coord, edges);
@@ -26,9 +37,12 @@ TEST(ElementBinUtilTest, begin_edge) {
   check(3.0, 2);
 }
 
-TEST(ElementBinUtilTest, end_edge) {
-  constexpr auto check = [](const double coord, const scipp::index expected) {
-    const std::vector<double> edges{0, 1, 2, 3};
+TYPED_TEST(ElementBinUtilTest, end_edge) {
+  typedef typename TypeParam::first_type CoordType;
+  typedef typename TypeParam::second_type EdgeType;
+  constexpr auto check = [](const CoordType coord,
+                            const scipp::index expected) {
+    const std::vector<EdgeType> edges{0, 1, 2, 3};
     scipp::index bin{0};
     scipp::index index;
     end_edge(bin, index, coord, edges);

--- a/src/scipp/data/__init__.py
+++ b/src/scipp/data/__init__.py
@@ -69,16 +69,27 @@ def vulcan_steel_strain_data() -> DataArray:
     return load_hdf5(get_path('VULCAN_221040_processed.h5'))
 
 
-def table_xyz(nrow: int) -> DataArray:
+def table_xyz(nrow: int, coord_max=None, coord_dtype=None) -> DataArray:
     """
     Return a 1-D data array ("table") with x, y, and z coord columns.
     """
     from numpy.random import default_rng
 
     rng = default_rng(seed=1234)
-    x = array(dims=['row'], unit='m', values=rng.random(nrow))
-    y = array(dims=['row'], unit='m', values=rng.random(nrow))
-    z = array(dims=['row'], unit='m', values=rng.random(nrow))
+
+    def random_coordinate():
+        return array(
+            dims=['row'],
+            unit='m',
+            values=(
+                rng.random(nrow) if coord_max is None else rng.random(nrow) * coord_max
+            ),
+            dtype=coord_dtype,
+        )
+
+    x = random_coordinate()
+    y = random_coordinate()
+    z = random_coordinate()
     data = ones(dims=['row'], unit='K', shape=[nrow])
     data.values += 0.1 * rng.random(nrow)
     return DataArray(data=data, coords={'x': x, 'y': y, 'z': z})


### PR DESCRIPTION
Fixes #3176.

Is there a reason why `float` was excluded in the original `arg_list`?
Now I just added all type combinations between `double, float, int32_t, int64_t`.