### PR TITLE
Remove mentions of attr from docs

### DIFF
--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -53,7 +53,7 @@ The data array concept
 ----------------------
 
 The core data structure of Scipp is :py:class:`scipp.DataArray`.
-A data array is essentially a multi-dimensional array with associated dicts of coordinates, masks, and attributes.
+A data array is essentially a multi-dimensional array with associated dicts of coordinates and masks.
 For a more detailed explanation we refer to the `documentation of DataArray <../user-guide/data-structures.rst#DataArray>`_.
 
 Scipp labels dimensions and their associated coordinates with labels such as ``'x'``, ``'temperature'``, or ``'wavelength'``.

--- a/docs/reference/developer/concepts.ipynb
+++ b/docs/reference/developer/concepts.ipynb
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mismatching attrs and unaligned coords are dropped:"
+    "Mismatching unaligned coords are dropped:"
    ]
   },
   {
@@ -141,31 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A missing attr is interpreted as mismatch to ensure that:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "a = da['x', 0].copy()\n",
-    "a.attrs['x'] = a.coords.pop('x')\n",
-    "b = da['x', 1].copy()\n",
-    "b.attrs['x'] = b.coords.pop('x')\n",
-    "c = da['x', 2].copy()\n",
-    "c.attrs['x'] = c.coords.pop('x')\n",
-    "assert sc.identical(a + (b + c), (a + b) + c)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Likewise, a missing unaligned coord is interpreted as mismatch:"
+    "Missing unaligned coords are interpreted as mismatch:"
    ]
   },
   {
@@ -207,50 +183,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Insertion order does not matter for attrs:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "a = da.copy()\n",
-    "a.attrs['attr'] = 1.0 * sc.units.m\n",
-    "b = da.copy()\n",
-    "b.attrs['attr'] = 2.0 * sc.units.m\n",
-    "ds1 = sc.Dataset({'a': a, 'b': b})\n",
-    "ds2 = sc.Dataset({'b': b, 'a': a})\n",
-    "assert sc.identical(ds1, ds2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Insert into dataset with mismatching attrs drops attr:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ds = sc.Dataset(coords={'x': x['x', 0]})\n",
-    "ds['a'] = da['x', 1] # Drops 'x' from 'a' \n",
-    "assert sc.identical(ds.coords['x'], ds['a'].coords['x']) # shadowing is NOT supported"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Masks of dataset items are independent:"
    ]
   },
@@ -269,41 +201,6 @@
     "assert not sc.identical(masked1, masked2)\n",
     "ds = sc.Dataset({'a': masked1, 'b': masked2})\n",
     "assert not sc.identical(ds['a'].masks['x'], ds['b'].masks['x'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If there is no coord, the attr is preserved for all items.\n",
-    "Adding a coord later makes the `meta` property invalid because of ambiguous name shadowing:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "a = da['x', 0].copy()\n",
-    "a.attrs['x'] = a.coords.pop('x')\n",
-    "b = da['x', 1].copy()\n",
-    "b.attrs['x'] = b.coords.pop('x')\n",
-    "ds = sc.Dataset({'a': a, 'b': b})\n",
-    "assert 'x' not in ds.coords\n",
-    "assert 'x' in ds['a'].attrs\n",
-    "assert 'x' in ds['b'].attrs\n",
-    "ds.coords['x'] = x['x', 0] # introduce shadowing\n",
-    "try:\n",
-    "    ds['a'].meta # raises because of shadowing\n",
-    "except:\n",
-    "    ok = True\n",
-    "else:\n",
-    "    ok = False\n",
-    "assert ok\n",
-    "del ds.coords['x']"
    ]
   },
   {
@@ -423,76 +320,6 @@
     "    ok = True\n",
     "assert not ok\n",
     "assert 'fail' not in da.coords"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`meta` contains dataset coordinates as well as item attributes, cannot add or erase, since ambiguous:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    ds['a'].meta['fail'] = 1.0 * sc.units.m\n",
-    "except sc.DataArrayError:\n",
-    "    ok = False\n",
-    "else:\n",
-    "    ok = True\n",
-    "assert not ok\n",
-    "assert 'fail' not in ds['a'].meta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ds['a'].attrs['attr'] = 1.0 * sc.units.m\n",
-    "assert 'attr' in ds['a'].meta\n",
-    "try:\n",
-    "    del ds['a'].meta['attr']\n",
-    "except sc.DataArrayError:\n",
-    "    ok = False\n",
-    "else:\n",
-    "    ok = True\n",
-    "assert not ok\n",
-    "assert 'attr' in ds['a'].meta"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Attributes are independent for each item, and show up in `meta` of the items:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ds['a'].attrs['attr'] = 1.0 * sc.units.m\n",
-    "ds['b'].attrs['attr'] = 2.0 * sc.units.m\n",
-    "assert 'attr' in ds['a'].meta\n",
-    "assert 'attr' in ds['b'].meta\n",
-    "assert 'attr' not in ds.meta\n",
-    "assert not sc.identical(ds['a'].attrs['attr'], ds['b'].attrs['attr'])\n",
-    "del ds['a'].attrs['attr']\n",
-    "del ds['b'].attrs['attr']"
    ]
   }
  ],

--- a/docs/reference/dtype.ipynb
+++ b/docs/reference/dtype.ipynb
@@ -83,7 +83,7 @@
     "- `string`\n",
     "- `datetime64`\n",
     "\n",
-    "It is also possible to nest Variables, DataArrays, or Datasets inside of Variables. This is useful for storing attributes in DataArrays and Datasets. But there is only limited interoperability with NumPy in those cases."
+    "It is also possible to nest Variables, DataArrays, or Datasets inside of Variables. But there is only limited interoperability with NumPy in those cases."
    ]
   },
   {

--- a/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
+++ b/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
@@ -171,7 +171,7 @@
    "id": "dc18c382-ac1b-4427-bfc0-55e0cc35b8c8",
    "metadata": {},
    "source": [
-    "Note that while the buffers are shared, the meta-data dicts such as `coords`, `masks`, or `attrs` are not.\n",
+    "Note that while the buffers are shared, the meta-data dicts `coords` and `masks` are not.\n",
     "Compare:"
    ]
   },
@@ -184,8 +184,8 @@
    },
    "outputs": [],
    "source": [
-    "ds['a'].attrs['attr'] = 1.2 * sc.units.m\n",
-    "'attr' in da.attrs  # the attrs *dict* is copied"
+    "ds['a'].masks['m'] = (da.coords['x'] < 670 * sc.Unit('m'))\n",
+    "'m' in da.masks  # the masks *dict* is copied"
    ]
   },
   {
@@ -206,7 +206,9 @@
    "outputs": [],
    "source": [
     "da.coords['x'] *= -1\n",
-    "ds.coords['x']  # the coords *dict* is copied, but the 'x' coordinate references same buffer"
+    "# the coords *dict* is copied, \n",
+    "# but the 'x' coordinate references same buffer\n",
+    "ds.coords['x']  "
    ]
   },
   {

--- a/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
+++ b/docs/reference/ownership-mechanism-and-readonly-flags.ipynb
@@ -208,7 +208,7 @@
     "da.coords['x'] *= -1\n",
     "# the coords *dict* is copied, \n",
     "# but the 'x' coordinate references same buffer\n",
-    "ds.coords['x']  "
+    "ds.coords['x']"
    ]
   },
   {
@@ -311,8 +311,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/prepare_data_rhessi.py
+++ b/docs/tutorials/prepare_data_rhessi.py
@@ -44,7 +44,7 @@ new = sc.DataGroup(
 )
 new['flares'].coords['max_energy'] = new['flares'].attrs.pop('max_energy')
 new['flares'].coords['min_energy'] = new['flares'].attrs.pop('min_energy')
-new.save_hdf5("docs/tutorials/data/rhessi_flares.h5")
+new.save_hdf5("rhessi_flares.h5")
 """
 
 DATA_DIR = Path(__file__).parent / "data"

--- a/docs/tutorials/prepare_data_rhessi.py
+++ b/docs/tutorials/prepare_data_rhessi.py
@@ -20,6 +20,33 @@ import pooch
 
 import scipp as sc
 
+# IMPORTANT
+# NASA have updated the flare list.
+# It is now more heavily filtered which makes some steps in the tutorial obsolete.
+# Also, the parser in this script no longer works because there are some lines
+# where the total counts fill their entire column and there is no space to split by.
+# This could be fixed by using that the columns each have a fixed width.
+#
+# The old file was apparently removed from the public server.
+#
+# The following code converts the output file of this script
+# to the one used by the tutorial.
+"""
+import scipp as sc
+
+old = sc.io.load_hdf5("rhessi_flares-old.h5")
+print(old)
+new = sc.DataGroup(
+    flares=old,
+    non_solar=old.attrs.pop("non_solar"),
+    **{key: old.attrs.pop(key).value
+       for key in ("detector_efficiency", "citation", "description", "url")},
+)
+new['flares'].coords['max_energy'] = new['flares'].attrs.pop('max_energy')
+new['flares'].coords['min_energy'] = new['flares'].attrs.pop('min_energy')
+new.save_hdf5("docs/tutorials/data/rhessi_flares.h5")
+"""
+
 DATA_DIR = Path(__file__).parent / "data"
 
 

--- a/docs/tutorials/solar_flares.ipynb
+++ b/docs/tutorials/solar_flares.ipynb
@@ -112,16 +112,7 @@
     "tags": []
    },
    "source": [
-    "The data (`flares.data`) contains a weight for each flare.\n",
-    "Initially, all weights are 1.\n",
-    "\n",
-    "The most important metadata items are:\n",
-    "\n",
-    "- `start_time`, `end_time`: Time interval of flare.\n",
-    "- `peak_time`: Date and time of the highest x-ray flux.\n",
-    "- `x`, `y`: Position in the image seen by RHESSI.\n",
-    "- `min_energy`, `max_energy`: Energy band that a flare was observed in. Bands do not overlap.\n",
-    "- `non_solar`: The event was flagged as not coming from the Sun."
+    "The file contains a number of items that are loaded together as a data group."
    ]
   },
   {
@@ -138,9 +129,35 @@
    "outputs": [],
    "source": [
     "filename = sc.data.rhessi_flares()\n",
-    "flares = sc.io.load_hdf5(filename)\n",
-    "# Move min_energy from attributes to coordinates\n",
-    "flares.coords['min_energy'] = flares.attrs.pop('min_energy')\n",
+    "flare_data = sc.io.load_hdf5(filename)\n",
+    "flare_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e4ecc8f-de1e-40cf-ad29-38bf4d84d9c1",
+   "metadata": {},
+   "source": [
+    "For ease of use, we extract the `flares` data array.\n",
+    "Its data (`flares.data`) contains a weight for each flare.\n",
+    "Initially, all weights are 1.\n",
+    "\n",
+    "Its coordinates have the following meanings:\n",
+    "\n",
+    "- `start_time`, `end_time`: Time interval of flare.\n",
+    "- `peak_time`: Date and time of the highest x-ray flux.\n",
+    "- `x`, `y`: Position in the image seen by RHESSI.\n",
+    "- `min_energy`, `max_energy`: Energy band that a flare was observed in. Bands do not overlap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce2378ba-4360-4912-8777-9d2e39fce024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flares = flare_data['flares']\n",
     "flares"
    ]
   },
@@ -169,13 +186,13 @@
     "tags": []
    },
    "source": [
-    "Begin by inspecting the data array to gain a basic understanding of the data.\n",
-    "This task is open-ended, and you can continue when you feel confident that you know what `flares` contains.\n",
+    "Begin by inspecting the data group and flares data array to gain a basic understanding of the data.\n",
+    "This task is open-ended, and you can continue when you feel confident that you know what `flares` (and `flare_data`) contains.\n",
     "\n",
     "Possible actions:\n",
     "\n",
     "- Use [scipp.show](https://scipp.github.io/generated/functions/scipp.show.html) and [scipp.table](https://scipp.github.io/generated/functions/scipp.table.html) in addition to the HTML output of the cell above.\n",
-    "- Extract individual coordinates and attributes using `flares.coords['<name>']` and `flares.attrs['<name>']`.\n",
+    "- Inspect individual coordinates using `flares.coords['<name>']`.\n",
     "\n",
     "For guidance, you can answer the following questions. Or find your own.\n",
     "\n",
@@ -183,7 +200,7 @@
     "- How many flares are flagged as 'non_solar'?\n",
     "- What is the time range of the data?\n",
     "\n",
-    "**Tip**: Use [scipp.sum](https://scipp.github.io/generated/functions/scipp.sum.html), [scipp.max](https://scipp.github.io/generated/functions/scipp.max.html), and [scipp.min](https://scipp.github.io/generated/functions/scipp.min.html) with the coordinates and attributes of `flares`."
+    "**Tip**: Use [scipp.sum](https://scipp.github.io/generated/functions/scipp.sum.html), [scipp.max](https://scipp.github.io/generated/functions/scipp.max.html), and [scipp.min](https://scipp.github.io/generated/functions/scipp.min.html) with the coordinates of `flares` and items of `flare_data`."
    ]
   },
   {
@@ -206,7 +223,7 @@
    "cell_type": "markdown",
    "id": "44486819-1a13-40a2-a80b-e0bf5c9de3ab",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
+    "tags": []
    },
    "source": [
     "#### Solution"
@@ -216,7 +233,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7903232a-07f0-487a-a177-026fe5196246",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Number of flares\n",
@@ -227,18 +246,22 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "20eff55f-2cb7-4645-ba6c-9891f56b72c9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Number of flares flagged as non-solar\n",
-    "flares.attrs['non_solar'].sum()"
+    "flare_data['non_solar'].sum()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ad38c88d-9ec7-4333-976b-51f5ac2de843",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Start of time range\n",
@@ -249,7 +272,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f37f3588-fcf9-48e4-9df4-c19e9729ca7e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# End of time range\n",
@@ -291,7 +316,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "923be2ea-e1bf-47bf-9f3f-46d2556512cf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# YOUR CODE"
@@ -301,7 +328,6 @@
    "cell_type": "markdown",
    "id": "9cb29a55-0956-45a2-bc3d-a6e727dfc581",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -320,7 +346,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "12a58486-89db-4af8-ab0e-c0380c0ec081",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "duration = flares.coords['end_time'] - flares.coords['start_time']\n",
@@ -339,7 +367,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dd4a37f4-b50e-490d-b725-d43f12f00220",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def compute_duration(start_time, end_time):\n",
@@ -352,7 +382,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dcd87fde-d81e-4eb3-b214-88452b8f38ea",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "flares"
@@ -392,7 +424,7 @@
    "cell_type": "markdown",
    "id": "e20382fc-b277-4a16-acf7-207dd1536442",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
+    "tags": []
    },
    "source": [
     "#### Solution"
@@ -402,7 +434,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "02d7fcdd-3fcb-400c-a0c8-01f376605d18",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "sc.sum(duration).to(unit='D', dtype='float64')"
@@ -442,8 +476,8 @@
     "That is, the masks can be removed later to get the full event list back in order to determine the impact of the masks.\n",
     "\n",
     "#### Non-solar mask\n",
-    "First, store `'non_solar'` as a mask and remove it from the attributes.\n",
-    "Use `flares.attrs` and `flares.masks` which are `dict`-like objects (similar to `flares.coords`)."
+    "First, store `'non_solar'` as a mask.\n",
+    "Use `flare_data` and `flares.masks` which are `dict`-like objects (similar to `flares.coords`)."
    ]
   },
   {
@@ -462,7 +496,7 @@
    "cell_type": "markdown",
    "id": "5aed2960-d89e-45db-aed7-106a5daea6d1",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
+    "tags": []
    },
    "source": [
     "#### Solution"
@@ -472,10 +506,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1ca38b96-0e36-428d-8598-be70a2bea883",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "flares.masks['non_solar'] = flares.attrs.pop('non_solar')"
+    "flares.masks['non_solar'] = flare_data['non_solar']"
    ]
   },
   {
@@ -513,7 +549,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2d6da120-aa3a-4122-8403-da3fb274927a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# YOUR CODE"
@@ -523,7 +561,6 @@
    "cell_type": "markdown",
    "id": "379dac75-6b1d-4b46-8eed-2bf31a8fec4f",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -534,7 +571,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e21f1c3d-cf78-458e-a915-373f286c4c4c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "flares.masks['unknown_position'] = (\n",
@@ -565,7 +604,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "37ece29c-a823-4a77-9a17-8e1e33345b06",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# YOUR CODE"
@@ -575,7 +616,7 @@
    "cell_type": "markdown",
    "id": "ad1412df-fb93-4e4a-80e2-c1592b99d464",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
+    "tags": []
    },
    "source": [
     "#### Solution"
@@ -585,7 +626,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0523915c-0231-4be2-af30-520e411ba76a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ns_mask = flares.masks['non_solar']\n",
@@ -662,19 +705,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9cd94184-605e-4942-9a37-66ef1bfe9836",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# YOUR CODE"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "45c4239e-4674-4a4e-88c0-9a03ad3861e6",
    "metadata": {
     "editable": true,
-    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -696,7 +739,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "abf5dc78-3f0f-4a99-9c23-107b23053155",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "spatial = flares.bin(y=sc.linspace('y', -1200, 1200, 100, unit='asec'),\n",
@@ -716,7 +761,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c5944897-da22-40fa-af98-71a01d1fba09",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p = spatial.hist().plot(aspect='equal',\n",
@@ -773,7 +820,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3aca7442-6d7f-484f-9250-e4aa4a76ad56",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# YOUR CODE"
@@ -783,7 +832,6 @@
    "cell_type": "markdown",
    "id": "9113724b-e546-4698-bae9-c9c397a23b58",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -797,7 +845,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6900f4ba-a69b-43b3-a730-10c4b97e9473",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "spatial = flares.bin(y=sc.linspace('y', -600, 600, 90, unit='asec'),\n",
@@ -816,7 +866,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a3eaaba5-5a1e-4073-b841-c91e2453a571",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p = spatial.hist().plot(aspect='equal',\n",
@@ -858,7 +910,7 @@
     "(The reality is more complicated, of course. See the [wiki](https://sprg.ssl.berkeley.edu/~tohban/wiki/index.php/Category:RHESSI) for more information.)\n",
     "Furthermore, the tutorial data has been manipulated to simulate different efficiencies of the individual detectors.\n",
     "\n",
-    "The efficiency is available as an attribute:"
+    "The efficiency is available in the input data group:"
    ]
   },
   {
@@ -870,7 +922,7 @@
    },
    "outputs": [],
    "source": [
-    "efficiency = flares.attrs['detector_efficiency'].value\n",
+    "efficiency = flare_data['detector_efficiency']\n",
     "efficiency"
    ]
   },
@@ -897,7 +949,6 @@
    "cell_type": "markdown",
    "id": "c1fcefac-1d52-479b-beaa-129f0ca3065a",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -954,7 +1005,6 @@
    "cell_type": "markdown",
    "id": "1c95f462-89c8-4d3f-85b6-97b8bff9c083",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1064,7 +1114,6 @@
    "cell_type": "markdown",
    "id": "61d012c3-76f6-41e8-9294-686bad746738",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1203,7 +1252,7 @@
    "cell_type": "markdown",
    "id": "aa907e4b-524c-4ef2-8cf4-38d68b3c7b61",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
+    "tags": []
    },
    "source": [
     "#### Solution"
@@ -1277,7 +1326,7 @@
    "metadata": {},
    "source": [
     "The flares were recorded in several non-overlapping energy bands.\n",
-    "Those are identified by the 'min_energy' and 'max_energy' attributes in `flares`.\n",
+    "Those are identified by the 'min_energy' and 'max_energy' coordinates in `flares`.\n",
     "Since the bands do not overlap, it is sufficient to label them with 'min_energy' for simplicity.\n",
     "\n",
     "### 4.1 Group by energy content\n",
@@ -1369,7 +1418,6 @@
    "cell_type": "markdown",
    "id": "f8c62519-5e18-44c2-9fa2-f8abc43e2b15",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1434,7 +1482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/solar_flares.ipynb
+++ b/docs/tutorials/solar_flares.ipynb
@@ -112,7 +112,10 @@
     "tags": []
    },
    "source": [
-    "The file contains a number of items that are loaded together as a data group."
+    "The file contains a number of items that are loaded together as a data group.\n",
+    "- `flares`: The actual flare list.\n",
+    "- `non_solar`: Indicates whether a flare event actually originated from a source that is not the Sun.\n",
+    "- `detector_efficiency`: Relative efficiencies of the detector components. This is faked for the purposes of this tutorial! The official flare list is already corrected for such effects."
    ]
   },
   {
@@ -1482,7 +1485,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/solar_flares.ipynb
+++ b/docs/tutorials/solar_flares.ipynb
@@ -132,8 +132,8 @@
    "outputs": [],
    "source": [
     "filename = sc.data.rhessi_flares()\n",
-    "flare_data = sc.io.load_hdf5(filename)\n",
-    "flare_data"
+    "flare_datagroup = sc.io.load_hdf5(filename)\n",
+    "flare_datagroup"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flares = flare_data['flares']\n",
+    "flares = flare_datagroup['flares']\n",
     "flares"
    ]
   },
@@ -190,7 +190,7 @@
    },
    "source": [
     "Begin by inspecting the data group and flares data array to gain a basic understanding of the data.\n",
-    "This task is open-ended, and you can continue when you feel confident that you know what `flares` (and `flare_data`) contains.\n",
+    "This task is open-ended, and you can continue when you feel confident that you know what `flares` (and `flare_datagroup`) contains.\n",
     "\n",
     "Possible actions:\n",
     "\n",
@@ -203,7 +203,7 @@
     "- How many flares are flagged as 'non_solar'?\n",
     "- What is the time range of the data?\n",
     "\n",
-    "**Tip**: Use [scipp.sum](https://scipp.github.io/generated/functions/scipp.sum.html), [scipp.max](https://scipp.github.io/generated/functions/scipp.max.html), and [scipp.min](https://scipp.github.io/generated/functions/scipp.min.html) with the coordinates of `flares` and items of `flare_data`."
+    "**Tip**: Use [scipp.sum](https://scipp.github.io/generated/functions/scipp.sum.html), [scipp.max](https://scipp.github.io/generated/functions/scipp.max.html), and [scipp.min](https://scipp.github.io/generated/functions/scipp.min.html) with the coordinates of `flares` and items of `flare_datagroup`."
    ]
   },
   {
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "# Number of flares flagged as non-solar\n",
-    "flare_data['non_solar'].sum()"
+    "flare_datagroup['non_solar'].sum()"
    ]
   },
   {
@@ -480,7 +480,7 @@
     "\n",
     "#### Non-solar mask\n",
     "First, store `'non_solar'` as a mask.\n",
-    "Use `flare_data` and `flares.masks` which are `dict`-like objects (similar to `flares.coords`)."
+    "Use `flare_datagroup` and `flares.masks` which are `dict`-like objects (similar to `flares.coords`)."
    ]
   },
   {
@@ -514,7 +514,7 @@
    },
    "outputs": [],
    "source": [
-    "flares.masks['non_solar'] = flare_data['non_solar']"
+    "flares.masks['non_solar'] = flare_datagroup['non_solar']"
    ]
   },
   {
@@ -925,7 +925,7 @@
    },
    "outputs": [],
    "source": [
-    "efficiency = flare_data['detector_efficiency']\n",
+    "efficiency = flare_datagroup['detector_efficiency']\n",
     "efficiency"
    ]
   },

--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -125,12 +125,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import scipp as sc\n",
     "\n",
-    "da = sc.data.vulcan_steel_strain_data()\n",
+    "dg = sc.data.vulcan_steel_strain_data()\n",
+    "dg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da = dg['data']\n",
     "da"
    ]
   },
@@ -144,7 +156,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "da.hist().plot()"
@@ -165,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "strain = da.attrs['loadframe.strain'].value\n",
+    "strain = dg['loadframe.strain']\n",
     "strain.plot()"
    ]
   },
@@ -227,10 +241,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "proton_charge = da.attrs['proton_charge'].value\n",
+    "proton_charge = dg['proton_charge']\n",
     "proton_charge.plot()"
    ]
   },
@@ -323,10 +339,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "proton_charge = da.attrs['proton_charge'].value\n",
+    "proton_charge = dg['proton_charge']\n",
     "charge_per_time_interval = proton_charge.bin(time=strain.coords['time'])\n",
     "charge_per_time_interval.coords['strain'] = strain.data\n",
     "charge_per_strain_value = charge_per_time_interval.bin(strain=filtered.coords['strain']).hist()"
@@ -378,7 +396,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "coarse = normalized.hist(strain=6, dspacing=200)\n",
@@ -403,7 +423,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/computation.ipynb
+++ b/docs/user-guide/computation.ipynb
@@ -17,7 +17,6 @@
     "| coord | compare, abort on mismatch |\n",
     "| data | apply operation |\n",
     "| mask | combine with `or` |\n",
-    "| attr | typically ignored or dropped |\n",
     "\n",
     "In the special case of in-place operations such as `+=` or `*=` Scipp preserves existing attributes and ignores attributes of the right-hand-side.\n",
     "\n",

--- a/docs/user-guide/computation.ipynb
+++ b/docs/user-guide/computation.ipynb
@@ -18,8 +18,6 @@
     "| data | apply operation |\n",
     "| mask | combine with `or` |\n",
     "\n",
-    "In the special case of in-place operations such as `+=` or `*=` Scipp preserves existing attributes and ignores attributes of the right-hand-side.\n",
-    "\n",
     "### Dimension matching and transposing\n",
     "\n",
     "Operations \"align\" variables based on their dimension labels.\n",
@@ -552,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/data-structures/creating-arrays-and-datasets.ipynb
+++ b/docs/user-guide/data-structures/creating-arrays-and-datasets.ipynb
@@ -447,7 +447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Less frequently used, similar to `coords`, a data array can be created with `masks` and `attrs`:"
+    "Less frequently used, similar to `coords`, a data array can be created with `masks`:"
    ]
   },
   {
@@ -457,17 +457,16 @@
    "outputs": [],
    "source": [
     "x = sc.linspace('x', start=1.5, stop=3.0, num=4, unit='m')\n",
-    "a = sc.scalar('an attribute')\n",
     "m = sc.array(dims=['x'], values=[True, False, True, False])\n",
     "data = x ** 2\n",
-    "sc.DataArray(data, coords={'x': x}, attrs={'a': a}, masks={'m': m})"
+    "sc.DataArray(data, coords={'x': x}, masks={'m': m})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`coords`, `attrs`, and `masks` are optional but the `data` must always be given.\n",
+    "`coords` and `masks` are optional but the `data` must always be given.\n",
     "Note how the creation functions for `scipp.Variable` can be used to make the individual pieces of a data array.\n",
     "These variables are not copied into the data array.\n",
     "Rather, the data array contains a reference to the same underlying piece of memory.\n",
@@ -501,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da1 = sc.DataArray(data, coords={'x': x}, attrs={'a': a}, masks={'m': m})\n",
+    "da1 = sc.DataArray(data, coords={'x': x}, masks={'m': m})\n",
     "da2 = sc.DataArray(-data, coords={'x': x})\n",
     "sc.Dataset({'data1': da1, 'data2': da2})"
    ]
@@ -525,11 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from io import BytesIO\n",
@@ -552,11 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -568,9 +559,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "tags": []
    },
    "outputs": [],

--- a/docs/user-guide/data-structures/data-structures.ipynb
+++ b/docs/user-guide/data-structures/data-structures.ipynb
@@ -203,14 +203,13 @@
     "### Basics\n",
     "\n",
     "[scipp.DataArray](../../generated/classes/scipp.DataArray.rst#scipp.DataArray) is a labeled array with associated coordinates.\n",
-    "A data array is essentially a [Variable](../../generated/classes/scipp.Variable.rst#scipp.Variable) object with attached dicts of coordinates, masks, and attributes.\n",
+    "A data array is essentially a [Variable](../../generated/classes/scipp.Variable.rst#scipp.Variable) object with attached dicts of coordinates and masks.\n",
     "\n",
     "A data array has the following key properties:\n",
     "\n",
     "- `data`: the variable holding the array data (its values, variances, dims, and unit).\n",
     "- `coords`: a dict-like container of coordinates for the array.\n",
     "- `masks`: a dict-like container of masks for the array.\n",
-    "- `attrs`: a dict-like container of \"attributes\" for the array.\n",
     "\n",
     "All dict-likes are accessed using a string as key.\n",
     "\n",
@@ -220,9 +219,17 @@
     "\n",
     "`masks` allows for storing boolean-valued masks alongside data.\n",
     "\n",
-    "`attrs` holds additional metadata which is similar to coordinates but is dropped in operations if there is a mismatch.\n",
+    "`data` as well as the individual values of the `coords` and `masks` dictionaries are of type [Variable](../../generated/classes/scipp.Variable.rst#scipp.Variable), i.e., they have a physical unit and can be used for computation.\n",
     "\n",
-    "`data` as well as the individual values of the `coords`, `masks`, and `attrs` dictionaries are of type [Variable](../../generated/classes/scipp.Variable.rst#scipp.Variable), i.e., they have a physical unit and can be used for computation.\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "    **Deprecation**\n",
+    "\n",
+    "Data arrays also have `attrs` which are essentially unaligned coordinates.\n",
+    "`attrs` have been deprecated in version 23.09.0 and will be removed in version 24.12.0.\n",
+    "See [ADR 0016](../../reference/developer/adr/0016-do-not-support-attrs.rst)\n",
+    "</div>\n",
+    "\n",
     "A data array can be created from variables for its constituents as follows:"
    ]
   },
@@ -240,7 +247,9 @@
     "        'y': sc.array(dims=['y'], values=np.arange(2.0), unit='m'),\n",
     "        'x': sc.array(dims=['x'], values=np.arange(3.0), unit='m'),\n",
     "    },\n",
-    "    attrs={'aux': sc.array(dims=['x'], values=np.random.rand(3))},\n",
+    "    masks={\n",
+    "        'm': sc.array(dims=['x'], values=[False, True, False]),\n",
+    "    }\n",
     ")\n",
     "sc.show(da)"
    ]
@@ -249,7 +258,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note how the `'aux'` attribute is essentially a secondary coordinate for the x dimension.\n",
     "The dict-like `coords` and `masks` properties give access to the respective underlying variables:"
    ]
   },
@@ -268,40 +276,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da.attrs['aux']"
+    "da.masks['m']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Access to coords and attrs in a unified manner is possible with the `meta` property.\n",
-    "Essentially this allows us to ignore whether a coordinate is aligned or not:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "da.meta['x']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "da.meta['aux']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Unlike `values` when creating a variable, `data` as well as entries in the meta data dicts (`coords`, `masks`, and `attrs`) are *not* deep-copied on insertion into a data array.\n",
+    "Unlike `values` when creating a variable, `data` as well as entries in the metadata dicts (`coords` and `masks`) are *not* deep-copied on insertion into a data array.\n",
     "To avoid unwanted sharing, call the `copy()` method.\n",
     "Compare:"
    ]
@@ -332,7 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "del da.attrs['aux']"
+    "del da.coords['x2_shared']"
    ]
   },
   {
@@ -502,8 +484,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each data item is linked to its corresponding coordinates, masks, and attributes.\n",
-    "These are accessed using the `coords` , `masks`, and `attrs` properties.\n",
+    "Each data item is linked to its corresponding coordinates and masks.\n",
+    "These are accessed using the `coords` and `masks` properties.\n",
     "The variable holding the data of the dataset item is accessible via the `data` property:"
    ]
   },

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -225,10 +225,6 @@
     "        'y': sc.array(dims=['y'], values=np.arange(2.0), unit='m'),\n",
     "    },\n",
     "    masks={'mask': sc.array(dims=['x'], values=[True, False, False])},\n",
-    "    attrs={\n",
-    "        'aux_x': sc.array(dims=['x'], values=np.arange(3.0), unit='m'),\n",
-    "        'aux_y': sc.array(dims=['y'], values=np.arange(2.0), unit='m'),\n",
-    "    },\n",
     ")\n",
     "sc.show(a)\n",
     "a"
@@ -242,14 +238,14 @@
     "\n",
     "When slicing a data array the following additional rule applies:\n",
     "\n",
-    "- Meta data (coords, masks, attrs) that *do not depend on the slice dimension* are marked as *readonly*\n",
+    "- Meta data (coords, masks) that *do not depend on the slice dimension* are marked as *readonly*\n",
     "- Slicing **without range**:\n",
     "  - The *coordinates* for the sliced dimension become unaligned.\n",
     "- Slicing **with a range**:\n",
     "  - The *coordinates* for the sliced dimension keep their alignment.\n",
     "\n",
     "The rationale behind this mechanism is as follows.\n",
-    "Meta data is often of a lower dimensionality than data, such as in this example where coords, masks, and attrs are 1-D whereas data is 2-D.\n",
+    "Meta data is often of a lower dimensionality than data, such as in this example where coords and masks are 1-D whereas data is 2-D.\n",
     "Elements of meta data entries are thus shared by many data elements, and we must be careful to not apply operations to subsets of data while unintentionally modifying meta data for other unrelated data elements:"
    ]
   },
@@ -367,6 +363,7 @@
     "### Datasets\n",
     "\n",
     "Slicing for datasets works just like for data arrays.\n",
+    "In addition to making certain coords unaligned and marking certain meta data entries as read-only, slicing a dataset also marks lower-dimensional *data entries* readonly.\n",
     "Consider a dataset `d`:"
    ]
   },
@@ -506,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case `2023` is the second element of the coordinate so this is equivalent to positionally slicing `data['year', 1]` and [the usual rules](#Positional-indexing) regarding dropping dimensions and converting dimension coordinates to attributes apply:"
+    "In this case `2023` is the second element of the coordinate so this is equivalent to positionally slicing `data['year', 1]` and [the usual rules](#Positional-indexing) regarding dropping dimensions and making dimension coordinates unaligned apply:"
    ]
   },
   {

--- a/docs/user-guide/slicing.ipynb
+++ b/docs/user-guide/slicing.ipynb
@@ -956,7 +956,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/visualization/representations-and-tables.ipynb
+++ b/docs/visualization/representations-and-tables.ipynb
@@ -52,9 +52,7 @@
     "                       unit='angstrom')},\n",
     "    coords={'x':x, 'y':y, 'y_label':labels})\n",
     "ds['b'] = ds['a']\n",
-    "ds['a'].attrs['x_attr'] = sc.array(dims=['x'], values=[1.77, 3.32])\n",
-    "ds['b'].attrs['x_attr'] = sc.array(dims=['x'], values=[55.7, 105.1])\n",
-    "ds['b'].attrs['b_attr'] = 1.2 * sc.units.m"
+    "ds['c'] = 1.0 * sc.units.kg"
    ]
   },
   {

--- a/docs/visualization/representations-and-tables.ipynb
+++ b/docs/visualization/representations-and-tables.ipynb
@@ -51,8 +51,7 @@
     "                       variances=0.1 * np.random.random((3, 2)),\n",
     "                       unit='angstrom')},\n",
     "    coords={'x':x, 'y':y, 'y_label':labels})\n",
-    "ds['b'] = ds['a']\n",
-    "ds['c'] = 1.0 * sc.units.kg"
+    "ds['b'] = ds['a']"
    ]
   },
   {

--- a/src/scipp/data/__init__.py
+++ b/src/scipp/data/__init__.py
@@ -34,7 +34,7 @@ or install all optional components of Scipp:
         base_url='https://public.esss.dk/groups/scipp/scipp/{version}/',
         version=_version,
         registry={
-            'rhessi_flares.h5': 'md5:13a73789d3777e79d60ee172d63b4af6',
+            'rhessi_flares.h5': 'md5:b4fdc9508c6d1d7aab1c6ebdd13956f2',
             'VULCAN_221040_processed.h5': 'md5:626484b95372d3341b156dc2012722f9',
         },
     )

--- a/src/scipp/data/__init__.py
+++ b/src/scipp/data/__init__.py
@@ -3,10 +3,10 @@
 # @author Simon Heybrock
 from functools import lru_cache
 
-from ..core import DataArray, array, linspace, ones
+from ..core import DataArray, DataGroup, array, linspace, ones
 from ..io import load_hdf5
 
-_version = '1'
+_version = '2'
 
 
 @lru_cache(maxsize=1)
@@ -35,7 +35,7 @@ or install all optional components of Scipp:
         version=_version,
         registry={
             'rhessi_flares.h5': 'md5:13a73789d3777e79d60ee172d63b4af6',
-            'VULCAN_221040_processed.h5': 'md5:58342d57e0f12e362504fa27af7361f3',
+            'VULCAN_221040_processed.h5': 'md5:626484b95372d3341b156dc2012722f9',
         },
     )
 
@@ -65,7 +65,7 @@ def rhessi_flares() -> str:
     return get_path('rhessi_flares.h5')
 
 
-def vulcan_steel_strain_data() -> DataArray:
+def vulcan_steel_strain_data() -> DataGroup:
     return load_hdf5(get_path('VULCAN_221040_processed.h5'))
 
 


### PR DESCRIPTION
Part of #3166.

I did not yet touch the data creation scripts ~`prepare_data_rhessi.py` and `prepare-filtering-data.py`~. The former should wait until #3258 is merged ~and I haven't looked in detail at the latter yet~.

Also, I did not touch ADRs after talking to Neil about it. We agreed that ADRs should not change after they were accepted.

EDIT
Migrated the event filtering example.

EDIT
Migrated the solar flares example.
Unfortunately, NASA updated the flare list and it is now filtered such that the tutorial doesn't make much sense. So I stuck with the old data. But since I don't have a copy of the old flare list, I modified our old hdf5 file.