### PR TITLE
Do not drop inputs and intermediates in empty dataset `transform_coords`

### DIFF
--- a/tests/coords/transform_coords_test.py
+++ b/tests/coords/transform_coords_test.py
@@ -698,7 +698,7 @@ def test_dataset_without_data(a):
     ds = sc.Dataset(coords={'a': a.copy()})
     transformed = ds.transform_coords('b', graph={'b': 'a'})
     assert sc.identical(transformed.coords['b'], a.rename(a='b'))
-    assert 'a' not in transformed.coords
+    assert not transformed.coords['a'].aligned
     assert len(transformed) == 0
 
 


### PR DESCRIPTION
Closes #3156.

My comment in the linked issue actually overlooked that removing `attrs` is not enough to simplify the code, since we may still have binned data in dataset items, each with their own coords. Therefore, the core aspect cannot be simplified.

I found this minor leftover from the pre-alignment-flag implementation, which I fix here, making behavior of `transform_coords` consistent between `DataArray` and `Dataset`, even in the "empty" case.