### PR TITLE
Add missing dtypes in `where`

### DIFF
--- a/lib/core/include/scipp/core/element/util.h
+++ b/lib/core/include/scipp/core/element/util.h
@@ -8,6 +8,7 @@
 
 #include "scipp/common/numeric.h"
 #include "scipp/common/overloaded.h"
+#include "scipp/core/eigen.h"
 #include "scipp/core/element/arg_list.h"
 #include "scipp/core/subbin_sizes.h"
 #include "scipp/core/time_point.h"
@@ -128,12 +129,13 @@ constexpr auto fill_zeros =
     overloaded{arg_list<double, float, int64_t, int32_t, SubbinSizes>,
                [](units::Unit &) {}, [](auto &x) { x = 0; }};
 
+template <class... Ts>
+constexpr arg_list_t<std::tuple<bool, Ts, Ts>...> where_arg_list{};
+
 constexpr auto where = overloaded{
-    core::element::arg_list<
-        std::tuple<bool, double, double>, std::tuple<bool, float, float>,
-        std::tuple<bool, int64_t, int64_t>, std::tuple<bool, int32_t, int32_t>,
-        std::tuple<bool, bool, bool>, std::tuple<bool, time_point, time_point>,
-        std::tuple<bool, scipp::index_pair, scipp::index_pair>>,
+    where_arg_list<double, float, int64_t, int32_t, bool, core::time_point,
+                   index_pair, std::string, Eigen::Vector3d, Eigen::Matrix3d,
+                   Eigen::Affine3d, core::Quaternion, core::Translation>,
     transform_flags::force_variance_broadcast,
     [](const auto &condition, const auto &x, const auto &y) {
       return condition ? x : y;

--- a/tests/core/reduction_test.py
+++ b/tests/core/reduction_test.py
@@ -405,3 +405,10 @@ def test_any_single_dim(container):
     assert sc.identical(
         x.any('yy'), container(sc.array(dims=['xx'], values=[True, True]))
     )
+
+
+def test_reduction_with_mask_works_with_vectors():
+    data = sc.vectors(dims=['x'], values=np.arange(12, dtype=np.int64).reshape(4, 3))
+    mask = sc.array(dims=['x'], values=[False, True, False, True])
+    da = sc.DataArray(data=data, masks={'mask': mask})
+    da.sum()


### PR DESCRIPTION
Fixes #3271

Note that we are still not supporting nigher-level types such as `Variable` or `DataArray`.