### PR TITLE
Fix operations on transposed binned data; remove binned data operation overhead

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -33,6 +33,9 @@ vrelease
 Features
 ~~~~~~~~
 
+* Operations on binned variables with a data array content buffer now also work with slices of binned variables `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
+* Reduced per-bin overhead in many operations involving binned variables by about 20 milliseconds per 1 million bins `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
@@ -44,6 +47,7 @@ Bugfixes
 * Fixed reduction operations for data arrays containing vectors with masks `#3276 <https://github.com/scipp/scipp/pull/3276>`_.
 * Fixed :func:`scipp.where` to work with most dtypes `#3276 <https://github.com/scipp/scipp/pull/3276>`_.
 * Event-centric arithmetic now uses the correct dtype in the result `#3278 <https://github.com/scipp/scipp/pull/3278>`_.
+* Fixed a serious bug where operations on, e.g., transposed binned data resulted in corrupt coord, mask, and attr values of the bin contents  `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/lib/dataset/test/binned_arithmetic_test.cpp
+++ b/lib/dataset/test/binned_arithmetic_test.cpp
@@ -83,7 +83,7 @@ TEST_F(BinnedArithmeticTest, var_and_array) {
 TEST_F(BinnedArithmeticTest, op_on_transpose) {
   const auto indices2d =
       makeVariable<scipp::index_pair>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                      Values{std::pair{0, 1}, std::pair{1, 2},
+                                      Values{std::pair{0, 1}, std::pair{1, 1},
                                              std::pair{2, 4}, std::pair{4, 5}});
   const auto binned = make_bins(indices2d, Dim::Event, array);
   const auto transposed = transpose(binned);
@@ -94,7 +94,7 @@ TEST_F(BinnedArithmeticTest, op_on_transpose) {
 TEST_F(BinnedArithmeticTest, op_on_transpose_with_dtype_change) {
   const auto indices2d =
       makeVariable<scipp::index_pair>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                      Values{std::pair{0, 1}, std::pair{1, 2},
+                                      Values{std::pair{0, 1}, std::pair{1, 1},
                                              std::pair{2, 4}, std::pair{4, 5}});
   DataArray int_array =
       DataArray(astype(var, dtype<int>), {{Dim::X, var + var}});

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -104,8 +104,10 @@ private:
     auto buffer = DataArray(
         variable::variableFactory().create(type, dims, unit, variances),
         copy(source.coords()), copy(source.masks()), copy(source.attrs()));
-    // TODO is the copy needed?
-    return make_bins(copy(indices), dim, std::move(buffer));
+    // only caller appears to be BinVariableMaker::create, which makes its own
+    // valid indices? is all we need a buffer size check, or is that valid as
+    // well?
+    return make_bins_no_validate(indices, dim, std::move(buffer));
   }
   const Variable &data(const Variable &var) const override {
     return buffer(var).data();

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -104,7 +104,7 @@ private:
     auto data_buffer =
         variable::variableFactory().create(type, dims, unit, variances);
     // If the buffer size is unchanged and input indices match output indices we
-    // can use a cheap and simply copy of the buffers coords and masks.
+    // can use a cheap and simple copy of the buffer's coords and masks.
     // Otherwise we fall back to a copy via the binned views of the respective
     // content buffers.
     if (source.dims() == Dimensions{dim, dims.volume()} &&

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -104,9 +104,8 @@ private:
     auto buffer = DataArray(
         variable::variableFactory().create(type, dims, unit, variances),
         copy(source.coords()), copy(source.masks()), copy(source.attrs()));
-    // only caller appears to be BinVariableMaker::create, which makes its own
-    // valid indices? is all we need a buffer size check, or is that valid as
-    // well?
+    // The only caller is BinVariableMaker::create, which should ensure that
+    // indices and buffer size are valid and compatible.
     return make_bins_no_validate(indices, dim, std::move(buffer));
   }
   const Variable &data(const Variable &var) const override {

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -99,14 +99,29 @@ private:
             .dims()) // would need to select and copy slices from source coords
       throw std::runtime_error(
           "Shape changing operations with bucket<DataArray> not supported yet");
-    // TODO This may also fail if the input buffer has extra capacity (rows not
-    // in any bucket).
-    auto buffer = DataArray(
-        variable::variableFactory().create(type, dims, unit, variances),
-        copy(source.coords()), copy(source.masks()), copy(source.attrs()));
     // The only caller is BinVariableMaker::create, which should ensure that
     // indices and buffer size are valid and compatible.
-    return make_bins_no_validate(indices, dim, std::move(buffer));
+    auto data_buffer =
+        variable::variableFactory().create(type, dims, unit, variances);
+    // If the buffer size is unchanged and input indices match output indices we
+    // can use a cheap and simply copy of the buffers coords and masks.
+    // Otherwise we fall back to a copy via the binned views of the respective
+    // content buffers.
+    if (source.dims() == Dimensions{dim, dims.volume()} &&
+        indices == parent.bin_indices()) {
+      auto buffer = DataArray(std::move(data_buffer), copy(source.coords()),
+                              copy(source.masks()), copy(source.attrs()));
+      return make_bins_no_validate(indices, dim, std::move(buffer));
+    } else {
+      auto buffer = resize_default_init(source, dim, dims.volume());
+      auto out = make_bins_no_validate(indices, dim, std::move(buffer));
+      // Note the inefficiency here: The data is copied, even though it will be
+      // replaced and overwritten. Since this branch is a special case it is not
+      // worth the effort to avoid this.
+      copy(parent, out);
+      out.bin_buffer<DataArray>().setData(std::move(data_buffer));
+      return out;
+    }
   }
   const Variable &data(const Variable &var) const override {
     return buffer(var).data();

--- a/lib/variable/bin_array_variable.cpp
+++ b/lib/variable/bin_array_variable.cpp
@@ -28,10 +28,6 @@ scipp::index size_from_end_index(const Variable &end) {
                                  : 0;
 }
 
-const scipp::index &index_value(const Variable &index) {
-  return index.value<scipp::index>();
-}
-
 VariableConceptHandle zero_indices(const scipp::index size) {
   return makeVariable<scipp::index_pair>(Dims{Dim::X}, Shape{size})
       .data_handle();

--- a/lib/variable/bin_array_variable.cpp
+++ b/lib/variable/bin_array_variable.cpp
@@ -11,7 +11,7 @@ std::tuple<Variable, scipp::index> contiguous_indices(const Variable &parent,
   auto indices = Variable(parent, dims);
   copy(parent, indices);
   scipp::index size = 0;
-  for (auto &range : indices.values<scipp::index_pair>()) {
+  for (auto &range : indices.values<scipp::index_pair>().as_span()) {
     range.second += size - range.first;
     range.first = size;
     size = range.second;

--- a/lib/variable/include/scipp/variable/bin_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/bin_array_variable.tcc
@@ -30,7 +30,6 @@ contiguous_indices(const Variable &parent, const Dimensions &dims);
 SCIPP_VARIABLE_EXPORT const scipp::index_pair *
 index_pair_data(const Variable &indices);
 SCIPP_VARIABLE_EXPORT scipp::index size_from_end_index(const Variable &end);
-SCIPP_VARIABLE_EXPORT const scipp::index &index_value(const Variable &index);
 SCIPP_VARIABLE_EXPORT VariableConceptHandle
 zero_indices(const scipp::index size);
 } // namespace bin_array_variable_detail
@@ -81,8 +80,9 @@ public:
     }
     const auto end = cumsum(sizes_);
     const auto begin = end - sizes_;
-    const auto size = bin_array_variable_detail::index_value(sum(end - begin));
-    return make_bins(zip(begin, end), dim, resize_default_init(buf, dim, size));
+    const auto size = bin_array_variable_detail::size_from_end_index(end);
+    return make_bins_no_validate(zip(begin, end), dim,
+                                 resize_default_init(buf, dim, size));
   }
 };
 
@@ -129,6 +129,7 @@ public:
       const override {
     const Variable &parent = bin_parent(parents);
     const auto &[parentIndices, dim, buffer] = parent.constituents<T>();
+    // TODO is it faster to use sizes and cumsum approach, as elsewhere?
     auto [indices, size] =
         bin_array_variable_detail::contiguous_indices(parentIndices, dims);
     auto bufferDims = buffer.dims();

--- a/lib/variable/include/scipp/variable/bin_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/bin_array_variable.tcc
@@ -129,7 +129,6 @@ public:
       const override {
     const Variable &parent = bin_parent(parents);
     const auto &[parentIndices, dim, buffer] = parent.constituents<T>();
-    // TODO is it faster to use sizes and cumsum approach, as elsewhere?
     auto [indices, size] =
         bin_array_variable_detail::contiguous_indices(parentIndices, dims);
     auto bufferDims = buffer.dims();

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -26,8 +26,8 @@ private:
                           const bool variances) const override {
     // Buffer contains only variable, which is created with new dtype, no
     // information to copy from parent.
-    return make_bins(copy(indices), dim,
-                     variableFactory().create(type, dims, unit, variances));
+    return make_bins_no_validate(
+        indices, dim, variableFactory().create(type, dims, unit, variances));
   }
   const Variable &data(const Variable &var) const override {
     return this->buffer(var);


### PR DESCRIPTION
Fixes #3277.

Reviewer: **Please consider the logic very carefully, I think it is probably not enough to look at the diff. Please also verify that we can indeed skip the bin-index validation.**

Add support for operations on slices of binned data, which raised previously.

Aside from these changes, I am avoiding overhead in the setup logic of binned variables (tracing down this overhead is what actually led me to discover the linked bug). For few bins this is not so relevant, but it becomes significant when we have many bins. This may also impact some benchmarks @YooSunYoung is running for data-streaming applications.

Examples:

```python
# binned data array, with data-array as content
da.copy()
da * 1
da.bins.concat()
```
For 50M bins and 100M events in `da`, times reduce from around 2 seconds to 0.7 seconds, i.e., we removed 1.3 seconds overhead. For 10M bins I see around 250 ms gain, i.e., we can see this is roughly proportional to the total bin count.