### PR TITLE
Avoid internal use of deprecate `attrs` and `meta` properties

### DIFF
--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -95,8 +95,8 @@ def _combine_bins(
     # bins, without mixing contents from different unchanged bins.
     var = var.transpose(unchanged_dims + changed_dims)
     params = DataArray(var.bins.size(), coords=coords)
-    params.attrs['begin'] = var.bins.constituents['begin'].copy()
-    params.attrs['end'] = var.bins.constituents['end'].copy()
+    params.coords['begin'] = var.bins.constituents['begin'].copy()
+    params.coords['end'] = var.bins.constituents['end'].copy()
 
     # Sizes and begin/end indices of changed subspace
     sub_sizes = index(changed_volume).broadcast(
@@ -113,8 +113,8 @@ def _combine_bins(
     source = _cpp._bins_no_validate(
         data=var.bins.constituents['data'],
         dim=var.bins.constituents['dim'],
-        begin=params.bins.constituents['data'].attrs['begin'],
-        end=params.bins.constituents['data'].attrs['end'],
+        begin=params.bins.constituents['data'].coords['begin'],
+        end=params.bins.constituents['data'].coords['end'],
     )
     # Call `copy()` to reorder data. This is based on the underlying behavior of `copy`
     # for binned data: It computes a new contiguous and ordered mapping of bin contents
@@ -133,7 +133,7 @@ def combine_bins(
         data = _concat_bins(masked, dim=dim)
     else:
         names = [coord.dim for coord in itertools.chain(edges, groups)]
-        coords = {name: da.meta[name] for name in names}
+        coords = {name: da.coords[name] for name in names}
         data = _combine_bins(masked, coords=coords, edges=edges, groups=groups, dim=dim)
     out = rewrap_reduced_data(da, data, dim=dim)
     for coord in itertools.chain(edges, groups):

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -90,7 +90,7 @@ def lookup(
     """
     if dim is None:
         dim = func.dim
-    func = _cpp.DataArray(func.data, coords={dim: func.meta[dim]}, masks=func.masks)
+    func = _cpp.DataArray(func.data, coords={dim: func.coords[dim]}, masks=func.masks)
     if func.coords.is_edges(dim):
         if mode is not None:
             raise ValueError("Input is a histogram, 'mode' must not be set.")
@@ -164,9 +164,9 @@ class Bins:
             start = index.start
             stop = index.stop
             if start is None:
-                start = self._obj.bins.meta[dim].min()
+                start = self._obj.bins.coords[dim].min()
             if stop is None:
-                stop = _upper_bound(self._obj.bins.meta[dim].max())
+                stop = _upper_bound(self._obj.bins.coords[dim].max())
 
             if not (
                 isinstance(start, _cpp.Variable) and isinstance(stop, _cpp.Variable)
@@ -203,7 +203,7 @@ class Bins:
            store attributes in higher-level data structures.
         """
         _warn_attr_removal()
-        return _cpp._bins_view(self._data()).deprecated_meta
+        return self.deprecated_meta
 
     @property
     def attrs(self) -> MetaDataMap:
@@ -214,6 +214,14 @@ class Bins:
            store attributes in higher-level data structures.
         """
         _warn_attr_removal()
+        return self.deprecated_attrs
+
+    @property
+    def deprecated_meta(self) -> MetaDataMap:
+        return _cpp._bins_view(self._data()).deprecated_meta
+
+    @property
+    def deprecated_attrs(self) -> MetaDataMap:
         return _cpp._bins_view(self._data()).deprecated_attrs
 
     @property

--- a/src/scipp/core/concepts.py
+++ b/src/scipp/core/concepts.py
@@ -23,7 +23,7 @@ def rewrap_output_data(prototype: VariableLikeType, data) -> VariableLikeType:
         return DataArray(
             data=data,
             coords=prototype.coords,
-            attrs=prototype.attrs,
+            attrs=prototype.deprecated_attrs,
             masks=_copied(prototype.masks),
         )
     else:
@@ -65,7 +65,7 @@ def reduced_coords(da: DataArray, dim: Dims) -> Dict[str, Variable]:
 
 
 def reduced_attrs(da: DataArray, dim: Dims) -> Dict[str, Variable]:
-    return _reduced(da.attrs, concrete_dims(da, dim))
+    return _reduced(da.deprecated_attrs, concrete_dims(da, dim))
 
 
 def reduced_masks(da: DataArray, dim: Dims) -> Dict[str, Variable]:

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -114,16 +114,16 @@ def _rename_data_array(
     if out.bins is not None:
         out.data = bins(**out.bins.constituents)
     for old, new in renaming_dict.items():
-        if new in out.meta:
+        if new in out.deprecated_meta:
             raise CoordError(
                 f"Cannot rename '{old}' to '{new}', since a coord or attr named {new} "
                 "already exists."
             )
-        for meta in (out.coords, out.attrs):
+        for meta in (out.coords, out.deprecated_attrs):
             if old in meta:
                 meta[new] = meta.pop(old)
         if out.bins is not None:
-            for meta in (out.bins.coords, out.bins.attrs):
+            for meta in (out.bins.coords, out.bins.deprecated_attrs):
                 if old in meta:
                     meta[new] = meta.pop(old)
     return out

--- a/src/scipp/utils/comparison.py
+++ b/src/scipp/utils/comparison.py
@@ -69,13 +69,15 @@ def isnear(
         else True
     )
     same_len = (
-        len(x.meta) == len(y.meta) if include_attrs else len(x.coords) == len(y.coords)
+        len(x.deprecated_meta) == len(y.deprecated_meta)
+        if include_attrs
+        else len(x.coords) == len(y.coords)
     )
     if not same_len:
         return False
-    for key, val in x.meta.items() if include_attrs else x.coords.items():
-        a = x.meta[key] if include_attrs else x.coords[key]
-        b = y.meta[key] if include_attrs else y.coords[key]
+    for key, val in x.deprecated_meta.items() if include_attrs else x.coords.items():
+        a = x.deprecated_meta[key] if include_attrs else x.coords[key]
+        b = y.deprecated_meta[key] if include_attrs else y.coords[key]
         if a.shape != b.shape:
             raise CoordError(
                 f'Coord (or attr) with key {key} have different'

--- a/tests/bins_test.py
+++ b/tests/bins_test.py
@@ -520,28 +520,14 @@ def test_bins_concat_applies_irreducible_masks():
     assert sc.identical(da.bins.concat('x'), da['x', :4].bins.concat('x'))
 
 
-def test_bin_1d_by_coord_without_event_coord():
+@pytest.mark.parametrize('aligned', [True, False])
+def test_bin_1d_by_coord_without_event_coord(aligned: bool):
     table = sc.data.table_xyz(nrow=1000)
     da = table.bin(x=100)
     rng = default_rng(seed=1234)
     param = sc.array(dims='x', values=rng.random(da.sizes['x']))
     da.coords['param'] = param
-    edges = sc.linspace('param', 0.0, 1.0, num=13)
-    from scipp.core.bin_remapping import combine_bins
-
-    result = combine_bins(da, [edges], [], ['x'])
-    # Setup flat table with param for computing expected result
-    da.bins.coords['param'] = sc.bins_like(da, param)
-    table = da.bins.constituents['data']
-    assert sc.identical(result.hist(), table.hist(param=edges))
-
-
-def test_bin_1d_by_attr_without_event_coord():
-    table = sc.data.table_xyz(nrow=1000)
-    da = table.bin(x=100)
-    rng = default_rng(seed=1234)
-    param = sc.array(dims='x', values=rng.random(da.sizes['x']))
-    da.attrs['param'] = param
+    da.coords.set_aligned('param', aligned)
     edges = sc.linspace('param', 0.0, 1.0, num=13)
     from scipp.core.bin_remapping import combine_bins
 

--- a/tests/compat/wrapping_test.py
+++ b/tests/compat/wrapping_test.py
@@ -31,9 +31,9 @@ def make_array():
     mask = y.copy()
     mask.unit = ''
     da.masks['yy'] = mask < mask**2
-    da.attrs['xx'] = x
-    da.attrs['yy'] = y
-    da.attrs['scalar'] = x[0]
+    da.deprecated_attrs['xx'] = x
+    da.deprecated_attrs['yy'] = y
+    da.deprecated_attrs['scalar'] = x[0]
     return da
 
 


### PR DESCRIPTION
This avoids warnings in a number of operations.