### PR TITLE
Support init from numpy with any number of dimensions

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -36,7 +36,8 @@ Features
 * Operations on binned variables with a data array content buffer now also work with slices of binned variables `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
 * Reduced per-bin overhead in many operations involving binned variables by about 20 milliseconds per 1 million bins `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
 * It is now possible to construct Scipp variables from Numpy arrays with up to 6 dimensions for arbitrary memory layouts and any number of dimensions for c-contiguous memory layouts.
-  The limit used to be ``ndim <= 4`` `#3284 <https://github.com/scipp/scipp/pull/3284>`_.
+  The limit used to be ``ndim <= 4``.
+  This also improves performance in many cases `#3284 <https://github.com/scipp/scipp/pull/3284>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,6 +35,8 @@ Features
 
 * Operations on binned variables with a data array content buffer now also work with slices of binned variables `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
 * Reduced per-bin overhead in many operations involving binned variables by about 20 milliseconds per 1 million bins `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
+* It is now possible to construct Scipp variables from Numpy arrays with any number of dimensions.
+  It used to be limited to ``ndim <= 4`` `#3284 <https://github.com/scipp/scipp/pull/3284>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -35,8 +35,8 @@ Features
 
 * Operations on binned variables with a data array content buffer now also work with slices of binned variables `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
 * Reduced per-bin overhead in many operations involving binned variables by about 20 milliseconds per 1 million bins `#3282 <https://github.com/scipp/scipp/pull/3282>`_.
-* It is now possible to construct Scipp variables from Numpy arrays with any number of dimensions.
-  It used to be limited to ``ndim <= 4`` `#3284 <https://github.com/scipp/scipp/pull/3284>`_.
+* It is now possible to construct Scipp variables from Numpy arrays with up to 6 dimensions for arbitrary memory layouts and any number of dimensions for c-contiguous memory layouts.
+  The limit used to be ``ndim <= 4`` `#3284 <https://github.com/scipp/scipp/pull/3284>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/lib/python/numpy.h
+++ b/lib/python/numpy.h
@@ -78,6 +78,8 @@ auto cast_to_array_like(const py::object &obj, const units::Unit unit) {
 
 namespace scipp::detail {
 namespace {
+constexpr static size_t grainsize_1d = 10000;
+
 template <class T> bool is_c_contiguous(const py::array_t<T> &array) {
   Py_buffer buffer;
   if (PyObject_GetBuffer(array.ptr(), &buffer, PyBUF_C_CONTIGUOUS) != 0) {
@@ -109,7 +111,7 @@ void copy_array_1d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<1>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
+      core::parallel::blocked_range(0, src.shape(0), grainsize_1d),
       [&](const auto &range) {
         auto it = begin + range.begin();
         for (scipp::index i = range.begin(); i < range.end(); ++i, ++it) {
@@ -123,8 +125,7 @@ void copy_array_2d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<2>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
-      [&](const auto &range) {
+      core::parallel::blocked_range(0, src.shape(0)), [&](const auto &range) {
         auto it = begin + range.begin() * src.shape(1);
         for (scipp::index i = range.begin(); i < range.end(); ++i)
           for (scipp::index j = 0; j < src.shape(1); ++j, ++it)
@@ -137,8 +138,7 @@ void copy_array_3d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<3>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
-      [&](const auto &range) {
+      core::parallel::blocked_range(0, src.shape(0)), [&](const auto &range) {
         auto it = begin + range.begin() * src.shape(1) * src.shape(2);
         for (scipp::index i = range.begin(); i < range.end(); ++i)
           for (scipp::index j = 0; j < src.shape(1); ++j)
@@ -152,8 +152,7 @@ void copy_array_4d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<4>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
-      [&](const auto &range) {
+      core::parallel::blocked_range(0, src.shape(0)), [&](const auto &range) {
         auto it =
             begin + range.begin() * src.shape(1) * src.shape(2) * src.shape(3);
         for (scipp::index i = range.begin(); i < range.end(); ++i)
@@ -169,8 +168,7 @@ void copy_array_5d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<5>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
-      [&](const auto &range) {
+      core::parallel::blocked_range(0, src.shape(0)), [&](const auto &range) {
         auto it = begin + range.begin() * src.shape(1) * src.shape(2) *
                               src.shape(3) * src.shape(4);
         for (scipp::index i = range.begin(); i < range.end(); ++i)
@@ -187,8 +185,7 @@ void copy_array_6d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<6>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src.shape(0), 10000),
-      [&](const auto &range) {
+      core::parallel::blocked_range(0, src.shape(0)), [&](const auto &range) {
         auto it = begin + range.begin() * src.shape(1) * src.shape(2) *
                               src.shape(3) * src.shape(4) * src.shape(5);
         for (scipp::index i = range.begin(); i < range.end(); ++i)
@@ -207,7 +204,7 @@ void copy_flattened(const py::array_t<T> &src_array, Dst &dst) {
   auto src = reinterpret_cast<const T *>(src_buffer.ptr);
   const auto begin = dst.begin();
   core::parallel::parallel_for(
-      core::parallel::blocked_range(0, src_buffer.size, 10000),
+      core::parallel::blocked_range(0, src_buffer.size, grainsize_1d),
       [&](const auto &range) {
         auto it = begin + range.begin();
         for (scipp::index i = range.begin(); i < range.end(); ++i, ++it) {

--- a/lib/python/numpy.h
+++ b/lib/python/numpy.h
@@ -185,7 +185,7 @@ void copy_flattened(const typed_buffer<T> &src, Dst &dst) {
     const auto src_stride = src.stride(0);
     const auto dst_stride = inner_volume(src);
     core::parallel::parallel_for(
-        core::parallel::blocked_range(0, src.shape[0], 1000),
+        core::parallel::blocked_range(0, src.shape[0], 10000),
         [&](const auto &range) {
           auto block_dst = dst + range.begin() * dst_stride;
           copy_flattened_middle_dims<convert>(src, block_dst,

--- a/lib/python/numpy.h
+++ b/lib/python/numpy.h
@@ -98,14 +98,14 @@ void copy_element(const Source &src, Destination &&dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_0d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_0d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<0>();
   auto it = dst.begin();
   copy_element<convert>(src(), *it);
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_1d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_1d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<1>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -119,7 +119,7 @@ void copy_flattened_1d(const py::array_t<T> &src_array, Dst &dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_2d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_2d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<2>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -133,7 +133,7 @@ void copy_flattened_2d(const py::array_t<T> &src_array, Dst &dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_3d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_3d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<3>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -148,7 +148,7 @@ void copy_flattened_3d(const py::array_t<T> &src_array, Dst &dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_4d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_4d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<4>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -165,7 +165,7 @@ void copy_flattened_4d(const py::array_t<T> &src_array, Dst &dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_5d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_5d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<5>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -183,7 +183,7 @@ void copy_flattened_5d(const py::array_t<T> &src_array, Dst &dst) {
 }
 
 template <bool convert, class T, class Dst>
-void copy_flattened_6d(const py::array_t<T> &src_array, Dst &dst) {
+void copy_array_6d(const py::array_t<T> &src_array, Dst &dst) {
   const auto src = src_array.template unchecked<6>();
   const auto begin = dst.begin();
   core::parallel::parallel_for(
@@ -270,19 +270,19 @@ void copy_elements(const py::array_t<T> &src, Dst &dst) {
 
     switch (src_.ndim()) {
     case 0:
-      return copy_flattened_0d<convert>(src_, dst);
+      return copy_array_0d<convert>(src_, dst);
     case 1:
-      return copy_flattened_1d<convert>(src_, dst);
+      return copy_array_1d<convert>(src_, dst);
     case 2:
-      return copy_flattened_2d<convert>(src_, dst);
+      return copy_array_2d<convert>(src_, dst);
     case 3:
-      return copy_flattened_3d<convert>(src_, dst);
+      return copy_array_3d<convert>(src_, dst);
     case 4:
-      return copy_flattened_4d<convert>(src_, dst);
+      return copy_array_4d<convert>(src_, dst);
     case 5:
-      return copy_flattened_5d<convert>(src_, dst);
+      return copy_array_5d<convert>(src_, dst);
     case 6:
-      return copy_flattened_6d<convert>(src_, dst);
+      return copy_array_6d<convert>(src_, dst);
     default:
       throw std::runtime_error("Numpy array has more dimensions than supported "
                                "in the current implementation.");

--- a/lib/python/numpy.h
+++ b/lib/python/numpy.h
@@ -281,8 +281,11 @@ void copy_elements(const py::array_t<T> &src, Dst &dst) {
     case 6:
       return copy_array_6d<convert>(src_, dst);
     default:
-      throw std::runtime_error("Numpy array has more dimensions than supported "
-                               "in the current implementation.");
+      throw std::runtime_error(
+          "Numpy array with non-c-contiguous memory layout has more "
+          "dimensions than supported in the current implementation. "
+          "Try making a copy of the array first to get a "
+          "c-contiguous layout.");
     }
   };
   dispatch(memory_overlaps(src, dst) ? py::array_t<T>(src.request()) : src);

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -379,6 +379,29 @@ def test_array_nd_sliced_c_layout(ndim_and_slice_dim, step):
 
 
 @pytest.mark.parametrize(
+    'ndim_and_slice_dims',
+    [
+        (ndim, slice_dim0, slice_dim1)
+        for ndim in range(1, 7)
+        for slice_dim0 in range(ndim)
+        for slice_dim1 in range(ndim)
+    ],
+)
+@pytest.mark.parametrize('step', (2, -1, -2))
+def test_array_nd_sliced_twice_c_layout(ndim_and_slice_dims, step):
+    ndim, slice_dim0, slice_dim1 = ndim_and_slice_dims
+    shape = list(range(2, ndim + 2))
+    values = np.arange(np.prod(shape)).reshape(shape)
+    values = slice_array_in_dim(
+        slice_array_in_dim(values, slice_dim0, step), slice_dim1, step
+    )
+    var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
+    assert var.ndim == ndim
+    assert var.shape == values.shape
+    np.testing.assert_array_equal(var.values, values)
+
+
+@pytest.mark.parametrize(
     'ndim_and_slice_dim',
     [(ndim, slice_dim) for ndim in range(1, 7) for slice_dim in range(ndim)],
 )
@@ -389,6 +412,30 @@ def test_array_nd_sliced_fortran_layout(ndim_and_slice_dim, step):
     values = np.arange(np.prod(shape)).reshape(shape)
     values = np.asfortranarray(values)
     values = slice_array_in_dim(values, slice_dim, step)
+    var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
+    assert var.ndim == ndim
+    assert var.shape == values.shape
+    np.testing.assert_array_equal(var.values, values)
+
+
+@pytest.mark.parametrize(
+    'ndim_and_slice_dims',
+    [
+        (ndim, slice_dim0, slice_dim1)
+        for ndim in range(1, 7)
+        for slice_dim0 in range(ndim)
+        for slice_dim1 in range(ndim)
+    ],
+)
+@pytest.mark.parametrize('step', (2, -1, -2))
+def test_array_nd_sliced_twice_fortran_layout(ndim_and_slice_dims, step):
+    ndim, slice_dim0, slice_dim1 = ndim_and_slice_dims
+    shape = list(range(2, ndim + 2))
+    values = np.arange(np.prod(shape)).reshape(shape)
+    values = np.asfortranarray(values)
+    values = slice_array_in_dim(
+        slice_array_in_dim(values, slice_dim0, step), slice_dim1, step
+    )
     var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
     assert var.ndim == ndim
     assert var.shape == values.shape

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -343,34 +343,35 @@ def test_array_nd_contiguous_fortran_layout(ndim):
     np.testing.assert_array_equal(var.values, values)
 
 
-def slice_array_in_dim(array, dim):
+def slice_array_in_dim(array, dim, step):
     # We cannot use numpy.take here because we don't want to
     # copy the output but get a sliced array with corresponding strides.
     if dim == 0:
-        return array[::2]
+        return array[::step]
     elif dim == 1:
-        return array[:, ::2]
+        return array[:, ::step]
     elif dim == 2:
-        return array[:, :, ::2]
+        return array[:, :, ::step]
     elif dim == 3:
-        return array[:, :, :, ::2]
+        return array[:, :, :, ::step]
     elif dim == 4:
-        return array[:, :, :, :, ::2]
+        return array[:, :, :, :, ::step]
     elif dim == 5:
-        return array[:, :, :, :, :, ::2]
+        return array[:, :, :, :, :, ::step]
     elif dim == 6:
-        return array[:, :, :, :, :, :, ::2]
+        return array[:, :, :, :, :, :, ::step]
 
 
 @pytest.mark.parametrize(
     'ndim_and_slice_dim',
     [(ndim, slice_dim) for ndim in range(1, 7) for slice_dim in range(ndim)],
 )
-def test_array_nd_sliced_c_layout(ndim_and_slice_dim):
+@pytest.mark.parametrize('step', (2, -1, -2))
+def test_array_nd_sliced_c_layout(ndim_and_slice_dim, step):
     ndim, slice_dim = ndim_and_slice_dim
     shape = list(range(2, ndim + 2))
     values = np.arange(np.prod(shape)).reshape(shape)
-    values = slice_array_in_dim(values, slice_dim)
+    values = slice_array_in_dim(values, slice_dim, step)
     var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
     assert var.ndim == ndim
     assert var.shape == values.shape
@@ -381,12 +382,13 @@ def test_array_nd_sliced_c_layout(ndim_and_slice_dim):
     'ndim_and_slice_dim',
     [(ndim, slice_dim) for ndim in range(1, 7) for slice_dim in range(ndim)],
 )
-def test_array_nd_sliced_fortran_layout(ndim_and_slice_dim):
+@pytest.mark.parametrize('step', (2, -1, -2))
+def test_array_nd_sliced_fortran_layout(ndim_and_slice_dim, step):
     ndim, slice_dim = ndim_and_slice_dim
     shape = list(range(2, ndim + 2))
     values = np.arange(np.prod(shape)).reshape(shape)
     values = np.asfortranarray(values)
-    values = slice_array_in_dim(values, slice_dim)
+    values = slice_array_in_dim(values, slice_dim, step)
     var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
     assert var.ndim == ndim
     assert var.shape == values.shape

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -360,6 +360,8 @@ def slice_array_in_dim(array, dim, step):
         return array[:, :, :, :, :, ::step]
     elif dim == 6:
         return array[:, :, :, :, :, :, ::step]
+    else:
+        raise NotImplementedError()
 
 
 @pytest.mark.parametrize(

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -321,7 +321,8 @@ def test_array_empty_dims():
     )
 
 
-@pytest.mark.parametrize('ndim', range(7))
+# TODO slice first and last  element
+@pytest.mark.parametrize('ndim', range(9))
 def test_array_nd_contiguous_c_layout(ndim):
     shape = list(range(2, ndim + 2))
     values = np.arange(np.prod(shape)).reshape(shape)

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -321,7 +321,6 @@ def test_array_empty_dims():
     )
 
 
-# TODO slice first and last  element
 @pytest.mark.parametrize('ndim', range(9))
 def test_array_nd_contiguous_c_layout(ndim):
     shape = list(range(2, ndim + 2))
@@ -439,6 +438,28 @@ def test_array_nd_sliced_twice_fortran_layout(ndim_and_slice_dims, step):
     values = slice_array_in_dim(
         slice_array_in_dim(values, slice_dim0, step), slice_dim1, step
     )
+    var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
+    assert var.ndim == ndim
+    assert var.shape == values.shape
+    np.testing.assert_array_equal(var.values, values)
+
+
+@pytest.mark.parametrize('ndim', range(7, 9))
+def test_array_nd_high_dim_sliced_begin_c_layout(ndim):
+    shape = list(range(2, ndim + 2))
+    values = np.arange(np.prod(shape)).reshape(shape)
+    values = values[1:]
+    var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
+    assert var.ndim == ndim
+    assert var.shape == values.shape
+    np.testing.assert_array_equal(var.values, values)
+
+
+@pytest.mark.parametrize('ndim', range(7, 9))
+def test_array_nd_high_dim_sliced_end_c_layout(ndim):
+    shape = list(range(2, ndim + 2))
+    values = np.arange(np.prod(shape)).reshape(shape)
+    values = values[:-1]
     var = sc.array(dims=[f'dim_{d}' for d in range(ndim)], values=values)
     assert var.ndim == ndim
     assert var.shape == values.shape


### PR DESCRIPTION
Fixes #3224

# Changes

- Supports any number of dimensions without stamping out more templates.
- Parallelised for any number of dimensions.

`py::array` unfortunately has no interface indexing with a run-time-determined number of indices. So I went through the underlying buffer. 

# Performance

I did some benchmarks. For low dimensions (1, 2) the new code performs worse than the old code. E.g., using
```python
from timeit import timeit
import scipp as sc
import numpy as np

times = {}
for ndim in range(1, 4):
    a = np.zeros([1000]*ndim)
    dims = [f'dim{d}' for d in range(ndim)]
    times[ndim] = timeit(lambda: sc.array(dims=dims, values=a), number=10)

print(times)
```
I get **old**:
```python
{1: 0.00020559499898809008, 2: 0.006096607001381926, 3: 11.701265682000667}
```
**new**:
```python
{1: 0.0010022530004789587, 2: 0.004268341999704717, 3: 4.414793544001441}
```
This is quite a significant slowdown.

But for ndim=3,4 I found speedups.

Is this bad enough to warrant keeping the special cases for low dimensions?