### PR TITLE
Add workflow for nightly packaging

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -39,7 +39,6 @@ jobs:
           allowUpdates: true
           artifacts: 'dist/*.whl'
           body: 'Nightly release for testing of downstream projects.'
-          commit: 'main'
           makeLatest: false
           prerelease: true
           removeArtifacts: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -34,12 +34,14 @@ jobs:
         with:
           python-version: 3.8
       - run: python .github/workflows/rename-dev-wheels.py
+      - run: |
+          git tag -f nightly
+          git push -f origin nightly
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: 'dist/*.whl'
           body: 'Nightly release for testing of downstream projects.'
-          commit: 'main'
           makeLatest: false
           prerelease: true
           tag: 'nightly'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -44,4 +44,5 @@ jobs:
           body: 'Nightly release for testing of downstream projects.'
           makeLatest: false
           prerelease: true
+          removeArtifacts: true
           tag: 'nightly'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
       - run: python .github/workflows/rename-dev-wheels.py
       - uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,9 +2,6 @@ name: Nightly Release
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - '.github/workflows/release-nightly.yml'
   schedule:
     - cron: '0 20 * * *'
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,44 @@
+name: Nightly Release
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/release-nightly.yml'
+  schedule:
+    - cron: '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
+jobs:
+  build_wheels:
+    name: Wheels
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        build: [cp38]
+    uses: ./.github/workflows/wheel.yml
+    with:
+      os: ${{ matrix.os }}
+      build: ${{ matrix.build }}
+
+  release:
+    name: Make Release on GitHub
+    needs: build_wheels
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v3
+      - uses: actions/setup-python@v3
+      - uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: 'dist/*.whl'
+          commit: 'main'
+          makeLatest: false
+          prerelease: true
+          tag: 'nightly'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -6,11 +6,7 @@ on:
     paths:
       - '.github/workflows/release-nightly.yml'
   schedule:
-    - cron: '0 0 * * *'
-
-defaults:
-  run:
-    shell: bash -l {0}  # required for conda env
+    - cron: '0 20 * * *'
 
 jobs:
   build_wheels:
@@ -33,7 +29,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v3
-      - uses: actions/setup-python@v3
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -34,14 +34,12 @@ jobs:
         with:
           python-version: 3.8
       - run: python .github/workflows/rename-dev-wheels.py
-      - run: |
-          git tag -f nightly
-          git push -f origin nightly
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: 'dist/*.whl'
           body: 'Nightly release for testing of downstream projects.'
+          commit: 'main'
           makeLatest: false
           prerelease: true
           removeArtifacts: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,6 +29,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v3
+      - uses: actions/setup-python@v4
+      - run: python .github/workflows/rename-dev-wheels.py
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
       - uses: actions/setup-python@v4
       - run: python .github/workflows/rename-dev-wheels.py

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           allowUpdates: true
           artifacts: 'dist/*.whl'
+          body: 'Nightly release for testing of downstream projects.'
           commit: 'main'
           makeLatest: false
           prerelease: true

--- a/.github/workflows/rename-dev-wheels.py
+++ b/.github/workflows/rename-dev-wheels.py
@@ -2,9 +2,8 @@ import glob
 import os
 
 for filename in glob.glob('dist/*whl'):
-    base, remainder = filename.split('dev')
-    end = remainder[1].split('cp', 1)[1]
-    # We remove the Git hash and set the dev version to 0, to ensure we have a
+    # We remove the version number, dev number, and Git hash to ensure we have a
     # predictable URL of the uploaded release asset that downstream projects can use.
-    target = f"{base}dev0-cp{end}"
+    pkg, _, remainder = filename.split('-', 2)
+    target = f'{pkg}-nightly-{remainder}'
     os.rename(filename, target)

--- a/.github/workflows/rename-dev-wheels.py
+++ b/.github/workflows/rename-dev-wheels.py
@@ -1,0 +1,10 @@
+import glob
+import os
+
+for filename in glob.glob('dist/*whl'):
+    base, remainder = filename.split('dev')
+    end = remainder[1].split('cp', 1)[1]
+    # We remove the Git hash and set the dev version to 0, to ensure we have a
+    # predictable URL of the uploaded release asset that downstream projects can use.
+    target = f"{base}dev0-cp{end}"
+    os.rename(filename, target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0091 NEW)
 
 execute_process(
-  COMMAND git describe --tags --abbrev=0
+  COMMAND git describe --tags --abbrev=0 --exclude nightly
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE SCIPP_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This builds a wheel (currently only py38) and uses an action to attach it as a release asset. Note that we always use the same tag, `nightly`, without moving it. Setting that up would be more work, but I can't think of any benefit right now?