### PR TITLE
Support integer weights in `hist` and remove dtype limitations

### DIFF
--- a/lib/core/dict.cpp
+++ b/lib/core/dict.cpp
@@ -10,7 +10,7 @@
 namespace scipp::core {
 template <class It>
 std::string dict_keys_to_string(It it, const It end,
-                                const std::string_view dict_name) {
+                                const std::string_view &dict_name) {
   std::ostringstream ss;
   ss << "<" << dict_name << " {";
   bool first = true;
@@ -31,9 +31,9 @@ using dim_dict_key_iterator = Dict<Dim, int>::const_key_iterator;
 using str_dict_key_iterator = Dict<std::string, int>::const_key_iterator;
 
 template SCIPP_CORE_EXPORT std::string
-    dict_keys_to_string(dim_dict_key_iterator, dim_dict_key_iterator,
-                        std::string_view);
+dict_keys_to_string(dim_dict_key_iterator, dim_dict_key_iterator,
+                    const std::string_view &);
 template SCIPP_CORE_EXPORT std::string
-    dict_keys_to_string(str_dict_key_iterator, str_dict_key_iterator,
-                        std::string_view);
+dict_keys_to_string(str_dict_key_iterator, str_dict_key_iterator,
+                    const std::string_view &);
 } // namespace scipp::core

--- a/lib/core/include/scipp/core/dict.h
+++ b/lib/core/include/scipp/core/dict.h
@@ -383,11 +383,12 @@ private:
 };
 
 template <class It>
-std::string dict_keys_to_string(It it, It end, std::string_view dict_name);
+std::string dict_keys_to_string(It it, It end,
+                                const std::string_view &dict_name);
 
 template <class Key, class Value>
 std::string dict_keys_to_string(const Dict<Key, Value> &dict,
-                                const std::string_view dict_name = "Dict") {
+                                const std::string_view &dict_name = "Dict") {
   return dict_keys_to_string(dict.keys_begin(), dict.keys_end(), dict_name);
 }
 } // namespace scipp::core

--- a/lib/core/include/scipp/core/dtype.h
+++ b/lib/core/include/scipp/core/dtype.h
@@ -116,6 +116,9 @@ template <class T> constexpr bool canHaveVariances() noexcept {
 SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const DType &dtype);
 
+[[nodiscard]] SCIPP_CORE_EXPORT DType common_type(const DType &a,
+                                                  const DType &b);
+
 } // namespace scipp::core
 
 namespace scipp {

--- a/lib/core/include/scipp/core/element/histogram.h
+++ b/lib/core/include/scipp/core/element/histogram.h
@@ -30,33 +30,32 @@ constexpr auto iadd = [](const auto &x1, const scipp::index i1, const auto &x2,
 } // namespace
 
 namespace histogram_detail {
-template <class Out, class Coord, class Weight, class Edge>
-using args = std::tuple<scipp::span<Out>, scipp::span<const Coord>,
-                        scipp::span<const Weight>, scipp::span<const Edge>>;
+template <class Coord, class Weight>
+using args = std::tuple<scipp::span<Weight>, scipp::span<const Coord>,
+                        scipp::span<const Weight>, scipp::span<const Coord>>;
 }
 
 static constexpr auto histogram = overloaded{
-    element::arg_list<
-        histogram_detail::args<float, double, float, double>,
-        histogram_detail::args<float, float, float, double>,
-        histogram_detail::args<float, float, float, float>,
-        histogram_detail::args<float, int64_t, float, double>,
-        histogram_detail::args<float, int32_t, float, double>,
-        histogram_detail::args<float, int64_t, float, int64_t>,
-        histogram_detail::args<float, int32_t, float, int32_t>,
-        histogram_detail::args<double, double, double, double>,
-        histogram_detail::args<double, float, double, double>,
-        histogram_detail::args<double, double, double, float>,
-        histogram_detail::args<double, float, double, float>,
-        histogram_detail::args<double, double, float, double>,
-        histogram_detail::args<double, int64_t, double, int64_t>,
-        histogram_detail::args<double, int32_t, double, int64_t>,
-        histogram_detail::args<double, int64_t, double, int32_t>,
-        histogram_detail::args<double, int32_t, double, int32_t>,
-        histogram_detail::args<double, time_point, double, time_point>,
-        histogram_detail::args<double, time_point, float, time_point>,
-        histogram_detail::args<float, time_point, double, time_point>,
-        histogram_detail::args<float, time_point, float, time_point>>,
+    element::arg_list<histogram_detail::args<double, double>,
+                      histogram_detail::args<double, float>,
+                      histogram_detail::args<double, int64_t>,
+                      histogram_detail::args<double, int32_t>,
+                      histogram_detail::args<float, double>,
+                      histogram_detail::args<float, float>,
+                      histogram_detail::args<float, int64_t>,
+                      histogram_detail::args<float, int32_t>,
+                      histogram_detail::args<int32_t, double>,
+                      histogram_detail::args<int32_t, float>,
+                      histogram_detail::args<int32_t, int64_t>,
+                      histogram_detail::args<int32_t, int32_t>,
+                      histogram_detail::args<int64_t, double>,
+                      histogram_detail::args<int64_t, float>,
+                      histogram_detail::args<int64_t, int64_t>,
+                      histogram_detail::args<int64_t, int32_t>,
+                      histogram_detail::args<time_point, double>,
+                      histogram_detail::args<time_point, float>,
+                      histogram_detail::args<time_point, int64_t>,
+                      histogram_detail::args<time_point, int32_t>>,
     [](const auto &data, const auto &events, const auto &weights,
        const auto &edges) {
       zero(data);

--- a/lib/core/include/scipp/core/string.h
+++ b/lib/core/include/scipp/core/string.h
@@ -26,7 +26,7 @@ SCIPP_CORE_EXPORT std::ostream &operator<<(std::ostream &os,
                                            const scipp::index_pair &index);
 
 SCIPP_CORE_EXPORT const std::string &to_string(const std::string &s);
-SCIPP_CORE_EXPORT std::string_view to_string(const std::string_view s);
+SCIPP_CORE_EXPORT std::string_view to_string(const std::string_view &s);
 SCIPP_CORE_EXPORT std::string to_string(const char *s);
 SCIPP_CORE_EXPORT std::string to_string(const bool b);
 SCIPP_CORE_EXPORT std::string to_string(const DType dtype);

--- a/lib/core/string.cpp
+++ b/lib/core/string.cpp
@@ -57,7 +57,7 @@ std::string to_string(const Sizes &sizes) {
 }
 
 const std::string &to_string(const std::string &s) { return s; }
-std::string_view to_string(const std::string_view s) { return s; }
+std::string_view to_string(const std::string_view &s) { return s; }
 std::string to_string(const char *s) { return std::string(s); }
 
 std::string to_string(const bool b) { return b ? "True" : "False"; }

--- a/lib/core/test/CMakeLists.txt
+++ b/lib/core/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
   array_to_string_test.cpp
   dict_test.cpp
   dimensions_test.cpp
+  dtype_test.cpp
   eigen_test.cpp
   element_array_test.cpp
   element_array_view_test.cpp

--- a/lib/core/test/dtype_test.cpp
+++ b/lib/core/test/dtype_test.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "test_macros.h"
+#include <type_traits>
+
+#include "scipp/core/dtype.h"
+#include "scipp/core/except.h"
+
+using namespace scipp;
+
+TEST(CommonTypeTest, arithmetic_types) {
+  EXPECT_EQ(common_type(dtype<int32_t>, dtype<int32_t>),
+            (dtype<std::common_type_t<int32_t, int32_t>>));
+  EXPECT_EQ(common_type(dtype<int32_t>, dtype<int64_t>),
+            (dtype<std::common_type_t<int32_t, int64_t>>));
+  EXPECT_EQ(common_type(dtype<int32_t>, dtype<float>),
+            (dtype<std::common_type_t<int32_t, float>>));
+  EXPECT_EQ(common_type(dtype<int32_t>, dtype<double>),
+            (dtype<std::common_type_t<int32_t, double>>));
+
+  EXPECT_EQ(common_type(dtype<int64_t>, dtype<int32_t>),
+            (dtype<std::common_type_t<int64_t, int32_t>>));
+  EXPECT_EQ(common_type(dtype<int64_t>, dtype<int64_t>),
+            (dtype<std::common_type_t<int64_t, int64_t>>));
+  EXPECT_EQ(common_type(dtype<int64_t>, dtype<float>),
+            (dtype<std::common_type_t<int64_t, float>>));
+  EXPECT_EQ(common_type(dtype<int64_t>, dtype<double>),
+            (dtype<std::common_type_t<int64_t, double>>));
+
+  EXPECT_EQ(common_type(dtype<float>, dtype<int32_t>),
+            (dtype<std::common_type_t<float, int32_t>>));
+  EXPECT_EQ(common_type(dtype<float>, dtype<int64_t>),
+            (dtype<std::common_type_t<float, int64_t>>));
+  EXPECT_EQ(common_type(dtype<float>, dtype<float>),
+            (dtype<std::common_type_t<float, float>>));
+  EXPECT_EQ(common_type(dtype<float>, dtype<double>),
+            (dtype<std::common_type_t<float, double>>));
+
+  EXPECT_EQ(common_type(dtype<double>, dtype<int32_t>),
+            (dtype<std::common_type_t<double, int32_t>>));
+  EXPECT_EQ(common_type(dtype<double>, dtype<int64_t>),
+            (dtype<std::common_type_t<double, int64_t>>));
+  EXPECT_EQ(common_type(dtype<double>, dtype<float>),
+            (dtype<std::common_type_t<double, float>>));
+  EXPECT_EQ(common_type(dtype<double>, dtype<double>),
+            (dtype<std::common_type_t<double, double>>));
+}
+
+TEST(CommonTypeTest, same_non_arithmetic_type) {
+  EXPECT_EQ(common_type(dtype<core::time_point>, dtype<core::time_point>),
+            dtype<core::time_point>);
+}
+
+// NOTE: Exceptions not tested here, since DType name registry is initialized
+// only later, in scipp::variable. See tests in variable/test/astype_test.cpp

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -347,10 +347,14 @@ Variable histogram(const Variable &data, const Variable &binEdges) {
   }
 
   const auto masked = masked_data(buffer, dim);
+  const auto coord = buffer.meta()[hist_dim];
+  const auto dt = common_type(binEdges, coord);
+  const auto promoted_coord = astype(coord, dt, CopyPolicy::TryAvoid);
+  const auto promoted_edges = astype(binEdges, dt, CopyPolicy::TryAvoid);
   auto hist = variable::transform_subspan(
       buffer.dtype(), hist_dim, nbin,
-      subspan_view(buffer.meta()[hist_dim], dim, indices),
-      subspan_view(masked, dim, indices), binEdges, element::histogram,
+      subspan_view(promoted_coord, dim, indices),
+      subspan_view(masked, dim, indices), promoted_edges, element::histogram,
       "histogram");
   if (hist.dims().contains(dummy))
     return sum(hist, dummy);

--- a/lib/dataset/histogram.cpp
+++ b/lib/dataset/histogram.cpp
@@ -80,7 +80,7 @@ DataArray histogram(const DataArray &events, const Variable &binEdges) {
           }
           // Due to the combinatoric explosion of dtype combinations, we promote
           // either the bin edges or the coord in case their dtypes mismatch.
-          // This is less efficient, but hopefully and edge case. If performance
+          // This is less efficient, but hopefully an edge case. If performance
           // matters, users should ensure that they use bin edges and coord with
           // the same dtype.
           const auto dt = common_type(binEdges_, cont_coord);

--- a/lib/variable/astype.cpp
+++ b/lib/variable/astype.cpp
@@ -72,31 +72,9 @@ Variable astype(const Variable &var, DType type, const CopyPolicy copy) {
              : MakeVariableWithType::make(var, type);
 }
 
-namespace {
-template <class T, class... Ts> constexpr auto inner_lut() {
-  return std::array{std::pair{dtype<Ts>, dtype<std::common_type_t<T, Ts>>}...};
-}
-
-template <class... Ts> constexpr auto outer_lut() {
-  return std::array{std::pair{dtype<Ts>, inner_lut<Ts, Ts...>()}...};
-}
-} // namespace
-
 DType common_type(const Variable &a, const Variable &b) {
-  if (a.dtype() == b.dtype())
-    return a.dtype();
-  const auto lut = outer_lut<double, float, int64_t, int32_t>();
-  const auto it = std::find_if(lut.begin(), lut.end(), [&](const auto &pair) {
-    return pair.first == a.dtype();
-  });
-  if (it == lut.end())
-    throw except::TypeError("'common_type' does not support dtype ", a);
-  const auto it2 =
-      std::find_if(it->second.begin(), it->second.end(),
-                   [&](const auto &pair) { return pair.first == b.dtype(); });
-  if (it2 == it->second.end())
-    throw except::TypeError("'common_type' does not support dtype ", b);
-  return it2->second;
+  return common_type(variableFactory().elem_dtype(a),
+                     variableFactory().elem_dtype(b));
 }
 
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/accumulate.h
+++ b/lib/variable/include/scipp/variable/accumulate.h
@@ -111,7 +111,7 @@ static void do_accumulate(const std::tuple<Ts...> &types, Op op,
 
 template <class... Ts, class Op, class Var, class... Other>
 static void accumulate(const std::tuple<Ts...> &types, Op op,
-                       const std::string_view name, Var &&var,
+                       const std::string_view &name, Var &&var,
                        Other &&...other) {
   // `other` not const, threading for cumulative ops not possible
   if constexpr ((!std::is_const_v<std::remove_reference_t<Other>> || ...))
@@ -135,7 +135,7 @@ static void accumulate(const std::tuple<Ts...> &types, Op op,
 /// operations.
 template <class... Ts, class Var, class Other, class Op>
 void accumulate_in_place(Var &&var, Other &&other, Op op,
-                         const std::string_view name) {
+                         const std::string_view &name) {
   // Note lack of dims check here and below: transform_data calls `merge` on the
   // dims which does the required checks, supporting broadcasting of outputs and
   // inputs but ensuring compatibility otherwise.
@@ -145,7 +145,7 @@ void accumulate_in_place(Var &&var, Other &&other, Op op,
 
 template <class... Ts, class Var, class Op>
 void accumulate_in_place(Var &&var, const Variable &var1, const Variable &var2,
-                         Op op, const std::string_view name) {
+                         Op op, const std::string_view &name) {
   detail::accumulate(type_tuples<Ts...>(op), op, name, std::forward<Var>(var),
                      var1, var2);
 }
@@ -153,7 +153,7 @@ void accumulate_in_place(Var &&var, const Variable &var1, const Variable &var2,
 template <class... Ts, class Var, class Op>
 void accumulate_in_place(Var &&var, Variable &var1, const Variable &var2,
                          const Variable &var3, Op op,
-                         const std::string_view name) {
+                         const std::string_view &name) {
   detail::accumulate(type_tuples<Ts...>(op), op, name, std::forward<Var>(var),
                      var1, var2, var3);
 }

--- a/lib/variable/include/scipp/variable/astype.h
+++ b/lib/variable/include/scipp/variable/astype.h
@@ -11,7 +11,9 @@
 
 namespace scipp::variable {
 
-SCIPP_VARIABLE_EXPORT Variable astype(const Variable &var, DType type,
-                                      CopyPolicy copy = CopyPolicy::Always);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
+astype(const Variable &var, DType type, CopyPolicy copy = CopyPolicy::Always);
+[[nodiscard]] SCIPP_VARIABLE_EXPORT DType common_type(const Variable &a,
+                                                      const Variable &b);
 
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/transform.h
+++ b/lib/variable/include/scipp/variable/transform.h
@@ -636,7 +636,7 @@ template <bool dry_run> struct in_place {
 
   template <class... Ts, class Op, class Var, class... Other>
   static void transform_data(const std::tuple<Ts...> &, Op op,
-                             const std::string_view name, Var &&var,
+                             const std::string_view &name, Var &&var,
                              Other &&...other) {
     using namespace detail;
     try {
@@ -648,7 +648,7 @@ template <bool dry_run> struct in_place {
     }
   }
   template <class... Ts, class Op, class Var, class... Other>
-  static void transform(Op op, const std::string_view name, Var &&var,
+  static void transform(Op op, const std::string_view &name, Var &&var,
                         const Other &...other) {
     using namespace detail;
     (scipp::expect::includes(var.dims(), other.dims()), ...);
@@ -683,7 +683,7 @@ template <bool dry_run> struct in_place {
 /// equivalent to std::transform with a single input range and an output range
 /// identical to the input range, but avoids potentially costly element copies.
 template <class... Ts, class Var, class Op>
-void transform_in_place(Var &&var, Op op, const std::string_view name) {
+void transform_in_place(Var &&var, Op op, const std::string_view &name) {
   in_place<false>::transform<Ts...>(op, name, std::forward<Var>(var));
 }
 
@@ -694,7 +694,7 @@ void transform_in_place(Var &&var, Op op, const std::string_view name) {
 /// costly element copies.
 template <class... TypePairs, class Var, class Op>
 void transform_in_place(Var &&var, const Variable &other, Op op,
-                        const std::string_view name) {
+                        const std::string_view &name) {
   in_place<false>::transform<TypePairs...>(op, name, std::forward<Var>(var),
                                            other);
 }
@@ -702,7 +702,7 @@ void transform_in_place(Var &&var, const Variable &other, Op op,
 /// Transform the data elements of a variable in-place.
 template <class... TypePairs, class Var, class Op>
 void transform_in_place(Var &&var, const Variable &var1, const Variable &var2,
-                        Op op, const std::string_view name) {
+                        Op op, const std::string_view &name) {
   in_place<false>::transform<TypePairs...>(op, name, std::forward<Var>(var),
                                            var1, var2);
 }
@@ -711,19 +711,19 @@ void transform_in_place(Var &&var, const Variable &var1, const Variable &var2,
 template <class... TypePairs, class Var, class Op>
 void transform_in_place(Var &&var, const Variable &var1, const Variable &var2,
                         const Variable &var3, Op op,
-                        const std::string_view name) {
+                        const std::string_view &name) {
   in_place<false>::transform<TypePairs...>(op, name, std::forward<Var>(var),
                                            var1, var2, var3);
 }
 
 namespace dry_run {
 template <class... Ts, class Var, class Op>
-void transform_in_place(Var &&var, Op op, const std::string_view name) {
+void transform_in_place(Var &&var, Op op, const std::string_view &name) {
   in_place<true>::transform<Ts...>(op, name, std::forward<Var>(var));
 }
 template <class... TypePairs, class Var, class Op>
 void transform_in_place(Var &&var, const Variable &other, Op op,
-                        const std::string_view name) {
+                        const std::string_view &name) {
   in_place<true>::transform<TypePairs...>(op, name, std::forward<Var>(var),
                                           other);
 }
@@ -731,7 +731,7 @@ void transform_in_place(Var &&var, const Variable &other, Op op,
 
 namespace detail {
 template <class... Ts, class Op, class... Vars>
-Variable transform(std::tuple<Ts...> &&, Op op, const std::string_view name,
+Variable transform(std::tuple<Ts...> &&, Op op, const std::string_view &name,
                    const Vars &...vars) {
   using namespace detail;
   try {
@@ -750,7 +750,7 @@ Variable transform(std::tuple<Ts...> &&, Op op, const std::string_view name,
 /// need for, e.g., std::back_inserter.
 template <class... Ts, class Op>
 [[nodiscard]] Variable transform(const Variable &var, Op op,
-                                 const std::string_view name) {
+                                 const std::string_view &name) {
   return detail::transform(type_tuples<Ts...>(op), op, name, var);
 }
 
@@ -761,7 +761,7 @@ template <class... Ts, class Op>
 /// need for, e.g., std::back_inserter.
 template <class... Ts, class Op>
 [[nodiscard]] Variable transform(const Variable &var1, const Variable &var2,
-                                 Op op, const std::string_view name) {
+                                 Op op, const std::string_view &name) {
   return detail::transform(type_tuples<Ts...>(op), op, name, var1, var2);
 }
 
@@ -769,7 +769,7 @@ template <class... Ts, class Op>
 template <class... Ts, class Op>
 [[nodiscard]] Variable transform(const Variable &var1, const Variable &var2,
                                  const Variable &var3, Op op,
-                                 const std::string_view name) {
+                                 const std::string_view &name) {
   return detail::transform(type_tuples<Ts...>(op), op, name, var1, var2, var3);
 }
 
@@ -777,7 +777,7 @@ template <class... Ts, class Op>
 template <class... Ts, class Op>
 [[nodiscard]] Variable transform(const Variable &var1, const Variable &var2,
                                  const Variable &var3, const Variable &var4,
-                                 Op op, const std::string_view name) {
+                                 Op op, const std::string_view &name) {
   return detail::transform(type_tuples<Ts...>(op), op, name, var1, var2, var3,
                            var4);
 }


### PR DESCRIPTION
Fixes #3126.

As discussed in the linked issue, directly supporting all possible dtype combinations would require a very large number of template instantiations. With the change here I am converting to the common type of coord and edges, which avoid this. We thus have only `4*4+1*4 = 20` cases. Otherwise it would be `4*4*4+1*4 = 68`.

This adds `common_type`, which may be useful for other applications. Maybe it would even be worth exposing to Python?

Unrelated, I got a lot of compiler warnings about passing `std::string_view` by value, which apparently even made compilation fail with our current settings. I added references everywhere.