### PR TITLE
Support dataset init from empty dict

### DIFF
--- a/lib/python/dataset.cpp
+++ b/lib/python/dataset.cpp
@@ -223,15 +223,16 @@ Returned by :py:func:`DataArray.masks`)");
   options.disable_function_signatures();
   dataset.def(
       py::init([](const py::object &data, const py::object &coords) {
-        const auto data_dict = py::dict(data);
-        const auto coords_dict = py::dict(coords);
-        if (data_dict.empty() && coords_dict.empty())
+        if (data.is_none() && coords.is_none())
           throw py::type_error("Dataset needs data or coordinates or both.");
+        const auto data_dict = data.is_none() ? py::dict() : py::dict(data);
+        const auto coords_dict =
+            coords.is_none() ? py::dict() : py::dict(coords);
         auto d = dataset_from_data_and_coords(data_dict, coords_dict);
         return d.is_valid() ? d : dataset_from_coords(coords_dict);
       }),
-      py::arg("data") = py::dict(), py::kw_only(),
-      py::arg("coords") = std::map<std::string, Variable>{},
+      py::arg("data") = py::none{}, py::kw_only(),
+      py::arg("coords") = py::none{},
       R"doc(__init__(self, data: Union[typing.Mapping[str, Union[Variable, DataArray]], Iterable[Tuple[str, Union[Variable, DataArray]]]] = {}, coords: Union[typing.Mapping[str, Variable], Iterable[Tuple[str, Variable]]] = {}) -> None
 
       Dataset initializer.

--- a/tests/compat/xarray_compat_test.py
+++ b/tests/compat/xarray_compat_test.py
@@ -248,10 +248,11 @@ def test_from_xarray_dataset_with_attrs_warns():
 
 
 @pytest.mark.filterwarnings("ignore:.*attributes.*:UserWarning")
-def test_from_xarray_dataset_with_only_attrs_raises():
+def test_from_xarray_dataset_with_only_attrs():
     xr_ds = xr.Dataset(attrs={'a': 1, 'b': 2})
-    with pytest.raises(TypeError):
-        from_xarray(xr_ds)
+    sc_ds = from_xarray(xr_ds)
+    assert len(sc_ds) == 0
+    assert sc_ds.sizes == {}
 
 
 def test_to_xarray_variable():

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -13,6 +13,20 @@ def test_init_default():
         sc.Dataset()
 
 
+def test_init_empty():
+    ds = sc.Dataset({})
+    assert ds.sizes == {}
+    assert len(ds) == 0
+
+    ds = sc.Dataset(coords={})
+    assert ds.sizes == {}
+    assert len(ds) == 0
+
+    ds = sc.Dataset({}, coords={})
+    assert ds.sizes == {}
+    assert len(ds) == 0
+
+
 def test_init_dict_of_variables():
     d = sc.Dataset({'a': sc.arange('x', 5), 'b': sc.arange('x', 5, 10, unit='m')})
     assert sc.identical(d['a'], sc.DataArray(sc.arange('x', 5)))


### PR DESCRIPTION
Missed this in the recent dataset refactor