### PR TITLE
Another version of allowing noncontiguous bin edges.

### DIFF
--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -13,6 +13,7 @@
 #include "scipp/variable/reduction.h"
 #include "scipp/variable/shape.h"
 #include "scipp/variable/subspan_view.h"
+#include "scipp/variable/util.h"
 #include "scipp/variable/variable_factory.h"
 
 #include "scipp/dataset/bin.h"
@@ -413,13 +414,15 @@ public:
   void group(const Variable &groups) {
     const auto dim = groups.dims().inner();
     m_dims.addInner(dim, groups.dims()[dim]);
-    m_actions.emplace_back(AxisAction::Group, dim, groups);
+    const auto con_groups = scipp::variable::as_contiguous(groups, dim);
+    m_actions.emplace_back(AxisAction::Group, dim, con_groups);
   }
 
   void bin(const Variable &edges) {
     const auto dim = edges.dims().inner();
     m_dims.addInner(dim, edges.dims()[dim] - 1);
-    m_actions.emplace_back(AxisAction::Bin, dim, edges);
+    const auto con_edges = scipp::variable::as_contiguous(edges, dim);
+    m_actions.emplace_back(AxisAction::Bin, dim, con_edges);
   }
 
   void existing(const Dim dim, const scipp::index size) {

--- a/lib/dataset/bin_detail.cpp
+++ b/lib/dataset/bin_detail.cpp
@@ -27,13 +27,6 @@ Variable make_range(const scipp::index begin, const scipp::index end,
   return cumsum(broadcast(stride * units::none, {dim, (end - begin) / stride}),
                 dim, CumSumMode::Exclusive);
 }
-namespace {
-Variable to_subspan_view(const Variable &edges, const Dim dim) {
-  const auto con_edges = scipp::variable::as_contiguous(edges, dim);
-  return subspan_view(con_edges, dim);
-}
-
-} // namespace
 
 void update_indices_by_binning(Variable &indices, const Variable &key,
                                const Variable &edges, const bool linspace) {
@@ -45,7 +38,7 @@ void update_indices_by_binning(Variable &indices, const Variable &key,
         "event-coordinate. Provide an event coordinate or convert the "
         "bin-edge coordinate to a non-edge coordinate.");
   const auto &edge_view =
-      is_bins(edges) ? as_subspan_view(edges) : to_subspan_view(edges, dim);
+      is_bins(edges) ? as_subspan_view(edges) : subspan_view(edges, dim);
   if (linspace) {
     variable::transform_in_place(
         indices, key, edge_view,
@@ -62,8 +55,7 @@ void update_indices_by_binning(Variable &indices, const Variable &key,
 namespace {
 template <class Index>
 Variable groups_to_map(const Variable &var, const Dim dim) {
-  const auto con_var = scipp::variable::as_contiguous(var, dim);
-  return variable::transform(subspan_view(con_var, dim),
+  return variable::transform(subspan_view(var, dim),
                              core::element::groups_to_map<Index>,
                              "scipp.bin.groups_to_map");
 }

--- a/lib/dataset/bin_detail.h
+++ b/lib/dataset/bin_detail.h
@@ -13,11 +13,10 @@ namespace scipp::dataset::bin_detail {
 
 template <class T> Variable as_subspan_view(T &&binned) {
   auto &&[indices, dim, buffer] = binned.template constituents<Variable>();
-  auto con_buffer = scipp::variable::as_contiguous(buffer, dim);
   if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
-    return subspan_view(std::as_const(con_buffer), dim, indices);
+    return subspan_view(std::as_const(buffer), dim, indices);
   } else {
-    return subspan_view(con_buffer, dim, indices);
+    return subspan_view(buffer, dim, indices);
   }
 }
 

--- a/lib/variable/util.cpp
+++ b/lib/variable/util.cpp
@@ -44,8 +44,7 @@ Variable linspace(const Variable &start, const Variable &stop, const Dim dim,
 }
 
 Variable islinspace(const Variable &var, const Dim dim) {
-  const auto con_var = as_contiguous(var, dim);
-  return transform(subspan_view(con_var, dim), core::element::islinspace,
+  return transform(subspan_view(var, dim), core::element::islinspace,
                    "islinspace");
 }
 


### PR DESCRIPTION
Related to #3310.

In #3310, I tried to use `as_contiguous` in the smaller scope, but then it became a little more complicated than this simpler solution...
I'm not sure which way is better.