### PR TITLE
Release nightly for python version 3.9

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        build: [cp38]
+        build: [cp38, cp39]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #3313 

I opened an issue to remove python version 3.8 so that we don't forget. #3315 