### PR TITLE
Add Python 3.12 for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - {os: macos-11, target: osx_64}
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        build: [cp38, cp39, cp310, cp311]
+        build: [cp38, cp39, cp310, cp311, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - {os: macos-11, target: osx_64}
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-20.04, target: linux_64}
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        build: [cp38, cp311]
+        build: [cp38, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - cmake
-    - conan==1.59.0
     - cppcheck [linux64]
     - git
     - ninja
@@ -55,7 +54,6 @@ test:
     - bs4
     - cmake
     - comm>=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
-    - conan==1.59.0
     - h5py
     - hypothesis
     - ipykernel
@@ -73,6 +71,7 @@ test:
     - tests/
   commands:
     - python -m pytest -v tests
+    - pip install git+https://github.com/conan-io/conan@develop
     - python cmake-package-test/build.py
 {% endif %}
 
@@ -80,6 +79,7 @@ build:
   # Build number is number of Git commits since last tag, if that fails use 0
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   script:
+    - pip install git+https://github.com/conan-io/conan@develop
     # Passing Python_EXECUTABLE ensures that cmake sees the host interpreter instead of build.
     - cmake --preset package-{{ target_platform }} -DPython_EXECUTABLE=$PYTHON
     - cmake --build --preset build

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - cmake
+    - conan==1.59.0
     - cppcheck [linux64]
     - git
     - ninja
@@ -54,6 +55,7 @@ test:
     - bs4
     - cmake
     - comm>=0.1.3  # earlier versions break tests with ipywidgets with latest ipykernel
+    - conan==1.59.0
     - h5py
     - hypothesis
     - ipykernel
@@ -71,7 +73,6 @@ test:
     - tests/
   commands:
     - python -m pytest -v tests
-    - pip install git+https://github.com/conan-io/conan@develop
     - python cmake-package-test/build.py
 {% endif %}
 
@@ -79,7 +80,6 @@ build:
   # Build number is number of Git commits since last tag, if that fails use 0
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   script:
-    - pip install git+https://github.com/conan-io/conan@develop
     # Passing Python_EXECUTABLE ensures that cmake sees the host interpreter instead of build.
     - cmake --preset package-{{ target_platform }} -DPython_EXECUTABLE=$PYTHON
     - cmake --build --preset build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=68",
-  "conan @ git+https://github.com/conan-io/conan@develop",
+  "conan>=1.62.0",
   "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"
@@ -49,7 +49,6 @@ test = [
   "xarray",
   "pandas",
   "bs4",
-  #"numba",
   "ipython",
 ]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,6 @@ dynamic = ["version"]
 test = [
   "pytest",
   "matplotlib",
-  "xarray",
-  "pandas",
   "bs4",
   "ipython",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=68",
-  "conan>=1.62.0",
+  "conan==1.62.0",
   "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
   "xarray",
   "pandas",
   "bs4",
-  "numba",
+  #"numba",
   "ipython",
 ]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=68",
-  "conan==1.62.0",
+  "conan @ git+https://github.com/conan-io/conan@develop",
   "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=68",
-  "conan==1.61.0",
+  "conan==1.62.0",
   "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",

--- a/tests/compat/pandas_compat_test.py
+++ b/tests/compat/pandas_compat_test.py
@@ -1,10 +1,11 @@
-import pandas
 import pytest
 
 import scipp as sc
 from scipp.compat import from_pandas
 from scipp.compat.pandas_compat import parse_bracket_header
 from scipp.testing import assert_identical
+
+pandas = pytest.importorskip('pandas')
 
 
 def _make_reference_da(row_name, row_coords, values, dtype="int64"):

--- a/tests/compat/xarray_compat_test.py
+++ b/tests/compat/xarray_compat_test.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-import xarray as xr
 
 import scipp as sc
 from scipp.compat import from_xarray, to_xarray
@@ -14,6 +13,8 @@ from ..factory import (  # NOQA
     make_dense_dataset,
     make_variable,
 )
+
+xr = pytest.importorskip('xarray')
 
 
 def test_from_xarray_variable():

--- a/tests/elemwise_func_test.py
+++ b/tests/elemwise_func_test.py
@@ -1,15 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-import sys
-
 import pytest
 
 import scipp as sc
 
-# numba is not supported for these versions
-pytestmark = pytest.mark.skipif(
-    sys.version_info >= (3, 11), reason='numba does not support this Python version'
-)
+_ = pytest.importorskip('numba')
 
 
 def test_unary():

--- a/tests/io/csv_test.py
+++ b/tests/io/csv_test.py
@@ -8,6 +8,8 @@ import pytest
 import scipp as sc
 from scipp.testing import assert_identical
 
+_ = pytest.importorskip('pandas')
+
 
 def test_load_csv_dataset_default_sep():
     csv = '''x,y,z


### PR DESCRIPTION
No conda support for now. See #3322.

See passed package builds in https://github.com/scipp/scipp/actions/runs/7208433835.