### PR TITLE
Bin/histogram/group edge reference test.

### DIFF
--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -271,7 +271,7 @@ DataArray add_metadata(const Variable &data, std::unique_ptr<Mapper> mapper,
   for (const auto &c : {edges, groups})
     for (const auto &coord : c) {
       dims.emplace(coord.dims().inner());
-      auto to_insert = copy(coord);
+      Variable to_insert(coord);
       to_insert.set_aligned(true);
       out_coords.insert_or_assign(coord.dims().inner(), std::move(to_insert));
     }

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -707,3 +707,23 @@ TEST(BinLinspaceTest, many_events_many_bins) {
       linspace(0.0 * units::one, 1.0 * units::one, Dim::X, 70000);
   EXPECT_EQ(sum(bin(da, {edges}).data()), sum(da.data()));
 }
+
+TEST(BinEdgeTest, edge_reference_reserved) {
+  const auto table = make_table(10);
+  const auto x_edges =
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{-2, -1, 0, 1, 2});
+  const auto binned = bin(table, {x_edges});
+
+  EXPECT_EQ(&binned.coords()[Dim::X].values<double>()[0],
+            &x_edges.values<double>()[0]);
+}
+
+TEST(BinGroupTest, group_reference_reserved) {
+  const auto table = make_table(10);
+  const auto x_groups =
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{-2, -1, 0, 1, 2});
+  const auto binned = bin(table, {}, {x_groups});
+
+  EXPECT_EQ(&binned.coords()[Dim::X].values<double>()[0],
+            &x_groups.values<double>()[0]);
+}

--- a/lib/dataset/test/histogram_test.cpp
+++ b/lib/dataset/test/histogram_test.cpp
@@ -496,3 +496,13 @@ TEST(HistogramLinspaceTest, event_mapped_to_correct_bin_at_end) {
     }
   }
 }
+
+TEST(HistogramEdgeTest, edge_reference_reserved) {
+  const auto table = testdata::make_table(10);
+  const auto x_edges =
+      makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{-2, -1, 0, 1, 2});
+  const auto histogrammed = histogram(table, x_edges);
+
+  EXPECT_EQ(&histogrammed.coords()[Dim::X].values<double>()[0],
+            &x_edges.values<double>()[0]);
+}

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -954,3 +954,23 @@ def test_hist_edges_referencing_original_variable() -> None:
     assert not sc.identical(histogrammed.coords['x'], doubled_edges)
     edges *= 2
     assert_identical(histogrammed.coords['x'], doubled_edges)
+
+
+def test_bin_edges_referencing_original_variable() -> None:
+    table = sc.data.table_xyz(100)
+    edges = sc.linspace('x', 0, 1, 11, unit='m')
+    binned = table.bin(x=edges)
+    doubled_edges = edges * 2
+    assert not sc.identical(binned.coords['x'], doubled_edges)
+    edges *= 2
+    assert_identical(binned.coords['x'], doubled_edges)
+
+
+def test_group_edges_referencing_original_variable() -> None:
+    table = sc.data.table_xyz(100)
+    groups = sc.linspace('x', 0, 1, 10, unit='m')
+    binned = table.group(groups)
+    doubled_groups = groups * 2
+    assert not sc.identical(binned.coords['x'], doubled_groups)
+    groups *= 2
+    assert_identical(binned.coords['x'], doubled_groups)

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -944,3 +944,13 @@ def test_group_many_groups(ngroup):
     del expected.coords['label']
     assert_identical(grouped.bins.constituents['data'][::2], expected)
     assert_identical(grouped.bins.constituents['data'][1::2], expected)
+
+
+def test_hist_edges_referencing_original_variable() -> None:
+    table = sc.data.table_xyz(100)
+    edges = sc.linspace('x', 0, 1, 11, unit='m')
+    histogrammed = table.hist(x=edges)
+    doubled_edges = edges * 2
+    assert not sc.identical(histogrammed.coords['x'], doubled_edges)
+    edges *= 2
+    assert_identical(histogrammed.coords['x'], doubled_edges)


### PR DESCRIPTION
Before the change, binning and grouping copied edges and groups, but not the histogram.