### PR TITLE
Copy publish documentation workflow from plopp pr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,21 @@ jobs:
       version: ${{ needs.manage-versions.outputs.version-replaced }}
       branch: ${{ needs.manage-versions.outputs.version-replaced }}
     secrets: inherit
+
+  assets:
+    name: Upload docs
+    needs: docs
+    runs-on: 'ubuntu-22.04'
+    permissions:
+      contents: write  # This is needed so that the action can upload the asset
+    steps:
+    - uses: actions/download-artifact@v3
+    - name: Zip documentation
+      run: |
+        mv html documentation-${{ github.ref_name }}
+        zip -r documentation-${{ github.ref_name }}.zip documentation-${{ github.ref_name }}
+    - name: Upload release assets
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: ./documentation-${{ github.ref_name }}.zip
+        overwrite: false


### PR DESCRIPTION
Fixes [#3210](https://github.com/scipp/scipp/issues/3210).

Here's a suggestion for the script to upload old docs to the old releases.
I've not tested it yet, and I will not run it without approval, just posting it here so you can review if the approach makes sense and suggest changes.

```bash
#!/bin/bash

upload_repo_url="https://uploads.github.com/repos/scipp/scipp"

repo_url="https://github.com/scipp/scipp"
docs_url="https://github.com/scipp/scipp.github.io"

pushd `mktemp -d`
git clone $repo_url repo
git clone $docs_url docs
cd repo 
pwd

# The releases included here are the ones that show up in the dropdown menu on the scipp docs page
for release in 23.11 23.08 23.07 23.05 23.03 23.01 22.11 0.17 0.16 0.15 0.14 0.13 0.12 0.11 0.10 0.9 0.8
do 
    # Find all release tags (including minor releases)
    for tag in `git tag --list`
    do
        if [[ "$tag" =~ "$release"\.\d* ]]
        then
            echo $tag
            # Build documentation manually ?
            #git checkout $tag
            #tox -e docs
            #mv docs_html documentation-$tag

            # Use already existing docs in scipp.github.io
            cp ../docs/release/$release documentation-$tag

            zip -r documentation-$tag.zip documentation-$tag
            echo curl -L \
                -X POST \
                -H "Accept: application/vnd.github+json" \
                -H "Authorization: Bearer $GITHUB_TOKEN" \
                -H "X-GitHub-Api-Version: 2022-11-28" \
                -H "Content-Type: application/octet-stream" \
                "$upload_repo_url/releases/tag/$tag/assets?name=documentation-$tag.zip" \
                --data-binary "@documentation-$tag.zip"
            echo
        fi
    done
done

popd

```