### PR TITLE
Fix memory leak in `bin` introduced in 23.08.0

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -28,6 +28,14 @@ Release Notes
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
+v23.11.1
+--------
+
+Bugfixes
+~~~~~~~~
+
+* Fix a memory leak in functions such as :func:`scipp.bin` and :func:`scipp.group` that affects Scipp versions between 23.08.0 and 23.11.0 `#3342 <https://github.com/scipp/scipp/pull/3342>`_.
+
 v23.11.0
 --------
 

--- a/lib/dataset/bin.cpp
+++ b/lib/dataset/bin.cpp
@@ -49,6 +49,7 @@ template <class Builder> bool use_two_stage_remap(const Builder &bld) {
 }
 class Mapper {
 public:
+  virtual ~Mapper() = default;
   template <class T> T apply(const Variable &data) {
     const auto maybe_bin = [this](const auto &var) {
       return is_bins(var) ? apply_to_variable(var) : copy(var);


### PR DESCRIPTION
Fixes #3341, a memory leak that I introduced a couple of months ago.

The optimization in #3215 (released in 23.08.0) added a couple of helper classes that are deleted polymorphically. I forgot to add a virtual destructor, so the classes never properly released memory.