### PR TITLE
feat: add assert allclose

### DIFF
--- a/src/scipp/testing/__init__.py
+++ b/src/scipp/testing/__init__.py
@@ -6,6 +6,6 @@
 See also the `testing <../../reference/testing.rst>`_ reference.
 """
 
-from .assertions import assert_identical
+from .assertions import assert_allclose, assert_identical
 
-__all__ = ['assert_identical']
+__all__ = ['assert_identical', 'assert_allclose']


### PR DESCRIPTION
Fixes #3351 

There's an issue when the compared data is binned.
In that case the identical comparison is done in the c++ layer and we can't directly tell it to compare the values using `allclose`.