### PR TITLE
Specify pytest import mode in conda build.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -70,7 +70,7 @@ test:
   source_files:
     - tests/
   commands:
-    - python -m pytest -v tests
+    - python -m pytest -v tests --import-mode=importlib
     - python cmake-package-test/build.py
 {% endif %}
 


### PR DESCRIPTION
Fixes #3382 

As mentioned in the issue, we need to add ``import-mode`` option in the ``meta.yaml`` for conda build.