### PR TITLE
Add pyproject toml file as a source file in the conda meta.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -68,9 +68,10 @@ test:
   files:
     - cmake-package-test/
   source_files:
+    - pyproject.toml
     - tests/
   commands:
-    - python -m pytest -v tests --import-mode=importlib
+    - python -m pytest -v tests
     - python cmake-package-test/build.py
 {% endif %}
 


### PR DESCRIPTION
I just found out that ``copier-template`` projects just have `pyproject.toml` in the ``meta.yaml``.
So I added pyproject toml as a source file here as well.

Seems working in the action fine: https://github.com/scipp/scipp/actions/runs/7784926138/job/21226397862
Fixes #3382 ,
instead of #3383 