### PR TITLE
fix: make tests deterministic

### DIFF
--- a/tests/curve_fit_test.py
+++ b/tests/curve_fit_test.py
@@ -10,6 +10,11 @@ from scipp import curve_fit
 from scipp.compat.xarray_compat import from_xarray, to_xarray
 
 
+@pytest.fixture
+def rng():
+    return np.random.default_rng(seed=1234)
+
+
 def func(x, a, b):
     return a * sc.exp(-b * x)
 
@@ -196,17 +201,17 @@ def test_should_raise_TypeError_when_sigma_given_as_param():
         curve_fit(['x'], func, array1d(), sigma=np.arange(4))
 
 
-def test_should_raise_ValueError_when_sigma_contains_zeros():
+def test_should_raise_ValueError_when_sigma_contains_zeros(rng):
     da = array1d(size=50)
-    da.variances = np.random.default_rng().normal(0.0, 0.1, size=50) ** 2
+    da.variances = rng.normal(0.0, 0.1, size=50) ** 2
     da['xx', 21].variance = 0.0
     with pytest.raises(ValueError):
         curve_fit(['x'], func, da)
 
 
-def test_does_not_raise_when_sigma_contains_zeros_that_is_masked():
+def test_does_not_raise_when_sigma_contains_zeros_that_is_masked(rng):
     da = array1d(size=50)
-    da.variances = np.random.default_rng().normal(0.0, 0.1, size=50) ** 2
+    da.variances = rng.normal(0.0, 0.1, size=50) ** 2
     da.masks['m'] = sc.full(value=False, sizes=da.sizes)
     da['xx', 21].variance = 0.0
     da.masks['m']['xx', 21] = True


### PR DESCRIPTION
Fixes #3396 

Tests failed here https://github.com/scipp/scipp/actions/runs/7955172534/job/21713728068
in this test:
```python
    def test_does_not_raise_when_sigma_contains_zeros_that_is_masked():
        da = array1d(size=50)
        da.variances = np.random.default_rng().normal(0.0, 0.1, size=50) ** 2
        da.masks['m'] = sc.full(value=False, sizes=da.sizes)
        da['xx', 21].variance = 0.0
        da.masks['m']['xx', 21] = True
>       curve_fit(['x'], func, da)
```

The test probably failed because the call to `random.normal` produced an unusually low value.
Another possible fix would be to set the standard deviation to not be lower than say 1e-3.