### PR TITLE
Require identical units in mod operation

### DIFF
--- a/docs/user-guide/coordinate-transformations.ipynb
+++ b/docs/user-guide/coordinate-transformations.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "\n",
     "def time(local_datetime):\n",
-    "    seconds_per_day = sc.scalar(24 * 60 * 60, unit='s/D')\n",
+    "    seconds_per_day = sc.scalar(24 * 60 * 60, unit='s')\n",
     "    start_day = sc.scalar(start.value.astype('datetime64[D]'))\n",
     "    start_day_in_seconds = sc.scalar(start_day.values.astype('datetime64[s]'))\n",
     "    offset = local_datetime - start_day_in_seconds\n",

--- a/lib/core/test/element_arithmetic_test.cpp
+++ b/lib/core/test/element_arithmetic_test.cpp
@@ -200,7 +200,8 @@ TYPED_TEST(ElementArithmeticDivisionTest, remainder) {
 TEST(ElementArithmeticDivisionTest, units) {
   EXPECT_EQ(divide(units::m, units::s), units::m / units::s);
   EXPECT_EQ(floor_divide(units::m, units::s), units::m / units::s);
-  EXPECT_EQ(mod(units::m, units::s), units::m);
+  EXPECT_EQ(mod(units::m, units::m), units::m);
+  EXPECT_THROW(mod(units::m, units::s), except::UnitError);
 }
 
 class ElementNanArithmeticTest : public ::testing::Test {

--- a/lib/units/test/unit_test.cpp
+++ b/lib/units/test/unit_test.cpp
@@ -121,10 +121,13 @@ TEST(UnitTest, modulo) {
   Unit one{units::dimensionless};
   Unit l{units::m};
   Unit t{units::s};
-  EXPECT_EQ(l % one, l);
-  EXPECT_EQ(t % one, t);
+  Unit none{units::none};
   EXPECT_EQ(l % l, l);
-  EXPECT_EQ(l % t, l);
+  EXPECT_EQ(t % t, t);
+  EXPECT_THROW(l % t, except::UnitError);
+  EXPECT_THROW(l % one, except::UnitError);
+  EXPECT_THROW(l % none, except::UnitError);
+  EXPECT_THROW(t % l, except::UnitError);
 }
 
 TEST(UnitTest, pow) {

--- a/lib/units/unit.cpp
+++ b/lib/units/unit.cpp
@@ -132,7 +132,7 @@ Unit operator%(const Unit &a, const Unit &b) {
   if (a == b)
     return a;
   throw except::UnitError("Cannot perform modulo operation with " + a.name() +
-                          " and " + b.name() + ".");
+                          " and " + b.name() + ". Units must be the same.");
 }
 
 Unit operator-(const Unit &a) { return a; }

--- a/lib/units/unit.cpp
+++ b/lib/units/unit.cpp
@@ -129,11 +129,10 @@ Unit operator/(const Unit &a, const Unit &b) {
 }
 
 Unit operator%(const Unit &a, const Unit &b) {
-  if (a == none && b == none)
+  if (a == b)
     return a;
-  expect_not_none(a, "modulo");
-  expect_not_none(b, "modulo");
-  return a;
+  throw except::UnitError("Cannot perform modulo operation with " + a.name() +
+                          " and " + b.name() + ".");
 }
 
 Unit operator-(const Unit &a) { return a; }

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -259,7 +259,9 @@ def test_group_by_2d():
     table = sc.data.table_xyz(100)
     table.coords['label'] = (table.coords['x'] * 10).to(dtype='int64')
     da = table.bin(y=333).group('label')
-    da.coords['label'] = (sc.arange('y', 0, 333) * da.coords['label']) % 23
+    da.coords['label'] = (sc.arange('y', 0, 333) * da.coords['label']) % sc.scalar(
+        23, unit='m'
+    )
     grouped = da.group('label')
     assert grouped.sizes == {'y': 333, 'label': 23}
 


### PR DESCRIPTION
Fixes #3402

Note that:
```Py
sc.scalar(4., unit='m') % sc.scalar(3., unit='m')  # works
sc.scalar(4., unit='m') % sc.scalar(3., unit='s')  # raises
sc.scalar(4., unit='m') % 3.  # raises
sc.scalar(4.) % 3.  # works
```
i.e. dimensionless can work with bare numbers.