### PR TITLE
Do not truncate items in data group repr

### DIFF
--- a/src/scipp/core/data_group.py
+++ b/src/scipp/core/data_group.py
@@ -57,9 +57,9 @@ def _is_binned(item):
 
 def _summarize(item):
     if isinstance(item, DataGroup):
-        return f'{type(item).__name__}({len(item)}, {item.sizes})\n'
+        return f'{type(item).__name__}({len(item)}, {item.sizes})'
     if hasattr(item, 'sizes'):
-        return f'{type(item).__name__}({item.sizes})\n'
+        return f'{type(item).__name__}({item.sizes})'
     return str(item)
 
 
@@ -226,7 +226,7 @@ class DataGroup(MutableMapping):
     def __repr__(self):
         r = f'DataGroup(sizes={self.sizes}, keys=[\n'
         for name, var in self.items():
-            r += f'    {name}: {_summarize(var)[:-1]},\n'
+            r += f'    {name}: {_summarize(var)},\n'
         r += '])'
         return r
 

--- a/tests/repr_test.py
+++ b/tests/repr_test.py
@@ -41,6 +41,39 @@ def test_dataset_iterators_repr_does_not_raise():
     repr(ds.items())
 
 
+def test_data_group_repr_does_not_raise():
+    dg = sc.DataGroup(
+        {
+            'a': sc.data.table_xyz(10),
+            'b': sc.DataGroup(
+                {
+                    'da': sc.data.binned_x(10, 3),
+                    'int': 623,
+                }
+            ),
+            's': 'a string',
+            'var': sc.linspace('tt', 5, 8, 13, unit='Å'),
+        }
+    )
+    repr(dg)
+
+
+def test_data_group_repr_includes_items():
+    dg = sc.DataGroup(
+        {
+            'item 1': 'a string',
+            'another': sc.arange('d', 10, unit='Å'),
+        }
+    )
+    res = repr(dg)
+    idx1 = res.index('item 1')
+    idx2 = res.index('another')
+    assert idx1 < idx2
+    idx1 = res.index('a string')
+    idx2 = res.index('Variable')
+    assert idx1 < idx2
+
+
 @pytest.mark.parametrize("mapping", ["coords", "attrs", "meta", "masks"])
 def test_data_array_mapping_str_does_not_raise(mapping):
     da = sc.data.table_xyz(10)
@@ -74,3 +107,33 @@ def test_dataset_iterators_str_does_not_raise():
     str(ds.keys())
     str(ds.values())
     str(ds.items())
+
+
+def test_data_group_str_does_not_raise():
+    dg = sc.DataGroup(
+        {
+            'a': sc.data.table_xyz(10),
+            'b': sc.DataGroup(
+                {
+                    'da': sc.data.binned_x(10, 3),
+                    'int': 623,
+                }
+            ),
+            's': 'a string',
+            'var': sc.linspace('tt', 5, 8, 13, unit='Å'),
+        }
+    )
+    str(dg)
+
+
+def test_data_group_str_includes_items():
+    dg = sc.DataGroup(
+        {
+            'item 1': 'a string',
+            'another': sc.arange('d', 10, unit='Å'),
+        }
+    )
+    res = str(dg)
+    idx1 = res.index('item 1')
+    idx2 = res.index('another')
+    assert idx1 < idx2


### PR DESCRIPTION
Fixes #3406

Don't know why there were linefeeds in the first place.