### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
           micromamba-version: 1.5.6-0
           environment-file: env.yml
           cache-environment: true
-          create-args: python=3.9
+          create-args: python=3.10
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: |

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e static
@@ -40,7 +40,7 @@ jobs:
         - {os: ubuntu-22.04, cmake-preset: ci-linux}
         - {os: macos-11, cmake-preset: ci-macos}
         - {os: windows-2019, cmake-preset: ci-windows}
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        build: [cp39, cp310]
+        build: [cp310]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}
@@ -32,7 +32,7 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - run: python .github/workflows/rename-dev-wheels.py
       - uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e check-release
@@ -33,7 +33,7 @@ jobs:
           - {os: macos-11, target: osx_64}
           - {os: macos-11, target: osx_arm64}
           - {os: windows-2019, target: win_64}
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-11, windows-2019]
-        build: [cp39, cp310, cp311, cp312]
+        build: [cp310, cp311, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}
@@ -104,7 +104,7 @@ jobs:
           merge-multiple: true
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: conda install -c conda-forge --yes anaconda-client
       - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-*/*/*.tar.bz2)
 
@@ -121,7 +121,7 @@ jobs:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - name: Set outputs

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-22.04, target: linux_64}
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.10", "3.11"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        build: [cp39, cp312]
+        build: [cp310, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/docs/environments/developer.yml
+++ b/docs/environments/developer.yml
@@ -10,7 +10,6 @@ dependencies:
   - cmake>=3.21
   - conan==1.59.0
   - conda-build
-  - graphlib-backport # for python < 3.9
   - h5py
   - hypothesis
   - ipympl
@@ -26,7 +25,7 @@ dependencies:
   - pooch
   - pre-commit
   - pytest
-  - python=3.8
+  - python=3.10
   - python-graphviz
   - pythreejs
   - pyyaml

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Scipp requires Python 3.9 or above.
+Scipp requires Python 3.10 or above.
 
 Conda
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "numpy >= 1.20",
 ]

--- a/src/scipp/coords/rule.py
+++ b/src/scipp/coords/rule.py
@@ -223,4 +223,4 @@ def _arg_names(func) -> Dict[str, str]:
         args = spec.args[1:]
     names = tuple(args + spec.kwonlyargs)
     coords = getattr(func, '__transform_coords_input_keys__', names)
-    return dict(zip(coords, names))
+    return dict(zip(coords, names, strict=True))

--- a/src/scipp/curve_fit.py
+++ b/src/scipp/curve_fit.py
@@ -27,10 +27,10 @@ def _as_scalar(obj, unit):
 
 
 def _wrap_scipp_func(f, p_names, p_units):
-    _params = {k: _as_scalar(0.0, u) for k, u in zip(p_names, p_units)}
+    _params = {k: _as_scalar(0.0, u) for k, u in zip(p_names, p_units, strict=True)}
 
     def func(x, *args):
-        for k, v in zip(p_names, args):
+        for k, v in zip(p_names, args, strict=True):
             if isinstance(_params[k], Variable):
                 _params[k].value = v
             else:
@@ -46,8 +46,8 @@ def _wrap_numpy_func(f, p_names, coord_names):
         # Make x 2D for consistency.
         if len(x.shape) == 1:
             x = x.reshape(1, -1)
-        coords = dict(zip(coord_names, x))
-        params = dict(zip(p_names, args))
+        coords = dict(zip(coord_names, x, strict=True))
+        params = dict(zip(p_names, args, strict=True))
         return f(**coords, **params)
 
     return func
@@ -79,7 +79,7 @@ def _datagroup_outputs(da, params, p_units, map_over, pdata, covdata):
                     unit=u,
                 ),
             )
-            for i, (p, u) in enumerate(zip(params, p_units))
+            for i, (p, u) in enumerate(zip(params, p_units, strict=True))
         }
     )
     dgcov = DataGroup(
@@ -103,10 +103,10 @@ def _datagroup_outputs(da, params, p_units, map_over, pdata, covdata):
                             ),
                         ),
                     )
-                    for j, (q, q_u) in enumerate(zip(params, p_units))
+                    for j, (q, q_u) in enumerate(zip(params, p_units, strict=True))
                 }
             )
-            for i, (p, p_u) in enumerate(zip(params, p_units))
+            for i, (p, p_u) in enumerate(zip(params, p_units, strict=True))
         }
     )
     for c in da.coords:
@@ -138,7 +138,9 @@ def _make_defaults(f, coords, params):
     if not set(coords).issubset(all_args):
         raise ValueError("Function must take the provided coords as arguments")
     default_arguments = dict(
-        zip(spec.args[-len(spec.defaults) :], spec.defaults) if spec.defaults else {},
+        zip(spec.args[-len(spec.defaults) :], spec.defaults, strict=True)
+        if spec.defaults
+        else {},
         **(spec.kwonlydefaults or {}),
     )
     return {

--- a/src/scipp/format/formatter.py
+++ b/src/scipp/format/formatter.py
@@ -166,7 +166,8 @@ def _format_variable_compact(var: Variable, spec: FormatSpec) -> str:
         formatted = [_format_element_compact(v) for v in values]
     else:
         formatted = [
-            _format_element_compact(*_round(v, e)) for v, e in zip(values, variances)
+            _format_element_compact(*_round(v, e))
+            for v, e in zip(values, variances, strict=True)
         ]
     return f"{', '.join(formatted)}{unt}"
 

--- a/src/scipp/io/hdf5.py
+++ b/src/scipp/io/hdf5.py
@@ -42,7 +42,7 @@ def _dtype_lut():
         d.rotation3,
     ]
     names = [str(dtype) for dtype in dtypes]
-    return dict(zip(names, dtypes))
+    return dict(zip(names, dtypes, strict=True))
 
 
 def _as_hdf5_type(a):
@@ -328,7 +328,7 @@ class DataArrayIO:
         # Note that we write aligned and unaligned coords into the same group.
         # Distinction is via an attribute, which is more natural than having
         # 2 separate groups.
-        for view_name, view in zip(['coords', 'masks', 'attrs'], views):
+        for view_name, view in zip(['coords', 'masks', 'attrs'], views, strict=True):
             subgroup = group.create_group(view_name)
             _write_mapping(subgroup, view, override.get(view_name))
         return group

--- a/src/scipp/scipy/optimize/__init__.py
+++ b/src/scipp/scipy/optimize/__init__.py
@@ -26,7 +26,9 @@ def _as_scalar(obj, unit):
 
 def _wrap_func(f, p_names, p_units):
     def func(x, *args):
-        p = {k: _as_scalar(v, u) for k, v, u in zip(p_names, args, p_units)}
+        p = {
+            k: _as_scalar(v, u) for k, v, u in zip(p_names, args, p_units, strict=True)
+        }
         return f(x, **p).values
 
     return func
@@ -240,7 +242,9 @@ def curve_fit(
     )
     popt = {
         name: scalar(value=val, variance=var, unit=u)
-        for name, val, var, u in zip(params.keys(), popt, np.diag(pcov), p_units)
+        for name, val, var, u in zip(
+            params.keys(), popt, np.diag(pcov), p_units, strict=True
+        )
     }
     pcov = _covariance_with_units(list(params.keys()), pcov, p_units)
     return popt, pcov

--- a/src/scipp/utils/collapse_and_slices.py
+++ b/src/scipp/utils/collapse_and_slices.py
@@ -82,7 +82,7 @@ def collapse(scipp_obj, keep):
     slice_dims = []
     volume = 1
     slice_shape = {}
-    for d, size in zip(dims, shape):
+    for d, size in zip(dims, shape, strict=True):
         if d != keep:
             slice_dims.append(d)
             slice_shape[d] = size

--- a/src/scipp/visualization/formatting_html.py
+++ b/src/scipp/visualization/formatting_html.py
@@ -81,7 +81,7 @@ def _repr_item(bin_dim, item):
 def _get_events(var, variances, ellipsis_after):
     dim = var.bins.constituents['dim']
     dims = var.bins.constituents['data'].dims
-    bin_dim = dict(zip(dims, range(len(dims))))[dim]
+    bin_dim = dict(zip(dims, range(len(dims)), strict=True))[dim]
     s = []
     if not isinstance(var.values, (sc.Variable, sc.DataArray, sc.Dataset)):
         size = len(var.values)
@@ -168,7 +168,7 @@ def format_dims(dims, sizes, coords):
         f"<li><span{dim_css_map[dim]}>"
         f"{escape(str(dim))}</span>: "
         f"{size if size is not None else 'Events' }</li>"
-        for dim, size in zip(dims, sizes)
+        for dim, size in zip(dims, sizes, strict=True)
     )
 
     return f"<ul class='sc-dim-list'>{dims_li}</ul>"
@@ -278,7 +278,7 @@ def _make_dim_str(var, bin_edges, add_dim_size=False):
             _make_dim_labels(dim, bin_edges),
             f': {size}' if add_dim_size and size is not None else '',
         )
-        for dim, size in zip(var.dims, var.shape)
+        for dim, size in zip(var.dims, var.shape, strict=True)
     )
     return dims_text
 

--- a/src/scipp/visualization/resources.py
+++ b/src/scipp/visualization/resources.py
@@ -11,7 +11,7 @@ def _read_text(filename):
     return (
         importlib.resources.files('scipp.visualization.templates')
         .joinpath(filename)
-        .read_text()
+        .read_text(encoding='utf-8')
     )
 
 

--- a/src/scipp/visualization/show.py
+++ b/src/scipp/visualization/show.py
@@ -109,7 +109,7 @@ class VariableDrawer:
         """Compute 3D extent, remapping dimension order to target dim order"""
         shape = self._variable.shape
         dims = self._dims()
-        d = dict(zip(dims, shape))
+        d = dict(zip(dims, shape, strict=True))
         e = []
         max_extent = _cubes_in_full_width // 2
         for dim in self._target_dims:
@@ -439,10 +439,12 @@ class DatasetDrawer:
         ds = self._dataset
         if isinstance(ds, sc.DataArray):
             categories = zip(
-                ['coords', 'masks', 'attrs'], [ds.coords, ds.masks, ds.deprecated_attrs]
+                ['coords', 'masks', 'attrs'],
+                [ds.coords, ds.masks, ds.deprecated_attrs],
+                strict=True,
             )
         else:
-            categories = zip(['coords'], [ds.coords])
+            categories = zip(['coords'], [ds.coords], strict=True)
         for what, items in categories:
             for name, var in sorted(items.items()):
                 item = DrawerItem(

--- a/tests/curve_fit_test.py
+++ b/tests/curve_fit_test.py
@@ -305,7 +305,7 @@ def test_scipp_fun_and_numpy_fun_finds_same_optimized_params(f, fnp, array, coor
     popt, _ = curve_fit(coords, f, data)
     popt_np, _ = curve_fit(coords, fnp, data, unsafe_numpy_f=True)
 
-    for p, p_np in zip(popt.values(), popt_np.values()):
+    for p, p_np in zip(popt.values(), popt_np.values(), strict=True):
         assert sc.allclose(p.data, p_np.data, rtol=sc.scalar(2.0 * 1e-2))
 
 

--- a/tests/structured_test.py
+++ b/tests/structured_test.py
@@ -29,7 +29,7 @@ def test_structured_fields_dict_like():
 def test_structured_fields_keys_values():
     keys = list(var.fields.keys())
     values = list(var.fields.values())
-    for items in [dict(zip(keys, values)), dict(var.fields.items())]:
+    for items in [dict(zip(keys, values, strict=True)), dict(var.fields.items())]:
         assert len(keys) == 3
         assert len(values) == 3
         assert sc.identical(items['x'], 1.0 * sc.units.m)

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -930,30 +930,33 @@ def test_zeros_sizes():
     dims = ['x', 'y', 'z']
     shape = [2, 3, 4]
     assert sc.identical(
-        sc.zeros(dims=dims, shape=shape), sc.zeros(sizes=dict(zip(dims, shape)))
+        sc.zeros(dims=dims, shape=shape),
+        sc.zeros(sizes=dict(zip(dims, shape, strict=True))),
     )
     with pytest.raises(ValueError, match='dims and shape must both be None'):
-        sc.zeros(dims=dims, shape=shape, sizes=dict(zip(dims, shape)))
+        sc.zeros(dims=dims, shape=shape, sizes=dict(zip(dims, shape, strict=True)))
 
 
 def test_ones_sizes():
     dims = ['x', 'y', 'z']
     shape = [2, 3, 4]
     assert sc.identical(
-        sc.ones(dims=dims, shape=shape), sc.ones(sizes=dict(zip(dims, shape)))
+        sc.ones(dims=dims, shape=shape),
+        sc.ones(sizes=dict(zip(dims, shape, strict=True))),
     )
     with pytest.raises(ValueError, match='dims and shape must both be None'):
-        sc.ones(dims=dims, shape=shape, sizes=dict(zip(dims, shape)))
+        sc.ones(dims=dims, shape=shape, sizes=dict(zip(dims, shape, strict=True)))
 
 
 def test_empty_sizes():
     dims = ['x', 'y', 'z']
     shape = [2, 3, 4]
     _compare_properties(
-        sc.empty(dims=dims, shape=shape), sc.empty(sizes=dict(zip(dims, shape)))
+        sc.empty(dims=dims, shape=shape),
+        sc.empty(sizes=dict(zip(dims, shape, strict=True))),
     )
     with pytest.raises(ValueError, match='dims and shape must both be None'):
-        sc.empty(dims=dims, shape=shape, sizes=dict(zip(dims, shape)))
+        sc.empty(dims=dims, shape=shape, sizes=dict(zip(dims, shape, strict=True)))
 
 
 @pytest.mark.parametrize('timezone', ['Z', '-05:00', '+02'])

--- a/tools/benchmark_build.py
+++ b/tools/benchmark_build.py
@@ -169,7 +169,7 @@ def report(results):
     )
     printed_names = False
     for touch, group in groupby(results, key=lambda t: t[1]):
-        names, _, times = zip(*group)
+        names, _, times = zip(*group, strict=True)
         if not printed_names:
             print(
                 '                      '
@@ -196,7 +196,7 @@ def report(results):
 def main():
     results = []
     with TemporaryDirectory(dir='./') as working_dir:
-        for case, dirs in zip(CASES, make_dirs(working_dir)):
+        for case, dirs in zip(CASES, make_dirs(working_dir), strict=True):
             print(f"Running '{case.name}'")
             print('    Clean build')
             configure(case, *dirs)

--- a/tools/plot_benchmarks.py
+++ b/tools/plot_benchmarks.py
@@ -112,7 +112,9 @@ def designate_columns(data, plot_dims, ignored):
 
 def group_plots(data, designations):
     """Return the number of distinct plot groups and the groups themselves."""
-    meta_columns = [c for c, d in zip(data.columns, designations) if d == 'meta']
+    meta_columns = [
+        c for c, d in zip(data.columns, designations, strict=True) if d == 'meta'
+    ]
     groups = data.groupby(meta_columns)
     return len(groups), [group for _, group in groups]
 
@@ -121,7 +123,7 @@ def plot_title(data, designations):
     """Format a title for a plot of ``data``."""
     return ', '.join(
         f'{c}={data[c].unique()[0]}'
-        for c, d in zip(data.columns, designations)
+        for c, d in zip(data.columns, designations, strict=True)
         if d == 'meta'
     )
 


### PR DESCRIPTION
This only changes the version constraints / selections. I will open a separate PR for pyupgrade (`ruff check --select=UP`) to keep this one here easier to review.