### PR TITLE
ci: to avoid name collisions, include os in name

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -49,5 +49,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: conda-package-${{ inputs.os }}-py${{ inputs.python-version }}
+          name: conda-package-${{ inputs.target }}-py${{ inputs.python-version }}
           path: conda/package/*/scipp*.tar.bz2

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ inputs.build }}
+        name: dist-${{ inputs.os }}-${{ inputs.build }}
         path: wheelhouse/*.whl


### PR DESCRIPTION
The new upload artifact action (v4) expects all artifacts to have distinct names.
Previously the behavior was that artifacts were mutable so that multiple uploads to the same artifact just appended more files to the artifact.
See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md.