### PR TITLE
ci: conda workflow did not find files when they were put in 'dist'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: dist
           merge-multiple: true
           pattern: 'conda*'
       - uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
The conda workflow could not locate the files when they were placed in the `dist` dir.
I could not figure out if there was a specific reason why we put them in `dist`, but I removed it anyway because I think it must have been a mistake. Please correct me if this was wrong.
