### PR TITLE
fix: artifacts are downloaded to wrong directory for conda release wf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,23 +74,23 @@ jobs:
       os: ${{ matrix.os }}
       build: ${{ matrix.build }}
 
-  upload_pypi:
-    name: Deploy PyPI
-    needs: [build_wheels, build_sdist, build_conda]
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'release' && github.event.action == 'published'
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-          pattern: 'dist*'
-      - uses: actions/setup-python@v3
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+#  upload_pypi:
+#    name: Deploy PyPI
+#    needs: [build_wheels, build_sdist, build_conda]
+#    runs-on: ubuntu-22.04
+#    if: github.event_name == 'release' && github.event.action == 'published'
+#
+#    steps:
+#      - uses: actions/download-artifact@v4
+#        with:
+#          path: dist
+#          merge-multiple: true
+#          pattern: 'dist*'
+#      - uses: actions/setup-python@v3
+#      - uses: pypa/gh-action-pypi-publish@v1.8.14
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_TOKEN }}
 
   upload_conda:
     name: Deploy Conda Forge
@@ -131,7 +131,7 @@ jobs:
           echo "replaced=$(python docs/version.py --version=${GITHUB_REF_NAME} --action=get-replaced)" >> $GITHUB_OUTPUT
 
   docs:
-    needs: [upload_conda, upload_pypi, manage-versions]
+    needs: [upload_conda, manage-versions]
     uses: ./.github/workflows/docs.yml
     with:
       publish: ${{ github.event_name == 'release' && github.event.action == 'published' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
           pattern: 'conda*'
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: conda install -c conda-forge --yes anaconda-client
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-*/*/*.tar.bz2)
+      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(find . -type f -name "*.tar.bz2")
 
   manage-versions:
     name: Manage Versions


### PR DESCRIPTION
Currently they are downloaded to `$GITHUB_WORKSPACE`, but the conda publish command expects them to be in `$GITHUB_WORKSPACE/conda-package-*/etc` where `conda-package-*` are the artifact names...

Removing the `merge-multiple` option ([docs](https://github.com/actions/download-artifact?tab=readme-ov-file#inputs)) makes the artifacts "be extracted into individual named directories", I assume (hope) the directory names will be the same as the artifact names, because that is what we want.