### PR TITLE
fix: remove release folder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,5 +68,4 @@ jobs:
           folder: html
           target-folder: ${{ env.target }}
           single-commit: true
-          clean-exclude: release
           ssh-key: ${{ secrets.GH_PAGES_DEPLOY_KEY }}


### PR DESCRIPTION
Fixes #3464  

It seems the `release` folder is preserved because we exclude it from the clean.
This should make it go away next time we release.

Are there any links to this folder that might stop working because we do this?