### PR TITLE
Update to macos-14 CI images

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        description: 'Operating system: ubuntu-22.04, macos-11, or windows-2019'
+        description: 'Operating system: ubuntu-22.04, macos-14-large, or windows-2019'
         required: true
         type: string
       target:

--- a/.github/workflows/nightly-deps-test.yml
+++ b/.github/workflows/nightly-deps-test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         variant:
         - {os: ubuntu-22.04, cmake-preset: ci-linux}
-        - {os: macos-11, cmake-preset: ci-macos}
+        - {os: macos-14, cmake-preset: ci-macos}
         - {os: windows-2019, cmake-preset: ci-windows}
         python-version: ["3.10"]
 

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         variant:
         - {os: ubuntu-22.04, cmake-preset: ci-linux}
-        - {os: macos-11, cmake-preset: ci-macos}
+        - {os: macos-14, cmake-preset: ci-macos}
         - {os: windows-2019, cmake-preset: ci-windows}
         python-version: ["3.10"]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
       matrix:
         variant:
           - {os: ubuntu-22.04, target: linux_64}
-          - {os: macos-11, target: osx_64}
-          - {os: macos-11, target: osx_arm64}
+          - {os: macos-14-large, target: osx_64}
+          - {os: macos-14, target: osx_arm64}
           - {os: windows-2019, target: win_64}
         python-version: ["3.10", "3.11"]
     uses: ./.github/workflows/conda.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-11, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2019]
         build: [cp310, cp311, cp312]
     uses: ./.github/workflows/wheel.yml
     with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        description: 'Operating system: ubuntu-22.04, macos-11, or windows-2019'
+        description: 'Operating system: ubuntu-22.04, macos-14, or windows-2019'
         required: true
         type: string
       build:

--- a/lib/dataset/test/size_of_test.cpp
+++ b/lib/dataset/test/size_of_test.cpp
@@ -107,8 +107,8 @@ TEST(SizeOf, variable_of_vector3) {
 
 namespace {
 auto short_string_size([[maybe_unused]] const std::string &str) {
-#ifdef _MSC_VER
-  // MSVC does not use short string optimization.
+#if defined(_MSC_VER) || defined(__aarch64__)
+  // MSVC and MacOS arm64 do not use short string optimization.
   return sizeof(std::string) + str.size();
 #else
   return sizeof(std::string);


### PR DESCRIPTION
Fixes #3481.

This uses `macos-14` in PRs which is an arm64 machine. I think this makes sense as the number of M1 and M2 machines is only increasing. See https://github.com/actions/runner-images