### PR TITLE
Minor update in the quick-start page.

### DIFF
--- a/docs/getting-started/quick-start.ipynb
+++ b/docs/getting-started/quick-start.ipynb
@@ -105,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "array = array.copy()\n",
+    "array = array.copy()  # For more explanations why we `copy` see https://scipp.github.io/reference/ownership-mechanism-and-readonly-flags.html\n",
     "array.variances = np.square(rng.random((4, 5)))\n",
     "sc.show(array)"
    ]


### PR DESCRIPTION
Fixes #3458 

Extra line of `copy` might seem confusing to the new users, so I just added a link to the related in the markdown cell above.