### PR TITLE
fix: treat base is zero case specially

### DIFF
--- a/lib/core/include/scipp/core/value_and_variance.h
+++ b/lib/core/include/scipp/core/value_and_variance.h
@@ -71,8 +71,10 @@ template <class B, class E>
 constexpr auto pow(const ValueAndVariance<B> base, const E exponent) noexcept {
   const auto pow_1 = numeric::pow(base.value, exponent - 1);
   const auto var_factor = std::abs(exponent) * pow_1;
-  return ValueAndVariance{pow_1 * base.value,
-                          var_factor * var_factor * base.variance};
+  const auto pow_0 = (base.value == 0 && exponent >= 0 && exponent < 1)
+                         ? 0
+                         : pow_1 * base.value;
+  return ValueAndVariance{pow_0, var_factor * var_factor * base.variance};
 }
 
 template <class T> constexpr auto sqrt(const ValueAndVariance<T> a) noexcept {

--- a/lib/core/include/scipp/core/value_and_variance.h
+++ b/lib/core/include/scipp/core/value_and_variance.h
@@ -71,9 +71,9 @@ template <class B, class E>
 constexpr auto pow(const ValueAndVariance<B> base, const E exponent) noexcept {
   const auto pow_1 = numeric::pow(base.value, exponent - 1);
   const auto var_factor = std::abs(exponent) * pow_1;
-  const auto pow_0 = (base.value == 0 && exponent >= 0 && exponent < 1)
-                         ? 0
-                         : pow_1 * base.value;
+  const auto pow_0 = (base.value == 0 && exponent == 0  ? 1
+                      : base.value == 0 && exponent > 0 ? 0
+                                                        : pow_1 * base.value);
   return ValueAndVariance{pow_0, var_factor * var_factor * base.variance};
 }
 

--- a/lib/core/test/value_and_variance_test.cpp
+++ b/lib/core/test/value_and_variance_test.cpp
@@ -139,6 +139,19 @@ TEST(ValueAndVarianceTest, binary_pow) {
   EXPECT_NEAR(1.0 / 9.0, result.value, 1e-16);
   // pow.var = (|-2| * (base.val ^ -3)) ^ 2 * base.var
   EXPECT_NEAR(std::pow(2 / 27.0, 2.0) * base.variance, result.variance, 1e-16);
+
+  const ValueAndVariance zero{0.0, 1.0};
+  result = pow(zero, 0.5);
+  EXPECT_NEAR(0., result.value, 1e-15);
+  EXPECT_TRUE(std::isinf(result.variance));
+
+  result = pow(zero, 0.);
+  EXPECT_NEAR(1., result.value, 1e-15);
+
+  const ValueAndVariance zerozero{0.0, 0.0};
+  result = pow(zerozero, 0.5);
+  EXPECT_NEAR(0., result.value, 1e-15);
+  EXPECT_TRUE(std::isnan(result.variance));
 }
 
 TEST(ValueAndVarianceTest, comparison) {


### PR DESCRIPTION
Fixes #3507 

I think most of the cases in the issue are fine except:
```python
sc.scalar(0.0, variance=0.0)**0.5
# and
sc.scalar(0.0, variance=1.0)**0.5
```
because in those cases the value of the result should just be `0.0` and not `nan`.