### PR TITLE
Remove broken links

### DIFF
--- a/docs/development/dependencies.rst
+++ b/docs/development/dependencies.rst
@@ -74,7 +74,3 @@ This list is incomplete, but attempts to aid in better understanding how many th
      - x
      - x
      - ``pooch`` files, accessed during ``docs`` build
-   * - `<https://azure.archive.ubuntu.com>`_
-     - x
-     -
-     - ccache-action gets Ubuntu ``ccache`` from here

--- a/docs/development/notebook-style-guide.ipynb
+++ b/docs/development/notebook-style-guide.ipynb
@@ -52,7 +52,7 @@
     "- Line lengths should be limited to avoid horizontal scroll bars when viewing documentation pages in a browser or in Jupyter.\n",
     "  - A line length of 88 (default in `black`) seems to work well.\n",
     "- Automatic code formatting (such as `black`, `yapf`, or `flake8`) is recommended, but in some cases it may hurt readability, so no binding recommendation is made, i.e., exceptions are allowed.\n",
-    "  - [jupyterlab-code-formatter](https://ryantam626.github.io/jupyterlab_code_formatter/index.html) is a useful tool for applying automatic formatting to individual cells or entire notebooks. Example config for `black`:\n",
+    "  - [jupyterlab-code-formatter](https://jupyterlab-code-formatter.readthedocs.io/) is a useful tool for applying automatic formatting to individual cells or entire notebooks. Example config for `black`:\n",
     "    ```\n",
     "    {\n",
     "        {\n",


### PR DESCRIPTION
Fixes #3513 

Updated the outdated link to jupyter formatting tool.

Removed the link to where ccache is sourced.
Is it really necessary to declare this? If it is, I think there are some more entries that ought to be added here.