### PR TITLE
 Use windows-2019 image for nightly build release 

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly Release
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * *'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,7 +1,6 @@
 name: Nightly Release
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * *'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
         build: [cp310, cp312]
     uses: ./.github/workflows/wheel.yml
     with:


### PR DESCRIPTION
Let's see if this fixes https://github.com/scipp/scipp/issues/3528, the CI is complaining about MSVC compiler versions.