### PR TITLE
Fix `hist` to preserve unrelated coord in multi-dim cases

### DIFF
--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1203,6 +1203,19 @@ def test_op_on_binned_with_explicit_dim_arg_yields_expected_output_dims(z):
     assert xy.nanhist(z=4, dim=()).dims == ('x', 'y', 'z')
 
 
+@pytest.mark.parametrize('op', [sc.bin, sc.hist, sc.nanhist])
+def test_op_with_explicit_dim_arg_keeps_aux_coord(op) -> None:
+    data = sc.ones(dims=['xyz'], shape=(60,))
+    da = sc.DataArray(data)
+    da.coords['u'] = sc.sin(sc.linspace('xyz', 0.0, 2.0, num=60, unit='rad'))
+    da.coords['v'] = sc.cos(sc.linspace('xyz', 0.0, 2.0, num=60, unit='rad'))
+    da.coords['aux'] = sc.cos(sc.linspace('xyz', 0.0, 2.0, num=60, unit='rad'))
+    da = da.fold(dim='xyz', sizes={'x': 3, 'y': 4, 'z': 5})
+    da.coords['x'] = sc.linspace(dim='x', start=0.0, stop=1.0, num=3)
+    result = op(da, u=2, v=2, dim=('y', 'z'))
+    assert sc.identical(result.coords['x'], da.coords['x'])
+
+
 @pytest.mark.parametrize(
     'z_coord',
     [


### PR DESCRIPTION
This fixes a bug in a newly introduced feature in #3501. Previously it was not possible to get into such a case because `hist` did not support this mode of operation.

Looking at the diff in that PR 
<img width="681" alt="image" src="https://github.com/user-attachments/assets/0fe887bb-7fa4-44a9-987a-859cd82202f7">
it is evident that I had begun changing the code, but then keep the old way of computing `drop`. I wonder if there is a static analysis tool that could catch something like this (the `drop` defined on line 579 is unused)? Isn't it in some sense similar to an "unused argument" check?