### PR TITLE
Also build nightly wheels for 311

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
-        build: [cp310, cp312]
+        build: [cp310, cp311, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
This is needed for the DMSC integration testing.