### PR TITLE
Change the name of the nightly wheels so that pip>24.1 and uv can install them

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
-        build: [cp310, cp312]
+        build: [cp310, cp311, cp312]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/rename-dev-wheels.py
+++ b/.github/workflows/rename-dev-wheels.py
@@ -4,7 +4,10 @@ import os
 for filename in glob.glob('dist/*whl'):
     # We remove the version number, dev number, and Git hash to ensure we have a
     # predictable URL of the uploaded release asset that downstream projects can use.
+    # We have to use a dummy version number as this is required by
+    # pip (https://github.com/pypa/pip/issues/12063) and
+    # uv (https://github.com/astral-sh/uv/issues/5478)
     pkg, _, remainder = filename.split('-', 2)
-    target = f'{pkg}-nightly-{remainder}'
+    target = f'{pkg}-9999.99.99-{remainder}'
     print(f'Renaming wheel {filename} to {target}')
     os.rename(filename, target)


### PR DESCRIPTION
New `pip` and `uv` require a version number in the wheel name to install the package.

Not sure if we want to keep the `nightly` in the name or not?...

**Attention:** after this is merged, either ALL the nightly builds in the downstream packages will fail, or they might still find the old uploded wheels but they will no longer by "nightly" builds, they will remain frozen to the version of today.
We need to make sure we update this in all packages.
The copier template will also need to be updated: https://github.com/scipp/copier_template/blob/main/template/requirements/make_base.py#L62