### PR TITLE
MAINT: Do not delete nightlies from anaconda pypi

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -63,6 +63,11 @@ jobs:
           artifacts_path: dist
           anaconda_nightly_upload_organization: scipp-nightly-wheels
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_NIGHTLY_WHEEL_TOKEN}}
+      # The current implementation in this workflow has a bug, commenting out the delete step
+      # so we don't mistakenly delete the current nightly release. This will be fixed once we
+      # can start using the delete wheel action from scientific-python/upload-nightly-action
+      # upstream. It's okay to keep uploading wheels to pypi.anaconda.org/scipp-nightly-wheels
+      # for now, we can clean it up once the new action is released.
       # - name: Delete old dev wheels from pypi.anaconda.org
       #   # We use pixi exec to reuse the pixi already installed by the upload nightly action
       #   run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -63,10 +63,10 @@ jobs:
           artifacts_path: dist
           anaconda_nightly_upload_organization: scipp-nightly-wheels
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_NIGHTLY_WHEEL_TOKEN}}
-      - name: Delete old dev wheels from pypi.anaconda.org
-        # We use pixi exec to reuse the pixi already installed by the upload nightly action
-        run: |
-          while read -r package_name; do
-            echo "Removing $package_name"
-            pixi exec -s anaconda-client=1.12.3 anaconda --token "${{secrets.ANACONDA_NIGHTLY_WHEEL_TOKEN}}" remove -f "$package_name"
-          done < dev_wheels.txt
+      # - name: Delete old dev wheels from pypi.anaconda.org
+      #   # We use pixi exec to reuse the pixi already installed by the upload nightly action
+      #   run: |
+      #     while read -r package_name; do
+      #       echo "Removing $package_name"
+      #       pixi exec -s anaconda-client=1.12.3 anaconda --token "${{secrets.ANACONDA_NIGHTLY_WHEEL_TOKEN}}" remove -f "$package_name"
+      #     done < dev_wheels.txt


### PR DESCRIPTION
The current action has a bug as it will delete the nightly wheels if there wasn't a new commit to the main branch since the last nightly release.

Let's just turn it off for now. We can use the action upstream https://github.com/scientific-python/upload-nightly-action/pull/95 to remove the wheels once it's merged in.