### PR TITLE
Drop points with NaNs coord values when histogramming or binning

### DIFF
--- a/lib/core/include/scipp/core/histogram.h
+++ b/lib/core/include/scipp/core/histogram.h
@@ -33,9 +33,9 @@ Index get_bin(const T &x, const Edges &edges, const Params &params) {
   // integer overflow when converting the "bin" computation result to `Index`.
   if (x < edges.front() || x >= edges.back())
     return -1;
-  // If x is not finite we also return early as it cannot be in any bin.
+  // If x is NaN we also return early as it cannot be in any bin.
   if constexpr (!std::is_same_v<T, time_point>)
-    if (!std::isfinite(x))
+    if (std::isnan(x))
       return -1;
   const auto [offset, nbin, scale] = params;
   Index bin = (x - offset) * scale;

--- a/lib/core/include/scipp/core/histogram.h
+++ b/lib/core/include/scipp/core/histogram.h
@@ -33,6 +33,10 @@ Index get_bin(const T &x, const Edges &edges, const Params &params) {
   // integer overflow when converting the "bin" computation result to `Index`.
   if (x < edges.front() || x >= edges.back())
     return -1;
+  // If x is not finite we also return early as it cannot be in any bin.
+  if constexpr (!std::is_same_v<T, time_point>)
+    if (!std::isfinite(x))
+      return -1;
   const auto [offset, nbin, scale] = params;
   Index bin = (x - offset) * scale;
   bin = std::clamp(bin, Index(0), Index(nbin - 1));

--- a/lib/core/test/element_histogram_test.cpp
+++ b/lib/core/test/element_histogram_test.cpp
@@ -100,8 +100,8 @@ TEST(ElementHistogramTest, nan_values_are_dropped_linspace_bins) {
 
 TEST(ElementHistogramTest, infinite_values_are_dropped) {
   std::vector<double> edges{0, 4, 6};
-  std::vector<double> events{std::numeric_limits<double>::infinity(), 2, 3, 4,
-                             std::numeric_limits<double>::infinity(), 6, 7};
+  std::vector<double> events{std::numeric_limits<double>::infinity(),  2, 3, 4,
+                             -std::numeric_limits<double>::infinity(), 6, 7};
   std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
   std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
   std::vector<double> result_vals{0, 0};
@@ -117,8 +117,8 @@ TEST(ElementHistogramTest, infinite_values_are_dropped) {
 
 TEST(ElementHistogramTest, infinite_values_are_dropped_linspace_bins) {
   std::vector<double> edges{0, 2, 4, 6};
-  std::vector<double> events{std::numeric_limits<double>::infinity(), 2, 3, 4,
-                             std::numeric_limits<double>::infinity(), 6, 7};
+  std::vector<double> events{std::numeric_limits<double>::infinity(),  2, 3, 4,
+                             -std::numeric_limits<double>::infinity(), 6, 7};
   std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
   std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
   std::vector<double> result_vals{0, 0, 0};

--- a/lib/core/test/element_histogram_test.cpp
+++ b/lib/core/test/element_histogram_test.cpp
@@ -65,3 +65,69 @@ TEST(ElementHistogramTest, no_variance) {
                      edges);
   EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40 + 50}));
 }
+
+TEST(ElementHistogramTest, nan_values_are_dropped) {
+  std::vector<double> edges{0, 4, 6};
+  std::vector<double> events{1, std::nan("2"), 3, 4, 5, 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
+  std::vector<double> result_vals{0, 0};
+  std::vector<double> result_vars{0, 0};
+  element::histogram(
+      ValueAndVariance(scipp::span(result_vals), scipp::span(result_vars)),
+      events,
+      ValueAndVariance(scipp::span(weight_vals), scipp::span(weight_vars)),
+      edges);
+  EXPECT_EQ(result_vals, std::vector<double>({10 + 30, 40 + 50}));
+  EXPECT_EQ(result_vars, std::vector<double>({100 + 300, 400 + 500}));
+}
+
+TEST(ElementHistogramTest, nan_values_are_dropped_linspace_bins) {
+  std::vector<double> edges{0, 2, 4, 6};
+  std::vector<double> events{1, std::nan("2"), 3, 4, 5, 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
+  std::vector<double> result_vals{0, 0, 0};
+  std::vector<double> result_vars{0, 0, 0};
+  element::histogram(
+      ValueAndVariance(scipp::span(result_vals), scipp::span(result_vars)),
+      events,
+      ValueAndVariance(scipp::span(weight_vals), scipp::span(weight_vars)),
+      edges);
+  EXPECT_EQ(result_vals, std::vector<double>({10, 30, 40 + 50}));
+  EXPECT_EQ(result_vars, std::vector<double>({100, 300, 400 + 500}));
+}
+
+TEST(ElementHistogramTest, infinite_values_are_dropped) {
+  std::vector<double> edges{0, 4, 6};
+  std::vector<double> events{std::numeric_limits<double>::infinity(), 2, 3, 4,
+                             std::numeric_limits<double>::infinity(), 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
+  std::vector<double> result_vals{0, 0};
+  std::vector<double> result_vars{0, 0};
+  element::histogram(
+      ValueAndVariance(scipp::span(result_vals), scipp::span(result_vars)),
+      events,
+      ValueAndVariance(scipp::span(weight_vals), scipp::span(weight_vars)),
+      edges);
+  EXPECT_EQ(result_vals, std::vector<double>({20 + 30, 40}));
+  EXPECT_EQ(result_vars, std::vector<double>({200 + 300, 400}));
+}
+
+TEST(ElementHistogramTest, infinite_values_are_dropped_linspace_bins) {
+  std::vector<double> edges{0, 2, 4, 6};
+  std::vector<double> events{std::numeric_limits<double>::infinity(), 2, 3, 4,
+                             std::numeric_limits<double>::infinity(), 6, 7};
+  std::vector<double> weight_vals{10, 20, 30, 40, 50, 60, 70};
+  std::vector<double> weight_vars{100, 200, 300, 400, 500, 600, 700};
+  std::vector<double> result_vals{0, 0, 0};
+  std::vector<double> result_vars{0, 0, 0};
+  element::histogram(
+      ValueAndVariance(scipp::span(result_vals), scipp::span(result_vars)),
+      events,
+      ValueAndVariance(scipp::span(weight_vals), scipp::span(weight_vars)),
+      edges);
+  EXPECT_EQ(result_vals, std::vector<double>({0, 20 + 30, 40}));
+  EXPECT_EQ(result_vars, std::vector<double>({0, 200 + 300, 400}));
+}

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -819,3 +819,75 @@ TEST(BinTest, bin_by_noncontiguous_int_group) {
 
   EXPECT_EQ(bin(table, {}, {non_cont_group}), bin(table, {}, {cont_group}));
 }
+
+TEST(BinTest, nan_values_are_dropped) {
+  const auto table = make_table(10);
+  const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
+                                            Values{-2.1, -1.0, 0.0, 1.0, 2.0});
+
+  const scipp::core::Slice slice(Dim::Row, 1, 9, 1);
+  const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
+
+  // Add nan values at start and end of table
+  auto table_nan = table;
+  table_nan.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  table_nan.coords()[Dim::X].values<double>()[9] =
+      std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_EQ(bins_sum(bin(table_nan, {x_edges})), expected);
+}
+
+TEST(BinTest, nan_values_are_dropped_linspace_bins) {
+  const auto table = make_table(10);
+  const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
+                                            Values{-2.0, -1.0, 0.0, 1.0, 2.0});
+
+  const scipp::core::Slice slice(Dim::Row, 1, 9, 1);
+  const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
+
+  // Add nan values at start and end of table
+  auto table_nan = table;
+  table_nan.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  table_nan.coords()[Dim::X].values<double>()[9] =
+      std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_EQ(bins_sum(bin(table_nan, {x_edges})), expected);
+}
+
+TEST(BinTest, infinite_values_are_dropped) {
+  const auto table = make_table(10);
+  const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
+                                            Values{-2.1, -1.0, 0.0, 1.0, 2.0});
+
+  const scipp::core::Slice slice(Dim::Row, 2, 10, 1);
+  const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
+
+  // Add infinite values at start of the table
+  auto table_inf = table;
+  table_inf.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::infinity();
+  table_inf.coords()[Dim::X].values<double>()[1] =
+      -std::numeric_limits<double>::infinity();
+
+  EXPECT_EQ(bins_sum(bin(table_inf, {x_edges})), expected);
+}
+
+TEST(BinTest, infinite_values_are_dropped_linspace_bins) {
+  const auto table = make_table(10);
+  const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
+                                            Values{-2.0, -1.0, 0.0, 1.0, 2.0});
+
+  const scipp::core::Slice slice(Dim::Row, 2, 10, 1);
+  const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
+
+  // Add infinite values at start of the table
+  auto table_inf = table;
+  table_inf.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::infinity();
+  table_inf.coords()[Dim::X].values<double>()[1] =
+      -std::numeric_limits<double>::infinity();
+
+  EXPECT_EQ(bins_sum(bin(table_inf, {x_edges})), expected);
+}

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -821,73 +821,61 @@ TEST(BinTest, bin_by_noncontiguous_int_group) {
 }
 
 TEST(BinTest, nan_values_are_dropped) {
-  const auto table = make_table(10);
+  auto table = make_table(10);
+  table.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  table.coords()[Dim::X].values<double>()[9] =
+      std::numeric_limits<double>::quiet_NaN();
+
   const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
                                             Values{-2.1, -1.0, 0.0, 1.0, 2.0});
 
   const scipp::core::Slice slice(Dim::Row, 1, 9, 1);
   const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
-
-  // Add nan values at start and end of table
-  auto table_nan = table;
-  table_nan.coords()[Dim::X].values<double>()[0] =
-      std::numeric_limits<double>::quiet_NaN();
-  table_nan.coords()[Dim::X].values<double>()[9] =
-      std::numeric_limits<double>::quiet_NaN();
-
-  EXPECT_EQ(bins_sum(bin(table_nan, {x_edges})), expected);
+  EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
 TEST(BinTest, nan_values_are_dropped_linspace_bins) {
-  const auto table = make_table(10);
+  auto table = make_table(10);
+  table.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::quiet_NaN();
+  table.coords()[Dim::X].values<double>()[9] =
+      std::numeric_limits<double>::quiet_NaN();
+
   const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
                                             Values{-2.0, -1.0, 0.0, 1.0, 2.0});
 
   const scipp::core::Slice slice(Dim::Row, 1, 9, 1);
   const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
-
-  // Add nan values at start and end of table
-  auto table_nan = table;
-  table_nan.coords()[Dim::X].values<double>()[0] =
-      std::numeric_limits<double>::quiet_NaN();
-  table_nan.coords()[Dim::X].values<double>()[9] =
-      std::numeric_limits<double>::quiet_NaN();
-
-  EXPECT_EQ(bins_sum(bin(table_nan, {x_edges})), expected);
+  EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
 TEST(BinTest, infinite_values_are_dropped) {
-  const auto table = make_table(10);
+  auto table = make_table(10);
+  table.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::infinity();
+  table.coords()[Dim::X].values<double>()[1] =
+      -std::numeric_limits<double>::infinity();
+
   const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
                                             Values{-2.1, -1.0, 0.0, 1.0, 2.0});
 
   const scipp::core::Slice slice(Dim::Row, 2, 10, 1);
   const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
-
-  // Add infinite values at start of the table
-  auto table_inf = table;
-  table_inf.coords()[Dim::X].values<double>()[0] =
-      std::numeric_limits<double>::infinity();
-  table_inf.coords()[Dim::X].values<double>()[1] =
-      -std::numeric_limits<double>::infinity();
-
-  EXPECT_EQ(bins_sum(bin(table_inf, {x_edges})), expected);
+  EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
 TEST(BinTest, infinite_values_are_dropped_linspace_bins) {
-  const auto table = make_table(10);
+  auto table = make_table(10);
+  table.coords()[Dim::X].values<double>()[0] =
+      std::numeric_limits<double>::infinity();
+  table.coords()[Dim::X].values<double>()[1] =
+      -std::numeric_limits<double>::infinity();
+
   const auto x_edges = makeVariable<double>(Dims{Dim::X}, Shape{5},
                                             Values{-2.0, -1.0, 0.0, 1.0, 2.0});
 
   const scipp::core::Slice slice(Dim::Row, 2, 10, 1);
   const auto expected = bins_sum(bin(table.slice(slice), {x_edges}));
-
-  // Add infinite values at start of the table
-  auto table_inf = table;
-  table_inf.coords()[Dim::X].values<double>()[0] =
-      std::numeric_limits<double>::infinity();
-  table_inf.coords()[Dim::X].values<double>()[1] =
-      -std::numeric_limits<double>::infinity();
-
-  EXPECT_EQ(bins_sum(bin(table_inf, {x_edges})), expected);
+  EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -820,7 +820,7 @@ TEST(BinTest, bin_by_noncontiguous_int_group) {
   EXPECT_EQ(bin(table, {}, {non_cont_group}), bin(table, {}, {cont_group}));
 }
 
-TEST(BinTest, nan_values_are_dropped) {
+TEST(BinTest, points_with_nan_coord_values_are_dropped) {
   auto table = make_table(10);
   table.coords()[Dim::X].values<double>()[0] =
       std::numeric_limits<double>::quiet_NaN();
@@ -835,7 +835,7 @@ TEST(BinTest, nan_values_are_dropped) {
   EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
-TEST(BinTest, nan_values_are_dropped_linspace_bins) {
+TEST(BinTest, points_with_nan_coord_values_are_dropped_linspace_bins) {
   auto table = make_table(10);
   table.coords()[Dim::X].values<double>()[0] =
       std::numeric_limits<double>::quiet_NaN();
@@ -850,7 +850,7 @@ TEST(BinTest, nan_values_are_dropped_linspace_bins) {
   EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
-TEST(BinTest, infinite_values_are_dropped) {
+TEST(BinTest, points_with_inf_coord_values_are_dropped) {
   auto table = make_table(10);
   table.coords()[Dim::X].values<double>()[0] =
       std::numeric_limits<double>::infinity();
@@ -865,7 +865,7 @@ TEST(BinTest, infinite_values_are_dropped) {
   EXPECT_EQ(bins_sum(bin(table, {x_edges})), expected);
 }
 
-TEST(BinTest, infinite_values_are_dropped_linspace_bins) {
+TEST(BinTest, points_with_inf_coord_values_are_dropped_linspace_bins) {
   auto table = make_table(10);
   table.coords()[Dim::X].values<double>()[0] =
       std::numeric_limits<double>::infinity();


### PR DESCRIPTION
Fixes #3556.

Note that the bug is only present when using linspace bins.