### PR TITLE
MAINT: Support Python 3.13 while building wheels

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
-        build: [cp310, cp311, cp312]
+        build: [cp310, cp311, cp312, cp313]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, macos-14, windows-2019]
-        build: [cp310, cp311, cp312]
+        build: [cp310, cp311, cp312, cp313]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        build: [cp310, cp312]
+        build: [cp310, cp313]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
The wheel built just fine https://github.com/scipp/scipp/actions/runs/11399946525 for python 3.13

Numba doesn't support python 3.13 yet but it is an optional dep.