### PR TITLE
MAINT: Sync up to windows-2022 in github actions

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        description: 'Operating system: ubuntu-22.04, macos-14-large, or windows-2019'
+        description: 'Operating system: ubuntu-22.04, macos-14-large, or windows-2022'
         required: true
         type: string
       target:

--- a/.github/workflows/nightly-deps-test.yml
+++ b/.github/workflows/nightly-deps-test.yml
@@ -18,7 +18,7 @@ jobs:
         variant:
         - {os: ubuntu-22.04, cmake-preset: ci-linux}
         - {os: macos-14, cmake-preset: ci-macos}
-        - {os: windows-2019, cmake-preset: ci-windows}
+        - {os: windows-2022, cmake-preset: ci-windows}
         python-version: ["3.10"]
 
     steps:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-13, macos-14, windows-2022]
         build: [cp310, cp311, cp312, cp313]
     uses: ./.github/workflows/wheel.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           - {os: ubuntu-22.04, target: linux_64}
           - {os: macos-13, target: osx_64}
           - {os: macos-14, target: osx_arm64}
-          - {os: windows-2019, target: win_64}
+          - {os: windows-2022, target: win_64}
         python-version: ["3.10", "3.11", "3.12"]
     uses: ./.github/workflows/conda.yml
     with:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
         build: [cp310, cp311, cp312, cp313]
     uses: ./.github/workflows/wheel.yml
     with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        description: 'Operating system: ubuntu-22.04, macos-14, or windows-2019'
+        description: 'Operating system: ubuntu-22.04, macos-14, or windows-2022'
         required: true
         type: string
       build:


### PR DESCRIPTION
We test with windows-2022 image in CI runs on PRs https://github.com/scipp/scipp/blob/16b7f0f3bb974d3620395ea30e81d163257dfbdf/.github/workflows/pr_and_main.yml#L42