### PR TITLE
Support callable instances of class with `__call__` in `scipp.curve_fit`

### DIFF
--- a/src/scipp/curve_fit.py
+++ b/src/scipp/curve_fit.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 from collections.abc import Callable, Mapping, Sequence
-from inspect import getfullargspec
+from functools import partial
+from inspect import getfullargspec, isfunction
 from numbers import Real
 
 import numpy as np
@@ -120,6 +121,10 @@ def _make_defaults(f, coords, p0):
     non_default_args = (
         spec.args[: -len(spec.defaults)] if spec.defaults is not None else spec.args
     )
+    if not isfunction(f) and not isinstance(f, partial):
+        # f is a class with a __call__ method,
+        # first argument is 'self', exclude it.
+        non_default_args = non_default_args[1:]
     args = {*non_default_args, *spec.kwonlyargs} - set(spec.kwonlydefaults or ())
     if not set(coords).issubset(args):
         raise ValueError("Function must take the provided coords as arguments")

--- a/tests/curve_fit_test.py
+++ b/tests/curve_fit_test.py
@@ -700,3 +700,15 @@ def test_ignores_default_arguments():
         ['x'], lambda x, a, *, b=1.3: func(x, a, b=b), da, p0={'b': sc.scalar(1.3)}
     )
     assert 'b' in res
+
+
+def test_with_callable_class():
+    da = array1d(a=1.2, b=1.3, noise_scale=0.01)
+
+    class Model:
+        def __call__(self, x, a, b):
+            return func(x, a, b)
+
+    popt, _ = curve_fit(['x'], Model(), da)
+    assert sc.allclose(popt['a'].data, sc.scalar(1.2), rtol=sc.scalar(2.0 * 0.01))
+    assert sc.allclose(popt['b'].data, sc.scalar(1.3), rtol=sc.scalar(2.0 * 0.01))


### PR DESCRIPTION
This change addresses #3418 but only for `scipp.curve_fit`.

