### PR TITLE
Fix `sc.lookup` when data as a 2d coord

### DIFF
--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -108,7 +108,7 @@ def lookup(
     if dim is None:
         dim = func.dim
     func = DataArray(func.data, coords={dim: func.coords[dim]}, masks=func.masks)
-    if func.coords.is_edges(dim):
+    if func.coords.is_edges(dim, dim):
         if mode is not None:
             raise ValueError("Input is a histogram, 'mode' must not be set.")
         return Lookup(_cpp.buckets.map, func, dim, fill_value)

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -172,3 +172,17 @@ def test_promotes_to_dtype_of_events(op, dtype):
     hist = sc.DataArray(weight, coords={'x': edges})
     result = op(da.bins, sc.lookup(func=hist, dim='x'))
     assert result.bins.constituents['data'].dtype == dtype
+
+
+def test_lookup_2d_coord():
+    edges = sc.array(dims=['x', 'y'], values=[[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]])
+    da = sc.DataArray(
+        sc.array(dims=['x', 'y'], values=[[10.0, 11.0], [12.0, 13.0]]),
+        coords={'y': edges},
+    )
+
+    expected = sc.array(
+        dims=['x', 'y'], values=[[10.0, 11.0, np.nan], [12.0, 13.0, np.nan]]
+    )
+
+    assert sc.identical(sc.lookup(da, dim='y')[edges + 0.1], expected, equal_nan=True)


### PR DESCRIPTION
Example:
```Py
import scipp as sc

edges = sc.array(dims=['x', 'y'], values=[[0., 1., 2.], [1., 2., 3.]])
da = sc.DataArray(sc.array(dims=['x', 'y'], values=[[10., 11.], [12., 13.]]), coords={'y': edges})

sc.lookup(da, dim='y')[edges + 0.1]
```
would fail with `is_edges` error.