### PR TITLE
Remove broken link

### DIFF
--- a/docs/getting-started/tutorials/solar_flares.ipynb
+++ b/docs/getting-started/tutorials/solar_flares.ipynb
@@ -911,7 +911,7 @@
    "metadata": {},
    "source": [
     "In this tutorial, we assume that the instrument consists of a 3x3 grid of detectors which each record x-rays from distinct directions.\n",
-    "(The reality is more complicated, of course. See the [wiki](https://sprg.ssl.berkeley.edu/~tohban/wiki/index.php/Category:RHESSI) for more information.)\n",
+    "(The reality is more complicated, of course.)\n",
     "Furthermore, the tutorial data has been manipulated to simulate different efficiencies of the individual detectors.\n",
     "\n",
     "The efficiency is available in the input data group:"


### PR DESCRIPTION
This failed linkcheck. It looks like the wiki page has been removed or is behind a login now. The link is not crucial for the tutorial.