### PR TITLE
MAINT: Move sanitizers specific blocks behind a flag

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,8 @@
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF",
         "FULL_BUILD": "ON",
-        "BENCHMARK": "ON"
+        "BENCHMARK": "ON",
+        "SANITIZERS": "ON"
       }
     },
     {
@@ -56,7 +57,8 @@
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "$env{PREFIX}",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON",
-        "BENCHMARK": "OFF"
+        "BENCHMARK": "OFF",
+        "SANITIZERS": "OFF"
       }
     },
     {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,7 +22,10 @@ set(Python_FIND_IMPLEMENTATIONS CPython PyPy)
 find_package(Benchmark)
 find_package(Boost 1.67 REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Sanitizers REQUIRED)
+option(SANITIZERS "Enable sanitizers" OFF)
+if(SANITIZERS)
+  find_package(Sanitizers REQUIRED)
+endif()
 find_package(GTest CONFIG REQUIRED)
 # libpython is not available on `manylinux` images, use `Development.Module`
 # instead of `Development`

--- a/lib/cmake/scipp-install.cmake
+++ b/lib/cmake/scipp-install.cmake
@@ -8,7 +8,9 @@ function(scipp_install_component)
   cmake_parse_arguments(
     PARSE_ARGV 0 SCIPP_INSTALL_COMPONENT "${options}" "${oneValueArgs}" ""
   )
-  add_sanitizers(${SCIPP_INSTALL_COMPONENT_TARGET})
+  if(SANITIZERS)
+    add_sanitizers(${SCIPP_INSTALL_COMPONENT_TARGET})
+  endif()
   if(DYNAMIC_LIB)
     install(
       TARGETS ${SCIPP_INSTALL_COMPONENT_TARGET}

--- a/lib/common/test/CMakeLists.txt
+++ b/lib/common/test/CMakeLists.txt
@@ -18,5 +18,7 @@ set_property(
 set_property(
   TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL $<NOT:$<BOOL:${FULL_BUILD}>>
 )
-add_sanitizers(${TARGET_NAME})
+if(SANITIZERS)
+  add_sanitizers(${TARGET_NAME})
+endif()
 scipp_test(${TARGET_NAME} common)

--- a/lib/core/test/CMakeLists.txt
+++ b/lib/core/test/CMakeLists.txt
@@ -54,5 +54,7 @@ set_property(
 set_property(
   TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL $<NOT:$<BOOL:${FULL_BUILD}>>
 )
-add_sanitizers(${TARGET_NAME})
+if(SANITIZERS)
+  add_sanitizers(${TARGET_NAME})
+endif()
 scipp_test(${TARGET_NAME} core)

--- a/lib/dataset/test/CMakeLists.txt
+++ b/lib/dataset/test/CMakeLists.txt
@@ -67,5 +67,7 @@ set_property(
 set_property(
   TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL $<NOT:$<BOOL:${FULL_BUILD}>>
 )
-add_sanitizers(${TARGET_NAME})
+if(SANITIZERS)
+  add_sanitizers(${TARGET_NAME})
+endif()
 scipp_test(${TARGET_NAME} dataset)

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -163,7 +163,7 @@ protected:
   Variable edges_y_coarse =
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{-2, -1, 2});
 
-  void expect_near(const DataArray &a, const DataArray &b, double rtol = 1e-14,
+  void expect_near(const DataArray &a, const DataArray &b, double rtol = 1e-13,
                    double atol = 0.0) {
     const auto tolerance =
         values(max(bins_sum(a.data())) * (rtol * units::one));

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -163,7 +163,7 @@ protected:
   Variable edges_y_coarse =
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{-2, -1, 2});
 
-  void expect_near(const DataArray &a, const DataArray &b, double rtol = 1e-13,
+  void expect_near(const DataArray &a, const DataArray &b, double rtol = 11e-15,
                    double atol = 0.0) {
     const auto tolerance =
         values(max(bins_sum(a.data())) * (rtol * units::one));

--- a/lib/python/CMakeLists.txt
+++ b/lib/python/CMakeLists.txt
@@ -59,7 +59,9 @@ if(PRECOMPILED_HEADERS)
   target_precompile_headers(_scipp PRIVATE pybind11.h)
 endif()
 
-add_sanitizers(_scipp)
+if(SANITIZERS)
+  add_sanitizers(_scipp)
+endif()
 
 install(TARGETS _scipp DESTINATION ${PYTHONDIR})
 

--- a/lib/units/test/CMakeLists.txt
+++ b/lib/units/test/CMakeLists.txt
@@ -15,5 +15,7 @@ set_property(
 set_property(
   TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL $<NOT:$<BOOL:${FULL_BUILD}>>
 )
-add_sanitizers(${TARGET_NAME})
+if(SANITIZERS)
+  add_sanitizers(${TARGET_NAME})
+endif()
 scipp_test(${TARGET_NAME} units)

--- a/lib/variable/test/CMakeLists.txt
+++ b/lib/variable/test/CMakeLists.txt
@@ -64,5 +64,7 @@ set_property(
 set_property(
   TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL $<NOT:$<BOOL:${FULL_BUILD}>>
 )
-add_sanitizers(${TARGET_NAME})
+if(SANITIZERS)
+  add_sanitizers(${TARGET_NAME})
+endif()
 scipp_test(${TARGET_NAME} variable)


### PR DESCRIPTION
This lets us build (and package) scipp without including the cmake-sanitizers submodule. Conda-forge doesn't really like building with submodules.