### PR TITLE
Support data arrays in where

### DIFF
--- a/lib/python/operations.cpp
+++ b/lib/python/operations.cpp
@@ -95,21 +95,10 @@ extract_where_argument(const py::object &arg) {
   return {da.data(), std::optional(da.coords())};
 }
 
-Variable apply_where(const Variable &c_data, const Variable &x_data,
-                     const Variable &y_data,
-                     const std::optional<Coords> &c_coords,
-                     const std::optional<Coords> &x_coords,
-                     const std::optional<Coords> &y_coords) {
-  py::gil_scoped_release _release;
-
-  if (c_coords.has_value() && x_coords.has_value()) {
-    dataset::expect::coords_are_superset(c_coords.value(), x_coords.value(),
-                                         "where (condition and x)");
-  }
-  if (c_coords.has_value() && y_coords.has_value()) {
-    dataset::expect::coords_are_superset(c_coords.value(), y_coords.value(),
-                                         "where (condition and y)");
-  }
+std::optional<Coords>
+combine_coords_for_where(const std::optional<Coords> &c_coords,
+                         std::optional<Coords> &x_coords,
+                         const std::optional<Coords> &y_coords) {
   if (x_coords.has_value() && y_coords.has_value()) {
     if (x_coords.value() != y_coords.value()) {
       throw except::CoordMismatchError(
@@ -117,7 +106,21 @@ Variable apply_where(const Variable &c_data, const Variable &x_data,
     }
   }
 
-  return where(c_data, x_data, y_data);
+  if (x_coords.has_value()) {
+    if (c_coords.has_value()) {
+      return Coords{AutoSizeTag{},
+                    union_(c_coords.value(), x_coords.value(), "where")};
+    }
+    return x_coords.value();
+  }
+  if (y_coords.has_value()) {
+    if (c_coords.has_value()) {
+      return Coords{AutoSizeTag{},
+                    union_(c_coords.value(), y_coords.value(), "where")};
+    }
+    return y_coords.value();
+  }
+  return std::nullopt;
 }
 
 void bind_where(py::module &m) {
@@ -128,16 +131,14 @@ void bind_where(py::module &m) {
         auto [c_data, c_coords] = extract_where_argument(condition);
         auto [x_data, x_coords] = extract_where_argument(x);
         auto [y_data, y_coords] = extract_where_argument(y);
-        const Variable new_data =
-            apply_where(c_data, x_data, y_data, c_coords, x_coords, y_coords);
+        auto coords = combine_coords_for_where(c_coords, x_coords, y_coords);
+        Variable new_data = where(c_data, x_data, y_data);
 
-        if (x_coords.has_value()) {
-          return py::cast(DataArray(new_data, x_coords.value(), {}));
+        if (coords.has_value()) {
+          return py::cast(
+              DataArray(std::move(new_data), std::move(coords.value()), {}));
         }
-        if (y_coords.has_value()) {
-          return py::cast(DataArray(new_data, y_coords.value(), {}));
-        }
-        return py::cast(new_data);
+        return py::cast(std::move(new_data));
       },
       py::arg("condition"), py::arg("x"), py::arg("y"));
 }

--- a/src/scipp/core/operations.py
+++ b/src/scipp/core/operations.py
@@ -219,22 +219,40 @@ def stddevs(x: VariableLikeType) -> VariableLikeType:
     return _call_cpp_func(_cpp.stddevs, x)  # type: ignore[return-value]
 
 
-def where(condition: Variable, x: Variable, y: Variable) -> Variable:
+@overload
+def where(
+    condition: Variable | DataArray, x: DataArray, y: Variable | DataArray
+) -> DataArray: ...
+
+
+@overload
+def where(
+    condition: Variable | DataArray, x: Variable | DataArray, y: DataArray
+) -> DataArray: ...
+
+
+@overload
+def where(condition: Variable | DataArray, x: Variable, y: Variable) -> Variable: ...
+
+
+def where(
+    condition: Variable | DataArray, x: Variable | DataArray, y: Variable | DataArray
+) -> Variable | DataArray:
     """Return elements chosen from x or y depending on condition.
 
     Parameters
     ----------
     condition:
-        Variable with dtype=bool.
+        Array with dtype=bool.
     x:
-        Variable with values from which to choose.
+        Array with values from which to choose.
     y:
-        Variable with values from which to choose.
+        Array with values from which to choose.
 
     Returns
     -------
     :
-        Variable with elements from x where condition is True
+        Array with elements from x where condition is True
         and elements from y elsewhere.
     """
     return _call_cpp_func(_cpp.where, condition, x, y)  # type: ignore[return-value]

--- a/tests/core/operations_test.py
+++ b/tests/core/operations_test.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import pytest
+
+import scipp as sc
+
+
+def test_where_with_v_v_v() -> None:
+    condition = sc.array(dims=['a'], values=[True, False, False])
+    x = sc.array(dims=['a'], values=[1, 2, 3], unit='m')
+    y = sc.array(dims=['a'], values=[-13, -11, -12], unit='m')
+    result = sc.where(condition, x, y)
+    expected = sc.array(dims=['a'], values=[1, -11, -12], unit='m')
+    assert sc.identical(result, expected)
+
+
+def test_where_with_da_v_v() -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+    x = sc.array(dims=['a'], values=[1, 2, 3], unit='m')
+    y = sc.array(dims=['a'], values=[-13, -11, -12], unit='m')
+    result = sc.where(condition, x, y)
+    expected = sc.array(dims=['a'], values=[1, -11, -12], unit='m')
+    assert sc.identical(result, expected)
+
+
+def test_where_with_da_da_v() -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    y = sc.array(dims=['a'], values=[-13, -11, -12], unit='m')
+    result = sc.where(condition, x, y)
+    expected = sc.DataArray(
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=x.coords
+    )
+    assert sc.identical(result, expected)
+
+
+def test_where_with_da_v_da() -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+    x = sc.array(dims=['a'], values=[1, 2, 3], unit='m')
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    result = sc.where(condition, x, y)
+    expected = sc.DataArray(
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=y.coords
+    )
+    assert sc.identical(result, expected)
+
+
+def test_where_with_da_da_da() -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    result = sc.where(condition, x, y)
+    expected = sc.DataArray(
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=x.coords
+    )
+    assert sc.identical(result, expected)
+
+
+def test_where_with_v_da_da() -> None:
+    condition = sc.array(dims=['a'], values=[True, False, False])
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    result = sc.where(condition, x, y)
+    expected = sc.DataArray(
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=x.coords
+    )
+    assert sc.identical(result, expected)
+
+
+def test_where_condition_coords_must_be_superset_of_others() -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3)},
+    )
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
+    )
+
+    # condition is missing coord
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+    # condition has differing coord value
+    condition.coords['b'] = x.coords['b']
+    condition.coords['a'][0] = -1
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+
+def test_where_value_coords_must_match() -> None:
+    condition = sc.array(dims=['a'], values=[True, False, False])
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': -sc.arange('a', 3)},
+    )
+
+    # differing values
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+    # differing values
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+    # alignment differs
+    y.coords['a'] = x.coords['a']
+    x.coords.set_aligned('a', False)
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+    # extra coord
+    y.coords['b'] = sc.arange('a', 3)
+    with pytest.raises(sc.DatasetError):
+        sc.where(condition, x, y)
+
+
+@pytest.mark.parametrize('argument', ['condition', 'x', 'y'])
+def test_where_does_not_allow_masks(argument: str) -> None:
+    condition = sc.DataArray(
+        sc.array(dims=['a'], values=[True, False, False]),
+        coords={'a': sc.arange('a', 3)},
+    )
+    x = sc.DataArray(
+        sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+    y = sc.DataArray(
+        sc.array(dims=['a'], values=[-13, -11, -12], unit='m'),
+        coords={'a': sc.arange('a', 3)},
+    )
+
+    locals()[argument].masks['m'] = sc.array(dims=['a'], values=[True, False, True])
+    with pytest.raises(ValueError, match="must not have masks"):
+        sc.where(condition, x, y)

--- a/tests/core/operations_test.py
+++ b/tests/core/operations_test.py
@@ -130,10 +130,6 @@ def test_where_value_coords_must_match() -> None:
     with pytest.raises(sc.DatasetError):
         sc.where(condition, x, y)
 
-    # differing values
-    with pytest.raises(sc.DatasetError):
-        sc.where(condition, x, y)
-
     # alignment differs
     y.coords['a'] = x.coords['a']
     x.coords.set_aligned('a', False)

--- a/tests/core/operations_test.py
+++ b/tests/core/operations_test.py
@@ -127,7 +127,9 @@ def test_where_value_coords_must_match() -> None:
     )
 
     # differing values
-    with pytest.raises(sc.DatasetError):
+    with pytest.raises(
+        sc.DatasetError, match="Expected coords of x and y to match in 'where'"
+    ):
         sc.where(condition, x, y)
 
     # alignment differs

--- a/tests/core/operations_test.py
+++ b/tests/core/operations_test.py
@@ -38,7 +38,7 @@ def test_where_with_da_da_v() -> None:
     y = sc.array(dims=['a'], values=[-13, -11, -12], unit='m')
     result = sc.where(condition, x, y)
     expected = sc.DataArray(
-        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=x.coords
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=condition.coords
     )
     assert sc.identical(result, expected)
 
@@ -55,7 +55,7 @@ def test_where_with_da_v_da() -> None:
     )
     result = sc.where(condition, x, y)
     expected = sc.DataArray(
-        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=y.coords
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=condition.coords
     )
     assert sc.identical(result, expected)
 
@@ -75,7 +75,7 @@ def test_where_with_da_da_da() -> None:
     )
     result = sc.where(condition, x, y)
     expected = sc.DataArray(
-        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=x.coords
+        sc.array(dims=['a'], values=[1, -11, -12], unit='m'), coords=condition.coords
     )
     assert sc.identical(result, expected)
 
@@ -97,10 +97,10 @@ def test_where_with_v_da_da() -> None:
     assert sc.identical(result, expected)
 
 
-def test_where_condition_coords_must_be_superset_of_others() -> None:
+def test_where_condition_coords_must_be_compatible_with_others() -> None:
     condition = sc.DataArray(
         sc.array(dims=['a'], values=[True, False, False]),
-        coords={'a': sc.arange('a', 3)},
+        coords={'a': -sc.arange('a', 3)},
     )
     x = sc.DataArray(
         sc.array(dims=['a'], values=[1, 2, 3], unit='m'),
@@ -111,14 +111,7 @@ def test_where_condition_coords_must_be_superset_of_others() -> None:
         coords={'a': sc.arange('a', 3), 'b': sc.arange('a', 4)},
     )
 
-    # condition is missing coord
-    with pytest.raises(sc.DatasetError):
-        sc.where(condition, x, y)
-
-    # condition has differing coord value
-    condition.coords['b'] = x.coords['b']
-    condition.coords['a'][0] = -1
-    with pytest.raises(sc.DatasetError):
+    with pytest.raises(sc.DatasetError, match="Mismatch in coordinate 'a'"):
         sc.where(condition, x, y)
 
 


### PR DESCRIPTION
Fixes #3648

I disallowed masks in all operands because supporting them is complicated. I think the output `result.masks.keys()` should be the union of all input masks. But the masks of `x` and `y` should not be or-ed. Instead, their elements should be selected based on the condition and then or-ed with the condition's masks.