### PR TITLE
Fix bad bin/hist range detection when passing "bare" binned variable

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -63,7 +63,9 @@ def make_histogrammed(
     scipp.bin:
         For binning data.
     """
-    if isinstance(x, Variable):
+    if isinstance(x, Variable) and x.bins is not None:
+        x = DataArray(x)
+    elif isinstance(x, Variable):
         data = scalar(1.0, unit='counts').broadcast(sizes=x.sizes)
         x = DataArray(data, coords={edges.dim: x})
     elif isinstance(x, DataArray) and x.bins is not None:
@@ -289,7 +291,7 @@ def _require_coord(name: str, coord: object) -> None:
 
 def _get_coord(x: Variable | DataArray | Dataset, name: str) -> Variable:
     if isinstance(x, Variable):
-        return x
+        return x if x.bins is None else x.bins.coords[name]
     if isinstance(x, Dataset):
         if not x.values():
             raise ValueError("Dataset is empty")

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -670,6 +670,45 @@ def test_variable_bin_equivalent_to_bin_of_data_array_with_counts() -> None:
     assert sc.identical(coord.bin(x=3), da.bin(x=3))
 
 
+def test_binned_variable_hist_uses_binned_coord_to_determine_edges() -> None:
+    var = sc.bins(
+        data=sc.DataArray(sc.ones(sizes={'e': 4}), coords={'x': sc.arange('e', 4.0)}),
+        dim='e',
+        begin=sc.array(dims=['x'], values=[0, 1, 3], unit=None),
+    )
+    result = var.hist(x=3)
+    assert result.sum().value == 4
+    assert sc.identical(
+        result.coords['x'], sc.linspace('x', 0.0, np.nextafter(3.0, 4), num=4)
+    )
+
+
+def test_binned_variable_nanhist_uses_binned_coord_to_determine_edges() -> None:
+    var = sc.bins(
+        data=sc.DataArray(sc.ones(sizes={'e': 4}), coords={'x': sc.arange('e', 4.0)}),
+        dim='e',
+        begin=sc.array(dims=['x'], values=[0, 1, 3], unit=None),
+    )
+    result = var.nanhist(x=3)
+    assert result.sum().value == 4
+    assert sc.identical(
+        result.coords['x'], sc.linspace('x', 0.0, np.nextafter(3.0, 4), num=4)
+    )
+
+
+def test_binned_variable_bin_uses_binned_coord_to_determine_edges() -> None:
+    var = sc.bins(
+        data=sc.DataArray(sc.ones(sizes={'e': 4}), coords={'x': sc.arange('e', 4.0)}),
+        dim='e',
+        begin=sc.array(dims=['x'], values=[0, 1, 3], unit=None),
+    )
+    result = var.bin(x=3)
+    assert result.bins.size().sum().value == 4
+    assert sc.identical(
+        result.coords['x'], sc.linspace('x', 0.0, np.nextafter(3.0, 4), num=4)
+    )
+
+
 def test_group_many_to_many_uses_optimized_codepath() -> None:
     size = 512
     table = sc.data.table_xyz(int(1e3))


### PR DESCRIPTION
Fixes #3700.

Also brings the `hist` behavior in line with `bin`. The former lacked a check that raised an exception when trying to `hist` a binned variable that was not wrapped in a DataArray.