### PR TITLE
Remove stefanzweifel/git-auto-commit-action from CI

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -22,9 +22,6 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e static
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Apply automatic formatting
 
   build_and_test:
     needs: formatting


### PR DESCRIPTION
This isn't part of our copier template.