### PR TITLE
Enable detailed error messages in pybind11

### DIFF
--- a/lib/python/CMakeLists.txt
+++ b/lib/python/CMakeLists.txt
@@ -42,6 +42,7 @@ target_include_directories(
   _scipp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(_scipp LINK_PRIVATE scipp-dataset pybind11::headers)
+target_compile_definitions(_scipp PUBLIC PYBIND11_DETAILED_ERROR_MESSAGES)
 
 # SCIPP_EXPORT is used in macros defined in variable/
 target_compile_definitions(_scipp PRIVATE SCIPP_EXPORT=)


### PR DESCRIPTION
Fixes #3709

This turns the reported error from 
```
RuntimeError: Unable to cast Python instance of type <class 'list'> to C++ type '?'
  (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
  ```
into
```
RuntimeError: Unable to cast Python instance of type <class 'list'> to C++ type 'scipp::variable::Variable'
```

I do not see a difference in binary size for a release library on Linux.