### PR TITLE
Use default LLNL::Units namespace

### DIFF
--- a/lib/benchmark/bin_benchmark.cpp
+++ b/lib/benchmark/bin_benchmark.cpp
@@ -20,9 +20,10 @@ auto make_table(const scipp::index size) {
 }
 
 auto make_edges(const Dim dim, const scipp::index size) {
-  return cumsum(broadcast((4.0 / size) * units::one, Dimensions(dim, size + 1)),
-                CumSumMode::Exclusive) -
-         (2.0 * units::one);
+  return cumsum(
+             broadcast((4.0 / size) * sc_units::one, Dimensions(dim, size + 1)),
+             CumSumMode::Exclusive) -
+         (2.0 * sc_units::one);
 }
 
 static void BM_bin_table(benchmark::State &state) {

--- a/lib/benchmark/groupby_benchmark.cpp
+++ b/lib/benchmark/groupby_benchmark.cpp
@@ -50,7 +50,7 @@ template <class T> static void BM_groupby_concat(benchmark::State &state) {
                                      Values(group_.begin(), group_.end()));
   events.coords().set(
       Dim("group"),
-      astype(group / (nHist / nGroup * units::one), dtype<int64_t>));
+      astype(group / (nHist / nGroup * sc_units::one), dtype<int64_t>));
   for (auto _ : state) {
     auto flat = groupby(events, Dim("group")).concat(Dim::X);
     state.PauseTiming();
@@ -93,8 +93,8 @@ static void BM_groupby_large_table(benchmark::State &state) {
   d["a"].masks().set("mask", makeVariable<bool>(Dims{Dim::X}, Shape{nRow}));
   auto group = makeVariable<int64_t>(Dims{Dim::X}, Shape{nRow},
                                      Values(group_.begin(), group_.end()));
-  d.coords().set(Dim("group"),
-                 astype(group / (nRow / nGroup * units::one), dtype<int64_t>));
+  d.coords().set(Dim("group"), astype(group / (nRow / nGroup * sc_units::one),
+                                      dtype<int64_t>));
   for (auto _ : state) {
     auto grouped = groupby(d, Dim("group")).sum(Dim::X);
     state.PauseTiming();

--- a/lib/benchmark/histogram_benchmark.cpp
+++ b/lib/benchmark/histogram_benchmark.cpp
@@ -43,7 +43,7 @@ static void BM_histogram(benchmark::State &state) {
     edges_.back() += 0.0001;
   auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{nEdge},
                                     Values(edges_.begin(), edges_.end()));
-  edges *= 1000.0 / nEdge * units::one; // ensure all events are in range
+  edges *= 1000.0 / nEdge * sc_units::one; // ensure all events are in range
   for (auto _ : state) {
     benchmark::DoNotOptimize(histogram(events, edges));
   }

--- a/lib/benchmark/variable_benchmark.cpp
+++ b/lib/benchmark/variable_benchmark.cpp
@@ -196,8 +196,8 @@ BENCHMARK(BM_VariableView_assign_1d)
     ->Arg(1e9);
 
 static void BM_Variable_sin_rad(benchmark::State &state) {
-  const auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{1000}, units::Unit{units::rad});
+  const auto a = makeVariable<double>(Dims{Dim::X}, Shape{1000},
+                                      sc_units::Unit{sc_units::rad});
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(sin(a));
@@ -206,8 +206,8 @@ static void BM_Variable_sin_rad(benchmark::State &state) {
 BENCHMARK(BM_Variable_sin_rad);
 
 static void BM_Variable_sin_deg(benchmark::State &state) {
-  const auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{1000}, units::Unit{units::deg});
+  const auto a = makeVariable<double>(Dims{Dim::X}, Shape{1000},
+                                      sc_units::Unit{sc_units::deg});
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(sin(a));

--- a/lib/cmake/.conan-recipes/llnl-units/conanfile.py
+++ b/lib/cmake/.conan-recipes/llnl-units/conanfile.py
@@ -63,30 +63,14 @@ class UnitsConan(ConanFile):
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()""",
         )
-        tools.replace_in_file(
-            "units/units/r20_conv.cpp",
-            "namespace units {",
-            "namespace UNITS_NAMESPACE {"
-        )
-        tools.replace_in_file(
-            "units/units/r20_conv.cpp",
-            "}  // namespace units",
-            "}  // namespace UNITS_NAMESPACE"
-        )
 
     def build(self):
         cmake = CMake(self)
-        units_namespace = self.options.get_safe("namespace")
         cmake.definitions["UNITS_ENABLE_TESTS"] = "OFF"
         cmake.definitions["UNITS_BASE_TYPE"] = self.options.base_type
-        if units_namespace:
-            cmake.definitions["UNITS_NAMESPACE"] = units_namespace
         if self.options["shared"]:
             cmake.definitions["UNITS_BUILD_SHARED_LIBRARY"] = "ON"
             cmake.definitions["UNITS_BUILD_STATIC_LIBRARY"] = "OFF"
-        # The library uses C++14, but we want to set the namespace
-        # to llnl::units which requires C++17.
-        cmake.definitions["CMAKE_CXX_STANDARD"] = "17"
         cmake.configure(source_folder="units")
         cmake.build(target="units")
 
@@ -100,7 +84,4 @@ conan_basic_setup()""",
 
     def package_info(self):
         self.cpp_info.libs = ["units"]
-        units_namespace = self.options.get_safe("namespace")
         self.cpp_info.defines = [f"UNITS_BASE_TYPE={self.options.base_type}"]
-        if units_namespace:
-            self.cpp_info.defines.append(f"UNITS_NAMESPACE={units_namespace}")

--- a/lib/cmake/scipp-conan.cmake
+++ b/lib/cmake/scipp-conan.cmake
@@ -50,7 +50,7 @@ if(SKBUILD)
     LLNL-Units:shared=False
     LLNL-Units:fPIC=True
     LLNL-Units:base_type=uint64_t
-    LLNL-Units:namespace=llnl::units
+    LLNL-Units:namespace=units
     GENERATORS
     cmake_find_package_multi
     deploy
@@ -63,7 +63,7 @@ else()
     LLNL-Units:shared=False
     LLNL-Units:fPIC=True
     LLNL-Units:base_type=uint64_t
-    LLNL-Units:namespace=llnl::units
+    LLNL-Units:namespace=units
     GENERATORS
     cmake_find_package_multi
   )

--- a/lib/cmake/scipp-conan.cmake
+++ b/lib/cmake/scipp-conan.cmake
@@ -50,7 +50,6 @@ if(SKBUILD)
     LLNL-Units:shared=False
     LLNL-Units:fPIC=True
     LLNL-Units:base_type=uint64_t
-    LLNL-Units:namespace=units
     GENERATORS
     cmake_find_package_multi
     deploy
@@ -63,7 +62,6 @@ else()
     LLNL-Units:shared=False
     LLNL-Units:fPIC=True
     LLNL-Units:base_type=uint64_t
-    LLNL-Units:namespace=units
     GENERATORS
     cmake_find_package_multi
   )

--- a/lib/cmake/scipp-functions.cmake
+++ b/lib/cmake/scipp-functions.cmake
@@ -8,7 +8,7 @@ set(convert_to_rad
     "#include \"scipp/variable/to_unit.h\"
 namespace {
 decltype(auto) preprocess(const scipp::variable::Variable &var) {
-  return to_unit(var, scipp::units::rad)\;
+  return to_unit(var, scipp::sc_units::rad)\;
 }
 }"
 )

--- a/lib/core/include/scipp/core/array_to_string.h
+++ b/lib/core/include/scipp/core/array_to_string.h
@@ -20,12 +20,12 @@ namespace scipp::core {
 template <class T>
 std::string
 array_to_string(const T &arr,
-                const std::optional<units::Unit> &unit = std::nullopt);
+                const std::optional<sc_units::Unit> &unit = std::nullopt);
 
 template <class T>
 std::string
 element_to_string(const T &item,
-                  const std::optional<units::Unit> &unit = std::nullopt) {
+                  const std::optional<sc_units::Unit> &unit = std::nullopt) {
   using core::to_string;
   using std::to_string;
   if constexpr (std::is_same_v<T, std::string>) {
@@ -65,14 +65,14 @@ element_to_string(const T &item,
 
 template <class T>
 std::string scalar_array_to_string(const T &arr,
-                                   const std::optional<units::Unit> &unit) {
+                                   const std::optional<sc_units::Unit> &unit) {
   auto s = element_to_string(arr[0], unit);
   return s.substr(0, s.size() - 2);
 }
 
 template <class T>
 std::string array_to_string(const T &arr,
-                            const std::optional<units::Unit> &unit) {
+                            const std::optional<sc_units::Unit> &unit) {
   const auto size = scipp::size(arr);
   if (size == 0)
     return "[]";

--- a/lib/core/include/scipp/core/element/arithmetic.h
+++ b/lib/core/include/scipp/core/element/arithmetic.h
@@ -162,7 +162,7 @@ constexpr auto apply_spatial_transformation = overloaded{
     apply_spatial_transformation_t{},
     transform_flags::expect_no_in_variance_if_out_cannot_have_variance,
     [](const auto a, const auto b) { return a * b; },
-    [](const units::Unit &a, const units::Unit &b) {
+    [](const sc_units::Unit &a, const sc_units::Unit &b) {
       if (a != b)
         throw except::UnitError(
             "Cannot apply spatial transform as the units of the transformation "
@@ -176,21 +176,21 @@ constexpr auto divide = overloaded{
     true_divide_types_t{},
     transform_flags::expect_no_in_variance_if_out_cannot_have_variance,
     [](const auto &a, const auto &b) { return numeric::true_divide(a, b); },
-    [](const units::Unit &a, const units::Unit &b) { return a / b; }};
+    [](const sc_units::Unit &a, const sc_units::Unit &b) { return a / b; }};
 
 // floordiv defined as in Python. Complementary to mod.
 constexpr auto floor_divide = overloaded{
     floor_divide_types_t{}, transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     [](const auto a, const auto b) { return numeric::floor_divide(a, b); },
-    [](const units::Unit &a, const units::Unit &b) { return a / b; }};
+    [](const sc_units::Unit &a, const sc_units::Unit &b) { return a / b; }};
 
 // remainder defined as in Python
 constexpr auto mod = overloaded{
     remainder_types_t{}, transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
     [](const auto a, const auto b) { return numeric::remainder(a, b); },
-    [](const units::Unit &a, const units::Unit &b) { return a % b; }};
+    [](const sc_units::Unit &a, const sc_units::Unit &b) { return a % b; }};
 
 constexpr auto remainder_inplace_types =
     arg_list<double, float, int64_t, int32_t, std::tuple<double, float>,
@@ -202,7 +202,7 @@ constexpr auto remainder_inplace_types =
 constexpr auto mod_equals = overloaded{
     remainder_inplace_types, transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
-    [](units::Unit &a, const units::Unit &b) { a %= b; },
+    [](sc_units::Unit &a, const sc_units::Unit &b) { a %= b; },
     [](auto &&a, const auto &b) { a = mod(a, b); }};
 
 constexpr auto negative =

--- a/lib/core/include/scipp/core/element/bin.h
+++ b/lib/core/include/scipp/core/element/bin.h
@@ -44,10 +44,10 @@ static constexpr auto update_indices_by_binning = overloaded{
                       update_indices_by_binning_arg<int32_t, double, float>,
                       update_indices_by_binning_arg<int64_t, int32_t, int64_t>,
                       update_indices_by_binning_arg<int32_t, int32_t, int64_t>>,
-    [](units::Unit &indices, const units::Unit &coord,
-       const units::Unit &groups) {
+    [](sc_units::Unit &indices, const sc_units::Unit &coord,
+       const sc_units::Unit &groups) {
       expect::equals(coord, groups);
-      expect::equals(units::none, indices);
+      expect::equals(sc_units::none, indices);
     },
     transform_flags::expect_no_variance_arg<1>,
     transform_flags::expect_no_variance_arg<2>};
@@ -89,7 +89,7 @@ static constexpr auto groups_to_map = overloaded{
                       scipp::span<const bool>, scipp::span<const std::string>,
                       scipp::span<const time_point>>,
     transform_flags::expect_no_variance_arg<0>,
-    [](const units::Unit &u) { return u; },
+    [](const sc_units::Unit &u) { return u; },
     [](const auto &groups) {
       std::unordered_map<typename std::decay_t<decltype(groups)>::value_type,
                          Index>
@@ -128,10 +128,10 @@ static constexpr auto update_indices_by_grouping = overloaded{
                       update_indices_by_grouping_arg<int32_t, std::string>,
                       update_indices_by_grouping_arg<int32_t, time_point>,
                       update_indices_by_grouping_arg<int64_t, time_point>>,
-    [](units::Unit &indices, const units::Unit &coord,
-       const units::Unit &groups) {
+    [](sc_units::Unit &indices, const sc_units::Unit &coord,
+       const sc_units::Unit &groups) {
       expect::equals(coord, groups);
-      expect::equals(units::none, indices);
+      expect::equals(sc_units::none, indices);
     },
     [](auto &index, const auto &x, const auto &groups) {
       if (index == -1)
@@ -158,11 +158,11 @@ static constexpr auto update_indices_by_grouping_contiguous = overloaded{
         update_indices_by_grouping_contiguous_arg<int64_t, int32_t>,
         update_indices_by_grouping_contiguous_arg<int32_t, int32_t>,
         update_indices_by_grouping_contiguous_arg<int32_t, int32_t, int64_t>>,
-    [](units::Unit &indices, const units::Unit &coord,
-       const units::Unit &ngroup, const units::Unit &offset) {
+    [](sc_units::Unit &indices, const sc_units::Unit &coord,
+       const sc_units::Unit &ngroup, const sc_units::Unit &offset) {
       expect::equals(coord, offset);
-      expect::equals(units::none, ngroup);
-      expect::equals(units::none, indices);
+      expect::equals(sc_units::none, ngroup);
+      expect::equals(sc_units::none, indices);
     },
     [](auto &index, const auto &x, const auto &ngroup, const auto &offset) {
       if (index == -1)
@@ -175,7 +175,7 @@ static constexpr auto update_indices_by_grouping_contiguous = overloaded{
 static constexpr auto update_indices_from_existing = overloaded{
     element::arg_list<std::tuple<int64_t, scipp::index, scipp::index>,
                       std::tuple<int32_t, scipp::index, scipp::index>>,
-    [](units::Unit &, const units::Unit &, const units::Unit &) {},
+    [](sc_units::Unit &, const sc_units::Unit &, const sc_units::Unit &) {},
     [](auto &index, const auto bin_index, const auto nbin) {
       if (index == -1)
         return;
@@ -187,11 +187,11 @@ static constexpr auto count_indices = overloaded{
     element::arg_list<
         std::tuple<scipp::span<const int64_t>, scipp::index, scipp::index>,
         std::tuple<scipp::span<const int32_t>, scipp::index, scipp::index>>,
-    [](const units::Unit &indices, const auto &offset, const auto &nbin) {
-      expect::equals(units::none, indices);
-      expect::equals(units::none, offset);
-      expect::equals(units::none, nbin);
-      return units::none;
+    [](const sc_units::Unit &indices, const auto &offset, const auto &nbin) {
+      expect::equals(sc_units::none, indices);
+      expect::equals(sc_units::none, offset);
+      expect::equals(sc_units::none, nbin);
+      return sc_units::none;
     },
     [](const auto &indices, const auto offset, const auto nbin) {
       typename SubbinSizes::container_type counts(nbin);

--- a/lib/core/include/scipp/core/element/bin_detail.h
+++ b/lib/core/include/scipp/core/element/bin_detail.h
@@ -46,9 +46,9 @@ static constexpr auto end_edge =
 constexpr auto subbin_sizes_exclusive_scan = overloaded{
     arg_list<SubbinSizes>, [](auto &sum, auto &x) { sum.exclusive_scan(x); }};
 
-constexpr auto subbin_sizes_add_intersection =
-    overloaded{arg_list<SubbinSizes>,
-               overloaded{[](units::Unit &a, const units::Unit &b) { a += b; },
-                          [](auto &a, auto &b) { a.add_intersection(b); }}};
+constexpr auto subbin_sizes_add_intersection = overloaded{
+    arg_list<SubbinSizes>,
+    overloaded{[](sc_units::Unit &a, const sc_units::Unit &b) { a += b; },
+               [](auto &a, auto &b) { a.add_intersection(b); }}};
 
 } // namespace scipp::core::element

--- a/lib/core/include/scipp/core/element/comparison.h
+++ b/lib/core/include/scipp/core/element/comparison.h
@@ -25,11 +25,12 @@ using isclose_types_t = arg_list_t<
     std::tuple<int32_t, int32_t, int64_t>,
     std::tuple<int32_t, int64_t, int64_t>>;
 
-constexpr auto isclose_units = [](const units::Unit &x, const units::Unit &y,
-                                  const units::Unit &t) {
+constexpr auto isclose_units = [](const sc_units::Unit &x,
+                                  const sc_units::Unit &y,
+                                  const sc_units::Unit &t) {
   expect::equals(x, y);
   expect::equals(x, t);
-  return units::none;
+  return sc_units::none;
 };
 
 constexpr auto isclose = overloaded{
@@ -74,9 +75,9 @@ struct equality_types_t {
 // See issue #3266
 constexpr auto comparison = overloaded{
     transform_flags::no_out_variance, transform_flags::force_variance_broadcast,
-    [](const units::Unit &x, const units::Unit &y) {
+    [](const sc_units::Unit &x, const sc_units::Unit &y) {
       expect::equals(x, y);
-      return units::none;
+      return sc_units::none;
     }};
 
 constexpr auto inequality = overloaded{comparison_types_t{}, comparison};

--- a/lib/core/include/scipp/core/element/creation.h
+++ b/lib/core/include/scipp/core/element/creation.h
@@ -20,7 +20,7 @@ constexpr auto special_like =
     overloaded{arg_list<double, float, int64_t, int32_t, bool, SubbinSizes,
                         time_point, Eigen::Vector3d>,
                transform_flags::force_variance_broadcast,
-               [](const units::Unit &u) { return u; }};
+               [](const sc_units::Unit &u) { return u; }};
 
 constexpr auto zeros_not_bool_like =
     overloaded{special_like, [](const auto &x) {

--- a/lib/core/include/scipp/core/element/event_operations.h
+++ b/lib/core/include/scipp/core/element/event_operations.h
@@ -77,8 +77,8 @@ constexpr auto map = overloaded{
                       map_detail::args<double, float, bool>>,
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
-    [](const units::Unit &x, const units::Unit &edges,
-       const units::Unit &weights, const units::Unit &fill) {
+    [](const sc_units::Unit &x, const sc_units::Unit &edges,
+       const sc_units::Unit &weights, const sc_units::Unit &fill) {
       expect::equals(x, edges);
       expect::equals(weights, fill);
       return weights;
@@ -130,8 +130,8 @@ constexpr auto map_and_mul = overloaded{
     transform_flags::expect_no_variance_arg<3>, // caught in transform anyway,
                                                 // but adding this should save
                                                 // binary size and compile time
-    [](units::Unit &data, const units::Unit &x, const units::Unit &edges,
-       const units::Unit &weights) {
+    [](sc_units::Unit &data, const sc_units::Unit &x,
+       const sc_units::Unit &edges, const sc_units::Unit &weights) {
       expect::equals(x, edges);
       data *= weights;
     }};

--- a/lib/core/include/scipp/core/element/geometric_operations.h
+++ b/lib/core/include/scipp/core/element/geometric_operations.h
@@ -13,27 +13,28 @@
 /// geometric operations for Variable.
 namespace scipp::core::element::geometry {
 
-constexpr auto position = overloaded{
-    arg_list<double>,
-    transform_flags::expect_no_variance_arg<0>,
-    transform_flags::expect_no_variance_arg<1>,
-    transform_flags::expect_no_variance_arg<2>,
-    [](const auto &x, const auto &y, const auto &z) {
-      using T = double; // currently only double precision support
-      return Eigen::Matrix<T, 3, 1>(x, y, z);
-    },
-    [](const units::Unit &x, const units::Unit &y, const units::Unit &z) {
-      expect::equals(x, y);
-      expect::equals(x, z);
-      return x;
-    }};
+constexpr auto position =
+    overloaded{arg_list<double>,
+               transform_flags::expect_no_variance_arg<0>,
+               transform_flags::expect_no_variance_arg<1>,
+               transform_flags::expect_no_variance_arg<2>,
+               [](const auto &x, const auto &y, const auto &z) {
+                 using T = double; // currently only double precision support
+                 return Eigen::Matrix<T, 3, 1>(x, y, z);
+               },
+               [](const sc_units::Unit &x, const sc_units::Unit &y,
+                  const sc_units::Unit &z) {
+                 expect::equals(x, y);
+                 expect::equals(x, z);
+                 return x;
+               }};
 
 namespace detail {
 template <int N>
 static constexpr auto component =
     overloaded{arg_list<Eigen::Vector3d>,
                [](const auto &pos) { return pos[N]; },
-               [](const units::Unit &u) { return u; }};
+               [](const sc_units::Unit &u) { return u; }};
 } // namespace detail
 constexpr auto x = detail::component<0>;
 constexpr auto y = detail::component<1>;

--- a/lib/core/include/scipp/core/element/histogram.h
+++ b/lib/core/include/scipp/core/element/histogram.h
@@ -79,8 +79,8 @@ static constexpr auto histogram = overloaded{
         }
       }
     },
-    [](const units::Unit &events_unit, const units::Unit &weights_unit,
-       const units::Unit &edge_unit) {
+    [](const sc_units::Unit &events_unit, const sc_units::Unit &weights_unit,
+       const sc_units::Unit &edge_unit) {
       if (events_unit != edge_unit)
         throw except::UnitError(
             "Bin edges must have same unit as the input coordinate.");

--- a/lib/core/include/scipp/core/element/logical.h
+++ b/lib/core/include/scipp/core/element/logical.h
@@ -12,14 +12,14 @@ namespace scipp::core::element {
 
 constexpr auto logical =
     overloaded{arg_list<bool>,
-               [](const units::Unit &a) {
-                 expect::equals(units::none, a);
+               [](const sc_units::Unit &a) {
+                 expect::equals(sc_units::none, a);
                  return a;
                },
-               [](const units::Unit &a, const units::Unit &b) {
-                 expect::equals(units::none, a);
-                 expect::equals(units::none, b);
-                 return units::none;
+               [](const sc_units::Unit &a, const sc_units::Unit &b) {
+                 expect::equals(sc_units::none, a);
+                 expect::equals(sc_units::none, b);
+                 return sc_units::none;
                }};
 
 constexpr auto logical_and =
@@ -31,11 +31,11 @@ constexpr auto logical_xor =
 constexpr auto logical_not =
     overloaded{logical, [](const auto &x) { return !x; }};
 
-constexpr auto logical_inplace =
-    overloaded{arg_list<bool>, [](units::Unit &var, const units::Unit &other) {
-                 expect::equals(units::none, var);
-                 expect::equals(units::none, other);
-               }};
+constexpr auto logical_inplace = overloaded{
+    arg_list<bool>, [](sc_units::Unit &var, const sc_units::Unit &other) {
+      expect::equals(sc_units::none, var);
+      expect::equals(sc_units::none, other);
+    }};
 
 constexpr auto logical_and_equals =
     overloaded{logical_inplace, [](auto &&a, const auto &b) { a = a && b; }};

--- a/lib/core/include/scipp/core/element/map_to_bins.h
+++ b/lib/core/include/scipp/core/element/map_to_bins.h
@@ -108,8 +108,8 @@ static constexpr auto bin = overloaded{
         bin_arg<std::string, int64_t>, bin_arg<std::string, int32_t>,
         bin_arg<time_point, int64_t>, bin_arg<time_point, int32_t>>,
     transform_flags::expect_in_variance_if_out_variance,
-    [](units::Unit &binned, const units::Unit &, const units::Unit &data,
-       const units::Unit &) { binned = data; },
+    [](sc_units::Unit &binned, const sc_units::Unit &,
+       const sc_units::Unit &data, const sc_units::Unit &) { binned = data; },
     [](const auto &binned, const auto &offsets, const auto &data,
        const auto &bin_indices) {
       auto bins(offsets.sizes());

--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -56,7 +56,7 @@ constexpr auto abs =
 
 constexpr auto norm = overloaded{arg_list<Eigen::Vector3d>,
                                  [](const auto &x) { return x.norm(); },
-                                 [](const units::Unit &x) { return x; }};
+                                 [](const sc_units::Unit &x) { return x; }};
 
 constexpr auto pow = overloaded{
     arg_list<std::tuple<double, double>, std::tuple<double, float>,
@@ -95,17 +95,17 @@ constexpr auto sqrt = overloaded{arg_list<double, float>, [](const auto x) {
 constexpr auto dot = overloaded{
     arg_list<Eigen::Vector3d>,
     [](const auto &a, const auto &b) { return a.dot(b); },
-    [](const units::Unit &a, const units::Unit &b) { return a * b; }};
+    [](const sc_units::Unit &a, const sc_units::Unit &b) { return a * b; }};
 
 constexpr auto cross = overloaded{
     arg_list<Eigen::Vector3d>,
     [](const auto &a, const auto &b) { return a.cross(b); },
-    [](const units::Unit &a, const units::Unit &b) { return a * b; }};
+    [](const sc_units::Unit &a, const sc_units::Unit &b) { return a * b; }};
 
 constexpr auto reciprocal = overloaded{
     arg_list<double, float>,
     [](const auto &x) { return static_cast<std::decay_t<decltype(x)>>(1) / x; },
-    [](const units::Unit &unit) { return units::one / unit; }};
+    [](const sc_units::Unit &unit) { return sc_units::one / unit; }};
 
 constexpr auto exp =
     overloaded{arg_list<double, float>, dimensionless_unit_check_return,
@@ -179,7 +179,7 @@ constexpr auto midpoint = overloaded{
     arg_list<double, float, int64_t, int32_t, time_point>,
     transform_flags::expect_no_variance_arg<0>,
     transform_flags::expect_no_variance_arg<1>,
-    [](const units::Unit &a, const units::Unit &b) {
+    [](const sc_units::Unit &a, const sc_units::Unit &b) {
       expect::equals(a, b);
       return a;
     },

--- a/lib/core/include/scipp/core/element/rebin.h
+++ b/lib/core/include/scipp/core/element/rebin.h
@@ -62,8 +62,8 @@ static constexpr auto rebin = overloaded{
         }
       }
     },
-    [](const units::Unit &target_edges, const units::Unit &data,
-       const units::Unit &edges) {
+    [](const sc_units::Unit &target_edges, const sc_units::Unit &data,
+       const sc_units::Unit &edges) {
       if (target_edges != edges)
         throw except::UnitError(
             "Input and output bin edges must have the same unit.");

--- a/lib/core/include/scipp/core/element/reduction.h
+++ b/lib/core/include/scipp/core/element/reduction.h
@@ -22,8 +22,8 @@ constexpr auto flatten = overloaded{
       if (mask)
         a.insert(a.end(), b.begin(), b.end());
     },
-    [](units::Unit &a, const units::Unit &b, const units::Unit &mask) {
-      core::expect::equals(units::one, mask);
+    [](sc_units::Unit &a, const sc_units::Unit &b, const sc_units::Unit &mask) {
+      core::expect::equals(sc_units::one, mask);
       core::expect::equals(a, b);
     }};
 

--- a/lib/core/include/scipp/core/element/sort.h
+++ b/lib/core/include/scipp/core/element/sort.h
@@ -21,7 +21,7 @@ template <class Compare> constexpr auto make_sort(Compare compare) {
                               scipp::span<double>, scipp::span<float>,
                               scipp::span<std::string>,
                               scipp::span<time_point>>,
-      [](units::Unit &) {},
+      [](sc_units::Unit &) {},
       [compare](auto &range) {
         using T = std::decay_t<decltype(range)>;
         constexpr bool vars = is_ValueAndVariance_v<T>;

--- a/lib/core/include/scipp/core/element/special_values.h
+++ b/lib/core/include/scipp/core/element/special_values.h
@@ -27,7 +27,7 @@ constexpr auto isnan =
                  using numeric::isnan;
                  return isnan(x);
                },
-               [](const units::Unit &) { return units::none; }};
+               [](const sc_units::Unit &) { return sc_units::none; }};
 
 constexpr auto isinf =
     overloaded{special_value_args<Eigen::Vector3d>,
@@ -35,7 +35,7 @@ constexpr auto isinf =
                  using numeric::isinf;
                  return isinf(x);
                },
-               [](const units::Unit &) { return units::none; }};
+               [](const sc_units::Unit &) { return sc_units::none; }};
 
 constexpr auto isfinite =
     overloaded{special_value_args<Eigen::Vector3d>,
@@ -43,7 +43,7 @@ constexpr auto isfinite =
                  using numeric::isfinite;
                  return isfinite(x);
                },
-               [](const units::Unit &) { return units::none; }};
+               [](const sc_units::Unit &) { return sc_units::none; }};
 
 namespace detail {
 template <typename T> auto isposinf(T x) {
@@ -61,7 +61,7 @@ constexpr auto isposinf =
                  using detail::isposinf;
                  return isposinf(x);
                },
-               [](const units::Unit &) { return units::none; }};
+               [](const sc_units::Unit &) { return sc_units::none; }};
 
 constexpr auto isneginf =
     overloaded{special_value_args<>,
@@ -69,12 +69,12 @@ constexpr auto isneginf =
                  using detail::isneginf;
                  return isneginf(x);
                },
-               [](const units::Unit &) { return units::none; }};
+               [](const sc_units::Unit &) { return sc_units::none; }};
 
 constexpr auto replace_special = overloaded{
     arg_list<double, float>, transform_flags::expect_all_or_none_have_variance,
     transform_flags::force_variance_broadcast,
-    [](const units::Unit &x, const units::Unit &repl) {
+    [](const sc_units::Unit &x, const sc_units::Unit &repl) {
       expect::equals(x, repl);
       return x;
     }};
@@ -82,7 +82,7 @@ constexpr auto replace_special = overloaded{
 constexpr auto replace_special_out_arg = overloaded{
     arg_list<double, float>, transform_flags::expect_all_or_none_have_variance,
     transform_flags::force_variance_broadcast,
-    [](units::Unit &a, const units::Unit &b, const units::Unit &repl) {
+    [](sc_units::Unit &a, const sc_units::Unit &b, const sc_units::Unit &repl) {
       expect::equals(b, repl);
       a = b;
     }};

--- a/lib/core/include/scipp/core/element/to_unit.h
+++ b/lib/core/include/scipp/core/element/to_unit.h
@@ -46,7 +46,7 @@ constexpr auto to_unit = overloaded{
              std::tuple<Eigen::Affine3d, double>,
              std::tuple<Translation, double>>,
     transform_flags::expect_no_variance_arg<1>,
-    [](const units::Unit &, const units::Unit &target) { return target; },
+    [](const sc_units::Unit &, const sc_units::Unit &target) { return target; },
     [](const time_point &x, const auto &scale) {
       return time_point{round<int64_t>(x.time_since_epoch() * scale)};
     },

--- a/lib/core/include/scipp/core/element/util.h
+++ b/lib/core/include/scipp/core/element/util.h
@@ -52,7 +52,7 @@ constexpr auto variances =
                  else
                    return x; // unreachable but required for instantiation
                },
-               [](const units::Unit &u) { return u * u; }};
+               [](const sc_units::Unit &u) { return u * u; }};
 
 constexpr auto stddevs =
     overloaded{transform_flags::no_out_variance,
@@ -66,7 +66,7 @@ constexpr auto stddevs =
                  else
                    return sqrt(x); // unreachable but required for instantiation
                },
-               [](const units::Unit &u) { return u; }};
+               [](const sc_units::Unit &u) { return u; }};
 
 constexpr auto issorted_common = overloaded{
     core::element::arg_list<
@@ -75,9 +75,10 @@ constexpr auto issorted_common = overloaded{
         std::tuple<bool, std::string, std::string>,
         std::tuple<bool, time_point, time_point>>,
     transform_flags::expect_no_variance_arg<1>,
-    [](units::Unit &out, const units::Unit &left, const units::Unit &right) {
+    [](sc_units::Unit &out, const sc_units::Unit &left,
+       const sc_units::Unit &right) {
       core::expect::equals(left, right);
-      out = units::none;
+      out = sc_units::none;
     }};
 
 constexpr auto issorted_nondescending = overloaded{
@@ -95,19 +96,19 @@ constexpr auto islinspace =
                         scipp::span<const int64_t>, scipp::span<const int32_t>,
                         scipp::span<const time_point>>,
                transform_flags::expect_no_variance_arg<0>,
-               [](const units::Unit &) { return units::none; },
+               [](const sc_units::Unit &) { return sc_units::none; },
                [](const auto &range) { return numeric::islinspace(range); }};
 
 constexpr auto isarange =
     overloaded{arg_list<scipp::span<const int64_t>, scipp::span<const int32_t>>,
                transform_flags::expect_no_variance_arg<0>,
-               [](const units::Unit &) { return units::none; },
+               [](const sc_units::Unit &) { return sc_units::none; },
                [](const auto &range) { return numeric::isarange(range); }};
 
 constexpr auto zip =
     overloaded{arg_list<int64_t>, transform_flags::expect_no_variance_arg<0>,
                transform_flags::expect_no_variance_arg<1>,
-               [](const units::Unit &first, const units::Unit &second) {
+               [](const sc_units::Unit &first, const sc_units::Unit &second) {
                  expect::equals(first, second);
                  return first;
                },
@@ -119,7 +120,7 @@ template <int N>
 constexpr auto get = overloaded{arg_list<std::pair<scipp::index, scipp::index>>,
                                 transform_flags::expect_no_variance_arg<0>,
                                 [](const auto &x) { return std::get<N>(x); },
-                                [](const units::Unit &u) { return u; }};
+                                [](const sc_units::Unit &u) { return u; }};
 
 constexpr auto fill =
     overloaded{arg_list<double, float, std::tuple<float, double>>,
@@ -127,7 +128,7 @@ constexpr auto fill =
 
 constexpr auto fill_zeros =
     overloaded{arg_list<double, float, int64_t, int32_t, SubbinSizes>,
-               [](units::Unit &) {}, [](auto &x) { x = 0; }};
+               [](sc_units::Unit &) {}, [](auto &x) { x = 0; }};
 
 template <class... Ts>
 constexpr arg_list_t<std::tuple<bool, Ts, Ts>...> where_arg_list{};
@@ -140,9 +141,9 @@ constexpr auto where = overloaded{
     [](const auto &condition, const auto &x, const auto &y) {
       return condition ? x : y;
     },
-    [](const units::Unit &condition, const units::Unit &x,
-       const units::Unit &y) {
-      expect::equals(units::none, condition);
+    [](const sc_units::Unit &condition, const sc_units::Unit &x,
+       const sc_units::Unit &y) {
+      expect::equals(sc_units::none, condition);
       expect::equals(x, y);
       return x;
     }};

--- a/lib/core/include/scipp/core/except.h
+++ b/lib/core/include/scipp/core/except.h
@@ -121,7 +121,7 @@ void sizeMatches(const T &range, const Ts &...other) {
 inline auto to_string(const std::string &s) { return s; }
 
 template <class T>
-void unit(const T &object, const units::Unit &unit,
+void unit(const T &object, const sc_units::Unit &unit,
           std::string optional_message = "") {
   expect::equals(object.unit(), unit, optional_message);
 }

--- a/lib/core/include/scipp/core/string.h
+++ b/lib/core/include/scipp/core/string.h
@@ -41,7 +41,7 @@ SCIPP_CORE_EXPORT std::string labels_to_string(const Dimensions &dims);
 // No timezone conversion is performed and the result does not show a
 // timezone offset.
 SCIPP_CORE_EXPORT std::string to_iso_date(const scipp::core::time_point &item,
-                                          const units::Unit &unit);
+                                          const sc_units::Unit &unit);
 
 /// Return the global dtype name registry instance
 SCIPP_CORE_EXPORT std::map<DType, std::string> &dtypeNameRegistry();

--- a/lib/core/include/scipp/core/transform_common.h
+++ b/lib/core/include/scipp/core/transform_common.h
@@ -39,24 +39,24 @@ using arithmetic_type_pairs_with_bool =
     pair_product_t<float, double, int32_t, int64_t, bool>;
 
 static constexpr auto keep_unit =
-    overloaded{[](const units::Unit &) {},
-               [](const units::Unit &, const units::Unit &) {}};
+    overloaded{[](const sc_units::Unit &) {},
+               [](const sc_units::Unit &, const sc_units::Unit &) {}};
 
 static constexpr auto dimensionless_unit_check =
-    [](units::Unit &varUnit, const units::Unit &otherUnit) {
-      expect::equals(units::one, varUnit);
-      expect::equals(units::one, otherUnit);
+    [](sc_units::Unit &varUnit, const sc_units::Unit &otherUnit) {
+      expect::equals(sc_units::one, varUnit);
+      expect::equals(sc_units::one, otherUnit);
     };
 
 static constexpr auto dimensionless_unit_check_return =
-    overloaded{[](const units::Unit &a) {
-                 expect::equals(units::one, a);
-                 return units::one;
+    overloaded{[](const sc_units::Unit &a) {
+                 expect::equals(sc_units::one, a);
+                 return sc_units::one;
                },
-               [](const units::Unit &a, const units::Unit &b) {
-                 expect::equals(units::one, a);
-                 expect::equals(units::one, b);
-                 return units::one;
+               [](const sc_units::Unit &a, const sc_units::Unit &b) {
+                 expect::equals(sc_units::one, a);
+                 expect::equals(sc_units::one, b);
+                 return sc_units::one;
                }};
 
 template <typename Op> struct assign_unary : Op {

--- a/lib/core/string.cpp
+++ b/lib/core/string.cpp
@@ -135,21 +135,22 @@ std::string to_string(const std::chrono::duration<Rep, Period> &duration) {
 } // namespace
 
 std::string to_iso_date(const scipp::core::time_point &item,
-                        const units::Unit &unit) {
-  if (unit == units::ns) {
+                        const sc_units::Unit &unit) {
+  if (unit == sc_units::ns) {
     return to_string(std::chrono::nanoseconds{item.time_since_epoch()});
-  } else if (unit == units::s) {
+  } else if (unit == sc_units::s) {
     return to_string(std::chrono::seconds{item.time_since_epoch()});
-  } else if (unit == units::us) {
+  } else if (unit == sc_units::us) {
     return to_string(std::chrono::microseconds{item.time_since_epoch()});
-  } else if (unit == units::Unit(llnl::units::precise::ms)) {
+  } else if (unit == sc_units::Unit(units::precise::ms)) {
     return to_string(std::chrono::milliseconds{item.time_since_epoch()});
-  } else if (unit == units::Unit(llnl::units::precise::minute)) {
+  } else if (unit == sc_units::Unit(units::precise::minute)) {
     return to_string(std::chrono::minutes{item.time_since_epoch()});
-  } else if (unit == units::Unit(llnl::units::precise::hr)) {
+  } else if (unit == sc_units::Unit(units::precise::hr)) {
     return to_string(std::chrono::hours{item.time_since_epoch()});
-  } else if (unit == units::Unit(llnl::units::precise::day) ||
-             unit == units::Unit("month") || unit == units::Unit("year")) {
+  } else if (unit == sc_units::Unit(units::precise::day) ||
+             unit == sc_units::Unit("month") ||
+             unit == sc_units::Unit("year")) {
     throw except::UnitError("Printing of time points with units greater than "
                             "hours is not yet implemented.");
   }

--- a/lib/core/test/element_arithmetic_test.cpp
+++ b/lib/core/test/element_arithmetic_test.cpp
@@ -198,10 +198,10 @@ TYPED_TEST(ElementArithmeticDivisionTest, remainder) {
 }
 
 TEST(ElementArithmeticDivisionTest, units) {
-  EXPECT_EQ(divide(units::m, units::s), units::m / units::s);
-  EXPECT_EQ(floor_divide(units::m, units::s), units::m / units::s);
-  EXPECT_EQ(mod(units::m, units::m), units::m);
-  EXPECT_THROW(mod(units::m, units::s), except::UnitError);
+  EXPECT_EQ(divide(sc_units::m, sc_units::s), sc_units::m / sc_units::s);
+  EXPECT_EQ(floor_divide(sc_units::m, sc_units::s), sc_units::m / sc_units::s);
+  EXPECT_EQ(mod(sc_units::m, sc_units::m), sc_units::m);
+  EXPECT_THROW(mod(sc_units::m, sc_units::s), except::UnitError);
 }
 
 class ElementNanArithmeticTest : public ::testing::Test {

--- a/lib/core/test/element_comparison_test.cpp
+++ b/lib/core/test/element_comparison_test.cpp
@@ -26,9 +26,9 @@ TYPED_TEST_SUITE(ElementEqualTest, ElementLessTestTypes);
 TYPED_TEST_SUITE(ElementNotEqualTest, ElementLessTestTypes);
 
 TEST(ElementComparisonTest, unit) {
-  const units::Unit m(units::m);
-  EXPECT_EQ(comparison(m, m), units::none);
-  const units::Unit rad(units::rad);
+  const sc_units::Unit m(sc_units::m);
+  EXPECT_EQ(comparison(m, m), sc_units::none);
+  const sc_units::Unit rad(sc_units::rad);
   EXPECT_THROW(comparison(rad, m), except::UnitError);
 }
 
@@ -186,10 +186,13 @@ TYPED_TEST(IsCloseTest, value_equal_infs_signbit) {
 }
 
 template <class Op> void do_isclose_units_test(Op op) {
-  EXPECT_EQ(units::none, op(units::m, units::m, units::m));
-  EXPECT_THROW_DISCARD(op(units::m, units::m, units::s), except::UnitError);
-  EXPECT_THROW_DISCARD(op(units::m, units::s, units::m), except::UnitError);
-  EXPECT_THROW_DISCARD(op(units::s, units::m, units::m), except::UnitError);
+  EXPECT_EQ(sc_units::none, op(sc_units::m, sc_units::m, sc_units::m));
+  EXPECT_THROW_DISCARD(op(sc_units::m, sc_units::m, sc_units::s),
+                       except::UnitError);
+  EXPECT_THROW_DISCARD(op(sc_units::m, sc_units::s, sc_units::m),
+                       except::UnitError);
+  EXPECT_THROW_DISCARD(op(sc_units::s, sc_units::m, sc_units::m),
+                       except::UnitError);
 }
 
 TEST(IsCloseTest, units) {

--- a/lib/core/test/element_event_operations_test.cpp
+++ b/lib/core/test/element_event_operations_test.cpp
@@ -15,9 +15,9 @@ using element::event::map_linspace;
 using element::event::map_sorted_edges;
 
 TEST(ElementEventMapTest, unit) {
-  units::Unit kg(units::kg);
-  units::Unit m(units::m);
-  units::Unit s(units::s);
+  sc_units::Unit kg(sc_units::kg);
+  sc_units::Unit m(sc_units::m);
+  sc_units::Unit s(sc_units::s);
   EXPECT_EQ(element::event::map(m, m, s, s), s);
   EXPECT_EQ(element::event::map(m, m, kg, kg), kg);
   EXPECT_THROW(element::event::map(m, s, s, s), except::UnitError);
@@ -27,9 +27,9 @@ TEST(ElementEventMapTest, unit) {
 }
 
 TEST(ElementEventMapTest, fill_unit_must_match_weight_unit) {
-  units::Unit kg(units::kg);
-  units::Unit m(units::m);
-  units::Unit s(units::s);
+  sc_units::Unit kg(sc_units::kg);
+  sc_units::Unit m(sc_units::m);
+  sc_units::Unit s(sc_units::s);
   EXPECT_EQ(element::event::map(m, m, kg, kg), kg);
   EXPECT_THROW(element::event::map(m, m, kg, s), except::UnitError);
 }

--- a/lib/core/test/element_geometric_operations_test.cpp
+++ b/lib/core/test/element_geometric_operations_test.cpp
@@ -13,8 +13,8 @@ using namespace scipp;
 using namespace scipp::core::element;
 
 TEST(ElementPositionTest, unit_in) {
-  const units::Unit m(units::m);
-  const units::Unit s(units::s); // Not supported
+  const sc_units::Unit m(sc_units::m);
+  const sc_units::Unit s(sc_units::s); // Not supported
   EXPECT_THROW(geometry::position(s, m, m), except::UnitError);
   EXPECT_THROW(geometry::position(m, s, m), except::UnitError);
   EXPECT_THROW(geometry::position(m, m, s), except::UnitError);
@@ -23,7 +23,7 @@ TEST(ElementPositionTest, unit_in) {
 }
 
 TEST(ElementPositionTest, unit_out) {
-  const units::Unit m(units::m);
+  const sc_units::Unit m(sc_units::m);
   EXPECT_EQ(geometry::position(m, m, m), m);
 }
 
@@ -36,7 +36,7 @@ TEST(ElementPositionNTest, unzip_position) {
   EXPECT_EQ(geometry::x(a), a[0]);
   EXPECT_EQ(geometry::y(a), a[1]);
   EXPECT_EQ(geometry::z(a), a[2]);
-  EXPECT_EQ(geometry::x(units::m), units::m);
-  EXPECT_EQ(geometry::y(units::m), units::m);
-  EXPECT_EQ(geometry::z(units::m), units::m);
+  EXPECT_EQ(geometry::x(sc_units::m), sc_units::m);
+  EXPECT_EQ(geometry::y(sc_units::m), sc_units::m);
+  EXPECT_EQ(geometry::z(sc_units::m), sc_units::m);
 }

--- a/lib/core/test/element_histogram_test.cpp
+++ b/lib/core/test/element_histogram_test.cpp
@@ -22,22 +22,24 @@ TEST(ElementHistogramTest, variance_flags) {
 TEST(ElementHistogramTest, unit) {
   // Note that this is an operator for `transform_subspan`, so the overload for
   // units has one argument fewer than the one for data.
-  EXPECT_EQ(element::histogram(units::m, units::counts, units::m),
-            units::counts);
+  EXPECT_EQ(element::histogram(sc_units::m, sc_units::counts, sc_units::m),
+            sc_units::counts);
 }
 
 TEST(ElementHistogramTest, event_and_edge_unit_must_match) {
-  EXPECT_NO_THROW(element::histogram(units::m, units::counts, units::m));
-  EXPECT_NO_THROW(element::histogram(units::s, units::counts, units::s));
-  EXPECT_THROW(element::histogram(units::m, units::counts, units::s),
+  EXPECT_NO_THROW(
+      element::histogram(sc_units::m, sc_units::counts, sc_units::m));
+  EXPECT_NO_THROW(
+      element::histogram(sc_units::s, sc_units::counts, sc_units::s));
+  EXPECT_THROW(element::histogram(sc_units::m, sc_units::counts, sc_units::s),
                except::UnitError);
-  EXPECT_THROW(element::histogram(units::s, units::counts, units::m),
+  EXPECT_THROW(element::histogram(sc_units::s, sc_units::counts, sc_units::m),
                except::UnitError);
 }
 
 TEST(ElementHistogramTest, weight_unit_propagates) {
-  for (const auto &unit : {units::m, units::counts, units::one})
-    EXPECT_EQ(element::histogram(units::m, unit, units::m), unit);
+  for (const auto &unit : {sc_units::m, sc_units::counts, sc_units::one})
+    EXPECT_EQ(element::histogram(sc_units::m, unit, sc_units::m), unit);
 }
 
 TEST(ElementHistogramTest, values) {

--- a/lib/core/test/element_logical_test.cpp
+++ b/lib/core/test/element_logical_test.cpp
@@ -15,18 +15,18 @@ TEST(LogicalTest, accepts_only_bool) {
 }
 
 TEST(LogicalTest, logical_unit) {
-  EXPECT_EQ(logical(units::none), units::none);
-  EXPECT_THROW(logical(units::m), except::UnitError);
+  EXPECT_EQ(logical(sc_units::none), sc_units::none);
+  EXPECT_THROW(logical(sc_units::m), except::UnitError);
 }
 
 TEST(LogicalTest, logical_inplace_unit) {
-  auto u = units::none;
-  EXPECT_NO_THROW(logical_inplace(u, units::none));
-  EXPECT_EQ(u, units::none);
-  EXPECT_THROW(logical_inplace(u, units::m), except::UnitError);
-  u = units::m;
-  EXPECT_THROW(logical_inplace(u, units::none), except::UnitError);
-  EXPECT_THROW(logical_inplace(u, units::m), except::UnitError);
+  auto u = sc_units::none;
+  EXPECT_NO_THROW(logical_inplace(u, sc_units::none));
+  EXPECT_EQ(u, sc_units::none);
+  EXPECT_THROW(logical_inplace(u, sc_units::m), except::UnitError);
+  u = sc_units::m;
+  EXPECT_THROW(logical_inplace(u, sc_units::none), except::UnitError);
+  EXPECT_THROW(logical_inplace(u, sc_units::m), except::UnitError);
 }
 
 TEST(LogicalTest, logical_and_op) {

--- a/lib/core/test/element_math_test.cpp
+++ b/lib/core/test/element_math_test.cpp
@@ -11,8 +11,8 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(ElementAbsTest, unit) {
-  units::Unit m(units::m);
-  EXPECT_EQ(element::abs(m), units::abs(m));
+  sc_units::Unit m(sc_units::m);
+  EXPECT_EQ(element::abs(m), sc_units::abs(m));
 }
 
 TEST(ElementAbsTest, value) {
@@ -32,9 +32,9 @@ TEST(ElementAbsTest, supported_types) {
 }
 
 TEST(ElementNormTest, unit) {
-  const units::Unit s(units::s);
-  const units::Unit m2(units::m * units::m);
-  const units::Unit dimless(units::dimensionless);
+  const sc_units::Unit s(sc_units::s);
+  const sc_units::Unit m2(sc_units::m * sc_units::m);
+  const sc_units::Unit dimless(sc_units::dimensionless);
   EXPECT_EQ(element::norm(m2), m2);
   EXPECT_EQ(element::norm(s), s);
   EXPECT_EQ(element::norm(dimless), dimless);
@@ -51,10 +51,13 @@ TEST(ElementPowTest, unit) {
   // element::pow cannot handle units itself as that requires the *value* of the
   // exponent and not its unit. This does not fit into the usual transform
   // framework.
-  EXPECT_EQ(element::pow(units::one, units::one), units::one);
-  EXPECT_THROW_DISCARD(element::pow(units::one, units::m), except::UnitError);
-  EXPECT_THROW_DISCARD(element::pow(units::s, units::one), except::UnitError);
-  EXPECT_THROW_DISCARD(element::pow(units::K, units::kg), except::UnitError);
+  EXPECT_EQ(element::pow(sc_units::one, sc_units::one), sc_units::one);
+  EXPECT_THROW_DISCARD(element::pow(sc_units::one, sc_units::m),
+                       except::UnitError);
+  EXPECT_THROW_DISCARD(element::pow(sc_units::s, sc_units::one),
+                       except::UnitError);
+  EXPECT_THROW_DISCARD(element::pow(sc_units::K, sc_units::kg),
+                       except::UnitError);
 }
 
 TEST(ElementPowTest, value) {
@@ -70,8 +73,8 @@ TEST(ElementPowTest, value_and_variance) {
 }
 
 TEST(ElementSqrtTest, unit) {
-  const units::Unit m2(units::m * units::m);
-  EXPECT_EQ(element::sqrt(m2), units::sqrt(m2));
+  const sc_units::Unit m2(sc_units::m * sc_units::m);
+  EXPECT_EQ(element::sqrt(m2), sc_units::sqrt(m2));
 }
 
 TEST(ElementSqrtTest, value) {
@@ -91,9 +94,9 @@ TEST(ElementSqrtTest, supported_types) {
 }
 
 template <class T> void element_vector_op_units_test(T op) {
-  const units::Unit m(units::m);
-  const units::Unit m2(units::m * units::m);
-  const units::Unit dimless(units::dimensionless);
+  const sc_units::Unit m(sc_units::m);
+  const sc_units::Unit m2(sc_units::m * sc_units::m);
+  const sc_units::Unit dimless(sc_units::dimensionless);
   EXPECT_EQ(op(m, m), m2);
   EXPECT_EQ(op(dimless, dimless), dimless);
 }
@@ -118,10 +121,10 @@ TEST(ElementCrossTest, value) {
 }
 
 TEST(ElementReciprocalTest, unit) {
-  const units::Unit one_over_m(units::one / units::m);
-  EXPECT_EQ(element::reciprocal(one_over_m), units::m);
-  const units::Unit one_over_s(units::one / units::s);
-  EXPECT_EQ(element::reciprocal(units::s), one_over_s);
+  const sc_units::Unit one_over_m(sc_units::one / sc_units::m);
+  EXPECT_EQ(element::reciprocal(one_over_m), sc_units::m);
+  const sc_units::Unit one_over_s(sc_units::one / sc_units::s);
+  EXPECT_EQ(element::reciprocal(sc_units::s), one_over_s);
 }
 
 TEST(ElementReciprocalTest, value) {
@@ -140,10 +143,10 @@ TEST(ElementExpTest, value) {
 }
 
 TEST(ElementExpTest, unit) {
-  EXPECT_EQ(element::exp(units::dimensionless), units::dimensionless);
+  EXPECT_EQ(element::exp(sc_units::dimensionless), sc_units::dimensionless);
 }
 
-TEST(ElementExpTest, bad_unit) { EXPECT_ANY_THROW(element::exp(units::m)); }
+TEST(ElementExpTest, bad_unit) { EXPECT_ANY_THROW(element::exp(sc_units::m)); }
 
 TEST(ElementLogTest, value) {
   EXPECT_EQ(element::log(1.23), std::log(1.23));
@@ -151,10 +154,10 @@ TEST(ElementLogTest, value) {
 }
 
 TEST(ElementLogTest, unit) {
-  EXPECT_EQ(element::log(units::dimensionless), units::dimensionless);
+  EXPECT_EQ(element::log(sc_units::dimensionless), sc_units::dimensionless);
 }
 
-TEST(ElementLogTest, bad_unit) { EXPECT_ANY_THROW(element::log(units::m)); }
+TEST(ElementLogTest, bad_unit) { EXPECT_ANY_THROW(element::log(sc_units::m)); }
 
 TEST(ElementLog10Test, value) {
   EXPECT_EQ(element::log10(1.23), std::log10(1.23));
@@ -162,10 +165,12 @@ TEST(ElementLog10Test, value) {
 }
 
 TEST(ElementLog10Test, unit) {
-  EXPECT_EQ(element::log10(units::dimensionless), units::dimensionless);
+  EXPECT_EQ(element::log10(sc_units::dimensionless), sc_units::dimensionless);
 }
 
-TEST(ElementLog10Test, bad_unit) { EXPECT_ANY_THROW(element::log10(units::m)); }
+TEST(ElementLog10Test, bad_unit) {
+  EXPECT_ANY_THROW(element::log10(sc_units::m));
+}
 
 namespace {
 template <class T>
@@ -195,14 +200,14 @@ TEST(ElementRoundingTest, rint) {
 
 TEST(ElementMathTest, erf) {
   EXPECT_EQ(element::erf(1.1), std::erf(1.1));
-  EXPECT_EQ(element::erf(units::one), units::one);
-  EXPECT_THROW_DISCARD(element::erf(units::m), except::UnitError);
+  EXPECT_EQ(element::erf(sc_units::one), sc_units::one);
+  EXPECT_THROW_DISCARD(element::erf(sc_units::m), except::UnitError);
 }
 
 TEST(ElementMathTest, erfc) {
   EXPECT_EQ(element::erfc(1.1), std::erfc(1.1));
-  EXPECT_EQ(element::erfc(units::one), units::one);
-  EXPECT_THROW_DISCARD(element::erfc(units::m), except::UnitError);
+  EXPECT_EQ(element::erfc(sc_units::one), sc_units::one);
+  EXPECT_THROW_DISCARD(element::erfc(sc_units::m), except::UnitError);
 }
 
 TEST(ElementMathTest, midpoint_of_medium_sized_int) {
@@ -240,7 +245,7 @@ TEST(ElementMathTest, midpoint_of_time_point_uses_underlying_int) {
 }
 
 TEST(ElementMathTest, midpoint_units_must_be_equal) {
-  EXPECT_EQ(element::midpoint(units::m, units::m), units::m);
-  EXPECT_THROW_DISCARD(element::midpoint(units::m, units::one),
+  EXPECT_EQ(element::midpoint(sc_units::m, sc_units::m), sc_units::m);
+  EXPECT_THROW_DISCARD(element::midpoint(sc_units::m, sc_units::one),
                        except::UnitError);
 }

--- a/lib/core/test/element_special_values_test.cpp
+++ b/lib/core/test/element_special_values_test.cpp
@@ -31,8 +31,8 @@ template <typename T> class ElementIsnanTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIsnanTest, ElementSpecialValuesTestTypes);
 
 TEST(ElementIsnanTest, unit) {
-  for (const auto &u : {units::dimensionless, units::m, units::meV}) {
-    EXPECT_EQ(element::isnan(u), units::none);
+  for (const auto &u : {sc_units::dimensionless, sc_units::m, sc_units::meV}) {
+    EXPECT_EQ(element::isnan(u), sc_units::none);
   }
 }
 
@@ -57,8 +57,8 @@ template <typename T> class ElementIsinfTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIsinfTest, ElementSpecialValuesTestTypes);
 
 TEST(ElementIsinfTest, unit) {
-  for (const auto &u : {units::dimensionless, units::m, units::meV}) {
-    EXPECT_EQ(element::isinf(u), units::none);
+  for (const auto &u : {sc_units::dimensionless, sc_units::m, sc_units::meV}) {
+    EXPECT_EQ(element::isinf(u), sc_units::none);
   }
 }
 
@@ -83,8 +83,8 @@ template <typename T> class ElementIsfiniteTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIsfiniteTest, ElementSpecialValuesTestTypes);
 
 TEST(ElementIsfiniteTest, unit) {
-  for (const auto &u : {units::dimensionless, units::m, units::meV}) {
-    EXPECT_EQ(element::isfinite(u), units::none);
+  for (const auto &u : {sc_units::dimensionless, sc_units::m, sc_units::meV}) {
+    EXPECT_EQ(element::isfinite(u), sc_units::none);
   }
 }
 
@@ -110,9 +110,9 @@ template <typename T> class ElementIssignedinfTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ElementIssignedinfTest, ElementSpecialValuesTestTypes);
 
 TEST(ElementIssignedinfTest, unit) {
-  for (const auto &u : {units::dimensionless, units::m, units::meV}) {
-    EXPECT_EQ(element::isposinf(u), units::none);
-    EXPECT_EQ(element::isneginf(u), units::none);
+  for (const auto &u : {sc_units::dimensionless, sc_units::m, sc_units::meV}) {
+    EXPECT_EQ(element::isposinf(u), sc_units::none);
+    EXPECT_EQ(element::isneginf(u), sc_units::none);
   }
 }
 
@@ -160,18 +160,18 @@ void targetted_replacement_out_arg_test(Op op, T &out, const T &replaceable,
 }
 
 template <typename Op> void targetted_unit_test(Op op) {
-  units::Unit m(units::m);
+  sc_units::Unit m(sc_units::m);
   EXPECT_EQ(m, op(m, m));
-  units::Unit s(units::s);
+  sc_units::Unit s(sc_units::s);
   EXPECT_THROW(op(s, m), except::UnitError);
 }
 
 template <typename Op> void targetted_unit_test_out(Op op) {
-  units::Unit m(units::m);
-  units::Unit u;
+  sc_units::Unit m(sc_units::m);
+  sc_units::Unit u;
   op(u, m, m);
   EXPECT_EQ(m, u);
-  units::Unit s(units::s);
+  sc_units::Unit s(sc_units::s);
   EXPECT_THROW(op(u, s, m), except::UnitError);
 }
 

--- a/lib/core/test/element_to_unit_test.cpp
+++ b/lib/core/test/element_to_unit_test.cpp
@@ -12,7 +12,7 @@ using scipp::core::element::to_unit;
 
 TEST(ElementToUnitTest, unit) {
   // Unit is simply replaced, not multiplied
-  EXPECT_EQ(to_unit(units::s, units::us), units::us);
+  EXPECT_EQ(to_unit(sc_units::s, sc_units::us), sc_units::us);
 }
 
 TEST(ElementToUnitTest, type_preserved) {

--- a/lib/core/test/element_trigonometry_test.cpp
+++ b/lib/core/test/element_trigonometry_test.cpp
@@ -13,9 +13,9 @@ using namespace scipp;
 using namespace scipp::core;
 
 TEST(ElementSinOutArgTest, unit_rad) {
-  EXPECT_EQ(element::sin(units::rad), units::sin(units::rad));
-  EXPECT_EQ(element::sin(units::deg), units::sin(units::deg));
-  EXPECT_THROW_DISCARD(element::sin(units::one), except::UnitError);
+  EXPECT_EQ(element::sin(sc_units::rad), sc_units::sin(sc_units::rad));
+  EXPECT_EQ(element::sin(sc_units::deg), sc_units::sin(sc_units::deg));
+  EXPECT_THROW_DISCARD(element::sin(sc_units::one), except::UnitError);
 }
 
 TEST(ElementSinOutArgTest, value_double) {
@@ -33,9 +33,9 @@ TEST(ElementSinOutArgTest, supported_types) {
 }
 
 TEST(ElementCosOutArgTest, unit_rad) {
-  EXPECT_EQ(element::cos(units::rad), units::cos(units::rad));
-  EXPECT_EQ(element::cos(units::deg), units::cos(units::deg));
-  EXPECT_THROW_DISCARD(element::cos(units::one), except::UnitError);
+  EXPECT_EQ(element::cos(sc_units::rad), sc_units::cos(sc_units::rad));
+  EXPECT_EQ(element::cos(sc_units::deg), sc_units::cos(sc_units::deg));
+  EXPECT_THROW_DISCARD(element::cos(sc_units::one), except::UnitError);
 }
 
 TEST(ElementCosOutArgTest, value_double) {
@@ -53,9 +53,9 @@ TEST(ElementCosOutArgTest, supported_types) {
 }
 
 TEST(ElementTanOutArgTest, unit_rad) {
-  EXPECT_EQ(element::tan(units::rad), units::tan(units::rad));
-  EXPECT_EQ(element::tan(units::deg), units::tan(units::deg));
-  EXPECT_THROW_DISCARD(element::tan(units::one), except::UnitError);
+  EXPECT_EQ(element::tan(sc_units::rad), sc_units::tan(sc_units::rad));
+  EXPECT_EQ(element::tan(sc_units::deg), sc_units::tan(sc_units::deg));
+  EXPECT_THROW_DISCARD(element::tan(sc_units::one), except::UnitError);
 }
 
 TEST(ElementTanOutArgTest, value_double) {
@@ -73,9 +73,9 @@ TEST(ElementTanOutArgTest, supported_types) {
 }
 
 TEST(ElementAsinTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::asin(dimensionless), units::asin(dimensionless));
-  const units::Unit rad(units::rad);
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::asin(dimensionless), sc_units::asin(dimensionless));
+  const sc_units::Unit rad(sc_units::rad);
   EXPECT_THROW(element::asin(rad), except::UnitError);
 }
 
@@ -87,8 +87,8 @@ TEST(ElementAsinTest, value) {
 }
 
 TEST(ElementAsinOutArgTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::asin(dimensionless), units::asin(dimensionless));
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::asin(dimensionless), sc_units::asin(dimensionless));
 }
 
 TEST(ElementAsinOutArgTest, value_double) {
@@ -106,9 +106,9 @@ TEST(ElementAsinOutArgTest, supported_types) {
 }
 
 TEST(ElementAcosTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::acos(dimensionless), units::acos(dimensionless));
-  const units::Unit rad(units::rad);
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::acos(dimensionless), sc_units::acos(dimensionless));
+  const sc_units::Unit rad(sc_units::rad);
   EXPECT_THROW(element::acos(rad), except::UnitError);
 }
 
@@ -120,8 +120,8 @@ TEST(ElementAcosTest, value) {
 }
 
 TEST(ElementAcosOutArgTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::acos(dimensionless), units::acos(dimensionless));
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::acos(dimensionless), sc_units::acos(dimensionless));
 }
 
 TEST(ElementAcosOutArgTest, value_double) {
@@ -139,9 +139,9 @@ TEST(ElementAcosOutArgTest, supported_types) {
 }
 
 TEST(ElementAtanTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::atan(dimensionless), units::atan(dimensionless));
-  const units::Unit rad(units::rad);
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::atan(dimensionless), sc_units::atan(dimensionless));
+  const sc_units::Unit rad(sc_units::rad);
   EXPECT_THROW(element::atan(rad), except::UnitError);
 }
 
@@ -151,8 +151,8 @@ TEST(ElementAtanTest, value) {
 }
 
 TEST(ElementAtanOutArgTest, unit) {
-  const units::Unit dimensionless(units::dimensionless);
-  EXPECT_EQ(element::atan(dimensionless), units::atan(dimensionless));
+  const sc_units::Unit dimensionless(sc_units::dimensionless);
+  EXPECT_EQ(element::atan(dimensionless), sc_units::atan(dimensionless));
 }
 
 TEST(ElementAtanOutArgTest, value_double) {
@@ -174,9 +174,9 @@ using ElementAtan2TestTypes = ::testing::Types<double, float>;
 TYPED_TEST_SUITE(ElementAtan2Test, ElementAtan2TestTypes);
 
 TYPED_TEST(ElementAtan2Test, unit) {
-  const units::Unit m(units::m);
-  EXPECT_EQ(element::atan2(m, m), units::atan2(m, m));
-  const units::Unit rad(units::rad);
+  const sc_units::Unit m(sc_units::m);
+  EXPECT_EQ(element::atan2(m, m), sc_units::atan2(m, m));
+  const sc_units::Unit rad(sc_units::rad);
   EXPECT_THROW(element::atan2(rad, m), except::UnitError);
 }
 
@@ -200,9 +200,9 @@ TYPED_TEST(ElementAtan2Test, value_only_arguments) {
 }
 
 TYPED_TEST(ElementAtan2Test, unit_out) {
-  const units::Unit m(units::m);
-  const units::Unit s(units::s);
-  EXPECT_EQ(element::atan2(m, m), units::atan2(m, m));
+  const sc_units::Unit m(sc_units::m);
+  const sc_units::Unit s(sc_units::s);
+  EXPECT_EQ(element::atan2(m, m), sc_units::atan2(m, m));
   EXPECT_THROW(element::atan2(m, s), except::UnitError);
   EXPECT_THROW(element::atan2(s, m), except::UnitError);
 }

--- a/lib/core/test/element_util_test.cpp
+++ b/lib/core/test/element_util_test.cpp
@@ -22,21 +22,22 @@ TEST(ElementUtilTest, where) {
 }
 
 TEST(ElementUtilTest, where_unit_preserved) {
-  for (const auto &unit : {units::m, units::one, units::s}) {
-    EXPECT_EQ(where(units::none, unit, unit), unit);
+  for (const auto &unit : {sc_units::m, sc_units::one, sc_units::s}) {
+    EXPECT_EQ(where(sc_units::none, unit, unit), unit);
   }
 }
 
 TEST(ElementUtilTest, where_unit_mismatch_fail) {
-  for (const auto &unit : {units::m, units::one, units::s}) {
-    EXPECT_THROW(where(units::none, unit, units::kg), except::UnitError);
+  for (const auto &unit : {sc_units::m, sc_units::one, sc_units::s}) {
+    EXPECT_THROW(where(sc_units::none, unit, sc_units::kg), except::UnitError);
   }
 }
 
 TEST(ElementUtilTest, where_rejects_condition_with_unit) {
-  EXPECT_NO_THROW_DISCARD(where(units::none, units::m, units::m));
-  for (const auto &unit : {units::m, units::kg, units::s, units::one}) {
-    EXPECT_THROW(where(unit, units::m, units::m), except::UnitError);
+  EXPECT_NO_THROW_DISCARD(where(sc_units::none, sc_units::m, sc_units::m));
+  for (const auto &unit :
+       {sc_units::m, sc_units::kg, sc_units::s, sc_units::one}) {
+    EXPECT_THROW(where(unit, sc_units::m, sc_units::m), except::UnitError);
   }
 }
 
@@ -56,13 +57,13 @@ TEST(ElementUtilTest, where_accepts_all_types) {
 
 TEST(ElementUtilTest, values_variances_stddev) {
   ValueAndVariance x{1.0, 2.0};
-  EXPECT_EQ(values(units::m), units::m);
+  EXPECT_EQ(values(sc_units::m), sc_units::m);
   EXPECT_EQ(values(x), 1.0);
   EXPECT_EQ(values(1.2), 1.2);
-  EXPECT_EQ(variances(units::m), units::m * units::m);
+  EXPECT_EQ(variances(sc_units::m), sc_units::m * sc_units::m);
   EXPECT_EQ(variances(x), 2.0);
-  EXPECT_EQ(stddevs(units::m), units::m);
-  EXPECT_EQ(stddevs(units::counts), units::counts);
+  EXPECT_EQ(stddevs(sc_units::m), sc_units::m);
+  EXPECT_EQ(stddevs(sc_units::counts), sc_units::counts);
   EXPECT_EQ(stddevs(x), sqrt(2.0));
 }
 
@@ -81,10 +82,10 @@ constexpr auto test_issorted = [](const auto sorted, const bool order) {
   expect_sorted_eq(2.0, 1.0, !order);
   expect_sorted_eq(1.0, -1.0, !order);
   expect_sorted_eq(-1.0, -2.0, !order);
-  units::Unit unit = units::one;
-  sorted(unit, units::m, units::m);
-  EXPECT_EQ(unit, units::none);
-  EXPECT_THROW(sorted(unit, units::m, units::s), except::UnitError);
+  sc_units::Unit unit = sc_units::one;
+  sorted(unit, sc_units::m, sc_units::m);
+  EXPECT_EQ(unit, sc_units::none);
+  EXPECT_THROW(sorted(unit, sc_units::m, sc_units::s), except::UnitError);
 };
 } // namespace
 
@@ -119,9 +120,9 @@ TEST(ElementUtilTest, islinspace_time_point) {
 TEST(ElementUtilTest, zip) {
   EXPECT_EQ(zip(1, 2), (std::pair{1, 2}));
   EXPECT_EQ(zip(3, 4), (std::pair{3, 4}));
-  EXPECT_EQ(zip(units::m, units::m), units::m);
-  EXPECT_EQ(zip(units::s, units::s), units::s);
-  EXPECT_THROW(zip(units::m, units::s), except::UnitError);
+  EXPECT_EQ(zip(sc_units::m, sc_units::m), sc_units::m);
+  EXPECT_EQ(zip(sc_units::s, sc_units::s), sc_units::s);
+  EXPECT_THROW(zip(sc_units::m, sc_units::s), except::UnitError);
 }
 
 TEST(ElementUtilTest, get) {
@@ -129,17 +130,17 @@ TEST(ElementUtilTest, get) {
   EXPECT_EQ(core::element::get<1>(std::pair{1, 2}), 2);
   EXPECT_EQ(core::element::get<0>(std::pair{3, 4}), 3);
   EXPECT_EQ(core::element::get<1>(std::pair{3, 4}), 4);
-  EXPECT_EQ(core::element::get<0>(units::m), units::m);
-  EXPECT_EQ(core::element::get<0>(units::s), units::s);
-  EXPECT_EQ(core::element::get<1>(units::m), units::m);
-  EXPECT_EQ(core::element::get<1>(units::s), units::s);
+  EXPECT_EQ(core::element::get<0>(sc_units::m), sc_units::m);
+  EXPECT_EQ(core::element::get<0>(sc_units::s), sc_units::s);
+  EXPECT_EQ(core::element::get<1>(sc_units::m), sc_units::m);
+  EXPECT_EQ(core::element::get<1>(sc_units::s), sc_units::s);
 }
 
 TEST(ElementUtilTest, fill) {
   double f64;
   float f32;
   ValueAndVariance x{1.0, 2.0};
-  units::Unit u;
+  sc_units::Unit u;
   fill(f64, 4.5);
   EXPECT_EQ(f64, 4.5);
   fill(f32, 4.5);
@@ -148,18 +149,18 @@ TEST(ElementUtilTest, fill) {
   EXPECT_EQ(x, (ValueAndVariance{4.5, 0.0}));
   fill(x, ValueAndVariance{1.2, 3.4});
   EXPECT_EQ(x, (ValueAndVariance{1.2, 3.4}));
-  fill(u, units::m);
-  EXPECT_EQ(u, units::m);
+  fill(u, sc_units::m);
+  EXPECT_EQ(u, sc_units::m);
 }
 
 TEST(ElementUtilTest, fill_zeros) {
   double x = 1.2;
   ValueAndVariance y{1.0, 2.0};
-  units::Unit u = units::m;
+  sc_units::Unit u = sc_units::m;
   fill_zeros(x);
   EXPECT_EQ(x, 0.0);
   fill_zeros(y);
   EXPECT_EQ(y, (ValueAndVariance{0.0, 0.0}));
   fill_zeros(u);
-  EXPECT_EQ(u, units::m); // unchanged
+  EXPECT_EQ(u, sc_units::m); // unchanged
 }

--- a/lib/core/test/string_test.cpp
+++ b/lib/core/test/string_test.cpp
@@ -22,35 +22,35 @@ protected:
 
 TEST_F(ISODateTest, ns) {
   const auto t = get_time<chrono::nanoseconds>();
-  EXPECT_EQ(to_iso_date(t, units::ns), "2020-07-27T10:41:11.123456789");
+  EXPECT_EQ(to_iso_date(t, sc_units::ns), "2020-07-27T10:41:11.123456789");
 }
 
 TEST_F(ISODateTest, us) {
   const auto t = get_time<chrono::microseconds>();
-  EXPECT_EQ(to_iso_date(t, units::us), "2020-07-27T10:41:11.123456");
+  EXPECT_EQ(to_iso_date(t, sc_units::us), "2020-07-27T10:41:11.123456");
 }
 
 TEST_F(ISODateTest, ms) {
   const auto t = get_time<chrono::milliseconds>();
-  EXPECT_EQ(to_iso_date(t, units::Unit{"ms"}), "2020-07-27T10:41:11.123");
+  EXPECT_EQ(to_iso_date(t, sc_units::Unit{"ms"}), "2020-07-27T10:41:11.123");
 }
 
 TEST_F(ISODateTest, s) {
   const auto t = get_time<chrono::seconds>();
-  EXPECT_EQ(to_iso_date(t, units::s), "2020-07-27T10:41:11");
+  EXPECT_EQ(to_iso_date(t, sc_units::s), "2020-07-27T10:41:11");
 }
 
 TEST_F(ISODateTest, min) {
   const auto t = get_time<chrono::minutes>();
-  EXPECT_EQ(to_iso_date(t, units::Unit{"min"}), "2020-07-27T10:41:00");
+  EXPECT_EQ(to_iso_date(t, sc_units::Unit{"min"}), "2020-07-27T10:41:00");
 }
 
 TEST_F(ISODateTest, h) {
   const auto t = get_time<chrono::hours>();
-  EXPECT_EQ(to_iso_date(t, units::Unit{"h"}), "2020-07-27T10:00:00");
+  EXPECT_EQ(to_iso_date(t, sc_units::Unit{"h"}), "2020-07-27T10:00:00");
 }
 
 TEST_F(ISODateTest, invalid_unit) {
-  EXPECT_THROW(to_iso_date(get_time<chrono::minutes>(), units::m),
+  EXPECT_THROW(to_iso_date(get_time<chrono::minutes>(), sc_units::m),
                scipp::except::UnitError);
 }

--- a/lib/core/test/transform_common_test.cpp
+++ b/lib/core/test/transform_common_test.cpp
@@ -34,11 +34,11 @@ TEST(TransformCommonTest, assign_unary_value) {
 
 TEST(TransformCommonTest, assign_unary_unit) {
   auto aop = assign_unary{core::element::sqrt};
-  units::Unit res;
-  aop(res, units::m * units::m);
-  EXPECT_EQ(res, units::m);
+  sc_units::Unit res;
+  aop(res, sc_units::m * sc_units::m);
+  EXPECT_EQ(res, sc_units::m);
 
-  EXPECT_THROW(aop(res, units::kg), except::UnitError);
+  EXPECT_THROW(aop(res, sc_units::kg), except::UnitError);
 }
 
 TEST(TransformCommontest, assign_unary_value_and_variance) {

--- a/lib/dataset/bin_detail.cpp
+++ b/lib/dataset/bin_detail.cpp
@@ -24,8 +24,9 @@ void map_to_bins(Variable &out, const Variable &var, const Variable &offsets,
 
 Variable make_range(const scipp::index begin, const scipp::index end,
                     const scipp::index stride, const Dim dim) {
-  return cumsum(broadcast(stride * units::none, {dim, (end - begin) / stride}),
-                dim, CumSumMode::Exclusive);
+  return cumsum(
+      broadcast(stride * sc_units::none, {dim, (end - begin) / stride}), dim,
+      CumSumMode::Exclusive);
 }
 
 void update_indices_by_binning(Variable &indices, const Variable &key,
@@ -84,7 +85,7 @@ void update_indices_by_grouping(Variable &indices, const Variable &key,
       // lookup would result in frequent cache misses.
       && isarange(con_groups, con_groups.dim()).value<bool>()) {
     const auto ngroup = makeVariable<scipp::index>(
-        Values{con_groups.dims().volume()}, units::none);
+        Values{con_groups.dims().volume()}, sc_units::none);
     const auto offset = con_groups.slice({con_groups.dim(), 0});
     variable::transform_in_place(
         indices, key, ngroup, offset,
@@ -104,7 +105,7 @@ void update_indices_by_grouping(Variable &indices, const Variable &key,
 void update_indices_from_existing(Variable &indices, const Dim dim) {
   const scipp::index nbin = indices.dims()[dim];
   const auto index = make_range(0, nbin, 1, dim);
-  variable::transform_in_place(indices, index, nbin * units::none,
+  variable::transform_in_place(indices, index, nbin * sc_units::none,
                                core::element::update_indices_from_existing,
                                "scipp.bin.update_indices_from_existing");
 }

--- a/lib/dataset/bins.cpp
+++ b/lib/dataset/bins.cpp
@@ -221,7 +221,7 @@ Variable pretend_bins_for_threading(const DataArray &da, Dim bin_dim) {
 
   const auto stride = std::max(scipp::index(1), size / nthread);
   auto begin = bin_detail::make_range(0, size, stride, bin_dim);
-  auto end = begin + stride * units::none;
+  auto end = begin + stride * sc_units::none;
   end.values<scipp::index>().as_span().back() = da.dims()[dim];
   const auto indices = zip(begin, end);
   return make_bins_no_validate(indices, dim, da);

--- a/lib/dataset/counts.cpp
+++ b/lib/dataset/counts.cpp
@@ -17,7 +17,7 @@ std::vector<Variable> getBinWidths(const Coords &c,
   std::vector<Variable> binWidths;
   for (const auto &dim : dims) {
     const auto &coord = c[dim];
-    if (coord.unit() == units::dimensionless)
+    if (coord.unit() == sc_units::dimensionless)
       throw std::runtime_error("Dimensionless axis cannot be used for "
                                "conversion from or to density");
     binWidths.emplace_back(coord.slice({dim, 1, coord.dims()[dim]}) -

--- a/lib/dataset/dataset.cpp
+++ b/lib/dataset/dataset.cpp
@@ -306,8 +306,8 @@ typename Masks::holder_type union_or(const Masks &currentMasks,
                out[key].dtype() != core::dtype<bool>) {
       throw except::TypeError(" Cannot combine non-boolean mask '" + key +
                               "' in operation");
-    } else if (item.unit() != scipp::units::none ||
-               out[key].unit() != scipp::units::none) {
+    } else if (item.unit() != scipp::sc_units::none ||
+               out[key].unit() != scipp::sc_units::none) {
       throw except::UnitError(" Cannot combine a unit-specified mask '" + key +
                               "' in operation");
     } else if (out[key].dims().includes(item.dims())) {
@@ -321,7 +321,7 @@ typename Masks::holder_type union_or(const Masks &currentMasks,
 
 void union_or_in_place(Masks &currentMasks, const Masks &otherMasks) {
   using core::to_string;
-  using units::to_string;
+  using sc_units::to_string;
 
   for (const auto &[key, item] : otherMasks) {
     const auto it = currentMasks.find(key);
@@ -339,8 +339,8 @@ void union_or_in_place(Masks &currentMasks, const Masks &otherMasks) {
       throw except::TypeError(" Cannot combine non-boolean mask '" + key +
                               "' in operation");
     } else if (it != currentMasks.end() &&
-               (item.unit() != scipp::units::none ||
-                currentMasks[key].unit() != scipp::units::none)) {
+               (item.unit() != scipp::sc_units::none ||
+                currentMasks[key].unit() != scipp::sc_units::none)) {
       throw except::UnitError(" Cannot combine a unit-specified mask '" + key +
                               "' in operation");
     }

--- a/lib/dataset/include/scipp/dataset/data_array.h
+++ b/lib/dataset/include/scipp/dataset/data_array.h
@@ -52,9 +52,9 @@ public:
     return m_data->strides();
   }
   [[nodiscard]] DType dtype() const { return m_data->dtype(); }
-  [[nodiscard]] units::Unit unit() const { return m_data->unit(); }
+  [[nodiscard]] sc_units::Unit unit() const { return m_data->unit(); }
 
-  void setUnit(const units::Unit unit) { m_data->setUnit(unit); }
+  void setUnit(const sc_units::Unit unit) { m_data->setUnit(unit); }
 
   /// Return true if the data array contains data variances.
   bool has_variances() const { return m_data->has_variances(); }

--- a/lib/dataset/include/scipp/dataset/to_unit.h
+++ b/lib/dataset/include/scipp/dataset/to_unit.h
@@ -12,7 +12,7 @@
 namespace scipp::dataset {
 
 [[nodiscard]] SCIPP_DATASET_EXPORT DataArray
-to_unit(const DataArray &array, const units::Unit &unit,
+to_unit(const DataArray &array, const sc_units::Unit &unit,
         CopyPolicy copy = CopyPolicy::Always);
 
 } // namespace scipp::dataset

--- a/lib/dataset/sized_dict.cpp
+++ b/lib/dataset/sized_dict.cpp
@@ -302,7 +302,7 @@ template <class Key, class Value>
 void SizedDict<Key, Value>::validateSlice(const Slice &s,
                                           const SizedDict &dict) const {
   using core::to_string;
-  using units::to_string;
+  using sc_units::to_string;
   for (const auto &[key, item] : dict) {
     const auto it = find(key);
     if (it == end()) {
@@ -350,7 +350,7 @@ SizedDict<Key, Value> SizedDict<Key, Value>::rename_dims(
       if (!m_sizes.contains(rename.second) &&
           item.second.dims().contains(rename.second))
         throw except::DimensionError("Duplicate dimension " +
-                                     units::to_string(rename.second) + ".");
+                                     sc_units::to_string(rename.second) + ".");
     item.second = item.second.rename_dims(names, false);
   }
   return out;
@@ -382,7 +382,7 @@ template <class Key, class Value>
 SizedDict<Key, Value>
 SizedDict<Key, Value>::merge_from(const SizedDict &other) const {
   using core::to_string;
-  using units::to_string;
+  using sc_units::to_string;
 
   auto out(*this);
   out.m_readonly = false;

--- a/lib/dataset/test/bin_test.cpp
+++ b/lib/dataset/test/bin_test.cpp
@@ -31,12 +31,12 @@ protected:
 
   Variable data =
       makeVariable<double>(Dims{Dim::Event}, Shape{4}, Values{1, 2, 3, 4},
-                           Variances{1, 3, 2, 4}, units::m);
+                           Variances{1, 3, 2, 4}, sc_units::m);
   Variable x = make_coord<0>(Dim::Event, 3, 2, 4, 1);
   Variable y = make_coord<1>(Dim::Event, 1, 2, 1, 2);
   Variable mask = makeVariable<bool>(Dims{Dim::Event}, Shape{4},
                                      Values{true, false, false, false});
-  Variable scalar = makeVariable<double>(Values{1.1}, units::kg);
+  Variable scalar = makeVariable<double>(Values{1.1}, sc_units::kg);
   DataArray table =
       DataArray(data, {{Dim::X, x}, {Dim("scalar"), scalar}}, {{"mask", mask}});
   Variable edges_x = make_coord<0>(Dim::X, 0, 2, 4);
@@ -54,7 +54,7 @@ TYPED_TEST_SUITE(DataArrayBinTest, DataArrayBinTestTypes);
 TYPED_TEST(DataArrayBinTest, 1d) {
   Variable sorted_data =
       makeVariable<double>(Dims{Dim::Event}, Shape{3}, Values{4, 1, 2},
-                           Variances{4, 1, 3}, units::m);
+                           Variances{4, 1, 3}, sc_units::m);
   Variable sorted_x = this->template make_coord<0>(Dim::Event, 1, 3, 2);
   Variable sorted_mask = makeVariable<bool>(Dims{Dim::Event}, Shape{3},
                                             Values{false, true, false});
@@ -76,7 +76,7 @@ TYPED_TEST(DataArrayBinTest, 2d) {
   this->table.coords().set(Dim::Y, this->y);
   Variable sorted_data =
       makeVariable<double>(Dims{Dim::Event}, Shape{3}, Values{4, 1, 2},
-                           Variances{4, 1, 3}, units::m);
+                           Variances{4, 1, 3}, sc_units::m);
   Variable sorted_x = this->template make_coord<0>(Dim::Event, 1, 3, 2);
   Variable sorted_y = this->template make_coord<1>(Dim::Event, 2, 1, 2);
   Variable sorted_mask = makeVariable<bool>(Dims{Dim::Event}, Shape{3},
@@ -166,10 +166,10 @@ protected:
   void expect_near(const DataArray &a, const DataArray &b, double rtol = 11e-15,
                    double atol = 0.0) {
     const auto tolerance =
-        values(max(bins_sum(a.data())) * (rtol * units::one));
+        values(max(bins_sum(a.data())) * (rtol * sc_units::one));
     EXPECT_TRUE(
         all(isclose(values(bins_sum(a.data())), values(bins_sum(b.data())),
-                    atol * units::one, tolerance))
+                    atol * sc_units::one, tolerance))
             .value<bool>());
     EXPECT_EQ(a.masks(), b.masks());
     EXPECT_EQ(a.coords(), b.coords());
@@ -284,7 +284,7 @@ TEST_P(BinTest, rebin_2d_with_2d_coord) {
   Variable edges_y_2d = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                              Values{-2, 1, 2, -3, 0, 3});
   xy.coords().set(Dim::Y, edges_y_2d);
-  bins_view<DataArray>(xy.data()).coords()[Dim::Y] += 0.5 * units::one;
+  bins_view<DataArray>(xy.data()).coords()[Dim::Y] += 0.5 * sc_units::one;
   EXPECT_THROW(bin(xy, {edges_x_coarse}), except::DimensionError);
   if (table.dims().volume() > 0) {
     EXPECT_NE(bin(xy, {edges_x_coarse, edges_y_coarse}),
@@ -292,7 +292,7 @@ TEST_P(BinTest, rebin_2d_with_2d_coord) {
     EXPECT_NE(bin(xy, {edges_x, edges_y_coarse}),
               bin(table, {edges_x, edges_y_coarse}));
   }
-  table.coords()[Dim::Y] += 0.5 * units::one;
+  table.coords()[Dim::Y] += 0.5 * sc_units::one;
   expect_near(bin(xy, {edges_x_coarse, edges_y_coarse}),
               bin(table, {edges_x_coarse, edges_y_coarse}));
   expect_near(bin(xy, {edges_x, edges_y_coarse}),
@@ -366,7 +366,7 @@ TEST_P(BinTest, group_and_bin) {
 
 TEST_P(BinTest, rebin_masked) {
   auto table = GetParam();
-  table.setUnit(units::counts); // we want to use `histogram` for comparison
+  table.setUnit(sc_units::counts); // we want to use `histogram` for comparison
   auto binned = bin(table, {edges_x_coarse});
   binned.masks().set("x-mask", makeVariable<bool>(Dims{Dim::X}, Shape{2},
                                                   Values{false, true}));
@@ -425,7 +425,7 @@ TEST_P(BinTest, bin_by_group) {
 TEST_P(BinTest, rebin_various_edges_1d) {
   // Trying to cover potential edge case in the bin sizes setup logic. No assert
   // since in general it is hard to come up with the expected result.
-  using units::one;
+  using sc_units::one;
   std::vector<Variable> edges;
   edges.emplace_back(linspace(-2.0 * one, 1.2 * one, Dim::X, 2));
   edges.emplace_back(linspace(-2.0 * one, 1.2 * one, Dim::X, 4));
@@ -626,11 +626,11 @@ TEST(BinLinspaceTest, many_events_many_bins) {
   Random rand(0.0, 1.0);
   rand.seed(0);
   const Dimensions dims(Dim::Row, 9000000);
-  const auto data = variable::ones(dims, units::one, dtype<double>);
+  const auto data = variable::ones(dims, sc_units::one, dtype<double>);
   const auto x = makeVariable<double>(dims, Values(rand(dims.volume())));
   auto da = DataArray(data, {{Dim::X, x}});
   const auto edges =
-      linspace(0.0 * units::one, 1.0 * units::one, Dim::X, 70000);
+      linspace(0.0 * sc_units::one, 1.0 * sc_units::one, Dim::X, 70000);
   EXPECT_EQ(sum(bin(da, {edges}).data()), sum(da.data()));
 }
 

--- a/lib/dataset/test/binned_arithmetic_test.cpp
+++ b/lib/dataset/test/binned_arithmetic_test.cpp
@@ -19,36 +19,38 @@ class BinnedArithmeticTest : public ::testing::Test {
 protected:
   Variable indices = makeVariable<scipp::index_pair>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
-  Variable var = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
+  Variable var = makeVariable<double>(Dims{Dim::Event}, Shape{5}, sc_units::m,
                                       Values{1, 2, 3, 4, 5});
-  Variable expected = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
-                                           Values{1, 2, 6, 8, 10});
+  Variable expected = makeVariable<double>(Dims{Dim::Event}, Shape{5},
+                                           sc_units::m, Values{1, 2, 6, 8, 10});
   DataArray array = DataArray(copy(var), {{Dim::X, var + var}});
 };
 
 TEST_F(BinnedArithmeticTest, fail_modify_slice_inplace_var) {
   Variable binned = make_bins(indices, Dim::Event, var);
-  EXPECT_THROW(binned.slice({Dim::X, 1}) *= 2.0 * units::m, except::UnitError);
+  EXPECT_THROW(binned.slice({Dim::X, 1}) *= 2.0 * sc_units::m,
+               except::UnitError);
   // unchanged
   EXPECT_EQ(binned, make_bins(indices, Dim::Event, var));
 }
 
 TEST_F(BinnedArithmeticTest, fail_modify_slice_inplace_array) {
   Variable binned = make_bins(indices, Dim::Event, array);
-  EXPECT_THROW(binned.slice({Dim::X, 1}) *= 2.0 * units::m, except::UnitError);
+  EXPECT_THROW(binned.slice({Dim::X, 1}) *= 2.0 * sc_units::m,
+               except::UnitError);
   // unchanged
   EXPECT_EQ(binned, make_bins(indices, Dim::Event, array));
 }
 
 TEST_F(BinnedArithmeticTest, modify_slice_inplace_var) {
   Variable binned = make_bins(indices, Dim::Event, var);
-  binned.slice({Dim::X, 1}) *= 2.0 * units::one;
+  binned.slice({Dim::X, 1}) *= 2.0 * sc_units::one;
   EXPECT_EQ(binned, make_bins(indices, Dim::Event, expected));
 }
 
 TEST_F(BinnedArithmeticTest, modify_slice_inplace_array) {
   Variable binned = make_bins(indices, Dim::Event, array);
-  binned.slice({Dim::X, 1}) *= 2.0 * units::one;
+  binned.slice({Dim::X, 1}) *= 2.0 * sc_units::one;
   DataArray expected_array = DataArray(expected, {{Dim::X, var + var}});
   EXPECT_EQ(binned, make_bins(indices, Dim::Event, expected_array));
 }

--- a/lib/dataset/test/binned_creation_test.cpp
+++ b/lib/dataset/test/binned_creation_test.cpp
@@ -12,8 +12,8 @@ class BinnedCreationTest : public ::testing::Test {
 protected:
   Variable m_indices = makeVariable<scipp::index_pair>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 5}});
-  Variable m_data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
-                                         Values{1, 2, 3, 4, 5});
+  Variable m_data = makeVariable<double>(Dims{Dim::Event}, Shape{5},
+                                         sc_units::m, Values{1, 2, 3, 4, 5});
   DataArray m_buffer =
       DataArray(m_data, {{Dim::X, m_data}}, {{"mask", m_data}});
   Variable m_var = make_bins(m_indices, Dim::Event, m_buffer);
@@ -22,7 +22,7 @@ protected:
     const auto [indices, dim, buf] = var.constituents<DataArray>();
     static_cast<void>(indices);
     static_cast<void>(dim);
-    EXPECT_EQ(buf.unit(), units::m);
+    EXPECT_EQ(buf.unit(), sc_units::m);
     EXPECT_TRUE(buf.masks().contains("mask"));
     EXPECT_TRUE(buf.coords().contains(Dim::X));
   }
@@ -49,8 +49,9 @@ TEST_F(BinnedCreationTest, empty_like_slice_default_shape) {
 }
 
 TEST_F(BinnedCreationTest, empty_like) {
-  Variable shape = makeVariable<scipp::index>(
-      Dims{Dim::X, Dim::Y}, Shape{2, 3}, units::none, Values{1, 2, 5, 6, 3, 4});
+  Variable shape =
+      makeVariable<scipp::index>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
+                                 sc_units::none, Values{1, 2, 5, 6, 3, 4});
   const auto empty = empty_like(m_var, {}, shape);
   EXPECT_EQ(empty.dims(), shape.dims());
   const auto [indices, dim, buf] = empty.constituents<DataArray>();

--- a/lib/dataset/test/bins_reduction_test.cpp
+++ b/lib/dataset/test/bins_reduction_test.cpp
@@ -116,7 +116,7 @@ protected:
 TEST_F(DataArrayBoolBinsReductionTest, sum) {
   EXPECT_EQ(bins_sum(binned_da),
             DataArray(makeVariable<int64_t>(indices.dims(), Values{1, 0, 0, 2},
-                                            units::none)));
+                                            sc_units::none)));
 }
 
 TEST_F(DataArrayBoolBinsReductionTest, max) {

--- a/lib/dataset/test/concat_test.cpp
+++ b/lib/dataset/test/concat_test.cpp
@@ -270,8 +270,8 @@ TEST(ConcatenateTest, concat_2d_coord) {
 
   Dataset b = copy(a);
   EXPECT_EQ(a, b);
-  b.coords()[Dim::X] += 3 * units::one;
-  b["data_1"].data() += 100 * units::one;
+  b.coords()[Dim::X] += 3 * sc_units::one;
+  b["data_1"].data() += 100 * sc_units::one;
 
   Dataset expected(
       {{"data_1", makeVariable<int>(Dims{Dim::Y, Dim::X}, Shape{4, 3},
@@ -293,9 +293,9 @@ TEST(ConcatenateTest, concat_2d_coord) {
 }
 
 TEST(ConcatenateTest, broadcast_coord) {
-  DataArray a(1.0 * units::one, {{Dim::X, 1.0 * units::one}});
+  DataArray a(1.0 * sc_units::one, {{Dim::X, 1.0 * sc_units::one}});
   DataArray b(makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2, 3}),
-              {{Dim::X, 2.0 * units::one}});
+              {{Dim::X, 2.0 * sc_units::one}});
   EXPECT_EQ(
       concat2(a, b, Dim::X),
       DataArray(makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 2, 3}),
@@ -435,9 +435,9 @@ protected:
 
 TEST_F(ConcatenateBinnedTest, mismatching_buffer) {
   for (const auto &buffer2 :
-       {buffer * (1.0 * units::m),
-        DataArray(data, {{Dim::X, data + data}}, {{"mask", 1.0 * units::one}},
-                  {}),
+       {buffer * (1.0 * sc_units::m),
+        DataArray(data, {{Dim::X, data + data}},
+                  {{"mask", 1.0 * sc_units::one}}, {}),
         DataArray(data, {{Dim::Y, data + data}, {Dim::X, data + data}}),
         DataArray(data, {})}) {
     auto var2 = make_bins(indices, Dim::Event, buffer2);
@@ -452,8 +452,8 @@ TEST_F(ConcatenateBinnedTest, existing_dim) {
   auto out = concat2(var, var, Dim::X);
   EXPECT_EQ(out.slice({Dim::X, 0, 2}), var);
   EXPECT_EQ(out.slice({Dim::X, 2, 4}), var);
-  out = concat2(var + 1.2 * units::one, out, Dim::X);
-  EXPECT_EQ(out.slice({Dim::X, 0, 2}), var + 1.2 * units::one);
+  out = concat2(var + 1.2 * sc_units::one, out, Dim::X);
+  EXPECT_EQ(out.slice({Dim::X, 0, 2}), var + 1.2 * sc_units::one);
   EXPECT_EQ(out.slice({Dim::X, 2, 4}), var);
   EXPECT_EQ(out.slice({Dim::X, 4, 6}), var);
 }
@@ -462,8 +462,8 @@ TEST_F(ConcatenateBinnedTest, new_dim) {
   auto out = concat2(var, var, Dim::Y);
   EXPECT_EQ(out.slice({Dim::Y, 0}), var);
   EXPECT_EQ(out.slice({Dim::Y, 1}), var);
-  out = concat2(var + 1.2 * units::one, out, Dim::Y);
-  EXPECT_EQ(out.slice({Dim::Y, 0}), var + 1.2 * units::one);
+  out = concat2(var + 1.2 * sc_units::one, out, Dim::Y);
+  EXPECT_EQ(out.slice({Dim::Y, 0}), var + 1.2 * sc_units::one);
   EXPECT_EQ(out.slice({Dim::Y, 1}), var);
   EXPECT_EQ(out.slice({Dim::Y, 2}), var);
 }

--- a/lib/dataset/test/copy_test.cpp
+++ b/lib/dataset/test/copy_test.cpp
@@ -42,7 +42,7 @@ TEST_F(CopyTest, dataset_with_bin_edge_coord) {
 
 struct CopyOutArgTest : public CopyTest {
   CopyOutArgTest() : dataset_copy(copy(dataset)), array_copy(copy(array)) {
-    const auto one = 1.0 * units::one;
+    const auto one = 1.0 * sc_units::one;
     array_copy.data() += one;
     array_copy.coords()[Dim::X] += one;
     array_copy.coords()[Dim::Y] += one;

--- a/lib/dataset/test/counts_test.cpp
+++ b/lib/dataset/test/counts_test.cpp
@@ -10,18 +10,18 @@ using namespace scipp;
 using namespace scipp::dataset;
 
 TEST(CountsTest, toDensity_fromDensity) {
-  Dataset d({{"", makeVariable<double>(Dims{Dim::Time}, Shape{3}, units::counts,
-                                       Values{12, 12, 12})}});
+  Dataset d({{"", makeVariable<double>(Dims{Dim::Time}, Shape{3},
+                                       sc_units::counts, Values{12, 12, 12})}});
   d.setCoord(Dim::Time, makeVariable<double>(Dims{Dim::Time}, Shape{4},
-                                             units::us, Values{1, 2, 4, 8}));
+                                             sc_units::us, Values{1, 2, 4, 8}));
 
   d = counts::toDensity(d, Dim::Time);
   auto result = d[""];
-  EXPECT_EQ(result.unit(), units::counts / units::us);
+  EXPECT_EQ(result.unit(), sc_units::counts / sc_units::us);
   EXPECT_TRUE(equals(result.values<double>(), {12, 6, 3}));
 
   d = counts::fromDensity(d, Dim::Time);
   result = d[""];
-  EXPECT_EQ(result.unit(), units::counts);
+  EXPECT_EQ(result.unit(), sc_units::counts);
   EXPECT_TRUE(equals(result.values<double>(), {12, 12, 12}));
 }

--- a/lib/dataset/test/data_array_comparison_test.cpp
+++ b/lib/dataset/test/data_array_comparison_test.cpp
@@ -62,49 +62,51 @@ template <class T> auto make_values(const Dimensions &dims) {
 }
 
 template <class T, class T2>
-auto make_1_coord(const Dim dim, const Dimensions &dims, const units::Unit unit,
+auto make_1_coord(const Dim dim, const Dimensions &dims,
+                  const sc_units::Unit unit,
                   const std::initializer_list<T2> &data) {
   auto a = make_values<T>(dims);
-  a.coords().set(dim, makeVariable<T>(dims, units::Unit(unit), Values(data)));
+  a.coords().set(dim,
+                 makeVariable<T>(dims, sc_units::Unit(unit), Values(data)));
   return a;
 }
 
 template <class T, class T2>
 auto make_1_labels(const std::string &name, const Dimensions &dims,
-                   const units::Unit unit,
+                   const sc_units::Unit unit,
                    const std::initializer_list<T2> &data) {
   auto a = make_values<T>(dims);
   a.coords().set(Dim(name),
-                 makeVariable<T>(dims, units::Unit(unit), Values(data)));
+                 makeVariable<T>(dims, sc_units::Unit(unit), Values(data)));
   return a;
 }
 
 template <class T, class T2>
 auto make_1_mask(const std::string &name, const Dimensions &dims,
-                 const units::Unit unit,
+                 const sc_units::Unit unit,
                  const std::initializer_list<T2> &data) {
   auto a = make_values<T>(dims);
-  a.masks().set(
-      name, makeVariable<T>(Dimensions(dims), units::Unit(unit), Values(data)));
+  a.masks().set(name, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
+                                      Values(data)));
   return a;
 }
 
 template <class T, class T2>
 auto make_values(const std::string &name, const Dimensions &dims,
-                 const units::Unit unit,
+                 const sc_units::Unit unit,
                  const std::initializer_list<T2> &data) {
   DataArray da(
-      makeVariable<T>(Dimensions(dims), units::Unit(unit), Values(data)));
+      makeVariable<T>(Dimensions(dims), sc_units::Unit(unit), Values(data)));
   da.setName(name);
   return da;
 }
 
 template <class T, class T2>
 auto make_values_and_variances(const std::string &name, const Dimensions &dims,
-                               const units::Unit unit,
+                               const sc_units::Unit unit,
                                const std::initializer_list<T2> &values,
                                const std::initializer_list<T2> &variances) {
-  DataArray da(makeVariable<T>(Dimensions(dims), units::Unit(unit),
+  DataArray da(makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                                Values(values), Variances(variances)));
   da.setName(name);
   return da;
@@ -116,76 +118,82 @@ auto make_values_and_variances(const std::string &name, const Dimensions &dims,
 // comparison of Variable, but it ensures that the content is actually compared
 // and thus serves as a baseline for the follow-up tests.
 TEST_F(DataArray_comparison_operators, single_coord) {
-  auto a =
-      make_1_coord<double>(Dim::X, {Dim::X, 3}, units::m, {false, true, false});
+  auto a = make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::m,
+                                {false, true, false});
   expect_eq(a, a);
   expect_ne(a, make_values<double>({Dim::X, 3}));
-  expect_ne(a, make_1_coord<float>(Dim::X, {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_coord<double>(Dim::Y, {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_coord<double>(Dim::X, {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_coord<double>(Dim::X, {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(a, make_1_coord<double>(Dim::X, {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(a, make_1_coord<double>(Dim::X, {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(a,
+            make_1_coord<float>(Dim::X, {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a,
+            make_1_coord<double>(Dim::Y, {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a,
+            make_1_coord<double>(Dim::X, {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_1_coord<double>(Dim::X, {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(a,
+            make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(a,
+            make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(DataArray_comparison_operators, single_labels) {
-  auto a = make_1_labels<double>("a", {Dim::X, 3}, units::m, {1, 2, 3});
+  auto a = make_1_labels<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3});
   expect_eq(a, a);
   expect_ne(a, make_values<double>({Dim::X, 3}));
-  expect_ne(a, make_1_labels<float>("a", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_labels<double>("b", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_labels<double>("a", {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_1_labels<double>("a", {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(a, make_1_labels<double>("a", {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(a, make_1_labels<double>("a", {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(a, make_1_labels<float>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_1_labels<double>("b", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_1_labels<double>("a", {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_1_labels<double>("a", {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(a, make_1_labels<double>("a", {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(a, make_1_labels<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(DataArray_comparison_operators, single_mask) {
-  auto a = make_1_mask<bool>("a", {Dim::X, 3}, units::m, {true, false, true});
+  auto a =
+      make_1_mask<bool>("a", {Dim::X, 3}, sc_units::m, {true, false, true});
   expect_eq(a, a);
   expect_ne(a, make_values<bool>({Dim::X, 3}));
-  expect_ne(a,
-            make_1_mask<bool>("b", {Dim::X, 3}, units::m, {true, false, true}));
-  expect_ne(a,
-            make_1_mask<bool>("a", {Dim::Y, 3}, units::m, {true, false, true}));
-  expect_ne(a, make_1_mask<bool>("a", {Dim::X, 2}, units::m, {true, false}));
-  expect_ne(a,
-            make_1_mask<bool>("a", {Dim::X, 3}, units::s, {true, false, true}));
   expect_ne(
-      a, make_1_mask<bool>("a", {Dim::X, 3}, units::m, {false, false, false}));
+      a, make_1_mask<bool>("b", {Dim::X, 3}, sc_units::m, {true, false, true}));
+  expect_ne(
+      a, make_1_mask<bool>("a", {Dim::Y, 3}, sc_units::m, {true, false, true}));
+  expect_ne(a, make_1_mask<bool>("a", {Dim::X, 2}, sc_units::m, {true, false}));
+  expect_ne(
+      a, make_1_mask<bool>("a", {Dim::X, 3}, sc_units::s, {true, false, true}));
+  expect_ne(a, make_1_mask<bool>("a", {Dim::X, 3}, sc_units::m,
+                                 {false, false, false}));
 }
 
 TEST_F(DataArray_comparison_operators, single_values) {
-  auto a = make_values<double>("a", {Dim::X, 3}, units::m, {1, 2, 3});
+  auto a = make_values<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3});
   expect_eq(a, a);
   // Name of DataArray is ignored in comparison.
-  expect_eq(a, make_values<double>("b", {Dim::X, 3}, units::m, {1, 2, 3}));
+  expect_eq(a, make_values<double>("b", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
   expect_ne(a, make_values<double>({Dim::X, 3}));
-  expect_ne(a, make_values<float>("a", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_values<double>("a", {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(a, make_values<double>("a", {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(a, make_values<double>("a", {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(a, make_values<double>("a", {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(a, make_values<float>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_values<double>("a", {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(a, make_values<double>("a", {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(a, make_values<double>("a", {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(a, make_values<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(DataArray_comparison_operators, single_values_and_variances) {
-  auto a = make_values_and_variances<double>("a", {Dim::X, 3}, units::m,
+  auto a = make_values_and_variances<double>("a", {Dim::X, 3}, sc_units::m,
                                              {1, 2, 3}, {4, 5, 6});
   expect_eq(a, a);
   // Name of DataArray is ignored in comparison.
-  expect_eq(a, make_values_and_variances<double>("b", {Dim::X, 3}, units::m,
+  expect_eq(a, make_values_and_variances<double>("b", {Dim::X, 3}, sc_units::m,
                                                  {1, 2, 3}, {4, 5, 6}));
-  expect_ne(a, make_values_and_variances<float>("a", {Dim::X, 3}, units::m,
+  expect_ne(a, make_values_and_variances<float>("a", {Dim::X, 3}, sc_units::m,
                                                 {1, 2, 3}, {4, 5, 6}));
-  expect_ne(a, make_values_and_variances<double>("a", {Dim::Y, 3}, units::m,
+  expect_ne(a, make_values_and_variances<double>("a", {Dim::Y, 3}, sc_units::m,
                                                  {1, 2, 3}, {4, 5, 6}));
-  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 2}, units::m,
+  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 2}, sc_units::m,
                                                  {1, 2}, {4, 5}));
-  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, units::s,
+  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, sc_units::s,
                                                  {1, 2, 3}, {4, 5, 6}));
-  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, units::m,
+  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, sc_units::m,
                                                  {1, 2, 4}, {4, 5, 6}));
-  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, units::m,
+  expect_ne(a, make_values_and_variances<double>("a", {Dim::X, 3}, sc_units::m,
                                                  {1, 2, 3}, {4, 5, 7}));
 }
 // End baseline checks.

--- a/lib/dataset/test/data_view_test.cpp
+++ b/lib/dataset/test/data_view_test.cpp
@@ -57,8 +57,8 @@ TYPED_TEST(DataArrayViewTest, dtype) {
 TYPED_TEST(DataArrayViewTest, unit) {
   Dataset d = testdata::make_dataset_x();
   typename TestFixture::dataset_type &d_ref(d);
-  EXPECT_EQ(d_ref["a"].unit(), units::kg);
-  EXPECT_EQ(d_ref["b"].unit(), units::s);
+  EXPECT_EQ(d_ref["a"].unit(), sc_units::kg);
+  EXPECT_EQ(d_ref["b"].unit(), sc_units::s);
 }
 
 TYPED_TEST(DataArrayViewTest, coords) {

--- a/lib/dataset/test/dataset_arithmetic_test.cpp
+++ b/lib/dataset/test/dataset_arithmetic_test.cpp
@@ -240,10 +240,10 @@ TYPED_TEST(DatasetBinaryEqualsOpTest, return_value) {
     ASSERT_EQ(&result, &a);
   }
 
-  ASSERT_TRUE((std::is_same_v<decltype(TestFixture::op(a, 5.0 * units::one)),
+  ASSERT_TRUE((std::is_same_v<decltype(TestFixture::op(a, 5.0 * sc_units::one)),
                               Dataset &>));
   {
-    const auto &result = TestFixture::op(a, 5.0 * units::one);
+    const auto &result = TestFixture::op(a, 5.0 * sc_units::one);
     ASSERT_EQ(&result, &a);
   }
 }
@@ -607,7 +607,7 @@ TYPED_TEST(DatasetBinaryOpTest, broadcast) {
 
 TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_scalar_rhs) {
   const auto dataset = std::get<0>(generateBinaryOpTestCase());
-  const auto scalar = 4.5 * units::one;
+  const auto scalar = 4.5 * sc_units::one;
 
   const auto res = TestFixture::op(dataset, scalar);
 
@@ -623,7 +623,7 @@ TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_scalar_rhs) {
 
 TYPED_TEST(DatasetBinaryOpTest, scalar_lhs_dataset_rhs) {
   const auto dataset = std::get<0>(generateBinaryOpTestCase());
-  const auto scalar = 4.5 * units::one;
+  const auto scalar = 4.5 * sc_units::one;
 
   const auto res = TestFixture::op(scalar, dataset);
 
@@ -640,7 +640,7 @@ TYPED_TEST(DatasetBinaryOpTest, scalar_lhs_dataset_rhs) {
 TYPED_TEST(DatasetBinaryOpTest, dataset_lhs_scalar_rhs_empty_operand) {
   auto dataset = std::get<1>(generateBinaryOpTestCase());
   dataset.erase("data_a");
-  const auto scalar = 4.5 * units::one;
+  const auto scalar = 4.5 * sc_units::one;
 
   const auto res = TestFixture::op(dataset, scalar);
   EXPECT_TRUE(res.is_valid());
@@ -732,7 +732,7 @@ TEST(DatasetInPlaceStrongExceptionGuarantee, events) {
   Variable indicesBad = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 4}});
   Variable table =
-      makeVariable<double>(Dims{Dim::Event}, Shape{4}, units::m,
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, sc_units::m,
                            Values{1, 2, 3, 4}, Variances{5, 6, 7, 8});
   Variable good = make_bins(indicesGood, Dim::Event, table);
   Variable bad = make_bins(indicesBad, Dim::Event, table);
@@ -766,7 +766,7 @@ TEST(DatasetInPlaceStrongExceptionGuarantee, events) {
 
 TEST(DataArrayMasks, can_contain_any_type_but_only_OR_bools) {
   DataArray a(makeVariable<double>(Values{1}));
-  a.masks().set("double", makeVariable<double>(units::none, Values{1}));
+  a.masks().set("double", makeVariable<double>(sc_units::none, Values{1}));
   ASSERT_THROW(a += a, except::TypeError);
   ASSERT_THROW_DISCARD(a + a, except::TypeError);
   a.masks().set("bool", makeVariable<bool>(Values{false}));

--- a/lib/dataset/test/dataset_comparison_test.cpp
+++ b/lib/dataset/test/dataset_comparison_test.cpp
@@ -61,60 +61,65 @@ protected:
 // comparison of Variable, but it ensures that the content is actually compared
 // and thus serves as a baseline for the follow-up tests.
 TEST_F(Dataset_comparison_operators, single_coord) {
-  auto d = make_1_coord<double>(Dim::X, {Dim::X, 3}, units::m, {1, 2, 3});
+  auto d = make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::m, {1, 2, 3});
   expect_eq(d, d);
   expect_ne(d, Dataset{});
-  expect_ne(d, make_1_coord<float>(Dim::X, {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_coord<double>(Dim::Y, {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_coord<double>(Dim::X, {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_coord<double>(Dim::X, {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(d, make_1_coord<double>(Dim::X, {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(d, make_1_coord<double>(Dim::X, {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(d,
+            make_1_coord<float>(Dim::X, {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d,
+            make_1_coord<double>(Dim::Y, {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d,
+            make_1_coord<double>(Dim::X, {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_coord<double>(Dim::X, {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(d,
+            make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(d,
+            make_1_coord<double>(Dim::X, {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(Dataset_comparison_operators, single_labels) {
-  auto d = make_1_labels<double>("a", {Dim::X, 3}, units::m, {1, 2, 3});
+  auto d = make_1_labels<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3});
   expect_eq(d, d);
   expect_ne(d, Dataset{});
-  expect_ne(d, make_1_labels<float>("a", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_labels<double>("b", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_labels<double>("a", {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_labels<double>("a", {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(d, make_1_labels<double>("a", {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(d, make_1_labels<double>("a", {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(d, make_1_labels<float>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_labels<double>("b", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_labels<double>("a", {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_labels<double>("a", {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(d, make_1_labels<double>("a", {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(d, make_1_labels<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(Dataset_comparison_operators, single_values) {
-  auto d = make_1_values<double>("a", {Dim::X, 3}, units::m, {1, 2, 3});
+  auto d = make_1_values<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3});
   expect_eq(d, d);
   expect_ne(d, Dataset{});
-  expect_ne(d, make_1_values<float>("a", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_values<double>("b", {Dim::X, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_values<double>("a", {Dim::Y, 3}, units::m, {1, 2, 3}));
-  expect_ne(d, make_1_values<double>("a", {Dim::X, 2}, units::m, {1, 2}));
-  expect_ne(d, make_1_values<double>("a", {Dim::X, 3}, units::s, {1, 2, 3}));
-  expect_ne(d, make_1_values<double>("a", {Dim::X, 3}, units::m, {1, 2, 4}));
+  expect_ne(d, make_1_values<float>("a", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_values<double>("b", {Dim::X, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_values<double>("a", {Dim::Y, 3}, sc_units::m, {1, 2, 3}));
+  expect_ne(d, make_1_values<double>("a", {Dim::X, 2}, sc_units::m, {1, 2}));
+  expect_ne(d, make_1_values<double>("a", {Dim::X, 3}, sc_units::s, {1, 2, 3}));
+  expect_ne(d, make_1_values<double>("a", {Dim::X, 3}, sc_units::m, {1, 2, 4}));
 }
 
 TEST_F(Dataset_comparison_operators, single_values_and_variances) {
-  auto d = make_1_values_and_variances<double>("a", {Dim::X, 3}, units::m,
+  auto d = make_1_values_and_variances<double>("a", {Dim::X, 3}, sc_units::m,
                                                {1, 2, 3}, {4, 5, 6});
   expect_eq(d, d);
   expect_ne(d, Dataset{});
-  expect_ne(d, make_1_values_and_variances<float>("a", {Dim::X, 3}, units::m,
+  expect_ne(d, make_1_values_and_variances<float>("a", {Dim::X, 3}, sc_units::m,
                                                   {1, 2, 3}, {4, 5, 6}));
-  expect_ne(d, make_1_values_and_variances<double>("b", {Dim::X, 3}, units::m,
-                                                   {1, 2, 3}, {4, 5, 6}));
-  expect_ne(d, make_1_values_and_variances<double>("a", {Dim::Y, 3}, units::m,
-                                                   {1, 2, 3}, {4, 5, 6}));
-  expect_ne(d, make_1_values_and_variances<double>("a", {Dim::X, 2}, units::m,
-                                                   {1, 2}, {4, 5}));
-  expect_ne(d, make_1_values_and_variances<double>("a", {Dim::X, 3}, units::s,
-                                                   {1, 2, 3}, {4, 5, 6}));
-  expect_ne(d, make_1_values_and_variances<double>("a", {Dim::X, 3}, units::m,
-                                                   {1, 2, 4}, {4, 5, 6}));
-  expect_ne(d, make_1_values_and_variances<double>("a", {Dim::X, 3}, units::m,
-                                                   {1, 2, 3}, {4, 5, 7}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "b", {Dim::X, 3}, sc_units::m, {1, 2, 3}, {4, 5, 6}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "a", {Dim::Y, 3}, sc_units::m, {1, 2, 3}, {4, 5, 6}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "a", {Dim::X, 2}, sc_units::m, {1, 2}, {4, 5}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "a", {Dim::X, 3}, sc_units::s, {1, 2, 3}, {4, 5, 6}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "a", {Dim::X, 3}, sc_units::m, {1, 2, 4}, {4, 5, 6}));
+  expect_ne(d, make_1_values_and_variances<double>(
+                   "a", {Dim::X, 3}, sc_units::m, {1, 2, 3}, {4, 5, 7}));
 }
 // End baseline checks.
 

--- a/lib/dataset/test/dataset_operations_test.cpp
+++ b/lib/dataset/test/dataset_operations_test.cpp
@@ -15,7 +15,7 @@ using namespace scipp::dataset;
 
 TEST(DatasetOperationsTest, sum_over_dim) {
   auto ds = make_1_values_and_variances<float>(
-      "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+      "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3}, {12, 15, 18});
   EXPECT_EQ(sum(ds, Dim::X)["a"].data(),
             makeVariable<float>(Values{6}, Variances{45}));
   EXPECT_EQ(sum(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
@@ -33,7 +33,7 @@ TEST(DatasetOperationsTest, sum_all_dims) {
 
 TEST(DatasetOperationsTest, sum_over_dim_empty_dataset) {
   auto ds = make_1_values_and_variances<float>(
-      "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+      "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3}, {12, 15, 18});
   ds.erase("a");
   auto res = sum(ds, Dim::X);
   EXPECT_TRUE(res.is_valid());
@@ -42,7 +42,7 @@ TEST(DatasetOperationsTest, sum_over_dim_empty_dataset) {
 
 TEST(DatasetOperationsTest, nansum_over_dim) {
   auto ds = make_1_values_and_variances<double>(
-      "a", {Dim::X, 3}, units::dimensionless, {1.0, 2.0, double(NAN)},
+      "a", {Dim::X, 3}, sc_units::dimensionless, {1.0, 2.0, double(NAN)},
       {2.0, 5.0, 6.0});
   EXPECT_EQ(nansum(ds, Dim::X)["a"].data(),
             makeVariable<double>(Values{3}, Variances{7}));
@@ -59,7 +59,7 @@ TEST(DatasetOperationsTest, nansum_all_dims) {
 
 TEST(DatasetOperationsTest, nansum_over_dim_empty_dataset) {
   auto ds = make_1_values_and_variances<float>(
-      "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+      "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3}, {12, 15, 18});
   ds.erase("a");
   auto res = nansum(ds, Dim::X);
   EXPECT_TRUE(res.is_valid());

--- a/lib/dataset/test/dataset_test_common.cpp
+++ b/lib/dataset/test/dataset_test_common.cpp
@@ -25,7 +25,7 @@ std::vector<bool> make_bools(const scipp::index size, bool pattern) {
 DatasetFactory::DatasetFactory()
     : DatasetFactory(Dimensions{{Dim::X, 4}, {Dim::Y, 3}, {Dim::Z, 5}}) {}
 
-DatasetFactory::DatasetFactory(const scipp::units::Dim dim,
+DatasetFactory::DatasetFactory(const scipp::sc_units::Dim dim,
                                const scipp::index length)
     : DatasetFactory(Dimensions({{dim, length}})) {}
 
@@ -95,14 +95,14 @@ Dataset make_1d_masked() {
 namespace scipp::testdata {
 
 Dataset make_dataset_x() {
-  return Dataset({{"a", makeVariable<double>(Dims{Dim::X}, units::kg, Shape{3},
-                                             Values{4, 5, 6})},
-                  {"b", makeVariable<int32_t>(Dims{Dim::X}, units::s, Shape{3},
-                                              Values{7, 8, 9})}},
-                 {{Dim("scalar"), 1.2 * units::K},
-                  {Dim::X, makeVariable<double>(Dims{Dim::X}, units::m,
+  return Dataset({{"a", makeVariable<double>(Dims{Dim::X}, sc_units::kg,
+                                             Shape{3}, Values{4, 5, 6})},
+                  {"b", makeVariable<int32_t>(Dims{Dim::X}, sc_units::s,
+                                              Shape{3}, Values{7, 8, 9})}},
+                 {{Dim("scalar"), 1.2 * sc_units::K},
+                  {Dim::X, makeVariable<double>(Dims{Dim::X}, sc_units::m,
                                                 Shape{3}, Values{1, 2, 4})},
-                  {Dim::Y, makeVariable<double>(Dims{Dim::X}, units::m,
+                  {Dim::Y, makeVariable<double>(Dims{Dim::X}, sc_units::m,
                                                 Shape{3}, Values{1, 2, 3})}});
 }
 

--- a/lib/dataset/test/dataset_test_common.h
+++ b/lib/dataset/test/dataset_test_common.h
@@ -41,40 +41,42 @@ private:
 };
 
 template <class T, class T2>
-auto make_1_coord(const Dim dim, const Dimensions &dims, const units::Unit unit,
+auto make_1_coord(const Dim dim, const Dimensions &dims,
+                  const sc_units::Unit unit,
                   const std::initializer_list<T2> &data) {
-  return Dataset({{"a", makeVariable<T>(Dimensions(dims), units::Unit(unit),
+  return Dataset({{"a", makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                                         Values(data))}},
-                 {{dim, makeVariable<T>(Dimensions(dims), units::Unit(unit),
+                 {{dim, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                                         Values(data))}});
 }
 
 template <class T, class T2>
 auto make_1_labels(const std::string &name, const Dimensions &dims,
-                   const units::Unit unit,
+                   const sc_units::Unit unit,
                    const std::initializer_list<T2> &data) {
   return Dataset(
       {{"a",
-        makeVariable<T>(Dimensions(dims), units::Unit(unit), Values(data))}},
-      {{Dim(name),
-        makeVariable<T>(Dimensions(dims), units::Unit(unit), Values(data))}});
+        makeVariable<T>(Dimensions(dims), sc_units::Unit(unit), Values(data))}},
+      {{Dim(name), makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
+                                   Values(data))}});
 }
 
 template <class T, class T2>
 auto make_1_values(const std::string &name, const Dimensions &dims,
-                   const units::Unit unit,
+                   const sc_units::Unit unit,
                    const std::initializer_list<T2> &data) {
-  return Dataset({{name, makeVariable<T>(Dimensions(dims), units::Unit(unit),
+  return Dataset({{name, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                                          Values(data))}});
 }
 
 template <class T, class T2>
 auto make_1_values_and_variances(const std::string &name,
-                                 const Dimensions &dims, const units::Unit unit,
+                                 const Dimensions &dims,
+                                 const sc_units::Unit unit,
                                  const std::initializer_list<T2> &values,
                                  const std::initializer_list<T2> &variances) {
   return Dataset(
-      {{name, makeVariable<T>(Dimensions(dims), units::Unit(unit),
+      {{name, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                               Values(values), Variances(variances))}});
 }
 

--- a/lib/dataset/test/event_data_operations_consistency_test.cpp
+++ b/lib/dataset/test/event_data_operations_consistency_test.cpp
@@ -13,10 +13,10 @@ using namespace scipp::dataset;
 static auto make_events() {
   Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::Y}, Shape{2}, Values{std::pair{0, 3}, std::pair{3, 7}});
-  auto weights = makeVariable<double>(Dims{Dim::Event}, Shape{7}, units::counts,
-                                      Values{1, 1, 1, 1, 1, 1, 1},
-                                      Variances{1, 1, 1, 1, 1, 1, 1});
-  auto x = makeVariable<double>(Dims{Dim::Event}, Shape{7}, units::us,
+  auto weights = makeVariable<double>(
+      Dims{Dim::Event}, Shape{7}, sc_units::counts, Values{1, 1, 1, 1, 1, 1, 1},
+      Variances{1, 1, 1, 1, 1, 1, 1});
+  auto x = makeVariable<double>(Dims{Dim::Event}, Shape{7}, sc_units::us,
                                 Values{1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 5.5});
   DataArray buf(weights, {{Dim::X, x}});
   return make_bins(indices, Dim::Event, buf);
@@ -29,7 +29,7 @@ static auto make_events_array_default_weights() {
 
 static auto make_histogram() {
   auto edges = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 3}},
-                                    units::us, Values{0, 2, 4, 1, 3, 5});
+                                    sc_units::us, Values{0, 2, 4, 1, 3, 5});
   auto data = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                    Values{2.0, 3.0, 2.0, 3.0});
 
@@ -41,7 +41,7 @@ TEST(EventsDataOperationsConsistencyTest, multiply) {
   // it would broadcast), the order of operations does not matter. We can either
   // first multiply and then histogram, or first histogram and then multiply.
   const auto events = make_events_array_default_weights();
-  auto edges = makeVariable<double>(Dimensions{Dim::X, 4}, units::us,
+  auto edges = makeVariable<double>(Dimensions{Dim::X, 4}, sc_units::us,
                                     Values{1, 2, 3, 4});
   auto data =
       makeVariable<double>(Dimensions{Dim::X, 3}, Values{2.0, 3.0, 4.0});
@@ -68,16 +68,16 @@ TEST(EventsDataOperationsConsistencyTest, multiply) {
 
 TEST(EventsDataOperationsConsistencyTest, concatenate_sum) {
   const auto events = make_events_array_default_weights();
-  auto edges =
-      makeVariable<double>(Dimensions{Dim::X, 3}, units::us, Values{1, 3, 6});
+  auto edges = makeVariable<double>(Dimensions{Dim::X, 3}, sc_units::us,
+                                    Values{1, 3, 6});
   EXPECT_EQ(sum(histogram(events, edges), Dim::Y),
             histogram(buckets::concatenate(events, Dim::Y), edges));
 }
 
 TEST(EventsDataOperationsConsistencyTest, concatenate_multiply_sum) {
   const auto events = make_events_array_default_weights();
-  auto edges =
-      makeVariable<double>(Dimensions{Dim::X, 3}, units::us, Values{1, 3, 5});
+  auto edges = makeVariable<double>(Dimensions{Dim::X, 3}, sc_units::us,
+                                    Values{1, 3, 5});
   auto data = makeVariable<double>(Dimensions{Dim::X, 2}, Values{2.0, 3.0});
   auto hist = DataArray(data, {{Dim::X, edges}});
 

--- a/lib/dataset/test/generated_test.cpp
+++ b/lib/dataset/test/generated_test.cpp
@@ -104,7 +104,7 @@ TEST_F(GeneratedBinaryDataArrayTest, mask_is_deep_copied_even_if_same) {
 TEST_F(GeneratedBinaryDataArrayTest, non_bool_masks_with_same_names) {
   auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.1, 0.2});
   auto coord =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m, Values{1, 2});
   auto mask = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.1, 0.1});
   a = DataArray(data, {{Dim::X, coord}}, {{"mask", mask}});
   ASSERT_THROW_DISCARD(less(a, a), except::TypeError);

--- a/lib/dataset/test/histogram_test.cpp
+++ b/lib/dataset/test/histogram_test.cpp
@@ -84,8 +84,9 @@ DataArray make_1d_events_default_weights() {
       Dims{Dim::Event}, Shape{22},
       Values{1.5, 2.5, 3.5, 4.5, 5.5, 3.5, 4.5, 5.5, 6.5, 7.5, -1.0,
              0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0, 6.0});
-  const auto weights = copy(broadcast(
-      makeVariable<double>(units::counts, Values{1}, Variances{1}), y.dims()));
+  const auto weights = copy(
+      broadcast(makeVariable<double>(sc_units::counts, Values{1}, Variances{1}),
+                y.dims()));
   const DataArray table(weights, {{Dim::Y, y}});
   const auto indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::X}, Shape{3},
@@ -105,8 +106,9 @@ TEST(HistogramTest, fail_edges_not_sorted) {
 auto make_single_events() {
   const auto x =
       makeVariable<double>(Dims{Dim::Event}, Shape{5}, Values{0, 1, 1, 2, 3});
-  const auto weights = copy(broadcast(
-      makeVariable<double>(units::counts, Values{1}, Variances{1}), x.dims()));
+  const auto weights = copy(
+      broadcast(makeVariable<double>(sc_units::counts, Values{1}, Variances{1}),
+                x.dims()));
   const DataArray table(weights, {{Dim::X, x}});
   const auto indices = makeVariable<std::pair<scipp::index, scipp::index>>(
       Values{std::pair{0, 5}});
@@ -126,10 +128,10 @@ TEST(HistogramTest, below) {
   auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{-2.0, -1.0, 0.0});
   auto hist = dataset::histogram(events["events"], edges);
-  auto expected =
-      make_expected(makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
-                                         Values{0, 0}, Variances{0, 0}),
-                    edges);
+  auto expected = make_expected(
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::counts,
+                           Values{0, 0}, Variances{0, 0}),
+      edges);
   EXPECT_EQ(hist, expected);
 }
 
@@ -138,10 +140,10 @@ TEST(HistogramTest, between) {
   auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1.5, 1.6, 1.7});
   auto hist = dataset::histogram(events["events"], edges);
-  auto expected =
-      make_expected(makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
-                                         Values{0, 0}, Variances{0, 0}),
-                    edges);
+  auto expected = make_expected(
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::counts,
+                           Values{0, 0}, Variances{0, 0}),
+      edges);
   EXPECT_EQ(hist, expected);
 }
 
@@ -150,10 +152,10 @@ TEST(HistogramTest, above) {
   auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{3.5, 4.5, 5.5});
   auto hist = dataset::histogram(events["events"], edges);
-  auto expected =
-      make_expected(makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
-                                         Values{0, 0}, Variances{0, 0}),
-                    edges);
+  auto expected = make_expected(
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::counts,
+                           Values{0, 0}, Variances{0, 0}),
+      edges);
   EXPECT_EQ(hist, expected);
 }
 
@@ -164,7 +166,7 @@ TEST(HistogramTest, data_view) {
       makeVariable<double>(Dims{Dim::Y}, Shape{6}, Values{1, 2, 3, 4, 5, 6});
   auto hist = dataset::histogram(events, edges);
   auto expected = make_expected(
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 5}, units::counts,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 5}, sc_units::counts,
                            Values(ref.begin(), ref.end()),
                            Variances(ref.begin(), ref.end())),
       edges);
@@ -212,7 +214,7 @@ DataArray make_1d_events() {
       Values{1.5, 2.5, 3.5, 4.5, 5.5, 3.5, 4.5, 5.5, 6.5, 7.5, -1.0,
              0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 4.0, 4.0, 4.0, 6.0});
   const auto weights = makeVariable<double>(
-      y.dims(), units::counts,
+      y.dims(), sc_units::counts,
       Values{1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
       Variances{1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1,
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
@@ -230,7 +232,7 @@ TEST(HistogramTest, weight_lists) {
       makeVariable<double>(Dims{Dim::Y}, Shape{6}, Values{1, 2, 3, 4, 5, 6});
   std::vector<double> ref{1, 1, 1, 2, 2, 0, 0, 2, 2, 2, 2, 3, 0, 3, 0};
   auto expected = make_expected(
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 5}, units::counts,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 5}, sc_units::counts,
                            Values(ref.begin(), ref.end()),
                            Variances(ref.begin(), ref.end())),
       edges);
@@ -239,7 +241,7 @@ TEST(HistogramTest, weight_lists) {
 
 TEST(HistogramTest, non_finite_values) {
   const auto data = makeVariable<double>(
-      Dims{Dim::Event}, Shape{6}, units::counts,
+      Dims{Dim::Event}, Shape{6}, sc_units::counts,
       Values{1.0, 2.0, 3.0, std::numeric_limits<double>::quiet_NaN(), 4.0,
              std::numeric_limits<double>::infinity()});
   const auto coord = makeVariable<double>(Dims{Dim::Event}, Shape{6},
@@ -250,10 +252,10 @@ TEST(HistogramTest, non_finite_values) {
   const DataArray events{data, {{Dim::X, coord}}, {{"m", mask}}};
   const auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{0.0, 2.0, 4.0, 6.0});
-  const auto expected =
-      make_expected(makeVariable<double>(Dims{Dim::X}, Shape{3}, units::counts,
-                                         Values{1.0, 3.0, 4.0}),
-                    edges);
+  const auto expected = make_expected(
+      makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::counts,
+                           Values{1.0, 3.0, 4.0}),
+      edges);
   EXPECT_EQ(dataset::histogram(events, edges), expected);
 }
 
@@ -263,7 +265,7 @@ TEST(HistogramTest, dense_vs_binned) {
   table_no_variance.data().setVariances(Variable{});
   for (auto table :
        {make_table(0), make_table(100), make_table(1000), table_no_variance}) {
-    table.setUnit(units::counts);
+    table.setUnit(sc_units::counts);
     const auto binned_x =
         bin(table, {makeVariable<double>(Dims{Dim::X}, Shape{5},
                                          Values{-2, -1, 0, 1, 2})});
@@ -283,7 +285,7 @@ TEST(HistogramTest, binned_with_mismatching_coord_and_edge_dtype) {
   using testdata::make_table;
   auto table = make_table(100);
   EXPECT_EQ(table.coords()[Dim::X].dtype(), dtype<double>);
-  table.setUnit(units::counts);
+  table.setUnit(sc_units::counts);
   const auto old_edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{-2, 0, 2});
   const auto new_edges =
@@ -306,11 +308,11 @@ TEST(HistogramTest, binned_with_mismatching_coord_and_edge_dtype) {
 struct Histogram1DTest : public ::testing::Test {
 protected:
   Histogram1DTest() {
-    data = makeVariable<double>(Dims{Dim::X}, Shape{10}, units::counts,
+    data = makeVariable<double>(Dims{Dim::X}, Shape{10}, sc_units::counts,
                                 Values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
     coord = makeVariable<double>(Dims{Dim::X}, Shape{10},
                                  Values{1, 2, 1, 2, 3, 4, 3, 2, 1, 1});
-    mask = less(data, 4.0 * units::counts);
+    mask = less(data, 4.0 * sc_units::counts);
   }
   Variable data;
   Variable coord;
@@ -322,7 +324,7 @@ TEST_F(Histogram1DTest, coord_name_matches_dim) {
   const auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
   EXPECT_EQ(histogram(da, edges).data(),
-            makeVariable<double>(Dims{Dim::X}, Shape{3}, units::counts,
+            makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::counts,
                                  Values{19, 12, 12}));
 }
 
@@ -332,7 +334,7 @@ TEST_F(Histogram1DTest, coord_name_differs_dim) {
   const auto edges =
       makeVariable<double>(Dims{Dim::Y}, Shape{4}, Values{1, 2, 3, 4});
   EXPECT_EQ(histogram(da, edges).data(),
-            makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::counts,
+            makeVariable<double>(Dims{Dim::Y}, Shape{3}, sc_units::counts,
                                  Values{19, 12, 12}));
 }
 
@@ -342,14 +344,14 @@ TEST_F(Histogram1DTest, int64_weights) {
   const auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
   EXPECT_EQ(histogram(da, edges).data(),
-            makeVariable<int64_t>(Dims{Dim::X}, Shape{3}, units::counts,
+            makeVariable<int64_t>(Dims{Dim::X}, Shape{3}, sc_units::counts,
                                   Values{19, 12, 12}));
 }
 
 TEST_F(Histogram1DTest, mismatching_coord_and_edge_dtype) {
   const auto coord_dtype = dtype<double>;
   const auto expected_data = makeVariable<int64_t>(
-      Dims{Dim::X}, Shape{3}, units::counts, Values{19, 12, 12});
+      Dims{Dim::X}, Shape{3}, sc_units::counts, Values{19, 12, 12});
   DataArray da(astype(data, dtype<int64_t>),
                {{Dim::X, astype(coord, coord_dtype)}}, {{"mask", mask}});
 
@@ -368,7 +370,7 @@ struct Histogram2DTest : public ::testing::Test {
 protected:
   Histogram2DTest() {
     data = makeVariable<double>(
-        Dims{Dim::Y, Dim::X}, Shape{3, 4}, units::counts,
+        Dims{Dim::Y, Dim::X}, Shape{3, 4}, sc_units::counts,
         Values{11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34});
     coord = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 4},
                                  Values{1, 2, 1, 2, 3, 4, 3, 2, 1, 1, 2, 3});
@@ -388,7 +390,7 @@ TEST_F(Histogram2DTest, outer_1d_coord) {
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1.0, 2.5, 5.0});
   EXPECT_EQ(histogram(da, edges).data(),
             makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2},
-                                 units::counts,
+                                 sc_units::counts,
                                  Values{42, 21, 44, 22, 46, 23, 48, 24}));
 }
 
@@ -406,7 +408,7 @@ TEST_F(Histogram2DTest, outer_2d_coord) {
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1.0, 2.5, 5.0});
   EXPECT_EQ(histogram(da, edges).data(),
             makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2},
-                                 units::counts,
+                                 sc_units::counts,
                                  Values{42, 21, 44, 22, 46, 23, 38, 34}));
 }
 

--- a/lib/dataset/test/logical_reduction_test.cpp
+++ b/lib/dataset/test/logical_reduction_test.cpp
@@ -13,24 +13,24 @@ using namespace scipp::dataset;
 
 TEST(AllTest, masked_elements_are_ignored) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{true, false, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto all_x = makeVariable<bool>(Dimensions{Dim::Y, 3}, units::m,
+  const auto all_x = makeVariable<bool>(Dimensions{Dim::Y, 3}, sc_units::m,
                                         Values{true, true, false});
-  const auto all_y =
-      makeVariable<bool>(Dimensions{Dim::X, 2}, units::m, Values{false, false});
+  const auto all_y = makeVariable<bool>(Dimensions{Dim::X, 2}, sc_units::m,
+                                        Values{false, false});
   EXPECT_EQ(all(a, Dim::X).data(), all_x);
   EXPECT_EQ(all(a, Dim::Y).data(), all_y);
 }
 
 TEST(AllTest, mask_along_reduction_dim_is_dropped) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{true, false, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
@@ -42,7 +42,7 @@ TEST(AllTest, mask_along_reduction_dim_is_dropped) {
 
 TEST(AllTest, mask_along_other_dim_is_kept) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{true, false, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
@@ -54,24 +54,24 @@ TEST(AllTest, mask_along_other_dim_is_kept) {
 
 TEST(AnyTest, masked_elements_are_ignored) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{false, true, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto any_x = makeVariable<bool>(Dimensions{Dim::Y, 3}, units::m,
+  const auto any_x = makeVariable<bool>(Dimensions{Dim::Y, 3}, sc_units::m,
                                         Values{false, true, false});
-  const auto any_y =
-      makeVariable<bool>(Dimensions{Dim::X, 2}, units::m, Values{true, true});
+  const auto any_y = makeVariable<bool>(Dimensions{Dim::X, 2}, sc_units::m,
+                                        Values{true, true});
   EXPECT_EQ(any(a, Dim::X).data(), any_x);
   EXPECT_EQ(any(a, Dim::Y).data(), any_y);
 }
 
 TEST(AnyTest, mask_along_reduction_dim_is_dropped) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{false, true, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
@@ -83,7 +83,7 @@ TEST(AnyTest, mask_along_reduction_dim_is_dropped) {
 
 TEST(AnyTest, mask_along_other_dim_is_kept) {
   const auto var =
-      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<bool>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                          Values{false, true, true, true, false, false});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});

--- a/lib/dataset/test/mean_test.cpp
+++ b/lib/dataset/test/mean_test.cpp
@@ -14,7 +14,7 @@ using namespace scipp;
 
 TEST(DatasetTest, sum_and_mean) {
   Dataset ds(
-      {{"a", makeVariable<float>(Dimensions{Dim::X, 3}, units::one,
+      {{"a", makeVariable<float>(Dimensions{Dim::X, 3}, sc_units::one,
                                  Values{1, 2, 3}, Variances{12, 15, 18})}});
   EXPECT_EQ(sum(ds, Dim::X)["a"].data(),
             makeVariable<float>(Values{6}, Variances{45}));
@@ -34,32 +34,33 @@ TYPED_TEST_SUITE(MeanTest, MeanTestTypes);
 
 template <class T, class T2>
 auto make_one_item_dataset(const std::string &name, const Dimensions &dims,
-                           const units::Unit unit,
+                           const sc_units::Unit unit,
                            const std::initializer_list<T2> &values,
                            const std::initializer_list<T2> &variances) {
   return Dataset(
-      {{name, makeVariable<T>(Dimensions(dims), units::Unit(unit),
+      {{name, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                               Values(values), Variances(variances))}});
 }
 template <class T, class T2>
 auto make_one_item_dataset(const std::string &name, const Dimensions &dims,
-                           const units::Unit unit,
+                           const sc_units::Unit unit,
                            const std::initializer_list<T2> &values) {
-  return Dataset({{name, makeVariable<T>(Dimensions(dims), units::Unit(unit),
+  return Dataset({{name, makeVariable<T>(Dimensions(dims), sc_units::Unit(unit),
                                          Values(values))}});
 }
 
 template <typename Op> void test_masked_data_array_1_mask(Op op) {
-  const auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
-  const auto meanX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 3.0});
-  const auto meanY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{2.0, 3.0});
+  const auto meanX = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                          Values{1.0, 3.0});
+  const auto meanY = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{2.0, 3.0});
   EXPECT_EQ(op(a, Dim::X).data(), meanX);
   EXPECT_EQ(op(a, Dim::Y).data(), meanY);
   EXPECT_FALSE(op(a, Dim::X).masks().contains("mask"));
@@ -67,8 +68,9 @@ template <typename Op> void test_masked_data_array_1_mask(Op op) {
 }
 
 template <typename Op> void test_masked_data_array_2_masks(Op op) {
-  const auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   const auto maskX =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   const auto maskY =
@@ -76,10 +78,10 @@ template <typename Op> void test_masked_data_array_2_masks(Op op) {
   DataArray a(var);
   a.masks().set("x", maskX);
   a.masks().set("y", maskY);
-  const auto meanX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 3.0});
-  const auto meanY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 2.0});
+  const auto meanX = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                          Values{1.0, 3.0});
+  const auto meanY = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{1.0, 2.0});
   EXPECT_EQ(op(a, Dim::X).data(), meanX);
   EXPECT_EQ(op(a, Dim::Y).data(), meanY);
   EXPECT_FALSE(op(a, Dim::X).masks().contains("x"));
@@ -89,20 +91,21 @@ template <typename Op> void test_masked_data_array_2_masks(Op op) {
 }
 
 template <typename Op> void test_masked_data_array_nd_mask(Op op) {
-  const auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   // Just a single masked element
   const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
                                        Values{false, true, false, false});
   DataArray a(var);
   a.masks().set("mask", mask);
   const auto meanX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m,
+      makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
                            Values{(1.0 + 0.0) / 1, (3.0 + 4.0) / 2});
   const auto meanY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m,
+      makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
                            Values{(1.0 + 3.0) / 2, (0.0 + 4.0) / 1});
-  const auto mean = makeVariable<double>(units::m, Shape{1},
+  const auto mean = makeVariable<double>(sc_units::m, Shape{1},
                                          Values{(1.0 + 0.0 + 3.0 + 4.0) / 3});
   EXPECT_EQ(op(a, Dim::X).data(), meanX);
   EXPECT_EQ(op(a, Dim::Y).data(), meanY);
@@ -145,9 +148,9 @@ TYPED_TEST(MeanTest, nanmean_masked_data_with_nans) {
         "Test skipped for non-FP types"); // If type does not support nans skip
   else {
     // Two Nans
-    const auto var =
-        makeVariable<TypeParam>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, units::m,
-                                Values{double(NAN), double(NAN), 3.0, 4.0});
+    const auto var = makeVariable<TypeParam>(
+        Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+        Values{double(NAN), double(NAN), 3.0, 4.0});
     // Two masked element
     const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
                                          Values{false, true, true, false});
@@ -156,7 +159,7 @@ TYPED_TEST(MeanTest, nanmean_masked_data_with_nans) {
     // First element NaN, second NaN AND masked, third masked, forth non-masked
     // finite number
     const auto mean = makeVariable<typename TestFixture::ReturnType>(
-        units::m, Values{(0.0 + 0.0 + 0.0 + 4.0) / 1});
+        sc_units::m, Values{(0.0 + 0.0 + 0.0 + 4.0) / 1});
     EXPECT_EQ(nanmean(a).data(), mean);
   }
 }
@@ -165,14 +168,14 @@ TYPED_TEST(MeanTest, mean_over_dim) {
   if constexpr (TestFixture::TestVariances) {
     // Test with variances
     auto ds = make_one_item_dataset<TypeParam>(
-        "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+        "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3}, {12, 15, 18});
     EXPECT_EQ(mean(ds, Dim::X)["a"].data(),
               makeVariable<TypeParam>(Values{2}, Variances{5.0}));
     EXPECT_EQ(mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
               makeVariable<TypeParam>(Values{1.5}, Variances{6.75}));
   } else {
-    auto ds = make_one_item_dataset<TypeParam>("a", {Dim::X, 3},
-                                               units::dimensionless, {1, 2, 3});
+    auto ds = make_one_item_dataset<TypeParam>(
+        "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3});
     EXPECT_EQ(mean(ds, Dim::X)["a"].data(), makeVariable<double>(Values{2}));
     EXPECT_EQ(mean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
               makeVariable<double>(Values{1.5}));
@@ -197,7 +200,7 @@ TYPED_TEST(MeanTest, nanmean_over_dim) {
   if constexpr (TestFixture::TestVariances) {
     // Test variances and values
     auto ds = make_one_item_dataset<TypeParam>(
-        "a", {Dim::X, 3}, units::dimensionless, {1, 2, 3}, {12, 15, 18});
+        "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3}, {12, 15, 18});
     EXPECT_EQ(nanmean(ds, Dim::X)["a"].data(),
               makeVariable<TypeParam>(Values{2}, Variances{5.0}));
     EXPECT_EQ(nanmean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
@@ -209,8 +212,8 @@ TYPED_TEST(MeanTest, nanmean_over_dim) {
     EXPECT_EQ(nanmean(ds["a"], Dim::X).data(),
               makeVariable<TypeParam>(Values{1.5}, Variances{6.75}));
   } else {
-    auto ds = make_one_item_dataset<TypeParam>("a", {Dim::X, 3},
-                                               units::dimensionless, {1, 2, 3});
+    auto ds = make_one_item_dataset<TypeParam>(
+        "a", {Dim::X, 3}, sc_units::dimensionless, {1, 2, 3});
     EXPECT_EQ(nanmean(ds, Dim::X)["a"].data(), makeVariable<double>(Values{2}));
     EXPECT_EQ(nanmean(ds.slice({Dim::X, 0, 2}), Dim::X)["a"].data(),
               makeVariable<double>(Values{1.5}));

--- a/lib/dataset/test/minmax_test.cpp
+++ b/lib/dataset/test/minmax_test.cpp
@@ -15,17 +15,17 @@ using namespace scipp::dataset;
 
 TEST(MaxTest, masked_data_array) {
   const auto var =
-      makeVariable<double>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<double>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                            Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto max_x = makeVariable<double>(Dimensions{Dim::Y, 3}, units::m,
+  const auto max_x = makeVariable<double>(Dimensions{Dim::Y, 3}, sc_units::m,
                                           Values{1.0, 3.0, 5.0});
-  const auto max_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{5.0, 6.0});
+  const auto max_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{5.0, 6.0});
   EXPECT_EQ(max(a, Dim::X).data(), max_x);
   EXPECT_EQ(max(a, Dim::Y).data(), max_y);
   EXPECT_FALSE(max(a, Dim::X).masks().contains("mask"));
@@ -34,17 +34,17 @@ TEST(MaxTest, masked_data_array) {
 
 TEST(MaxTest, masked_data_with_nan) {
   const auto var = makeVariable<double>(
-      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, units::m,
+      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
       Values{1.0, 2.0, std::numeric_limits<double>::quiet_NaN(), 4.0});
   const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
                                        Values{false, false, true, false});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto max_x =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{2.0, 4.0});
-  const auto max_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 4.0});
+  const auto max_x = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                          Values{2.0, 4.0});
+  const auto max_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{1.0, 4.0});
   EXPECT_EQ(max(a, Dim::X).data(), max_x);
   EXPECT_EQ(max(a, Dim::Y).data(), max_y);
   EXPECT_FALSE(max(a, Dim::X).masks().contains("mask"));
@@ -53,7 +53,7 @@ TEST(MaxTest, masked_data_with_nan) {
 
 TEST(NanMaxTest, masked_data_array) {
   const auto var = makeVariable<double>(
-      Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
       Values{1.0, std::numeric_limits<double>::quiet_NaN(), 3.0, 4.0,
              std::numeric_limits<double>::quiet_NaN(), 6.0});
   const auto mask =
@@ -62,10 +62,10 @@ TEST(NanMaxTest, masked_data_array) {
   a.masks().set("mask", mask);
 
   const auto max_x = makeVariable<double>(
-      Dimensions{Dim::Y, 3}, units::m,
+      Dimensions{Dim::Y, 3}, sc_units::m,
       Values{1.0, 3.0, std::numeric_limits<double>::lowest()});
-  const auto max_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{3.0, 6.0});
+  const auto max_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{3.0, 6.0});
   EXPECT_EQ(nanmax(a, Dim::X).data(), max_x);
   EXPECT_EQ(nanmax(a, Dim::Y).data(), max_y);
   EXPECT_FALSE(nanmax(a, Dim::X).masks().contains("mask"));
@@ -74,17 +74,17 @@ TEST(NanMaxTest, masked_data_array) {
 
 TEST(MinTest, masked_data_array) {
   const auto var =
-      makeVariable<double>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      makeVariable<double>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
                            Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto min_x = makeVariable<double>(Dimensions{Dim::Y, 3}, units::m,
+  const auto min_x = makeVariable<double>(Dimensions{Dim::Y, 3}, sc_units::m,
                                           Values{1.0, 3.0, 5.0});
-  const auto min_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 2.0});
+  const auto min_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{1.0, 2.0});
   EXPECT_EQ(min(a, Dim::X).data(), min_x);
   EXPECT_EQ(min(a, Dim::Y).data(), min_y);
   EXPECT_FALSE(min(a, Dim::X).masks().contains("mask"));
@@ -93,17 +93,17 @@ TEST(MinTest, masked_data_array) {
 
 TEST(MinTest, masked_data_with_nan) {
   const auto var = makeVariable<double>(
-      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, units::m,
+      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
       Values{1.0, 2.0, std::numeric_limits<double>::quiet_NaN(), 4.0});
   const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
                                        Values{false, false, true, false});
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto min_x =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 4.0});
-  const auto min_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 2.0});
+  const auto min_x = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                          Values{1.0, 4.0});
+  const auto min_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{1.0, 2.0});
   EXPECT_EQ(min(a, Dim::X).data(), min_x);
   EXPECT_EQ(min(a, Dim::Y).data(), min_y);
   EXPECT_FALSE(min(a, Dim::X).masks().contains("mask"));
@@ -112,7 +112,7 @@ TEST(MinTest, masked_data_with_nan) {
 
 TEST(NanMinTest, masked_data_array) {
   const auto var = makeVariable<double>(
-      Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, units::m,
+      Dimensions{{Dim::Y, 3}, {Dim::X, 2}}, sc_units::m,
       Values{1.0, std::numeric_limits<double>::quiet_NaN(), 3.0, 4.0,
              std::numeric_limits<double>::quiet_NaN(), 6.0});
   const auto mask =
@@ -121,10 +121,10 @@ TEST(NanMinTest, masked_data_array) {
   a.masks().set("mask", mask);
 
   const auto min_x = makeVariable<double>(
-      Dimensions{Dim::Y, 3}, units::m,
+      Dimensions{Dim::Y, 3}, sc_units::m,
       Values{1.0, 3.0, std::numeric_limits<double>::max()});
-  const auto min_y =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 4.0});
+  const auto min_y = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                          Values{1.0, 4.0});
   EXPECT_EQ(nanmin(a, Dim::X).data(), min_x);
   EXPECT_EQ(nanmin(a, Dim::Y).data(), min_y);
   EXPECT_FALSE(nanmin(a, Dim::X).masks().contains("mask"));

--- a/lib/dataset/test/rebin_test.cpp
+++ b/lib/dataset/test/rebin_test.cpp
@@ -16,14 +16,14 @@ using namespace scipp::dataset;
 class RebinTest : public ::testing::Test {
 protected:
   Variable counts =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, sc_units::counts,
                            Values{1, 2, 3, 4, 5, 6, 7, 8});
   Variable x =
       makeVariable<double>(Dims{Dim::X}, Shape{5}, Values{1, 2, 3, 4, 5});
   Variable y = makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1, 2, 3});
   DataArray array{counts, {{Dim::X, x}, {Dim::Y, y}}, {}};
   DataArray array_with_variances{
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, sc_units::counts,
                            Values{1, 2, 3, 4, 5, 6, 7, 8},
                            Variances{9, 10, 11, 12, 13, 14, 15, 16}),
       {{Dim::X, x}, {Dim::Y, y}},
@@ -33,7 +33,8 @@ protected:
 TEST_F(RebinTest, inner_stride1_data_array) {
   auto edges = makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 3, 5});
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 7, 11, 15}),
+                                          sc_units::counts,
+                                          Values{3, 7, 11, 15}),
                      {{Dim::X, edges}, {Dim::Y, y}}, {});
   ASSERT_EQ(rebin(array, Dim::X, edges), expected);
 }
@@ -43,7 +44,8 @@ TEST_F(RebinTest, inner_stride1_strided_edges) {
                                      Values{1, 0, 3, 0, 5, 0});
   auto edges = buffer.slice({Dim::Z, 0});
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 7, 11, 15}),
+                                          sc_units::counts,
+                                          Values{3, 7, 11, 15}),
                      {{Dim::X, edges}, {Dim::Y, y}}, {});
   ASSERT_EQ(rebin(array, Dim::X, edges), expected);
 }
@@ -51,17 +53,18 @@ TEST_F(RebinTest, inner_stride1_strided_edges) {
 TEST_F(RebinTest, outer_stride1_data_array) {
   auto edges = makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 3, 5});
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 7, 11, 15}),
+                                          sc_units::counts,
+                                          Values{3, 7, 11, 15}),
                      {{Dim::X, edges}, {Dim::Y, y}}, {});
   ASSERT_EQ(rebin(transpose(array), Dim::X, edges), transpose(expected));
 }
 
 TEST_F(RebinTest, inner_data_array_with_variances) {
   auto edges = makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 3, 5});
-  DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 7, 11, 15},
-                                          Variances{19, 23, 27, 31}),
-                     {{Dim::X, edges}, {Dim::Y, y}}, {});
+  DataArray expected(
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::counts,
+                           Values{3, 7, 11, 15}, Variances{19, 23, 27, 31}),
+      {{Dim::X, edges}, {Dim::Y, y}}, {});
 
   ASSERT_EQ(rebin(array_with_variances, Dim::X, edges), expected);
 }
@@ -70,7 +73,7 @@ TEST_F(RebinTest, inner_data_array_unaligned_edges) {
   auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1.5, 3.5, 5.5});
   DataArray expected(
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::counts,
                            Values{0.5 * 1 + 2 + 0.5 * 3, 0.5 * 3 + 4,
                                   0.5 * 5 + 6 + 0.5 * 7, 0.5 * 7 + 8}),
       {{Dim::X, edges}, {Dim::Y, y}}, {});
@@ -81,7 +84,8 @@ TEST_F(RebinTest, inner_data_array_unaligned_edges) {
 TEST_F(RebinTest, outer_data_array) {
   auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 3});
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 4},
-                                          units::counts, Values{6, 8, 10, 12}),
+                                          sc_units::counts,
+                                          Values{6, 8, 10, 12}),
                      {{Dim::X, x}, {Dim::Y, edges}}, {});
 
   ASSERT_EQ(rebin(array, Dim::Y, edges), expected);
@@ -90,7 +94,8 @@ TEST_F(RebinTest, outer_data_array) {
 TEST_F(RebinTest, outer_data_array_different_edge_dtype) {
   auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 3});
   DataArray expected(makeVariable<float>(Dims{Dim::Y, Dim::X}, Shape{1, 4},
-                                         units::counts, Values{6, 8, 10, 12}),
+                                         sc_units::counts,
+                                         Values{6, 8, 10, 12}),
                      {{Dim::X, x}, {Dim::Y, edges}}, {});
   DataArray array_float(astype(counts, dtype<float>),
                         {{Dim::X, x}, {Dim::Y, y}});
@@ -100,10 +105,10 @@ TEST_F(RebinTest, outer_data_array_different_edge_dtype) {
 
 TEST_F(RebinTest, outer_data_array_with_variances) {
   auto edges = makeVariable<double>(Dims{Dim::Y}, Shape{2}, Values{1, 3});
-  DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 4},
-                                          units::counts, Values{6, 8, 10, 12},
-                                          Variances{22, 24, 26, 28}),
-                     {{Dim::X, x}, {Dim::Y, edges}}, {});
+  DataArray expected(
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 4}, sc_units::counts,
+                           Values{6, 8, 10, 12}, Variances{22, 24, 26, 28}),
+      {{Dim::X, x}, {Dim::Y, edges}}, {});
 
   ASSERT_EQ(rebin(array_with_variances, Dim::Y, edges), expected);
 }
@@ -112,7 +117,7 @@ TEST_F(RebinTest, outer_data_array_unaligned_edges) {
   auto edges =
       makeVariable<double>(Dims{Dim::Y}, Shape{3}, Values{1.0, 2.5, 3.5});
   DataArray expected(
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4}, sc_units::counts,
                            Values{1.0 + 0.5 * 5, 2.0 + 0.5 * 6, 3.0 + 0.5 * 7,
                                   4.0 + 0.5 * 8, 0.5 * 5, 0.5 * 6, 0.5 * 7,
                                   0.5 * 8}),
@@ -131,7 +136,7 @@ TEST_F(RebinTest, keeps_unrelated_labels_but_drops_others) {
   const auto edges =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1, 3, 5});
   DataArray expected(
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::counts,
                            Values{3, 7, 11, 15}),
       {{Dim::X, edges}, {Dim::Y, y}, {Dim("labels_y"), labels_y}});
 
@@ -140,7 +145,7 @@ TEST_F(RebinTest, keeps_unrelated_labels_but_drops_others) {
 
 TEST_F(RebinTest, rebin_with_ragged_coord) {
   Variable data = makeVariable<double>(
-      Dims{Dim::Z, Dim::Y, Dim::X}, Shape{3, 2, 4}, units::counts,
+      Dims{Dim::Z, Dim::Y, Dim::X}, Shape{3, 2, 4}, sc_units::counts,
       Values{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24});
   Variable var_x = makeVariable<double>(
@@ -157,7 +162,7 @@ TEST_F(RebinTest, rebin_with_ragged_coord) {
       makeVariable<double>(Dims{Dim::Z}, Shape{3}, Values{0.0, 2.5, 5.0});
   DataArray expected(
       makeVariable<double>(
-          Dims{Dim::Z, Dim::Y, Dim::X}, Shape{2, 2, 4}, units::counts,
+          Dims{Dim::Z, Dim::Y, Dim::X}, Shape{2, 2, 4}, sc_units::counts,
           Values{5.5, 7.0, 8.5, 10.0, 11.5, 13.0, 14.5, 16.0, 21.5, 23.0, 24.5,
                  26.0, 27.5, 29.0, 30.5, 32.0}),
       {{Dim::Z, edges}, {Dim::X, var_x}, {Dim::Y, var_y}}, {});
@@ -168,7 +173,7 @@ TEST_F(RebinTest, rebin_with_ragged_coord) {
 class RebinRaggedTest : public ::testing::Test {
 protected:
   Variable counts =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3}, units::counts,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3}, sc_units::counts,
                            Values{1, 2, 3, 4, 5, 6});
   Variable x = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 4},
                                     Values{1, 2, 3, 4, 5, 6, 7, 8});
@@ -179,7 +184,7 @@ protected:
 
 TEST_F(RebinRaggedTest, stride1_data_and_edges) {
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 3, 0, 9}),
+                                          sc_units::counts, Values{3, 3, 0, 9}),
                      {{Dim::X, edges}});
   ASSERT_EQ(rebin(da, Dim::X, edges), expected);
   ASSERT_EQ(rebin(transpose(da), Dim::X, edges), transpose(expected));
@@ -187,7 +192,7 @@ TEST_F(RebinRaggedTest, stride1_data_and_edges) {
 
 TEST_F(RebinRaggedTest, stride1_edges) {
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 3, 0, 9}),
+                                          sc_units::counts, Values{3, 3, 0, 9}),
                      {{Dim::X, edges}});
   ASSERT_EQ(rebin(copy(transpose(da)), Dim::X, edges), transpose(expected));
 }
@@ -195,7 +200,7 @@ TEST_F(RebinRaggedTest, stride1_edges) {
 TEST_F(RebinRaggedTest, stride1_data) {
   da.coords().set(Dim::X, copy(transpose(x)));
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 3, 0, 9}),
+                                          sc_units::counts, Values{3, 3, 0, 9}),
                      {{Dim::X, edges}});
   ASSERT_EQ(rebin(da, Dim::X, edges), expected);
 }
@@ -203,14 +208,14 @@ TEST_F(RebinRaggedTest, stride1_data) {
 TEST_F(RebinRaggedTest, no_stride1) {
   da.coords().set(Dim::X, copy(transpose(x)));
   DataArray expected(makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                          units::counts, Values{3, 3, 0, 9}),
+                                          sc_units::counts, Values{3, 3, 0, 9}),
                      {{Dim::X, edges}});
   ASSERT_EQ(rebin(copy(transpose(da)), Dim::X, edges), transpose(expected));
 }
 
 TEST(RebinWithMaskTest, applies_mask_along_rebin_dim) {
   DataArray da(
-      broadcast(makeVariable<double>(Dimensions{Dim::X, 5}, units::counts,
+      broadcast(makeVariable<double>(Dimensions{Dim::X, 5}, sc_units::counts,
                                      Values{1, 2, 3, 4, 5}),
                 Dimensions({Dim::Y, Dim::X}, {5, 5})),
       {{Dim::X, makeVariable<double>(Dimensions{Dim::X, 6},
@@ -226,14 +231,14 @@ TEST(RebinWithMaskTest, applies_mask_along_rebin_dim) {
 
   EXPECT_FALSE(result.masks().contains("mask_x"));
   EXPECT_EQ(result.data(),
-            broadcast(makeVariable<double>(Dimensions{Dim::X, 2}, units::counts,
-                                           Values{3, 4}),
+            broadcast(makeVariable<double>(Dimensions{Dim::X, 2},
+                                           sc_units::counts, Values{3, 4}),
                       Dimensions({Dim::Y, Dim::X}, {5, 2})));
 }
 
 TEST(RebinWithMaskTest, preserves_unrelated_mask) {
   Dataset ds({{"data_xy", broadcast(makeVariable<double>(Dimensions{Dim::X, 5},
-                                                         units::counts,
+                                                         sc_units::counts,
                                                          Values{1, 2, 3, 4, 5}),
                                     Dimensions({Dim::Y, Dim::X}, {5, 5}))}},
              {{Dim::X, makeVariable<double>(Dimensions{Dim::X, 6},
@@ -247,8 +252,8 @@ TEST(RebinWithMaskTest, preserves_unrelated_mask) {
   const Dataset result = rebin(ds, Dim::X, edges);
 
   ASSERT_EQ(result["data_xy"].data(),
-            broadcast(makeVariable<double>(Dimensions{Dim::X, 2}, units::counts,
-                                           Values{3, 7}),
+            broadcast(makeVariable<double>(Dimensions{Dim::X, 2},
+                                           sc_units::counts, Values{3, 7}),
                       Dimensions({Dim::Y, Dim::X}, {5, 2})));
   ASSERT_EQ(result["data_xy"].masks()["mask_y"],
             ds["data_xy"].masks()["mask_y"]);

--- a/lib/dataset/test/set_slice_test.cpp
+++ b/lib/dataset/test/set_slice_test.cpp
@@ -168,7 +168,7 @@ TEST_F(SetSliceTest, set_dataarray_slice_with_different_data_units_forbidden) {
   auto da = make_example_dataarray("mask", Dim::X);
   auto original = copy(da);
   auto other = copy(da);
-  other.setUnit(scipp::units::K); // slice to use now had different unit
+  other.setUnit(scipp::sc_units::K); // slice to use now had different unit
   other = other.slice({Dim::X, 1}).slice({Dim::Y, 1});
   EXPECT_THROW_DISCARD(da.setSlice(Slice{Dim::X, 0}, other), except::UnitError);
   // We test for a partially-applied modification as a result of an aborted

--- a/lib/dataset/test/shape_test.cpp
+++ b/lib/dataset/test/shape_test.cpp
@@ -51,15 +51,15 @@ TEST(ResizeTest, data_array_2d) {
 TEST(ReshapeTest, fold_x) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}});
   DataArray expected(rshp);
   expected.coords().set(
       Dim::X, fold(arange(Dim::X, 6), Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}}) +
-                  0.1 * units::one);
+                  0.1 * sc_units::one);
   expected.coords().set(Dim::Y, a.coords()[Dim::Y]);
 
   EXPECT_EQ(fold(a, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}}), expected);
@@ -68,15 +68,15 @@ TEST(ReshapeTest, fold_x) {
 TEST(ReshapeTest, fold_y) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::X, 6}, {Dim::Row, 2}, {Dim::Time, 2}});
   DataArray expected(rshp);
   expected.coords().set(
       Dim::Y, fold(arange(Dim::Y, 4), Dim::Y, {{Dim::Row, 2}, {Dim::Time, 2}}) +
-                  0.2 * units::one);
+                  0.2 * sc_units::one);
   expected.coords().set(Dim::X, a.coords()[Dim::X]);
 
   EXPECT_EQ(fold(a, Dim::Y, {{Dim::Row, 2}, {Dim::Time, 2}}), expected);
@@ -85,12 +85,12 @@ TEST(ReshapeTest, fold_y) {
 TEST(ReshapeTest, fold_into_3_dims) {
   const auto var = arange(Dim::X, 24);
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 24) + 0.1 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 24) + 0.1 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::Time, 2}, {Dim::Y, 3}, {Dim::Z, 4}});
   DataArray expected(rshp);
-  expected.coords().set(Dim::X, rshp + 0.1 * units::one);
+  expected.coords().set(Dim::X, rshp + 0.1 * sc_units::one);
 
   EXPECT_EQ(fold(a, Dim::X, {{Dim::Time, 2}, {Dim::Y, 3}, {Dim::Z, 4}}),
             expected);
@@ -99,10 +99,10 @@ TEST(ReshapeTest, fold_into_3_dims) {
 TEST(ReshapeTest, flatten) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
-  a.coords().set(Dim{"xy"}, 0.3 * units::one + var);
-  a.coords().set(Dim{"yx"}, copy(transpose(0.4 * units::one + var,
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
+  a.coords().set(Dim{"xy"}, 0.3 * sc_units::one + var);
+  a.coords().set(Dim{"yx"}, copy(transpose(0.4 * sc_units::one + var,
                                            std::vector{Dim{"y"}, Dim{"x"}})));
 
   const auto expected_data = arange(Dim::Z, 24);
@@ -119,8 +119,8 @@ TEST(ReshapeTest, flatten) {
                            Values{0.2, 1.2, 2.2, 3.2, 0.2, 1.2, 2.2, 3.2,
                                   0.2, 1.2, 2.2, 3.2, 0.2, 1.2, 2.2, 3.2,
                                   0.2, 1.2, 2.2, 3.2, 0.2, 1.2, 2.2, 3.2}));
-  expected.coords().set(Dim{"xy"}, 0.3 * units::one + expected_data);
-  expected.coords().set(Dim{"yx"}, 0.4 * units::one + expected_data);
+  expected.coords().set(Dim{"xy"}, 0.3 * sc_units::one + expected_data);
+  expected.coords().set(Dim{"yx"}, 0.4 * sc_units::one + expected_data);
 
   EXPECT_EQ(flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z), expected);
 }
@@ -128,10 +128,10 @@ TEST(ReshapeTest, flatten) {
 TEST(ReshapeTest, flatten_single_dim) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
-  a.coords().set(Dim{"xy"}, 0.3 * units::one + var);
-  a.coords().set(Dim{"yx"}, copy(transpose(0.4 * units::one + var,
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
+  a.coords().set(Dim{"xy"}, 0.3 * sc_units::one + var);
+  a.coords().set(Dim{"yx"}, copy(transpose(0.4 * sc_units::one + var,
                                            std::vector<Dim>{Dim::Y, Dim::X})));
 
   EXPECT_EQ(flatten(a, std::vector<Dim>{Dim::X}, Dim::Z),
@@ -143,8 +143,8 @@ TEST(ReshapeTest, flatten_single_dim) {
 TEST(ReshapeTest, flatten_all_dims) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
   a.coords().set(Dim("scalar"), makeVariable<double>(Values{1.2}));
 
   const auto flat = flatten(a, std::nullopt, Dim::Z);
@@ -158,8 +158,8 @@ TEST(ReshapeTest, flatten_all_dims) {
 TEST(ReshapeTest, flatten_dim_not_in_input) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   EXPECT_THROW_DISCARD(flatten(a, std::vector<Dim>{Dim::Time}, Dim::Z),
                        except::DimensionError);
@@ -172,8 +172,8 @@ TEST(ReshapeTest, flatten_dim_not_in_input) {
 TEST(ReshapeTest, flatten_bad_dim_order) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   EXPECT_THROW_MSG_DISCARD(
       flatten(a, std::vector<Dim>{Dim::Y, Dim::X}, Dim::Z),
@@ -184,8 +184,8 @@ TEST(ReshapeTest, flatten_bad_dim_order) {
 TEST(ReshapeTest, flatten_empty_from_arg) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   DataArray expected(
       broadcast(var, Dimensions{{Dim::X, Dim::Y, Dim::Z}, {6, 4, 1}}));
@@ -198,7 +198,7 @@ TEST(ReshapeTest, flatten_empty_from_arg) {
 TEST(ReshapeTest, flatten_scalar_no_dims) {
   const auto var = makeVariable<double>(Dims{}, Shape{}, Values{2.0});
   DataArray a(var);
-  a.coords().set(Dim::X, 0.1 * units::one + var);
+  a.coords().set(Dim::X, 0.1 * sc_units::one + var);
 
   DataArray expected(makeVariable<double>(Dims{Dim::Z}, Shape{1}, Values{2.0}));
   expected.coords().set(Dim::X, a.coords()[Dim::X]);
@@ -209,10 +209,10 @@ TEST(ReshapeTest, flatten_scalar_no_dims) {
 TEST(ReshapeTest, flatten_scalar_all_dims) {
   const auto var = makeVariable<double>(Dims{}, Shape{}, Values{2.0});
   DataArray a(var);
-  a.coords().set(Dim::X, 0.1 * units::one + var);
+  a.coords().set(Dim::X, 0.1 * sc_units::one + var);
 
   DataArray expected(makeVariable<double>(Dims{Dim::Z}, Shape{1}, Values{2.0}));
-  expected.coords().set(Dim::X, 0.1 * units::one + expected.data());
+  expected.coords().set(Dim::X, 0.1 * sc_units::one + expected.data());
 
   EXPECT_EQ(flatten(a, std::nullopt, Dim::Z), expected);
 }
@@ -220,8 +220,8 @@ TEST(ReshapeTest, flatten_scalar_all_dims) {
 TEST(ReshapeTest, round_trip) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   auto reshaped = fold(a, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}});
   EXPECT_EQ(flatten(reshaped, std::vector<Dim>{Dim::Row, Dim::Time}, Dim::X),
@@ -231,8 +231,8 @@ TEST(ReshapeTest, round_trip) {
 TEST(ReshapeTest, fold_x_binedges_x) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}});
@@ -249,8 +249,8 @@ TEST(ReshapeTest, fold_x_binedges_x) {
 TEST(ReshapeTest, fold_y_binedges_y) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 5) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 5) + 0.2 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::X, 6}, {Dim::Row, 2}, {Dim::Time, 2}});
@@ -273,8 +273,8 @@ TEST(ReshapeTest, flatten_binedges_1d) {
 TEST(ReshapeTest, flatten_drops_unjoinable_outer_binedges) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto flat = flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
   EXPECT_FALSE(flat.coords().contains(Dim::X));
@@ -283,8 +283,8 @@ TEST(ReshapeTest, flatten_drops_unjoinable_outer_binedges) {
 TEST(ReshapeTest, flatten_drops_unjoinable_inner_binedges) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 5) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 5) + 0.2 * sc_units::one);
 
   const auto flat = flatten(a, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
   EXPECT_FALSE(flat.coords().contains(Dim::Y));
@@ -293,8 +293,8 @@ TEST(ReshapeTest, flatten_drops_unjoinable_inner_binedges) {
 TEST(ReshapeTest, round_trip_binedges) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   auto reshaped = fold(a, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}});
   EXPECT_EQ(flatten(reshaped, std::vector<Dim>{Dim::Row, Dim::Time}, Dim::X),
@@ -306,8 +306,8 @@ TEST(ReshapeTest, fold_x_with_2d_coord) {
   DataArray a(var);
   a.coords().set(Dim::X,
                  fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}}) +
-                     0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+                     0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto rshp = fold(arange(Dim::X, 24), Dim::X,
                          {{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}});
@@ -315,7 +315,7 @@ TEST(ReshapeTest, fold_x_with_2d_coord) {
   expected.coords().set(Dim::X,
                         fold(arange(Dim::X, 24), Dim::X,
                              {{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}}) +
-                            0.1 * units::one);
+                            0.1 * sc_units::one);
   expected.coords().set(Dim::Y, a.coords()[Dim::Y]);
 
   EXPECT_EQ(fold(a, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}}), expected);
@@ -326,12 +326,12 @@ TEST(ReshapeTest, flatten_with_2d_coord) {
   DataArray a(var);
   a.coords().set(Dim::X,
                  fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}}) +
-                     0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+                     0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
 
   const auto rshp = arange(Dim::Z, 24);
   DataArray expected(rshp);
-  expected.coords().set(Dim::X, arange(Dim::Z, 24) + 0.1 * units::one);
+  expected.coords().set(Dim::X, arange(Dim::Z, 24) + 0.1 * sc_units::one);
   expected.coords().set(
       Dim::Y,
       makeVariable<double>(Dims{Dim::Z}, Shape{24},
@@ -345,8 +345,8 @@ TEST(ReshapeTest, flatten_with_2d_coord) {
 TEST(ReshapeTest, fold_x_with_masks) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
   a.masks().set("mask_x", makeVariable<bool>(
                               Dims{Dim::X}, Shape{6},
                               Values{true, true, true, false, false, false}));
@@ -365,7 +365,7 @@ TEST(ReshapeTest, fold_x_with_masks) {
   DataArray expected(rshp);
   expected.coords().set(
       Dim::X, fold(arange(Dim::X, 6), Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}}) +
-                  0.1 * units::one);
+                  0.1 * sc_units::one);
   expected.coords().set(Dim::Y, a.coords()[Dim::Y]);
   expected.masks().set(
       "mask_x",
@@ -388,8 +388,8 @@ TEST(ReshapeTest, fold_x_with_masks) {
 TEST(ReshapeTest, flatten_with_masks) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 6) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
   a.masks().set("mask_x", makeVariable<bool>(
                               Dims{Dim::X}, Shape{6},
                               Values{true, true, true, false, false, false}));
@@ -445,11 +445,11 @@ TEST(ReshapeTest, flatten_with_masks) {
 TEST(ReshapeTest, round_trip_with_all) {
   const auto var = fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}});
   DataArray a(var);
-  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * units::one);
-  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * units::one);
+  a.coords().set(Dim::X, arange(Dim::X, 7) + 0.1 * sc_units::one);
+  a.coords().set(Dim::Y, arange(Dim::Y, 4) + 0.2 * sc_units::one);
   a.coords().set(Dim::Z,
                  fold(arange(Dim::X, 24), Dim::X, {{Dim::X, 6}, {Dim::Y, 4}}) +
-                     0.5 * units::one);
+                     0.5 * sc_units::one);
   a.masks().set("mask_x", makeVariable<bool>(
                               Dims{Dim::X}, Shape{6},
                               Values{true, true, true, false, false, false}));

--- a/lib/dataset/test/slice_by_value_test.cpp
+++ b/lib/dataset/test/slice_by_value_test.cpp
@@ -17,7 +17,7 @@ namespace {
 template <int N>
 constexpr auto make_array_common = [](const auto... values) {
   const auto size = sizeof...(values);
-  Variable coord = makeVariable<double>(units::s, Dims{Dim::X}, Shape{size},
+  Variable coord = makeVariable<double>(sc_units::s, Dims{Dim::X}, Shape{size},
                                         Values{values...});
   Variable data = makeVariable<int64_t>(Dims{Dim::X}, Shape{size - N});
   return DataArray{data, {{Dim::X, coord}}};
@@ -80,11 +80,11 @@ TEST(SliceByValueTest, test_begin_end_not_0D_throws) {
 TEST(SliceByValueTest, test_unit_mismatch_throws) {
   auto da = make_points(0, 1, 2, 3);
   const auto test = [](const auto &sliceable) {
-    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, 1 * units::m),
+    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, 1 * sc_units::m),
                          except::UnitError);
-    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, 1 * units::m, {}),
+    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, 1 * sc_units::m, {}),
                          except::UnitError);
-    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, {}, 1 * units::m),
+    EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, {}, 1 * sc_units::m),
                          except::UnitError);
   };
   test(da);
@@ -92,14 +92,14 @@ TEST(SliceByValueTest, test_unit_mismatch_throws) {
 }
 
 TEST(SliceByValueTest, test_dtype_string) {
-  Variable coord = makeVariable<std::string>(units::s, Dims{Dim::X}, Shape{3},
-                                             Values{"a"s, "b"s, "c"s});
+  Variable coord = makeVariable<std::string>(
+      sc_units::s, Dims{Dim::X}, Shape{3}, Values{"a"s, "b"s, "c"s});
   Variable data = makeVariable<int64_t>(Dims{Dim::X}, Shape{3});
   const DataArray da{data, {{Dim::X, coord}}};
 
   const auto test = [](const auto &sliceable) {
     const auto x =
-        makeVariable<std::string>(units::s, Dims{}, Shape{}, Values{"a"s});
+        makeVariable<std::string>(sc_units::s, Dims{}, Shape{}, Values{"a"s});
     EXPECT_EQ(slice(sliceable, Dim::X, x), sliceable.slice(Slice{Dim::X, 0}));
     EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, x, {}), except::TypeError);
     EXPECT_THROW_DISCARD(slice(sliceable, Dim::X, {}, x), except::TypeError);
@@ -111,7 +111,7 @@ TEST(SliceByValueTest, test_dtype_string) {
 TEST(SliceByValueTest, test_slicing_defaults_ascending) {
   auto da = make_points(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 13.0 * units::s));
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 13.0 * sc_units::s));
     EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, {}));
   };
   test(da);
@@ -121,7 +121,7 @@ TEST(SliceByValueTest, test_slicing_defaults_ascending) {
 TEST(SliceByValueTest, test_slicing_defaults_descending) {
   auto da = make_points(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 2.0 * units::s));
+    EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, 2.0 * sc_units::s));
     EXPECT_EQ(sliceable, slice(sliceable, Dim::X, {}, {}));
   };
   test(da);
@@ -132,22 +132,22 @@ TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_ascending) {
   auto da = make_points(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
   auto test = [](const auto &sliceable) {
     // No effect slicing
-    auto out = slice(sliceable, Dim::X, 3.0 * units::s, 13.0 * units::s);
+    auto out = slice(sliceable, Dim::X, 3.0 * sc_units::s, 13.0 * sc_units::s);
     EXPECT_EQ(sliceable, out);
     // Test start on left boundary (closed on left), so includes boundary
-    out = slice(sliceable, Dim::X, 3.0 * units::s, 4.0 * units::s);
+    out = slice(sliceable, Dim::X, 3.0 * sc_units::s, 4.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test start out of bounds on left truncated
-    out = slice(sliceable, Dim::X, 2.0 * units::s, 4.0 * units::s);
+    out = slice(sliceable, Dim::X, 2.0 * sc_units::s, 4.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test inner values
-    out = slice(sliceable, Dim::X, 3.5 * units::s, 5.5 * units::s);
+    out = slice(sliceable, Dim::X, 3.5 * sc_units::s, 5.5 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
     // Test end on right boundary (open on right), so does not include boundary
-    out = slice(sliceable, Dim::X, 11.0 * units::s, 12.0 * units::s);
+    out = slice(sliceable, Dim::X, 11.0 * sc_units::s, 12.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
     // Test end out of bounds on right truncated
-    out = slice(sliceable, Dim::X, 11.0 * units::s, 13.0 * units::s);
+    out = slice(sliceable, Dim::X, 11.0 * sc_units::s, 13.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 10}));
   };
   test(da);
@@ -158,22 +158,22 @@ TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_descending) {
   auto da = make_points(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
   auto test = [](const auto &sliceable) {
     // No effect slicing
-    auto out = slice(sliceable, Dim::X, 12.0 * units::s, 2.0 * units::s);
+    auto out = slice(sliceable, Dim::X, 12.0 * sc_units::s, 2.0 * sc_units::s);
     EXPECT_EQ(sliceable, out);
     // Test start on left boundary (closed on left), so includes boundary
-    out = slice(sliceable, Dim::X, 12.0 * units::s, 11.0 * units::s);
+    out = slice(sliceable, Dim::X, 12.0 * sc_units::s, 11.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test start out of bounds on left truncated
-    out = slice(sliceable, Dim::X, 13.0 * units::s, 11.0 * units::s);
+    out = slice(sliceable, Dim::X, 13.0 * sc_units::s, 11.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test inner values
-    out = slice(sliceable, Dim::X, 11.5 * units::s, 9.5 * units::s);
+    out = slice(sliceable, Dim::X, 11.5 * sc_units::s, 9.5 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
     // Test end on right boundary (open on right), so does not include boundary
-    out = slice(sliceable, Dim::X, 4.0 * units::s, 3.0 * units::s);
+    out = slice(sliceable, Dim::X, 4.0 * sc_units::s, 3.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
     // Test end out of bounds on right truncated
-    out = slice(sliceable, Dim::X, 4.0 * units::s, 1.0 * units::s);
+    out = slice(sliceable, Dim::X, 4.0 * sc_units::s, 1.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 10}));
   };
   test(da);
@@ -184,27 +184,27 @@ TEST(SliceByValueTest, test_slice_range_on_edge_coord_1D_ascending) {
   auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
   const auto test = [](const auto &sliceable) {
     // No effect slicing
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::s, 12.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * sc_units::s, 12.0 * sc_units::s),
               sliceable);
     // Test start on left boundary (closed on left), so includes boundary
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::s, 4.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * sc_units::s, 4.0 * sc_units::s),
               sliceable.slice({Dim::X, 0, 1}));
     // Left range boundary inside edge, same result as above
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * units::s, 4.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * sc_units::s, 4.0 * sc_units::s),
               sliceable.slice({Dim::X, 0, 1}));
     // Right range boundary inside edge, same result as above
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * units::s, 3.9 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * sc_units::s, 3.9 * sc_units::s),
               sliceable.slice({Dim::X, 0, 1}));
     // New bound gets included if stop == bound + epsilon
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * units::s,
-                    std::nextafter(4.0, 9.0) * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.1 * sc_units::s,
+                    std::nextafter(4.0, 9.0) * sc_units::s),
               sliceable.slice({Dim::X, 0, 2}));
     // Test slicing with range lower boundary on upper edge of bin (open on
     // right test): The bin containing the stop value is *included*
-    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::s, 6.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * sc_units::s, 6.0 * sc_units::s),
               sliceable.slice({Dim::X, 1, 3}));
     // Test end on right boundary (open on right), so does not include boundary
-    EXPECT_EQ(slice(sliceable, Dim::X, 11.0 * units::s, 12.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 11.0 * sc_units::s, 12.0 * sc_units::s),
               sliceable.slice({Dim::X, 8, 9}));
   };
   test(da);
@@ -215,21 +215,21 @@ TEST(SliceByValueTest, test_slice_range_on_edge_coord_1D_descending) {
   auto da = make_histogram(12, 11, 10, 9, 8, 7, 6, 5, 4, 3);
   // No effect slicing
   auto test = [](const auto &sliceable) {
-    auto out = slice(sliceable, Dim::X, 12.0 * units::s, 3.0 * units::s);
+    auto out = slice(sliceable, Dim::X, 12.0 * sc_units::s, 3.0 * sc_units::s);
     EXPECT_EQ(out, sliceable);
     // Test start on left boundary (closed on left), so includes boundary
-    out = slice(sliceable, Dim::X, 12.0 * units::s, 11.0 * units::s);
+    out = slice(sliceable, Dim::X, 12.0 * sc_units::s, 11.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test slicing with range boundary inside edge, same result as above
     // expected
-    out = slice(sliceable, Dim::X, 11.9 * units::s, 11.0 * units::s);
+    out = slice(sliceable, Dim::X, 11.9 * sc_units::s, 11.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 0, 1}));
     // Test slicing with range lower boundary on upper edge of bin (open on
     // right test)
-    out = slice(sliceable, Dim::X, 11.0 * units::s, 9.0 * units::s);
+    out = slice(sliceable, Dim::X, 11.0 * sc_units::s, 9.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 1, 3}));
     // Test end on right boundary (open on right), so does not include boundary
-    out = slice(sliceable, Dim::X, 4.0 * units::s, 3.0 * units::s);
+    out = slice(sliceable, Dim::X, 4.0 * sc_units::s, 3.0 * sc_units::s);
     EXPECT_EQ(out, sliceable.slice({Dim::X, 8, 9}));
   };
   test(da);
@@ -239,13 +239,13 @@ TEST(SliceByValueTest, test_slice_range_on_edge_coord_1D_descending) {
 TEST(SliceByValueTest, test_point_on_point_coord_1D) {
   auto da = make_points(1, 3, 5, 4, 2);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * sc_units::s),
               sliceable.slice({Dim::X, 1}));
-    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * sc_units::s),
               sliceable.slice({Dim::X, 3}));
-    EXPECT_EQ(slice(sliceable, Dim::X, 2.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 2.0 * sc_units::s),
               sliceable.slice({Dim::X, 4}));
   };
   test(da);
@@ -255,11 +255,11 @@ TEST(SliceByValueTest, test_point_on_point_coord_1D) {
 TEST(SliceByValueTest, test_point_on_point_coord_1D_not_unique) {
   auto da = make_points(1, 3, 5, 3, 2);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 1.0 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
-    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 3.0 * units::s),
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 3.0 * sc_units::s),
                  except::SliceError);
-    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 4.0 * units::s),
+    EXPECT_THROW(auto s = slice(sliceable, Dim::X, 4.0 * sc_units::s),
                  except::SliceError);
   };
   test(da);
@@ -270,24 +270,24 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D) {
   auto da = make_histogram(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
   const auto test = [](const auto &sliceable) {
     // Test start on left boundary (closed on left), so includes boundary
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.0 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
     // Same as above, takes lower bounds of bin so same bin
-    EXPECT_EQ(slice(sliceable, Dim::X, 3.5 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 3.5 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
     // Next bin
-    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * sc_units::s),
               sliceable.slice({Dim::X, 1}));
     // Last bin
-    EXPECT_EQ(slice(sliceable, Dim::X, 11.9 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 11.9 * sc_units::s),
               sliceable.slice({Dim::X, 8}));
     // (closed on right) so out of bounds
     EXPECT_THROW([[maybe_unused]] auto view =
-                     slice(sliceable, Dim::X, 12.0 * units::s),
+                     slice(sliceable, Dim::X, 12.0 * sc_units::s),
                  except::SliceError);
     // out of bounds for left for completeness
     EXPECT_THROW([[maybe_unused]] auto view =
-                     slice(sliceable, Dim::X, 2.99 * units::s),
+                     slice(sliceable, Dim::X, 2.99 * sc_units::s),
                  except::SliceError);
   };
   test(da);
@@ -297,7 +297,7 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D) {
 TEST(SliceByValueTest, test_slice_range_on_point_coord_1D_duplicate) {
   auto da = make_points(3, 4, 4, 5);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::s, 4.6 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * sc_units::s, 4.6 * sc_units::s),
               sliceable.slice({Dim::X, 1, 3}));
   };
   test(da);
@@ -308,7 +308,7 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_duplicate) {
   // [4,4) is empty bin, 4 is in [4,5)
   auto da = make_histogram(3, 4, 4, 5);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 4.0 * sc_units::s),
               sliceable.slice({Dim::X, 2}));
   };
   test(da);
@@ -318,7 +318,7 @@ TEST(SliceByValueTest, test_slice_point_on_edge_coord_1D_duplicate) {
 TEST(SliceByValueTest, test_slice_point_on_single_point_1D) {
   auto da = make_points(2);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 2 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 2 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
   };
   test(da);
@@ -328,7 +328,7 @@ TEST(SliceByValueTest, test_slice_point_on_single_point_1D) {
 TEST(SliceByValueTest, test_slice_point_on_single_edge_1D) {
   auto da = make_histogram(2, 3);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 2 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 2 * sc_units::s),
               sliceable.slice({Dim::X, 0}));
   };
   test(da);
@@ -338,7 +338,7 @@ TEST(SliceByValueTest, test_slice_point_on_single_edge_1D) {
 TEST(SliceByValueTest, test_slice_range_on_single_point_1D) {
   auto da = make_points(2);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 2 * units::s, 3 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 2 * sc_units::s, 3 * sc_units::s),
               sliceable.slice({Dim::X, 0, 1}));
   };
   test(da);
@@ -348,7 +348,7 @@ TEST(SliceByValueTest, test_slice_range_on_single_point_1D) {
 TEST(SliceByValueTest, test_slice_range_on_single_edge_1D) {
   auto da = make_histogram(2, 3);
   const auto test = [](const auto &sliceable) {
-    EXPECT_EQ(slice(sliceable, Dim::X, 2 * units::s, 3 * units::s),
+    EXPECT_EQ(slice(sliceable, Dim::X, 2 * sc_units::s, 3 * sc_units::s),
               sliceable.slice({Dim::X, 0, 1}));
   };
   test(da);

--- a/lib/dataset/test/slice_test.cpp
+++ b/lib/dataset/test/slice_test.cpp
@@ -35,7 +35,7 @@ protected:
   Dataset3DTest() : dataset(factory.make("data_xyz")) {}
 
   Dataset
-  datasetWithEdges(const std::initializer_list<units::Dim::Id> &edgeDims) {
+  datasetWithEdges(const std::initializer_list<sc_units::Dim::Id> &edgeDims) {
     auto d = dataset;
     for (const auto dim : edgeDims) {
       auto dims = dataset.coords()[dim].dims();

--- a/lib/dataset/test/sort_test.cpp
+++ b/lib/dataset/test/sort_test.cpp
@@ -9,29 +9,29 @@ using namespace scipp;
 using namespace scipp::dataset;
 
 TEST(SortTest, variable_1d) {
-  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6});
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
   const auto expected = makeVariable<float>(
-      Dims{Dim::X}, Shape{3}, units::m, Values{3, 1, 2}, Variances{6, 4, 5});
+      Dims{Dim::X}, Shape{3}, sc_units::m, Values{3, 1, 2}, Variances{6, 4, 5});
 
   EXPECT_EQ(sort(var, key), expected);
 }
 
 TEST(SortTest, variable_1d_descending) {
-  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6});
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
   const auto expected = makeVariable<float>(
-      Dims{Dim::X}, Shape{3}, units::m, Values{2, 1, 3}, Variances{5, 4, 6});
+      Dims{Dim::X}, Shape{3}, sc_units::m, Values{2, 1, 3}, Variances{5, 4, 6});
 
   EXPECT_EQ(sort(var, key, SortOrder::Descending), expected);
 }
 
 TEST(SortTest, variable_1d_bad_key_shape_throws) {
-  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+  const auto var = makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6});
   const auto key =
       makeVariable<int>(Dims{Dim::X}, Shape{5}, Values{10, 20, -1, 5, 3});
@@ -40,16 +40,16 @@ TEST(SortTest, variable_1d_bad_key_shape_throws) {
 
 TEST(SortTest, variable_2d) {
   const auto var = makeVariable<int>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                     units::m, Values{1, 2, 3, 4, 5, 6});
+                                     sc_units::m, Values{1, 2, 3, 4, 5, 6});
 
   const auto keyX =
       makeVariable<int>(Dims{Dim::X}, Shape{3}, Values{10, 20, -1});
-  const auto expectedX = makeVariable<int>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                           units::m, Values{3, 1, 2, 6, 4, 5});
+  const auto expectedX = makeVariable<int>(
+      Dims{Dim::Y, Dim::X}, Shape{2, 3}, sc_units::m, Values{3, 1, 2, 6, 4, 5});
 
   const auto keyY = makeVariable<int>(Dims{Dim::Y}, Shape{2}, Values{1, 0});
-  const auto expectedY = makeVariable<int>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                           units::m, Values{4, 5, 6, 1, 2, 3});
+  const auto expectedY = makeVariable<int>(
+      Dims{Dim::Y, Dim::X}, Shape{2, 3}, sc_units::m, Values{4, 5, 6, 1, 2, 3});
 
   EXPECT_EQ(sort(var, keyX), expectedX);
   EXPECT_EQ(sort(var, keyY), expectedY);
@@ -146,19 +146,19 @@ TEST(SortTest, data_array_bin_edge_coord_throws) {
 }
 
 TEST(SortTest, dataset_1d) {
-  Dataset d({{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+  Dataset d({{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6})},
-             {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
+             {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::s,
                                         Values{0.1, 0.2, 0.3})}},
-            {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+            {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                            Values{1, 2, 3})}});
 
   Dataset expected(
-      {{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+      {{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                  Values{3, 1, 2}, Variances{6, 4, 5})},
-       {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
+       {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::s,
                                   Values{0.3, 0.1, 0.2})}},
-      {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+      {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                      Values{3, 1, 2})}});
 
   const auto key =
@@ -168,19 +168,19 @@ TEST(SortTest, dataset_1d) {
 }
 
 TEST(SortTest, dataset_1d_descending) {
-  Dataset d({{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+  Dataset d({{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                        Values{1, 2, 3}, Variances{4, 5, 6})},
-             {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
+             {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::s,
                                         Values{0.1, 0.2, 0.3})}},
-            {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+            {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                            Values{1, 2, 3})}});
 
   Dataset expected(
-      {{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, units::m,
+      {{"a", makeVariable<float>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                  Values{2, 1, 3}, Variances{5, 4, 6})},
-       {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, units::s,
+       {"b", makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::s,
                                   Values{0.2, 0.1, 0.3})}},
-      {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+      {{Dim::X, makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                      Values{2, 1, 3})}});
 
   const auto key =

--- a/lib/dataset/test/sum_test.cpp
+++ b/lib/dataset/test/sum_test.cpp
@@ -14,16 +14,17 @@ using namespace scipp;
 using namespace scipp::dataset;
 
 TEST(SumTest, masked_data_array) {
-  const auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   const auto mask =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   DataArray a(var);
   a.masks().set("mask", mask);
-  const auto sumX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 3.0});
-  const auto sumY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{4.0, 6.0});
+  const auto sumX = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                         Values{1.0, 3.0});
+  const auto sumY = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                         Values{4.0, 6.0});
   EXPECT_EQ(sum(a, Dim::X).data(), sumX);
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
   EXPECT_FALSE(sum(a, Dim::X).masks().contains("mask"));
@@ -37,7 +38,7 @@ TEST(SumTest, masked_data_array) {
 
 TEST(SumTest, masked_data_with_special_vals) {
   const auto var = makeVariable<double>(
-      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, units::m,
+      Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
       Values{1.0, std::numeric_limits<double>::quiet_NaN(), 3.0, 4.0});
   const auto mask = makeVariable<bool>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
                                        Values{false, true, false, false});
@@ -45,18 +46,19 @@ TEST(SumTest, masked_data_with_special_vals) {
   DataArray a(var);
   a.masks().set("mask", mask);
 
-  const auto sumX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 7.0});
-  const auto sumY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{4.0, 4.0});
+  const auto sumX = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                         Values{1.0, 7.0});
+  const auto sumY = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                         Values{4.0, 4.0});
 
   EXPECT_EQ(sum(a, Dim::X).data(), sumX);
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
 }
 
 TEST(SumTest, masked_data_array_two_masks) {
-  const auto var = makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   const auto maskX =
       makeVariable<bool>(Dimensions{Dim::X, 2}, Values{false, true});
   const auto maskY =
@@ -64,10 +66,10 @@ TEST(SumTest, masked_data_array_two_masks) {
   DataArray a(var);
   a.masks().set("x", maskX);
   a.masks().set("y", maskY);
-  const auto sumX =
-      makeVariable<double>(Dimensions{Dim::Y, 2}, units::m, Values{1.0, 3.0});
-  const auto sumY =
-      makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{1.0, 2.0});
+  const auto sumX = makeVariable<double>(Dimensions{Dim::Y, 2}, sc_units::m,
+                                         Values{1.0, 3.0});
+  const auto sumY = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m,
+                                         Values{1.0, 2.0});
   EXPECT_EQ(sum(a, Dim::X).data(), sumX);
   EXPECT_EQ(sum(a, Dim::Y).data(), sumY);
   EXPECT_FALSE(sum(a, Dim::X).masks().contains("x"));
@@ -134,14 +136,14 @@ protected:
   Variable indices = makeVariable<index_pair>(
       Dims{Dim::Y}, Shape{3},
       Values{std::pair{0, 2}, std::pair{2, 2}, std::pair{2, 5}});
-  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
+  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, sc_units::m,
                                        Values{1, 2, 3, 4, 5});
   DataArray buffer = DataArray(data);
   Variable binned = make_bins(indices, Dim::Event, buffer);
 };
 
 TEST_F(ReduceBinnedTest, sum) {
-  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, units::m, Values{15}));
+  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, sc_units::m, Values{15}));
 }
 
 TEST_F(ReduceBinnedTest, sum_masked_events) {
@@ -149,7 +151,8 @@ TEST_F(ReduceBinnedTest, sum_masked_events) {
       "mask", makeVariable<bool>(Dims{Dim::Event}, Shape{5},
                                  Values{true, true, false, true, false}));
   binned = make_bins(indices, Dim::Event, buffer);
-  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, units::m, Values{3 + 5}));
+  EXPECT_EQ(sum(binned),
+            makeVariable<double>(Dims{}, sc_units::m, Values{3 + 5}));
 }
 
 TEST_F(ReduceBinnedTest, sum_masked_events_bool) {
@@ -159,12 +162,13 @@ TEST_F(ReduceBinnedTest, sum_masked_events_bool) {
   buffer.setData(makeVariable<bool>(Dims{Dim::Event}, Shape{5},
                                     Values{false, true, true, false, true}));
   binned = make_bins(indices, Dim::Event, buffer);
-  EXPECT_EQ(sum(binned), makeVariable<int64_t>(Dims{}, units::none, Values{2}));
+  EXPECT_EQ(sum(binned),
+            makeVariable<int64_t>(Dims{}, sc_units::none, Values{2}));
 }
 
 TEST_F(ReduceBinnedTest, mean) {
   EXPECT_EQ(mean(binned),
-            makeVariable<double>(Dims{}, units::m, Values{(15.0) / 5}));
+            makeVariable<double>(Dims{}, sc_units::m, Values{(15.0) / 5}));
 }
 
 TEST_F(ReduceBinnedTest, mean_masked_events) {
@@ -173,7 +177,7 @@ TEST_F(ReduceBinnedTest, mean_masked_events) {
                                  Values{true, true, false, true, false}));
   binned = make_bins(indices, Dim::Event, buffer);
   EXPECT_EQ(mean(binned),
-            makeVariable<double>(Dims{}, units::m, Values{(3.0 + 5.0) / 2}));
+            makeVariable<double>(Dims{}, sc_units::m, Values{(3.0 + 5.0) / 2}));
 }
 
 class ReduceMaskedBinnedTest : public ::testing::Test {
@@ -181,7 +185,7 @@ protected:
   Variable indices = makeVariable<index_pair>(
       Dims{Dim::Y}, Shape{3},
       Values{std::pair{0, 2}, std::pair{2, 2}, std::pair{2, 5}});
-  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
+  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{5}, sc_units::m,
                                        Values{1, 2, 3, 4, 5});
   DataArray buffer = DataArray(data);
   Variable binned_var = make_bins(indices, Dim::Event, buffer);
@@ -193,7 +197,7 @@ protected:
 
 TEST_F(ReduceMaskedBinnedTest, sum) {
   EXPECT_EQ(sum(binned),
-            DataArray(makeVariable<double>(Dims{}, units::m, Values{12})));
+            DataArray(makeVariable<double>(Dims{}, sc_units::m, Values{12})));
 }
 
 TEST_F(ReduceMaskedBinnedTest, sum_masked_events) {
@@ -203,12 +207,12 @@ TEST_F(ReduceMaskedBinnedTest, sum_masked_events) {
   binned = DataArray(make_bins(indices, Dim::Event, buffer), {},
                      {{"mask", binned.masks()["mask"]}});
   EXPECT_EQ(sum(binned),
-            DataArray(makeVariable<double>(Dims{}, units::m, Values{7})));
+            DataArray(makeVariable<double>(Dims{}, sc_units::m, Values{7})));
 }
 
 TEST_F(ReduceMaskedBinnedTest, mean) {
   EXPECT_EQ(mean(binned),
-            DataArray(makeVariable<double>(Dims{}, units::m, Values{4})));
+            DataArray(makeVariable<double>(Dims{}, sc_units::m, Values{4})));
 }
 
 TEST_F(ReduceMaskedBinnedTest, mean_masked_events) {
@@ -218,7 +222,7 @@ TEST_F(ReduceMaskedBinnedTest, mean_masked_events) {
   binned = DataArray(make_bins(indices, Dim::Event, buffer), {},
                      {{"mask", binned.masks()["mask"]}});
   EXPECT_EQ(mean(binned),
-            DataArray(makeVariable<double>(Dims{}, units::m, Values{3.5})));
+            DataArray(makeVariable<double>(Dims{}, sc_units::m, Values{3.5})));
 }
 
 class Reduce2dBinnedTest : public ::testing::Test {
@@ -227,25 +231,26 @@ protected:
       makeVariable<index_pair>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
                                Values{std::pair{0, 2}, std::pair{2, 2},
                                       std::pair{2, 5}, std::pair{5, 7}});
-  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{7}, units::m,
+  Variable data = makeVariable<double>(Dims{Dim::Event}, Shape{7}, sc_units::m,
                                        Values{1, 2, 3, 4, 5, 6, 7});
   DataArray buffer = DataArray(data);
   Variable binned = make_bins(indices, Dim::Event, buffer);
 };
 
 TEST_F(Reduce2dBinnedTest, sum_all_dims) {
-  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, units::m, Values{28}));
+  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, sc_units::m, Values{28}));
 }
 
 TEST_F(Reduce2dBinnedTest, sum_inner_dim) {
-  EXPECT_EQ(sum(binned, Dim::X), makeVariable<double>(Dims{Dim::Y}, Shape{2},
-                                                      units::m, Values{3, 25}));
+  EXPECT_EQ(
+      sum(binned, Dim::X),
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m, Values{3, 25}));
 }
 
 TEST_F(Reduce2dBinnedTest, sum_outer_dim) {
-  EXPECT_EQ(
-      sum(binned, Dim::Y),
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{15, 13}));
+  EXPECT_EQ(sum(binned, Dim::Y),
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                 Values{15, 13}));
 }
 
 TEST_F(Reduce2dBinnedTest, sum_masked_all_dims) {
@@ -254,7 +259,7 @@ TEST_F(Reduce2dBinnedTest, sum_masked_all_dims) {
       makeVariable<bool>(Dims{Dim::Event}, Shape{7},
                          Values{true, false, false, false, true, true, true}));
   binned = make_bins(indices, Dim::Event, buffer);
-  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, units::m, Values{9}));
+  EXPECT_EQ(sum(binned), makeVariable<double>(Dims{}, sc_units::m, Values{9}));
 }
 
 TEST_F(Reduce2dBinnedTest, sum_masked_inner_dims) {
@@ -263,8 +268,9 @@ TEST_F(Reduce2dBinnedTest, sum_masked_inner_dims) {
       makeVariable<bool>(Dims{Dim::Event}, Shape{7},
                          Values{true, false, false, false, true, true, true}));
   binned = make_bins(indices, Dim::Event, buffer);
-  EXPECT_EQ(sum(binned, Dim::X), makeVariable<double>(Dims{Dim::Y}, Shape{2},
-                                                      units::m, Values{2, 7}));
+  EXPECT_EQ(
+      sum(binned, Dim::X),
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m, Values{2, 7}));
 }
 
 TEST_F(Reduce2dBinnedTest, sum_masked_outer_dims) {
@@ -273,24 +279,25 @@ TEST_F(Reduce2dBinnedTest, sum_masked_outer_dims) {
       makeVariable<bool>(Dims{Dim::Event}, Shape{7},
                          Values{true, false, false, false, true, true, true}));
   binned = make_bins(indices, Dim::Event, buffer);
-  EXPECT_EQ(sum(binned, Dim::Y), makeVariable<double>(Dims{Dim::X}, Shape{2},
-                                                      units::m, Values{9, 0}));
+  EXPECT_EQ(
+      sum(binned, Dim::Y),
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m, Values{9, 0}));
 }
 
 TEST_F(Reduce2dBinnedTest, mean_all_dims) {
   EXPECT_EQ(mean(binned),
-            makeVariable<double>(Dims{}, units::m, Values{28.0 / 7}));
+            makeVariable<double>(Dims{}, sc_units::m, Values{28.0 / 7}));
 }
 
 TEST_F(Reduce2dBinnedTest, mean_inner_dim) {
   EXPECT_EQ(mean(binned, Dim::X),
-            makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m,
                                  Values{3.0 / 2, 25.0 / 5}));
 }
 
 TEST_F(Reduce2dBinnedTest, mean_outer_dim) {
   EXPECT_EQ(mean(binned, Dim::Y),
-            makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+            makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                  Values{15.0 / 5, 13.0 / 2}));
 }
 
@@ -301,7 +308,7 @@ TEST_F(Reduce2dBinnedTest, mean_masked_all_dims) {
                          Values{true, false, false, false, true, true, true}));
   binned = make_bins(indices, Dim::Event, buffer);
   EXPECT_EQ(mean(binned),
-            makeVariable<double>(Dims{}, units::m, Values{9.0 / 3}));
+            makeVariable<double>(Dims{}, sc_units::m, Values{9.0 / 3}));
 }
 
 TEST_F(Reduce2dBinnedTest, mean_masked_inner_dims) {
@@ -311,7 +318,7 @@ TEST_F(Reduce2dBinnedTest, mean_masked_inner_dims) {
                          Values{true, false, false, false, true, true, true}));
   binned = make_bins(indices, Dim::Event, buffer);
   EXPECT_EQ(mean(binned, Dim::X),
-            makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m,
                                  Values{2.0 / 1, 7.0 / 2}));
 }
 

--- a/lib/dataset/test/test_data_arrays.cpp
+++ b/lib/dataset/test/test_data_arrays.cpp
@@ -11,11 +11,11 @@
 using namespace scipp;
 
 DataArray make_data_array_1d(const int64_t seed) {
-  auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
+  auto data = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::counts,
                                    Values{seed + 1, seed + 2},
                                    Variances{seed + 3, seed + 4});
   auto coord =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
+      makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m, Values{1, 2});
   auto mask =
       makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{seed % 2 == 0, false});
   const auto name = std::to_string(seed);

--- a/lib/dataset/test/to_unit_test.cpp
+++ b/lib/dataset/test/to_unit_test.cpp
@@ -9,99 +9,101 @@
 using namespace scipp;
 
 auto make_array() {
-  return DataArray(makeVariable<double>(Values{2.0}, units::m),
-                   {{Dim("coord"), makeVariable<int>(Values{4}, units::s)}},
+  return DataArray(makeVariable<double>(Values{2.0}, sc_units::m),
+                   {{Dim("coord"), makeVariable<int>(Values{4}, sc_units::s)}},
                    {{"mask1", makeVariable<bool>(Values{true})}});
 }
 
 class ToUnitTest
-    : public testing::TestWithParam<std::tuple<units::Unit, CopyPolicy>> {
+    : public testing::TestWithParam<std::tuple<sc_units::Unit, CopyPolicy>> {
 protected:
   DataArray da = make_array();
 };
 
 TEST_F(ToUnitTest, conversion_to_same_unit_returns_identical_copy) {
-  da.setData(makeVariable<double>(Values{3.0}, units::m));
-  EXPECT_EQ(to_unit(da, units::m), da);
+  da.setData(makeVariable<double>(Values{3.0}, sc_units::m));
+  EXPECT_EQ(to_unit(da, sc_units::m), da);
 }
 
 TEST_F(ToUnitTest, converts_unit_of_data) {
-  da.setData(makeVariable<double>(Values{3.0}, units::m));
-  const auto result = to_unit(da, units::mm);
-  EXPECT_EQ(result.data(), makeVariable<double>(Values{3000.0}, units::mm));
+  da.setData(makeVariable<double>(Values{3.0}, sc_units::m));
+  const auto result = to_unit(da, sc_units::mm);
+  EXPECT_EQ(result.data(), makeVariable<double>(Values{3000.0}, sc_units::mm));
 }
 
 TEST_F(ToUnitTest, preserves_masks) {
-  da.setData(makeVariable<double>(Values{3.0}, units::m));
+  da.setData(makeVariable<double>(Values{3.0}, sc_units::m));
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::mm);
+  const auto result = to_unit(da, sc_units::mm);
   EXPECT_EQ(result.masks()["mask"], da.masks()["mask"]);
 }
 
 TEST_F(ToUnitTest, with_new_target_unit_copies_buffers_when_default_policy) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::mm);
+  const auto result = to_unit(da, sc_units::mm);
   EXPECT_FALSE(result.data().is_same(da.data()));
   EXPECT_FALSE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 TEST_F(ToUnitTest,
        with_new_target_unit_copies_buffers_when_copy_policy_always) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::mm, CopyPolicy::Always);
+  const auto result = to_unit(da, sc_units::mm, CopyPolicy::Always);
   EXPECT_FALSE(result.data().is_same(da.data()));
   EXPECT_FALSE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 TEST_F(ToUnitTest,
        with_new_target_unit_copies_buffers_when_copy_policy_try_avoid) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::mm, CopyPolicy::TryAvoid);
+  const auto result = to_unit(da, sc_units::mm, CopyPolicy::TryAvoid);
   EXPECT_FALSE(result.data().is_same(da.data()));
   EXPECT_FALSE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 TEST_F(ToUnitTest, with_same_target_unit_copies_buffers_when_default_policy) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::m);
+  const auto result = to_unit(da, sc_units::m);
   EXPECT_FALSE(result.data().is_same(da.data()));
   EXPECT_FALSE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 TEST_F(ToUnitTest,
        with_same_target_unit_copies_buffers_when_copy_policy_always) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::m, CopyPolicy::Always);
+  const auto result = to_unit(da, sc_units::m, CopyPolicy::Always);
   EXPECT_FALSE(result.data().is_same(da.data()));
   EXPECT_FALSE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 TEST_F(ToUnitTest,
        with_same_target_unit_shares_buffers_when_copy_policy_try_avoid) {
-  da.setUnit(units::m);
+  da.setUnit(sc_units::m);
   da.masks().set("mask", makeVariable<bool>(Values{true}));
-  const auto result = to_unit(da, units::m, CopyPolicy::TryAvoid);
+  const auto result = to_unit(da, sc_units::m, CopyPolicy::TryAvoid);
   EXPECT_TRUE(result.data().is_same(da.data()));
   EXPECT_TRUE(result.masks()["mask"].is_same(da.masks()["mask"]));
 }
 
 INSTANTIATE_TEST_SUITE_P(UnitAndCopyPolicy, ToUnitTest,
-                         testing::Combine(testing::Values(units::m, units::mm),
+                         testing::Combine(testing::Values(sc_units::m,
+                                                          sc_units::mm),
                                           testing::Values(CopyPolicy::TryAvoid,
                                                           CopyPolicy::Always)));
 
 TEST_P(ToUnitTest, does_not_affect_coords) {
-  da.coords().set(Dim::X, makeVariable<int>(Values{4}, units::s));
+  da.coords().set(Dim::X, makeVariable<int>(Values{4}, sc_units::s));
 
   const auto [unit, policy] = GetParam();
   const auto converted = to_unit(da, unit, policy);
 
-  EXPECT_EQ(converted.coords()[Dim::X], makeVariable<int>(Values{4}, units::s));
+  EXPECT_EQ(converted.coords()[Dim::X],
+            makeVariable<int>(Values{4}, sc_units::s));
   EXPECT_EQ(converted.coords(), da.coords());
   EXPECT_TRUE(converted.coords()[Dim::X].is_same(da.coords()[Dim::X]));
 }

--- a/lib/dataset/to_unit.cpp
+++ b/lib/dataset/to_unit.cpp
@@ -9,7 +9,7 @@
 
 namespace scipp::dataset {
 
-DataArray to_unit(const DataArray &array, const units::Unit &unit,
+DataArray to_unit(const DataArray &array, const sc_units::Unit &unit,
                   const CopyPolicy copy) {
   auto new_data = to_unit(array.data(), unit, copy);
   auto new_masks = new_data.is_same(array.data())

--- a/lib/dataset/variable_instantiate_bin_elements.cpp
+++ b/lib/dataset/variable_instantiate_bin_elements.cpp
@@ -89,7 +89,7 @@ class BinVariableMakerDataArray : public variable::BinVariableMaker<DataArray> {
 private:
   Variable call_make_bins(const Variable &parent, const Variable &indices,
                           const Dim dim, const DType type,
-                          const Dimensions &dims, const units::Unit &unit,
+                          const Dimensions &dims, const sc_units::Unit &unit,
                           const bool variances) const override {
     const auto &source = buffer(parent);
     if (parent.dims() !=
@@ -146,7 +146,7 @@ private:
 /// This is currently a dummy implemented just to make `is_bins` work.
 class BinVariableMakerDataset
     : public variable::BinVariableMakerCommon<Dataset> {
-  Variable create(const DType, const Dimensions &, const units::Unit &,
+  Variable create(const DType, const Dimensions &, const sc_units::Unit &,
                   const bool, const parent_list &) const override {
     throw std::runtime_error("not implemented");
   }
@@ -156,14 +156,14 @@ class BinVariableMakerDataset
   DType elem_dtype(const Variable &) const override {
     throw std::runtime_error("undefined");
   }
-  units::Unit elem_unit(const Variable &) const override {
+  sc_units::Unit elem_unit(const Variable &) const override {
     throw std::runtime_error("undefined");
   }
   void expect_can_set_elem_unit(const Variable &,
-                                const units::Unit &) const override {
+                                const sc_units::Unit &) const override {
     throw std::runtime_error("undefined");
   }
-  void set_elem_unit(Variable &, const units::Unit &) const override {
+  void set_elem_unit(Variable &, const sc_units::Unit &) const override {
     throw std::runtime_error("undefined");
   }
   bool has_variances(const Variable &) const override {

--- a/lib/python/bind_data_access.h
+++ b/lib/python/bind_data_access.h
@@ -181,7 +181,7 @@ template <class... Ts> class as_ElementArrayViewImpl {
   }
 
   template <class View>
-  static void set(const Dimensions &dims, const units::Unit unit,
+  static void set(const Dimensions &dims, const sc_units::Unit unit,
                   const View &view, const py::object &obj) {
     std::visit(
         [&dims, &unit, &obj](const auto &view_) {
@@ -526,8 +526,8 @@ void bind_data_properties(pybind11::class_<T, Ignored...> &c) {
       "unit",
       [](const T &self) {
         const auto &var = get_data_variable(self, "unit");
-        return var.unit() == units::none ? std::optional<units::Unit>()
-                                         : var.unit();
+        return var.unit() == sc_units::none ? std::optional<sc_units::Unit>()
+                                            : var.unit();
       },
       [](const T &self, const ProtoUnit &unit) {
         auto var = get_data_variable(self, "unit");

--- a/lib/python/bind_data_array.h
+++ b/lib/python/bind_data_array.h
@@ -266,7 +266,7 @@ void bind_mutable_view_no_dim(py::module &m, const std::string &name,
   py::class_<T> view(m, name.c_str(), docs.c_str());
   bind_common_mutable_view_operators(view);
   bind_inequality_to_operator<T>(view);
-  bind_dict_update(view, [](T &self, const units::Dim &key,
+  bind_dict_update(view, [](T &self, const sc_units::Dim &key,
                             const Variable &value) { self.set(key, value); });
   bind_pop(view);
   bind_set_aligned(view);

--- a/lib/python/bind_operators.h
+++ b/lib/python/bind_operators.h
@@ -31,7 +31,7 @@ void bind_common_operators(pybind11::class_<T, Ignored...> &c) {
   c.def("__repr__", [](const T &self) { return to_string(self); });
   c.def("__bool__", [](const T &self) {
     if constexpr (std::is_same_v<T, scipp::Variable>) {
-      if (self.unit() != scipp::units::none)
+      if (self.unit() != scipp::sc_units::none)
         throw scipp::except::UnitError(
             "The truth value of a variable with unit is undefined.");
       return self.template value<bool>() == true;
@@ -98,7 +98,7 @@ void bind_astype(py::class_<T, Ignored...> &c) {
         const auto [scipp_dtype, dtype_unit] =
             cast_dtype_and_unit(type, DefaultUnit{});
         if (dtype_unit.has_value() &&
-            (dtype_unit != scipp::units::one && dtype_unit != self.unit())) {
+            (dtype_unit != scipp::sc_units::one && dtype_unit != self.unit())) {
           throw scipp::except::UnitError(scipp::python::format(
               "Conversion of units via the dtype is not allowed. Occurred when "
               "trying to change dtype from ",
@@ -142,7 +142,7 @@ struct Identity {
 };
 struct ScalarToVariable {
   template <class T> scipp::Variable operator()(const T &x) const noexcept {
-    return x * scipp::units::one;
+    return x * scipp::sc_units::one;
   }
 };
 

--- a/lib/python/bins.cpp
+++ b/lib/python/bins.cpp
@@ -45,7 +45,7 @@ auto call_make_bins(const std::optional<Variable> &begin_arg,
       }
     }
   } else if (!end_arg.has_value()) {
-    const auto one = scipp::index{1} * units::none;
+    const auto one = scipp::index{1} * sc_units::none;
     const auto ones = broadcast(one, {dim, data.dims()[dim]});
     const auto begin = cumsum(ones, dim, CumSumMode::Exclusive);
     indices = zip(begin, begin + one);

--- a/lib/python/dtype.h
+++ b/lib/python/dtype.h
@@ -19,7 +19,7 @@ scipp::core::DType dtype_of(const pybind11::object &x);
 
 scipp::core::DType scipp_dtype(const pybind11::object &type);
 
-std::tuple<scipp::core::DType, std::optional<scipp::units::Unit>>
+std::tuple<scipp::core::DType, std::optional<scipp::sc_units::Unit>>
 cast_dtype_and_unit(const pybind11::object &dtype, const ProtoUnit &unit);
 
 void ensure_conversion_possible(scipp::core::DType from, scipp::core::DType to,
@@ -52,7 +52,7 @@ common_dtype(const pybind11::object &values, const pybind11::object &variances,
 
 bool has_datetime_dtype(const pybind11::object &obj);
 
-[[nodiscard]] scipp::units::Unit
+[[nodiscard]] scipp::sc_units::Unit
 parse_datetime_dtype(const std::string &dtype_name);
-[[nodiscard]] scipp::units::Unit
+[[nodiscard]] scipp::sc_units::Unit
 parse_datetime_dtype(const pybind11::object &dtype);

--- a/lib/python/numpy.cpp
+++ b/lib/python/numpy.cpp
@@ -8,7 +8,7 @@
 #include "dtype.h"
 
 void ElementTypeMap<scipp::core::time_point>::check_assignable(
-    const py::object &obj, const units::Unit unit) {
+    const py::object &obj, const sc_units::Unit unit) {
   const auto &dtype = obj.cast<py::array>().dtype();
   if (dtype.attr("kind").cast<char>() == 'i') {
     return; // just assume we can assign from int

--- a/lib/python/numpy.h
+++ b/lib/python/numpy.h
@@ -24,27 +24,27 @@ template <class T> struct ElementTypeMap {
   using PyType = T;
   constexpr static bool convert = false;
 
-  static void check_assignable(const py::object &, const units::Unit &) {}
+  static void check_assignable(const py::object &, const sc_units::Unit &) {}
 };
 
 template <> struct ElementTypeMap<scipp::core::time_point> {
   using PyType = int64_t;
   constexpr static bool convert = true;
 
-  static void check_assignable(const py::object &obj, units::Unit unit);
+  static void check_assignable(const py::object &obj, sc_units::Unit unit);
 };
 
 template <> struct ElementTypeMap<scipp::python::PyObject> {
   using PyType = py::object;
   constexpr static bool convert = true;
 
-  static void check_assignable(const py::object &, const units::Unit &) {}
+  static void check_assignable(const py::object &, const sc_units::Unit &) {}
 };
 
 /// Cast a py::object referring to an array to py::array_t<auto> if supported.
 /// Otherwise, copies the contents into a std::vector<auto>.
 template <class T>
-auto cast_to_array_like(const py::object &obj, const units::Unit unit) {
+auto cast_to_array_like(const py::object &obj, const sc_units::Unit unit) {
   using TM = ElementTypeMap<T>;
   using PyType = typename TM::PyType;
   TM::check_assignable(obj, unit);

--- a/lib/python/transform.cpp
+++ b/lib/python/transform.cpp
@@ -22,9 +22,9 @@ template <class T, class... Ts> void bind_transform(py::module &m) {
                    core::transform_flags::expect_no_variance_arg<1>,
                    core::transform_flags::expect_no_variance_arg<2>,
                    core::transform_flags::expect_no_variance_arg<3>,
-                   [&kernel](const units::Unit &u, const auto &...us) {
+                   [&kernel](const sc_units::Unit &u, const auto &...us) {
                      py::gil_scoped_acquire acquire;
-                     return py::cast<units::Unit>(
+                     return py::cast<sc_units::Unit>(
                          kernel.attr("unit_func")(u, us...));
                    },
                    [fptr](const auto &...args) { return fptr(args...); }},

--- a/lib/python/unit.h
+++ b/lib/python/unit.h
@@ -13,36 +13,36 @@
 
 struct DefaultUnit {};
 
-using ProtoUnit =
-    std::variant<std::string, scipp::units::Unit, pybind11::none, DefaultUnit>;
+using ProtoUnit = std::variant<std::string, scipp::sc_units::Unit,
+                               pybind11::none, DefaultUnit>;
 
-std::tuple<scipp::units::Unit, int64_t>
-get_time_unit(std::optional<scipp::units::Unit> value_unit,
-              std::optional<scipp::units::Unit> dtype_unit,
-              scipp::units::Unit sc_unit);
+std::tuple<scipp::sc_units::Unit, int64_t>
+get_time_unit(std::optional<scipp::sc_units::Unit> value_unit,
+              std::optional<scipp::sc_units::Unit> dtype_unit,
+              scipp::sc_units::Unit sc_unit);
 
-std::tuple<scipp::units::Unit, int64_t>
+std::tuple<scipp::sc_units::Unit, int64_t>
 get_time_unit(const pybind11::buffer &value, const pybind11::object &dtype,
-              scipp::units::Unit unit);
+              scipp::sc_units::Unit unit);
 
 template <class T>
-std::tuple<scipp::units::Unit, scipp::units::Unit>
-common_unit(const pybind11::object &, const scipp::units::Unit unit) {
+std::tuple<scipp::sc_units::Unit, scipp::sc_units::Unit>
+common_unit(const pybind11::object &, const scipp::sc_units::Unit unit) {
   // In the general case, values and variances do not encode units themselves.
   return std::tuple{unit, unit};
 }
 
 template <>
-std::tuple<scipp::units::Unit, scipp::units::Unit>
+std::tuple<scipp::sc_units::Unit, scipp::sc_units::Unit>
 common_unit<scipp::core::time_point>(const pybind11::object &values,
-                                     const scipp::units::Unit unit);
+                                     const scipp::sc_units::Unit unit);
 
 /// Format a time unit as an ASCII string.
 /// Only time units are supported!
 // TODO Can be removed if / when the units library supports this.
-std::string to_numpy_time_string(scipp::units::Unit unit);
+std::string to_numpy_time_string(scipp::sc_units::Unit unit);
 std::string to_numpy_time_string(const ProtoUnit &unit);
 
-scipp::units::Unit
+scipp::sc_units::Unit
 unit_or_default(const ProtoUnit &unit,
                 const scipp::core::DType type = scipp::core::dtype<void>);

--- a/lib/python/variable_creation.cpp
+++ b/lib/python/variable_creation.cpp
@@ -18,7 +18,7 @@ namespace py = pybind11;
 template <class T> struct MakeZeros {
   static variable::Variable apply(const std::vector<std::string> &dims,
                                   const std::vector<scipp::index> &shape,
-                                  const units::Unit &unit,
+                                  const sc_units::Unit &unit,
                                   const bool with_variances) {
     return with_variances
                ? makeVariable<T>(make_dims(dims, shape), unit, Values{},

--- a/lib/python/variable_init.cpp
+++ b/lib/python/variable_init.cpp
@@ -147,7 +147,7 @@ void ensure_is_scalar(const py::buffer &array) {
 }
 
 template <class T>
-T extract_scalar(const py::object &obj, const units::Unit unit) {
+T extract_scalar(const py::object &obj, const sc_units::Unit unit) {
   using TM = ElementTypeMap<T>;
   using PyType = typename TM::PyType;
   TM::check_assignable(obj, unit);
@@ -161,7 +161,7 @@ T extract_scalar(const py::object &obj, const units::Unit unit) {
 
 template <>
 core::time_point extract_scalar<core::time_point>(const py::object &obj,
-                                                  const units::Unit unit) {
+                                                  const sc_units::Unit unit) {
   using TM = ElementTypeMap<core::time_point>;
   using PyType = typename TM::PyType;
   TM::check_assignable(obj, unit);
@@ -177,7 +177,7 @@ core::time_point extract_scalar<core::time_point>(const py::object &obj,
 
 template <>
 python::PyObject extract_scalar<python::PyObject>(const py::object &obj,
-                                                  const units::Unit unit) {
+                                                  const sc_units::Unit unit) {
   using TM = ElementTypeMap<python::PyObject>;
   TM::check_assignable(obj, unit);
   return obj;
@@ -185,7 +185,7 @@ python::PyObject extract_scalar<python::PyObject>(const py::object &obj,
 
 template <class T>
 auto make_element_array(const Dimensions &dims, const py::object &source,
-                        const units::Unit unit) {
+                        const sc_units::Unit unit) {
   if (source.is_none()) {
     return element_array<T>();
   } else if (dims.ndim() == 0) {
@@ -199,7 +199,8 @@ auto make_element_array(const Dimensions &dims, const py::object &source,
 
 template <class T> struct MakeVariable {
   static Variable apply(const Dimensions &dims, const py::object &values,
-                        const py::object &variances, const units::Unit unit) {
+                        const py::object &variances,
+                        const sc_units::Unit unit) {
     const auto [values_unit, final_unit] = common_unit<T>(values, unit);
     auto values_array =
         Values(make_element_array<T>(dims, values, values_unit));
@@ -216,7 +217,8 @@ template <class T> struct MakeVariable {
 
 Variable make_variable(const py::object &dim_labels, const py::object &values,
                        const py::object &variances,
-                       const std::optional<units::Unit> &unit_, DType dtype) {
+                       const std::optional<sc_units::Unit> &unit_,
+                       DType dtype) {
   const auto converted_values = parse_data_sequence(dim_labels, values);
   const auto converted_variances = parse_data_sequence(dim_labels, variances);
   dtype = common_dtype(converted_values, converted_variances, dtype);
@@ -247,7 +249,7 @@ template <class T, class Elem, int... N>
 Variable make_structured_variable(const py::object &dim_labels,
                                   const py::object &values_,
                                   const py::object &variances,
-                                  const std::optional<units::Unit> &unit_) {
+                                  const std::optional<sc_units::Unit> &unit_) {
   if (!variances.is_none())
     throw except::VariancesError("Variances not supported for dtype " +
                                  to_string(dtype<Elem>));

--- a/lib/units/dim.cpp
+++ b/lib/units/dim.cpp
@@ -11,7 +11,7 @@
 #include "scipp/common/index.h"
 #include "scipp/units/dim.h"
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 namespace {
 const auto &builtin_ids() {
@@ -80,4 +80,4 @@ std::string Dim::name() const {
 
 std::string to_string(const Dim dim) { return dim.name(); }
 
-} // namespace scipp::units
+} // namespace scipp::sc_units

--- a/lib/units/except.cpp
+++ b/lib/units/except.cpp
@@ -8,8 +8,8 @@ namespace scipp::except {
 UnitError::UnitError(const std::string &msg) : Error{msg} {}
 
 template <>
-void throw_mismatch_error(const units::Unit &expected,
-                          const units::Unit &actual,
+void throw_mismatch_error(const sc_units::Unit &expected,
+                          const sc_units::Unit &actual,
                           const std::string &optional_message) {
   throw UnitError("Expected unit " + to_string(expected) + ", got " +
                   to_string(actual) + '.' + optional_message);

--- a/lib/units/include/scipp/units/dim.h
+++ b/lib/units/include/scipp/units/dim.h
@@ -9,7 +9,7 @@
 
 #include "scipp-units_export.h"
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 class SCIPP_UNITS_EXPORT Dim {
 public:
@@ -87,17 +87,17 @@ private:
 
 SCIPP_UNITS_EXPORT std::string to_string(const Dim dim);
 
-} // namespace scipp::units
+} // namespace scipp::sc_units
 
 // Hashing required temporarily while we use Dim as a key for the coord dict.
 namespace std {
-template <> struct hash<scipp::units::Dim> {
-  std::size_t operator()(const scipp::units::Dim &k) const {
-    return hash<scipp::units::Dim::Id>()(k.id());
+template <> struct hash<scipp::sc_units::Dim> {
+  std::size_t operator()(const scipp::sc_units::Dim &k) const {
+    return hash<scipp::sc_units::Dim::Id>()(k.id());
   }
 };
 } // namespace std
 
 namespace scipp {
-using scipp::units::Dim;
+using scipp::sc_units::Dim;
 }

--- a/lib/units/include/scipp/units/except.h
+++ b/lib/units/include/scipp/units/except.h
@@ -11,13 +11,14 @@
 
 namespace scipp::except {
 
-struct SCIPP_UNITS_EXPORT UnitError : public Error<units::Unit> {
+struct SCIPP_UNITS_EXPORT UnitError : public Error<sc_units::Unit> {
   explicit UnitError(const std::string &msg);
 };
 
 template <>
 [[noreturn]] SCIPP_UNITS_EXPORT void
-throw_mismatch_error(const units::Unit &expected, const units::Unit &actual,
+throw_mismatch_error(const sc_units::Unit &expected,
+                     const sc_units::Unit &actual,
                      const std::string &optional_message);
 
 } // namespace scipp::except

--- a/lib/units/include/scipp/units/string.h
+++ b/lib/units/include/scipp/units/string.h
@@ -11,12 +11,12 @@
 #include "scipp/units/dim.h"
 #include "scipp/units/unit.h"
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 SCIPP_UNITS_EXPORT std::ostream &operator<<(std::ostream &os, const Dim dim);
 SCIPP_UNITS_EXPORT std::ostream &operator<<(std::ostream &os, const Unit unit);
 
-SCIPP_UNITS_EXPORT std::string to_string(const units::Unit &unit);
+SCIPP_UNITS_EXPORT std::string to_string(const sc_units::Unit &unit);
 template <class T> std::string to_string(const std::initializer_list<T> items);
 
-} // namespace scipp::units
+} // namespace scipp::sc_units

--- a/lib/units/include/scipp/units/unit.h
+++ b/lib/units/include/scipp/units/unit.h
@@ -13,13 +13,12 @@
 
 #include "scipp-units_export.h"
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 class SCIPP_UNITS_EXPORT Unit {
 public:
   constexpr Unit() = default;
-  constexpr explicit Unit(const llnl::units::precise_unit &u) noexcept
-      : m_unit(u) {}
+  constexpr explicit Unit(const units::precise_unit &u) noexcept : m_unit(u) {}
   explicit Unit(const std::string &unit);
 
   [[nodiscard]] constexpr bool has_value() const noexcept {
@@ -66,7 +65,7 @@ public:
   }
 
 private:
-  std::optional<llnl::units::precise_unit> m_unit;
+  std::optional<units::precise_unit> m_unit;
 };
 
 SCIPP_UNITS_EXPORT Unit operator+(const Unit &a, const Unit &b);
@@ -102,30 +101,29 @@ SCIPP_UNITS_EXPORT void add_unit_alias(const std::string &name,
 SCIPP_UNITS_EXPORT void clear_unit_aliases();
 
 constexpr Unit none{};
-constexpr Unit dimensionless{llnl::units::precise::one};
-constexpr Unit one{llnl::units::precise::one}; /// alias for dimensionless
-constexpr Unit m{llnl::units::precise::meter};
-constexpr Unit s{llnl::units::precise::second};
-constexpr Unit kg{llnl::units::precise::kg};
-constexpr Unit K{llnl::units::precise::K};
-constexpr Unit rad{llnl::units::precise::rad};
-constexpr Unit deg{llnl::units::precise::deg};
-constexpr Unit us{llnl::units::precise::micro * llnl::units::precise::second};
-constexpr Unit ns{llnl::units::precise::ns};
-constexpr Unit mm{llnl::units::precise::mm};
-constexpr Unit counts{llnl::units::precise::count};
-constexpr Unit angstrom{llnl::units::precise::distance::angstrom};
-constexpr Unit meV{llnl::units::precise::milli *
-                   llnl::units::precise::energy::eV};
-constexpr Unit c{llnl::units::precise_unit{
-    299792458, llnl::units::precise::m / llnl::units::precise::s}};
+constexpr Unit dimensionless{units::precise::one};
+constexpr Unit one{units::precise::one}; /// alias for dimensionless
+constexpr Unit m{units::precise::meter};
+constexpr Unit s{units::precise::second};
+constexpr Unit kg{units::precise::kg};
+constexpr Unit K{units::precise::K};
+constexpr Unit rad{units::precise::rad};
+constexpr Unit deg{units::precise::deg};
+constexpr Unit us{units::precise::micro * units::precise::second};
+constexpr Unit ns{units::precise::ns};
+constexpr Unit mm{units::precise::mm};
+constexpr Unit counts{units::precise::count};
+constexpr Unit angstrom{units::precise::distance::angstrom};
+constexpr Unit meV{units::precise::milli * units::precise::energy::eV};
+constexpr Unit c{
+    units::precise_unit{299792458, units::precise::m / units::precise::s}};
 
-} // namespace scipp::units
+} // namespace scipp::sc_units
 
 namespace std {
-template <> struct hash<scipp::units::Unit> {
-  std::size_t operator()(const scipp::units::Unit &u) const {
-    return hash<llnl::units::precise_unit>()(u.underlying());
+template <> struct hash<scipp::sc_units::Unit> {
+  std::size_t operator()(const scipp::sc_units::Unit &u) const {
+    return hash<units::precise_unit>()(u.underlying());
   }
 };
 } // namespace std

--- a/lib/units/string.cpp
+++ b/lib/units/string.cpp
@@ -5,7 +5,7 @@
 #include "scipp/units/string.h"
 #include <sstream>
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 std::ostream &operator<<(std::ostream &os, const Dim dim) {
   return os << to_string(dim);
@@ -15,7 +15,7 @@ std::ostream &operator<<(std::ostream &os, const Unit unit) {
   return os << to_string(unit);
 }
 
-std::string to_string(const units::Unit &unit) { return unit.name(); }
+std::string to_string(const sc_units::Unit &unit) { return unit.name(); }
 
 template <class T> std::string to_string(const std::initializer_list<T> items) {
   std::stringstream ss;
@@ -27,7 +27,7 @@ template <class T> std::string to_string(const std::initializer_list<T> items) {
   return ss.str();
 }
 
-template SCIPP_UNITS_EXPORT std::string to_string<scipp::units::Unit>(
-    const std::initializer_list<scipp::units::Unit> items);
+template SCIPP_UNITS_EXPORT std::string to_string<scipp::sc_units::Unit>(
+    const std::initializer_list<scipp::sc_units::Unit> items);
 
-} // namespace scipp::units
+} // namespace scipp::sc_units

--- a/lib/units/test/dim_test.cpp
+++ b/lib/units/test/dim_test.cpp
@@ -9,7 +9,7 @@
 #include "scipp/common/index.h"
 #include "scipp/units/dim.h"
 
-using namespace scipp::units;
+using namespace scipp::sc_units;
 
 TEST(DimTest, basics) {
   EXPECT_EQ(Dim(), Dim(Dim::Invalid));

--- a/lib/units/test/unit_test.cpp
+++ b/lib/units/test/unit_test.cpp
@@ -8,23 +8,23 @@
 #include "scipp/units/unit.h"
 
 using namespace scipp;
-using scipp::units::Unit;
+using scipp::sc_units::Unit;
 
 TEST(UnitTest, c) {
-  EXPECT_EQ(units::c.underlying().multiplier(), 299792458.0);
+  EXPECT_EQ(sc_units::c.underlying().multiplier(), 299792458.0);
 }
 
 TEST(UnitTest, cancellation) {
-  EXPECT_EQ(Unit(units::deg / units::deg), units::dimensionless);
-  EXPECT_EQ(units::deg / units::deg, units::dimensionless);
-  EXPECT_EQ(units::deg * Unit(units::rad / units::deg), units::rad);
+  EXPECT_EQ(Unit(sc_units::deg / sc_units::deg), sc_units::dimensionless);
+  EXPECT_EQ(sc_units::deg / sc_units::deg, sc_units::dimensionless);
+  EXPECT_EQ(sc_units::deg * Unit(sc_units::rad / sc_units::deg), sc_units::rad);
 }
 
-TEST(UnitTest, construct) { ASSERT_NO_THROW(Unit{units::dimensionless}); }
+TEST(UnitTest, construct) { ASSERT_NO_THROW(Unit{sc_units::dimensionless}); }
 
 TEST(UnitTest, construct_default) {
   Unit u;
-  ASSERT_EQ(u, units::none);
+  ASSERT_EQ(u, sc_units::none);
 }
 
 TEST(UnitTest, construct_bad_string) {
@@ -42,17 +42,17 @@ TEST(UnitTest, custom_unit_strings_get_rejected) {
 TEST(UnitTest, overflows) {
   // These would run out of bits in llnl/units and wrap, ensure that scipp
   // prevents this and throws instead.
-  Unit m64{pow(units::m, 64)};
-  Unit inv_m128{units::one / m64 / m64};
+  Unit m64{pow(sc_units::m, 64)};
+  Unit inv_m128{sc_units::one / m64 / m64};
   EXPECT_THROW(m64 * m64, except::UnitError);
-  EXPECT_THROW(units::one / inv_m128, except::UnitError);
-  EXPECT_THROW(inv_m128 / units::m, except::UnitError);
-  EXPECT_THROW(pow(units::m, 128), except::UnitError);
+  EXPECT_THROW(sc_units::one / inv_m128, except::UnitError);
+  EXPECT_THROW(inv_m128 / sc_units::m, except::UnitError);
+  EXPECT_THROW(pow(sc_units::m, 128), except::UnitError);
 }
 
 TEST(UnitTest, compare) {
-  Unit u1{units::dimensionless};
-  Unit u2{units::m};
+  Unit u1{sc_units::dimensionless};
+  Unit u2{sc_units::m};
   ASSERT_TRUE(u1 == u1);
   ASSERT_TRUE(u1 != u2);
   ASSERT_TRUE(u2 == u2);
@@ -61,9 +61,9 @@ TEST(UnitTest, compare) {
 }
 
 TEST(UnitTest, add) {
-  Unit a{units::dimensionless};
-  Unit b{units::m};
-  Unit c{units::m * units::m};
+  Unit a{sc_units::dimensionless};
+  Unit b{sc_units::m};
+  Unit c{sc_units::m * sc_units::m};
   EXPECT_EQ(a + a, a);
   EXPECT_EQ(b + b, b);
   EXPECT_EQ(c + c, c);
@@ -76,36 +76,36 @@ TEST(UnitTest, add) {
 }
 
 TEST(UnitTest, multiply) {
-  Unit a{units::dimensionless};
-  Unit b{units::m};
-  Unit c{units::m * units::m};
+  Unit a{sc_units::dimensionless};
+  Unit b{sc_units::m};
+  Unit c{sc_units::m * sc_units::m};
   EXPECT_EQ(a * a, a);
   EXPECT_EQ(a * b, b);
   EXPECT_EQ(b * a, b);
   EXPECT_EQ(a * c, c);
   EXPECT_EQ(c * a, c);
   EXPECT_EQ(b * b, c);
-  EXPECT_EQ(b * c, units::m * units::m * units::m);
-  EXPECT_EQ(c * b, units::m * units::m * units::m);
+  EXPECT_EQ(b * c, sc_units::m * sc_units::m * sc_units::m);
+  EXPECT_EQ(c * b, sc_units::m * sc_units::m * sc_units::m);
 }
 
 TEST(UnitTest, counts_variances) {
-  Unit counts{units::counts};
-  EXPECT_EQ(counts * counts, units::Unit("counts**2"));
+  Unit counts{sc_units::counts};
+  EXPECT_EQ(counts * counts, sc_units::Unit("counts**2"));
 }
 
 TEST(UnitTest, multiply_counts) {
-  Unit counts{units::counts};
-  Unit none{units::dimensionless};
+  Unit counts{sc_units::counts};
+  Unit none{sc_units::dimensionless};
   EXPECT_EQ(counts * none, counts);
   EXPECT_EQ(none * counts, counts);
 }
 
 TEST(UnitTest, divide) {
-  Unit one{units::dimensionless};
-  Unit l{units::m};
-  Unit t{units::s};
-  Unit v{units::m / units::s};
+  Unit one{sc_units::dimensionless};
+  Unit l{sc_units::m};
+  Unit t{sc_units::s};
+  Unit v{sc_units::m / sc_units::s};
   EXPECT_EQ(l / one, l);
   EXPECT_EQ(t / one, t);
   EXPECT_EQ(l / l, one);
@@ -113,15 +113,15 @@ TEST(UnitTest, divide) {
 }
 
 TEST(UnitTest, divide_counts) {
-  Unit counts{units::counts};
-  EXPECT_EQ(counts / counts, units::dimensionless);
+  Unit counts{sc_units::counts};
+  EXPECT_EQ(counts / counts, sc_units::dimensionless);
 }
 
 TEST(UnitTest, modulo) {
-  Unit one{units::dimensionless};
-  Unit l{units::m};
-  Unit t{units::s};
-  Unit none{units::none};
+  Unit one{sc_units::dimensionless};
+  Unit l{sc_units::m};
+  Unit t{sc_units::s};
+  Unit none{sc_units::none};
   EXPECT_EQ(l % l, l);
   EXPECT_EQ(t % t, t);
   EXPECT_THROW(l % t, except::UnitError);
@@ -131,149 +131,150 @@ TEST(UnitTest, modulo) {
 }
 
 TEST(UnitTest, pow) {
-  EXPECT_EQ(pow(units::m, 0), units::one);
-  EXPECT_EQ(pow(units::m, 1), units::m);
-  EXPECT_EQ(pow(units::m, 2), units::m * units::m);
-  EXPECT_EQ(pow(units::m, -1), units::one / units::m);
+  EXPECT_EQ(pow(sc_units::m, 0), sc_units::one);
+  EXPECT_EQ(pow(sc_units::m, 1), sc_units::m);
+  EXPECT_EQ(pow(sc_units::m, 2), sc_units::m * sc_units::m);
+  EXPECT_EQ(pow(sc_units::m, -1), sc_units::one / sc_units::m);
 }
 
 TEST(UnitTest, neutron_units) {
-  Unit c(units::c);
-  EXPECT_EQ(c * units::m, Unit(units::c * units::m));
-  EXPECT_EQ(c * units::m / units::m, units::c);
-  EXPECT_EQ(units::meV / c, Unit(units::meV / units::c));
-  EXPECT_EQ(units::meV / c / units::meV, Unit(units::dimensionless / units::c));
+  Unit c(sc_units::c);
+  EXPECT_EQ(c * sc_units::m, Unit(sc_units::c * sc_units::m));
+  EXPECT_EQ(c * sc_units::m / sc_units::m, sc_units::c);
+  EXPECT_EQ(sc_units::meV / c, Unit(sc_units::meV / sc_units::c));
+  EXPECT_EQ(sc_units::meV / c / sc_units::meV,
+            Unit(sc_units::dimensionless / sc_units::c));
 }
 
 TEST(UnitTest, isCounts) {
-  EXPECT_FALSE(units::dimensionless.isCounts());
-  EXPECT_TRUE(units::counts.isCounts());
-  EXPECT_FALSE(Unit(units::counts / units::us).isCounts());
-  EXPECT_FALSE(Unit(units::counts / units::meV).isCounts());
-  EXPECT_FALSE(Unit(units::dimensionless / units::m).isCounts());
+  EXPECT_FALSE(sc_units::dimensionless.isCounts());
+  EXPECT_TRUE(sc_units::counts.isCounts());
+  EXPECT_FALSE(Unit(sc_units::counts / sc_units::us).isCounts());
+  EXPECT_FALSE(Unit(sc_units::counts / sc_units::meV).isCounts());
+  EXPECT_FALSE(Unit(sc_units::dimensionless / sc_units::m).isCounts());
 }
 
 TEST(UnitTest, isCountDensity) {
-  EXPECT_FALSE(units::dimensionless.isCountDensity());
-  EXPECT_FALSE(units::counts.isCountDensity());
-  EXPECT_TRUE(Unit(units::counts / units::us).isCountDensity());
-  EXPECT_TRUE(Unit(units::counts / units::meV).isCountDensity());
-  EXPECT_FALSE(Unit(units::dimensionless / units::m).isCountDensity());
+  EXPECT_FALSE(sc_units::dimensionless.isCountDensity());
+  EXPECT_FALSE(sc_units::counts.isCountDensity());
+  EXPECT_TRUE(Unit(sc_units::counts / sc_units::us).isCountDensity());
+  EXPECT_TRUE(Unit(sc_units::counts / sc_units::meV).isCountDensity());
+  EXPECT_FALSE(Unit(sc_units::dimensionless / sc_units::m).isCountDensity());
 }
 
 TEST(UnitFunctionsTest, abs) {
-  EXPECT_EQ(abs(units::one), units::one);
-  EXPECT_EQ(abs(units::m), units::m);
+  EXPECT_EQ(abs(sc_units::one), sc_units::one);
+  EXPECT_EQ(abs(sc_units::m), sc_units::m);
 }
 
 TEST(UnitFunctionsTest, ceil) {
-  EXPECT_EQ(ceil(units::one), units::one);
-  EXPECT_EQ(ceil(units::m), units::m);
+  EXPECT_EQ(ceil(sc_units::one), sc_units::one);
+  EXPECT_EQ(ceil(sc_units::m), sc_units::m);
 }
 
 TEST(UnitFunctionsTest, floor) {
-  EXPECT_EQ(floor(units::one), units::one);
-  EXPECT_EQ(floor(units::m), units::m);
+  EXPECT_EQ(floor(sc_units::one), sc_units::one);
+  EXPECT_EQ(floor(sc_units::m), sc_units::m);
 }
 
 TEST(UnitFunctionsTest, rint) {
-  EXPECT_EQ(rint(units::one), units::one);
-  EXPECT_EQ(rint(units::m), units::m);
+  EXPECT_EQ(rint(sc_units::one), sc_units::one);
+  EXPECT_EQ(rint(sc_units::m), sc_units::m);
 }
 
 TEST(UnitFunctionsTest, sqrt) {
-  EXPECT_EQ(sqrt(units::m * units::m), units::m);
-  EXPECT_EQ(sqrt(units::counts * units::counts), units::counts);
-  EXPECT_EQ(sqrt(units::one), units::one);
-  EXPECT_THROW_MSG(sqrt(units::m), except::UnitError,
+  EXPECT_EQ(sqrt(sc_units::m * sc_units::m), sc_units::m);
+  EXPECT_EQ(sqrt(sc_units::counts * sc_units::counts), sc_units::counts);
+  EXPECT_EQ(sqrt(sc_units::one), sc_units::one);
+  EXPECT_THROW_MSG(sqrt(sc_units::m), except::UnitError,
                    "Unsupported unit as result of sqrt: sqrt(m).");
-  EXPECT_THROW_MSG(sqrt(units::Unit("J")), except::UnitError,
+  EXPECT_THROW_MSG(sqrt(sc_units::Unit("J")), except::UnitError,
                    "Unsupported unit as result of sqrt: sqrt(J).");
-  EXPECT_THROW_MSG(sqrt(units::Unit("eV")), except::UnitError,
+  EXPECT_THROW_MSG(sqrt(sc_units::Unit("eV")), except::UnitError,
                    "Unsupported unit as result of sqrt: sqrt(eV).");
 }
 
 TEST(UnitFunctionsTest, sin) {
-  EXPECT_EQ(sin(units::rad), units::dimensionless);
-  EXPECT_EQ(sin(units::deg), units::dimensionless);
-  EXPECT_THROW(sin(units::m), except::UnitError);
-  EXPECT_THROW(sin(units::dimensionless), except::UnitError);
+  EXPECT_EQ(sin(sc_units::rad), sc_units::dimensionless);
+  EXPECT_EQ(sin(sc_units::deg), sc_units::dimensionless);
+  EXPECT_THROW(sin(sc_units::m), except::UnitError);
+  EXPECT_THROW(sin(sc_units::dimensionless), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, cos) {
-  EXPECT_EQ(cos(units::rad), units::dimensionless);
-  EXPECT_EQ(cos(units::deg), units::dimensionless);
-  EXPECT_THROW(cos(units::m), except::UnitError);
-  EXPECT_THROW(cos(units::dimensionless), except::UnitError);
+  EXPECT_EQ(cos(sc_units::rad), sc_units::dimensionless);
+  EXPECT_EQ(cos(sc_units::deg), sc_units::dimensionless);
+  EXPECT_THROW(cos(sc_units::m), except::UnitError);
+  EXPECT_THROW(cos(sc_units::dimensionless), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, tan) {
-  EXPECT_EQ(tan(units::rad), units::dimensionless);
-  EXPECT_EQ(tan(units::deg), units::dimensionless);
-  EXPECT_THROW(tan(units::m), except::UnitError);
-  EXPECT_THROW(tan(units::dimensionless), except::UnitError);
+  EXPECT_EQ(tan(sc_units::rad), sc_units::dimensionless);
+  EXPECT_EQ(tan(sc_units::deg), sc_units::dimensionless);
+  EXPECT_THROW(tan(sc_units::m), except::UnitError);
+  EXPECT_THROW(tan(sc_units::dimensionless), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, asin) {
-  EXPECT_EQ(asin(units::dimensionless), units::rad);
-  EXPECT_THROW(asin(units::m), except::UnitError);
-  EXPECT_THROW(asin(units::rad), except::UnitError);
-  EXPECT_THROW(asin(units::deg), except::UnitError);
+  EXPECT_EQ(asin(sc_units::dimensionless), sc_units::rad);
+  EXPECT_THROW(asin(sc_units::m), except::UnitError);
+  EXPECT_THROW(asin(sc_units::rad), except::UnitError);
+  EXPECT_THROW(asin(sc_units::deg), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, acos) {
-  EXPECT_EQ(acos(units::dimensionless), units::rad);
-  EXPECT_THROW(acos(units::m), except::UnitError);
-  EXPECT_THROW(acos(units::rad), except::UnitError);
-  EXPECT_THROW(acos(units::deg), except::UnitError);
+  EXPECT_EQ(acos(sc_units::dimensionless), sc_units::rad);
+  EXPECT_THROW(acos(sc_units::m), except::UnitError);
+  EXPECT_THROW(acos(sc_units::rad), except::UnitError);
+  EXPECT_THROW(acos(sc_units::deg), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, atan) {
-  EXPECT_EQ(atan(units::dimensionless), units::rad);
-  EXPECT_THROW(atan(units::m), except::UnitError);
-  EXPECT_THROW(atan(units::rad), except::UnitError);
-  EXPECT_THROW(atan(units::deg), except::UnitError);
+  EXPECT_EQ(atan(sc_units::dimensionless), sc_units::rad);
+  EXPECT_THROW(atan(sc_units::m), except::UnitError);
+  EXPECT_THROW(atan(sc_units::rad), except::UnitError);
+  EXPECT_THROW(atan(sc_units::deg), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, atan2) {
-  EXPECT_EQ(atan2(units::m, units::m), units::rad);
-  EXPECT_EQ(atan2(units::s, units::s), units::rad);
-  EXPECT_THROW(atan2(units::m, units::s), except::UnitError);
+  EXPECT_EQ(atan2(sc_units::m, sc_units::m), sc_units::rad);
+  EXPECT_EQ(atan2(sc_units::s, sc_units::s), sc_units::rad);
+  EXPECT_THROW(atan2(sc_units::m, sc_units::s), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, sinh) {
-  EXPECT_EQ(sinh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(sinh(units::m), except::UnitError);
+  EXPECT_EQ(sinh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(sinh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, cosh) {
-  EXPECT_EQ(cosh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(cosh(units::m), except::UnitError);
+  EXPECT_EQ(cosh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(cosh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, tanh) {
-  EXPECT_EQ(tanh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(tanh(units::m), except::UnitError);
+  EXPECT_EQ(tanh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(tanh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, asinh) {
-  EXPECT_EQ(asinh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(asinh(units::m), except::UnitError);
+  EXPECT_EQ(asinh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(asinh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, acosh) {
-  EXPECT_EQ(acosh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(acosh(units::m), except::UnitError);
+  EXPECT_EQ(acosh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(acosh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitFunctionsTest, atanh) {
-  EXPECT_EQ(atanh(units::dimensionless), units::dimensionless);
-  EXPECT_THROW(atanh(units::m), except::UnitError);
+  EXPECT_EQ(atanh(sc_units::dimensionless), sc_units::dimensionless);
+  EXPECT_THROW(atanh(sc_units::m), except::UnitError);
 }
 
 TEST(UnitParseTest, singular_plural) {
-  EXPECT_EQ(units::Unit("counts"), units::counts);
-  EXPECT_EQ(units::Unit("count"), units::counts);
+  EXPECT_EQ(sc_units::Unit("counts"), sc_units::counts);
+  EXPECT_EQ(sc_units::Unit("count"), sc_units::counts);
 }
 
 TEST(UnitFormatTest, roundtrip_string) {
@@ -282,9 +283,9 @@ TEST(UnitFormatTest, roundtrip_string) {
         "ns",       "counts",    "counts^2", "counts/meV", "1/counts",
         "counts/m", "rad",       "$",        "Y",          "M",
         "D",        "arb. unit", "EQXUN[1]", "EQXUN[23]",  "°C"}) {
-    const auto unit = units::Unit(s);
+    const auto unit = sc_units::Unit(s);
     EXPECT_EQ(to_string(unit), s);
-    EXPECT_EQ(units::Unit(to_string(unit)), unit);
+    EXPECT_EQ(sc_units::Unit(to_string(unit)), unit);
   }
 }
 
@@ -293,14 +294,14 @@ TEST(UnitFormatTest, roundtrip_unit) {
   // some are actually formatted badly right now, but at least roundtrip works.
   for (const auto &s : {"us", "angstrom", "counts/us", "Y", "M", "D",
                         "decibels", "a.u.", "arbitraryunit", "Sv", "degC"}) {
-    const auto unit = units::Unit(s);
-    EXPECT_EQ(units::Unit(to_string(unit)), unit);
+    const auto unit = sc_units::Unit(s);
+    EXPECT_EQ(sc_units::Unit(to_string(unit)), unit);
   }
 }
 
 TEST(UnitTest, binary_operations_with_one_none_operand_throw_UnitError) {
-  using units::none;
-  const auto u = units::m;
+  using sc_units::none;
+  const auto u = sc_units::m;
   EXPECT_THROW_DISCARD(none + u, except::UnitError);
   EXPECT_THROW_DISCARD(u + none, except::UnitError);
   EXPECT_THROW_DISCARD(none - u, except::UnitError);
@@ -317,8 +318,8 @@ TEST(UnitTest, binary_operations_with_one_none_operand_throw_UnitError) {
 
 TEST(UnitTest,
      inplace_binary_operations_with_one_none_operand_throw_UnitError) {
-  auto none = units::none;
-  auto u = units::m;
+  auto none = sc_units::none;
+  auto u = sc_units::m;
   EXPECT_THROW_DISCARD(none += u, except::UnitError);
   EXPECT_THROW_DISCARD(u += none, except::UnitError);
   EXPECT_THROW_DISCARD(none -= u, except::UnitError);
@@ -332,7 +333,7 @@ TEST(UnitTest,
 }
 
 TEST(UnitTest, binary_operations_with_two_none_operands_return_none) {
-  using units::none;
+  using sc_units::none;
   EXPECT_EQ(none + none, none);
   EXPECT_EQ(none - none, none);
   EXPECT_EQ(none * none, none);
@@ -341,14 +342,14 @@ TEST(UnitTest, binary_operations_with_two_none_operands_return_none) {
 }
 
 TEST(UnitTest, trigonometric_of_none_throw_UnitError) {
-  using units::none;
+  using sc_units::none;
   EXPECT_THROW_DISCARD(sin(none), except::UnitError);
   EXPECT_THROW_DISCARD(cos(none), except::UnitError);
   EXPECT_THROW_DISCARD(tan(none), except::UnitError);
 }
 
 TEST(UnitTest, inverse_trigonometric_of_none_throw_UnitError) {
-  using units::none;
+  using sc_units::none;
   EXPECT_THROW_DISCARD(asin(none), except::UnitError);
   EXPECT_THROW_DISCARD(acos(none), except::UnitError);
   EXPECT_THROW_DISCARD(atan(none), except::UnitError);
@@ -356,9 +357,9 @@ TEST(UnitTest, inverse_trigonometric_of_none_throw_UnitError) {
 }
 
 TEST(UnitTest, sqrt_of_none_returns_none) {
-  EXPECT_EQ(sqrt(units::none), units::none);
+  EXPECT_EQ(sqrt(sc_units::none), sc_units::none);
 }
 
 TEST(UnitTest, pow_of_none_returns_none) {
-  EXPECT_EQ(sqrt(units::none), units::none);
+  EXPECT_EQ(sqrt(sc_units::none), sc_units::none);
 }

--- a/lib/units/unit.cpp
+++ b/lib/units/unit.cpp
@@ -12,7 +12,7 @@
 #include "scipp/units/except.h"
 #include "scipp/units/unit.h"
 
-namespace scipp::units {
+namespace scipp::sc_units {
 
 namespace {
 std::string map_unit_string(const std::string &unit) {
@@ -26,8 +26,8 @@ std::string map_unit_string(const std::string &unit) {
                                           : unit;
 }
 
-bool is_special_unit(const llnl::units::precise_unit &unit) {
-  using namespace llnl::units::precise::custom;
+bool is_special_unit(const units::precise_unit &unit) {
+  using namespace units::precise::custom;
   const auto &base = unit.base_units();
 
   // Allowing custom_count_unit_number == 1 because that is 'arbitrary unit'
@@ -38,8 +38,7 @@ bool is_special_unit(const llnl::units::precise_unit &unit) {
 } // namespace
 
 Unit::Unit(const std::string &unit)
-    : Unit(llnl::units::unit_from_string(map_unit_string(unit),
-                                         llnl::units::strict_si)) {
+    : Unit(units::unit_from_string(map_unit_string(unit), units::strict_si)) {
   if (const auto &u = m_unit.value(); is_special_unit(u) || !is_valid(u))
     throw except::UnitError("Failed to convert string `" + unit +
                             "` to valid unit.");
@@ -111,7 +110,7 @@ Unit operator*(const Unit &a, const Unit &b) {
     return none;
   expect_not_none(a, "multiply");
   expect_not_none(b, "multiply");
-  if (llnl::units::times_overflows(a.underlying(), b.underlying()))
+  if (units::times_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of multiplication: (" +
                             a.name() + ") * (" + b.name() + ')');
   return Unit{a.underlying() * b.underlying()};
@@ -122,7 +121,7 @@ Unit operator/(const Unit &a, const Unit &b) {
     return none;
   expect_not_none(a, "divide");
   expect_not_none(b, "divide");
-  if (llnl::units::divides_overflows(a.underlying(), b.underlying()))
+  if (units::divides_overflows(a.underlying(), b.underlying()))
     throw except::UnitError("Unsupported unit as result of division: (" +
                             a.name() + ") / (" + b.name() + ')');
   return Unit{a.underlying() / b.underlying()};
@@ -148,7 +147,7 @@ Unit rint(const Unit &a) { return a; }
 Unit sqrt(const Unit &a) {
   if (a == none)
     return a;
-  if (llnl::units::is_error(sqrt(a.underlying())))
+  if (units::is_error(sqrt(a.underlying())))
     throw except::UnitError("Unsupported unit as result of sqrt: sqrt(" +
                             a.name() + ").");
   return Unit{sqrt(a.underlying())};
@@ -157,22 +156,22 @@ Unit sqrt(const Unit &a) {
 Unit pow(const Unit &a, const int64_t power) {
   if (a == none)
     return a;
-  if (llnl::units::pow_overflows(a.underlying(), static_cast<int>(power)))
+  if (units::pow_overflows(a.underlying(), static_cast<int>(power)))
     throw except::UnitError("Unsupported unit as result of pow: pow(" +
                             a.name() + ", " + std::to_string(power) + ").");
   return Unit{a.underlying().pow(static_cast<int>(power))};
 }
 
 Unit trigonometric(const Unit &a) {
-  if (a == units::rad || a == units::deg)
-    return units::dimensionless;
+  if (a == sc_units::rad || a == sc_units::deg)
+    return sc_units::dimensionless;
   throw except::UnitError(
       "Trigonometric function requires rad or deg unit, got " + a.name() + ".");
 }
 
 Unit inverse_trigonometric(const Unit &a) {
-  if (a == units::dimensionless)
-    return units::rad;
+  if (a == sc_units::dimensionless)
+    return sc_units::rad;
   throw except::UnitError(
       "Inverse trigonometric function requires dimensionless unit, got " +
       a.name() + ".");
@@ -188,15 +187,15 @@ Unit atan2(const Unit &y, const Unit &x) {
   expect_not_none(x, "atan2");
   expect_not_none(y, "atan2");
   if (x == y)
-    return units::rad;
+    return sc_units::rad;
   throw except::UnitError(
       "atan2 function requires matching units for input, got a " + x.name() +
       " b " + y.name() + ".");
 }
 
 Unit hyperbolic(const Unit &a) {
-  if (a == units::dimensionless)
-    return units::dimensionless;
+  if (a == sc_units::dimensionless)
+    return sc_units::dimensionless;
   throw except::UnitError(
       "Hyperbolic function requires dimensionless input, got " + a.name() +
       ".");
@@ -215,9 +214,9 @@ bool identical(const Unit &a, const Unit &b) {
 }
 
 void add_unit_alias(const std::string &name, const Unit &unit) {
-  llnl::units::addUserDefinedUnit(name, unit.underlying());
+  units::addUserDefinedUnit(name, unit.underlying());
 }
 
-void clear_unit_aliases() { llnl::units::clearUserDefinedUnits(); }
+void clear_unit_aliases() { units::clearUserDefinedUnits(); }
 
-} // namespace scipp::units
+} // namespace scipp::sc_units

--- a/lib/variable/arithmetic.cpp
+++ b/lib/variable/arithmetic.cpp
@@ -20,9 +20,9 @@ bool is_transform_with_translation(const Variable &var) {
 }
 
 auto make_factor(const Variable &prototype, const double value) {
-  const auto unit = variableFactory().elem_unit(prototype) == units::none
-                        ? units::none
-                        : units::one;
+  const auto unit = variableFactory().elem_unit(prototype) == sc_units::none
+                        ? sc_units::none
+                        : sc_units::one;
   return astype(makeVariable<double>(Values{value}, unit),
                 variableFactory().elem_dtype(prototype));
 }

--- a/lib/variable/astype.cpp
+++ b/lib/variable/astype.cpp
@@ -44,7 +44,7 @@ struct MakeVariableWithType {
       return transform<SourceTypes...>(
           parent,
           overloaded{
-              expect_input_variances, [](const units::Unit &x) { return x; },
+              expect_input_variances, [](const sc_units::Unit &x) { return x; },
               [](const auto &x) {
                 if constexpr (is_ValueAndVariance_v<std::decay_t<decltype(x)>>)
                   return ValueAndVariance<T>{static_cast<T>(x.value),

--- a/lib/variable/bin_detail.cpp
+++ b/lib/variable/bin_detail.cpp
@@ -20,7 +20,7 @@ namespace scipp::variable::bin_detail {
 /// 0 if the coord is less than the first edge, nbin-1 if greater or equal last
 /// edge. Assumes both `edges` and `coord` are sorted.
 Variable begin_edge(const Variable &coord, const Variable &edges) {
-  auto indices = makeVariable<scipp::index>(coord.dims(), units::none);
+  auto indices = makeVariable<scipp::index>(coord.dims(), sc_units::none);
   const auto dim = edges.dims().inner();
   if (indices.dims()[dim] == 0)
     return indices;
@@ -36,7 +36,7 @@ Variable begin_edge(const Variable &coord, const Variable &edges) {
 /// nbin if the coord is greater than the last edge. Assumes both `edges` and
 /// `coord` are sorted.
 Variable end_edge(const Variable &coord, const Variable &edges) {
-  auto indices = makeVariable<scipp::index>(coord.dims(), units::none);
+  auto indices = makeVariable<scipp::index>(coord.dims(), sc_units::none);
   const auto dim = edges.dims().inner();
   if (indices.dims()[dim] == 0)
     return indices;
@@ -49,7 +49,7 @@ Variable end_edge(const Variable &coord, const Variable &edges) {
 Variable cumsum_exclusive_subbin_sizes(const Variable &var) {
   return transform<core::SubbinSizes>(
       var,
-      overloaded{[](const units::Unit &u) { return u; },
+      overloaded{[](const sc_units::Unit &u) { return u; },
                  [](const auto &sizes) { return sizes.cumsum_exclusive(); }},
       "scipp.bin.cumsum_exclusive");
 }
@@ -57,7 +57,7 @@ Variable cumsum_exclusive_subbin_sizes(const Variable &var) {
 Variable sum_subbin_sizes(const Variable &var) {
   return transform<core::SubbinSizes>(
       var,
-      overloaded{[](const units::Unit &u) { return u; },
+      overloaded{[](const sc_units::Unit &u) { return u; },
                  [](const auto &sizes) { return sizes.sum(); }},
       "scipp.bin.sum_subbin_sizes");
 }

--- a/lib/variable/bins.cpp
+++ b/lib/variable/bins.cpp
@@ -36,7 +36,7 @@ Variable bin_sizes(const Variable &var) {
     const auto [begin, end] = unzip(var.bin_indices());
     return end - begin;
   }
-  return makeVariable<scipp::index>(var.dims(), units::none);
+  return makeVariable<scipp::index>(var.dims(), sc_units::none);
 }
 
 void copy_slices(const Variable &src, Variable dst, const Dim dim,

--- a/lib/variable/comparison.cpp
+++ b/lib/variable/comparison.cpp
@@ -35,8 +35,9 @@ try_isclose_spatial(const Variable &a, const Variable &b, const Variable &rtol,
 
 void expect_rtol_unit_dimensionless_or_none(const Variable &rtol,
                                             const Variable &ref) {
-  const auto expected = ref.unit() == units::none ? scipp::units::none
-                                                  : scipp::units::dimensionless;
+  const auto expected = ref.unit() == sc_units::none
+                            ? scipp::sc_units::none
+                            : scipp::sc_units::dimensionless;
   core::expect::equals(expected, rtol.unit(), " For rtol arg");
 }
 } // namespace

--- a/lib/variable/creation.cpp
+++ b/lib/variable/creation.cpp
@@ -11,7 +11,7 @@
 
 namespace scipp::variable {
 
-Variable empty(const Dimensions &dims, const units::Unit &unit,
+Variable empty(const Dimensions &dims, const sc_units::Unit &unit,
                const DType type, const bool with_variances,
                const bool aligned) {
   auto var = variableFactory().create(type, dims, unit, with_variances);
@@ -19,8 +19,8 @@ Variable empty(const Dimensions &dims, const units::Unit &unit,
   return var;
 }
 
-Variable ones(const Dimensions &dims, const units::Unit &unit, const DType type,
-              const bool with_variances) {
+Variable ones(const Dimensions &dims, const sc_units::Unit &unit,
+              const DType type, const bool with_variances) {
   const auto make_prototype = [&](auto &&one) {
     return with_variances
                ? Variable{type, Dimensions{}, unit, Values{one}, Variances{one}}

--- a/lib/variable/include/scipp/variable/arithmetic.h
+++ b/lib/variable/include/scipp/variable/arithmetic.h
@@ -35,20 +35,20 @@ SCIPP_VARIABLE_EXPORT Variable floor_divide_equals(Variable &&a,
 
 } // namespace scipp::variable
 
-namespace scipp::units {
+namespace scipp::sc_units {
 template <typename T>
 std::enable_if_t<std::is_arithmetic_v<T> ||
                      std::is_same_v<T, scipp::core::time_point>,
                  Variable>
-operator*(T v, const units::Unit &unit) {
-  return makeVariable<T>(units::Unit{unit}, Values{v});
+operator*(T v, const sc_units::Unit &unit) {
+  return makeVariable<T>(sc_units::Unit{unit}, Values{v});
 }
 
 template <typename T>
 std::enable_if_t<std::is_arithmetic_v<T> ||
                      std::is_same_v<T, scipp::core::time_point>,
                  Variable>
-operator/(T v, const units::Unit &unit) {
-  return makeVariable<T>(units::one / unit, Values{v});
+operator/(T v, const sc_units::Unit &unit) {
+  return makeVariable<T>(sc_units::one / unit, Values{v});
 }
-} // namespace scipp::units
+} // namespace scipp::sc_units

--- a/lib/variable/include/scipp/variable/bin_array_model.h
+++ b/lib/variable/include/scipp/variable/bin_array_model.h
@@ -22,12 +22,12 @@ namespace scipp::variable {
 template <class Indices> class BinModelBase : public VariableConcept {
 public:
   BinModelBase(const VariableConceptHandle &indices, const Dim dim)
-      : VariableConcept(units::none), m_indices(indices), m_dim(dim) {}
+      : VariableConcept(sc_units::none), m_indices(indices), m_dim(dim) {}
 
   scipp::index size() const override { return indices()->size(); }
 
-  void setUnit(const units::Unit &unit) override {
-    if (unit != units::none)
+  void setUnit(const sc_units::Unit &unit) override {
+    if (unit != sc_units::none)
       throw except::UnitError(
           "Bins cannot have a unit. Did you mean to set the unit of the bin "
           "elements? This can be set with `array.bins.unit = 'm'`.");

--- a/lib/variable/include/scipp/variable/bin_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/bin_array_variable.tcc
@@ -110,7 +110,7 @@ private:
   virtual Variable call_make_bins(const Variable &parent,
                                   const Variable &indices, const Dim dim,
                                   const DType type, const Dimensions &dims,
-                                  const units::Unit &unit,
+                                  const sc_units::Unit &unit,
                                   const bool variances) const = 0;
 
 protected:
@@ -124,7 +124,7 @@ protected:
 
 public:
   Variable create(const DType elem_dtype, const Dimensions &dims,
-                  const units::Unit &unit, const bool variances,
+                  const sc_units::Unit &unit, const bool variances,
                   const typename AbstractVariableMaker::parent_list &parents)
       const override {
     const Variable &parent = bin_parent(parents);
@@ -143,16 +143,16 @@ public:
   DType elem_dtype(const Variable &var) const override {
     return std::get<2>(var.constituents<T>()).dtype();
   }
-  units::Unit elem_unit(const Variable &var) const override {
+  sc_units::Unit elem_unit(const Variable &var) const override {
     return std::get<2>(var.constituents<T>()).unit();
   }
   void expect_can_set_elem_unit(const Variable &var,
-                                const units::Unit &u) const override {
+                                const sc_units::Unit &u) const override {
     if (elem_unit(var) != u && var.is_slice())
       throw except::UnitError("Partial view on data of variable cannot be "
                               "used to change the unit.");
   }
-  void set_elem_unit(Variable &var, const units::Unit &u) const override {
+  void set_elem_unit(Variable &var, const sc_units::Unit &u) const override {
     std::get<2>(var.constituents<T>()).setUnit(u);
   }
   bool has_masks(const Variable &var) const override {

--- a/lib/variable/include/scipp/variable/creation.h
+++ b/lib/variable/include/scipp/variable/creation.h
@@ -13,11 +13,11 @@
 namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-empty(const Dimensions &dims, const units::Unit &unit, const DType type,
+empty(const Dimensions &dims, const sc_units::Unit &unit, const DType type,
       const bool with_variances = false, const bool aligned = true);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-ones(const Dimensions &dims, const units::Unit &unit, const DType type,
+ones(const Dimensions &dims, const sc_units::Unit &unit, const DType type,
      const bool with_variances = false);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable

--- a/lib/variable/include/scipp/variable/element_array_model.h
+++ b/lib/variable/include/scipp/variable/element_array_model.h
@@ -63,7 +63,7 @@ public:
   static_assert(!core::is_structured(core::template dtype<T>));
   using value_type = T;
 
-  ElementArrayModel(const scipp::index size, const units::Unit &unit,
+  ElementArrayModel(const scipp::index size, const sc_units::Unit &unit,
                     element_array<T> model,
                     std::optional<element_array<T>> variances = std::nullopt);
 

--- a/lib/variable/include/scipp/variable/element_array_variable.tcc
+++ b/lib/variable/include/scipp/variable/element_array_variable.tcc
@@ -8,7 +8,7 @@
 namespace scipp::variable {
 
 template <class T>
-Variable make_default_init(const Dimensions &dims, const units::Unit &unit,
+Variable make_default_init(const Dimensions &dims, const sc_units::Unit &unit,
                            const bool variances) {
   if (variances && !core::canHaveVariances<T>())
     throw except::VariancesError("This data type cannot have variances.");
@@ -35,20 +35,20 @@ Variable make_default_init(const Dimensions &dims, const units::Unit &unit,
 template <class T> class VariableMaker : public AbstractVariableMaker {
   using AbstractVariableMaker::create;
   bool is_bins() const override { return false; }
-  Variable create(const DType, const Dimensions &dims, const units::Unit &unit,
+  Variable create(const DType, const Dimensions &dims, const sc_units::Unit &unit,
                   const bool variances, const parent_list &) const override {
     return make_default_init<T>(dims, unit, variances);
   }
   Dim elem_dim(const Variable &) const override { return Dim::Invalid; }
   DType elem_dtype(const Variable &var) const override { return var.dtype(); }
-  units::Unit elem_unit(const Variable &var) const override {
+  sc_units::Unit elem_unit(const Variable &var) const override {
     return var.unit();
   }
   void expect_can_set_elem_unit(const Variable &var,
-                                const units::Unit &u) const override {
+                                const sc_units::Unit &u) const override {
     var.expect_can_set_unit(u);
   }
-  void set_elem_unit(Variable &var, const units::Unit &u) const override {
+  void set_elem_unit(Variable &var, const sc_units::Unit &u) const override {
     var.setUnit(u);
   }
   bool has_variances(const Variable &var) const override {
@@ -67,7 +67,7 @@ template <class T> class VariableMaker : public AbstractVariableMaker {
 
 template <class T>
 ElementArrayModel<T>::ElementArrayModel(
-    const scipp::index size, const units::Unit &unit, element_array<T> model,
+    const scipp::index size, const sc_units::Unit &unit, element_array<T> model,
     std::optional<element_array<T>> variances)
     : VariableConcept(unit),
       m_values(model ? std::move(model)
@@ -141,7 +141,7 @@ void ElementArrayModel<T>::setVariances(const Variable &variances) {
 
 #define INSTANTIATE_ELEMENT_ARRAY_VARIABLE_BASE(name, ...)                     \
   template SCIPP_EXPORT Variable variable::make_default_init<__VA_ARGS__>(     \
-      const Dimensions &, const units::Unit &, const bool);                    \
+      const Dimensions &, const sc_units::Unit &, const bool);                 \
   INSTANTIATE_VARIABLE_BASE(name, __VA_ARGS__)                                 \
   namespace {                                                                  \
   auto register_variable_maker_##name((                                        \
@@ -150,7 +150,7 @@ void ElementArrayModel<T>::setVariances(const Variable &variances) {
       0));                                                                     \
   }                                                                            \
   template SCIPP_EXPORT Variable::Variable(                                    \
-      const std::optional<units::Unit> &, const Dimensions &,                  \
+      const std::optional<sc_units::Unit> &, const Dimensions &,               \
       element_array<__VA_ARGS__>, std::optional<element_array<__VA_ARGS__>>);  \
   template SCIPP_EXPORT ElementArrayView<const __VA_ARGS__>                    \
   Variable::variances() const;                                                 \

--- a/lib/variable/include/scipp/variable/string.h
+++ b/lib/variable/include/scipp/variable/string.h
@@ -16,7 +16,7 @@ namespace scipp::variable {
 template <class T> std::string format_variable_like(const T &obj) {
   auto s =
       "(dims=" + to_string(obj.dims()) + ", dtype=" + to_string(obj.dtype());
-  if (obj.unit() != units::none)
+  if (obj.unit() != sc_units::none)
     s += ", unit=" + to_string(obj.unit());
   return s + ')';
 }

--- a/lib/variable/include/scipp/variable/structure_array_model.h
+++ b/lib/variable/include/scipp/variable/structure_array_model.h
@@ -28,14 +28,14 @@ public:
   static constexpr scipp::index element_count = sizeof(T) / sizeof(Elem);
   static_assert(sizeof(Elem) * element_count == sizeof(T));
 
-  StructureArrayModel(const scipp::index size, const units::Unit &unit,
+  StructureArrayModel(const scipp::index size, const sc_units::Unit &unit,
                       element_array<Elem> model)
-      : VariableConcept(units::one), // unit ignored
+      : VariableConcept(sc_units::one), // unit ignored
         m_elements(std::make_shared<ElementArrayModel<Elem>>(
             size * element_count, unit, std::move(model))) {}
 
   StructureArrayModel(VariableConceptHandle &&elements)
-      : VariableConcept(units::one), // unit ignored
+      : VariableConcept(sc_units::one), // unit ignored
         m_elements(std::move(elements)) {}
 
   ~StructureArrayModel() override;
@@ -46,8 +46,10 @@ public:
     return m_elements->size() / element_count;
   }
 
-  const units::Unit &unit() const override { return m_elements->unit(); }
-  void setUnit(const units::Unit &unit) override { m_elements->setUnit(unit); }
+  const sc_units::Unit &unit() const override { return m_elements->unit(); }
+  void setUnit(const sc_units::Unit &unit) override {
+    m_elements->setUnit(unit);
+  }
 
   VariableConceptHandle
   makeDefaultFromParent(const scipp::index size) const override;

--- a/lib/variable/include/scipp/variable/structures.h
+++ b/lib/variable/include/scipp/variable/structures.h
@@ -10,27 +10,27 @@ namespace scipp::variable {
 
 template <class T, class Elem>
 [[nodiscard]] Variable make_structures(const Dimensions &dims,
-                                       const units::Unit &unit,
+                                       const sc_units::Unit &unit,
                                        element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_vectors(const Dimensions &dims, const units::Unit &unit,
+make_vectors(const Dimensions &dims, const sc_units::Unit &unit,
              element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_matrices(const Dimensions &dims, const units::Unit &unit,
+make_matrices(const Dimensions &dims, const sc_units::Unit &unit,
               element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_affine_transforms(const Dimensions &dims, const units::Unit &unit,
+make_affine_transforms(const Dimensions &dims, const sc_units::Unit &unit,
                        element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_rotations(const Dimensions &dims, const units::Unit &unit,
+make_rotations(const Dimensions &dims, const sc_units::Unit &unit,
                element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-make_translations(const Dimensions &dims, const units::Unit &unit,
+make_translations(const Dimensions &dims, const sc_units::Unit &unit,
                   element_array<double> &&values);
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT std::vector<std::string>

--- a/lib/variable/include/scipp/variable/to_unit.h
+++ b/lib/variable/include/scipp/variable/to_unit.h
@@ -12,7 +12,7 @@
 namespace scipp::variable {
 
 [[nodiscard]] SCIPP_VARIABLE_EXPORT Variable
-to_unit(const Variable &var, const units::Unit &unit,
+to_unit(const Variable &var, const sc_units::Unit &unit,
         CopyPolicy copy = CopyPolicy::Always);
 
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/variable.h
+++ b/lib/variable/include/scipp/variable/variable.h
@@ -23,7 +23,7 @@
 
 #include "scipp/variable/variable_keyword_arg_constructor.h"
 
-namespace llnl::units {
+namespace units {
 class precise_measurement;
 }
 
@@ -33,7 +33,7 @@ class VariableConcept;
 using VariableConceptHandle = std::shared_ptr<VariableConcept>;
 
 /// Return the default unit (dimensionless or none) for a given dtype.
-[[nodiscard]] SCIPP_VARIABLE_EXPORT units::Unit
+[[nodiscard]] SCIPP_VARIABLE_EXPORT sc_units::Unit
 default_unit_for(const DType type);
 
 /// Variable is a type-erased handle to any data structure representing a
@@ -45,9 +45,9 @@ public:
   Variable(const Variable &parent, const Dimensions &dims);
   Variable(const Dimensions &dims, VariableConceptHandle data);
   template <class T>
-  Variable(const std::optional<units::Unit> &unit, const Dimensions &dimensions,
-           T values, std::optional<T> variances);
-  explicit Variable(const llnl::units::precise_measurement &m);
+  Variable(const std::optional<sc_units::Unit> &unit,
+           const Dimensions &dimensions, T values, std::optional<T> variances);
+  explicit Variable(const units::precise_measurement &m);
 
   /// Keyword-argument constructor.
   ///
@@ -64,9 +64,9 @@ public:
 
   ~Variable() noexcept = default;
 
-  [[nodiscard]] const units::Unit &unit() const;
-  void setUnit(const units::Unit &unit);
-  void expect_can_set_unit(const units::Unit &unit) const;
+  [[nodiscard]] const sc_units::Unit &unit() const;
+  void setUnit(const sc_units::Unit &unit);
+  void expect_can_set_unit(const sc_units::Unit &unit) const;
 
   [[nodiscard]] const Dimensions &dims() const;
   [[nodiscard]] Dim dim() const;

--- a/lib/variable/include/scipp/variable/variable.tcc
+++ b/lib/variable/include/scipp/variable/variable.tcc
@@ -54,7 +54,7 @@ template <int I, class T> decltype(auto) get(T &&t) {
 }
 
 template <class T>
-auto make_model(const units::Unit unit, const Dimensions &dimensions,
+auto make_model(const sc_units::Unit unit, const Dimensions &dimensions,
                 element_array<T> values,
                 std::optional<element_array<T>> variances) {
   if constexpr (std::is_same_v<model_t<T>, ElementArrayModel<T>>) {
@@ -77,7 +77,7 @@ auto make_model(const units::Unit unit, const Dimensions &dimensions,
 
 /// See also default_unit_for, for similar runtime functionality.
 template <class T>
-units::Unit unit_for_dtype(const std::optional<units::Unit> &unit) {
+sc_units::Unit unit_for_dtype(const std::optional<sc_units::Unit> &unit) {
   if (unit.has_value())
     return *unit;
   return default_unit_for(dtype<T>);
@@ -86,7 +86,7 @@ units::Unit unit_for_dtype(const std::optional<units::Unit> &unit) {
 } // namespace
 
 template <class T>
-Variable::Variable(const std::optional<units::Unit> &unit,
+Variable::Variable(const std::optional<sc_units::Unit> &unit,
                    const Dimensions &dimensions, T values_,
                    std::optional<T> variances_)
     : m_dims(dimensions), m_strides(dimensions),

--- a/lib/variable/include/scipp/variable/variable_concept.h
+++ b/lib/variable/include/scipp/variable/variable_concept.h
@@ -32,7 +32,7 @@ using VariableConceptHandle = std::shared_ptr<VariableConcept>;
 /// - BinArrayModel for "arrays" of bins, i.e., event data.
 class SCIPP_VARIABLE_EXPORT VariableConcept {
 public:
-  VariableConcept(const units::Unit &unit);
+  VariableConcept(const sc_units::Unit &unit);
   virtual ~VariableConcept() = default;
 
   virtual VariableConceptHandle clone() const = 0;
@@ -42,10 +42,10 @@ public:
   makeDefaultFromParent(const Variable &shape) const = 0;
 
   virtual DType dtype() const noexcept = 0;
-  virtual const units::Unit &unit() const { return m_unit; }
+  virtual const sc_units::Unit &unit() const { return m_unit; }
   virtual scipp::index size() const = 0;
 
-  virtual void setUnit(const units::Unit &unit) { m_unit = unit; }
+  virtual void setUnit(const sc_units::Unit &unit) { m_unit = unit; }
 
   virtual bool has_variances() const noexcept = 0;
   virtual void setVariances(const Variable &variances) = 0;
@@ -63,7 +63,7 @@ public:
   friend class Variable;
 
 private:
-  units::Unit m_unit;
+  sc_units::Unit m_unit;
 };
 
 } // namespace scipp::variable

--- a/lib/variable/include/scipp/variable/variable_factory.h
+++ b/lib/variable/include/scipp/variable/variable_factory.h
@@ -26,14 +26,14 @@ public:
   virtual ~AbstractVariableMaker() = default;
   virtual bool is_bins() const = 0;
   virtual Variable create(const DType elem_dtype, const Dimensions &dims,
-                          const units::Unit &unit, const bool variances,
+                          const sc_units::Unit &unit, const bool variances,
                           const parent_list &parents) const = 0;
   virtual Dim elem_dim(const Variable &var) const = 0;
   virtual DType elem_dtype(const Variable &var) const = 0;
-  virtual units::Unit elem_unit(const Variable &var) const = 0;
+  virtual sc_units::Unit elem_unit(const Variable &var) const = 0;
   virtual void expect_can_set_elem_unit(const Variable &var,
-                                        const units::Unit &u) const = 0;
-  virtual void set_elem_unit(Variable &var, const units::Unit &u) const = 0;
+                                        const sc_units::Unit &u) const = 0;
+  virtual void set_elem_unit(Variable &var, const sc_units::Unit &u) const = 0;
   virtual bool has_masks(const Variable &) const { return false; }
   virtual bool has_variances(const Variable &var) const = 0;
   virtual const Variable &data(const Variable &) const { throw unreachable(); }
@@ -77,7 +77,7 @@ public:
   bool is_bins(const Variable &var) const;
   template <class... Parents>
   Variable create(const DType elem_dtype, const Dimensions &dims,
-                  const units::Unit &unit, const bool with_variances,
+                  const sc_units::Unit &unit, const bool with_variances,
                   const Parents &...parents) const {
     const auto parents_ = parent_list{parents...};
     const auto key = bin_dtype(parents_);
@@ -86,10 +86,10 @@ public:
   }
   Dim elem_dim(const Variable &var) const;
   DType elem_dtype(const Variable &var) const;
-  units::Unit elem_unit(const Variable &var) const;
+  sc_units::Unit elem_unit(const Variable &var) const;
   void expect_can_set_elem_unit(const Variable &var,
-                                const units::Unit &u) const;
-  void set_elem_unit(Variable &var, const units::Unit &u) const;
+                                const sc_units::Unit &u) const;
+  void set_elem_unit(Variable &var, const sc_units::Unit &u) const;
   bool has_masks(const Variable &var) const;
   bool has_variances(const Variable &var) const;
   template <class T, class Var> auto values(Var &&var) const {

--- a/lib/variable/include/scipp/variable/variable_keyword_arg_constructor.h
+++ b/lib/variable/include/scipp/variable/variable_keyword_arg_constructor.h
@@ -69,14 +69,14 @@ throw_keyword_arg_constructor_bad_dtype(const DType dtype);
 ///
 /// This is an implementation detail of `makeVariable`.
 template <class ElemT> struct ArgParser {
-  std::tuple<std::optional<units::Unit>, Dimensions, element_array<ElemT>,
+  std::tuple<std::optional<sc_units::Unit>, Dimensions, element_array<ElemT>,
              std::optional<element_array<ElemT>>>
       args;
   Dims dims;
   Shape shape;
 
-  void parse(const units::Unit &arg) {
-    std::get<std::optional<units::Unit>>(args) = arg;
+  void parse(const sc_units::Unit &arg) {
+    std::get<std::optional<sc_units::Unit>>(args) = arg;
   }
 
   void parse(const Dimensions &arg) { std::get<Dimensions>(args) = arg; }

--- a/lib/variable/inv.cpp
+++ b/lib/variable/inv.cpp
@@ -17,10 +17,10 @@ constexpr auto inv =
                core::transform_flags::expect_no_variance_arg<0>,
                core::transform_flags::expect_no_variance_arg<1>,
                [](const auto &transform) { return transform.inverse(); },
-               [](const units::Unit &) {
+               [](const sc_units::Unit &) {
                  // The resulting unit depends on the dtype;
                  // the calling code assigns it.
-                 return units::none;
+                 return sc_units::none;
                }};
 } // namespace element
 
@@ -37,7 +37,7 @@ bool is_transform_with_translation(const Variable &var) {
 //            in case the user sets one manually.
 auto result_unit(const Variable &var) {
   return is_transform_with_translation(var) ? var.unit()
-                                            : units::one / var.unit();
+                                            : sc_units::one / var.unit();
 }
 
 } // namespace

--- a/lib/variable/operations_common.h
+++ b/lib/variable/operations_common.h
@@ -23,7 +23,7 @@ template <class T> T normalize_impl(const T &numerator, T denominator) {
   // This approach would be wrong if we supported vectors of float
   const auto type =
       numerator.dtype() == dtype<float> ? dtype<float> : dtype<double>;
-  denominator.setUnit(units::one);
+  denominator.setUnit(sc_units::one);
   return numerator *
          reciprocal(astype(denominator, type, CopyPolicy::TryAvoid));
 }

--- a/lib/variable/pow.cpp
+++ b/lib/variable/pow.cpp
@@ -34,8 +34,8 @@ Variable pow_do_transform(V &&base, const Variable &exponent,
 }
 
 template <class T> struct PowUnit {
-  static units::Unit apply(const units::Unit base_unit,
-                           const Variable &exponent) {
+  static sc_units::Unit apply(const sc_units::Unit base_unit,
+                              const Variable &exponent) {
     const auto exp_val = exponent.value<T>();
     if constexpr (std::is_floating_point_v<T>) {
       if (static_cast<T>(static_cast<int64_t>(exp_val)) != exp_val) {
@@ -52,13 +52,13 @@ template <class V>
 Variable pow_handle_unit(V &&base, const Variable &exponent,
                          const bool in_place) {
   if (const auto exp_unit = variableFactory().elem_unit(exponent);
-      exp_unit != units::one) {
+      exp_unit != sc_units::one) {
     throw except::UnitError("Powers must be dimensionless, got exponent.unit=" +
                             to_string(exp_unit) + ".");
   }
 
   const auto base_unit = variableFactory().elem_unit(base);
-  if (base_unit == units::one) {
+  if (base_unit == sc_units::one) {
     return pow_do_transform(std::forward<V>(base), exponent, in_place);
   }
   if (exponent.dims().ndim() != 0) {
@@ -69,7 +69,7 @@ Variable pow_handle_unit(V &&base, const Variable &exponent,
   }
 
   Variable res = in_place ? std::forward<V>(base) : copy(std::forward<V>(base));
-  variableFactory().set_elem_unit(res, units::one);
+  variableFactory().set_elem_unit(res, sc_units::one);
   pow_do_transform(res, exponent, true);
   variableFactory().set_elem_unit(
       res, core::CallDType<double, float, int64_t, int32_t>::apply<PowUnit>(

--- a/lib/variable/reduction.cpp
+++ b/lib/variable/reduction.cpp
@@ -130,9 +130,9 @@ Variable unmasked_events(const Variable &data) {
 template <class... Dim> Variable count(const Variable &var, Dim &&...dim) {
   if (!is_bins(var)) {
     if constexpr (sizeof...(dim) == 0)
-      return var.dims().volume() * units::none;
+      return var.dims().volume() * sc_units::none;
     else
-      return ((var.dims()[dim] * units::none) * ...);
+      return ((var.dims()[dim] * sc_units::none) * ...);
   }
   if (const auto unmasked = unmasked_events(var); unmasked.is_valid()) {
     return sum(unmasked, dim...);

--- a/lib/variable/string.cpp
+++ b/lib/variable/string.cpp
@@ -78,7 +78,7 @@ auto apply(const DType dtype, Args &&...args) {
 
 std::string format_variable_compact(const Variable &variable) {
   const auto s = to_string(variable.dtype());
-  if (variable.unit() == units::none)
+  if (variable.unit() == sc_units::none)
     return s;
   else
     return s + '[' + variable.unit().name() + ']';
@@ -93,7 +93,7 @@ std::string format_variable(const Variable &variable,
   if (!datasetSizes)
     s << to_string(variable.dims()) << colSep;
   s << std::setw(9) << to_string(variable.dtype());
-  if (variable.unit() == units::none)
+  if (variable.unit() == sc_units::none)
     s << colSep << std::setw(15) << "<no unit>";
   else
     s << colSep << std::setw(15) << '[' + variable.unit().name() + ']';
@@ -111,7 +111,7 @@ std::string to_string(const Variable &variable) {
 }
 
 std::string to_string(const std::pair<Dim, Variable> &coord) {
-  using units::to_string;
+  using sc_units::to_string;
   return to_string(coord.first) + ":\n" + to_string(coord.second);
 }
 

--- a/lib/variable/structures.cpp
+++ b/lib/variable/structures.cpp
@@ -10,7 +10,7 @@
 namespace scipp::variable {
 
 template <class T, class Elem>
-Variable make_structures(const Dimensions &dims, const units::Unit &unit,
+Variable make_structures(const Dimensions &dims, const sc_units::Unit &unit,
                          element_array<double> &&values) {
   return {dims, std::make_shared<StructureArrayModel<T, Elem>>(
                     dims.volume(), unit, std::move(values))};
@@ -18,38 +18,38 @@ Variable make_structures(const Dimensions &dims, const units::Unit &unit,
 
 template SCIPP_VARIABLE_EXPORT Variable
 make_structures<Eigen::Vector3d, double>(const Dimensions &,
-                                         const units::Unit &,
+                                         const sc_units::Unit &,
                                          element_array<double> &&);
 
 template SCIPP_VARIABLE_EXPORT Variable
 make_structures<Eigen::Matrix3d, double>(const Dimensions &,
-                                         const units::Unit &,
+                                         const sc_units::Unit &,
                                          element_array<double> &&);
 
 template SCIPP_VARIABLE_EXPORT Variable
 make_structures<Eigen::Affine3d, double>(const Dimensions &,
-                                         const units::Unit &,
+                                         const sc_units::Unit &,
                                          element_array<double> &&);
 
 template SCIPP_VARIABLE_EXPORT Variable
 make_structures<scipp::core::Quaternion, double>(const Dimensions &,
-                                                 const units::Unit &,
+                                                 const sc_units::Unit &,
                                                  element_array<double> &&);
 
 template SCIPP_VARIABLE_EXPORT Variable
 make_structures<scipp::core::Translation, double>(const Dimensions &,
-                                                  const units::Unit &,
+                                                  const sc_units::Unit &,
                                                   element_array<double> &&);
 
 /// Construct a variable containing vectors from a variable of elements.
-Variable make_vectors(const Dimensions &dims, const units::Unit &unit,
+Variable make_vectors(const Dimensions &dims, const sc_units::Unit &unit,
                       element_array<double> &&values) {
   return make_structures<Eigen::Vector3d, double>(dims, unit,
                                                   std::move(values));
 }
 
 /// Construct a variable containing matrices from a variable of elements.
-Variable make_matrices(const Dimensions &dims, const units::Unit &unit,
+Variable make_matrices(const Dimensions &dims, const sc_units::Unit &unit,
                        element_array<double> &&values) {
   return make_structures<Eigen::Matrix3d, double>(dims, unit,
                                                   std::move(values));
@@ -57,21 +57,22 @@ Variable make_matrices(const Dimensions &dims, const units::Unit &unit,
 
 /// Construct a variable containing affine transforms from a variable of
 /// elements.
-Variable make_affine_transforms(const Dimensions &dims, const units::Unit &unit,
+Variable make_affine_transforms(const Dimensions &dims,
+                                const sc_units::Unit &unit,
                                 element_array<double> &&values) {
   return make_structures<Eigen::Affine3d, double>(dims, unit,
                                                   std::move(values));
 }
 
 /// Construct a variable containing rotations from a variable of elements.
-Variable make_rotations(const Dimensions &dims, const units::Unit &unit,
+Variable make_rotations(const Dimensions &dims, const sc_units::Unit &unit,
                         element_array<double> &&values) {
   return make_structures<scipp::core::Quaternion, double>(dims, unit,
                                                           std::move(values));
 }
 
 /// Construct a variable containing translations from a variable of elements.
-Variable make_translations(const Dimensions &dims, const units::Unit &unit,
+Variable make_translations(const Dimensions &dims, const sc_units::Unit &unit,
                            element_array<double> &&values) {
   return make_structures<scipp::core::Translation, double>(dims, unit,
                                                            std::move(values));

--- a/lib/variable/subspan_view.cpp
+++ b/lib/variable/subspan_view.cpp
@@ -25,7 +25,7 @@ auto make_subspans(T *base, const Variable &indices,
   return variable::transform<scipp::index_pair>(
       indices,
       overloaded{core::transform_flags::expect_no_variance_arg<0>,
-                 [](const units::Unit &) { return units::one; },
+                 [](const sc_units::Unit &) { return sc_units::one; },
                  [base, stride](const auto &offset) {
                    return scipp::span(base + stride * offset.first,
                                       base + stride * offset.second);
@@ -70,19 +70,19 @@ Variable subspan_view_impl(Var &var, const Dim dim, Args &&...args) {
 
 auto make_range(const scipp::index num, const scipp::index stride,
                 const Dim dim) {
-  return cumsum(broadcast(stride * units::one, {dim, num}), dim,
+  return cumsum(broadcast(stride * sc_units::one, {dim, num}), dim,
                 CumSumMode::Exclusive);
 }
 
 Variable make_indices(const Variable &var, const Dim dim) {
   auto dims = var.dims();
   dims.erase(dim);
-  auto start = scipp::index(0) * units::one;
+  auto start = scipp::index(0) * sc_units::one;
   for (const auto &label : dims) {
     const auto stride = var.stride(label);
     start = start + make_range(dims[label], stride, label);
   }
-  return zip(start, start + var.dims()[dim] * units::one);
+  return zip(start, start + var.dims()[dim] * sc_units::one);
 }
 
 } // namespace

--- a/lib/variable/test/accumulate_test.cpp
+++ b/lib/variable/test/accumulate_test.cpp
@@ -24,8 +24,8 @@ protected:
 };
 
 TEST_F(AccumulateTest, in_place) {
-  const auto var =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1.0, 2.0});
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                        Values{1.0, 2.0});
   const auto expected = makeVariable<double>(Values{3.0});
   // Note how accumulate is ignoring the unit.
   auto result = makeVariable<double>(Values{double{}});
@@ -35,7 +35,7 @@ TEST_F(AccumulateTest, in_place) {
 
 TEST_F(AccumulateTest, bad_dims) {
   const auto var = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
-                                        units::m, Values{1, 2, 3, 4, 5, 6});
+                                        sc_units::m, Values{1, 2, 3, 4, 5, 6});
   auto result = makeVariable<double>(Dims{Dim::X}, Shape{3});
   const auto orig = copy(result);
   EXPECT_THROW(accumulate_in_place<pair_self_t<double>>(result, var, op, name),
@@ -44,8 +44,8 @@ TEST_F(AccumulateTest, bad_dims) {
 }
 
 TEST_F(AccumulateTest, broadcast) {
-  const auto var =
-      makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::m, Values{1, 2, 3});
+  const auto var = makeVariable<double>(Dims{Dim::Y}, Shape{3}, sc_units::m,
+                                        Values{1, 2, 3});
   const auto expected =
       makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{6, 6});
   auto result = makeVariable<double>(Dims{Dim::X}, Shape{2});
@@ -168,6 +168,6 @@ TEST_F(AccumulateTest, 1d_to_scalar_non_idempotent_init) {
     accumulate_in_place<pair_self_t<int64_t>>(result, var, op, name);
     EXPECT_EQ(result, expected) << i;
     accumulate_in_place<pair_self_t<int64_t>>(result, var, op, name);
-    EXPECT_EQ(result, 2 * units::one * expected) << i;
+    EXPECT_EQ(result, 2 * sc_units::one * expected) << i;
   }
 }

--- a/lib/variable/test/arithmetic_test.cpp
+++ b/lib/variable/test/arithmetic_test.cpp
@@ -13,33 +13,34 @@
 using namespace scipp;
 
 TEST(ArithmeticTest, x_plus_x_with_variances_equals_2_x) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   const auto two = makeVariable<double>(Values{2.0});
   EXPECT_EQ(x + x, two * x);
 }
 
 TEST(ArithmeticTest, x_plus_x_with_variances_and_no_unit_equals_2_x) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::none);
-  const auto two = makeVariable<double>(Values{2.0}, units::none);
+  const auto x =
+      makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::none);
+  const auto two = makeVariable<double>(Values{2.0}, sc_units::none);
   EXPECT_EQ(x + x, two * x);
 }
 
 TEST(ArithmeticTest,
      x_plus_shallow_copy_of_x_with_variances_handles_correlations) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   EXPECT_EQ(x + Variable(x), x + x);
 }
 
 TEST(ArithmeticTest,
      x_plus_copy_of_x_with_variances_does_not_handle_correlations) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   // x and copy(x) are NOT detected as correlated
   EXPECT_NE(x + copy(x), x + x);
 }
 
 TEST(ArithmeticTest, slice_of_x_plus_slice_of_x_handles_correlations) {
   const auto x = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2.0, 3.0},
-                                      Variances{4.0, 3.0}, units::m);
+                                      Variances{4.0, 3.0}, sc_units::m);
   const auto two = makeVariable<double>(Values{2.0});
   EXPECT_EQ(x.slice({Dim::X, 0}) + x.slice({Dim::X, 0}),
             two * x.slice({Dim::X, 0}));
@@ -81,13 +82,13 @@ TEST(ArithmeticTest, x_minus_equals_x_with_variances_equals_0_x) {
 }
 
 TEST(ArithmeticTest, x_times_x_with_variances_equals_x_squared) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   const auto two = makeVariable<double>(Values{2.0});
   EXPECT_EQ(x * x, pow(x, two));
 }
 
 TEST(ArithmeticTest, x_times_equals_x_with_variances_equals_x_squared) {
-  auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   const auto two = makeVariable<double>(Values{2.0});
   const auto expected = pow(x, two);
   EXPECT_EQ(x *= x, expected);
@@ -95,14 +96,14 @@ TEST(ArithmeticTest, x_times_equals_x_with_variances_equals_x_squared) {
 }
 
 TEST(ArithmeticTest, x_divide_x_with_variances_equals_x_to_the_power_of_zero) {
-  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  const auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   const auto zero = makeVariable<double>(Values{0.0});
   EXPECT_EQ(x / x, pow(x, zero));
 }
 
 TEST(ArithmeticTest,
      x_divide_equals_x_with_variances_equals_x_to_the_power_of_zero) {
-  auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, units::m);
+  auto x = makeVariable<double>(Values{2.0}, Variances{4.0}, sc_units::m);
   const auto zero = makeVariable<double>(Values{0.0});
   const auto expected = pow(x, zero);
   EXPECT_EQ(x /= x, expected);
@@ -112,7 +113,7 @@ TEST(ArithmeticTest,
 TEST(ArithmeticTest, binned_x_plus_x_with_variances_equals_2_x) {
   const auto indices = makeVariable<scipp::index_pair>(Values{std::pair{0, 1}});
   const auto buffer = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{2.0},
-                                           Variances{4.0}, units::m);
+                                           Variances{4.0}, sc_units::m);
   const auto x = make_bins(indices, Dim::X, buffer);
   const auto two = makeVariable<double>(Values{2.0});
   EXPECT_EQ(x + x, two * x);

--- a/lib/variable/test/astype_test.cpp
+++ b/lib/variable/test/astype_test.cpp
@@ -30,10 +30,10 @@ TYPED_TEST(AsTypeTest, dense) {
   var1 = makeVariable<T1>(Values{1});
   var2 = makeVariable<T2>(Values{1});
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
-  var1 =
-      makeVariable<T1>(Dims{Dim::X}, Shape{3}, units::m, Values{1.0, 2.0, 3.0});
-  var2 =
-      makeVariable<T2>(Dims{Dim::X}, Shape{3}, units::m, Values{1.0, 2.0, 3.0});
+  var1 = makeVariable<T1>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                          Values{1.0, 2.0, 3.0});
+  var2 = makeVariable<T2>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                          Values{1.0, 2.0, 3.0});
 
   ASSERT_EQ(astype(var1, core::dtype<T2>), var2);
   ASSERT_FALSE(astype(var1, core::dtype<T2>, CopyPolicy::Always).is_same(var1));
@@ -44,10 +44,10 @@ TYPED_TEST(AsTypeTest, dense) {
 TYPED_TEST(AsTypeTest, binned) {
   using T1 = typename TypeParam::first_type;
   using T2 = typename TypeParam::second_type;
-  auto var1 =
-      makeVariable<T1>(Dims{Dim::X}, Shape{3}, units::m, Values{1.0, 2.0, 3.0});
-  auto var2 =
-      makeVariable<T2>(Dims{Dim::X}, Shape{3}, units::m, Values{1.0, 2.0, 3.0});
+  auto var1 = makeVariable<T1>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                               Values{1.0, 2.0, 3.0});
+  auto var2 = makeVariable<T2>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                               Values{1.0, 2.0, 3.0});
   auto indices =
       makeVariable<scipp::index_pair>(Values{scipp::index_pair{0, 3}});
   auto binned1 = make_bins(indices, Dim::X, var1);

--- a/lib/variable/test/bin_array_model_test.cpp
+++ b/lib/variable/test/bin_array_model_test.cpp
@@ -116,7 +116,7 @@ TEST_F(BucketModelTest, values) {
   core::ElementArrayViewParams params(0, indices.dims(), Strides{1}, {});
   EXPECT_EQ(*(model.values(params).begin() + 0), buffer.slice({Dim::X, 0, 2}));
   EXPECT_EQ(*(model.values(params).begin() + 1), buffer.slice({Dim::X, 2, 4}));
-  (*model.values(params).begin()) += 2.0 * units::one;
+  (*model.values(params).begin()) += 2.0 * sc_units::one;
   EXPECT_EQ(*(model.values(params).begin() + 0), buffer.slice({Dim::X, 2, 4}));
 }
 

--- a/lib/variable/test/comparison_test.cpp
+++ b/lib/variable/test/comparison_test.cpp
@@ -9,7 +9,7 @@
 
 using namespace scipp;
 using namespace scipp::variable;
-using namespace scipp::units;
+using namespace scipp::sc_units;
 
 template <typename T> class IsCloseTest : public ::testing::Test {};
 using TestTypes = ::testing::Types<double, float, int64_t, int32_t>;
@@ -20,7 +20,7 @@ TYPED_TEST(IsCloseTest, atol_when_variable_equal) {
   const auto a = makeVariable<TypeParam>(Values{1});
   const auto rtol = makeVariable<TypeParam>(Values{0});
   const auto atol = makeVariable<TypeParam>(Values{1});
-  EXPECT_EQ(isclose(a, a, rtol, atol), true * units::none);
+  EXPECT_EQ(isclose(a, a, rtol, atol), true * sc_units::none);
 }
 
 TYPED_TEST(IsCloseTest, atol_when_variables_within_tolerance) {
@@ -28,7 +28,7 @@ TYPED_TEST(IsCloseTest, atol_when_variables_within_tolerance) {
   const auto b = makeVariable<TypeParam>(Values{1});
   const auto rtol = makeVariable<TypeParam>(Values{0});
   const auto atol = makeVariable<TypeParam>(Values{1});
-  EXPECT_EQ(isclose(a, b, rtol, atol), true * units::none);
+  EXPECT_EQ(isclose(a, b, rtol, atol), true * sc_units::none);
 }
 
 TYPED_TEST(IsCloseTest, atol_when_variables_outside_tolerance) {
@@ -36,7 +36,7 @@ TYPED_TEST(IsCloseTest, atol_when_variables_outside_tolerance) {
   const auto b = makeVariable<TypeParam>(Values{2});
   const auto rtol = makeVariable<TypeParam>(Values{0});
   const auto atol = makeVariable<TypeParam>(Values{1});
-  EXPECT_EQ(isclose(a, b, rtol, atol), false * units::none);
+  EXPECT_EQ(isclose(a, b, rtol, atol), false * sc_units::none);
 }
 
 TYPED_TEST(IsCloseTest, rtol_when_variables_within_tolerance) {
@@ -45,7 +45,7 @@ TYPED_TEST(IsCloseTest, rtol_when_variables_within_tolerance) {
   // tol = atol + rtol * b = 1
   const auto rtol = makeVariable<double>(Values{1.0 / 9});
   const auto atol = makeVariable<TypeParam>(Values{0});
-  EXPECT_EQ(isclose(a, b, rtol, atol), true * units::none);
+  EXPECT_EQ(isclose(a, b, rtol, atol), true * sc_units::none);
 }
 
 TYPED_TEST(IsCloseTest, rtol_when_variables_outside_tolerance) {
@@ -54,7 +54,7 @@ TYPED_TEST(IsCloseTest, rtol_when_variables_outside_tolerance) {
   // tol = atol + rtol * b = 1
   const auto rtol = makeVariable<double>(Values{1.0 / 9});
   const auto atol = makeVariable<TypeParam>(Values{0});
-  EXPECT_EQ(isclose(a, b, rtol, atol), false * units::none);
+  EXPECT_EQ(isclose(a, b, rtol, atol), false * sc_units::none);
 }
 
 TEST(IsCloseTest, with_vectors) {
@@ -64,8 +64,8 @@ TEST(IsCloseTest, with_vectors) {
       makeVariable<Eigen::Vector3d>(Values{Eigen::Vector3d{1, 1, 1}});
   const auto w =
       makeVariable<Eigen::Vector3d>(Values{Eigen::Vector3d{1, 1, 1.0001}});
-  const auto rtol = 0.0 * units::one;
-  const auto atol = 1.0 * units::one;
+  const auto rtol = 0.0 * sc_units::one;
+  const auto atol = 1.0 * sc_units::one;
   EXPECT_EQ(isclose(u, u, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(u, v, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(v, w, rtol, atol), makeVariable<bool>(Values{true}));
@@ -79,8 +79,8 @@ TEST(IsCloseTest, with_matrices) {
   const auto v = makeVariable<Eigen::Matrix3d>(Values{mat_v});
   const Eigen::Matrix3d mat_w = Eigen::Matrix3d::Constant(3, 3, 1.0001);
   const auto w = makeVariable<Eigen::Matrix3d>(Values{mat_w});
-  const auto rtol = 0.0 * units::one;
-  const auto atol = 1.0 * units::one;
+  const auto rtol = 0.0 * sc_units::one;
+  const auto atol = 1.0 * sc_units::one;
   EXPECT_EQ(isclose(u, u, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(u, v, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(v, w, rtol, atol), makeVariable<bool>(Values{true}));
@@ -105,8 +105,8 @@ TEST(IsCloseTest, with_affine) {
   const Eigen::Affine3d w_affine = w_rotation * w_translation;
   const auto w = makeVariable<Eigen::Affine3d>(Values{w_affine});
 
-  const auto rtol = 0.0 * units::one;
-  const auto atol = 1.0 * units::one;
+  const auto rtol = 0.0 * sc_units::one;
+  const auto atol = 1.0 * sc_units::one;
   EXPECT_EQ(isclose(u, u, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(u, v, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(v, w, rtol, atol), makeVariable<bool>(Values{true}));
@@ -120,8 +120,8 @@ TEST(IsCloseTest, with_translation) {
       Values{core::Translation{Eigen::Vector3d{1, 1, 1}}});
   const auto w = makeVariable<core::Translation>(
       Values{core::Translation{Eigen::Vector3d{1, 1, 1.0001}}});
-  const auto rtol = 0.0 * units::one;
-  const auto atol = 1.0 * units::one;
+  const auto rtol = 0.0 * sc_units::one;
+  const auto atol = 1.0 * sc_units::one;
   EXPECT_EQ(isclose(u, u, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(u, v, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(v, w, rtol, atol), makeVariable<bool>(Values{true}));
@@ -135,8 +135,8 @@ TEST(IsCloseTest, with_quaternion) {
       Values{core::Quaternion{Eigen::Quaterniond{1, -1, 0.5, -0.25}}});
   const auto w = makeVariable<core::Quaternion>(
       Values{core::Quaternion{Eigen::Quaterniond{1, -1, 0.5, -1.2}}});
-  const auto rtol = 0.0 * units::one;
-  const auto atol = 1.0 * units::one;
+  const auto rtol = 0.0 * sc_units::one;
+  const auto atol = 1.0 * sc_units::one;
   EXPECT_EQ(isclose(u, u, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(u, v, rtol, atol), makeVariable<bool>(Values{true}));
   EXPECT_EQ(isclose(v, w, rtol, atol), makeVariable<bool>(Values{true}));
@@ -144,9 +144,10 @@ TEST(IsCloseTest, with_quaternion) {
 }
 
 TEST(IsCloseTest, works_for_counts) {
-  const auto a = makeVariable<double>(Values{1}, Variances{1}, units::counts);
-  const auto rtol = 1e-5 * units::one;
-  const auto atol = 0.0 * units::counts;
+  const auto a =
+      makeVariable<double>(Values{1}, Variances{1}, sc_units::counts);
+  const auto rtol = 1e-5 * sc_units::one;
+  const auto atol = 0.0 * sc_units::counts;
   EXPECT_NO_THROW_DISCARD(isclose(a, a, rtol, atol));
 }
 
@@ -157,10 +158,10 @@ TEST(IsCloseTest, compare_variances_only) {
   const auto b = makeVariable<double>(Values{10.0}, Variances{1.0});
   EXPECT_EQ(isclose(a, b, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{1.0})),
-            true * units::none);
+            true * sc_units::none);
   EXPECT_EQ(isclose(a, b, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{0.9})),
-            false * units::none);
+            false * sc_units::none);
 }
 
 TEST(IsCloseTest, compare_values_and_variances) {
@@ -173,60 +174,62 @@ TEST(IsCloseTest, compare_values_and_variances) {
   // sanity check no mismatch
   EXPECT_EQ(isclose(w, w, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{0.9})),
-            true * units::none);
+            true * sc_units::none);
   // mismatch value only
   EXPECT_EQ(isclose(w, x, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{0.9})),
-            false * units::none);
+            false * sc_units::none);
   // mismatch variance only
   EXPECT_EQ(isclose(w, y, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{0.9})),
-            false * units::none);
+            false * sc_units::none);
   // mismatch value and variance
   EXPECT_EQ(isclose(w, z, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{0.9})),
-            false * units::none);
+            false * sc_units::none);
 
   // same as above but looser tolerance
   EXPECT_EQ(isclose(w, z, makeVariable<double>(Values{0.0}),
                     makeVariable<double>(Values{1.0})),
-            true * units::none);
+            true * sc_units::none);
 }
 
 TEST(IsCloseTest, rtol_units) {
-  auto unit = scipp::units::m;
+  auto unit = scipp::sc_units::m;
   const auto a = makeVariable<double>(Values{1.0}, Variances{1.0}, unit);
   // This is fine
-  EXPECT_EQ(isclose(a, a, 1.0 * scipp::units::one, 1.0 * unit),
-            true * scipp::units::none);
+  EXPECT_EQ(isclose(a, a, 1.0 * scipp::sc_units::one, 1.0 * unit),
+            true * scipp::sc_units::none);
   // Now rtol has units m
   EXPECT_THROW_DISCARD(isclose(a, a, 1.0 * unit, 1.0 * unit),
                        except::UnitError);
 }
 
 TEST(IsCloseTest, no_unit) {
-  const auto a = makeVariable<double>(Values{1.0}, Variances{1.0}, units::none);
-  EXPECT_EQ(isclose(a, a, 1.0 * scipp::units::none, 1.0 * scipp::units::none),
-            true * scipp::units::none);
-  EXPECT_THROW_DISCARD(isclose(a, a, 1.0 * scipp::units::dimensionless,
-                               1.0 * scipp::units::none),
+  const auto a =
+      makeVariable<double>(Values{1.0}, Variances{1.0}, sc_units::none);
+  EXPECT_EQ(
+      isclose(a, a, 1.0 * scipp::sc_units::none, 1.0 * scipp::sc_units::none),
+      true * scipp::sc_units::none);
+  EXPECT_THROW_DISCARD(isclose(a, a, 1.0 * scipp::sc_units::dimensionless,
+                               1.0 * scipp::sc_units::none),
                        except::UnitError);
-  const auto b =
-      makeVariable<double>(Values{1.0}, Variances{1.0}, units::dimensionless);
-  EXPECT_THROW_DISCARD(isclose(b, b, 1.0 * scipp::units::dimensionless,
-                               1.0 * scipp::units::none),
+  const auto b = makeVariable<double>(Values{1.0}, Variances{1.0},
+                                      sc_units::dimensionless);
+  EXPECT_THROW_DISCARD(isclose(b, b, 1.0 * scipp::sc_units::dimensionless,
+                               1.0 * scipp::sc_units::none),
                        except::UnitError);
 }
 
 TEST(ComparisonTest, variances_test) {
   const auto a = makeVariable<float>(Values{1.0}, Variances{1.0});
   const auto b = makeVariable<float>(Values{2.0}, Variances{2.0});
-  EXPECT_EQ(less(a, b), true * units::none);
-  EXPECT_EQ(less_equal(a, b), true * units::none);
-  EXPECT_EQ(greater(a, b), false * units::none);
-  EXPECT_EQ(greater_equal(a, b), false * units::none);
-  EXPECT_EQ(equal(a, b), false * units::none);
-  EXPECT_EQ(not_equal(a, b), true * units::none);
+  EXPECT_EQ(less(a, b), true * sc_units::none);
+  EXPECT_EQ(less_equal(a, b), true * sc_units::none);
+  EXPECT_EQ(greater(a, b), false * sc_units::none);
+  EXPECT_EQ(greater_equal(a, b), false * sc_units::none);
+  EXPECT_EQ(equal(a, b), false * sc_units::none);
+  EXPECT_EQ(not_equal(a, b), true * sc_units::none);
 }
 
 TEST(ComparisonTest, can_broadcast_variances) {
@@ -246,23 +249,23 @@ TEST(ComparisonTest, can_broadcast_variances) {
 TEST(ComparisonTest, less_units_test) {
   const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0});
   auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{0.0, 3.0});
-  b.setUnit(units::m);
+  b.setUnit(sc_units::m);
   EXPECT_THROW([[maybe_unused]] auto out = less(a, b), std::runtime_error);
 }
 
 namespace {
-const auto a = 1.0 * units::m;
-const auto b = 2.0 * units::m;
+const auto a = 1.0 * sc_units::m;
+const auto b = 2.0 * sc_units::m;
 const auto sa = makeVariable<std::string>(Dims{}, Values{"a"});
 const auto sb = makeVariable<std::string>(Dims{}, Values{"b"});
-const auto va = make_vectors(Dimensions{}, units::m, {1.0, 2.0, 3.0});
-const auto vb = make_vectors(Dimensions{}, units::m, {4.0, 5.0, 6.0});
-const auto ma = make_matrices(Dimensions{}, units::m,
+const auto va = make_vectors(Dimensions{}, sc_units::m, {1.0, 2.0, 3.0});
+const auto vb = make_vectors(Dimensions{}, sc_units::m, {4.0, 5.0, 6.0});
+const auto ma = make_matrices(Dimensions{}, sc_units::m,
                               {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
-const auto mb = make_matrices(Dimensions{}, units::m,
+const auto mb = make_matrices(Dimensions{}, sc_units::m,
                               {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9});
-const auto true_ = true * units::none;
-const auto false_ = false * units::none;
+const auto true_ = true * sc_units::none;
+const auto false_ = false * sc_units::none;
 } // namespace
 
 TEST(ComparisonTest, less_test) {

--- a/lib/variable/test/concat_test.cpp
+++ b/lib/variable/test/concat_test.cpp
@@ -12,12 +12,12 @@ using namespace scipp;
 class ConcatTest : public ::testing::Test {
 protected:
   Variable base = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                       units::m, Values{1, 2, 3, 4});
+                                       sc_units::m, Values{1, 2, 3, 4});
 };
 
 TEST_F(ConcatTest, unit_mismatch) {
   auto other = copy(base);
-  other.setUnit(units::s);
+  other.setUnit(sc_units::s);
   EXPECT_THROW_DISCARD(concat(std::vector{base, other}, Dim::X),
                        except::UnitError);
 }
@@ -62,42 +62,42 @@ TEST_F(ConcatTest, new_dim_strided_inputs) {
 
 TEST_F(ConcatTest, existing_outer_dim) {
   auto expected =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2}, sc_units::m,
                            Values{1, 2, 3, 4, 2, 4, 6, 8});
   EXPECT_EQ(concat(std::vector{base, base + base}, Dim::X), expected);
 }
 
 TEST_F(ConcatTest, existing_inner_dim) {
   auto expected =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 4}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 4}, sc_units::m,
                            Values{1, 2, 2, 4, 3, 4, 6, 8});
   EXPECT_EQ(concat(std::vector{base, base + base}, Dim::Y), expected);
 }
 
 TEST_F(ConcatTest, existing_outer_transposed_other) {
   auto expected =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{4, 2}, sc_units::m,
                            Values{1, 2, 3, 4, 1, 2, 3, 4});
   EXPECT_EQ(concat(std::vector{base, copy(transpose(base))}, Dim::X), expected);
 }
 
 TEST_F(ConcatTest, existing_inner_transposed_other) {
   auto expected =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 4}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 4}, sc_units::m,
                            Values{1, 2, 1, 2, 3, 4, 3, 4});
   EXPECT_EQ(concat(std::vector{base, copy(transpose(base))}, Dim::Y), expected);
 }
 
 TEST_F(ConcatTest, existing_outer_dim_and_new_dim) {
   auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 2},
-                                       units::m, Values{1, 2, 3, 4, 3, 4});
+                                       sc_units::m, Values{1, 2, 3, 4, 3, 4});
   EXPECT_EQ(concat(std::vector{base, base.slice({Dim::X, 1})}, Dim::X),
             expected);
 }
 
 TEST_F(ConcatTest, new_dim_and_existing_outer_dim) {
   auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 2},
-                                       units::m, Values{3, 4, 1, 2, 3, 4});
+                                       sc_units::m, Values{3, 4, 1, 2, 3, 4});
   EXPECT_EQ(concat(std::vector{base.slice({Dim::X, 1}), base}, Dim::X),
             expected);
 }

--- a/lib/variable/test/copy_test.cpp
+++ b/lib/variable/test/copy_test.cpp
@@ -26,7 +26,7 @@ protected:
   }
 
   Variable xy =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 3}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{3, 3}, sc_units::m,
                            Values{1, 2, 3, 4, 5, 6, 7, 8, 9},
                            Variances{10, 11, 12, 13, 14, 15, 16, 17, 18});
 };
@@ -56,7 +56,7 @@ TEST_F(CopyTest, slice) {
 }
 
 TEST_F(CopyTest, broadcast) {
-  const auto var = broadcast(1.2 * units::m, Dimensions(Dim::X, 3));
+  const auto var = broadcast(1.2 * sc_units::m, Dimensions(Dim::X, 3));
   const auto copied = copy(var);
   check_copied(copied, var);
   EXPECT_FALSE(equals(copied.strides(), var.strides()));

--- a/lib/variable/test/creation_test.cpp
+++ b/lib/variable/test/creation_test.cpp
@@ -11,14 +11,14 @@ using namespace scipp::variable;
 
 TEST(CreationTest, empty) {
   const auto dims = Dimensions(Dim::X, 2);
-  const auto var1 = variable::empty(dims, units::m, dtype<double>, true);
+  const auto var1 = variable::empty(dims, sc_units::m, dtype<double>, true);
   EXPECT_EQ(var1.dims(), dims);
-  EXPECT_EQ(var1.unit(), units::m);
+  EXPECT_EQ(var1.unit(), sc_units::m);
   EXPECT_EQ(var1.dtype(), dtype<double>);
   EXPECT_EQ(var1.has_variances(), true);
-  const auto var2 = variable::empty(dims, units::s, dtype<int32_t>);
+  const auto var2 = variable::empty(dims, sc_units::s, dtype<int32_t>);
   EXPECT_EQ(var2.dims(), dims);
-  EXPECT_EQ(var2.unit(), units::s);
+  EXPECT_EQ(var2.unit(), sc_units::s);
   EXPECT_EQ(var2.dtype(), dtype<int32_t>);
   EXPECT_EQ(var2.has_variances(), false);
 }
@@ -26,13 +26,13 @@ TEST(CreationTest, empty) {
 TEST(CreationTest, ones) {
   const auto dims = Dimensions(Dim::X, 2);
   EXPECT_EQ(
-      variable::ones(dims, units::m, dtype<double>, true),
-      makeVariable<double>(dims, units::m, Values{1, 1}, Variances{1, 1}));
-  EXPECT_EQ(variable::ones(dims, units::s, dtype<int32_t>),
-            makeVariable<int32_t>(dims, units::s, Values{1, 1}));
+      variable::ones(dims, sc_units::m, dtype<double>, true),
+      makeVariable<double>(dims, sc_units::m, Values{1, 1}, Variances{1, 1}));
+  EXPECT_EQ(variable::ones(dims, sc_units::s, dtype<int32_t>),
+            makeVariable<int32_t>(dims, sc_units::s, Values{1, 1}));
   // Not a broadcast of a scalar
   EXPECT_FALSE(
-      variable::ones(dims, units::m, dtype<double>, true).is_readonly());
+      variable::ones(dims, sc_units::m, dtype<double>, true).is_readonly());
 }
 
 TEST_P(DenseVariablesTest, empty_like_fail_if_sizes) {
@@ -73,7 +73,7 @@ TEST_P(DenseVariablesTest, empty_like) {
 }
 
 TEST(CreationTest, special_like_double) {
-  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                         Values{1, 2}, Variances{3, 4});
   EXPECT_EQ(special_like(var, FillValue::Default),
             makeVariable<double>(var.dims(), var.unit(), Values{0, 0},
@@ -99,7 +99,7 @@ TEST(CreationTest, special_like_double) {
 
 TEST(CreationTest, special_like_int) {
   const auto var =
-      makeVariable<int64_t>(Dims{Dim::X}, Shape{2}, units::m, Values{1, 2});
+      makeVariable<int64_t>(Dims{Dim::X}, Shape{2}, sc_units::m, Values{1, 2});
   EXPECT_EQ(special_like(var, FillValue::Default),
             makeVariable<int64_t>(var.dims(), var.unit(), Values{0, 0}));
   EXPECT_EQ(special_like(var, FillValue::ZeroNotBool),
@@ -120,8 +120,8 @@ TEST(CreationTest, special_like_int) {
 }
 
 TEST(CreationTest, special_like_bool) {
-  const auto var =
-      makeVariable<bool>(Dims{Dim::X}, Shape{2}, units::m, Values{true, false});
+  const auto var = makeVariable<bool>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                      Values{true, false});
   EXPECT_EQ(special_like(var, FillValue::Default),
             makeVariable<bool>(var.dims(), var.unit(), Values{false, false}));
   EXPECT_EQ(special_like(var, FillValue::ZeroNotBool),
@@ -138,21 +138,22 @@ TEST(CreationTest, special_like_bool) {
 
 TEST(CreationTest, special_like_time_point) {
   using core::time_point;
-  const auto var = makeVariable<time_point>(units::ns, Values{time_point(1)});
+  const auto var =
+      makeVariable<time_point>(sc_units::ns, Values{time_point(1)});
   EXPECT_EQ(special_like(var, FillValue::Default),
-            makeVariable<time_point>(units::ns, Values{time_point(0)}));
+            makeVariable<time_point>(sc_units::ns, Values{time_point(0)}));
   EXPECT_EQ(special_like(var, FillValue::ZeroNotBool),
-            makeVariable<time_point>(units::ns, Values{time_point(0)}));
+            makeVariable<time_point>(sc_units::ns, Values{time_point(0)}));
   EXPECT_EQ(special_like(var, FillValue::True),
-            makeVariable<bool>(units::ns, Values{true}));
+            makeVariable<bool>(sc_units::ns, Values{true}));
   EXPECT_EQ(special_like(var, FillValue::False),
-            makeVariable<bool>(units::ns, Values{false}));
-  EXPECT_EQ(
-      special_like(var, FillValue::Max),
-      makeVariable<time_point>(
-          units::ns, Values{time_point(std::numeric_limits<int64_t>::max())}));
+            makeVariable<bool>(sc_units::ns, Values{false}));
+  EXPECT_EQ(special_like(var, FillValue::Max),
+            makeVariable<time_point>(
+                sc_units::ns,
+                Values{time_point(std::numeric_limits<int64_t>::max())}));
   EXPECT_EQ(special_like(var, FillValue::Lowest),
             makeVariable<time_point>(
-                units::ns,
+                sc_units::ns,
                 Values{time_point(std::numeric_limits<int64_t>::lowest())}));
 }

--- a/lib/variable/test/equals_nan_test.cpp
+++ b/lib/variable/test/equals_nan_test.cpp
@@ -36,7 +36,7 @@ TEST(EqualsNanTest, nested) {
 
 TEST(EqualsNanTest, structured) {
   auto var =
-      variable::make_vectors(Dimensions(Dim::X, 1), units::m, {1, 2, NAN});
+      variable::make_vectors(Dimensions(Dim::X, 1), sc_units::m, {1, 2, NAN});
   check_equal(var, var);
 }
 

--- a/lib/variable/test/hyperbolic_test.cpp
+++ b/lib/variable/test/hyperbolic_test.cpp
@@ -13,7 +13,7 @@
 
 using namespace scipp;
 using namespace scipp::variable;
-using namespace scipp::units;
+using namespace scipp::sc_units;
 
 TEST(VariableHyperbolicTest, sinh) {
   const auto input = makeVariable<double>(Dims{}, Values{0.5});

--- a/lib/variable/test/inv_test.cpp
+++ b/lib/variable/test/inv_test.cpp
@@ -19,10 +19,11 @@ bool is_close(const Variable &var, const Eigen::Vector3d &vec) {
 TEST(ElementInverseTest, linear_transform) {
   const Eigen::Matrix3d t({{0.1, 2.3, 1.7}, {3.1, 0.4, 0.6}, {0.9, 1.2, 1.6}});
   const auto transform =
-      makeVariable<Eigen::Matrix3d>(Dims{}, Values{t}, units::m);
+      makeVariable<Eigen::Matrix3d>(Dims{}, Values{t}, sc_units::m);
 
   const Eigen::Vector3d v(0.1, 2.1, 1.4);
-  const auto vec = makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, units::s);
+  const auto vec =
+      makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, sc_units::s);
 
   const auto rtol = makeVariable<double>(Values{0});
   const auto atol = makeVariable<Eigen::Vector3d>(
@@ -40,10 +41,11 @@ TEST(ElementInverseTest, affine_transform) {
   Eigen::Affine3d t(Eigen::Translation<double, 3>(Eigen::Vector3d(1, 2, 3)));
   t *= rotation;
   const auto transform =
-      makeVariable<Eigen::Affine3d>(Dims{}, Values{t}, units::m);
+      makeVariable<Eigen::Affine3d>(Dims{}, Values{t}, sc_units::m);
 
   const Eigen::Vector3d v(1.1, -5.2, 4.0);
-  const auto vec = makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, units::m);
+  const auto vec =
+      makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, sc_units::m);
 
   const auto res = inv(transform) * transform * vec;
   EXPECT_TRUE(is_close(res, v));
@@ -54,10 +56,11 @@ TEST(ElementInverseTest, affine_transform) {
 TEST(ElementInverseTest, translation) {
   const core::Translation t(Eigen::Vector3d(4, 2, -3));
   const auto transform =
-      makeVariable<core::Translation>(Dims{}, Values{t}, units::s);
+      makeVariable<core::Translation>(Dims{}, Values{t}, sc_units::s);
 
   const Eigen::Vector3d v(-0.2, 0.5, 11.2);
-  const auto vec = makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, units::s);
+  const auto vec =
+      makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, sc_units::s);
 
   const auto res = inv(transform) * transform * vec;
   EXPECT_TRUE(is_close(res, v));
@@ -70,7 +73,8 @@ TEST(ElementInverseTest, rotation) {
   const auto transform = makeVariable<core::Quaternion>(Dims{}, Values{t});
 
   const Eigen::Vector3d v(4.1, -4.1, -2.2);
-  const auto vec = makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, units::kg);
+  const auto vec =
+      makeVariable<Eigen::Vector3d>(Dims{}, Values{v}, sc_units::kg);
 
   const auto res = inv(transform) * transform * vec;
   EXPECT_TRUE(is_close(res, v));

--- a/lib/variable/test/linalg_test.cpp
+++ b/lib/variable/test/linalg_test.cpp
@@ -11,7 +11,7 @@ using namespace scipp;
 
 class LinalgVectorTest : public ::testing::Test {
 protected:
-  Variable vectors = variable::make_vectors(Dimensions(Dim::Y, 2), units::m,
+  Variable vectors = variable::make_vectors(Dimensions(Dim::Y, 2), sc_units::m,
                                             {1, 2, 3, 4, 5, 6});
 };
 
@@ -23,7 +23,7 @@ TEST_F(LinalgVectorTest, basics) {
 
 TEST_F(LinalgVectorTest, elem_access) {
   Variable elems = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                        units::m, Values{1, 2, 3, 4, 5, 6});
+                                        sc_units::m, Values{1, 2, 3, 4, 5, 6});
   for (auto i : {0, 1, 2}) {
     EXPECT_EQ(vectors.elements<Eigen::Vector3d>().slice(
                   {Dim::InternalStructureComponent, i}),
@@ -39,7 +39,7 @@ TEST_F(LinalgVectorTest, elem_access) {
 class LinalgMatrixTest : public ::testing::Test {
 protected:
   Variable matrices = variable::make_matrices(
-      Dimensions(Dim::X, 2), units::m,
+      Dimensions(Dim::X, 2), sc_units::m,
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19});
 };
 

--- a/lib/variable/test/math_test.cpp
+++ b/lib/variable/test/math_test.cpp
@@ -26,7 +26,7 @@ TYPED_TEST_SUITE(VariableMathTest, FloatTypes);
 
 TYPED_TEST(VariableMathTest, abs) {
   for (TypeParam x : {0.0, -1.23, 3.45, -1.23456789}) {
-    for (auto u : {units::dimensionless, units::m}) {
+    for (auto u : {sc_units::dimensionless, sc_units::m}) {
       const auto v = x * u;
       const auto ref = element::abs(x);
       EXPECT_EQ(abs(v), ref * u);
@@ -35,13 +35,13 @@ TYPED_TEST(VariableMathTest, abs) {
 }
 
 TEST(Variable, abs_out_arg) {
-  const auto x = -1.23 * units::m;
-  auto out = 0.0 * units::dimensionless;
+  const auto x = -1.23 * sc_units::m;
+  auto out = 0.0 * sc_units::dimensionless;
   const auto &view = abs(x, out);
 
-  EXPECT_EQ(x, -1.23 * units::m);
+  EXPECT_EQ(x, -1.23 * sc_units::m);
   EXPECT_EQ(&view, &out);
-  EXPECT_EQ(view, 1.23 * units::m);
+  EXPECT_EQ(view, 1.23 * sc_units::m);
 }
 
 TEST(Variable, abs_out_arg_self) {
@@ -59,31 +59,31 @@ TEST(Variable, norm_of_vector) {
   Eigen::Vector3d v2(1, 1, 0);
   Eigen::Vector3d v3(0, 0, -2);
   auto reference = makeVariable<double>(
-      Dims{Dim::X}, Shape{3}, units::m,
+      Dims{Dim::X}, Shape{3}, sc_units::m,
       Values{element::norm(v1), element::norm(v2), element::norm(v3)});
-  auto var = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{3}, units::m,
+  auto var = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                            Values{v1, v2, v3});
   EXPECT_EQ(norm(var), reference);
 }
 
 TEST(Variable, pow_unit_exponent_dims) {
-  const Variable base = 2.0 * units::m;
-  const Variable scalar_exponent = 3.0 * units::one;
+  const Variable base = 2.0 * sc_units::m;
+  const Variable scalar_exponent = 3.0 * sc_units::one;
   const Variable array_exponent = makeVariable<double>(Dims{Dim::X}, Shape{2});
   EXPECT_NO_THROW_DISCARD(pow(base, scalar_exponent));
   EXPECT_THROW_DISCARD(pow(base, array_exponent), except::DimensionError);
 }
 
 TEST(Variable, pow_unit_float_exponent) {
-  EXPECT_NO_THROW_DISCARD(pow(1.0 * units::one, 2.2 * units::one));
-  EXPECT_THROW_DISCARD(pow(1.0 * units::m, 2.2 * units::one),
+  EXPECT_NO_THROW_DISCARD(pow(1.0 * sc_units::one, 2.2 * sc_units::one));
+  EXPECT_THROW_DISCARD(pow(1.0 * sc_units::m, 2.2 * sc_units::one),
                        except::UnitError);
-  EXPECT_THROW_DISCARD(pow(int64_t{1} * units::m, 2.2 * units::one),
+  EXPECT_THROW_DISCARD(pow(int64_t{1} * sc_units::m, 2.2 * sc_units::one),
                        except::UnitError);
 
-  auto out = -1.0 * units::one;
-  EXPECT_NO_THROW_DISCARD(pow(1.0 * units::one, 2.2 * units::one, out));
-  EXPECT_THROW_DISCARD(pow(1.0 * units::m, 2.2 * units::one, out),
+  auto out = -1.0 * sc_units::one;
+  EXPECT_NO_THROW_DISCARD(pow(1.0 * sc_units::one, 2.2 * sc_units::one, out));
+  EXPECT_THROW_DISCARD(pow(1.0 * sc_units::m, 2.2 * sc_units::one, out),
                        except::UnitError);
 }
 
@@ -99,25 +99,26 @@ TYPED_TEST(VariablePowTest, pow_unit) {
   using B = std::tuple_element_t<0, TypeParam>;
   using E = std::tuple_element_t<1, TypeParam>;
 
-  const auto base_one = static_cast<B>(1) * units::one;
-  const auto exp_one = static_cast<E>(1) * units::one;
-  const auto exp_two = static_cast<E>(2) * units::one;
-  const auto exp_three = static_cast<E>(3) * units::one;
-  const auto exp_four = static_cast<E>(4) * units::one;
+  const auto base_one = static_cast<B>(1) * sc_units::one;
+  const auto exp_one = static_cast<E>(1) * sc_units::one;
+  const auto exp_two = static_cast<E>(2) * sc_units::one;
+  const auto exp_three = static_cast<E>(3) * sc_units::one;
+  const auto exp_four = static_cast<E>(4) * sc_units::one;
 
-  const auto base_m = static_cast<B>(1) * units::m;
-  const auto exp_m = static_cast<E>(1) * units::m;
-  const auto base_s = static_cast<B>(1) * units::s;
-  const auto exp_s = static_cast<E>(1) * units::s;
+  const auto base_m = static_cast<B>(1) * sc_units::m;
+  const auto exp_m = static_cast<E>(1) * sc_units::m;
+  const auto base_s = static_cast<B>(1) * sc_units::s;
+  const auto exp_s = static_cast<E>(1) * sc_units::s;
 
-  EXPECT_EQ(pow(base_one, exp_one).unit(), units::one);
-  EXPECT_EQ(pow(base_m, exp_one).unit(), units::m);
-  EXPECT_EQ(pow(base_s, exp_one).unit(), units::s);
-  EXPECT_EQ(pow(base_m, exp_two).unit(), units::m * units::m);
-  EXPECT_EQ(pow(base_s, exp_two).unit(), units::s * units::s);
-  EXPECT_EQ(pow(base_m, exp_three).unit(), units::m * units::m * units::m);
+  EXPECT_EQ(pow(base_one, exp_one).unit(), sc_units::one);
+  EXPECT_EQ(pow(base_m, exp_one).unit(), sc_units::m);
+  EXPECT_EQ(pow(base_s, exp_one).unit(), sc_units::s);
+  EXPECT_EQ(pow(base_m, exp_two).unit(), sc_units::m * sc_units::m);
+  EXPECT_EQ(pow(base_s, exp_two).unit(), sc_units::s * sc_units::s);
+  EXPECT_EQ(pow(base_m, exp_three).unit(),
+            sc_units::m * sc_units::m * sc_units::m);
   EXPECT_EQ(pow(base_s, exp_four).unit(),
-            units::s * units::s * units::s * units::s);
+            sc_units::s * sc_units::s * sc_units::s * sc_units::s);
   EXPECT_THROW_DISCARD(pow(base_one, exp_m), except::UnitError);
   EXPECT_THROW_DISCARD(pow(base_one, exp_s), except::UnitError);
   EXPECT_THROW_DISCARD(pow(base_s, exp_m), except::UnitError);
@@ -128,11 +129,11 @@ TYPED_TEST(VariablePowTest, pow_unit_in_place) {
   using E = std::tuple_element_t<1, TypeParam>;
   using O = std::common_type_t<B, E>;
 
-  auto out = static_cast<O>(-1) * units::one;
-  auto ret =
-      pow(static_cast<B>(1) * units::m, static_cast<E>(2) * units::one, out);
-  EXPECT_EQ(out.unit(), units::m * units::m);
-  EXPECT_EQ(ret.unit(), units::m * units::m);
+  auto out = static_cast<O>(-1) * sc_units::one;
+  auto ret = pow(static_cast<B>(1) * sc_units::m,
+                 static_cast<E>(2) * sc_units::one, out);
+  EXPECT_EQ(out.unit(), sc_units::m * sc_units::m);
+  EXPECT_EQ(ret.unit(), sc_units::m * sc_units::m);
 }
 
 TYPED_TEST(VariablePowTest, pow_dims) {
@@ -143,7 +144,7 @@ TYPED_TEST(VariablePowTest, pow_dims) {
   Dimensions y{{Dim::Y, 3}};
   Dimensions xy{{Dim::X, 2}, {Dim::Y, 3}};
 
-  for (auto &&base_unit : {units::one, units::m, units::s}) {
+  for (auto &&base_unit : {sc_units::one, sc_units::m, sc_units::s}) {
     const auto base_scalar = makeVariable<B>(Dims{}, base_unit);
     const auto base_x = makeVariable<B>(x, base_unit);
     const auto base_y = makeVariable<B>(y, base_unit);
@@ -156,7 +157,7 @@ TYPED_TEST(VariablePowTest, pow_dims) {
     EXPECT_EQ(pow(base_scalar, exp_scalar).dims().ndim(), 0);
 
     EXPECT_EQ(pow(base_x, exp_scalar).dims(), x);
-    if (base_unit == units::one) {
+    if (base_unit == sc_units::one) {
       EXPECT_EQ(pow(base_scalar, exp_x).dims(), x);
       EXPECT_EQ(pow(base_x, exp_x).dims(), x);
       EXPECT_EQ(pow(base_x, exp_y).dims(), xy);
@@ -178,7 +179,7 @@ TYPED_TEST(VariablePowTest, pow_dims_in_place) {
   using E = std::tuple_element_t<1, TypeParam>;
   using O = std::common_type_t<B, E>;
   Dimensions x{{Dim::X, 2}};
-  for (auto &&base_unit : {units::one, units::m, units::s}) {
+  for (auto &&base_unit : {sc_units::one, sc_units::m, sc_units::s}) {
     const auto base_scalar = makeVariable<B>(Dims{}, base_unit);
     const auto base_x = makeVariable<B>(x, base_unit);
     const auto exp_scalar = makeVariable<E>(Dims{});
@@ -189,7 +190,7 @@ TYPED_TEST(VariablePowTest, pow_dims_in_place) {
     EXPECT_THROW_DISCARD(pow(base_x, exp_scalar, out_scalar),
                          except::DimensionError);
     EXPECT_EQ(pow(base_x, exp_scalar, out_x).dims(), x);
-    if (base_unit == units::one) {
+    if (base_unit == sc_units::one) {
       EXPECT_THROW_DISCARD(pow(base_scalar, exp_x, out_scalar),
                            except::DimensionError);
       EXPECT_EQ(pow(base_scalar, exp_x, out_x).dims(), x);
@@ -235,30 +236,34 @@ TEST(Variable, pow_negative_exponent) {
 }
 
 TEST(Variable, pow_value) {
-  for (auto &&base_unit : {units::one, units::m}) {
-    EXPECT_NEAR(pow(3.0 * base_unit, 4.0 * units::one).value<double>(), 81.0,
+  for (auto &&base_unit : {sc_units::one, sc_units::m}) {
+    EXPECT_NEAR(pow(3.0 * base_unit, 4.0 * sc_units::one).value<double>(), 81.0,
                 1e-12);
-    EXPECT_NEAR(pow(int64_t{3} * base_unit, 4.0 * units::one).value<double>(),
-                81.0, 1e-12);
-    EXPECT_NEAR(pow(3.0 * base_unit, int64_t{4} * units::one).value<double>(),
-                81.0, 1e-12);
-    EXPECT_EQ(
-        pow(int64_t{3} * base_unit, int64_t{4} * units::one).value<int64_t>(),
-        int64_t{81});
+    EXPECT_NEAR(
+        pow(int64_t{3} * base_unit, 4.0 * sc_units::one).value<double>(), 81.0,
+        1e-12);
+    EXPECT_NEAR(
+        pow(3.0 * base_unit, int64_t{4} * sc_units::one).value<double>(), 81.0,
+        1e-12);
+    EXPECT_EQ(pow(int64_t{3} * base_unit, int64_t{4} * sc_units::one)
+                  .value<int64_t>(),
+              int64_t{81});
 
-    EXPECT_NEAR(pow(3.0 * base_unit, -4.0 * units::one).value<double>(),
+    EXPECT_NEAR(pow(3.0 * base_unit, -4.0 * sc_units::one).value<double>(),
                 1.0 / 81.0, 1e-12);
-    EXPECT_NEAR(pow(int64_t{3} * base_unit, -4.0 * units::one).value<double>(),
-                1.0 / 81.0, 1e-12);
-    EXPECT_NEAR(pow(3.0 * base_unit, int64_t{-4} * units::one).value<double>(),
-                1.0 / 81.0, 1e-12);
+    EXPECT_NEAR(
+        pow(int64_t{3} * base_unit, -4.0 * sc_units::one).value<double>(),
+        1.0 / 81.0, 1e-12);
+    EXPECT_NEAR(
+        pow(3.0 * base_unit, int64_t{-4} * sc_units::one).value<double>(),
+        1.0 / 81.0, 1e-12);
   }
 }
 
 TEST(Variable, pow_value_in_place) {
-  auto base = 3.0 * units::one;
-  const auto exponent = 2.0 * units::one;
-  auto out = -1.0 * units::one;
+  auto base = 3.0 * sc_units::one;
+  const auto exponent = 2.0 * sc_units::one;
+  auto out = -1.0 * sc_units::one;
   auto ret = pow(base, exponent, out);
   EXPECT_NEAR(out.value<double>(), 9.0, 1e-15);
   EXPECT_TRUE(ret.is_same(out));
@@ -269,7 +274,7 @@ TEST(Variable, pow_value_in_place) {
 
 TEST(Variable, pow_value_and_variance) {
   const auto base = makeVariable<double>(Dims{}, Values{4.0}, Variances{2.0});
-  const auto result = pow(base, int64_t{2} * units::one);
+  const auto result = pow(base, int64_t{2} * sc_units::one);
   EXPECT_NEAR(result.value<double>(), 16.0, 1e-14);
   // pow.var = (2 * (base.val ^ 1)) ^ 2 * base.var
   EXPECT_NEAR(result.variance<double>(), 64.0 * base.variance<double>(), 1e-14);
@@ -282,15 +287,15 @@ TEST(Variable, pow_value_and_variance) {
 
 TEST(Variable, pow_binned_variable) {
   const auto buffer = makeVariable<double>(
-      Dims{Dim::Event}, Shape{5}, Values{1.0, 2.0, 3.0, 4.0, 5.0}, units::m);
+      Dims{Dim::Event}, Shape{5}, Values{1.0, 2.0, 3.0, 4.0, 5.0}, sc_units::m);
   const auto indices = makeVariable<index_pair>(
       Dims{Dim::X}, Shape{2}, Values{index_pair{0, 2}, index_pair{2, 5}});
   const auto base = make_bins(indices, Dim::Event, buffer);
-  const auto result = pow(base, int64_t{2} * units::one);
+  const auto result = pow(base, int64_t{2} * sc_units::one);
 
   const auto expected_buffer = makeVariable<double>(
       Dims{Dim::Event}, Shape{5}, Values{1.0, 4.0, 9.0, 16.0, 25.0},
-      units::m * units::m);
+      sc_units::m * sc_units::m);
   const auto expected = make_bins(indices, Dim::Event, expected_buffer);
 
   EXPECT_EQ(result, expected);
@@ -298,19 +303,19 @@ TEST(Variable, pow_binned_variable) {
 
 TEST(Variable, pow_binned_variable_exp) {
   const auto buffer = makeVariable<double>(
-      Dims{Dim::Event}, Shape{5}, Values{1.0, 2.0, 3.0, 4.0, 5.0}, units::m);
+      Dims{Dim::Event}, Shape{5}, Values{1.0, 2.0, 3.0, 4.0, 5.0}, sc_units::m);
   const auto indices = makeVariable<index_pair>(
       Dims{Dim::X}, Shape{2}, Values{index_pair{0, 2}, index_pair{2, 5}});
   const auto exponent = make_bins(indices, Dim::Event, buffer);
-  EXPECT_THROW_DISCARD(pow(int64_t{2} * units::one, exponent),
+  EXPECT_THROW_DISCARD(pow(int64_t{2} * sc_units::one, exponent),
                        std::invalid_argument);
 }
 
 TYPED_TEST(VariableMathTest, sqrt) {
   for (TypeParam x : {0.0, 1.23, 1.23456789, 3.45}) {
     for (auto [uin, uout] :
-         {std::tuple{units::dimensionless, units::dimensionless},
-          std::tuple{units::m * units::m, units::m}}) {
+         {std::tuple{sc_units::dimensionless, sc_units::dimensionless},
+          std::tuple{sc_units::m * sc_units::m, sc_units::m}}) {
       const auto v = x * uin;
       const auto ref = element::sqrt(x);
       EXPECT_EQ(sqrt(v), ref * uout);
@@ -333,14 +338,14 @@ TEST(Variable, dot_of_vector) {
   Eigen::Vector3d v2(-4.4, -5.5, -6.6);
   Eigen::Vector3d v3(0, 0, 0);
   auto reference = makeVariable<double>(
-      Dims{Dim::X}, Shape{3}, units::m * units::m,
+      Dims{Dim::X}, Shape{3}, sc_units::m * sc_units::m,
       Values{element::dot(v1, v1), element::dot(v2, v2), element::dot(v3, v3)});
-  auto var = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{3}, units::m,
+  auto var = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                            Values{v1, v2, v3});
   const auto result = dot(var, var);
   EXPECT_TRUE(
-      all(isclose(result, reference, 1e-14 * units::one,
-                  makeVariable<double>(Values{0.0}, units::m * units::m)))
+      all(isclose(result, reference, 1e-14 * sc_units::one,
+                  makeVariable<double>(Values{0.0}, sc_units::m * sc_units::m)))
           .value<bool>());
 }
 
@@ -350,13 +355,14 @@ TEST(Variable, cross_of_vector) {
   Eigen::Vector3d v3(0, 0, 1);
 
   auto reference = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{3}, units::Unit(units::m) * units::Unit(units::m),
+      Dims{Dim::X}, Shape{3},
+      sc_units::Unit(sc_units::m) * sc_units::Unit(sc_units::m),
       Values{element::cross(v1, v2), element::cross(v2, v1),
              element::cross(v2, v2)});
   auto var1 = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{v1, v2, v2});
+      Dims{Dim::X}, Shape{3}, sc_units::Unit(sc_units::m), Values{v1, v2, v2});
   auto var2 = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{3}, units::Unit(units::m), Values{v2, v1, v2});
+      Dims{Dim::X}, Shape{3}, sc_units::Unit(sc_units::m), Values{v2, v1, v2});
   EXPECT_EQ(cross(var1, var2), reference);
 }
 
@@ -370,23 +376,25 @@ TEST(Variable, reciprocal) {
 }
 
 TEST(Variable, reciprocal_out_arg_full_in_place) {
-  auto var =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 4, 9});
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                                  Values{1, 4, 9});
   auto &view = reciprocal(var, var);
-  EXPECT_EQ(var, makeVariable<double>(Dims{Dim::X}, Shape{3},
-                                      units::Unit(units::one / units::m),
-                                      Values{1., 1. / 4., 1. / 9.}));
+  EXPECT_EQ(var,
+            makeVariable<double>(Dims{Dim::X}, Shape{3},
+                                 sc_units::Unit(sc_units::one / sc_units::m),
+                                 Values{1., 1. / 4., 1. / 9.}));
   EXPECT_EQ(&view, &var);
 }
 
 TEST(Variable, reciprocal_out_arg_partial) {
-  const auto var =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 4, 9});
-  auto out = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                                        Values{1, 4, 9});
+  auto out = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
   auto &view = reciprocal(var.slice({Dim::X, 1, 3}), out);
-  EXPECT_EQ(out, makeVariable<double>(Dims{Dim::X}, Shape{2},
-                                      units::Unit(units::one / units::m),
-                                      Values{1. / 4., 1. / 9.}));
+  EXPECT_EQ(out,
+            makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                 sc_units::Unit(sc_units::one / sc_units::m),
+                                 Values{1. / 4., 1. / 9.}));
   EXPECT_EQ(&view, &out);
 }
 
@@ -412,7 +420,7 @@ TEST(Variable, exp_out_arg) {
 }
 
 TEST(Variable, exp_bad_unit) {
-  EXPECT_THROW_DISCARD(exp(0.0 * units::s), except::UnitError);
+  EXPECT_THROW_DISCARD(exp(0.0 * sc_units::s), except::UnitError);
 }
 
 TYPED_TEST(VariableMathTest, log) {
@@ -437,7 +445,7 @@ TEST(Variable, log_out_arg) {
 }
 
 TEST(Variable, log_bad_unit) {
-  EXPECT_THROW_DISCARD(log(1.0 * units::s), except::UnitError);
+  EXPECT_THROW_DISCARD(log(1.0 * sc_units::s), except::UnitError);
 }
 
 TYPED_TEST(VariableMathTest, log10) {
@@ -462,29 +470,29 @@ TEST(Variable, log10_out_arg) {
 }
 
 TEST(Variable, log10_bad_unit) {
-  EXPECT_THROW_DISCARD(log10(1.0 * units::s), except::UnitError);
+  EXPECT_THROW_DISCARD(log10(1.0 * sc_units::s), except::UnitError);
 }
 
 TEST(Variable, rint) {
   auto preRoundedVar = makeVariable<double>(
-      Dims{scipp::units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
-  auto roundedVar = makeVariable<double>(Dims{scipp::units::Dim::X},
+      Dims{scipp::sc_units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
+  auto roundedVar = makeVariable<double>(Dims{scipp::sc_units::Dim::X},
                                          Values{1, 3, 2, 2}, Shape{4});
   EXPECT_EQ(rint(preRoundedVar), roundedVar);
 }
 
 TEST(Variable, ceil) {
   auto preRoundedVar = makeVariable<double>(
-      Dims{scipp::units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
-  auto roundedVar = makeVariable<double>(Dims{scipp::units::Dim::X},
+      Dims{scipp::sc_units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
+  auto roundedVar = makeVariable<double>(Dims{scipp::sc_units::Dim::X},
                                          Values{2, 3, 2, 3}, Shape{4});
   EXPECT_EQ(ceil(preRoundedVar), roundedVar);
 }
 
 TEST(Variable, floor) {
   auto preRoundedVar = makeVariable<double>(
-      Dims{scipp::units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
-  auto roundedVar = makeVariable<double>(Dims{scipp::units::Dim::X},
+      Dims{scipp::sc_units::Dim::X}, Values{1.2, 2.9, 1.5, 2.5}, Shape{4});
+  auto roundedVar = makeVariable<double>(Dims{scipp::sc_units::Dim::X},
                                          Values{1, 2, 1, 2}, Shape{4});
   EXPECT_EQ(floor(preRoundedVar), roundedVar);
 }

--- a/lib/variable/test/mean_test.cpp
+++ b/lib/variable/test/mean_test.cpp
@@ -18,39 +18,43 @@ using MeanTestTypes = testing::Types<int32_t, int64_t, float, double>;
 TYPED_TEST_SUITE(MeanTest, MeanTestTypes);
 
 template <typename Op> void unknown_dim_fail(Op op) {
-  const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                        units::m, Values{1.0, 2.0, 3.0, 4.0});
+  const auto var =
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
+                           Values{1.0, 2.0, 3.0, 4.0});
   EXPECT_THROW(const auto view = op(var, Dim::Z), except::DimensionError);
 }
 
 template <typename TestFixture, typename Op> void basic(Op op) {
   const auto var = makeVariable<typename TestFixture::TestType>(
-      Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m, Values{1.0, 2.0, 3.0, 4.0});
+      Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
+      Values{1.0, 2.0, 3.0, 4.0});
   using RetType = typename TestFixture::ReturnType;
-  const auto meanX =
-      makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m, Values{1.5, 3.5});
-  const auto meanY =
-      makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  const auto meanX = makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, sc_units::m,
+                                           Values{1.5, 3.5});
+  const auto meanY = makeVariable<RetType>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                           Values{2.0, 3.0});
   EXPECT_EQ(op(var, Dim::X), meanX);
   EXPECT_EQ(op(var, Dim::Y), meanY);
 }
 
 template <typename TestFixture, typename Op> void basic_all_dims(Op op) {
   const auto var = makeVariable<typename TestFixture::TestType>(
-      Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m, Values{1.0, 2.0, 3.0, 4.0});
+      Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
+      Values{1.0, 2.0, 3.0, 4.0});
   const auto meanAll =
-      makeVariable<typename TestFixture::ReturnType>(units::m, Values{2.5});
+      makeVariable<typename TestFixture::ReturnType>(sc_units::m, Values{2.5});
   EXPECT_EQ(op(var), meanAll);
 }
 
 template <typename TestFixture, typename Op> void dtype_preservation(Op op) {
   const auto var = makeVariable<typename TestFixture::TestType>(
-      Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m, Values{1.0, 2.0, 3.0, 4.0});
+      Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
+      Values{1.0, 2.0, 3.0, 4.0});
   using RetType = typename TestFixture::ReturnType;
-  const auto meanX =
-      makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m, Values{1.5, 3.5});
-  const auto meanY =
-      makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  const auto meanX = makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, sc_units::m,
+                                           Values{1.5, 3.5});
+  const auto meanY = makeVariable<RetType>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                           Values{2.0, 3.0});
   EXPECT_EQ(op(var, Dim::X), meanX);
   EXPECT_EQ(op(var, Dim::Y), meanY);
 }
@@ -59,15 +63,15 @@ template <typename TestFixture, typename Op>
 void variances_as_standard_deviation_of_the_mean([[maybe_unused]] Op op) {
   if constexpr (TestFixture::TestVariances) {
     const auto var = makeVariable<typename TestFixture::TestType>(
-        Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m, Values{1.0, 2.0, 3.0, 4.0},
-        Variances{5.0, 6.0, 7.0, 8.0});
+        Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
+        Values{1.0, 2.0, 3.0, 4.0}, Variances{5.0, 6.0, 7.0, 8.0});
 
     using RetType = typename TestFixture::ReturnType;
-    const auto meanX = makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m,
-                                             Values{1.5, 3.5},
+    const auto meanX = makeVariable<RetType>(Dims{Dim::Y}, Shape{2},
+                                             sc_units::m, Values{1.5, 3.5},
                                              Variances{0.5 * 5.5, 0.5 * 7.5});
-    const auto meanY = makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m,
-                                             Values{2.0, 3.0},
+    const auto meanY = makeVariable<RetType>(Dims{Dim::X}, Shape{2},
+                                             sc_units::m, Values{2.0, 3.0},
                                              Variances{0.5 * 6.0, 0.5 * 7.0});
     EXPECT_EQ(op(var, Dim::X), meanX);
     EXPECT_EQ(op(var, Dim::Y), meanY);
@@ -115,23 +119,23 @@ TYPED_TEST(MeanTest, variances_as_standard_deviation_of_the_mean) {
 
 TYPED_TEST(MeanTest, nanmean_basic) {
   auto var = makeVariable<TypeParam>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                     units::m, Values{1, 2, 3, 4});
+                                     sc_units::m, Values{1, 2, 3, 4});
   using RetType = typename TestFixture::ReturnType;
-  const auto meanX =
-      makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m, Values{1.5, 3.5});
-  const auto meanY =
-      makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  const auto meanX = makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, sc_units::m,
+                                           Values{1.5, 3.5});
+  const auto meanY = makeVariable<RetType>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                           Values{2.0, 3.0});
   EXPECT_EQ(nanmean(var, Dim::X), meanX);
   EXPECT_EQ(nanmean(var, Dim::Y), meanY);
   if constexpr (TestFixture::TestNans) {
     var.template values<TypeParam>().data()[3] = TypeParam{NAN};
     EXPECT_EQ(nanmean(var, Dim::X),
-              makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, units::m,
+              makeVariable<RetType>(Dims{Dim::Y}, Shape{2}, sc_units::m,
                                     Values{1.5, 3.0}));
     EXPECT_EQ(nanmean(var, Dim::Y),
-              makeVariable<RetType>(Dims{Dim::X}, Shape{2}, units::m,
+              makeVariable<RetType>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                     Values{2.0, 2.0}));
-    EXPECT_EQ(nanmean(var), makeVariable<RetType>(units::m, Values{2.0}));
+    EXPECT_EQ(nanmean(var), makeVariable<RetType>(sc_units::m, Values{2.0}));
   }
 }
 

--- a/lib/variable/test/operations_test.cpp
+++ b/lib/variable/test/operations_test.cpp
@@ -31,45 +31,45 @@ using ScalarTypes = ::testing::Types<double, float, int64_t, int32_t>;
 TYPED_TEST_SUITE(VariableScalarOperatorTest, ScalarTypes);
 
 TYPED_TEST(VariableScalarOperatorTest, plus_equals) {
-  this->variable += this->scalar * units::one;
+  this->variable += this->scalar * sc_units::one;
   EXPECT_EQ(this->value(), 12);
 }
 
 TYPED_TEST(VariableScalarOperatorTest, minus_equals) {
-  this->variable -= this->scalar * units::one;
+  this->variable -= this->scalar * sc_units::one;
   EXPECT_EQ(this->value(), 8);
 }
 
 TYPED_TEST(VariableScalarOperatorTest, times_equals) {
-  this->variable *= this->scalar * units::one;
+  this->variable *= this->scalar * sc_units::one;
   EXPECT_EQ(this->value(), 20);
 }
 
 TYPED_TEST(VariableScalarOperatorTest, divide_equals) {
   if (this->variable.dtype() == dtype<double> ||
       this->variable.dtype() == dtype<float>) {
-    this->variable /= this->scalar * units::one;
+    this->variable /= this->scalar * sc_units::one;
     EXPECT_EQ(this->value(), 5);
   } else {
-    EXPECT_THROW(this->variable /= this->scalar * units::one,
+    EXPECT_THROW(this->variable /= this->scalar * sc_units::one,
                  except::TypeError);
   }
 }
 
 TEST(Variable, operator_unary_minus) {
-  const auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1.1, 2.2});
-  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
-                                             Values{-1.1, -2.2});
+  const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                      Values{1.1, 2.2});
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                             sc_units::m, Values{-1.1, -2.2});
   auto b = -a;
   EXPECT_EQ(b, expected);
 }
 
 TEST(VariableView, unary_minus) {
-  const auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1.1, 2.2});
+  const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                      Values{1.1, 2.2});
   const auto expected =
-      makeVariable<double>(Dims(), Shape(), units::m, Values{-2.2});
+      makeVariable<double>(Dims(), Shape(), sc_units::m, Values{-2.2});
   auto b = -a.slice({Dim::X, 1});
   EXPECT_EQ(b, expected);
 }
@@ -93,15 +93,16 @@ TEST(Variable, operator_plus_equal_automatic_broadcast_of_rhs) {
 }
 
 TEST(Variable, operator_plus_equal_transpose) {
-  auto a = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 2}, units::m,
+  auto a = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 2}, sc_units::m,
                                 Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   auto transpose =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3}, sc_units::m,
                            Values{1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
   EXPECT_NO_THROW(a += transpose);
-  ASSERT_EQ(a, makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 2}, units::m,
-                                    Values{2.0, 4.0, 6.0, 8.0, 10.0, 12.0}));
+  ASSERT_EQ(a,
+            makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 2}, sc_units::m,
+                                 Values{2.0, 4.0, 6.0, 8.0, 10.0, 12.0}));
 }
 
 TEST(Variable, operator_plus_equal_different_dimensions) {
@@ -117,7 +118,7 @@ TEST(Variable, operator_plus_equal_different_unit) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.1, 2.2});
 
   auto different_unit = copy(a);
-  different_unit.setUnit(units::m);
+  different_unit.setUnit(sc_units::m);
   EXPECT_THROW(a += different_unit, except::UnitError);
 }
 
@@ -129,23 +130,23 @@ TEST(Variable, operator_plus_equal_non_arithmetic_type) {
 
 TEST(Variable, operator_plus_equal_time_type) {
   using time_point = scipp::core::time_point;
-  auto a = makeVariable<time_point>(Shape{1}, units::Unit{units::ns},
+  auto a = makeVariable<time_point>(Shape{1}, sc_units::Unit{sc_units::ns},
                                     Values{time_point{2}});
-  EXPECT_THROW(a += static_cast<float>(1.0) * units::ns, except::TypeError);
-  EXPECT_NO_THROW(a += static_cast<int64_t>(1) * units::ns);
-  EXPECT_NO_THROW(a += static_cast<int32_t>(2) * units::ns);
-  EXPECT_EQ(a, makeVariable<time_point>(Shape{1}, units::Unit{units::ns},
+  EXPECT_THROW(a += static_cast<float>(1.0) * sc_units::ns, except::TypeError);
+  EXPECT_NO_THROW(a += static_cast<int64_t>(1) * sc_units::ns);
+  EXPECT_NO_THROW(a += static_cast<int32_t>(2) * sc_units::ns);
+  EXPECT_EQ(a, makeVariable<time_point>(Shape{1}, sc_units::Unit{sc_units::ns},
                                         Values{time_point{5}}));
 }
 
 TEST(Variable, operator_minus_equal_time_type) {
   using time_point = scipp::core::time_point;
-  auto a = makeVariable<time_point>(Shape{1}, units::Unit{units::ns},
+  auto a = makeVariable<time_point>(Shape{1}, sc_units::Unit{sc_units::ns},
                                     Values{time_point{10}});
-  EXPECT_THROW(a -= static_cast<float>(1.0) * units::ns, except::TypeError);
-  EXPECT_NO_THROW(a -= static_cast<int64_t>(1) * units::ns);
-  EXPECT_NO_THROW(a -= static_cast<int32_t>(2) * units::ns);
-  EXPECT_EQ(a, makeVariable<time_point>(Shape{1}, units::Unit{units::ns},
+  EXPECT_THROW(a -= static_cast<float>(1.0) * sc_units::ns, except::TypeError);
+  EXPECT_NO_THROW(a -= static_cast<int64_t>(1) * sc_units::ns);
+  EXPECT_NO_THROW(a -= static_cast<int32_t>(2) * sc_units::ns);
+  EXPECT_EQ(a, makeVariable<time_point>(Shape{1}, sc_units::Unit{sc_units::ns},
                                         Values{time_point{7}}));
 }
 
@@ -165,7 +166,7 @@ TEST(Variable, operator_plus_equal_different_variables_same_element_type) {
 TEST(Variable, operator_plus_equal_scalar) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.1, 2.2});
 
-  EXPECT_NO_THROW(a += 1.0 * units::one);
+  EXPECT_NO_THROW(a += 1.0 * sc_units::one);
   EXPECT_EQ(a.values<double>()[0], 2.1);
   EXPECT_EQ(a.values<double>()[1], 3.2);
 }
@@ -181,12 +182,12 @@ TEST(Variable, operator_plus_equal_custom_type) {
 TEST(Variable, operator_plus_unit_fail) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0},
                                 Variances{3.0, 4.0});
-  a.setUnit(units::m);
+  a.setUnit(sc_units::m);
   auto b = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1.0, 2.0},
                                 Variances{3.0, 4.0});
-  b.setUnit(units::s);
+  b.setUnit(sc_units::s);
   ASSERT_ANY_THROW_DISCARD(a + b);
-  b.setUnit(units::m);
+  b.setUnit(sc_units::m);
   ASSERT_NO_THROW_DISCARD(a + b);
 }
 
@@ -203,31 +204,31 @@ TEST(Variable, operator_plus_eigen_type) {
 }
 
 TEST(Variable, operator_times_equal) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                Values{2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), units::m);
+  EXPECT_EQ(a.unit(), sc_units::m);
   EXPECT_NO_THROW(a *= a);
   EXPECT_EQ(a.values<double>()[0], 4.0);
   EXPECT_EQ(a.values<double>()[1], 9.0);
-  EXPECT_EQ(a.unit(), units::m * units::m);
+  EXPECT_EQ(a.unit(), sc_units::m * sc_units::m);
 }
 
 TEST(Variable, operator_times_equal_scalar) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                Values{2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), units::m);
-  EXPECT_NO_THROW(a *= 2.0 * units::one);
+  EXPECT_EQ(a.unit(), sc_units::m);
+  EXPECT_NO_THROW(a *= 2.0 * sc_units::one);
   EXPECT_EQ(a.values<double>()[0], 4.0);
   EXPECT_EQ(a.values<double>()[1], 6.0);
-  EXPECT_EQ(a.unit(), units::m);
+  EXPECT_EQ(a.unit(), sc_units::m);
 }
 
 TEST(Variable, operator_plus_equal_unit_fail_integrity) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2},
-                           units::Unit(units::m * units::m), Values{2.0, 3.0});
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                sc_units::Unit(sc_units::m * sc_units::m),
+                                Values{2.0, 3.0});
   const auto expected(a);
 
   ASSERT_THROW(a += a * a, std::runtime_error);
@@ -247,52 +248,52 @@ TEST(Variable, operator_times_can_broadcast) {
 TEST(Variable, operator_divide_equal) {
   auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{2.0, 3.0});
   auto b = makeVariable<double>(Values{2.0});
-  b.setUnit(units::m);
+  b.setUnit(sc_units::m);
 
   EXPECT_NO_THROW(a /= b);
   EXPECT_EQ(a.values<double>()[0], 1.0);
   EXPECT_EQ(a.values<double>()[1], 1.5);
-  EXPECT_EQ(a.unit(), units::one / units::m);
+  EXPECT_EQ(a.unit(), sc_units::one / sc_units::m);
 }
 
 TEST(Variable, operator_divide_equal_self) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 3.0});
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                Values{2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), units::m);
+  EXPECT_EQ(a.unit(), sc_units::m);
   EXPECT_NO_THROW(a /= a);
   EXPECT_EQ(a.values<double>()[0], 1.0);
   EXPECT_EQ(a.values<double>()[1], 1.0);
-  EXPECT_EQ(a.unit(), units::one);
+  EXPECT_EQ(a.unit(), sc_units::one);
 }
 
 TEST(Variable, operator_divide_equal_scalar) {
-  auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 4.0});
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                Values{2.0, 4.0});
 
-  EXPECT_EQ(a.unit(), units::m);
-  EXPECT_NO_THROW(a /= 2.0 * units::one);
+  EXPECT_EQ(a.unit(), sc_units::m);
+  EXPECT_NO_THROW(a /= 2.0 * sc_units::one);
   EXPECT_EQ(a.values<double>()[0], 1.0);
   EXPECT_EQ(a.values<double>()[1], 2.0);
-  EXPECT_EQ(a.unit(), units::m);
+  EXPECT_EQ(a.unit(), sc_units::m);
 }
 
 TEST(Variable, operator_divide_scalar_double) {
-  const auto a =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 4.0});
-  const auto result = 1.111 * units::one / a;
+  const auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                      Values{2.0, 4.0});
+  const auto result = 1.111 * sc_units::one / a;
   EXPECT_EQ(result.values<double>()[0], 1.111 / 2.0);
   EXPECT_EQ(result.values<double>()[1], 1.111 / 4.0);
-  EXPECT_EQ(result.unit(), units::one / units::m);
+  EXPECT_EQ(result.unit(), sc_units::one / sc_units::m);
 }
 
 TEST(Variable, operator_divide_scalar_float) {
-  const auto a =
-      makeVariable<float>(Dims{Dim::X}, Shape{2}, units::m, Values{2.0, 4.0});
-  const auto result = 1.111f * units::one / a;
+  const auto a = makeVariable<float>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                     Values{2.0, 4.0});
+  const auto result = 1.111f * sc_units::one / a;
   EXPECT_EQ(result.values<float>()[0], 1.111f / 2.0f);
   EXPECT_EQ(result.values<float>()[1], 1.111f / 4.0f);
-  EXPECT_EQ(result.unit(), units::one / units::m);
+  EXPECT_EQ(result.unit(), sc_units::one / sc_units::m);
 }
 
 TEST(Variable, operator_allowed_types) {
@@ -650,24 +651,24 @@ TEST(VariableView, slice_binary_operations) {
 TEST(Variable, non_in_place_scalar_operations) {
   auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, Values{1, 2});
 
-  auto sum = var + 1.0 * units::one;
+  auto sum = var + 1.0 * sc_units::one;
   EXPECT_TRUE(equals(sum.values<double>(), {2, 3}));
-  sum = 2.0 * units::one + var;
+  sum = 2.0 * sc_units::one + var;
   EXPECT_TRUE(equals(sum.values<double>(), {3, 4}));
 
-  auto diff = var - 1.0 * units::one;
+  auto diff = var - 1.0 * sc_units::one;
   EXPECT_TRUE(equals(diff.values<double>(), {0, 1}));
-  diff = 2.0 * units::one - var;
+  diff = 2.0 * sc_units::one - var;
   EXPECT_TRUE(equals(diff.values<double>(), {1, 0}));
 
-  auto prod = var * (2.0 * units::one);
+  auto prod = var * (2.0 * sc_units::one);
   EXPECT_TRUE(equals(prod.values<double>(), {2, 4}));
-  prod = 3.0 * units::one * var;
+  prod = 3.0 * sc_units::one * var;
   EXPECT_TRUE(equals(prod.values<double>(), {3, 6}));
 
-  auto ratio = var / (2.0 * units::one);
+  auto ratio = var / (2.0 * sc_units::one);
   EXPECT_TRUE(equals(ratio.values<double>(), {1.0 / 2.0, 1.0}));
-  ratio = 3.0 * units::one / var;
+  ratio = 3.0 * sc_units::one / var;
   EXPECT_TRUE(equals(ratio.values<double>(), {3.0, 1.5}));
 }
 
@@ -675,17 +676,17 @@ TEST(VariableView, scalar_operations) {
   auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
                                   Values{11, 12, 13, 21, 22, 23});
 
-  var.slice({Dim::X, 0}) += 1.0 * units::one;
+  var.slice({Dim::X, 0}) += 1.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 13, 22, 22, 23}));
-  var.slice({Dim::Y, 1}) += 1.0 * units::one;
+  var.slice({Dim::Y, 1}) += 1.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 13, 23, 23, 24}));
-  var.slice({Dim::X, 1, 3}) += 1.0 * units::one;
+  var.slice({Dim::X, 1, 3}) += 1.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {12, 13, 14, 23, 24, 25}));
-  var.slice({Dim::X, 1}) -= 1.0 * units::one;
+  var.slice({Dim::X, 1}) -= 1.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 14, 23, 23, 25}));
-  var.slice({Dim::X, 2}) *= 0.0 * units::one;
+  var.slice({Dim::X, 2}) *= 0.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {12, 12, 0, 23, 23, 0}));
-  var.slice({Dim::Y, 0}) /= 2.0 * units::one;
+  var.slice({Dim::Y, 0}) /= 2.0 * sc_units::one;
   EXPECT_TRUE(equals(var.values<double>(), {6, 6, 0, 23, 23, 0}));
 }
 
@@ -801,8 +802,8 @@ TEST(VariableTest, boolean_xor) {
 }
 
 TEST(VariableTest, zip_positions) {
-  const Variable x =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 2, 3});
+  const Variable x = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                                          Values{1, 2, 3});
   auto positions = geometry::position(x, x, x);
   auto values = positions.values<Eigen::Vector3d>();
   EXPECT_EQ(values.size(), 3);
@@ -814,18 +815,18 @@ TEST(VariableTest, zip_positions) {
 TEST(VariableTest, rotate) {
   Eigen::Vector3d vec1(1, 2, 3);
   Eigen::Vector3d vec2(4, 5, 6);
-  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{2}, units::m,
+  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                            Values{vec1, vec2});
   Eigen::Quaterniond rot1(1.1, 2.2, 3.3, 4.4);
   Eigen::Quaterniond rot2(5.5, 6.6, 7.7, 8.8);
   rot1.normalize();
   rot2.normalize();
   const Variable rot = makeVariable<Eigen::Matrix3d>(
-      Dims{Dim::X}, Shape{2}, units::one,
+      Dims{Dim::X}, Shape{2}, sc_units::one,
       Values{rot1.toRotationMatrix(), rot2.toRotationMatrix()});
   auto vec_new = rot * vec;
   const auto rotated = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{2}, units::m,
+      Dims{Dim::X}, Shape{2}, sc_units::m,
       Values{rot1.toRotationMatrix() * vec1, rot2.toRotationMatrix() * vec2});
   EXPECT_EQ(vec_new, rotated);
 }
@@ -835,15 +836,15 @@ TEST(VariableTest, combine_translations) {
   Eigen::Vector3d translation2(4, 5, 6);
 
   auto trans1 = makeVariable<scipp::core::Translation>(
-      Dims{Dim::X}, Shape{1}, units::m,
+      Dims{Dim::X}, Shape{1}, sc_units::m,
       Values{scipp::core::Translation(translation1)});
   auto trans2 = makeVariable<scipp::core::Translation>(
-      Dims{Dim::X}, Shape{1}, units::m,
+      Dims{Dim::X}, Shape{1}, sc_units::m,
       Values{scipp::core::Translation(translation2)});
 
   Eigen::Vector3d expected(5, 7, 9);
   auto expected_var = makeVariable<scipp::core::Translation>(
-      Dims{Dim::X}, Shape{1}, units::m,
+      Dims{Dim::X}, Shape{1}, sc_units::m,
       Values{scipp::core::Translation(expected)});
 
   EXPECT_EQ(trans1 * trans2, expected_var);
@@ -855,17 +856,17 @@ TEST(VariableTest, combine_translation_and_rotation) {
   rotation = Eigen::AngleAxisd(pi<double>, Eigen::Vector3d::UnitX());
 
   const Variable translation_var = makeVariable<scipp::core::Translation>(
-      Dims{Dim::X}, Shape{1}, units::m,
+      Dims{Dim::X}, Shape{1}, sc_units::m,
       Values{scipp::core::Translation(translation)});
   const Variable rotation_var = makeVariable<scipp::core::Quaternion>(
-      Dims{Dim::X}, Shape{1}, units::one,
+      Dims{Dim::X}, Shape{1}, sc_units::one,
       Values{scipp::core::Quaternion(rotation)});
 
   // Translation and rotation -> affine
   const Eigen::Affine3d expected(Eigen::Translation<double, 3>(translation) *
                                  rotation);
   const Variable expected_var = makeVariable<Eigen::Affine3d>(
-      Dims{Dim::X}, Shape{1}, units::m, Values{expected});
+      Dims{Dim::X}, Shape{1}, sc_units::m, Values{expected});
 
   EXPECT_EQ(translation_var * rotation_var, expected_var);
 }
@@ -878,17 +879,17 @@ TEST(VariableTest, combine_rotations) {
   rotation2 = Eigen::AngleAxisd(pi<double> / 2.0, Eigen::Vector3d::UnitX());
 
   const Variable rotation1_var = makeVariable<scipp::core::Quaternion>(
-      Dims{Dim::X}, Shape{1}, units::one,
+      Dims{Dim::X}, Shape{1}, sc_units::one,
       Values{scipp::core::Quaternion(rotation1)});
 
   const Variable rotation2_var = makeVariable<scipp::core::Quaternion>(
-      Dims{Dim::X}, Shape{1}, units::one,
+      Dims{Dim::X}, Shape{1}, sc_units::one,
       Values{scipp::core::Quaternion(rotation2)});
 
   // Rotation and rotation -> rotation
   const Eigen::Quaterniond expected(rotation1 * rotation2);
   const Variable expected_var = makeVariable<scipp::core::Quaternion>(
-      Dims{Dim::X}, Shape{1}, units::one,
+      Dims{Dim::X}, Shape{1}, sc_units::one,
       Values{scipp::core::Quaternion(expected)});
 
   EXPECT_EQ(rotation1_var * rotation2_var, expected_var);
@@ -896,7 +897,7 @@ TEST(VariableTest, combine_rotations) {
 
 class ApplyTransformTest : public ::testing::Test {
 public:
-  Variable makeTransformVar(const units::Unit unit) {
+  Variable makeTransformVar(const sc_units::Unit unit) {
     Eigen::Vector3d rotation_axis(1, 0, 0);
     Eigen::Affine3d t(Eigen::AngleAxisd(pi<double> / 2.0, rotation_axis));
 
@@ -904,7 +905,7 @@ public:
                                          Values{t});
   }
 
-  Variable makeVectorVar(const units::Unit unit) {
+  Variable makeVectorVar(const sc_units::Unit unit) {
     Eigen::Vector3d eigen_vec(1, 2, 3);
     return makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, unit,
                                          Values{eigen_vec});
@@ -912,11 +913,11 @@ public:
 };
 
 TEST_F(ApplyTransformTest, apply_transform_to_vector) {
-  auto transformed = makeTransformVar(units::m) * makeVectorVar(units::m);
+  auto transformed = makeTransformVar(sc_units::m) * makeVectorVar(sc_units::m);
 
   Eigen::Vector3d expected(1, -3, 2);
   EXPECT_EQ(transformed,
-            makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, units::m,
+            makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, sc_units::m,
                                           Values{expected}));
 }
 
@@ -924,20 +925,22 @@ TEST_F(ApplyTransformTest, apply_transform_to_vector_with_different_units) {
   // Even though the transform and vector both have units of length, we don't
   // allow this application of a transform. The units must match exactly as the
   // transform may contain translations which get added to the vector.
-  EXPECT_THROW_DISCARD(makeTransformVar(units::m) * makeVectorVar(units::mm),
+  EXPECT_THROW_DISCARD(makeTransformVar(sc_units::m) *
+                           makeVectorVar(sc_units::mm),
                        except::UnitError);
 }
 
 TEST(VariableTest, mul_vector) {
   Eigen::Vector3d vec1(1, 2, 3);
   Eigen::Vector3d vec2(2, 4, 6);
-  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, units::m,
+  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, sc_units::m,
                                            Values{vec1});
   auto expected_vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1},
-                                                    units::m, Values{vec2});
-  auto scale = makeVariable<double>(Dims{}, Shape{1}, units::one, Values{2.0});
-  auto scale_with_variance = makeVariable<double>(Dims{}, Shape{1}, units::one,
-                                                  Values{2.0}, Variances{1.0});
+                                                    sc_units::m, Values{vec2});
+  auto scale =
+      makeVariable<double>(Dims{}, Shape{1}, sc_units::one, Values{2.0});
+  auto scale_with_variance = makeVariable<double>(
+      Dims{}, Shape{1}, sc_units::one, Values{2.0}, Variances{1.0});
 
   auto left_scaled_vec = scale * vec;
   auto right_scaled_vec = vec * scale;
@@ -950,11 +953,12 @@ TEST(VariableTest, mul_vector) {
 TEST(VariableTest, divide_vector) {
   Eigen::Vector3d vec1(1, 2, 3);
   Eigen::Vector3d vec2(2, 4, 6);
-  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, units::m,
+  auto vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1}, sc_units::m,
                                            Values{vec2});
   auto expected_vec = makeVariable<Eigen::Vector3d>(Dims{Dim::X}, Shape{1},
-                                                    units::m, Values{vec1});
-  auto scale = makeVariable<double>(Dims{}, Shape{1}, units::one, Values{2.0});
+                                                    sc_units::m, Values{vec1});
+  auto scale =
+      makeVariable<double>(Dims{}, Shape{1}, sc_units::one, Values{2.0});
 
   auto scaled_vec = vec / scale;
 

--- a/lib/variable/test/rebin_test.cpp
+++ b/lib/variable/test/rebin_test.cpp
@@ -12,8 +12,8 @@
 using namespace scipp;
 
 TEST(RebinTest, inner) {
-  const auto base = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::counts,
-                                         Values{1.0, 2.0});
+  const auto base = makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                         sc_units::counts, Values{1.0, 2.0});
   const auto oldEdge =
       makeVariable<double>(Dims{Dim::X}, Shape{3}, Values{1.0, 2.0, 3.0});
   const auto newEdge =
@@ -21,7 +21,7 @@ TEST(RebinTest, inner) {
   for (const auto &var :
        {base, astype(base, dtype<int64_t>), astype(base, dtype<int32_t>)}) {
     EXPECT_EQ(rebin(var, Dim::X, oldEdge, newEdge),
-              makeVariable<double>(Dims{Dim::X}, Shape{1}, units::counts,
+              makeVariable<double>(Dims{Dim::X}, Shape{1}, sc_units::counts,
                                    Values{3.0}));
   }
 }
@@ -30,7 +30,7 @@ TEST(RebinTest, inner_descending) {
   auto var = makeVariable<double>(
       Dims{Dim::X}, Shape{10},
       Values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
-  var.setUnit(units::counts);
+  var.setUnit(sc_units::counts);
   const auto oldEdge = makeVariable<double>(
       Dims{Dim::X}, Shape{11},
       Values{10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0});
@@ -40,15 +40,15 @@ TEST(RebinTest, inner_descending) {
 
   auto expected = makeVariable<double>(Dims{Dim::X}, Shape{5},
                                        Values{4.5, 5.5, 8.0, 18.0, 19.0});
-  expected.setUnit(units::counts);
+  expected.setUnit(sc_units::counts);
 
   ASSERT_EQ(rebinned, expected);
 }
 
 TEST(RebinTest, outer) {
-  auto base =
-      makeVariable<double>(Dimensions{{Dim::Y, 6}, {Dim::X, 2}}, units::counts,
-                           Values{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
+  auto base = makeVariable<double>(Dimensions{{Dim::Y, 6}, {Dim::X, 2}},
+                                   sc_units::counts,
+                                   Values{1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6});
   const auto oldEdge =
       makeVariable<double>(Dims{Dim::Y}, Shape{7}, Values{1, 2, 3, 4, 5, 6, 7});
   const auto newEdge =
@@ -59,7 +59,7 @@ TEST(RebinTest, outer) {
     EXPECT_EQ(rebin(var, Dim::Y, oldEdge, newEdge),
 
               makeVariable<double>(Dimensions{{Dim::Y, 2}, {Dim::X, 2}},
-                                   units::counts, Values{4, 6, 14, 18}));
+                                   sc_units::counts, Values{4, 6, 14, 18}));
   }
 }
 
@@ -68,7 +68,7 @@ TEST(RebinTest, outer) {
 // for stride[rebin_dim] == 1.
 TEST(RebinTest, outer_increasing_1_inner) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
-                                        Values{1, 2, 3, 4}, units::counts);
+                                        Values{1, 2, 3, 4}, sc_units::counts);
   constexpr auto varY = [](const auto... vals) {
     return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
                                 Values{vals...});
@@ -76,7 +76,7 @@ TEST(RebinTest, outer_increasing_1_inner) {
   const auto oldY = varY(0, 1, 2, 3, 4);
   constexpr auto var1x1 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
-                                Values{value}, units::counts);
+                                Values{value}, sc_units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -107,7 +107,7 @@ TEST(RebinTest, outer_increasing_1_inner) {
 TEST(RebinTest, outer_increasing_2_inner) {
   const auto var =
       makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 2},
-                           Values{1, 2, 2, 4, 3, 6, 4, 8}, units::counts);
+                           Values{1, 2, 2, 4, 3, 6, 4, 8}, sc_units::counts);
   constexpr auto varY = [](const auto... vals) {
     return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
                                 Values{vals...});
@@ -115,7 +115,7 @@ TEST(RebinTest, outer_increasing_2_inner) {
   const auto oldY = varY(0, 1, 2, 3, 4);
   constexpr auto var1x2 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
-                                Values{value, 2 * value}, units::counts);
+                                Values{value, 2 * value}, sc_units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -145,7 +145,7 @@ TEST(RebinTest, outer_increasing_2_inner) {
 
 TEST(RebinTest, outer_decreasing_1_inner) {
   const auto var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 1},
-                                        Values{4, 3, 2, 1}, units::counts);
+                                        Values{4, 3, 2, 1}, sc_units::counts);
   constexpr auto varY = [](const auto... vals) {
     return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
                                 Values{vals...});
@@ -153,7 +153,7 @@ TEST(RebinTest, outer_decreasing_1_inner) {
   const auto oldY = varY(4, 3, 2, 1, 0);
   constexpr auto var1x1 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 1},
-                                Values{value}, units::counts);
+                                Values{value}, sc_units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -184,7 +184,7 @@ TEST(RebinTest, outer_decreasing_1_inner) {
 TEST(RebinTest, outer_decreasing_2_inner) {
   const auto var =
       makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{4, 2},
-                           Values{4, 8, 3, 6, 2, 4, 1, 2}, units::counts);
+                           Values{4, 8, 3, 6, 2, 4, 1, 2}, sc_units::counts);
   constexpr auto varY = [](const auto... vals) {
     return makeVariable<double>(Dims{Dim::Y}, Shape{sizeof...(vals)},
                                 Values{vals...});
@@ -192,7 +192,7 @@ TEST(RebinTest, outer_decreasing_2_inner) {
   const auto oldY = varY(4, 3, 2, 1, 0);
   constexpr auto var1x2 = [](const double value) {
     return makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{1, 2},
-                                Values{value, 2 * value}, units::counts);
+                                Values{value, 2 * value}, sc_units::counts);
   };
   // full range
   EXPECT_EQ(rebin(var, Dim::Y, oldY, oldY), var);
@@ -234,7 +234,7 @@ TEST_F(RebinBool1DTest, without_fractional_overlap_yields_ones_and_zeros) {
   const auto edges =
       makeVariable<double>(Dimensions{Dim::X, 5}, Values{1, 3, 5, 7, 10});
   const auto expected = makeVariable<double>(
-      Dimensions{Dim::X, 4}, Values{0.0, 1.0, 0.0, 0.0}, units::none);
+      Dimensions{Dim::X, 4}, Values{0.0, 1.0, 0.0, 0.0}, sc_units::none);
 
   const auto result = rebin(mask, Dim::X, x, edges);
 
@@ -245,7 +245,7 @@ TEST_F(RebinBool1DTest, with_fractional_overlap_yields_fractions) {
   const auto edges = makeVariable<double>(Dimensions{Dim::X, 5},
                                           Values{1.0, 3.5, 5.5, 7.0, 10.0});
   const auto expected = makeVariable<double>(
-      Dimensions{Dim::X, 4}, Values{0.5, 0.5, 0.0, 0.0}, units::none);
+      Dimensions{Dim::X, 4}, Values{0.5, 0.5, 0.0, 0.0}, sc_units::none);
 
   const auto result = rebin(mask, Dim::X, x, edges);
 
@@ -264,7 +264,7 @@ TEST(RebinBool2DTest, inner) {
                                           Values{1.0, 3.0, 4.0, 5.5, 6.0});
   const auto expected = makeVariable<double>(
       Dimensions{{Dim::Y, 2}, {Dim::X, 4}},
-      Values{1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.0, 0.0}, units::none);
+      Values{1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.0, 0.0}, sc_units::none);
 
   const auto result = rebin(mask, Dim::X, x, edges);
 
@@ -282,9 +282,9 @@ TEST(RebinBool2DTest, outer) {
 
   const auto newEdge =
       makeVariable<double>(Dimensions{Dim::Y, 4}, Values{0.0, 2.0, 3.5, 6.5});
-  const auto expected =
-      makeVariable<double>(Dimensions{{Dim::Y, 3}, {Dim::X, 2}},
-                           Values{0.0, 1.0, 0.5, 0.0, 0.5, 1.0}, units::none);
+  const auto expected = makeVariable<double>(
+      Dimensions{{Dim::Y, 3}, {Dim::X, 2}},
+      Values{0.0, 1.0, 0.5, 0.0, 0.5, 1.0}, sc_units::none);
 
   const auto result = rebin(mask, Dim::Y, oldEdge, newEdge);
 
@@ -302,7 +302,7 @@ TEST(RebinBool2DTest, outer_single) {
   const auto newEdge =
       makeVariable<double>(Dimensions{Dim::Y, 2}, Values{0.0, 6.5});
   const auto expected = makeVariable<double>(
-      Dimensions{{Dim::Y, 1}, {Dim::X, 2}}, Values{0.0, 1.0}, units::none);
+      Dimensions{{Dim::Y, 1}, {Dim::X, 2}}, Values{0.0, 1.0}, sc_units::none);
 
   const auto result = rebin(mask, Dim::Y, oldEdge, newEdge);
 

--- a/lib/variable/test/reduce_various_test.cpp
+++ b/lib/variable/test/reduce_various_test.cpp
@@ -122,7 +122,7 @@ protected:
       makeVariable<index_pair>(Dims{Dim::Y, Dim::Z}, Shape{2, 2},
                                Values{std::pair{0, 2}, std::pair{2, 2},
                                       std::pair{2, 5}, std::pair{5, 6}});
-  Variable buffer = makeVariable<double>(Dims{Dim::X}, Shape{6}, units::m,
+  Variable buffer = makeVariable<double>(Dims{Dim::X}, Shape{6}, sc_units::m,
                                          Values{1, 2, 3, 4, 5, 6},
                                          Variances{1, 2, 3, 4, 5, 6});
   Variable binned = make_bins(indices, Dim::X, buffer);
@@ -144,10 +144,10 @@ TEST_F(ReduceBinnedTest, all_dims_of_0d) {
 
 TEST_F(ReduceBinnedTest, one_dim) {
   EXPECT_EQ(sum(binned, Dim::Y),
-            makeVariable<double>(Dims{Dim::Z}, Shape{2}, units::m,
+            makeVariable<double>(Dims{Dim::Z}, Shape{2}, sc_units::m,
                                  Values{15, 6}, Variances{15, 6}));
   EXPECT_EQ(sum(binned, Dim::Z),
-            makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m,
+            makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m,
                                  Values{3, 18}, Variances{3, 18}));
   EXPECT_EQ(mean(binned), mean(buffer));
 }

--- a/lib/variable/test/shape_test.cpp
+++ b/lib/variable/test/shape_test.cpp
@@ -143,34 +143,36 @@ TEST(ShapeTest, fold_temporary) {
 
 TEST(ShapeTest, fold_outer) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));
-  const auto expected = cumsum(variable::ones(
-      {{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, sc_units::m, dtype<double>));
+  const auto expected =
+      cumsum(variable::ones({{Dim::Row, 2}, {Dim::Time, 3}, {Dim::Y, 4}},
+                            sc_units::m, dtype<double>));
   EXPECT_EQ(fold(var, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}}), expected);
 }
 
 TEST(ShapeTest, fold_inner) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));
-  const auto expected = cumsum(variable::ones(
-      {{Dim::X, 6}, {Dim::Row, 2}, {Dim::Time, 2}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, sc_units::m, dtype<double>));
+  const auto expected =
+      cumsum(variable::ones({{Dim::X, 6}, {Dim::Row, 2}, {Dim::Time, 2}},
+                            sc_units::m, dtype<double>));
   EXPECT_EQ(fold(var, Dim::Y, {{Dim::Row, 2}, {Dim::Time, 2}}), expected);
 }
 
 TEST(ShapeTest, fold_into_3_dims) {
   const auto var =
-      cumsum(variable::ones({{Dim::X, 24}}, units::m, dtype<double>));
+      cumsum(variable::ones({{Dim::X, 24}}, sc_units::m, dtype<double>));
   const auto expected = cumsum(variable::ones(
-      {{Dim::Time, 2}, {Dim::Y, 3}, {Dim::Z, 4}}, units::m, dtype<double>));
+      {{Dim::Time, 2}, {Dim::Y, 3}, {Dim::Z, 4}}, sc_units::m, dtype<double>));
   EXPECT_EQ(fold(var, Dim::X, {{Dim::Time, 2}, {Dim::Y, 3}, {Dim::Z, 4}}),
             expected);
 }
 
 TEST(ShapeTest, flatten) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, sc_units::m, dtype<double>));
   const auto expected =
-      cumsum(variable::ones({{Dim::Z, 24}}, units::m, dtype<double>));
+      cumsum(variable::ones({{Dim::Z, 24}}, sc_units::m, dtype<double>));
   const auto flat = flatten(var, std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
   EXPECT_EQ(flat, expected);
   EXPECT_EQ(flat.data_handle(), var.data_handle()); // shared
@@ -178,9 +180,9 @@ TEST(ShapeTest, flatten) {
 
 TEST(ShapeTest, flatten_nothing) {
   const auto var =
-      cumsum(variable::ones({{Dim::X, 4}}, units::m, dtype<double>));
+      cumsum(variable::ones({{Dim::X, 4}}, sc_units::m, dtype<double>));
   const auto expected = cumsum(
-      variable::ones({{Dim::X, 4}, {Dim::Y, 1}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 4}, {Dim::Y, 1}}, sc_units::m, dtype<double>));
   const auto flat = flatten(var, std::vector<Dim>{}, Dim::Y);
   EXPECT_EQ(flat, expected);
   EXPECT_EQ(flat.data_handle(), var.data_handle()); // shared
@@ -189,17 +191,17 @@ TEST(ShapeTest, flatten_nothing) {
 
 TEST(ShapeTest, flatten_only_2_dims) {
   const auto var = cumsum(variable::ones(
-      {{Dim::X, 2}, {Dim::Y, 3}, {Dim::Z, 4}}, units::m, dtype<double>));
+      {{Dim::X, 2}, {Dim::Y, 3}, {Dim::Z, 4}}, sc_units::m, dtype<double>));
   const auto expected = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Z, 4}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Z, 4}}, sc_units::m, dtype<double>));
   EXPECT_EQ(flatten(var, std::vector<Dim>{Dim::X, Dim::Y}, Dim::X), expected);
 }
 
 TEST(ShapeTest, flatten_slice) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 4}, {Dim::Y, 5}}, units::m, dtype<double>));
-  const auto expected = makeVariable<double>(Dims{Dim::Z}, Shape{6}, units::m,
-                                             Values{7, 8, 9, 12, 13, 14});
+      variable::ones({{Dim::X, 4}, {Dim::Y, 5}}, sc_units::m, dtype<double>));
+  const auto expected = makeVariable<double>(
+      Dims{Dim::Z}, Shape{6}, sc_units::m, Values{7, 8, 9, 12, 13, 14});
   const auto flat = flatten(var.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 4}),
                             std::vector<Dim>{Dim::X, Dim::Y}, Dim::Z);
   EXPECT_EQ(flat, expected);
@@ -208,7 +210,7 @@ TEST(ShapeTest, flatten_slice) {
 
 TEST(ShapeTest, flatten_bad_dim_order) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, sc_units::m, dtype<double>));
   EXPECT_THROW_DISCARD(flatten(var, std::vector<Dim>{Dim::Y, Dim::X}, Dim::Z),
                        except::DimensionError);
 }
@@ -232,7 +234,7 @@ TEST(ShapeTest, flatten_0d) {
 
 TEST(ShapeTest, round_trip) {
   const auto var = cumsum(
-      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, units::m, dtype<double>));
+      variable::ones({{Dim::X, 6}, {Dim::Y, 4}}, sc_units::m, dtype<double>));
   const auto reshaped = fold(var, Dim::X, {{Dim::Row, 2}, {Dim::Time, 3}});
   EXPECT_EQ(flatten(reshaped, std::vector<Dim>{Dim::Row, Dim::Time}, Dim::X),
             var);

--- a/lib/variable/test/special_values_test.cpp
+++ b/lib/variable/test/special_values_test.cpp
@@ -31,41 +31,43 @@ TYPED_TEST_SUITE(VariableSpecialValueTest, FloatTypes);
 
 TYPED_TEST(VariableSpecialValueTest, isnan) {
   for (TypeParam x : values_for_special_value_tests<TypeParam>()) {
-    EXPECT_EQ(variable::isnan(x * units::m), element::isnan(x) * units::none);
+    EXPECT_EQ(variable::isnan(x * sc_units::m),
+              element::isnan(x) * sc_units::none);
   }
 }
 
 TYPED_TEST(VariableSpecialValueTest, isinf) {
   for (TypeParam x : values_for_special_value_tests<TypeParam>()) {
-    EXPECT_EQ(variable::isinf(x * units::m), element::isinf(x) * units::none);
+    EXPECT_EQ(variable::isinf(x * sc_units::m),
+              element::isinf(x) * sc_units::none);
   }
 }
 
 TYPED_TEST(VariableSpecialValueTest, isfinite) {
   for (TypeParam x : values_for_special_value_tests<TypeParam>()) {
-    EXPECT_EQ(variable::isfinite(x * units::m),
-              element::isfinite(x) * units::none);
+    EXPECT_EQ(variable::isfinite(x * sc_units::m),
+              element::isfinite(x) * sc_units::none);
   }
-  EXPECT_EQ(variable::isfinite(1 * units::dimensionless),
-            element::isfinite(1) * units::none);
+  EXPECT_EQ(variable::isfinite(1 * sc_units::dimensionless),
+            element::isfinite(1) * sc_units::none);
 }
 
 TYPED_TEST(VariableSpecialValueTest, isposinf) {
   for (TypeParam x : values_for_special_value_tests<TypeParam>()) {
-    EXPECT_EQ(variable::isposinf(x * units::m),
-              element::isposinf(x) * units::none);
+    EXPECT_EQ(variable::isposinf(x * sc_units::m),
+              element::isposinf(x) * sc_units::none);
   }
 }
 
 TYPED_TEST(VariableSpecialValueTest, isneginf) {
   for (TypeParam x : values_for_special_value_tests<TypeParam>()) {
-    EXPECT_EQ(variable::isneginf(x * units::m),
-              element::isneginf(x) * units::none);
+    EXPECT_EQ(variable::isneginf(x * sc_units::m),
+              element::isneginf(x) * sc_units::none);
   }
 }
 
 template <typename Op> void check_no_out_variances(Op op) {
-  const auto var = makeVariable<double>(Dimensions{Dim::Z, 2}, units::m,
+  const auto var = makeVariable<double>(Dimensions{Dim::Z, 2}, sc_units::m,
                                         Values{1.0, 2.0}, Variances{1.0, 2.0});
   const Variable applied = op(var);
   EXPECT_FALSE(applied.has_variances());

--- a/lib/variable/test/subspan_view_test.cpp
+++ b/lib/variable/test/subspan_view_test.cpp
@@ -12,10 +12,10 @@ using namespace scipp;
 
 class SubspanViewTest : public ::testing::Test {
 protected:
-  Variable var{makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3}, units::m,
-                                    Values{1, 2, 3, 4, 5, 6})};
+  Variable var{makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
+                                    sc_units::m, Values{1, 2, 3, 4, 5, 6})};
   Variable var_with_errors{makeVariable<double>(
-      Dims{Dim::Y, Dim::X}, Shape{2, 3}, units::m, Values{1, 2, 3, 4, 5, 6},
+      Dims{Dim::Y, Dim::X}, Shape{2, 3}, sc_units::m, Values{1, 2, 3, 4, 5, 6},
       Variances{7, 8, 9, 10, 11, 12})};
 };
 
@@ -27,7 +27,7 @@ TEST_F(SubspanViewTest, fail_not_inner) {
 TEST_F(SubspanViewTest, values) {
   auto view = subspan_view(var, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
-  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_EQ(view.unit(), sc_units::m);
   EXPECT_TRUE(equals(view.values<scipp::span<double>>()[0], {1, 2, 3}));
   EXPECT_TRUE(equals(view.values<scipp::span<double>>()[1], {4, 5, 6}));
   EXPECT_FALSE(view.has_variances());
@@ -36,7 +36,7 @@ TEST_F(SubspanViewTest, values) {
 TEST_F(SubspanViewTest, values_length_0) {
   auto view = subspan_view(var.slice({Dim::X, 0, 0}), Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
-  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_EQ(view.unit(), sc_units::m);
   // Note the `const` here: Temporary returned by `slice()` uses `const Variable
   // &` overload.
   EXPECT_TRUE(view.values<scipp::span<const double>>()[0].empty());
@@ -47,7 +47,7 @@ TEST_F(SubspanViewTest, values_length_0) {
 TEST_F(SubspanViewTest, values_and_errors) {
   auto view = subspan_view(var_with_errors, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
-  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_EQ(view.unit(), sc_units::m);
   EXPECT_TRUE(equals(view.values<scipp::span<double>>()[0], {1, 2, 3}));
   EXPECT_TRUE(equals(view.values<scipp::span<double>>()[1], {4, 5, 6}));
   EXPECT_TRUE(equals(view.variances<scipp::span<double>>()[0], {7, 8, 9}));
@@ -57,7 +57,7 @@ TEST_F(SubspanViewTest, values_and_errors) {
 TEST_F(SubspanViewTest, values_and_errors_length_0) {
   auto view = subspan_view(var_with_errors.slice({Dim::X, 0, 0}), Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
-  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_EQ(view.unit(), sc_units::m);
   EXPECT_TRUE(view.values<scipp::span<const double>>()[0].empty());
   EXPECT_TRUE(view.values<scipp::span<const double>>()[1].empty());
   EXPECT_TRUE(view.variances<scipp::span<const double>>()[0].empty());
@@ -74,7 +74,7 @@ TEST_F(SubspanViewTest, broadcast) {
   const auto &broadcasted = broadcast(var.slice({Dim::Y, 0}), var.dims());
   auto view = subspan_view(broadcasted, Dim::X);
   EXPECT_EQ(view.dims(), Dimensions({Dim::Y, 2}));
-  EXPECT_EQ(view.unit(), units::m);
+  EXPECT_EQ(view.unit(), sc_units::m);
   EXPECT_TRUE(equals(view.values<scipp::span<const double>>()[0], {1, 2, 3}));
   EXPECT_TRUE(equals(view.values<scipp::span<const double>>()[1], {1, 2, 3}));
 }
@@ -91,7 +91,7 @@ TEST_F(SubspanViewTest, broadcast_mutable_fails) {
 class SubspanViewOfSliceTest : public ::testing::Test {
 protected:
   Variable var{makeVariable<double>(
-      Dims{Dim::Z, Dim::Y, Dim::X}, Shape{3, 3, 3}, units::m,
+      Dims{Dim::Z, Dim::Y, Dim::X}, Shape{3, 3, 3}, sc_units::m,
       Values{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
              15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27})};
 };

--- a/lib/variable/test/sum_test.cpp
+++ b/lib/variable/test/sum_test.cpp
@@ -14,17 +14,17 @@ using namespace scipp::variable;
 class SumTest : public ::testing::Test {
 protected:
   Variable var = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                      units::m, Values{1.0, 2.0, 3.0, 4.0});
+                                      sc_units::m, Values{1.0, 2.0, 3.0, 4.0});
   Variable var_bool =
-      makeVariable<bool>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, units::m,
+      makeVariable<bool>(Dims{Dim::Y, Dim::X}, Shape{2, 2}, sc_units::m,
                          Values{true, false, true, true});
 };
 
 TEST_F(SumTest, sum) {
-  const auto expectedX =
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{3.0, 7.0});
-  const auto expectedY =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{4.0, 6.0});
+  const auto expectedX = makeVariable<double>(Dims{Dim::Y}, Shape{2},
+                                              sc_units::m, Values{3.0, 7.0});
+  const auto expectedY = makeVariable<double>(Dims{Dim::X}, Shape{2},
+                                              sc_units::m, Values{4.0, 6.0});
   EXPECT_EQ(sum(var, Dim::X), expectedX);
   EXPECT_EQ(sum(var, Dim::Y), expectedY);
 }
@@ -33,27 +33,28 @@ TEST_F(SumTest, sum_with_empty_dim) {
   const auto empty_slice = var.slice({Dim::X, 0, 0});
   EXPECT_EQ(
       sum(empty_slice, Dim::X),
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{0, 0}));
-  EXPECT_EQ(sum(empty_slice, Dim::Y),
-            makeVariable<double>(Dims{Dim::X}, Shape{0}, units::m, Values{}));
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m, Values{0, 0}));
+  EXPECT_EQ(
+      sum(empty_slice, Dim::Y),
+      makeVariable<double>(Dims{Dim::X}, Shape{0}, sc_units::m, Values{}));
 }
 
 TEST(VectorReduceTest, sum_vector) {
   const auto vector_var = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{2}, units::m,
+      Dims{Dim::X}, Shape{2}, sc_units::m,
       Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
   const auto expected = makeVariable<Eigen::Vector3d>(
-      Dims{}, Shape{1}, units::m, Values{Eigen::Vector3d{5, 7, 9}});
+      Dims{}, Shape{1}, sc_units::m, Values{Eigen::Vector3d{5, 7, 9}});
   auto summed = sum(vector_var, Dim::X);
   EXPECT_EQ(summed, expected);
 }
 
 TEST(VectorReduceTest, mean_vector) {
   const auto vector_var = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::X}, Shape{2}, units::m,
+      Dims{Dim::X}, Shape{2}, sc_units::m,
       Values{Eigen::Vector3d{1, 2, 3}, Eigen::Vector3d{4, 5, 6}});
   const auto expected = makeVariable<Eigen::Vector3d>(
-      Dims{}, Shape{1}, units::m, Values{Eigen::Vector3d{2.5, 3.5, 4.5}});
+      Dims{}, Shape{1}, sc_units::m, Values{Eigen::Vector3d{2.5, 3.5, 4.5}});
   auto averaged = mean(vector_var, Dim::X);
   EXPECT_EQ(averaged, expected);
 }

--- a/lib/variable/test/test_variables.cpp
+++ b/lib/variable/test/test_variables.cpp
@@ -13,19 +13,19 @@ INSTANTIATE_TEST_SUITE_P(
     Scalar, DenseVariablesTest,
     testing::Values(makeVariable<double>(Values{1.2}),
                     makeVariable<double>(Values{1.2}, Variances{1.3}),
-                    makeVariable<float>(Values{1.2}, units::m),
+                    makeVariable<float>(Values{1.2}, sc_units::m),
                     makeVariable<int64_t>(Values{12}),
-                    makeVariable<int32_t>(Values{4}, units::s),
+                    makeVariable<int32_t>(Values{4}, sc_units::s),
                     makeVariable<std::string>(Values{"abc"})));
 
 INSTANTIATE_TEST_SUITE_P(
     1D, DenseVariablesTest,
-    testing::Values(makeVariable<double>(Dims{Dim::X}, Shape{0}, units::m),
-                    makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+    testing::Values(makeVariable<double>(Dims{Dim::X}, Shape{0}, sc_units::m),
+                    makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                          Values{1, 2}, Variances{3, 4}),
-                    makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+                    makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                          Values{1, 2}),
-                    makeVariable<double>(Dims{Dim::Y}, Shape{3}, units::s,
+                    makeVariable<double>(Dims{Dim::Y}, Shape{3}, sc_units::s,
                                          Values{1, 2, 3}, Variances{3, 4, 5}),
                     makeVariable<std::string>(Dims{Dim::Row}, Shape{3},
                                               Values{"abc", "de", "f"})));
@@ -33,10 +33,10 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     2D, DenseVariablesTest,
     testing::Values(
-        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 0}, units::m),
-        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 2}, units::m),
-        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 0}, units::m),
-        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3}, units::m,
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 0}, sc_units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{0, 2}, sc_units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 0}, sc_units::m),
+        makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3}, sc_units::m,
                              Values{1, 2, 3, 4, 5, 6},
                              Variances{1, 1, 2, 2, 3, 3})));
 

--- a/lib/variable/test/to_unit_test.cpp
+++ b/lib/variable/test/to_unit_test.cpp
@@ -18,13 +18,13 @@ using Vector3d = Eigen::Vector3d;
 
 TEST(ToUnitTest, not_compatible) {
   const Dimensions dims(Dim::X, 2);
-  const auto var = makeVariable<float>(dims, units::Unit("m"), Values{1, 2});
-  EXPECT_THROW_DISCARD(to_unit(var, units::Unit("s")), except::UnitError);
+  const auto var = makeVariable<float>(dims, sc_units::Unit("m"), Values{1, 2});
+  EXPECT_THROW_DISCARD(to_unit(var, sc_units::Unit("s")), except::UnitError);
 }
 
 TEST(ToUnitTest, buffer_handling) {
   const Dimensions dims(Dim::X, 2);
-  const auto var = makeVariable<float>(dims, units::Unit("m"), Values{1, 2});
+  const auto var = makeVariable<float>(dims, sc_units::Unit("m"), Values{1, 2});
   const auto force_copy = to_unit(var, var.unit());
   EXPECT_FALSE(force_copy.is_same(var));
   EXPECT_EQ(force_copy.values<float>(), var.values<float>());
@@ -35,60 +35,61 @@ TEST(ToUnitTest, buffer_handling) {
   EXPECT_TRUE(no_copy.is_same(var));
   EXPECT_EQ(no_copy.values<float>(), var.values<float>());
   const auto required_copy =
-      to_unit(var, units::Unit("mm"), CopyPolicy::TryAvoid);
+      to_unit(var, sc_units::Unit("mm"), CopyPolicy::TryAvoid);
   EXPECT_FALSE(required_copy.is_same(var));
 }
 
 TEST(ToUnitTest, same) {
   const Dimensions dims(Dim::X, 2);
-  const auto var = makeVariable<float>(dims, units::Unit("m"), Values{1, 2});
+  const auto var = makeVariable<float>(dims, sc_units::Unit("m"), Values{1, 2});
   EXPECT_EQ(to_unit(var, var.unit()), var);
 }
 
 TEST(ToUnitTest, m_to_mm) {
   const Dimensions dims(Dim::X, 2);
-  const auto var = makeVariable<float>(dims, units::Unit("m"), Values{1, 2});
-  EXPECT_EQ(to_unit(var, units::Unit("mm")),
-            makeVariable<float>(dims, units::Unit("mm"), Values{1000, 2000}));
+  const auto var = makeVariable<float>(dims, sc_units::Unit("m"), Values{1, 2});
+  EXPECT_EQ(
+      to_unit(var, sc_units::Unit("mm")),
+      makeVariable<float>(dims, sc_units::Unit("mm"), Values{1000, 2000}));
 }
 
 TEST(ToUnitTest, mm_to_m) {
   const Dimensions dims(Dim::X, 2);
   const auto var =
-      makeVariable<float>(dims, units::Unit("mm"), Values{100, 1000});
-  EXPECT_EQ(to_unit(var, units::Unit("m")),
-            makeVariable<float>(dims, units::Unit("m"), Values{0.1, 1.0}));
+      makeVariable<float>(dims, sc_units::Unit("mm"), Values{100, 1000});
+  EXPECT_EQ(to_unit(var, sc_units::Unit("m")),
+            makeVariable<float>(dims, sc_units::Unit("m"), Values{0.1, 1.0}));
 }
 
 TEST(ToUnitTest, ints) {
   const Dimensions dims(Dim::X, 2);
   const auto var =
-      makeVariable<int32_t>(dims, units::Unit("mm"), Values{100, 2000});
-  EXPECT_EQ(to_unit(var, units::Unit("m")),
-            makeVariable<int32_t>(dims, units::Unit("m"), Values{0, 2}));
-  EXPECT_EQ(
-      to_unit(var, units::Unit("um")),
-      makeVariable<int32_t>(dims, units::Unit("um"), Values{100000, 2000000}));
+      makeVariable<int32_t>(dims, sc_units::Unit("mm"), Values{100, 2000});
+  EXPECT_EQ(to_unit(var, sc_units::Unit("m")),
+            makeVariable<int32_t>(dims, sc_units::Unit("m"), Values{0, 2}));
+  EXPECT_EQ(to_unit(var, sc_units::Unit("um")),
+            makeVariable<int32_t>(dims, sc_units::Unit("um"),
+                                  Values{100000, 2000000}));
 }
 
 TEST(ToUnitTest, time_point) {
   const Dimensions dims(Dim::X, 8);
   const auto var = makeVariable<core::time_point>(
-      dims, units::Unit("s"),
+      dims, sc_units::Unit("s"),
       Values{core::time_point{10}, core::time_point{20}, core::time_point{30},
              core::time_point{40}, core::time_point{10 + 60},
              core::time_point{20 + 60}, core::time_point{30 + 60},
              core::time_point{40 + 60}});
   EXPECT_EQ(
-      to_unit(var, units::Unit("min")),
+      to_unit(var, sc_units::Unit("min")),
       makeVariable<core::time_point>(
-          dims, units::Unit("min"),
+          dims, sc_units::Unit("min"),
           Values{core::time_point{0}, core::time_point{0}, core::time_point{1},
                  core::time_point{1}, core::time_point{1}, core::time_point{1},
                  core::time_point{2}, core::time_point{2}}));
-  EXPECT_EQ(to_unit(var, units::Unit("ms")),
+  EXPECT_EQ(to_unit(var, sc_units::Unit("ms")),
             makeVariable<core::time_point>(
-                dims, units::Unit("ms"),
+                dims, sc_units::Unit("ms"),
                 Values{core::time_point{10000}, core::time_point{20000},
                        core::time_point{30000}, core::time_point{40000},
                        core::time_point{10000 + 60000},
@@ -99,8 +100,9 @@ TEST(ToUnitTest, time_point) {
 
 TEST(ToUnitTest, time_point_large_units) {
   const auto do_to_unit = [](const char *initial, const char *target) {
-    return to_unit(makeVariable<core::time_point>(Dims{}, units::Unit(initial)),
-                   units::Unit(target));
+    return to_unit(
+        makeVariable<core::time_point>(Dims{}, sc_units::Unit(initial)),
+        sc_units::Unit(target));
   };
 
   // Conversions to or from time points with unit day or larger are complicated
@@ -130,18 +132,18 @@ TEST(ToUnitTest, time_point_large_units) {
 
 TEST(ToUnitTest, time_point_bad_unit) {
   EXPECT_THROW_DISCARD(
-      to_unit(makeVariable<core::time_point>(Dims{}, units::Unit("m")),
-              units::Unit("mm")),
+      to_unit(makeVariable<core::time_point>(Dims{}, sc_units::Unit("m")),
+              sc_units::Unit("mm")),
       except::UnitError);
 }
 
 TEST(ToUnitTest, vector3d) {
   const Dimensions dims(Dim::X, 1);
   const auto var =
-      makeVariable<Vector3d>(dims, Values{Vector3d{0, 1, 2}}, units::m);
-  const auto expected =
-      makeVariable<Vector3d>(dims, Values{Vector3d{0, 1000, 2000}}, units::mm);
-  EXPECT_EQ(to_unit(var, units::mm), expected);
+      makeVariable<Vector3d>(dims, Values{Vector3d{0, 1, 2}}, sc_units::m);
+  const auto expected = makeVariable<Vector3d>(
+      dims, Values{Vector3d{0, 1000, 2000}}, sc_units::mm);
+  EXPECT_EQ(to_unit(var, sc_units::mm), expected);
 }
 
 TEST(ToUnitTest, affine3d) {
@@ -153,139 +155,142 @@ TEST(ToUnitTest, affine3d) {
   const Eigen::Affine3d expected_affine = rotation * expected_translation;
 
   const Dimensions dims(Dim::X, 1);
-  const auto var = makeVariable<Affine3d>(dims, Values{affine}, units::m);
+  const auto var = makeVariable<Affine3d>(dims, Values{affine}, sc_units::m);
   const auto expected =
-      makeVariable<Affine3d>(dims, Values{expected_affine}, units::mm);
-  EXPECT_TRUE(all(isclose(to_unit(var, units::mm), expected, 1e-8 * units::one,
-                          0.0 * units::mm))
+      makeVariable<Affine3d>(dims, Values{expected_affine}, sc_units::mm);
+  EXPECT_TRUE(all(isclose(to_unit(var, sc_units::mm), expected,
+                          1e-8 * sc_units::one, 0.0 * sc_units::mm))
                   .value<bool>());
 }
 
 TEST(ToUnitTest, translation) {
   const Dimensions dims(Dim::X, 1);
   const auto var = makeVariable<Translation>(
-      dims, Values{Translation{Vector3d{1, 2, 3}}}, units::m);
+      dims, Values{Translation{Vector3d{1, 2, 3}}}, sc_units::m);
   const auto expected = makeVariable<Translation>(
-      dims, Values{Translation{Vector3d{1000, 2000, 3000}}}, units::mm);
-  EXPECT_EQ(to_unit(var, units::mm), expected);
+      dims, Values{Translation{Vector3d{1000, 2000, 3000}}}, sc_units::mm);
+  EXPECT_EQ(to_unit(var, sc_units::mm), expected);
 }
 
 TEST(ToUnitTest, quaternion) {
   const Dimensions dims(Dim::X, 1);
   const auto var = makeVariable<Quaternion>(
-      dims, Values{Quaternion{Eigen::Quaterniond{0, 0, 0, 0}}}, units::m);
-  EXPECT_THROW_DISCARD(to_unit(var, units::mm), except::TypeError);
+      dims, Values{Quaternion{Eigen::Quaterniond{0, 0, 0, 0}}}, sc_units::m);
+  EXPECT_THROW_DISCARD(to_unit(var, sc_units::mm), except::TypeError);
 }
 
 TEST(ToUnitTest, binned) {
   const auto indices = makeVariable<scipp::index_pair>(
       Dims{Dim::Y}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 4}});
-  const auto input_buffer =
-      makeVariable<double>(Dims{Dim::X}, Shape{4},
-                           Values{1000, 2000, 3000, 4000}, units::Unit{"mm"});
-  const auto expected_buffer = to_unit(input_buffer, units::Unit("m"));
+  const auto input_buffer = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                                 Values{1000, 2000, 3000, 4000},
+                                                 sc_units::Unit{"mm"});
+  const auto expected_buffer = to_unit(input_buffer, sc_units::Unit("m"));
   const auto var = make_bins(indices, Dim::X, input_buffer);
-  EXPECT_EQ(to_unit(var, units::Unit{"m"}),
+  EXPECT_EQ(to_unit(var, sc_units::Unit{"m"}),
             make_bins(indices, Dim::X, expected_buffer));
 }
 
 TEST(ToUnitTest, binned_can_avoid_copy) {
   const auto indices = makeVariable<scipp::index_pair>(
       Dims{Dim::Y}, Shape{2}, Values{std::pair{0, 2}, std::pair{2, 4}});
-  const auto input_buffer =
-      makeVariable<double>(Dims{Dim::X}, Shape{4},
-                           Values{1000, 2000, 3000, 4000}, units::Unit{"mm"});
+  const auto input_buffer = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                                 Values{1000, 2000, 3000, 4000},
+                                                 sc_units::Unit{"mm"});
   const auto var = make_bins(indices, Dim::X, input_buffer);
   EXPECT_TRUE(
-      to_unit(var, units::Unit{"mm"}, CopyPolicy::TryAvoid).is_same(var));
+      to_unit(var, sc_units::Unit{"mm"}, CopyPolicy::TryAvoid).is_same(var));
   EXPECT_FALSE(
-      to_unit(var, units::Unit{"mm"}, CopyPolicy::Always).is_same(var));
+      to_unit(var, sc_units::Unit{"mm"}, CopyPolicy::Always).is_same(var));
 }
 
 TEST(ToUnitTest, throws_if_none_unit) {
+  EXPECT_THROW_DISCARD(
+      to_unit(makeVariable<int32_t>(Dims{Dim::X}, Shape{2}, sc_units::none,
+                                    Values{1, 2}),
+              sc_units::m),
+      except::UnitError);
   EXPECT_THROW_DISCARD(to_unit(makeVariable<int32_t>(Dims{Dim::X}, Shape{2},
-                                                     units::none, Values{1, 2}),
-                               units::m),
-                       except::UnitError);
-  EXPECT_THROW_DISCARD(to_unit(makeVariable<int32_t>(Dims{Dim::X}, Shape{2},
-                                                     units::m, Values{1, 2}),
-                               units::none),
+                                                     sc_units::m, Values{1, 2}),
+                               sc_units::none),
                        except::UnitError);
 }
 
 TEST(ToUnitTest, does_not_throws_if_both_are_none) {
-  EXPECT_NO_THROW_DISCARD(to_unit(
-      makeVariable<int32_t>(Dims{Dim::X}, Shape{2}, units::none, Values{1, 2}),
-      units::none));
+  EXPECT_NO_THROW_DISCARD(
+      to_unit(makeVariable<int32_t>(Dims{Dim::X}, Shape{2}, sc_units::none,
+                                    Values{1, 2}),
+              sc_units::none));
 }
 
 TEST(ToUnitTest, large_to_small_rounding_error_float) {
-  const auto one_m = makeVariable<float>(units::Unit("m"), Values{1});
-  EXPECT_EQ(to_unit(one_m, units::Unit("nm")),
-            makeVariable<float>(units::Unit("nm"), Values{1e9}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("pm")),
-            makeVariable<float>(units::Unit("pm"), Values{1e12}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("fm")),
-            makeVariable<float>(units::Unit("fm"), Values{1e15}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("am")),
-            makeVariable<float>(units::Unit("am"), Values{1e18}));
+  const auto one_m = makeVariable<float>(sc_units::Unit("m"), Values{1});
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("nm")),
+            makeVariable<float>(sc_units::Unit("nm"), Values{1e9}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("pm")),
+            makeVariable<float>(sc_units::Unit("pm"), Values{1e12}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("fm")),
+            makeVariable<float>(sc_units::Unit("fm"), Values{1e15}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("am")),
+            makeVariable<float>(sc_units::Unit("am"), Values{1e18}));
 }
 
 TEST(ToUnitTest, large_to_small_rounding_error_double) {
-  const auto one_m = makeVariable<double>(units::Unit("m"), Values{1});
-  EXPECT_EQ(to_unit(one_m, units::Unit("nm")),
-            makeVariable<double>(units::Unit("nm"), Values{1e9}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("pm")),
-            makeVariable<double>(units::Unit("pm"), Values{1e12}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("fm")),
-            makeVariable<double>(units::Unit("fm"), Values{1e15}));
-  EXPECT_EQ(to_unit(one_m, units::Unit("am")),
-            makeVariable<double>(units::Unit("am"), Values{1e18}));
+  const auto one_m = makeVariable<double>(sc_units::Unit("m"), Values{1});
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("nm")),
+            makeVariable<double>(sc_units::Unit("nm"), Values{1e9}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("pm")),
+            makeVariable<double>(sc_units::Unit("pm"), Values{1e12}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("fm")),
+            makeVariable<double>(sc_units::Unit("fm"), Values{1e15}));
+  EXPECT_EQ(to_unit(one_m, sc_units::Unit("am")),
+            makeVariable<double>(sc_units::Unit("am"), Values{1e18}));
 }
 
 TEST(ToUnitTest, small_to_large_rounding_error_float) {
-  const auto one_m = makeVariable<float>(units::Unit("m"), Values{1});
-  EXPECT_EQ(to_unit(makeVariable<float>(units::Unit("nm"), Values{1e9}),
-                    units::Unit("m")),
+  const auto one_m = makeVariable<float>(sc_units::Unit("m"), Values{1});
+  EXPECT_EQ(to_unit(makeVariable<float>(sc_units::Unit("nm"), Values{1e9}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<float>(units::Unit("pm"), Values{1e12}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<float>(sc_units::Unit("pm"), Values{1e12}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<float>(units::Unit("fm"), Values{1e15}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<float>(sc_units::Unit("fm"), Values{1e15}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<float>(units::Unit("am"), Values{1e18}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<float>(sc_units::Unit("am"), Values{1e18}),
+                    sc_units::Unit("m")),
             one_m);
 }
 
 TEST(ToUnitTest, small_to_large_rounding_error_double) {
-  const auto one_m = makeVariable<double>(units::Unit("m"), Values{1});
-  EXPECT_EQ(to_unit(makeVariable<double>(units::Unit("nm"), Values{1e9}),
-                    units::Unit("m")),
+  const auto one_m = makeVariable<double>(sc_units::Unit("m"), Values{1});
+  EXPECT_EQ(to_unit(makeVariable<double>(sc_units::Unit("nm"), Values{1e9}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<double>(units::Unit("pm"), Values{1e12}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<double>(sc_units::Unit("pm"), Values{1e12}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<double>(units::Unit("fm"), Values{1e15}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<double>(sc_units::Unit("fm"), Values{1e15}),
+                    sc_units::Unit("m")),
             one_m);
-  EXPECT_EQ(to_unit(makeVariable<double>(units::Unit("am"), Values{1e18}),
-                    units::Unit("m")),
+  EXPECT_EQ(to_unit(makeVariable<double>(sc_units::Unit("am"), Values{1e18}),
+                    sc_units::Unit("m")),
             one_m);
 }
 
 TEST(ToUnitTest, small_number_to_small_unit) {
-  const auto unit = units::angstrom * units::angstrom;
-  const auto small = makeVariable<double>(units::Unit("m**2"), Values{1e-20});
+  const auto unit = sc_units::angstrom * sc_units::angstrom;
+  const auto small =
+      makeVariable<double>(sc_units::Unit("m**2"), Values{1e-20});
   const auto result = to_unit(small, unit);
   EXPECT_EQ(result.unit(), unit);
   EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);
 }
 
 TEST(ToUnitTest, small_number_to_small_unit_non_power_of_10) {
-  const auto unit = units::Unit("1.45e-21");
-  const auto small = makeVariable<double>(units::one, Values{1.45e-21});
+  const auto unit = sc_units::Unit("1.45e-21");
+  const auto small = makeVariable<double>(sc_units::one, Values{1.45e-21});
   const auto result = to_unit(small, unit);
   EXPECT_EQ(result.unit(), unit);
   EXPECT_DOUBLE_EQ(result.value<double>(), 1.0);

--- a/lib/variable/test/transform_test.cpp
+++ b/lib/variable/test/transform_test.cpp
@@ -111,17 +111,17 @@ constexpr auto user_op(const double) { return 123.0; }
 constexpr auto user_op(const ValueAndVariance<double>) {
   return ValueAndVariance<double>{123.0, 456.0};
 }
-constexpr auto user_op(const units::Unit &) { return units::s; }
+constexpr auto user_op(const sc_units::Unit &) { return sc_units::s; }
 
 TEST(TransformTest, user_op_with_variances) {
-  auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m,
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
                                   Values{1.1, 2.2}, Variances{1.1, 3.0});
 
   const auto result =
       transform<double>(var, [](auto x) { return user_op(x); }, name);
   transform_in_place<double>(var, [](auto &x) { x = user_op(x); }, name);
 
-  auto expected = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::s,
+  auto expected = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::s,
                                        Values{123, 123}, Variances{456, 456});
   EXPECT_EQ(result, expected);
   EXPECT_EQ(result, var);
@@ -137,7 +137,7 @@ protected:
 // without dry-run, transform_in_place should not touch the data if there is a
 // failure. Maybe this should be a parametrized test?
 TEST_F(TransformInPlaceDryRunTest, unit_fail) {
-  auto a = makeVariable<double>(Dims(), Shape(), units::m);
+  auto a = makeVariable<double>(Dims(), Shape(), sc_units::m);
   const auto original(a);
 
   EXPECT_THROW(dry_run::transform_in_place<double>(
@@ -151,7 +151,7 @@ TEST_F(TransformInPlaceDryRunTest, unit_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, slice_unit_fail) {
-  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
   const auto original = copy(a);
 
   EXPECT_THROW(
@@ -165,8 +165,8 @@ TEST_F(TransformInPlaceDryRunTest, slice_unit_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, dimensions_fail) {
-  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
-  auto b = makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m);
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
+  auto b = makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m);
   const auto original = copy(a);
 
   EXPECT_THROW(
@@ -176,8 +176,8 @@ TEST_F(TransformInPlaceDryRunTest, dimensions_fail) {
 }
 
 TEST_F(TransformInPlaceDryRunTest, variances_fail) {
-  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
-  auto b = makeVariable<double>(Dimensions{Dim::X, 2}, units::m, Values{},
+  auto a = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
+  auto b = makeVariable<double>(Dimensions{Dim::X, 2}, sc_units::m, Values{},
                                 Variances{});
   const auto original = copy(a);
 
@@ -194,10 +194,10 @@ protected:
   Variable indicesB = makeVariable<std::pair<scipp::index, scipp::index>>(
       Dims{Dim::X}, Shape{2}, Values{std::pair{0, 3}, std::pair{3, 5}});
   Variable tableA =
-      makeVariable<double>(Dims{Dim::Event}, Shape{4}, units::m,
+      makeVariable<double>(Dims{Dim::Event}, Shape{4}, sc_units::m,
                            Values{1, 2, 3, 4}, Variances{5, 6, 7, 8});
   Variable tableB =
-      makeVariable<double>(Dims{Dim::Event}, Shape{5}, units::m,
+      makeVariable<double>(Dims{Dim::Event}, Shape{5}, sc_units::m,
                            Values{1, 2, 3, 4, 5}, Variances{5, 6, 7, 8, 9});
   Variable a = make_bins(indicesA, Dim::Event, tableA);
   Variable b = make_bins(indicesB, Dim::Event, tableB);
@@ -335,9 +335,9 @@ TEST(TransformFlagsTest, no_out_variance) {
   constexpr auto op =
       overloaded{transform_flags::no_out_variance, element::arg_list<double>,
                  [](const auto) { return true; },
-                 [](const units::Unit &) { return units::one; }};
+                 [](const sc_units::Unit &) { return sc_units::one; }};
   const auto var = makeVariable<double>(Values{1.0}, Variances{1.0});
-  EXPECT_EQ(transform(var, op, name), true * units::one);
+  EXPECT_EQ(transform(var, op, name), true * sc_units::one);
 }
 
 TEST(TransformFlagsTest, variance_on_arg_in_place) {
@@ -426,7 +426,7 @@ TEST(TransformFlagsTest, expect_no_in_variance_if_out_cannot_have_variance) {
   constexpr auto op_has_flags = scipp::overloaded{
       element::arg_list<double>,
       transform_flags::expect_no_in_variance_if_out_cannot_have_variance,
-      unary_op, [](const units::Unit &) { return units::one; }};
+      unary_op, [](const sc_units::Unit &) { return sc_units::one; }};
   Variable out;
   EXPECT_THROW(out = transform(var_with_variance, op_has_flags, name),
                except::VariancesError);

--- a/lib/variable/test/transform_unary_test.cpp
+++ b/lib/variable/test/transform_unary_test.cpp
@@ -28,10 +28,10 @@ const char *name = "transform_test";
 class TransformUnaryTest : public ::testing::Test {
 protected:
   static constexpr auto op_in_place{
-      overloaded{[](auto &x) { x *= 2.0; }, [](units::Unit &) {}}};
+      overloaded{[](auto &x) { x *= 2.0; }, [](sc_units::Unit &) {}}};
   static constexpr auto op{
       overloaded{[](const auto x) { return x * 2.0; },
-                 [](const units::Unit &unit) { return unit; }}};
+                 [](const sc_units::Unit &unit) { return unit; }}};
 
   template <typename T>
   static auto op_manual_values(const ElementArrayView<T> &values) {
@@ -234,11 +234,11 @@ TEST_P(TransformUnaryIrregularBinsTest, elements_of_bins) {
 }
 
 TEST(TransformUnaryTest, in_place_unit_change) {
-  const auto var =
-      makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m, Values{1.0, 2.0});
-  const auto expected =
-      makeVariable<double>(Dims{Dim::X}, Shape{2},
-                           units::Unit(units::m * units::m), Values{1.0, 4.0});
+  const auto var = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m,
+                                        Values{1.0, 2.0});
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{2}, sc_units::Unit(sc_units::m * sc_units::m),
+      Values{1.0, 4.0});
   auto op_ = [](auto &&a) { a *= a; };
   Variable result;
 
@@ -257,7 +257,7 @@ TEST(TransformUnaryTest, drop_variances_when_not_supported_on_out_type) {
                                   Variances{1.1, 2.2});
   const auto result = transform<double>(
       var,
-      overloaded{[](const units::Unit &) { return units::none; },
+      overloaded{[](const sc_units::Unit &) { return sc_units::none; },
                  [](const auto) { return true; }},
       name);
   EXPECT_EQ(result,
@@ -268,11 +268,11 @@ TEST(TransformUnaryTest, apply_implicit_conversion) {
   const auto var =
       makeVariable<float>(Dims{Dim::X}, Shape{2}, Values{1.1, 2.2});
   // The functor returns double, so the output type is also double.
-  auto out =
-      transform<float>(var,
-                       overloaded{[](const auto x) { return -1.0 * x; },
-                                  [](const units::Unit &unit) { return unit; }},
-                       name);
+  auto out = transform<float>(
+      var,
+      overloaded{[](const auto x) { return -1.0 * x; },
+                 [](const sc_units::Unit &unit) { return unit; }},
+      name);
   EXPECT_TRUE(equals(out.values<double>(), {-1.1f, -2.2f}));
 }
 
@@ -292,9 +292,10 @@ TEST(TransformUnaryTest, apply_dtype_preserved) {
 TEST(TransformUnaryTest, dtype_bool) {
   auto var = makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{true, false});
 
-  EXPECT_EQ(transform<bool>(var,
-                            overloaded{[](const units::Unit &u) { return u; },
-                                       [](const auto x) { return !x; }},
-                            name),
-            makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{false, true}));
+  EXPECT_EQ(
+      transform<bool>(var,
+                      overloaded{[](const sc_units::Unit &u) { return u; },
+                                 [](const auto x) { return !x; }},
+                      name),
+      makeVariable<bool>(Dims{Dim::X}, Shape{2}, Values{false, true}));
 }

--- a/lib/variable/test/trigonometry_test.cpp
+++ b/lib/variable/test/trigonometry_test.cpp
@@ -13,7 +13,7 @@
 
 using namespace scipp;
 using namespace scipp::variable;
-using namespace scipp::units;
+using namespace scipp::sc_units;
 
 class VariableTrigonometryTest : public ::testing::Test {
 protected:
@@ -22,11 +22,11 @@ protected:
                                 Values{0.0, pi<double> / 2.0, pi<double>,
                                        -pi<double> * 3.0 / 2.0,
                                        2.0 * pi<double>, -0.123, 1.654},
-                                Unit{units::rad});
+                                Unit{sc_units::rad});
   }
 
   [[nodiscard]] static Variable input_in_deg() {
-    return to_unit(input_in_rad(), units::deg);
+    return to_unit(input_in_rad(), sc_units::deg);
   }
 
   [[nodiscard]] static Variable expected_for_op(double (*op)(const double)) {
@@ -139,7 +139,7 @@ TEST_F(VariableTrigonometryTest, tan_out_arg_deg) {
 TEST_F(VariableTrigonometryTest, asin) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(asin(var),
-            makeVariable<double>(Values{std::asin(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::asin(1.0)}, Unit{sc_units::rad}));
 }
 
 TEST_F(VariableTrigonometryTest, asin_out_arg) {
@@ -148,14 +148,14 @@ TEST_F(VariableTrigonometryTest, asin_out_arg) {
   auto &view = asin(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
-            makeVariable<double>(Values{std::asin(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::asin(1.0)}, Unit{sc_units::rad}));
   EXPECT_EQ(&view, &out);
 }
 
 TEST_F(VariableTrigonometryTest, acos) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(acos(var),
-            makeVariable<double>(Values{std::acos(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::acos(1.0)}, Unit{sc_units::rad}));
 }
 
 TEST_F(VariableTrigonometryTest, acos_out_arg) {
@@ -164,14 +164,14 @@ TEST_F(VariableTrigonometryTest, acos_out_arg) {
   auto &view = acos(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
-            makeVariable<double>(Values{std::acos(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::acos(1.0)}, Unit{sc_units::rad}));
   EXPECT_EQ(&view, &out);
 }
 
 TEST_F(VariableTrigonometryTest, atan) {
   const auto var = makeVariable<double>(Values{1.0});
   EXPECT_EQ(atan(var),
-            makeVariable<double>(Values{std::atan(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::atan(1.0)}, Unit{sc_units::rad}));
 }
 
 TEST_F(VariableTrigonometryTest, atan_out_arg) {
@@ -180,23 +180,23 @@ TEST_F(VariableTrigonometryTest, atan_out_arg) {
   auto &view = atan(x.slice({Dim::X, 0}), out);
 
   EXPECT_EQ(out,
-            makeVariable<double>(Values{std::atan(1.0)}, Unit{units::rad}));
+            makeVariable<double>(Values{std::atan(1.0)}, Unit{sc_units::rad}));
   EXPECT_EQ(&view, &out);
 }
 
 TEST_F(VariableTrigonometryTest, atan2) {
-  auto x = makeVariable<double>(units::m, Values{1.0});
+  auto x = makeVariable<double>(sc_units::m, Values{1.0});
   auto y = x;
   auto expected =
-      makeVariable<double>(units::rad, Values{scipp::pi<double> / 4});
+      makeVariable<double>(sc_units::rad, Values{scipp::pi<double> / 4});
   EXPECT_EQ(atan2(y, x), expected);
 }
 
 TEST_F(VariableTrigonometryTest, atan2_out_arg) {
-  auto x = makeVariable<double>(units::m, Values{1.0});
+  auto x = makeVariable<double>(sc_units::m, Values{1.0});
   auto y = x;
   auto expected =
-      makeVariable<double>(units::rad, Values{scipp::pi<double> / 4});
+      makeVariable<double>(sc_units::rad, Values{scipp::pi<double> / 4});
   auto out = atan2(y, x, y);
   EXPECT_EQ(out, expected);
   EXPECT_EQ(y, expected);
@@ -204,7 +204,7 @@ TEST_F(VariableTrigonometryTest, atan2_out_arg) {
 
 TEST_P(BinnedVariablesTest, trigonometry) {
   const auto var = GetParam();
-  if (variableFactory().elem_unit(var) == units::one) {
+  if (variableFactory().elem_unit(var) == sc_units::one) {
     EXPECT_NO_THROW_DISCARD(sin(asin(var)));
     EXPECT_NO_THROW_DISCARD((acos(var)));
     EXPECT_NO_THROW_DISCARD(tan(atan(var)));

--- a/lib/variable/test/util_test.cpp
+++ b/lib/variable/test/util_test.cpp
@@ -14,29 +14,32 @@ using namespace scipp;
 
 TEST(LinspaceTest, dim_mismatch) {
   EXPECT_THROW_DISCARD(
-      linspace(1.0 * units::one,
-               makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::one), Dim::X,
-               4),
+      linspace(1.0 * sc_units::one,
+               makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::one),
+               Dim::X, 4),
       except::DimensionError);
 }
 
 TEST(LinspaceTest, unit_mismatch) {
-  EXPECT_THROW_DISCARD(linspace(1.0 * units::one, 4.0 * units::m, Dim::X, 4),
-                       except::UnitError);
+  EXPECT_THROW_DISCARD(
+      linspace(1.0 * sc_units::one, 4.0 * sc_units::m, Dim::X, 4),
+      except::UnitError);
 }
 
 TEST(LinspaceTest, dtype_mismatch) {
-  EXPECT_THROW_DISCARD(linspace(1.0 * units::one, 4.0f * units::one, Dim::X, 4),
-                       except::TypeError);
+  EXPECT_THROW_DISCARD(
+      linspace(1.0 * sc_units::one, 4.0f * sc_units::one, Dim::X, 4),
+      except::TypeError);
 }
 
 TEST(LinspaceTest, non_float_fail) {
-  EXPECT_THROW_DISCARD(linspace(1 * units::one, 4 * units::one, Dim::X, 4),
-                       except::TypeError);
+  EXPECT_THROW_DISCARD(
+      linspace(1 * sc_units::one, 4 * sc_units::one, Dim::X, 4),
+      except::TypeError);
 }
 
 TEST(LinspaceTest, variances_fail) {
-  const auto a = 1.0 * units::one;
+  const auto a = 1.0 * sc_units::one;
   const auto b = makeVariable<double>(Values{1}, Variances{1});
   EXPECT_THROW_DISCARD(linspace(a, b, Dim::X, 4), except::VariancesError);
   EXPECT_THROW_DISCARD(linspace(b, a, Dim::X, 4), except::VariancesError);
@@ -46,32 +49,37 @@ TEST(LinspaceTest, variances_fail) {
 TEST(LinspaceTest, increasing) {
   const auto expected =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
-  EXPECT_EQ(linspace(1.0 * units::one, 4.0 * units::one, Dim::X, 4), expected);
+  EXPECT_EQ(linspace(1.0 * sc_units::one, 4.0 * sc_units::one, Dim::X, 4),
+            expected);
 }
 
 TEST(LinspaceTest, increasing_float) {
   const auto expected =
       makeVariable<float>(Dims{Dim::X}, Shape{4}, Values{1, 2, 3, 4});
-  EXPECT_EQ(linspace(1.0f * units::one, 4.0f * units::one, Dim::X, 4),
+  EXPECT_EQ(linspace(1.0f * sc_units::one, 4.0f * sc_units::one, Dim::X, 4),
             expected);
 }
 
 TEST(LinspaceTest, with_unit) {
-  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{4}, units::m,
-                                             Values{1, 2, 3, 4});
-  EXPECT_EQ(linspace(1.0 * units::m, 4.0 * units::m, Dim::X, 4), expected);
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{4},
+                                             sc_units::m, Values{1, 2, 3, 4});
+  EXPECT_EQ(linspace(1.0 * sc_units::m, 4.0 * sc_units::m, Dim::X, 4),
+            expected);
 }
 
 TEST(LinspaceTest, fractional) {
-  const auto expected = makeVariable<double>(
-      Dims{Dim::X}, Shape{4}, units::m, Values{0.1, 0.1 + 0.1, 0.1 + 0.2, 0.4});
-  EXPECT_EQ(linspace(0.1 * units::m, 0.4 * units::m, Dim::X, 4), expected);
+  const auto expected =
+      makeVariable<double>(Dims{Dim::X}, Shape{4}, sc_units::m,
+                           Values{0.1, 0.1 + 0.1, 0.1 + 0.2, 0.4});
+  EXPECT_EQ(linspace(0.1 * sc_units::m, 0.4 * sc_units::m, Dim::X, 4),
+            expected);
 }
 
 TEST(LinspaceTest, decreasing) {
   const auto expected =
       makeVariable<double>(Dims{Dim::X}, Shape{4}, Values{4, 3, 2, 1});
-  EXPECT_EQ(linspace(4.0 * units::one, 1.0 * units::one, Dim::X, 4), expected);
+  EXPECT_EQ(linspace(4.0 * sc_units::one, 1.0 * sc_units::one, Dim::X, 4),
+            expected);
 }
 
 TEST(LinspaceTest, increasing_2d) {
@@ -83,9 +91,9 @@ TEST(LinspaceTest, increasing_2d) {
 }
 
 TEST(UtilTest, values_variances) {
-  const auto var = makeVariable<double>(Values{1}, Variances{2}, units::m);
-  EXPECT_EQ(values(var), 1.0 * units::m);
-  EXPECT_EQ(variances(var), 2.0 * (units::m * units::m));
+  const auto var = makeVariable<double>(Values{1}, Variances{2}, sc_units::m);
+  EXPECT_EQ(values(var), 1.0 * sc_units::m);
+  EXPECT_EQ(variances(var), 2.0 * (sc_units::m * sc_units::m));
 }
 
 TEST(UtilTest, issorted_unknown_dim) {
@@ -98,8 +106,9 @@ TEST(UtilTest, issorted_unknown_dim) {
 }
 
 TEST(UtilTest, issorted) {
-  auto var = makeVariable<float>(Dimensions{{Dim::X, 3}, {Dim::Y, 3}}, units::m,
-                                 Values{1, 2, 3, 1, 3, 2, 2, 2, 2});
+  auto var =
+      makeVariable<float>(Dimensions{{Dim::X, 3}, {Dim::Y, 3}}, sc_units::m,
+                          Values{1, 2, 3, 1, 3, 2, 2, 2, 2});
   EXPECT_EQ(issorted(var.slice({Dim::Y, 1, 1}), Dim::X, SortOrder::Ascending),
             makeVariable<bool>(Dimensions{{Dim::Y, 0}}, Values{}));
   EXPECT_EQ(
@@ -117,8 +126,8 @@ TEST(UtilTest, issorted) {
 }
 
 TEST(UtilTest, issorted_small_dimensions) {
-  auto var = makeVariable<float>(Dimensions{{Dim::X, 1}, {Dim::Y, 1}}, units::m,
-                                 Values{1});
+  auto var = makeVariable<float>(Dimensions{{Dim::X, 1}, {Dim::Y, 1}},
+                                 sc_units::m, Values{1});
   EXPECT_EQ(issorted(var, Dim::X, SortOrder::Ascending),
             makeVariable<bool>(Dimensions{{Dim::Y, 1}}, Values{true}));
   EXPECT_EQ(issorted(var, Dim::X, SortOrder::Descending),
@@ -151,11 +160,11 @@ TEST(UtilTest, allsorted_multidimensional) {
 }
 
 TEST(VariableTest, where) {
-  auto var =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 2, 3});
+  auto var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                                  Values{1, 2, 3});
   auto mask =
       makeVariable<bool>(Dims{Dim::X}, Shape{3}, Values{true, false, true});
-  auto expected_var =
-      makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m, Values{1, 4, 3});
+  auto expected_var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
+                                           Values{1, 4, 3});
   EXPECT_EQ(where(mask, var, var + var), expected_var);
 }

--- a/lib/variable/test/variable_bin_test.cpp
+++ b/lib/variable/test/variable_bin_test.cpp
@@ -21,7 +21,7 @@ protected:
 };
 
 TEST_F(VariableBinsTest, default_unit_of_bins_is_none) {
-  EXPECT_EQ(make_bins(indices, Dim::X, buffer).unit(), units::none);
+  EXPECT_EQ(make_bins(indices, Dim::X, buffer).unit(), sc_units::none);
 }
 
 TEST_F(VariableBinsTest, make_bins_from_slice) {
@@ -88,13 +88,13 @@ TEST_F(VariableBinsTest, copy_slice) {
 }
 
 TEST_F(VariableBinsTest, cannot_set_unit) {
-  EXPECT_EQ(var.unit(), units::none);
-  EXPECT_THROW(var.setUnit(units::m), except::UnitError);
-  EXPECT_EQ(var.unit(), units::none);
+  EXPECT_EQ(var.unit(), sc_units::none);
+  EXPECT_THROW(var.setUnit(sc_units::m), except::UnitError);
+  EXPECT_EQ(var.unit(), sc_units::none);
 }
 
 TEST_F(VariableBinsTest, basics) {
-  EXPECT_EQ(var.unit(), units::none);
+  EXPECT_EQ(var.unit(), sc_units::none);
   EXPECT_EQ(var.dims(), dims);
   const auto vals = var.values<bucket<Variable>>();
   EXPECT_EQ(vals.size(), 2);
@@ -243,7 +243,7 @@ protected:
 };
 
 TEST_F(VariableBinnedStructuredTest, copy_vector) {
-  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), units::m,
+  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), sc_units::m,
                                            {1, 2, 3, 4, 5, 6, 7, 8, 9});
   Variable var = make_bins(indices, Dim::X, buffer);
   ASSERT_EQ(copy(var), var);
@@ -251,26 +251,28 @@ TEST_F(VariableBinnedStructuredTest, copy_vector) {
 
 TEST_F(VariableBinnedStructuredTest, copy_translation) {
   auto translations = variable::make_translations(
-      Dimensions(Dim::X, 3), units::m, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+      Dimensions(Dim::X, 3), sc_units::m, {1, 2, 3, 4, 5, 6, 7, 8, 9});
   auto binned = make_bins(indices, Dim::X, translations);
   ASSERT_EQ(copy(binned), binned);
 }
 
 TEST_F(VariableBinnedStructuredTest, copy_rotations) {
-  auto rotations = variable::make_rotations(
-      Dimensions(Dim::X, 3), units::m, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  auto rotations =
+      variable::make_rotations(Dimensions(Dim::X, 3), sc_units::m,
+                               {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
   auto binned = make_bins(indices, Dim::X, rotations);
   ASSERT_EQ(copy(binned), binned);
 }
 
 TEST_F(VariableBinnedStructuredTest, copy_vector_field) {
-  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), units::m,
+  Variable buffer = variable::make_vectors(Dimensions(Dim::X, 3), sc_units::m,
                                            {1, 2, 3, 4, 5, 6, 7, 8, 9});
   Variable var = make_bins(indices, Dim::X, buffer);
   const auto &elem = var.elements<Eigen::Vector3d>("x");
   ASSERT_EQ(copy(elem), elem);
-  const auto expected = make_bins(
-      indices, Dim::X,
-      makeVariable<double>(Dimensions(Dim::X, 3), units::m, Values{1, 4, 7}));
+  const auto expected =
+      make_bins(indices, Dim::X,
+                makeVariable<double>(Dimensions(Dim::X, 3), sc_units::m,
+                                     Values{1, 4, 7}));
   ASSERT_EQ(copy(elem), expected);
 }

--- a/lib/variable/test/variable_comparison_test.cpp
+++ b/lib/variable/test/variable_comparison_test.cpp
@@ -134,9 +134,9 @@ TEST_F(Variable_comparison_operators, dimension_length) {
 
 TEST_F(Variable_comparison_operators, unit) {
   const auto m =
-      makeVariable<double>(Dims{Dim::X}, Shape{1}, units::m, Values{1.1});
+      makeVariable<double>(Dims{Dim::X}, Shape{1}, sc_units::m, Values{1.1});
   const auto s =
-      makeVariable<double>(Dims{Dim::X}, Shape{1}, units::s, Values{1.1});
+      makeVariable<double>(Dims{Dim::X}, Shape{1}, sc_units::s, Values{1.1});
   expect_eq(m, m);
   expect_ne(m, s);
 }
@@ -167,7 +167,7 @@ TEST_F(Variable_comparison_operators, events) {
                                             Values{1, 2, 3, 4}, Variances{});
   auto a = make_bins(indices, Dim::X, buf);
   auto b = make_bins(indices, Dim::X, buf);
-  auto c = make_bins(indices, Dim::X, buf * (2.0 * units::one));
+  auto c = make_bins(indices, Dim::X, buf * (2.0 * sc_units::one));
   auto d = make_bins(indices2, Dim::X, buf);
   auto a_with_vars = make_bins(indices, Dim::X, buf_with_vars);
 
@@ -180,11 +180,11 @@ TEST_F(Variable_comparison_operators, events) {
 
 TEST_F(Variable_comparison_operators, slice) {
   const auto xy = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
-                                       units::m, Values{1, 2, 3, 4, 5, 6},
+                                       sc_units::m, Values{1, 2, 3, 4, 5, 6},
                                        Variances{7, 8, 9, 10, 11, 12});
   const auto sliced = xy.slice({Dim::X, 1, 2}).slice({Dim::Y, 1, 3});
   const auto section =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{1, 2}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{1, 2}, sc_units::m,
                            Values{5, 6}, Variances{11, 12});
   EXPECT_FALSE(equals(sliced.strides(), section.strides()));
   EXPECT_NE(sliced.offset(), section.offset());
@@ -192,9 +192,9 @@ TEST_F(Variable_comparison_operators, slice) {
 }
 
 TEST_F(Variable_comparison_operators, broadcast) {
-  const auto a = makeVariable<double>(Dimensions(Dim::X, 3), units::m,
+  const auto a = makeVariable<double>(Dimensions(Dim::X, 3), sc_units::m,
                                       Values{1.2, 1.2, 1.2});
-  const auto b = broadcast(1.2 * units::m, Dimensions(Dim::X, 3));
+  const auto b = broadcast(1.2 * sc_units::m, Dimensions(Dim::X, 3));
   EXPECT_FALSE(equals(a.strides(), b.strides()));
   EXPECT_TRUE(equals(b.strides(), {0}));
   expect_eq(a, b);
@@ -202,9 +202,9 @@ TEST_F(Variable_comparison_operators, broadcast) {
 
 TEST_F(Variable_comparison_operators, transpose) {
   const auto xy = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                       units::m, Values{1, 2, 3, 4});
+                                       sc_units::m, Values{1, 2, 3, 4});
   const auto yx = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 2},
-                                       units::m, Values{1, 3, 2, 4});
+                                       sc_units::m, Values{1, 3, 2, 4});
   expect_ne(xy, yx);
   const auto transposed = transpose(yx);
   EXPECT_FALSE(equals(xy.strides(), transposed.strides()));

--- a/lib/variable/test/variable_keyword_args_constructor_test.cpp
+++ b/lib/variable/test/variable_keyword_args_constructor_test.cpp
@@ -77,20 +77,20 @@ TEST(CreateVariableTest, from_vector) {
 
 TEST(VariableUniversalConstructorTest, dimensions_unit_basic) {
   auto variable =
-      Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3}, units::kg);
+      Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3}, sc_units::kg);
 
   EXPECT_EQ(variable.dims(), (Dimensions{{Dim::X, Dim::Y}, {2, 3}}));
-  EXPECT_EQ(variable.unit(), units::kg);
+  EXPECT_EQ(variable.unit(), sc_units::kg);
   EXPECT_EQ(variable.values<float>().size(), 6);
   EXPECT_FALSE(variable.has_variances());
 
   auto otherVariable =
       Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3});
-  variable.setUnit(units::one);
+  variable.setUnit(sc_units::one);
   EXPECT_EQ(variable, otherVariable);
 
   auto oneMore =
-      Variable(dtype<float>, units::one, Dims{Dim::X, Dim::Y}, Shape{2, 3});
+      Variable(dtype<float>, sc_units::one, Dims{Dim::X, Dim::Y}, Shape{2, 3});
   EXPECT_EQ(oneMore, variable);
 }
 
@@ -100,7 +100,7 @@ TEST(VariableUniversalConstructorTest, type_constructors_mix) {
                      Values(flt.begin(), flt.end()), Variances{2.0, 3.0});
   auto v2 = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 1},
                      Values{1.5, 3.6}, Variances{2, 3});
-  auto v3 = Variable(dtype<float>, units::one, Dims{Dim::X, Dim::Y},
+  auto v3 = Variable(dtype<float>, sc_units::one, Dims{Dim::X, Dim::Y},
                      Shape{2, 1}, Values{1.5f, 3.6f});
   v3.setVariances(
       makeVariable<float>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, Values{2, 3}));
@@ -122,7 +122,7 @@ TEST(VariableUniversalConstructorTest, no_copy_on_matched_types) {
   auto varAddr = variances.data();
 
   auto variable = Variable(dtype<double>, Dims{Dim::X, Dim::Y}, Shape{2, 3},
-                           Values(std::move(values)), units::kg,
+                           Values(std::move(values)), sc_units::kg,
                            Variances(std::move(variances)));
 
   auto vval = variable.values<double>();
@@ -140,7 +140,7 @@ TEST(VariableUniversalConstructorTest, convertable_types) {
   std::transform(data.begin(), data.end(), float_data.begin(),
                  [](const double x) { return static_cast<float>(x); });
   auto variable = Variable(dtype<float>, Dims{Dim::X, Dim::Y}, Shape{2, 3},
-                           Values(data), units::kg, Variances(data));
+                           Values(data), sc_units::kg, Variances(data));
 
   EXPECT_EQ(variable.dtype(), dtype<float>);
   EXPECT_TRUE(equals(variable.values<float>(), float_data));

--- a/lib/variable/test/variable_structure_test.cpp
+++ b/lib/variable/test/variable_structure_test.cpp
@@ -10,10 +10,10 @@ using namespace scipp;
 
 class VariableStructureTest : public ::testing::Test {
 protected:
-  Variable vectors = variable::make_vectors(Dimensions(Dim::Y, 2), units::m,
+  Variable vectors = variable::make_vectors(Dimensions(Dim::Y, 2), sc_units::m,
                                             {1, 2, 3, 4, 5, 6});
   Variable matrices = variable::make_matrices(
-      Dimensions(Dim::Y, 2), units::m,
+      Dimensions(Dim::Y, 2), sc_units::m,
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19});
 };
 
@@ -32,7 +32,7 @@ TEST_F(VariableStructureTest, copy) {
 
 TEST_F(VariableStructureTest, elem_access) {
   Variable elems = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                        units::m, Values{1, 2, 3, 4, 5, 6});
+                                        sc_units::m, Values{1, 2, 3, 4, 5, 6});
   for (auto i : {0, 1, 2}) {
     EXPECT_EQ(vectors.elements<Eigen::Vector3d>().slice(
                   {Dim::InternalStructureComponent, i}),
@@ -47,22 +47,22 @@ TEST_F(VariableStructureTest, matrices_elem_access) {
   // storage order is column-major
   EXPECT_EQ(
       matrices.elements<Eigen::Matrix3d>("xy"),
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{4, 14}));
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m, Values{4, 14}));
   EXPECT_EQ(
       matrices.elements<Eigen::Matrix3d>("yx"),
-      makeVariable<double>(Dims{Dim::Y}, Shape{2}, units::m, Values{2, 12}));
+      makeVariable<double>(Dims{Dim::Y}, Shape{2}, sc_units::m, Values{2, 12}));
 }
 
 TEST_F(VariableStructureTest, elem_access_unit_overwrite) {
   auto elems = vectors.elements<Eigen::Vector3d>();
-  EXPECT_EQ(vectors.unit(), units::m);
-  EXPECT_EQ(elems.unit(), units::m);
-  vectors.setUnit(units::kg);
-  EXPECT_EQ(vectors.unit(), units::kg);
-  EXPECT_EQ(elems.unit(), units::kg);
-  elems.setUnit(units::s);
-  EXPECT_EQ(vectors.unit(), units::s);
-  EXPECT_EQ(elems.unit(), units::s);
+  EXPECT_EQ(vectors.unit(), sc_units::m);
+  EXPECT_EQ(elems.unit(), sc_units::m);
+  vectors.setUnit(sc_units::kg);
+  EXPECT_EQ(vectors.unit(), sc_units::kg);
+  EXPECT_EQ(elems.unit(), sc_units::kg);
+  elems.setUnit(sc_units::s);
+  EXPECT_EQ(vectors.unit(), sc_units::s);
+  EXPECT_EQ(elems.unit(), sc_units::s);
 }
 
 TEST_F(VariableStructureTest, readonly) {
@@ -75,7 +75,7 @@ TEST_F(VariableStructureTest, binned) {
       Dimensions(Dim::X, 2), Values{std::pair{0, 1}, std::pair{1, 2}});
   Variable var = make_bins(indices, Dim::Y, vectors);
   Variable elems = makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{2, 3},
-                                        units::m, Values{1, 2, 3, 4, 5, 6});
+                                        sc_units::m, Values{1, 2, 3, 4, 5, 6});
   for (auto x : {0, 1}) {
     for (auto i : {0, 1, 2}) {
       EXPECT_EQ(var.elements<Eigen::Vector3d>()

--- a/lib/variable/test/variable_test.cpp
+++ b/lib/variable/test/variable_test.cpp
@@ -37,7 +37,7 @@ TEST(Variable, many_dims_works_or_fails_gracefully) {
   EXPECT_EQ(var.ndim(), 15);
   EXPECT_EQ(copy(var), var);
   EXPECT_EQ(var + var, makeVariable<double>(dims, Values{2}));
-  EXPECT_EQ(var + 1.0 * units::one, makeVariable<double>(dims, Values{2}));
+  EXPECT_EQ(var + 1.0 * sc_units::one, makeVariable<double>(dims, Values{2}));
   // TODO In principle we should be able to support all of the below with
   // flattening, but the current implementation dos not handle this.
   ASSERT_THROW(var +=
@@ -52,42 +52,44 @@ TEST(Variable, many_dims_works_or_fails_gracefully) {
 }
 
 TEST(Variable, default_unit_of_numeric_is_dimensionless) {
-  EXPECT_EQ(makeVariable<double>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<float>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<int64_t>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<int32_t>(Dimensions{}).unit(), units::one);
+  EXPECT_EQ(makeVariable<double>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<float>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<int64_t>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<int32_t>(Dimensions{}).unit(), sc_units::one);
 }
 
 TEST(Variable, default_unit_of_bool_is_none) {
-  EXPECT_EQ(makeVariable<bool>(Dimensions{}).unit(), units::none);
+  EXPECT_EQ(makeVariable<bool>(Dimensions{}).unit(), sc_units::none);
 }
 
 TEST(Variable, default_unit_of_time_point_is_dimensionless) {
-  EXPECT_EQ(makeVariable<core::time_point>(Dimensions{}).unit(), units::one);
+  EXPECT_EQ(makeVariable<core::time_point>(Dimensions{}).unit(), sc_units::one);
 }
 
 TEST(Variable, default_unit_of_spatial_types_is_dimensionless) {
-  EXPECT_EQ(makeVariable<Eigen::Vector3d>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<Eigen::Matrix3d>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<Eigen::Affine3d>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<core::Translation>(Dimensions{}).unit(), units::one);
-  EXPECT_EQ(makeVariable<core::Quaternion>(Dimensions{}).unit(), units::one);
+  EXPECT_EQ(makeVariable<Eigen::Vector3d>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<Eigen::Matrix3d>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<Eigen::Affine3d>(Dimensions{}).unit(), sc_units::one);
+  EXPECT_EQ(makeVariable<core::Translation>(Dimensions{}).unit(),
+            sc_units::one);
+  EXPECT_EQ(makeVariable<core::Quaternion>(Dimensions{}).unit(), sc_units::one);
 }
 
 TEST(Variable, default_unit_of_index_pair_is_none) {
-  EXPECT_EQ(makeVariable<scipp::index_pair>(Dimensions{}).unit(), units::none);
+  EXPECT_EQ(makeVariable<scipp::index_pair>(Dimensions{}).unit(),
+            sc_units::none);
 }
 
 TEST(Variable, default_unit_of_string_is_none) {
-  EXPECT_EQ(makeVariable<std::string>(Dimensions{}).unit(), units::none);
+  EXPECT_EQ(makeVariable<std::string>(Dimensions{}).unit(), sc_units::none);
 }
 
 TEST(Variable, construct_llnl_units_quantity) {
-  EXPECT_EQ(Variable(1.2 * llnl::units::precise::meter),
-            makeVariable<double>(Values{1.2}, units::m));
+  EXPECT_EQ(Variable(1.2 * units::precise::meter),
+            makeVariable<double>(Values{1.2}, sc_units::m));
   // llnl measurement is always double
-  EXPECT_EQ(Variable(1.0f * llnl::units::precise::meter),
-            makeVariable<double>(Values{1.0}, units::m));
+  EXPECT_EQ(Variable(1.0f * units::precise::meter),
+            makeVariable<double>(Values{1.0}, sc_units::m));
 }
 
 TEST(Variable, construct_fail) {
@@ -262,10 +264,10 @@ TEST(Variable, span_references_Variable) {
 
 TEST(VariableTest, copy_and_move) {
   const auto reference =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, sc_units::m,
                            Values{1.1, 2.2}, Variances{0.1, 0.2});
   const auto var =
-      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, units::m,
+      makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 1}, sc_units::m,
                            Values{1.1, 2.2}, Variances{0.1, 0.2});
 
   const Variable shallow(var);
@@ -314,9 +316,9 @@ TEST(Variable, copy_slice) {
 
 TEST(Variable, copy_slice_unit_checks) {
   const auto parent =
-      makeVariable<double>(Dims(), Shape(), units::m, Values{1});
+      makeVariable<double>(Dims(), Shape(), sc_units::m, Values{1});
   auto dimensionless = makeVariable<double>(Dims{Dim::X}, Shape{4});
-  auto m = makeVariable<double>(Dims{Dim::X}, Shape{4}, units::m);
+  auto m = makeVariable<double>(Dims{Dim::X}, Shape{4}, sc_units::m);
 
   EXPECT_THROW(copy(parent, dimensionless.slice({Dim::X, 1})),
                except::UnitError);
@@ -342,7 +344,7 @@ TEST(Variable, copy_slice_variance_checks) {
 class VariableTest_3d : public ::testing::Test {
 protected:
   const Variable parent{makeVariable<double>(
-      Dims{Dim::X, Dim::Y, Dim::Z}, Shape{4, 2, 3}, units::m,
+      Dims{Dim::X, Dim::Y, Dim::Z}, Shape{4, 2, 3}, sc_units::m,
       Values{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
       Variances{25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
@@ -398,43 +400,43 @@ protected:
 TEST_F(VariableTest_3d, slice_single) {
   Dimensions dims_no_x{{Dim::Y, 2}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::X, 0}),
-            makeVariable<double>(Dimensions(dims_no_x), units::m,
+            makeVariable<double>(Dimensions(dims_no_x), sc_units::m,
                                  Values(vals_x0.begin(), vals_x0.end()),
                                  Variances(vars_x0.begin(), vars_x0.end())));
   EXPECT_EQ(parent.slice({Dim::X, 1}),
-            makeVariable<double>(Dimensions(dims_no_x), units::m,
+            makeVariable<double>(Dimensions(dims_no_x), sc_units::m,
                                  Values(vals_x1.begin(), vals_x1.end()),
                                  Variances(vars_x1.begin(), vars_x1.end())));
   EXPECT_EQ(parent.slice({Dim::X, 2}),
-            makeVariable<double>(Dimensions(dims_no_x), units::m,
+            makeVariable<double>(Dimensions(dims_no_x), sc_units::m,
                                  Values(vals_x2.begin(), vals_x2.end()),
                                  Variances(vars_x2.begin(), vars_x2.end())));
   EXPECT_EQ(parent.slice({Dim::X, 3}),
-            makeVariable<double>(Dimensions(dims_no_x), units::m,
+            makeVariable<double>(Dimensions(dims_no_x), sc_units::m,
                                  Values(vals_x3.begin(), vals_x3.end()),
                                  Variances(vars_x3.begin(), vars_x3.end())));
 
   Dimensions dims_no_y{{Dim::X, 4}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::Y, 0}),
-            makeVariable<double>(Dimensions(dims_no_y), units::m,
+            makeVariable<double>(Dimensions(dims_no_y), sc_units::m,
                                  Values(vals_y0.begin(), vals_y0.end()),
                                  Variances(vars_y0.begin(), vars_y0.end())));
   EXPECT_EQ(parent.slice({Dim::Y, 1}),
-            makeVariable<double>(Dimensions(dims_no_y), units::m,
+            makeVariable<double>(Dimensions(dims_no_y), sc_units::m,
                                  Values(vals_y1.begin(), vals_y1.end()),
                                  Variances(vars_y1.begin(), vars_y1.end())));
 
   Dimensions dims_no_z{{Dim::X, 4}, {Dim::Y, 2}};
   EXPECT_EQ(parent.slice({Dim::Z, 0}),
-            makeVariable<double>(Dimensions(dims_no_z), units::m,
+            makeVariable<double>(Dimensions(dims_no_z), sc_units::m,
                                  Values(vals_z0.begin(), vals_z0.end()),
                                  Variances(vars_z0.begin(), vars_z0.end())));
   EXPECT_EQ(parent.slice({Dim::Z, 1}),
-            makeVariable<double>(Dimensions(dims_no_z), units::m,
+            makeVariable<double>(Dimensions(dims_no_z), sc_units::m,
                                  Values(vals_z1.begin(), vals_z1.end()),
                                  Variances(vars_z1.begin(), vars_z1.end())));
   EXPECT_EQ(parent.slice({Dim::Z, 2}),
-            makeVariable<double>(Dimensions(dims_no_z), units::m,
+            makeVariable<double>(Dimensions(dims_no_z), sc_units::m,
                                  Values(vals_z2.begin(), vals_z2.end()),
                                  Variances(vars_z2.begin(), vars_z2.end())));
 }
@@ -443,58 +445,58 @@ TEST_F(VariableTest_3d, slice_range) {
   // Length 1 slice
   Dimensions dims_x1{{Dim::X, 1}, {Dim::Y, 2}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::X, 0, 1}),
-            makeVariable<double>(Dimensions(dims_x1), units::m,
+            makeVariable<double>(Dimensions(dims_x1), sc_units::m,
                                  Values(vals_x0.begin(), vals_x0.end()),
                                  Variances(vars_x0.begin(), vars_x0.end())));
   EXPECT_EQ(parent.slice({Dim::X, 1, 2}),
-            makeVariable<double>(Dimensions(dims_x1), units::m,
+            makeVariable<double>(Dimensions(dims_x1), sc_units::m,
                                  Values(vals_x1.begin(), vals_x1.end()),
                                  Variances(vars_x1.begin(), vars_x1.end())));
   EXPECT_EQ(parent.slice({Dim::X, 2, 3}),
-            makeVariable<double>(Dimensions(dims_x1), units::m,
+            makeVariable<double>(Dimensions(dims_x1), sc_units::m,
                                  Values(vals_x2.begin(), vals_x2.end()),
                                  Variances(vars_x2.begin(), vars_x2.end())));
   EXPECT_EQ(parent.slice({Dim::X, 3, 4}),
-            makeVariable<double>(Dimensions(dims_x1), units::m,
+            makeVariable<double>(Dimensions(dims_x1), sc_units::m,
                                  Values(vals_x3.begin(), vals_x3.end()),
                                  Variances(vars_x3.begin(), vars_x3.end())));
 
   Dimensions dims_y1{{Dim::X, 4}, {Dim::Y, 1}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::Y, 0, 1}),
-            makeVariable<double>(Dimensions(dims_y1), units::m,
+            makeVariable<double>(Dimensions(dims_y1), sc_units::m,
                                  Values(vals_y0.begin(), vals_y0.end()),
                                  Variances(vars_y0.begin(), vars_y0.end())));
   EXPECT_EQ(parent.slice({Dim::Y, 1, 2}),
-            makeVariable<double>(Dimensions(dims_y1), units::m,
+            makeVariable<double>(Dimensions(dims_y1), sc_units::m,
                                  Values(vals_y1.begin(), vals_y1.end()),
                                  Variances(vars_y1.begin(), vars_y1.end())));
 
   Dimensions dims_z1{{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 1}};
   EXPECT_EQ(parent.slice({Dim::Z, 0, 1}),
-            makeVariable<double>(Dimensions(dims_z1), units::m,
+            makeVariable<double>(Dimensions(dims_z1), sc_units::m,
                                  Values(vals_z0.begin(), vals_z0.end()),
                                  Variances(vars_z0.begin(), vars_z0.end())));
   EXPECT_EQ(parent.slice({Dim::Z, 1, 2}),
-            makeVariable<double>(Dimensions(dims_z1), units::m,
+            makeVariable<double>(Dimensions(dims_z1), sc_units::m,
                                  Values(vals_z1.begin(), vals_z1.end()),
                                  Variances(vars_z1.begin(), vars_z1.end())));
   EXPECT_EQ(parent.slice({Dim::Z, 2, 3}),
-            makeVariable<double>(Dimensions(dims_z1), units::m,
+            makeVariable<double>(Dimensions(dims_z1), sc_units::m,
                                  Values(vals_z2.begin(), vals_z2.end()),
                                  Variances(vars_z2.begin(), vars_z2.end())));
 
   // Length 2 slice
   Dimensions dims_x2{{Dim::X, 2}, {Dim::Y, 2}, {Dim::Z, 3}};
   EXPECT_EQ(parent.slice({Dim::X, 0, 2}),
-            makeVariable<double>(Dimensions(dims_x2), units::m,
+            makeVariable<double>(Dimensions(dims_x2), sc_units::m,
                                  Values(vals_x02.begin(), vals_x02.end()),
                                  Variances(vars_x02.begin(), vars_x02.end())));
   EXPECT_EQ(parent.slice({Dim::X, 1, 3}),
-            makeVariable<double>(Dimensions(dims_x2), units::m,
+            makeVariable<double>(Dimensions(dims_x2), sc_units::m,
                                  Values(vals_x13.begin(), vals_x13.end()),
                                  Variances(vars_x13.begin(), vars_x13.end())));
   EXPECT_EQ(parent.slice({Dim::X, 2, 4}),
-            makeVariable<double>(Dimensions(dims_x2), units::m,
+            makeVariable<double>(Dimensions(dims_x2), sc_units::m,
                                  Values(vals_x24.begin(), vals_x24.end()),
                                  Variances(vars_x24.begin(), vars_x24.end())));
 
@@ -502,11 +504,11 @@ TEST_F(VariableTest_3d, slice_range) {
 
   Dimensions dims_z2{{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 2}};
   EXPECT_EQ(parent.slice({Dim::Z, 0, 2}),
-            makeVariable<double>(Dimensions(dims_z2), units::m,
+            makeVariable<double>(Dimensions(dims_z2), sc_units::m,
                                  Values(vals_z02.begin(), vals_z02.end()),
                                  Variances(vars_z02.begin(), vars_z02.end())));
   EXPECT_EQ(parent.slice({Dim::Z, 1, 3}),
-            makeVariable<double>(Dimensions(dims_z2), units::m,
+            makeVariable<double>(Dimensions(dims_z2), sc_units::m,
                                  Values(vals_z13.begin(), vals_z13.end()),
                                  Variances(vars_z13.begin(), vars_z13.end())));
 }
@@ -570,28 +572,28 @@ TEST(VariableView, slicing_does_not_transpose) {
 
 TEST(VariableView, variable_copy_from_slice) {
   const auto source =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, units::m,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, sc_units::m,
                            Values{11, 12, 13, 21, 22, 23, 31, 32, 33},
                            Variances{44, 45, 46, 54, 55, 56, 64, 65, 66});
 
   const Dimensions dims({{Dim::Y, 2}, {Dim::X, 2}});
   EXPECT_EQ(copy(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2})),
-            makeVariable<double>(Dimensions(dims), units::m,
+            makeVariable<double>(Dimensions(dims), sc_units::m,
                                  Values{11, 12, 21, 22},
                                  Variances{44, 45, 54, 55}));
 
   EXPECT_EQ(copy(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2})),
-            makeVariable<double>(Dimensions(dims), units::m,
+            makeVariable<double>(Dimensions(dims), sc_units::m,
                                  Values{12, 13, 22, 23},
                                  Variances{45, 46, 55, 56}));
 
   EXPECT_EQ(copy(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3})),
-            makeVariable<double>(Dimensions(dims), units::m,
+            makeVariable<double>(Dimensions(dims), sc_units::m,
                                  Values{21, 22, 31, 32},
                                  Variances{54, 55, 64, 65}));
 
   EXPECT_EQ(copy(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3})),
-            makeVariable<double>(Dimensions(dims), units::m,
+            makeVariable<double>(Dimensions(dims), sc_units::m,
                                  Values{22, 23, 32, 33},
                                  Variances{55, 56, 65, 66}));
 }
@@ -602,27 +604,27 @@ TEST(VariableView, variable_assign_from_slice) {
   auto target = makeVariable<double>(Dimensions(dims), Values{1, 2, 3, 4},
                                      Variances{1, 2, 3, 4});
   const auto source =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, units::m,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, sc_units::m,
                            Values{11, 12, 13, 21, 22, 23, 31, 32, 33},
                            Variances{44, 45, 46, 54, 55, 56, 64, 65, 66});
 
   copy(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2}), target);
-  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), units::m,
+  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), sc_units::m,
                                          Values{11, 12, 21, 22},
                                          Variances{44, 45, 54, 55}));
 
   copy(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 0, 2}), target);
-  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), units::m,
+  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), sc_units::m,
                                          Values{12, 13, 22, 23},
                                          Variances{45, 46, 55, 56}));
 
   copy(source.slice({Dim::X, 0, 2}).slice({Dim::Y, 1, 3}), target);
-  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), units::m,
+  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), sc_units::m,
                                          Values{21, 22, 31, 32},
                                          Variances{54, 55, 64, 65}));
 
   copy(source.slice({Dim::X, 1, 3}).slice({Dim::Y, 1, 3}), target);
-  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), units::m,
+  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), sc_units::m,
                                          Values{22, 23, 32, 33},
                                          Variances{55, 56, 65, 66}));
 }
@@ -632,11 +634,11 @@ TEST(VariableView, variable_assign_from_slice_clears_variances) {
   auto target = makeVariable<double>(Dimensions(dims), Values{1, 2, 3, 4},
                                      Variances{5, 6, 7, 8});
   const auto source =
-      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, units::m,
+      makeVariable<double>(Dims{Dim::Y, Dim::X}, Shape{3, 3}, sc_units::m,
                            Values{11, 12, 13, 21, 22, 23, 31, 32, 33});
 
   target = source.slice({Dim::X, 0, 2}).slice({Dim::Y, 0, 2});
-  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), units::m,
+  EXPECT_EQ(target, makeVariable<double>(Dimensions(dims), sc_units::m,
                                          Values{11, 12, 21, 22}));
 }
 
@@ -662,10 +664,10 @@ TEST(VariableView, variable_self_assign_via_slice) {
 }
 
 TEST(VariableView, slice_copy_from_variable_unit_fail) {
-  const auto source = makeVariable<double>(Dims{Dim::X}, Shape{1}, units::m);
+  const auto source = makeVariable<double>(Dims{Dim::X}, Shape{1}, sc_units::m);
   auto target = makeVariable<double>(Dims{Dim::X}, Shape{2});
   EXPECT_THROW(copy(source, target.slice({Dim::X, 1, 2})), except::UnitError);
-  target = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
+  target = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
   EXPECT_NO_THROW(copy(source, target.slice({Dim::X, 1, 2})));
 }
 
@@ -677,7 +679,7 @@ TEST(VariableView, slice_copy_from_variable_dimension_fail) {
 }
 
 TEST(VariableView, slice_copy_from_variable_full_slice_can_change_unit) {
-  const auto source = makeVariable<double>(Dims{Dim::X}, Shape{2}, units::m);
+  const auto source = makeVariable<double>(Dims{Dim::X}, Shape{2}, sc_units::m);
   auto target = makeVariable<double>(Dims{Dim::X}, Shape{2});
   copy(source, target.slice({Dim::X, 0, 2}));
   EXPECT_NO_THROW(copy(source, target.slice({Dim::X, 0, 2})));
@@ -749,8 +751,8 @@ TEST(VariableTest, rename_dims) {
 
 TEST(VariableTest, create_with_variance) {
   ASSERT_NO_THROW(makeVariable<double>(Values{1.0}, Variances{0.1}));
-  ASSERT_NO_THROW(makeVariable<double>(Dims(), Shape(), units::m, Values{1.0},
-                                       Variances{0.1}));
+  ASSERT_NO_THROW(makeVariable<double>(Dims(), Shape(), sc_units::m,
+                                       Values{1.0}, Variances{0.1}));
 }
 
 TEST(VariableTest, has_variances) {
@@ -758,7 +760,7 @@ TEST(VariableTest, has_variances) {
   ASSERT_FALSE(makeVariable<double>(Values{1.0}).has_variances());
   ASSERT_TRUE(
       makeVariable<double>(Values{1.0}, Variances{0.1}).has_variances());
-  ASSERT_TRUE(makeVariable<double>(Dims(), Shape(), units::m, Values{1.0},
+  ASSERT_TRUE(makeVariable<double>(Dims(), Shape(), sc_units::m, Values{1.0},
                                    Variances{0.1})
                   .has_variances());
 }
@@ -772,11 +774,11 @@ TEST(VariableTest, values_variances) {
 }
 
 template <typename Var> void test_set_variances(Var &var) {
-  const auto v = var * (2.0 * units::one);
+  const auto v = var * (2.0 * sc_units::one);
   var.setVariances(Variable(var));
   ASSERT_TRUE(equals(var.template variances<double>(), {1.0, 2.0, 3.0}));
   // Fail because `var` has variances (setVariances uses only the values)
-  EXPECT_THROW(var.setVariances(var * (2.0 * units::one)),
+  EXPECT_THROW(var.setVariances(var * (2.0 * sc_units::one)),
                except::VariancesError);
   var.setVariances(v);
   ASSERT_TRUE(equals(var.template variances<double>(), {2.0, 4.0, 6.0}));
@@ -785,14 +787,14 @@ template <typename Var> void test_set_variances(Var &var) {
   EXPECT_THROW(var.setVariances(bad_dims), except::DimensionError);
 
   Variable bad_unit = copy(v);
-  bad_unit.setUnit(units::s);
+  bad_unit.setUnit(sc_units::s);
   EXPECT_THROW(var.setVariances(bad_unit), except::UnitError);
 
   EXPECT_THROW(var.setVariances(astype(v, dtype<float>)), except::TypeError);
 }
 
 TEST(VariableTest, set_variances) {
-  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                       Values{1.0, 2.0, 3.0});
   test_set_variances(var);
 }
@@ -818,7 +820,7 @@ TEST(VariableTest, set_variances_remove_int) {
 }
 
 TEST(VariableViewTest, set_variances) {
-  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3}, units::m,
+  Variable var = makeVariable<double>(Dims{Dim::X}, Shape{3}, sc_units::m,
                                       Values{1.0, 2.0, 3.0});
   auto view(var);
   test_set_variances(view);
@@ -860,12 +862,12 @@ TEST(VariableTest, construct_view_dims) {
 }
 
 TEST(VariableTest, construct_mult_dev_unit) {
-  Variable refDiv =
-      makeVariable<float>(Dims(), Shape(), units::one / units::m, Values{1.0f});
+  Variable refDiv = makeVariable<float>(
+      Dims(), Shape(), sc_units::one / sc_units::m, Values{1.0f});
   Variable refMult =
-      makeVariable<int32_t>(Dims(), Shape(), units::kg, Values{1});
-  EXPECT_EQ(1.0f / units::m, refDiv);
-  EXPECT_EQ(int32_t(1) * units::kg, refMult);
+      makeVariable<int32_t>(Dims(), Shape(), sc_units::kg, Values{1});
+  EXPECT_EQ(1.0f / sc_units::m, refDiv);
+  EXPECT_EQ(int32_t(1) * sc_units::kg, refMult);
 }
 
 TEST(VariableTest, datetime_dtype) {
@@ -876,8 +878,8 @@ TEST(VariableTest, datetime_dtype) {
 
 TEST(VariableTest, construct_time_unit) {
   Variable refMult =
-      makeVariable<int64_t>(Dims(), Shape(), units::ns, Values{1000});
-  EXPECT_EQ(int64_t(1000) * units::ns, refMult);
+      makeVariable<int64_t>(Dims(), Shape(), sc_units::ns, Values{1000});
+  EXPECT_EQ(int64_t(1000) * sc_units::ns, refMult);
 }
 
 TEST(VariableTest, array_params) {

--- a/lib/variable/to_unit.cpp
+++ b/lib/variable/to_unit.cpp
@@ -15,10 +15,9 @@
 namespace scipp::variable {
 
 namespace {
-bool greater_than_days(const units::Unit &unit) {
-  static constexpr auto days_multiplier =
-      llnl::units::precise::day.multiplier();
-  if (!unit.has_same_base(units::s)) {
+bool greater_than_days(const sc_units::Unit &unit) {
+  static constexpr auto days_multiplier = units::precise::day.multiplier();
+  if (!unit.has_same_base(sc_units::s)) {
     throw except::UnitError("Cannot convert unit of datetime with non-time "
                             "unit, got `" +
                             to_string(unit) + "`.");
@@ -27,15 +26,15 @@ bool greater_than_days(const units::Unit &unit) {
 }
 } // namespace
 
-Variable to_unit(const Variable &var, const units::Unit &unit,
+Variable to_unit(const Variable &var, const sc_units::Unit &unit,
                  const CopyPolicy copy) {
   const auto var_unit = variableFactory().elem_unit(var);
   if (unit == var_unit)
     return copy == CopyPolicy::Always ? variable::copy(var) : var;
-  if ((var_unit == units::none) || (unit == units::none))
+  if ((var_unit == sc_units::none) || (unit == sc_units::none))
     throw except::UnitError("Unit conversion to / from None is not permitted.");
   const auto scale =
-      llnl::units::quick_convert(var_unit.underlying(), unit.underlying());
+      units::quick_convert(var_unit.underlying(), unit.underlying());
   if (std::isnan(scale))
     throw except::UnitError("Conversion from `" + to_string(var_unit) +
                             "` to `" + to_string(unit) + "` is not valid.");

--- a/lib/variable/util.cpp
+++ b/lib/variable/util.cpp
@@ -35,7 +35,7 @@ Variable linspace(const Variable &start, const Variable &stop, const Dim dim,
   Variable out(start, dims);
   const auto range = stop - start;
   for (scipp::index i = 0; i < num - 1; ++i)
-    copy(start + astype(static_cast<double>(i) / (num - 1) * units::one,
+    copy(start + astype(static_cast<double>(i) / (num - 1) * sc_units::one,
                         start.dtype()) *
                      range,
          out.slice({dim, i}));
@@ -60,7 +60,7 @@ Variable isarange(const Variable &var, const Dim dim) {
 Variable issorted(const Variable &x, const Dim dim, const SortOrder order) {
   auto dims = x.dims();
   dims.erase(dim);
-  auto out = variable::ones(dims, units::none, dtype<bool>);
+  auto out = variable::ones(dims, sc_units::none, dtype<bool>);
   const auto size = x.dims()[dim];
   if (size < 2)
     return out;

--- a/lib/variable/variable.cpp
+++ b/lib/variable/variable.cpp
@@ -29,10 +29,10 @@ bool is_default_dimensionless(DType type, std::tuple<Ts...>) {
 }
 } // namespace
 
-units::Unit default_unit_for(const DType type) {
+sc_units::Unit default_unit_for(const DType type) {
   return is_default_dimensionless(type, default_dimensionless_dtypes)
-             ? units::dimensionless
-             : units::none;
+             ? sc_units::dimensionless
+             : sc_units::none;
 }
 
 /// Construct from parent with same dtype, unit, and has_variances but new dims.
@@ -46,8 +46,8 @@ Variable::Variable(const Variable &parent, const Dimensions &dims)
 Variable::Variable(const Dimensions &dims, VariableConceptHandle data)
     : m_dims(dims), m_strides(dims), m_object(std::move(data)) {}
 
-Variable::Variable(const llnl::units::precise_measurement &m)
-    : Variable(m.value() * units::Unit(m.units())) {}
+Variable::Variable(const units::precise_measurement &m)
+    : Variable(m.value() * sc_units::Unit(m.units())) {}
 
 namespace {
 void check_nested_in_assign(const Variable &lhs, const Variable &rhs) {
@@ -105,15 +105,15 @@ DType Variable::dtype() const { return data().dtype(); }
 
 bool Variable::has_variances() const { return data().has_variances(); }
 
-void Variable::expect_can_set_unit(const units::Unit &unit) const {
+void Variable::expect_can_set_unit(const sc_units::Unit &unit) const {
   if (this->unit() != unit && is_slice())
     throw except::UnitError("Partial view on data of variable cannot be used "
                             "to change the unit.");
 }
 
-const units::Unit &Variable::unit() const { return m_object->unit(); }
+const sc_units::Unit &Variable::unit() const { return m_object->unit(); }
 
-void Variable::setUnit(const units::Unit &unit) {
+void Variable::setUnit(const sc_units::Unit &unit) {
   expect_writable();
   expect_can_set_unit(unit);
   m_object->setUnit(unit);

--- a/lib/variable/variable_concept.cpp
+++ b/lib/variable/variable_concept.cpp
@@ -3,6 +3,6 @@
 
 namespace scipp::variable {
 
-VariableConcept::VariableConcept(const units::Unit &unit) : m_unit(unit) {}
+VariableConcept::VariableConcept(const sc_units::Unit &unit) : m_unit(unit) {}
 
 } // namespace scipp::variable

--- a/lib/variable/variable_factory.cpp
+++ b/lib/variable/variable_factory.cpp
@@ -49,16 +49,17 @@ DType VariableFactory::elem_dtype(const Variable &var) const {
   return m_makers.at(var.dtype())->elem_dtype(var);
 }
 
-units::Unit VariableFactory::elem_unit(const Variable &var) const {
+sc_units::Unit VariableFactory::elem_unit(const Variable &var) const {
   return m_makers.at(var.dtype())->elem_unit(var);
 }
 
 void VariableFactory::expect_can_set_elem_unit(const Variable &var,
-                                               const units::Unit &u) const {
+                                               const sc_units::Unit &u) const {
   m_makers.at(var.dtype())->expect_can_set_elem_unit(var, u);
 }
 
-void VariableFactory::set_elem_unit(Variable &var, const units::Unit &u) const {
+void VariableFactory::set_elem_unit(Variable &var,
+                                    const sc_units::Unit &u) const {
   m_makers.at(var.dtype())->set_elem_unit(var, u);
 }
 

--- a/lib/variable/variable_instantiate_bin_elements.cpp
+++ b/lib/variable/variable_instantiate_bin_elements.cpp
@@ -22,7 +22,7 @@ template <class T> class BinVariableMakerVariable : public BinVariableMaker<T> {
 private:
   Variable call_make_bins(const Variable &, const Variable &indices,
                           const Dim dim, const DType type,
-                          const Dimensions &dims, const units::Unit &unit,
+                          const Dimensions &dims, const sc_units::Unit &unit,
                           const bool variances) const override {
     // Buffer contains only variable, which is created with new dtype, no
     // information to copy from parent.
@@ -37,7 +37,7 @@ private:
 
 void expect_valid_bin_indices(const Variable &indices, const Dim dim,
                               const Sizes &buffer_sizes) {
-  core::expect::equals(units::none, indices.unit());
+  core::expect::equals(sc_units::none, indices.unit());
   auto var = copy(indices);
   const auto vals = var.values<scipp::index_pair>().as_span();
   std::sort(vals.begin(), vals.end());


### PR DESCRIPTION
Fixes https://github.com/scipp/scipp/issues/3705
Supersedes part of https://github.com/scipp/scipp/pull/3697

I renamed our namespace to `scipp::sc_units` so that we can still use a short `sc_units::m` instead of having to spell out `scipp::units::m`. But that is only relevant in C++. So I am open to changing this to keep our original namespace name.