### PR TITLE
Drop support for python 3.10

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - cmake=4.0.0
   - conan=1.66.0
-  - cppcheck=2.6.2
+  - cppcheck=2.18.0
   - graphviz=12.0.0
   - gxx_linux-64=13.2.*
   - ninja=1.12.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
           micromamba-version: 1.5.6-0
           environment-file: env.yml
           cache-environment: true
-          create-args: python=3.10
+          create-args: python=3.11
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.18

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: |

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e static
@@ -40,7 +40,7 @@ jobs:
         - {os: ubuntu-24.04, cmake-preset: ci-linux}
         - {os: macos-14, cmake-preset: ci-macos}
         - {os: windows-2022, cmake-preset: ci-windows}
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2022, ubuntu-24.04-arm]
-        build: [cp310, cp311, cp312, cp313]
+        build: [cp311, cp312, cp313]
         nightly: [true]
     uses: ./.github/workflows/wheel.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           - {os: macos-14, target: osx_arm64}
           - {os: windows-2022, target: win_64}
           - {os: ubuntu-24.04-arm, target: linux_arm64}
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2022, ubuntu-24.04-arm]
-        build: [cp310, cp311, cp312, cp313]
+        build: [cp311, cp312, cp313]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -25,7 +25,7 @@ jobs:
           - {os: macos-14, target: osx_arm64}
           - {os: windows-2022, target: win_64}
           - {os: ubuntu-24.04-arm, target: linux_arm64}
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
     uses: ./.github/workflows/conda.yml
     with:
       os: ${{ matrix.variant.os }}
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-13, macos-14, windows-2022, ubuntu-24.04-arm]
-        build: [cp310, cp313]
+        build: [cp311, cp313]
     uses: ./.github/workflows/wheel.yml
     with:
       os: ${{ matrix.os }}

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -49,3 +49,4 @@ missingReturn
 passedByValueCallback
 unreadVariable
 accessMoved
+unusedStructMember

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -42,3 +42,4 @@ duplInheritedMember
 throwInNoexceptFunction
 returnByReference
 constParameterReference
+constStatement

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -44,3 +44,4 @@ returnByReference
 constParameterReference
 constStatement
 normalCheckLevelMaxBranches
+constVariableReference

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -35,3 +35,6 @@ useInitializationList
 // We have no control over constness in this case.
 // Generally, non-const callbacks should be fine.
 constParameterCallback
+
+uninitMemberVar
+passedByValue

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -40,3 +40,4 @@ uninitMemberVar
 passedByValue
 duplInheritedMember
 throwInNoexceptFunction
+returnByReference

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -39,3 +39,4 @@ constParameterCallback
 uninitMemberVar
 passedByValue
 duplInheritedMember
+throwInNoexceptFunction

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -38,3 +38,4 @@ constParameterCallback
 
 uninitMemberVar
 passedByValue
+duplInheritedMember

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -45,3 +45,4 @@ constParameterReference
 constStatement
 normalCheckLevelMaxBranches
 constVariableReference
+missingReturn

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -43,3 +43,4 @@ throwInNoexceptFunction
 returnByReference
 constParameterReference
 constStatement
+normalCheckLevelMaxBranches

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -46,3 +46,4 @@ constStatement
 normalCheckLevelMaxBranches
 constVariableReference
 missingReturn
+passedByValueCallback

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -47,3 +47,4 @@ normalCheckLevelMaxBranches
 constVariableReference
 missingReturn
 passedByValueCallback
+unreadVariable

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -48,3 +48,4 @@ constVariableReference
 missingReturn
 passedByValueCallback
 unreadVariable
+accessMoved

--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -41,3 +41,4 @@ passedByValue
 duplInheritedMember
 throwInNoexceptFunction
 returnByReference
+constParameterReference

--- a/docs/environments/developer.yml
+++ b/docs/environments/developer.yml
@@ -29,11 +29,11 @@ dependencies:
   - pre-commit
   - pybind11=2.13.6
   - pytest
-  - python=3.10
+  - python=3.11
   - python-graphviz
   - pythreejs
   - pyyaml
-  - scipp::plopp
+  - plopp
   - scipy>=1.7.0
   - tbb=2022.0.0
   - tbb-devel=2022.0.0

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-Scipp requires Python 3.10 or above.
+Scipp requires Python 3.11 or above.
 
 Conda
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -27,7 +26,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "numpy >= 1.20",
 ]


### PR DESCRIPTION
Mantid supports python 3.11 now https://github.com/mantidproject/mantid/releases