### PR TITLE
Avoid making many dimension labels

### DIFF
--- a/docs/reference/free-functions.rst
+++ b/docs/reference/free-functions.rst
@@ -25,6 +25,7 @@ General
    nanhist
    merge
    midpoints
+   new_dim_for
    rebin
    reduce
    slices

--- a/src/scipp/__init__.py
+++ b/src/scipp/__init__.py
@@ -142,7 +142,7 @@ from .core import (
     all,
     any,
 )
-from .core import broadcast, concat, fold, flatten, squeeze, transpose
+from .core import broadcast, concat, fold, flatten, squeeze, transpose, new_dim_for
 from .core import sinh, cosh, tanh, asinh, acosh, atanh
 from .core import sin, cos, tan, asin, acos, atan, atan2
 from .core import isnan, isinf, isfinite, isposinf, isneginf, to_unit
@@ -392,6 +392,7 @@ __all__ = [
     'nansum',
     'nanvar',
     'negative',
+    'new_dim_for',
     'norm',
     'not_equal',
     'ones',

--- a/src/scipp/core/__init__.py
+++ b/src/scipp/core/__init__.py
@@ -56,6 +56,7 @@ from .dimensions import (
     _rename_variable,
     _rename_data_array,
     _rename_dataset,
+    new_dim_for,
 )
 
 for cls in (Variable, DataArray, Dataset):
@@ -332,6 +333,7 @@ __all__ = [
     'nansum',
     'nanvar',
     'negative',
+    'new_dim_for',
     'norm',
     'not_equal',
     'ones',

--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Sequence
 from math import prod
 from typing import TYPE_CHECKING, TypeVar
@@ -12,6 +11,7 @@ from ..typing import Dims
 from .concepts import concrete_dims, irreducible_mask, rewrap_reduced_data
 from .cpp_classes import DataArray, Variable
 from .cumulative import cumsum
+from .dimensions import new_dim_for
 from .operations import where
 from .variable import index
 
@@ -110,7 +110,7 @@ def _combine_bins(
     sub_sizes = index(changed_volume).broadcast(
         dims=unchanged_dims, shape=unchanged_shape
     )
-    params = params.flatten(to=uuid.uuid4().hex)
+    params = params.flatten(to=new_dim_for(params))
     # Setup pseudo binning for unchanged subspace. All further reordering (for grouping
     # and binning) will then occur *within* those pseudo bins (by splitting them).
     params_data = _with_bin_sizes(params, sub_sizes)

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, SupportsIndex, TypeVar, overload
 
@@ -11,6 +10,7 @@ from .bin_remapping import combine_bins
 from .bins import Bins
 from .cpp_classes import BinEdgeError, CoordError, DataArray, Dataset, DType, Variable
 from .data_group import DataGroup, data_group_overload
+from .dimensions import new_dim_for
 from .math import round as round_
 from .shape import concat
 from .variable import arange, array, epoch, linspace, scalar
@@ -244,7 +244,7 @@ def _prepare_multi_dim_dense(x: DataArray, *edges_or_groups: Variable) -> DataAr
     helper_coords = {dim: arange(dim, x.sizes[dim]) for dim in extra}
     return (
         x.assign_coords(helper_coords)
-        .flatten(to=str(uuid.uuid4()))
+        .flatten(to=new_dim_for(x))
         .group(*helper_coords.values())
         .drop_coords(tuple(extra))
         .assign_coords(original_coords)

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -7,7 +7,6 @@ from typing import TypeVar
 
 from .._scipp.core import CoordError, DataArray, Dataset, Variable
 from .argument_handlers import combine_dict_args
-from .bins import bins
 from .variable import scalar
 
 _T = TypeVar('_T', Variable, DataArray, Dataset)
@@ -115,6 +114,8 @@ def _rename_data_array(
     renaming_dict = combine_dict_args(dims_dict, names)
     out = da.rename_dims(renaming_dict)
     if out.bins is not None:
+        from .bins import bins
+
         out.data = bins(**out.bins.constituents)
     for old, new in renaming_dict.items():
         if new in out.coords:

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -186,6 +186,16 @@ def new_dim_for(*data: Variable | DataArray) -> str:
     not become visible to users.
     The label is guaranteed to not be present in the input, but it may be used in
     other variables.
+
+    Parameters
+    ----------
+    data:
+        A number of variables or data arrays.
+
+    Returns
+    -------
+    :
+        A dimension label that is not in any variable or data array in ``data``.
     """
     used = {*(x.dims for x in data)}
     for dim in _USED_AUX_DIMS:

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -3,6 +3,7 @@
 # @author Simon Heybrock
 
 import uuid
+from itertools import chain
 from typing import TypeVar
 
 from .._scipp.core import CoordError, DataArray, Dataset, Variable
@@ -197,7 +198,7 @@ def new_dim_for(*data: Variable | DataArray) -> str:
     :
         A dimension label that is not in any variable or data array in ``data``.
     """
-    used = {*(x.dims for x in data)}
+    used: set[str] = set(chain(*(x.dims for x in data)))
     for dim in _USED_AUX_DIMS:
         if dim not in used:
             return dim

--- a/src/scipp/reduction.py
+++ b/src/scipp/reduction.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import uuid
 from collections.abc import Iterable, Sequence
 from typing import Generic, TypeVar
 
 from .core import DataArray, Dataset, Variable, concat, reduction
+from .core.dimensions import new_dim_for
 
 _O = TypeVar("_O", Variable, DataArray, Dataset)
 
@@ -24,7 +24,7 @@ class BinsReducer(Generic[_O]):
 
 class Reducer(Generic[_O]):
     def __init__(self, x: Sequence[_O]) -> None:
-        self._dim = uuid.uuid4().hex
+        self._dim = new_dim_for(*x)
         # concat in init avoids repeated costly step in case of multiple reductions
         self._obj: _O = concat(x, dim=self._dim)
 

--- a/tests/core/dimensions_test.py
+++ b/tests/core/dimensions_test.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import scipp as sc
+
+
+def test_new_dim_for_scalar() -> None:
+    var = sc.scalar(5, unit='m')
+    dim = sc.new_dim_for(var)
+    assert dim
+
+
+def test_new_dim_for_1d_array() -> None:
+    var = sc.array(dims=['abc'], values=[1, 2], unit='m')
+    dim = sc.new_dim_for(var)
+    assert dim
+    assert dim != 'abc'
+
+
+def test_new_dim_for_2d_array() -> None:
+    var = sc.array(dims=['abc', 'y'], values=[[1, 2], [3, 4]], unit='m')
+    dim = sc.new_dim_for(var)
+    assert dim
+    assert dim not in ('abc', 'y')
+
+
+def test_new_dim_for_data_array() -> None:
+    var = sc.DataArray(sc.array(dims=['x', 'asd'], values=[[1, 2], [3, 4]], unit='m'))
+    dim = sc.new_dim_for(var)
+    assert dim
+    assert dim not in ('x', 'asd')
+
+
+def test_new_dim_for_multiple() -> None:
+    a = sc.scalar(4, unit='s')
+    b = sc.array(dims=['y'], values=[2, 3])
+    c = sc.array(dims=['abc'], values=[1, 2, 3])
+    d = sc.DataArray(sc.array(dims=['y', 't'], values=[[1, 2], [3, 4]], unit='m'))
+    dim = sc.new_dim_for(a, b, c, d)
+    assert dim
+    assert dim not in ('y', 'abc', 't')


### PR DESCRIPTION
This still generates new dimension labels. But for it to lead to using too many labels, someone would have to pass the *same variable* through 2^16 nested calls of functions using `new_dim_for`. That seems highly unlikely.

Fixes #3747.