### PR TITLE
fix: remove uuid usage, replace by fixed aux dimension names

### DIFF
--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Sequence
 from math import prod
 from typing import TYPE_CHECKING, TypeVar
@@ -110,7 +109,7 @@ def _combine_bins(
     sub_sizes = index(changed_volume).broadcast(
         dims=unchanged_dims, shape=unchanged_shape
     )
-    params = params.flatten(to=uuid.uuid4().hex)
+    params = params.flatten(to='__remapping_aux__')
     # Setup pseudo binning for unchanged subspace. All further reordering (for grouping
     # and binning) will then occur *within* those pseudo bins (by splitting them).
     params_data = _with_bin_sizes(params, sub_sizes)

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, SupportsIndex, TypeVar, overload
 
@@ -244,7 +243,7 @@ def _prepare_multi_dim_dense(x: DataArray, *edges_or_groups: Variable) -> DataAr
     helper_coords = {dim: arange(dim, x.sizes[dim]) for dim in extra}
     return (
         x.assign_coords(helper_coords)
-        .flatten(to=str(uuid.uuid4()))
+        .flatten(to='__aux__')
         .group(*helper_coords.values())
         .drop_coords(tuple(extra))
         .assign_coords(original_coords)

--- a/src/scipp/reduction.py
+++ b/src/scipp/reduction.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-import uuid
 from collections.abc import Iterable, Sequence
 from typing import Generic, TypeVar
 
@@ -24,7 +23,7 @@ class BinsReducer(Generic[_O]):
 
 class Reducer(Generic[_O]):
     def __init__(self, x: Sequence[_O]) -> None:
-        self._dim = uuid.uuid4().hex
+        self._dim = "__reducer_aux__"
         # concat in init avoids repeated costly step in case of multiple reductions
         self._obj: _O = concat(x, dim=self._dim)
 


### PR DESCRIPTION
Fixes #3748 

Not 100% sure if I've understood the issue correctly.
Is it sufficient to just replace the random dimension names by some hardcoded "unique" dimension name?