### PR TITLE
Make tmp dims with hard-coded strings instead of generator

### DIFF
--- a/src/scipp/core/bin_remapping.py
+++ b/src/scipp/core/bin_remapping.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Sequence
 from math import prod
 from typing import TYPE_CHECKING, TypeVar
@@ -110,7 +109,7 @@ def _combine_bins(
     sub_sizes = index(changed_volume).broadcast(
         dims=unchanged_dims, shape=unchanged_shape
     )
-    params = params.flatten(to=uuid.uuid4().hex)
+    params = params.flatten(to="_combine_bins.flat_dim")
     # Setup pseudo binning for unchanged subspace. All further reordering (for grouping
     # and binning) will then occur *within* those pseudo bins (by splitting them).
     params_data = _with_bin_sizes(params, sub_sizes)

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import itertools
-import uuid
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, SupportsIndex, TypeVar, overload
 
@@ -244,7 +243,7 @@ def _prepare_multi_dim_dense(x: DataArray, *edges_or_groups: Variable) -> DataAr
     helper_coords = {dim: arange(dim, x.sizes[dim]) for dim in extra}
     return (
         x.assign_coords(helper_coords)
-        .flatten(to=str(uuid.uuid4()))
+        .flatten(to='_prepare_multi_dim_dense.flat_dim')
         .group(*helper_coords.values())
         .drop_coords(tuple(extra))
         .assign_coords(original_coords)

--- a/src/scipp/reduction.py
+++ b/src/scipp/reduction.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import uuid
 from collections.abc import Iterable, Sequence
-from itertools import chain
 from typing import Generic, TypeVar
 
 from .core import DataArray, Dataset, Variable, concat, reduction
@@ -23,64 +23,55 @@ class BinsReducer(Generic[_O]):
 
 
 class Reducer(Generic[_O]):
+    _DIM = uuid.uuid4().hex
+
     def __init__(self, x: Sequence[_O]) -> None:
-        self._dim = _make_extra_dim(x)
         # concat in init avoids repeated costly step in case of multiple reductions
-        self._obj: _O = concat(x, dim=self._dim)
+        self._obj: _O = concat(x, dim=self._DIM)
 
     @property
     def bins(self) -> BinsReducer[_O]:
-        return BinsReducer(self._obj, self._dim)
+        return BinsReducer(self._obj, self._DIM)
 
     def all(self) -> _O:
         """Element-wise 'all' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.all(self._obj, self._dim)
+        return reduction.all(self._obj, self._DIM)
 
     def any(self) -> _O:
         """Element-wise 'any' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.any(self._obj, self._dim)
+        return reduction.any(self._obj, self._DIM)
 
     def max(self) -> _O:
         """Element-wise 'max' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.max(self._obj, self._dim)
+        return reduction.max(self._obj, self._DIM)
 
     def min(self) -> _O:
         """Element-wise 'min' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.min(self._obj, self._dim)
+        return reduction.min(self._obj, self._DIM)
 
     def sum(self) -> _O:
         """Element-wise 'sum' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.sum(self._obj, self._dim)
+        return reduction.sum(self._obj, self._DIM)
 
     def mean(self) -> _O:
         """Element-wise 'mean' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.mean(self._obj, self._dim)
+        return reduction.mean(self._obj, self._DIM)
 
     def nanmax(self) -> _O:
         """Element-wise 'nanmax' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.nanmax(self._obj, self._dim)
+        return reduction.nanmax(self._obj, self._DIM)
 
     def nanmin(self) -> _O:
         """Element-wise 'nanmin' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.nanmin(self._obj, self._dim)
+        return reduction.nanmin(self._obj, self._DIM)
 
     def nansum(self) -> _O:
         """Element-wise 'nansum' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.nansum(self._obj, self._dim)
+        return reduction.nansum(self._obj, self._DIM)
 
     def nanmean(self) -> _O:
         """Element-wise 'nanmean' across inputs passed to :py:func:`scipp.reduce`."""
-        return reduction.nanmean(self._obj, self._dim)
-
-
-def _make_extra_dim(avoid: Sequence[_O]) -> str:
-    used = set(chain(*(x.dims for x in avoid)))
-    for i in range(1000):
-        dim = f"_reduce.dim_{i}"
-        if dim not in used:
-            return dim
-    # Realistically, this will never happen:
-    raise RuntimeError("Could not find extra dimension")
+        return reduction.nanmean(self._obj, self._DIM)
 
 
 def reduce(x: Iterable[_O]) -> Reducer[_O]:


### PR DESCRIPTION
Fixes #3747.
Alternative to #3748

#3748 is not thread safe which may be a problem especially for beamlime. The specific usages of tmp dims in Scipp are in non-recursive functions. So using hard-coded dims should be fine.

I chose dim labels that contain `.` because we encourage using valid Python identifiers which should reduce the risk of collisions with user provided labels. And I chose names starting with `_` to indicate that these are protected names.