### PR TITLE
ci: remove deploy to conda forge job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,22 +92,6 @@ jobs:
           pattern: 'dist*'
       - uses: pypa/gh-action-pypi-publish@v1.12.4
 
-  upload_conda:
-    name: Deploy Conda Forge
-    needs: [build_wheels, build_sdist, build_conda]
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'release' && github.event.action == 'published'
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: 'conda*'
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: '3.12'
-      - run: conda install -c conda-forge --yes anaconda-client
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(find . -type f -name "*.conda")
-
   manage-versions:
     name: Manage Versions
     needs: check_release
@@ -131,7 +115,7 @@ jobs:
           echo "replaced=$(python docs/version.py --version=${GITHUB_REF_NAME} --action=get-replaced)" >> $GITHUB_OUTPUT
 
   docs:
-    needs: [upload_conda, upload_pypi, manage-versions]
+    needs: [upload_pypi, manage-versions]
     uses: ./.github/workflows/docs.yml
     with:
       publish: ${{ github.event_name == 'release' && github.event.action == 'published' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash -l {0}  # required for conda env
+    shell: bash
 
 jobs:
   check_release:
@@ -22,24 +22,6 @@ jobs:
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e check-release
         if: github.event_name == 'release' && github.event.action == 'published'
-
-  build_conda:
-    name: Conda
-    needs: check_release
-    strategy:
-      matrix:
-        variant:
-          - {os: ubuntu-24.04, target: linux_64}
-          - {os: macos-13, target: osx_64}
-          - {os: macos-14, target: osx_arm64}
-          - {os: windows-2022, target: win_64}
-          - {os: ubuntu-24.04-arm, target: linux_arm64}
-        python-version: ["3.11", "3.12", "3.13"]
-    uses: ./.github/workflows/conda.yml
-    with:
-      os: ${{ matrix.variant.os }}
-      target: ${{ matrix.variant.target }}
-      python-version: ${{ matrix.python-version }}
 
   build_sdist:
     name: Build SDist
@@ -77,7 +59,7 @@ jobs:
 
   upload_pypi:
     name: Deploy PyPI
-    needs: [build_wheels, build_sdist, build_conda]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-24.04
     environment: release
     permissions:


### PR DESCRIPTION
If I understand correctly the conda-forge deployment is done automatically by the feedstock.
Then it seems reasonable we should not also deploy to conda forge in the release workflow.
Is that correct?
