### PR TITLE
feat: change midpoint definition to cast integers to float

### DIFF
--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -154,15 +154,14 @@ constexpr auto midpoint = overloaded{
       if constexpr (std::is_same_v<std::decay_t<decltype(a)>, time_point>) {
         return time_point{
             std::midpoint(a.time_since_epoch(), b.time_since_epoch())};
-      } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>,
-                                          Eigen::Vector3d>) {
-        Eigen::Vector3d mid;
-        for (int i = 0; i < 3; ++i) {
-          mid[i] = std::midpoint(a[i], b[i]);
-        }
-        return mid;
+      } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
+                           int32_t) {
+        return (static_cast<float>(a) + static_cast<float>(b)) / 2;
+      } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
+                           int64_t) {
+        return (static_cast<double>(a) + static_cast<double>(b)) / 2;
       } else {
-        return std::midpoint(a, b);
+        return (a + b) / 2;
       }
     }};
 

--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -162,7 +162,7 @@ constexpr auto midpoint = overloaded{
         }
         return mid;
       } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int32_t>) {
-        return std::midpoint(static_cast<float>(a) + static_cast<float>(b));
+        return std::midpoint(static_cast<float>(a), static_cast<float>(b));
       } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int64_t>) {
         return std::midpoint(static_cast<double>(a), static_cast<double>(b));
       } else {

--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -161,11 +161,9 @@ constexpr auto midpoint = overloaded{
           mid[i] = std::midpoint(a[i], b[i]);
         }
         return mid;
-      } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
-                           int32_t) {
+      } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int32_t>) {
         return std::midpoint(static_cast<float>(a) + static_cast<float>(b));
-      } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
-                           int64_t) {
+      } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int64_t>) {
         return std::midpoint(static_cast<double>(a), static_cast<double>(b));
       } else {
         return std::midpoint(a, b);

--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -162,7 +162,7 @@ constexpr auto midpoint = overloaded{
         }
         return mid;
       } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int32_t>) {
-        return std::midpoint(static_cast<float>(a), static_cast<float>(b));
+        return std::midpoint(static_cast<double>(a), static_cast<double>(b));
       } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>, int64_t>) {
         return std::midpoint(static_cast<double>(a), static_cast<double>(b));
       } else {

--- a/lib/core/include/scipp/core/element/math.h
+++ b/lib/core/include/scipp/core/element/math.h
@@ -154,14 +154,21 @@ constexpr auto midpoint = overloaded{
       if constexpr (std::is_same_v<std::decay_t<decltype(a)>, time_point>) {
         return time_point{
             std::midpoint(a.time_since_epoch(), b.time_since_epoch())};
+      } else if constexpr (std::is_same_v<std::decay_t<decltype(a)>,
+                                          Eigen::Vector3d>) {
+        Eigen::Vector3d mid;
+        for (int i = 0; i < 3; ++i) {
+          mid[i] = std::midpoint(a[i], b[i]);
+        }
+        return mid;
       } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
                            int32_t) {
-        return (static_cast<float>(a) + static_cast<float>(b)) / 2;
+        return std::midpoint(static_cast<float>(a) + static_cast<float>(b));
       } else if constexpr (std::is_same_v < std::decay_t<decltype(a)>,
                            int64_t) {
-        return (static_cast<double>(a) + static_cast<double>(b)) / 2;
+        return std::midpoint(static_cast<double>(a), static_cast<double>(b));
       } else {
-        return (a + b) / 2;
+        return std::midpoint(a, b);
       }
     }};
 

--- a/lib/core/test/element_math_test.cpp
+++ b/lib/core/test/element_math_test.cpp
@@ -224,11 +224,12 @@ TEST(ElementMathTest, midpoint_of_medium_sized_double) {
   EXPECT_EQ(element::midpoint(6.0, -7.0), -0.5);
 }
 
-TEST(ElementMathTest, midpoint_of_medium_sized_values_rounds_towards_first) {
-  EXPECT_EQ(element::midpoint(4, 1), 3);
-  EXPECT_EQ(element::midpoint(2, 7), 4);
-  EXPECT_EQ(element::midpoint(-3, -8), -5);
-  EXPECT_EQ(element::midpoint(6, -7), 0);
+TEST(ElementMathTest,
+     midpoint_of_medium_sized_values_does_not_round_towards_first) {
+  EXPECT_EQ(element::midpoint(4, 1), 2.5);
+  EXPECT_EQ(element::midpoint(2, 7), 4.5);
+  EXPECT_EQ(element::midpoint(-3, -8), -5.5);
+  EXPECT_EQ(element::midpoint(6, -7), -0.5);
 }
 
 TEST(ElementMathTest, midpoint_of_small_int_works) {

--- a/lib/core/test/element_math_test.cpp
+++ b/lib/core/test/element_math_test.cpp
@@ -241,7 +241,7 @@ TEST(ElementMathTest, midpoint_of_small_int_works) {
 TEST(ElementMathTest, midpoint_of_time_point_uses_underlying_int) {
   const time_point a{123};
   const time_point b{732};
-  EXPECT_EQ(element::midpoint(a, b), time_point{element::midpoint(123, 732)});
+  EXPECT_EQ(element::midpoint(a, b), time_point{std::midpoint(123, 732)});
 }
 
 TEST(ElementMathTest, midpoint_units_must_be_equal) {

--- a/lib/variable/test/math_test.cpp
+++ b/lib/variable/test/math_test.cpp
@@ -525,8 +525,8 @@ TEST(Variable, midpoints_1d_2_elements) {
 TEST(Variable, midpoints_1d_many_elements) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X}, Shape{7},
                                          Values{-3, -1, 0, 1, 1, 3, 6});
-  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{6},
-                                             Values{-2, -0.5, 0, 1, 2, 4.5});
+  const auto expected = makeVariable<double>(
+      Dims{Dim::X}, Shape{6}, Values{-2., -0.5, 0., 1., 2., 4.5});
   EXPECT_EQ(midpoints(var), expected);
 }
 
@@ -540,7 +540,7 @@ TEST(Variable, midpoints_2d_many_elements_inner) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                          Values{5, 1, -2, 3, 1, 1});
   const auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                             Values{3, -0.5, 2, 1});
+                                             Values{3., -0.5, 2., 1.});
   EXPECT_EQ(midpoints(var, Dim::Y), expected);
 }
 
@@ -548,6 +548,6 @@ TEST(Variable, midpoints_2d_2_elements_outer) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                          Values{5, 1, -2, 3, 1, 1});
   const auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{1, 3},
-                                             Values{4, 1, -0.5});
+                                             Values{4., 1., -0.5});
   EXPECT_EQ(midpoints(var, Dim::X), expected);
 }

--- a/lib/variable/test/math_test.cpp
+++ b/lib/variable/test/math_test.cpp
@@ -526,7 +526,7 @@ TEST(Variable, midpoints_1d_many_elements) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X}, Shape{7},
                                          Values{-3, -1, 0, 1, 1, 3, 6});
   const auto expected = makeVariable<double>(
-      Dims{Dim::X}, Shape{6}, Values{-2., -0.5, 0., 1., 2., 4.5});
+      Dims{Dim::X}, Shape{6}, Values{-2., -0.5, 0.5, 1., 2., 4.5});
   EXPECT_EQ(midpoints(var), expected);
 }
 

--- a/lib/variable/test/math_test.cpp
+++ b/lib/variable/test/math_test.cpp
@@ -518,16 +518,15 @@ TEST(Variable, midpoints_1d_throws_with_single_element) {
 
 TEST(Variable, midpoints_1d_2_elements) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X}, Shape{2}, Values{3, 7});
-  const auto expected =
-      makeVariable<int64_t>(Dims{Dim::X}, Shape{1}, Values{5});
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{1}, Values{5});
   EXPECT_EQ(midpoints(var), expected);
 }
 
 TEST(Variable, midpoints_1d_many_elements) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X}, Shape{7},
                                          Values{-3, -1, 0, 1, 1, 3, 6});
-  const auto expected =
-      makeVariable<int64_t>(Dims{Dim::X}, Shape{6}, Values{-2, -1, 0, 1, 2, 4});
+  const auto expected = makeVariable<double>(Dims{Dim::X}, Shape{6},
+                                             Values{-2, -0.5, 0, 1, 2, 4.5});
   EXPECT_EQ(midpoints(var), expected);
 }
 
@@ -540,15 +539,15 @@ TEST(Variable, midpoints_2d_requires_dim_argument) {
 TEST(Variable, midpoints_2d_many_elements_inner) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                          Values{5, 1, -2, 3, 1, 1});
-  const auto expected = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
-                                              Values{3, 0, 2, 1});
+  const auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{2, 2},
+                                             Values{3, -0.5, 2, 1});
   EXPECT_EQ(midpoints(var, Dim::Y), expected);
 }
 
 TEST(Variable, midpoints_2d_2_elements_outer) {
   const auto var = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{2, 3},
                                          Values{5, 1, -2, 3, 1, 1});
-  const auto expected = makeVariable<int64_t>(Dims{Dim::X, Dim::Y}, Shape{1, 3},
-                                              Values{4, 1, -1});
+  const auto expected = makeVariable<double>(Dims{Dim::X, Dim::Y}, Shape{1, 3},
+                                             Values{4, 1, -0.5});
   EXPECT_EQ(midpoints(var, Dim::X), expected);
 }

--- a/src/scipp/core/math.py
+++ b/src/scipp/core/math.py
@@ -490,16 +490,15 @@ def midpoints(x: Variable, dim: str | None = None) -> Variable:
       >>> x
       <scipp.Variable> (x: 4)      int64  [dimensionless]  [-2, 0, 4, 2]
       >>> sc.midpoints(x)
-      <scipp.Variable> (x: 3)      int64  [dimensionless]  [-1, 2, 3]
+      <scipp.Variable> (x: 3)      float64  [dimensionless]  [-1, 2, 3]
 
-    For integers, when the difference of adjacent elements is odd,
-    `midpoints` rounds towards the number that comes first in the array:
+    `midpoints` casts integers to float before computing the midpoints:
 
       >>> x = sc.array(dims=['x'], values=[0, 3, 0])
       >>> x
       <scipp.Variable> (x: 3)      int64  [dimensionless]  [0, 3, 0]
       >>> sc.midpoints(x)
-      <scipp.Variable> (x: 2)      int64  [dimensionless]  [1, 2]
+      <scipp.Variable> (x: 2)      float64  [dimensionless]  [1.5, 1.5]
 
     With multidimensional variables, `midpoints` is only applied
     to the specified dimension:
@@ -509,7 +508,7 @@ def midpoints(x: Variable, dim: str | None = None) -> Variable:
       array([[ 1,  3,  5],
              [ 2,  6, 10]])
       >>> sc.midpoints(xy, dim='x').values
-      array([[1, 4, 7]])
+      array([[1.5, 4, 7.5]])
       >>> sc.midpoints(xy, dim='y').values
       array([[2, 4],
              [4, 8]])

--- a/src/scipp/core/math.py
+++ b/src/scipp/core/math.py
@@ -508,9 +508,9 @@ def midpoints(x: Variable, dim: str | None = None) -> Variable:
       array([[ 1,  3,  5],
              [ 2,  6, 10]])
       >>> sc.midpoints(xy, dim='x').values
-      array([[1.5, 4, 7.5]])
+      array([[1.5, 4.5, 7.5]])
       >>> sc.midpoints(xy, dim='y').values
-      array([[2, 4],
-             [4, 8]])
+      array([[2., 4.],
+             [4., 8.]])
     """
     return _cpp.midpoints(x, dim)  # type: ignore[no-any-return]


### PR DESCRIPTION
Fixes #3765 

This returns something closer to what most users would expect.

It might fail for very large integers.