### PR TITLE
Convert dict-like args from compatible types

### DIFF
--- a/src/scipp/core/argument_handlers.py
+++ b/src/scipp/core/argument_handlers.py
@@ -1,21 +1,21 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
-from typing import TypeVar
+from collections.abc import Iterable, Mapping
+from typing import TypeAlias, TypeVar
 
-from .cpp_classes import Variable
-
-_ValueType = TypeVar('_ValueType', str, Variable)
+_V = TypeVar('_V')
+IntoStrDict: TypeAlias = Mapping[str, _V] | Iterable[tuple[str, _V]]
 
 
 def combine_dict_args(
-    arg: dict[str, _ValueType] | None, kwargs: dict[str, _ValueType]
-) -> dict[str, _ValueType]:
-    pos_dict = {} if arg is None else arg
+    arg: IntoStrDict[_V] | None, kwargs: Mapping[str, _V]
+) -> dict[str, _V]:
+    pos_dict = {} if arg is None else dict(arg)
 
     overlapped = set(pos_dict).intersection(kwargs)
     if overlapped:
-        raise ValueError(
+        raise TypeError(
             'The names passed in the dict and as keyword arguments must be distinct. '
             f'Following names are used in both arguments: {overlapped}'
         )

--- a/src/scipp/core/assignments.py
+++ b/src/scipp/core/assignments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Literal, TypeVar
 
-from .argument_handlers import combine_dict_args
+from .argument_handlers import IntoStrDict, combine_dict_args
 from .cpp_classes import DataArray, Dataset, Variable
 
 _T = TypeVar('_T', Dataset, DataArray)
@@ -14,7 +14,7 @@ _T = TypeVar('_T', Dataset, DataArray)
 def _assign(
     obj: _T,
     name: Literal['coords', 'masks'],
-    obj_attrs: dict[str, Variable] | None = None,
+    obj_attrs: IntoStrDict[Variable] | None = None,
     /,
     **kw_obj_attrs: Variable,
 ) -> _T:
@@ -44,7 +44,7 @@ def assign_data(self: DataArray, data: Variable) -> DataArray:
 
 
 def assign_coords(
-    self: _T, coords: dict[str, Variable] | None = None, /, **coords_kwargs: Variable
+    self: _T, coords: IntoStrDict[Variable] | None = None, /, **coords_kwargs: Variable
 ) -> _T:
     """Return new object with updated or inserted coordinate.
 
@@ -67,7 +67,7 @@ def assign_coords(
 
 def assign_masks(
     self: DataArray,
-    masks: dict[str, Variable] | None = None,
+    masks: IntoStrDict[Variable] | None = None,
     /,
     **masks_kwargs: Variable,
 ) -> DataArray:

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, SupportsIndex, TypeVar, overload
 
 from .._scipp import core as _cpp
+from .argument_handlers import IntoStrDict, combine_dict_args
 from .bin_remapping import combine_bins
 from .bins import Bins
 from .cpp_classes import BinEdgeError, CoordError, DataArray, Dataset, DType, Variable
@@ -358,12 +359,13 @@ def _parse_coords_arg(
 
 def _make_edges(
     x: Variable | DataArray | Dataset,
-    arg_dict: Mapping[str, SupportsIndex | Variable] | None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None,
     kwargs: Mapping[str, SupportsIndex | Variable],
 ) -> dict[str, Variable]:
-    if arg_dict is not None:
-        kwargs = dict(**arg_dict, **kwargs)
-    return {name: _parse_coords_arg(x, name, arg) for name, arg in kwargs.items()}
+    return {
+        name: _parse_coords_arg(x, name, arg)
+        for name, arg in combine_dict_args(arg_dict, kwargs).items()
+    }
 
 
 def _find_replaced_dims(
@@ -387,7 +389,7 @@ def _find_replaced_dims(
 @overload
 def hist(
     x: Variable | DataArray,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -398,7 +400,7 @@ def hist(
 @overload
 def hist(
     x: Dataset,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -409,7 +411,7 @@ def hist(
 @overload
 def hist(
     x: DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -420,7 +422,7 @@ def hist(
 @data_group_overload
 def hist(
     x: Variable | DataArray | Dataset | DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -616,7 +618,7 @@ def _get_op_dims(x: DataArray, *edges_or_groups: Variable) -> set[str]:
 @overload
 def nanhist(
     x: Variable | DataArray,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -627,7 +629,7 @@ def nanhist(
 @overload
 def nanhist(
     x: Dataset,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -638,7 +640,7 @@ def nanhist(
 @overload
 def nanhist(
     x: DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -649,7 +651,7 @@ def nanhist(
 @data_group_overload
 def nanhist(
     x: Variable | DataArray | Dataset | DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -692,7 +694,7 @@ def nanhist(
 @overload
 def bin(
     x: Variable | DataArray,
-    arg_dict: Mapping[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -703,7 +705,7 @@ def bin(
 @overload
 def bin(
     x: DataGroup[Any],
-    arg_dict: Mapping[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -714,7 +716,7 @@ def bin(
 @data_group_overload
 def bin(
     x: Variable | DataArray | DataGroup[Any],
-    arg_dict: Mapping[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     *,
     dim: str | tuple[str, ...] | None = None,
@@ -870,7 +872,7 @@ def bin(
 @overload
 def rebin(
     x: Variable | DataArray,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     **kwargs: SupportsIndex | Variable,
 ) -> DataArray: ...
@@ -879,7 +881,7 @@ def rebin(
 @overload
 def rebin(
     x: Dataset,
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     **kwargs: SupportsIndex | Variable,
 ) -> Dataset: ...
@@ -888,7 +890,7 @@ def rebin(
 @overload
 def rebin(
     x: DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     **kwargs: SupportsIndex | Variable,
 ) -> DataGroup[Any]: ...
@@ -897,7 +899,7 @@ def rebin(
 @data_group_overload
 def rebin(
     x: Variable | DataArray | Dataset | DataGroup[Any],
-    arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+    arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
     /,
     **kwargs: SupportsIndex | Variable,
 ) -> Variable | DataArray | Dataset | DataGroup[Any]:

--- a/src/scipp/core/bins.py
+++ b/src/scipp/core/bins.py
@@ -9,7 +9,7 @@ from typing import Generic, Literal, Sequence, TypedDict, TypeVar
 from .._scipp import core as _cpp
 from ..typing import Dims, MetaDataMap, VariableLike
 from ._cpp_wrapper_util import call_func as _call_cpp_func
-from .argument_handlers import combine_dict_args
+from .argument_handlers import IntoStrDict, combine_dict_args
 from .bin_remapping import concat_bins
 from .cpp_classes import Coords, DataArray, Dataset, DType, Unit, Variable
 from .data_group import DataGroup
@@ -289,7 +289,7 @@ class Bins(Generic[_O]):
         return _cpp._bins_view(self._data()).coords  # type: ignore[no-any-return]
 
     def assign_coords(
-        self, coords: dict[str, Variable] | None = None, /, **coords_kwargs: Variable
+        self, coords: IntoStrDict[Variable] | None = None, /, **coords_kwargs: Variable
     ) -> _O:
         """Return a new object with coords assigned to bin content."""
         # Shallow copy constituents
@@ -310,7 +310,7 @@ class Bins(Generic[_O]):
         return _cpp._bins_view(self._data()).masks  # type: ignore[no-any-return]
 
     def assign_masks(
-        self, masks: dict[str, Variable] | None = None, /, **masks_kwargs: Variable
+        self, masks: IntoStrDict[Variable] | None = None, /, **masks_kwargs: Variable
     ) -> _O:
         """Return a new object with masks assigned to bin content."""
         # Shallow copy constituents

--- a/src/scipp/core/cpp_classes.pyi
+++ b/src/scipp/core/cpp_classes.pyi
@@ -22,11 +22,12 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 
+from ..argument_handlers import IntoStrDict
 from ..coords.graph import GraphDict
 from ..typing import Dims, VariableLike
 from ..units import default_unit
-from .bins import Bins
 from ..typing import ScippIndex
+from .bins import Bins
 
 try:
     import h5py as h5
@@ -317,15 +318,15 @@ class DataArray:
     def any(self, dim: Dims = None) -> DataArray: ...
     def assign(self, data: Variable) -> DataArray: ...
     def assign_coords(
-        self, coords: dict[str, Variable] | None = None, /, **coords_kwargs: Variable
+        self, coords: IntoStrDict[Variable] | None = None, /, **coords_kwargs: Variable
     ) -> DataArray: ...
     def assign_masks(
-        self, masks: dict[str, Variable] | None = None, /, **masks_kwargs: Variable
+        self, masks: IntoStrDict[Variable] | None = None, /, **masks_kwargs: Variable
     ) -> DataArray: ...
     def astype(self, type: Any, *, copy: bool = True) -> DataArray: ...
     def bin(
         self,
-        arg_dict: Mapping[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         *,
         dim: str | tuple[str, ...] | None = None,
@@ -394,7 +395,7 @@ class DataArray:
     ) -> GroupByDataArray | GroupByDataset: ...
     def hist(
         self,
-        arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         **kwargs: SupportsIndex | Variable,
     ) -> DataArray: ...
@@ -412,7 +413,7 @@ class DataArray:
     def name(self, arg1: str) -> None: ...
     def nanhist(
         self,
-        arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         **kwargs: SupportsIndex | Variable,
     ) -> DataArray: ...
@@ -428,15 +429,15 @@ class DataArray:
     def plot(*args: Any, **kwargs: Any) -> Any: ...
     def rebin(
         self,
-        arg_dict: dict[str, int | Variable] | None = None,
+        arg_dict: IntoStrDict[int | Variable] | None = None,
         /,
         **kwargs: int | Variable,
     ) -> DataArray: ...
     def rename(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> DataArray: ...
     def rename_dims(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> DataArray: ...
     def round(
         self, *, decimals: int = 0, out: VariableLike | None = None
@@ -611,7 +612,7 @@ class Dataset(Mapping[str, DataArray]):
     def all(self, dim: Dims = None) -> Dataset: ...
     def any(self, dim: Dims = None) -> Dataset: ...
     def assign_coords(
-        self, coords: dict[str, Variable] | None = None, /, **coords_kwargs: Variable
+        self, coords: IntoStrDict[Variable] | None = None, /, **coords_kwargs: Variable
     ) -> Dataset: ...
     @property
     def bins(self) -> Bins[Dataset]: ...
@@ -635,7 +636,7 @@ class Dataset(Mapping[str, DataArray]):
     ) -> GroupByDataArray | GroupByDataset: ...
     def hist(
         self,
-        arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         *,
         dim: str | tuple[str, ...] | None = None,
@@ -665,15 +666,15 @@ class Dataset(Mapping[str, DataArray]):
     def pop(self, key: str, default: DataArray | _T) -> DataArray | _T: ...
     def rebin(
         self,
-        arg_dict: dict[str, int | Variable] | None = None,
+        arg_dict: IntoStrDict[int | Variable] | None = None,
         /,
         **kwargs: int | Variable,
     ) -> Dataset: ...
     def rename(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> Dataset: ...
     def rename_dims(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> Dataset: ...
     def save_hdf5(
         self, filename: str | PathLike[str] | StringIO | BytesIO | h5.Group
@@ -964,7 +965,7 @@ class Variable:
     def astype(self, type: Any, *, copy: bool = True) -> Variable: ...
     def bin(
         self,
-        arg_dict: Mapping[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         *,
         dim: str | tuple[str, ...] | None = None,
@@ -1023,7 +1024,7 @@ class Variable:
     ) -> Variable: ...
     def hist(
         self,
-        arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         **kwargs: SupportsIndex | Variable,
     ) -> DataArray: ...
@@ -1035,7 +1036,7 @@ class Variable:
     def min(self, dim: Dims = None) -> Variable: ...
     def nanhist(
         self,
-        arg_dict: dict[str, SupportsIndex | Variable] | None = None,
+        arg_dict: IntoStrDict[SupportsIndex | Variable] | None = None,
         /,
         *,
         dim: str | tuple[str, ...] | None = None,
@@ -1052,10 +1053,10 @@ class Variable:
     def ndim(self) -> int: ...
     def plot(*args: Any, **kwargs: Any) -> Any: ...
     def rename(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> Variable: ...
     def rename_dims(
-        self, dims_dict: dict[str, str] | None = None, /, **names: str
+        self, dims_dict: IntoStrDict[str] | None = None, /, **names: str
     ) -> Variable: ...
     def round(
         self, *, decimals: int = 0, out: VariableLike | None = None

--- a/src/scipp/core/dimensions.py
+++ b/src/scipp/core/dimensions.py
@@ -5,7 +5,7 @@
 from typing import TypeVar
 
 from .._scipp.core import CoordError, DataArray, Dataset, Variable
-from .argument_handlers import combine_dict_args
+from .argument_handlers import IntoStrDict, combine_dict_args
 from .bins import bins
 from .variable import scalar
 
@@ -13,7 +13,7 @@ _T = TypeVar('_T', Variable, DataArray, Dataset)
 
 
 def _rename_dims(
-    self: _T, dims_dict: dict[str, str] | None = None, /, **names: str
+    self: _T, dims_dict: IntoStrDict[str] | None = None, /, **names: str
 ) -> _T:
     """Rename dimensions.
 
@@ -33,7 +33,7 @@ def _rename_dims(
     Parameters
     ----------
     dims_dict:
-        Dictionary mapping old to new names.
+        Dictionary or items iterator mapping old to new names.
     names:
         Mapping of old to new names as keyword arguments.
 
@@ -46,7 +46,7 @@ def _rename_dims(
 
 
 def _rename_variable(
-    var: Variable, dims_dict: dict[str, str] | None = None, /, **names: str
+    var: Variable, dims_dict: IntoStrDict[str] | None = None, /, **names: str
 ) -> Variable:
     """Rename dimension labels.
 
@@ -62,7 +62,7 @@ def _rename_variable(
     Parameters
     ----------
     dims_dict:
-        Dictionary mapping old to new names.
+        Dictionary or items iterator mapping old to new names.
     names:
         Mapping of old to new names as keyword arguments.
 
@@ -80,7 +80,7 @@ def _rename_variable(
 
 
 def _rename_data_array(
-    da: DataArray, dims_dict: dict[str, str] | None = None, /, **names: str
+    da: DataArray, dims_dict: IntoStrDict[str] | None = None, /, **names: str
 ) -> DataArray:
     """Rename the dimensions, coordinates, and attributes.
 
@@ -96,7 +96,7 @@ def _rename_data_array(
     Parameters
     ----------
     dims_dict:
-        Dictionary mapping old to new names.
+        Dictionary or items iterator mapping old to new names.
     names:
         Mapping of old to new names as keyword arguments.
 
@@ -130,7 +130,7 @@ def _rename_data_array(
 
 
 def _rename_dataset(
-    ds: Dataset, dims_dict: dict[str, str] | None = None, /, **names: str
+    ds: Dataset, dims_dict: IntoStrDict[str] | None = None, /, **names: str
 ) -> Dataset:
     """Rename the dimensions, coordinates and attributes of all the items.
 
@@ -146,7 +146,7 @@ def _rename_dataset(
     Parameters
     ----------
     dims_dict:
-        Dictionary mapping old to new names.
+        Dictionary or items iterator mapping old to new names.
     names:
         Mapping of old to new names as keyword arguments.
 

--- a/tests/data_array_test.py
+++ b/tests/data_array_test.py
@@ -473,7 +473,7 @@ def test_assign_coords_overlapping_names() -> None:
     data = sc.array(dims=['x', 'y', 'z'], values=np.random.rand(4, 3, 5))
     da = sc.DataArray(data)
     coord0 = sc.linspace('x', start=0.2, stop=1.61, num=4)
-    with pytest.raises(ValueError, match='names .* distinct'):
+    with pytest.raises(TypeError, match='names .* distinct'):
         da.assign_coords({'coord0': coord0}, coord0=coord0)
 
 
@@ -521,7 +521,7 @@ def test_assign_masks_overlapping_names() -> None:
     data = sc.array(dims=['x', 'y', 'z'], values=np.random.rand(4, 3, 5))
     da = sc.DataArray(data)
     mask0 = sc.array(dims=['x'], values=[False, True, True, False])
-    with pytest.raises(ValueError, match='names .* distinct'):
+    with pytest.raises(TypeError, match='names .* distinct'):
         da.assign_masks({'mask0': mask0}, mask0=mask0)
 
 

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -727,7 +727,7 @@ def test_assign_coords_overlapping_names() -> None:
     ds = sc.Dataset(data={'data0': data})
     coord0 = sc.linspace('x', start=0.2, stop=1.61, num=4)
 
-    with pytest.raises(ValueError, match='names .* distinct'):
+    with pytest.raises(TypeError, match='names .* distinct'):
         ds.assign_coords({'coord0': coord0}, coord0=coord0)
 
 

--- a/tests/variable_test.py
+++ b/tests/variable_test.py
@@ -443,7 +443,7 @@ def test_rename_dims_dict_and_kwargs_must_be_distinct() -> None:
     values = np.arange(6).reshape(2, 3)
     xy = sc.Variable(dims=['x', 'y'], values=values)
     with pytest.raises(
-        ValueError, match='The names passed in the dict and as keyword arguments'
+        TypeError, match='The names passed in the dict and as keyword arguments'
     ):
         xy.rename_dims({'x': 'w'}, x='z')
 
@@ -472,7 +472,7 @@ def test_rename_dict_and_kwargs_must_be_distinct() -> None:
     values = np.arange(6).reshape(2, 3)
     xy = sc.Variable(dims=['x', 'y'], values=values)
     with pytest.raises(
-        ValueError, match='The names passed in the dict and as keyword arguments'
+        TypeError, match='The names passed in the dict and as keyword arguments'
     ):
         xy.rename({'x': 'w'}, x='z')
 


### PR DESCRIPTION
Similarly to #3797 this allows more flexible dict-like arguments in some functions. I specifically ran into this when using `da.assign_coords(other.coords)` which should intuitively be allowed. But mypy complained because `assign_coords` required a dict. (There was no problem at runtime.)

Note that there are two changes in behaviour:
- This PR makes the code more flexible and allows iterators over tuples as well as mappings. This should cover the types that one would typically pass to `dict()`.
- Passing the same argument via the dict like arg and `kwargs` now raises `TypeError` instead of `ValueError`. This matches the existing behaviour of bin, hist, etc. and more closely matches the typical error you get from bad function calls.