### PR TITLE
docs: fix link

### DIFF
--- a/src/scipp/scipy/signal/__init__.py
+++ b/src/scipp/scipy/signal/__init__.py
@@ -166,7 +166,7 @@ def find_peaks(
     """
     A routine that locates "peaks" in a 1D signal.
 
-    This is a wrapper around :py:func:`scipy.signal.find_peaks. See there for a
+    This is a wrapper around :py:func:`scipy.signal.find_peaks`. See there for a
     complete description of parameters.
 
     Returns


### PR DESCRIPTION
Seems the link to scipy docs was broken.