### PR TITLE
Bump MacOS deployment target to 14

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,7 +34,7 @@
       "inherits": "base",
       "description": "MacOS options for CI build (PR and Main)",
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0"
       }
     },
     {
@@ -76,7 +76,7 @@
       "inherits": "package",
       "description": "MacOS options for package build for x86_64",
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0",
         "CMAKE_OSX_ARCHITECTURES": "x86_64"
       }
     },
@@ -85,7 +85,7 @@
       "inherits": "package",
       "description": "MacOS options for package build for arm64",
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0",
         "CMAKE_OSX_ARCHITECTURES": "arm64"
       }
     },


### PR DESCRIPTION
We need at least MacOS 14 to fully support C++ 23. That limits us to Mac Book Pro from >2018 and Mac Book Air from >2020. But since we do not have many users, that should be fine at this point.

See #3821 for a concrete use case.