### PR TITLE
Avoid 0/0 in sqrt variance

### DIFF
--- a/lib/core/include/scipp/core/value_and_variance.h
+++ b/lib/core/include/scipp/core/value_and_variance.h
@@ -78,8 +78,10 @@ constexpr auto pow(const ValueAndVariance<B> base, const E exponent) noexcept {
 
 template <class T> constexpr auto sqrt(const ValueAndVariance<T> a) noexcept {
   using std::sqrt;
-  return ValueAndVariance{sqrt(a.value),
-                          static_cast<T>(0.25 * (a.variance / a.value))};
+  // Avoid 0/0 but allow x/0=inf as the limiting case for a.value -> 0
+  const auto variance =
+      a.variance == 0 ? 0 : static_cast<T>(0.25 * (a.variance / a.value));
+  return ValueAndVariance{sqrt(a.value), variance};
 }
 
 template <class T> constexpr auto abs(const ValueAndVariance<T> a) noexcept {


### PR DESCRIPTION
Fixes #3878

I think this is the best we can do as the variance diverges for `a.value -> 0` if `a.variance > 0`.