### PR TITLE
Guard SubbinSizes::exclusive_scan against negative delta

### DIFF
--- a/lib/core/subbin_sizes.cpp
+++ b/lib/core/subbin_sizes.cpp
@@ -100,6 +100,12 @@ void SubbinSizes::exclusive_scan(SubbinSizes &x) {
   const scipp::index osize = scipp::size(sizes());
   const scipp::index size = scipp::size(x.sizes());
   const auto delta = x.offset() - offset();
+  // Negative delta would cause out-of-bounds reads below. In practice this
+  // cannot happen: varying offsets only arise when the binning pipeline detects
+  // sorted input coordinates, which guarantees non-decreasing offsets along the
+  // accumulation dimension.
+  if (delta < 0)
+    throw std::logic_error("SubbinSizes::exclusive_scan: negative index");
   m_sizes.reserve(size);
   m_offset = x.m_offset;
   for (scipp::index i = 0; i < size; ++i) {


### PR DESCRIPTION
## Summary

- `SubbinSizes::exclusive_scan` had a potential out-of-bounds read when `x.offset() < offset()` (negative delta). The `>= osize` check does not catch negative indices, leading to UB.
- Analysis of the binning pipeline confirms this cannot happen in practice: varying offsets only arise via sorted input coordinates, which guarantees non-decreasing offsets along the accumulation dimension. Existing results are unaffected.
- Added a `std::logic_error` guard so the UB becomes an explicit error if assumptions ever break.

Closes #3879

🤖 Generated with [Claude Code](https://claude.com/claude-code)