### PR TITLE
CI: Use vs-shell to setup MSVC

### DIFF
--- a/.github/workflows/nightly-deps-test.yml
+++ b/.github/workflows/nightly-deps-test.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
           fetch-depth: 0  # history required so cmake can determine version
 
-      - uses: ilammy/msvc-dev-cmd@v1  # Required to set up MSVC dev environment for Ninja builds.
+      - uses: egor-tensin/vs-shell@v2  # Required to set up MSVC dev environment for Ninja builds.
 
       - name: Setup conda environment
         uses: mamba-org/setup-micromamba@v3

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: true
           fetch-depth: 0 # history required so cmake can determine version
 
-      - uses: ilammy/msvc-dev-cmd@v1 # Required to set up MSVC dev environment for Ninja builds.
+      - uses: egor-tensin/vs-shell@v2 # Required to set up MSVC dev environment for Ninja builds.
 
       - name: Setup conda environment
         uses: mamba-org/setup-micromamba@v3


### PR DESCRIPTION
@willend pointed out that ilammy/msvc-dev-cmd depends on a deprecated version of node, and it also seems like it isn't maintained anymore.