### PR TITLE
Specify numpy timedelta unit

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -334,7 +334,7 @@ def _upper_bound(x: Variable) -> Variable:
     if bound.dtype in ('int32', 'int64'):
         bound.value += 1
     elif bound.dtype == 'datetime64':
-        bound.value += np.timedelta64(1, np.datetime_data(bound.value))
+        bound.value += np.timedelta64(1, np.datetime_data(bound.value))  # type: ignore[arg-type]
     else:
         bound.value = np.nextafter(
             bound.value, (bound + scalar(1, unit=bound.unit, dtype=bound.dtype)).value

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -331,8 +331,10 @@ def _upper_bound(x: Variable) -> Variable:
     import numpy as np
 
     bound = x.nanmax()
-    if bound.dtype in ('int32', 'int64', 'datetime64'):
+    if bound.dtype in ('int32', 'int64'):
         bound.value += 1
+    elif bound.dtype == 'datetime64':
+        bound.value += np.timedelta64(1, np.datetime_data(bound.value))
     else:
         bound.value = np.nextafter(
             bound.value, (bound + scalar(1, unit=bound.unit, dtype=bound.dtype)).value

--- a/src/scipp/core/variable.py
+++ b/src/scipp/core/variable.py
@@ -791,7 +791,7 @@ def arange(
     dim: str,
     start: NumberOrVar | _np.datetime64 | str,
     stop: NumberOrVar | _np.datetime64 | str | None = None,
-    step: NumberOrVar | None = None,
+    step: NumberOrVar | _np.timedelta64 | None = None,
     *,
     unit: Unit | str | DefaultUnit | None = default_unit,
     dtype: DTypeLike | None = None,

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -225,13 +225,13 @@ def test_datetime_slicing(unit) -> None:
 
 def test_datetime_operations() -> None:
     dt = np.datetime64('now', 'ns')
-    values = np.array([dt, dt + 123456789])
+    values = np.array([dt, dt + np.timedelta64(123456789, 'ns')])
     var = sc.Variable(dims=['x'], values=values)
 
     res = var + 1 * sc.Unit('ns')
     assert str(res.dtype) == 'datetime64'
     assert res.unit == sc.units.ns
-    np.testing.assert_array_equal(res.values, values + 1)
+    np.testing.assert_array_equal(res.values, values + np.timedelta64(1, 'ns'))
 
     shift = np.random.randint(0, 100, len(values))
     res = var - (var - sc.Variable(dims=['x'], values=shift, unit=sc.units.ns))
@@ -242,7 +242,7 @@ def test_datetime_operations() -> None:
 
 def test_datetime_operations_mismatch() -> None:
     dt = np.datetime64('now', 'ns')
-    values = np.array([dt, dt + 123456789])
+    values = np.array([dt, dt + np.timedelta64(123456789, 'ns')])
     var = sc.Variable(dims=['x'], values=values)
 
     with pytest.raises(RuntimeError):

--- a/tests/variable_creation_test.py
+++ b/tests/variable_creation_test.py
@@ -897,7 +897,10 @@ def test_arange_datetime_from_int() -> None:
 
 def test_arange_datetime_from_np_datetime64() -> None:
     var = sc.arange(
-        't', np.datetime64('2022-08-02T11:18'), np.datetime64('2022-08-02T11:52'), 15
+        't',
+        np.datetime64('2022-08-02T11:18'),
+        np.datetime64('2022-08-02T11:52'),
+        np.timedelta64(15, 'm'),
     )
     expected = sc.datetimes(
         dims=['t'],


### PR DESCRIPTION
Fixes #3918

The tests did not fail yet because we are limited to numpy < 2.4 because if numba. But users can encounter this problem. Running this locally, I think I got all cases.