### PR TITLE
 BUILD: Turn off delvewheel for windows; we already package it up 

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly Release
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * *'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,7 +1,6 @@
 name: Nightly Release
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * *'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,12 @@ test-command = "pytest --ignore {project}/tests/plotting --ignore {project}/test
 skip = ["*musllinux*"]
 build-verbosity = 1
 
+[tool.cibuildwheel.windows]
+# cibuildwheel >= 4.0 runs delvewheel by default, but it fails on our wheels:
+# our CMake build already installs all needed DLLs (scipp-*.dll, tbb12.dll)
+# into the package, and delvewheel only searches PATH for dependencies.
+repair-wheel-command = ""
+
 [tool.bandit.assert_used]
 skips = [
   "*/*_test.py",


### PR DESCRIPTION
This should fix our failing nightly windows builds https://github.com/scipp/scipp/actions/workflows/release-nightly.yml 

https://github.com/pypa/cibuildwheel/releases#release-v4.0.0 turned on delvewheel for windows by default, we already ship the dlls inside the wheel.