### PR TITLE
Use huge pages for large buffers on Linux

### DIFF
--- a/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
+++ b/docs/user-guide/tips-tricks-and-anti-patterns.ipynb
@@ -599,7 +599,7 @@
    "source": [
     "#### Using HugePages transparently\n",
     "\n",
-    "The Linux kernel can be configured to transparently use HugePages for all allocations.\n",
+    "The Linux kernel can transparently use HugePages, i.e., without HugePages having been reserved explicitly.\n",
     "We can check the setting using\n",
     "\n",
     "```console\n",
@@ -607,17 +607,24 @@
     "always [madvise] never\n",
     "```\n",
     "\n",
-    "The `madvise` setting, which is the default on some systems, is not sufficient for Scipp to use HugePages, even when using `libtbbmalloc_proxy.so`.\n",
-    "Instead, we need to set the `transparent_hugepage` kernel parameter to `always`:\n",
-    "\n",
-    "```console\n",
-    "# echo always > /sys/kernel/mm/transparent_hugepage/enabled\n",
-    "```\n",
+    "With the `always` setting every sufficiently large allocation is backed by HugePages.\n",
+    "With the `madvise` setting, the default on many systems, this happens only for memory ranges that asked for it via `madvise(MADV_HUGEPAGE)`.\n",
+    "Scipp does this for its own buffers above a size threshold of 4 MByte, so neither setting requires any action.\n",
+    "NumPy does the same, which is why its arrays use HugePages even with the `madvise` setting.\n",
     "\n",
     "Notes:\n",
     "\n",
-    "- This enables hugepages globally and may adversely affect other applications.\n",
-    "- This does not require use of `libtbbmalloc_proxy.so`, but the two can be used together."
+    "- Setting `enabled` to `never` disables HugePages for Scipp as well, and requires root privileges to change.\n",
+    "- `TBB_MALLOC_USE_HUGE_PAGES` (see above) has no effect with the `madvise` setting, since the TBB allocator considers HugePages unavailable unless they are reserved explicitly or `enabled` is set to `always`.\n",
+    "\n",
+    "To prevent Scipp from requesting HugePages, set\n",
+    "\n",
+    "```console\n",
+    "$ export SCIPP_MADVISE_HUGEPAGE=0\n",
+    "```\n",
+    "\n",
+    "This can help on systems suffering from memory fragmentation:\n",
+    "the `defrag` setting in `/sys/kernel/mm/transparent_hugepage/` defaults to `madvise` on many systems, which makes the kernel compact memory *synchronously* when a page of such a range is first touched, stalling the thread that is allocating."
    ]
   },
   {
@@ -644,7 +651,7 @@
     "Now run your application:\n",
     "\n",
     "- When using transparent HugePages the size in `AnonHugePages` should increase.\n",
-    "  Note that NumPy appears to be using transparent HugePages as well (even when support is set to `madvise` instead of `always`), make sure you are not misled by this.\n",
+    "  Note that this includes HugePages used by NumPy arrays, make sure you are not misled by this.\n",
     "- When using explicit HugePages the size in `HugePages_Free` should decrease."
    ]
   }

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(INC_FILES
     include/scipp/core/element_array.h
     include/scipp/core/element_array_view.h
     include/scipp/core/histogram.h
+    include/scipp/core/hugepage.h
     include/scipp/core/memory_pool.h
     include/scipp/core/multi_index.h
     include/scipp/core/parallel-fallback.h
@@ -45,6 +46,7 @@ set(SRC_FILES
     dtype.cpp
     element_array_view.cpp
     except.cpp
+    hugepage.cpp
     multi_index.cpp
     sizes.cpp
     slice.cpp

--- a/lib/core/hugepage.cpp
+++ b/lib/core/hugepage.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#include "scipp/core/hugepage.h"
+
+#ifdef __linux__
+#include <cstdint>
+#include <cstdlib>
+#include <string_view>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+namespace scipp::core {
+
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+
+namespace {
+/// Smallest range for which huge pages are requested. Matches what NumPy uses.
+constexpr size_t min_size = 4 * 1024 * 1024;
+
+bool env_enabled() {
+  const char *const env = std::getenv("SCIPP_MADVISE_HUGEPAGE");
+  return env == nullptr || std::string_view{env} != "0";
+}
+} // namespace
+
+void madvise_hugepage(void *ptr, const size_t size) noexcept {
+  static const bool enabled = env_enabled();
+  if (!enabled || size < min_size)
+    return;
+  const auto page_size = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+  const auto address = reinterpret_cast<std::uintptr_t>(ptr);
+  // Shrink to whole pages so we never advise memory outside the allocation.
+  const auto begin = (address + page_size - 1) & ~(page_size - 1);
+  const auto end = (address + size) & ~(page_size - 1);
+  if (begin < end)
+    // Ignore failures: without kernel support for huge pages, or if the kernel
+    // declines for other reasons, we simply keep using normal pages.
+    static_cast<void>(
+        ::madvise(reinterpret_cast<void *>(begin), end - begin, MADV_HUGEPAGE));
+}
+
+#else
+
+void madvise_hugepage(void *, size_t) noexcept {}
+
+#endif
+
+} // namespace scipp::core

--- a/lib/core/include/scipp/core/element_array.h
+++ b/lib/core/include/scipp/core/element_array.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "scipp/common/index.h"
+#include "scipp/core/hugepage.h"
 #include "scipp/core/parallel.h"
 
 namespace scipp::core {
@@ -22,8 +23,11 @@ auto make_unique_for_overwrite_array(const scipp::index size) {
   // We add a size and sign check to avoid warnings about exceeding maximum
   // object size. See e.g.
   // https://gcc.gnu.org/bugzilla//show_bug.cgi?id=85783#c3
-  if ((size <= PTRDIFF_MAX) && (size >= 0))
-    return Ptr(new T[size]);
+  if ((size <= PTRDIFF_MAX) && (size >= 0)) {
+    auto ptr = Ptr(new T[size]);
+    madvise_hugepage(ptr.get(), static_cast<size_t>(size) * sizeof(T));
+    return ptr;
+  }
   throw std::runtime_error(
       "Allocation size is either negative or exceeds PTRDIFF_MAX");
 }

--- a/lib/core/include/scipp/core/hugepage.h
+++ b/lib/core/include/scipp/core/hugepage.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+/// @file
+/// @author Simon Heybrock
+#pragma once
+
+#include <cstddef>
+
+#include "scipp-core_export.h"
+
+namespace scipp::core {
+
+/// Ask the kernel to back a memory range with transparent huge pages.
+///
+/// Large buffers benefit from huge pages since fewer TLB entries are required
+/// to cover them. The Linux kernel uses huge pages for all memory only if
+/// /sys/kernel/mm/transparent_hugepage/enabled is set to `always`. With the
+/// common default of `madvise` it does so only for ranges that requested them
+/// via madvise(MADV_HUGEPAGE), which is what this function does.
+///
+/// Ranges shorter than an internal threshold are left alone, since the kernel
+/// rounds up to the huge page size (typically 2 MByte), which would waste
+/// memory for small buffers.
+///
+/// Has no effect on platforms other than Linux, or if the environment variable
+/// SCIPP_MADVISE_HUGEPAGE is set to 0. Disabling can help if the system suffers
+/// from memory fragmentation: with the `defrag` setting `madvise` (another
+/// common default) the kernel compacts memory synchronously when a page of an
+/// advised range is first touched, which may stall the allocating thread.
+SCIPP_CORE_EXPORT void madvise_hugepage(void *ptr, size_t size) noexcept;
+
+} // namespace scipp::core

--- a/lib/core/test/CMakeLists.txt
+++ b/lib/core/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   element_to_unit_test.cpp
   element_trigonometry_test.cpp
   element_util_test.cpp
+  hugepage_test.cpp
   multi_index_test.cpp
   slice_test.cpp
   sizes_test.cpp

--- a/lib/core/test/hugepage_test.cpp
+++ b/lib/core/test/hugepage_test.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+#include <gtest/gtest.h>
+
+#include "scipp/core/element_array.h"
+
+#ifdef __linux__
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+using scipp::core::element_array;
+using scipp::core::init_for_overwrite;
+
+namespace {
+/// Does the mapping containing ptr have the VM_HUGEPAGE flag, i.e., did someone
+/// call madvise(MADV_HUGEPAGE) on it?
+///
+/// The flag is a property of the mapping, not of an individual allocation, so
+/// its *absence* cannot be tested reliably: a small allocation may well be
+/// placed in a mapping that a preceding large allocation had advised.
+bool advises_hugepages(const void *ptr) {
+  const auto address = reinterpret_cast<std::uintptr_t>(ptr);
+  std::ifstream smaps("/proc/self/smaps");
+  bool in_mapping = false;
+  for (std::string line; std::getline(smaps, line);) {
+    unsigned long long begin = 0, end = 0;
+    if (std::sscanf(line.c_str(), "%llx-%llx", &begin, &end) == 2) {
+      in_mapping = begin <= address && address < end;
+    } else if (in_mapping && line.rfind("VmFlags:", 0) == 0) {
+      std::istringstream flags(line.substr(8));
+      for (std::string flag; flags >> flag;)
+        if (flag == "hg")
+          return true;
+      return false;
+    }
+  }
+  return false;
+}
+
+bool hugepages_testable() {
+  const char *const env = std::getenv("SCIPP_MADVISE_HUGEPAGE");
+  return std::filesystem::exists("/sys/kernel/mm/transparent_hugepage") &&
+         (env == nullptr || std::string_view{env} != "0");
+}
+} // namespace
+
+TEST(HugepageTest, large_allocation_advises_hugepages) {
+  if (!hugepages_testable())
+    GTEST_SKIP() << "kernel without huge page support, or disabled via "
+                    "SCIPP_MADVISE_HUGEPAGE";
+  const element_array<double> array(2 * 1024 * 1024, init_for_overwrite);
+  // Not array.data(): the leading partial page is not advised, so the kernel
+  // splits the mapping and the flag is set only from the next page boundary.
+  EXPECT_TRUE(advises_hugepages(array.data() + array.size() / 2));
+}
+
+#endif


### PR DESCRIPTION
It was always been possible to use Scipp with hugepages (see https://scipp.github.io/user-guide/tips-tricks-and-anti-patterns.html#Using-HugePages), but it required user intervention and adequate system settings, which required root permissions.

Scipp allocates its buffers with plain `new T[]`, which never calls `madvise(MADV_HUGEPAGE)`. On systems with `transparent_hugepage=madvise` — the default on many distributions, and the case users hit on HPC clusters where they cannot change the setting — Scipp therefore runs on 4 kByte pages, while NumPy in the same process uses huge pages, since it madvises every array of 4 MByte and more. Setting `transparent_hugepage=always` was the only documented workaround, and it needs root.

Neither `libtbbmalloc_proxy.so` nor `TBB_MALLOC_USE_HUGE_PAGES` help: tbbmalloc has no `madvise` call at all and treats huge pages as unavailable unless they are reserved explicitly or the kernel setting is `always`. The claim in our docs that the `madvise` setting "is not sufficient for Scipp" was accurate, but the reason was on our side, and it costs up to 1.7x on memory-bound operations.

Buffers of 4 MByte and more now request huge pages, matching NumPy's threshold. Below that the kernel would round up to the 2 MByte huge page size and waste memory. `SCIPP_MADVISE_HUGEPAGE=0` disables it, which may be needed on systems suffering from memory fragmentation: with the common `defrag=madvise` setting the kernel compacts memory synchronously when a page of an advised range is first touched, which can stall the allocating thread.

Reported in https://github.com/orgs/scipp/discussions/3936.

### Benchmarks

Operations on 1 GByte buffers, best of 3, on a system with `transparent_hugepage=madvise`, `defrag=madvise`, glibc 2.35, kernel 6.8:

| | without huge pages | with huge pages | speedup |
| --- | --- | --- | --- |
| elementwise `a * b + a` | 0.262 s | 0.178 s | 1.47x |
| `hist` of 1e8 events into 1e6 bins | 0.774 s | 0.465 s | 1.66x |

Both columns are the same build, the first one run with `SCIPP_MADVISE_HUGEPAGE=0`, i.e., with the behavior before this change.

The script used for this, and the raw output including a comparison with `libtbbmalloc_proxy.so` and `GLIBC_TUNABLES=glibc.malloc.hugetlb=1`, are in https://gist.github.com/SimonHeybrock/132292e373059e68f6ac970524caeb23.

### Test plan

The added unit test allocates a large buffer and checks `VmFlags` in `/proc/self/smaps` for the `hg` flag, i.e., that the kernel recorded the advice. This works independently of whether the system can actually provide huge pages, so it is meaningful in containers, and it skips on kernels built without huge page support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
