### PR TITLE
fix: pybind11 3.1 changes to type matching

### DIFF
--- a/lib/python/bind_operators.h
+++ b/lib/python/bind_operators.h
@@ -202,25 +202,26 @@ template <class RHSSetup> struct OpBinder {
   }
 
   template <class Other, class T, class... Ignored>
-  static void in_place_binary(pybind11::class_<T, Ignored...> &c) {
+  static void in_place_binary(pybind11::class_<T, Ignored...> &c,
+                              const py::arg &other = py::arg()) {
     using namespace scipp;
     c.def("__iadd__", inplace_op<T, Other>([](auto &a, auto &&b) { a += b; }),
-          py::is_operator());
+          other, py::is_operator());
     c.def("__isub__", inplace_op<T, Other>([](auto &a, auto &&b) { a -= b; }),
-          py::is_operator());
+          other, py::is_operator());
     c.def("__imul__", inplace_op<T, Other>([](auto &a, auto &&b) { a *= b; }),
-          py::is_operator());
+          other, py::is_operator());
     c.def("__itruediv__",
-          inplace_op<T, Other>([](auto &a, auto &&b) { a /= b; }),
+          inplace_op<T, Other>([](auto &a, auto &&b) { a /= b; }), other,
           py::is_operator());
     if constexpr (!(std::is_same_v<T, Dataset> ||
                     std::is_same_v<Other, Dataset>)) {
       c.def("__imod__", inplace_op<T, Other>([](auto &a, auto &&b) { a %= b; }),
-            py::is_operator());
+            other, py::is_operator());
       c.def("__ifloordiv__", inplace_op<T, Other>([](auto &a, auto &&b) {
               floor_divide_equals(a, b);
             }),
-            py::is_operator());
+            other, py::is_operator());
       if constexpr (!(std::is_same_v<T, DataArray> ||
                       std::is_same_v<Other, DataArray>)) {
         c.def(
@@ -228,26 +229,27 @@ template <class RHSSetup> struct OpBinder {
             [](T &base, Other &exponent) -> T & {
               return pow(base, RHSSetup{}(exponent), base);
             },
-            py::is_operator(), py::call_guard<py::gil_scoped_release>());
+            other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
       }
     }
   }
 
   template <class Other, class T, class... Ignored>
-  static void binary(pybind11::class_<T, Ignored...> &c) {
+  static void binary(pybind11::class_<T, Ignored...> &c,
+                     const py::arg &other = py::arg()) {
     using namespace scipp;
     c.def(
         "__add__", [](const T &a, const Other &b) { return a + RHSSetup{}(b); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__sub__", [](const T &a, const Other &b) { return a - RHSSetup{}(b); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__mul__", [](const T &a, const Other &b) { return a * RHSSetup{}(b); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__truediv__",
-        [](const T &a, const Other &b) { return a / RHSSetup{}(b); },
+        [](const T &a, const Other &b) { return a / RHSSetup{}(b); }, other,
         py::is_operator(), py::call_guard<py::gil_scoped_release>());
     if constexpr (!(std::is_same_v<T, Dataset> ||
                     std::is_same_v<Other, Dataset>)) {
@@ -256,35 +258,36 @@ template <class RHSSetup> struct OpBinder {
           [](const T &a, const Other &b) {
             return floor_divide(a, RHSSetup{}(b));
           },
-          py::is_operator(), py::call_guard<py::gil_scoped_release>());
+          other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
       c.def(
           "__mod__",
-          [](const T &a, const Other &b) { return a % RHSSetup{}(b); },
+          [](const T &a, const Other &b) { return a % RHSSetup{}(b); }, other,
           py::is_operator(), py::call_guard<py::gil_scoped_release>());
       c.def(
           "__pow__",
           [](const T &base, const Other &exponent) {
             return pow(base, RHSSetup{}(exponent));
           },
-          py::is_operator(), py::call_guard<py::gil_scoped_release>());
+          other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     }
   }
 
   template <class Other, class T, class... Ignored>
-  static void reverse_binary(pybind11::class_<T, Ignored...> &c) {
+  static void reverse_binary(pybind11::class_<T, Ignored...> &c,
+                             const py::arg &other = py::arg()) {
     using namespace scipp;
     c.def(
         "__radd__", [](const T &a, const Other b) { return RHSSetup{}(b) + a; },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__rsub__", [](const T &a, const Other b) { return RHSSetup{}(b)-a; },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__rmul__", [](const T &a, const Other b) { return RHSSetup{}(b)*a; },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__rtruediv__",
-        [](const T &a, const Other b) { return RHSSetup{}(b) / a; },
+        [](const T &a, const Other b) { return RHSSetup{}(b) / a; }, other,
         py::is_operator(), py::call_guard<py::gil_scoped_release>());
     if constexpr (!(std::is_same_v<T, Dataset> ||
                     std::is_same_v<Other, Dataset>)) {
@@ -293,44 +296,45 @@ template <class RHSSetup> struct OpBinder {
           [](const T &a, const Other &b) {
             return floor_divide(RHSSetup{}(b), a);
           },
-          py::is_operator(), py::call_guard<py::gil_scoped_release>());
+          other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
       c.def(
           "__rmod__",
-          [](const T &a, const Other &b) { return RHSSetup{}(b) % a; },
+          [](const T &a, const Other &b) { return RHSSetup{}(b) % a; }, other,
           py::is_operator(), py::call_guard<py::gil_scoped_release>());
       c.def(
           "__rpow__",
           [](const T &exponent, const Other &base) {
             return pow(RHSSetup{}(base), exponent);
           },
-          py::is_operator(), py::call_guard<py::gil_scoped_release>());
+          other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     }
   }
 
   template <class Other, class T, class... Ignored>
-  static void comparison(pybind11::class_<T, Ignored...> &c) {
+  static void comparison(pybind11::class_<T, Ignored...> &c,
+                         const py::arg &other = py::arg()) {
     c.def(
         "__eq__", [](const T &a, Other &b) { return equal(a, RHSSetup{}(b)); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__ne__",
-        [](const T &a, Other &b) { return not_equal(a, RHSSetup{}(b)); },
+        [](const T &a, Other &b) { return not_equal(a, RHSSetup{}(b)); }, other,
         py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__lt__", [](const T &a, Other &b) { return less(a, RHSSetup{}(b)); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__gt__",
-        [](const T &a, Other &b) { return greater(a, RHSSetup{}(b)); },
+        [](const T &a, Other &b) { return greater(a, RHSSetup{}(b)); }, other,
         py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__le__",
         [](const T &a, Other &b) { return less_equal(a, RHSSetup{}(b)); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
     c.def(
         "__ge__",
         [](const T &a, Other &b) { return greater_equal(a, RHSSetup{}(b)); },
-        py::is_operator(), py::call_guard<py::gil_scoped_release>());
+        other, py::is_operator(), py::call_guard<py::gil_scoped_release>());
   }
 };
 
@@ -351,25 +355,26 @@ static void bind_comparison(pybind11::class_<T, Ignored...> &c) {
 
 template <class T, class... Ignored>
 void bind_in_place_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::in_place_binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::in_place_binary<int64_t>(c,
+                                                       py::arg().noconvert());
   OpBinder<ScalarToVariable>::in_place_binary<double>(c);
 }
 
 template <class T, class... Ignored>
 void bind_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::binary<int64_t>(c, py::arg().noconvert());
   OpBinder<ScalarToVariable>::binary<double>(c);
 }
 
 template <class T, class... Ignored>
 static void bind_reverse_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::reverse_binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::reverse_binary<int64_t>(c, py::arg().noconvert());
   OpBinder<ScalarToVariable>::reverse_binary<double>(c);
 }
 
 template <class T, class... Ignored>
 void bind_comparison_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::comparison<int64_t>(c);
+  OpBinder<ScalarToVariable>::comparison<int64_t>(c, py::arg().noconvert());
   OpBinder<ScalarToVariable>::comparison<double>(c);
 }
 

--- a/lib/python/bind_operators.h
+++ b/lib/python/bind_operators.h
@@ -351,26 +351,26 @@ static void bind_comparison(pybind11::class_<T, Ignored...> &c) {
 
 template <class T, class... Ignored>
 void bind_in_place_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::in_place_binary<double>(c);
   OpBinder<ScalarToVariable>::in_place_binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::in_place_binary<double>(c);
 }
 
 template <class T, class... Ignored>
 void bind_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::binary<double>(c);
   OpBinder<ScalarToVariable>::binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::binary<double>(c);
 }
 
 template <class T, class... Ignored>
 static void bind_reverse_binary_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::reverse_binary<double>(c);
   OpBinder<ScalarToVariable>::reverse_binary<int64_t>(c);
+  OpBinder<ScalarToVariable>::reverse_binary<double>(c);
 }
 
 template <class T, class... Ignored>
 void bind_comparison_scalars(pybind11::class_<T, Ignored...> &c) {
-  OpBinder<ScalarToVariable>::comparison<double>(c);
   OpBinder<ScalarToVariable>::comparison<int64_t>(c);
+  OpBinder<ScalarToVariable>::comparison<double>(c);
 }
 
 template <class T, class... Ignored>

--- a/tests/python_scalar_operations_test.py
+++ b/tests/python_scalar_operations_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import numpy as np
+
 import scipp as sc
 
 
@@ -9,12 +11,32 @@ def test_operation_with_python_float() -> None:
     assert (a / b).value == (a / sc.scalar(b)).value
 
 
+def test_operation_with_numpy_float32() -> None:
+    result = sc.scalar(10) + np.float32(1.5)
+    assert sc.identical(result, sc.scalar(11.5))
+
+
+def test_reverse_operation_with_numpy_float32() -> None:
+    result = np.float32(1.5) + sc.scalar(10)
+    assert sc.identical(result, sc.scalar(11.5))
+
+
 def test_inplace_operation_with_python_float() -> None:
     a = sc.scalar(1.23456789)
     b = 9.87654321
     expected = a.value / b
     a /= b
     assert a.value == expected
+
+
+def test_inplace_operation_with_numpy_float32() -> None:
+    a = sc.scalar(10.0)
+    a += np.float32(1.5)
+    assert sc.identical(a, sc.scalar(11.5))
+
+
+def test_comparison_with_numpy_float32() -> None:
+    assert sc.identical(sc.scalar(1.2) < np.float32(1.5), sc.scalar(True))
 
 
 def test_operation_with_python_int32() -> None:

--- a/tests/style_test.py
+++ b/tests/style_test.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+
+from pathlib import Path
+
+TEMPLATE_ROOT = (
+    Path(__file__).resolve().parents[1] / 'src/scipp/visualization/templates'
+)
+
+
+def test_html_stylesheets_use_flat_rules() -> None:
+    style = TEMPLATE_ROOT.joinpath('style.css').read_text(encoding='utf-8')
+    datagroup_style = TEMPLATE_ROOT.joinpath('datagroup.css').read_text(
+        encoding='utf-8'
+    )
+
+    assert '@scope' not in style
+    assert '@scope' not in datagroup_style
+    assert '&' not in style
+    assert '&' not in datagroup_style
+
+    for selector in (
+        '.sc-root.sc-wrap,',
+        '.sc-root .sc-wrap {',
+        '.sc-root ul.sc-sections {',
+        '.sc-root pre.sc-var-data {',
+        '.sc-root dl.sc-attrs {',
+    ):
+        assert selector in style
+
+    for selector in (
+        '.dg-root * {',
+        '.dg-root input.dg-header-in {',
+        '.dg-root ul.dg-detail-list {',
+    ):
+        assert selector in datagroup_style


### PR DESCRIPTION
Pybind11 3.1 introduces changes to type conversion / matching (see https://github.com/pybind/pybind11/pull/5879), that makes our nightlies for scipp fail (https://github.com/scipp/scipp/actions/workflows/release-nightly.yml).

This change addresses that by moving the integer bind before the double bind and explicitly marking the integer argument as `noconvert` to make it not match floating types.