### PR TITLE
Fix OOM in multi-dim hist depending on argument order

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -213,7 +213,10 @@ def make_binned(
             extended_erase = tuple(set(erase) | set(rebinning_dims))
             if _can_operate_on_bins(x, edges, groups, extended_erase):
                 result = combine_bins(x, edges=edges, groups=groups, dim=extended_erase)
-                return result.transpose(x.dims)
+                # Erased dims are absent from the result, new dims are appended.
+                order = [dim for dim in x.dims if dim in result.dims]
+                order += [dim for dim in result.dims if dim not in x.dims]
+                return result.transpose(order)
     # Many-to-many mapping is expensive, concat first is generally cheaper,
     # despite extra copies. If some coords are dense, perform binning in two steps,
     # since concat is not possible then (without mapping dense coords to binned coords,
@@ -305,6 +308,9 @@ def _can_operate_on_bins(
         if coord.dim in x.bins.coords:
             return False
         if coord.dim not in x.coords:
+            return False
+        # Combining bins requires a single coord value per input bin.
+        if any(x.coords.is_edges(coord.dim, dim) for dim in x.coords[coord.dim].dims):
             return False
         dims.update(x.coords[coord.dim].dims)
     return dims <= set(erase)
@@ -622,15 +628,9 @@ def hist(
                     for k, v in x.items()
                 }
             )
-        edge_values = list(edges.values())
+        edge_values = _order_edges_for_hist(x, edges)
         remaining_erase = set(erase)
         if isinstance(x, DataArray) and x.is_binned:
-            # All but the final edges are applied by binning. Edges replacing an
-            # existing dim shrink that dim, whereas a dim not touched by the binning
-            # step survives at its original length. Applying the former first therefore
-            # avoids intermediate binned data with a bin count given by the product of
-            # the original and the new dim lengths.
-            edge_values.sort(key=lambda edge: edge.dims[-1] not in x.dims)
             # If histogramming by the final edges needs to use a non-event coord then we
             # must not erase that dim, since it removes the coord required for
             # histogramming.
@@ -650,6 +650,49 @@ def hist(
         if isinstance(out, DataArray):
             out = out.transpose(_restore_requested_dim_order(out.dims, edges))
     return out
+
+
+def _order_edges_for_hist(
+    x: Variable | DataArray | Dataset, edges: Mapping[str, Variable]
+) -> list[Variable]:
+    """Order edges such that those replacing an existing dim are applied first.
+
+    :py:func:`hist` applies all but the final edges by binning. A dim replaced in that
+    step shrinks to the requested length, whereas a dim left untouched survives at its
+    original length, so that the intermediate holds the product of the two. Applying
+    the former first therefore avoids a potentially huge intermediate.
+
+    Re-binning a dim drops coords defined over it. If any edges are derived from such a
+    coord then the given order is preserved, since reordering could remove a coord that
+    is still required.
+    """
+    values = list(edges.values())
+    if not isinstance(x, DataArray) or not x.is_binned:
+        return values
+    dims = set(edges)
+    if any(
+        (dims & set(x.coords[name].dims)) - {name} for name in edges if name in x.coords
+    ):
+        return values
+    ordered = sorted(values, key=lambda edge: not _replaces_existing_dim(x, edge))
+    # Histogramming by a non-event coord erases the dims of that coord, so which edges
+    # come last affects more than just the dim order of the result.
+    if ordered[-1].dims[-1] not in x.bins.coords:
+        return values
+    return ordered
+
+
+def _replaces_existing_dim(x: DataArray, edge: Variable) -> bool:
+    """Return whether binning by ``edge`` replaces an existing dim of ``x``."""
+    dim = edge.dims[-1]
+    if dim not in x.dims:
+        return False
+    if dim in x.bins.coords:
+        return True
+    # Without an event coord, binning requires a coord with one value per bin.
+    return dim in x.coords and not any(
+        x.coords.is_edges(dim, d) for d in x.coords[dim].dims
+    )
 
 
 def _restore_requested_dim_order(

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -623,10 +623,17 @@ def hist(
                 }
             )
         edge_values = list(edges.values())
-        # If histogramming by the final edges needs to use a non-event coord then we
-        # must not erase that dim, since it removes the coord required for histogramming
         remaining_erase = set(erase)
         if isinstance(x, DataArray) and x.is_binned:
+            # All but the final edges are applied by binning. Edges replacing an
+            # existing dim shrink that dim, whereas a dim not touched by the binning
+            # step survives at its original length. Applying the former first therefore
+            # avoids intermediate binned data with a bin count given by the product of
+            # the original and the new dim lengths.
+            edge_values.sort(key=lambda edge: edge.dims[-1] not in x.dims)
+            # If histogramming by the final edges needs to use a non-event coord then we
+            # must not erase that dim, since it removes the coord required for
+            # histogramming.
             hist_dim = edge_values[-1].dims[-1]
             if hist_dim not in x.bins.coords:
                 erase = [e for e in erase if e not in x.coords[hist_dim].dims]
@@ -640,7 +647,17 @@ def hist(
             edges=edge_values[-1],
             erase=remaining_erase,
         )
+        if isinstance(out, DataArray):
+            out = out.transpose(_restore_requested_dim_order(out.dims, edges))
     return out
+
+
+def _restore_requested_dim_order(
+    dims: tuple[str, ...], requested: Iterable[str]
+) -> list[str]:
+    """Reorder histogrammed dims as requested, leaving all other dims in place."""
+    order = iter([dim for dim in requested if dim in dims])
+    return [next(order) if dim in requested else dim for dim in dims]
 
 
 def _get_op_dims(x: DataArray, *edges_or_groups: Variable) -> set[str]:

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -309,9 +309,6 @@ def _can_operate_on_bins(
             return False
         if coord.dim not in x.coords:
             return False
-        # Combining bins requires a single coord value per input bin.
-        if any(x.coords.is_edges(coord.dim, dim) for dim in x.coords[coord.dim].dims):
-            return False
         dims.update(x.coords[coord.dim].dims)
     return dims <= set(erase)
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1765,6 +1765,12 @@ def test_hist_2d_with_outer_point_coord_and_erased_dim() -> None:
     assert_allclose(zx, reference)
 
 
+@pytest.mark.xfail(
+    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
+    "C++ implementation rejects. Here it drops the coord when flattening, so this "
+    "fails with a confusing KeyError instead.",
+    strict=True,
+)
 def test_hist_with_outer_bin_edge_coord_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(x=2, y=3)
     del da.bins.coords['y']
@@ -1792,11 +1798,45 @@ def test_bin_along_existing_dim_with_outer_point_coord_and_erase() -> None:
     assert_allclose(out.bins.sum(), reference.bins.sum())
 
 
+@pytest.mark.xfail(
+    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
+    "C++ implementation rejects. Here it drops the coord when flattening, so this "
+    "fails with a confusing KeyError instead.",
+    strict=True,
+)
 def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(x=2, y=3)
     del da.bins.coords['y']
     with pytest.raises(sc.BinEdgeError):
         da.bin(y=2, dim=da.dims)
+
+
+@pytest.mark.xfail(
+    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
+    "C++ implementation rejects. Flattening a single dim is a mere rename, so the "
+    "coord survives and its first values are used, one per input bin.",
+    strict=True,
+)
+def test_bin_by_outer_bin_edge_coord_on_single_erased_dim_raises_BinEdgeError() -> None:
+    da = sc.data.table_xyz(100).bin(x=5)
+    da.coords['s'] = sc.linspace('x', 0.0, 1.0, 6, unit='m')
+    assert da.coords.is_edges('s', 'x')
+    with pytest.raises(sc.BinEdgeError):
+        da.bin(s=sc.linspace('s', 0.0, 1.0, 3, unit='m'))
+
+
+@pytest.mark.xfail(
+    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
+    "C++ implementation rejects. Flattening a single dim is a mere rename, so the "
+    "coord survives and its first values are used, one per input bin.",
+    strict=True,
+)
+def test_bin_by_own_bin_edge_coord_on_single_erased_dim_raises_BinEdgeError() -> None:
+    da = sc.data.table_xyz(100).bin(y=3)
+    del da.bins.coords['y']
+    assert da.coords.is_edges('y', 'y')
+    with pytest.raises(sc.BinEdgeError):
+        da.bin(y=2, dim=('y',))
 
 
 @pytest.mark.xfail(

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1797,3 +1797,27 @@ def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
     del da.bins.coords['y']
     with pytest.raises(sc.BinEdgeError):
         da.bin(y=2, dim=da.dims)
+
+
+@pytest.mark.xfail(
+    reason="Re-binning a dim drops coords defined over it, so hist depends on the "
+    "argument order here. Note that bin() handles both orders.",
+    strict=True,
+)
+def test_hist_by_existing_dim_and_by_coord_on_that_dim_is_order_independent() -> None:
+    da = sc.data.binned_x(nevent=1000, nbin=12)
+    da.coords['p'] = sc.midpoints(da.coords['x'])
+    expected = da.hist(p=3, x=4)
+    assert_allclose(da.hist(x=4, p=3).transpose(expected.dims), expected)
+
+
+@pytest.mark.xfail(
+    reason="hist by a 1-D and a 2-D outer coord depends on the argument order",
+    strict=True,
+)
+def test_hist_by_1d_and_2d_outer_coords_is_order_independent() -> None:
+    da = sc.data.table_xyz(1000).bin(x=5, y=4)
+    da.coords['p'] = sc.arange('x', 5, unit='s')
+    da.coords['r'] = sc.arange('x', 5, unit='K') + 5 * sc.arange('y', 4, unit='K')
+    expected = da.hist(r=2, p=3, dim=())
+    assert_allclose(da.hist(p=3, r=2, dim=()).transpose(expected.dims), expected)

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.random import default_rng
 
 import scipp as sc
-from scipp.testing import assert_identical
+from scipp.testing import assert_allclose, assert_identical
 
 
 @pytest.mark.parametrize('op', ['bin', 'hist', 'nanhist', 'rebin'])
@@ -1700,3 +1700,39 @@ def test_bin_rebin_existing_edge_cases() -> None:
         result.bins.constituents['begin'],
         sc.array(dims=['x'], values=[0, 0, 0, 0, 0, 1, 1, 2, 3], unit=None),
     )
+
+
+def test_hist_2d_is_independent_of_argument_order() -> None:
+    da = sc.data.binned_x(nevent=10000, nbin=137)
+    xy = da.hist(x=7, y=5, dim=da.dims)
+    yx = da.hist(y=5, x=7, dim=da.dims)
+    assert xy.dims == ('x', 'y')
+    assert yx.dims == ('y', 'x')
+    # Not identical since the summation order differs
+    assert_allclose(yx.transpose(xy.dims), xy)
+
+
+def test_hist_2d_is_independent_of_argument_order_with_outer_only_coord() -> None:
+    da = _make_pixel_binned_2d(n_events=10000, n_pixels=100, nx=37, ny=8)
+    xy = da.hist(x=7, y=5, dim=da.dims)
+    yx = da.hist(y=5, x=7, dim=da.dims)
+    assert xy.dims == ('x', 'y')
+    assert yx.dims == ('y', 'x')
+    assert_allclose(yx.transpose(xy.dims), xy)
+
+
+def test_hist_3d_preserves_requested_dim_order() -> None:
+    da = sc.data.binned_x(nevent=10000, nbin=137)
+    sizes = {'x': 7, 'y': 5, 'z': 3}
+    ref = da.hist(sizes, dim=da.dims)
+    for order in itertools.permutations(sizes):
+        out = da.hist({dim: sizes[dim] for dim in order}, dim=da.dims)
+        assert out.dims == order
+        assert_allclose(out.transpose(ref.dims), ref)
+
+
+def test_hist_rebinning_existing_dim_last_does_not_create_huge_intermediate() -> None:
+    # Binning by the event coord `y` first would keep the 1e6 bins of `x` alive,
+    # yielding an intermediate with 1e8 bins, requiring hundreds of GByte.
+    da = sc.data.binned_x(nevent=10000, nbin=1_000_000)
+    assert da.hist(y=100, x=100, dim=da.dims).sizes == {'y': 100, 'x': 100}

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1800,8 +1800,8 @@ def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
 
 
 @pytest.mark.xfail(
-    reason="Re-binning a dim drops coords defined over it, so hist depends on the "
-    "argument order here. Note that bin() handles both orders.",
+    reason="scipp/scipp#3952: Re-binning a dim drops coords defined over it, so hist "
+    "depends on the argument order here. Note that bin() handles both orders.",
     strict=True,
 )
 def test_hist_by_existing_dim_and_by_coord_on_that_dim_is_order_independent() -> None:
@@ -1812,7 +1812,8 @@ def test_hist_by_existing_dim_and_by_coord_on_that_dim_is_order_independent() ->
 
 
 @pytest.mark.xfail(
-    reason="hist by a 1-D and a 2-D outer coord depends on the argument order",
+    reason="scipp/scipp#3952: hist by a 1-D and a 2-D outer coord depends on the "
+    "argument order",
     strict=True,
 )
 def test_hist_by_1d_and_2d_outer_coords_is_order_independent() -> None:

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1736,3 +1736,64 @@ def test_hist_rebinning_existing_dim_last_does_not_create_huge_intermediate() ->
     # yielding an intermediate with 1e8 bins, requiring hundreds of GByte.
     da = sc.data.binned_x(nevent=10000, nbin=1_000_000)
     assert da.hist(y=100, x=100, dim=da.dims).sizes == {'y': 100, 'x': 100}
+
+
+def _with_event_coord(da: sc.DataArray, name: str) -> sc.DataArray:
+    """Broadcast an outer coord onto the events, for an independent reference."""
+    out = da.copy()
+    out.bins.coords[name] = sc.bins_like(out, out.coords[name])
+    return out
+
+
+def test_hist_with_coord_defined_on_rebinned_dim() -> None:
+    # Re-binning `x` drops `p`, so `x` must not be applied before `p`.
+    da = sc.data.binned_x(nevent=1000, nbin=12)
+    da.coords['p'] = sc.midpoints(da.coords['x'])
+    out = da.hist(y=4, p=3, x=4, dim=da.dims)
+    assert out.dims == ('y', 'p', 'x')
+    assert_allclose(out, da.hist(p=3, y=4, x=4, dim=da.dims).transpose(out.dims))
+
+
+def test_hist_2d_with_outer_point_coord_and_erased_dim() -> None:
+    da = sc.data.table_xyz(1000).bin(x=4, y=3)
+    del da.bins.coords['x']
+    da.coords['x'] = sc.midpoints(da.coords['x'])
+    zx = da.hist(z=2, x=2, dim=da.dims)
+    assert zx.dims == ('z', 'x')
+    assert_allclose(da.hist(x=2, z=2, dim=da.dims), zx.transpose(('x', 'z')))
+    reference = _with_event_coord(da, 'x').hist(z=2, x=2, dim=da.dims)
+    assert_allclose(zx, reference)
+
+
+def test_hist_with_outer_bin_edge_coord_raises_BinEdgeError() -> None:
+    da = sc.data.table_xyz(100).bin(x=2, y=3)
+    del da.bins.coords['y']
+    for edges in ({'z': 2, 'y': 2}, {'y': 2, 'z': 2}):
+        with pytest.raises(sc.BinEdgeError):
+            da.hist(edges, dim=da.dims)
+
+
+def test_hist_does_not_reorder_when_final_edges_would_use_outer_coord() -> None:
+    # Histogramming by an outer coord erases that coord's dims, so reordering would
+    # change which dims the result has, not just their order.
+    da = sc.data.table_xyz(1000).bin(x=5, y=4)
+    da.coords['p'] = sc.arange('x', 5, unit='s')
+    assert da.hist(p=3, y=3, dim=()).sizes == {'x': 5, 'p': 3, 'y': 3}
+
+
+def test_bin_along_existing_dim_with_outer_point_coord_and_erase() -> None:
+    da = sc.data.table_xyz(1000).bin(x=4, y=3)
+    del da.bins.coords['x']
+    da.coords['x'] = sc.midpoints(da.coords['x'])
+    out = da.bin(x=2, dim=da.dims)
+    assert out.dims == ('x',)
+    assert out.bins.size().sum().value == da.bins.size().sum().value
+    reference = _with_event_coord(da, 'x').bin(x=2, dim=da.dims)
+    assert_allclose(out.bins.sum(), reference.bins.sum())
+
+
+def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
+    da = sc.data.table_xyz(100).bin(x=2, y=3)
+    del da.bins.coords['y']
+    with pytest.raises(sc.BinEdgeError):
+        da.bin(y=2, dim=da.dims)


### PR DESCRIPTION
Fixes #3948.

`hist` with more than one set of edges bins by all but the last edges and histograms the last one. Edges that replace an existing dim shrink that dim in the binning step, whereas a dim not touched by it survives at its original length. Deferring such edges to the final histogramming step therefore produced an intermediate with a bin count given by the product of the original and the new dim lengths — 1e6 x 200 bins for the example in the issue, which OOMs, while the same call with the edges given in the other order was fine.

Edges are now ordered such that those replacing an existing dim are applied first, and the output is transposed back to the requested dim order. On `sc.data.binned_x(1e5, 1e5).hist(y=200, x=200, dim=da.dims)` this goes from 4.7 s and 3964 MiB peak to 0.04 s and 19 MiB; the 1e6 example from the issue runs in 0.3 s and is bit-identical to the working argument order.

Reordering is not always safe, so it is skipped in two cases: re-binning a dim drops coords defined over that dim, and histogramming by an outer coord erases that coord's dims — the latter would silently change which dims the result has, not just their order. In both cases the given order is kept.

The reordering also exposed a latent bug in the re-binning fallback added in #3839, reachable on `main` without any reordering: restoring the input dim order after `combine_bins` raised `DimensionError` whenever dims were erased or added. Fixed here.

Side effect worth knowing: the output dim order now always follows the requested order. Previously `hist(y=5, x=7, z=3)` could come back as `('x', 'y', 'z')`, since `make_binned` canonicalizes dim order internally. The new behavior is what the docstring examples already imply.

Two classes of pre-existing problems turned up along the way and are marked as strict `xfail` here rather than fixed, so that a future fix does not go unnoticed:

- #3952: `hist` remains order-dependent when none of the edges replaces an existing dim, so no ordering helps.
- #3955: `bin` and `group` accept a bin-edge outer coord that the C++ implementation rejects. #3956 is stacked on this PR and fixes it, since doing so is a user-visible break that deserves its own change.

## Test plan

- New tests cover order-invariance of 2-D `hist` for both event-coord and outer-only-coord binning, dim order over all permutations of a 3-D `hist`, and a large input that would need hundreds of GByte with the old ordering.
- `hist`, `bin` and `group` were cross-checked against pre-PR behaviour by a differential run over 8 data layouts x all edge combinations, argument orders and `dim` values — 820 `hist` cases and 760 `bin`/`group` cases, comparing sizes, coords, masks, unit and a position-weighted checksum, with an independent reference that broadcasts the outer coord onto the events. Previously-crashing cases now work, with no regressions. Not committed, this was a one-off check.
