### PR TITLE
Reject bin-edge outer coords in combine_bins fast path

### DIFF
--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -331,7 +331,8 @@
     "The problem we run into with the above figure is that we have a lot more data (events) at zero strain than for the other strain values.\n",
     "We should therefore *normalize* the result to the incident flux.\n",
     "In this simplified example we can use the proton charge to accomplish this.\n",
-    "We compute the integrated proton charge for a given strain value:"
+    "We compute the integrated proton charge for a given strain value.\n",
+    "Binning by the `time` points of `strain` yields one interval fewer than there are strain values, so we drop the final value to label each interval by the strain at its start:"
    ]
   },
   {
@@ -344,7 +345,7 @@
    "source": [
     "proton_charge = dg['proton_charge']\n",
     "charge_per_time_interval = proton_charge.bin(time=strain.coords['time'])\n",
-    "charge_per_time_interval.coords['strain'] = strain.data\n",
+    "charge_per_time_interval.coords['strain'] = strain.data['time', :-1]\n",
     "charge_per_strain_value = charge_per_time_interval.bin(\n",
     "    strain=filtered.coords['strain']\n",
     ").hist()"

--- a/docs/user-guide/binned-data/filtering.ipynb
+++ b/docs/user-guide/binned-data/filtering.ipynb
@@ -332,7 +332,8 @@
     "We should therefore *normalize* the result to the incident flux.\n",
     "In this simplified example we can use the proton charge to accomplish this.\n",
     "We compute the integrated proton charge for a given strain value.\n",
-    "Binning by the `time` points of `strain` yields one interval fewer than there are strain values, so we drop the final value to label each interval by the strain at its start:"
+    "Binning by the `time` points of `strain` yields one interval fewer than there are strain values.\n",
+    "We label each interval by the strain at its start, matching the `mode=\"previous\"` interpolation used for the events above, so that numerator and denominator assign the same strain to a given pulse:"
    ]
   },
   {

--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -309,6 +309,11 @@ def _can_operate_on_bins(
             return False
         if coord.dim not in x.coords:
             return False
+        # Combining bins requires a single coord value per input bin. The C++
+        # implementation rejects bin-edge coords, so fall through to it for a clear
+        # error instead of silently using a different definition here.
+        if any(x.coords.is_edges(coord.dim, dim) for dim in x.coords[coord.dim].dims):
+            return False
         dims.update(x.coords[coord.dim].dims)
     return dims <= set(erase)
 

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1765,12 +1765,6 @@ def test_hist_2d_with_outer_point_coord_and_erased_dim() -> None:
     assert_allclose(zx, reference)
 
 
-@pytest.mark.xfail(
-    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
-    "C++ implementation rejects. Here it drops the coord when flattening, so this "
-    "fails with a confusing KeyError instead.",
-    strict=True,
-)
 def test_hist_with_outer_bin_edge_coord_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(x=2, y=3)
     del da.bins.coords['y']
@@ -1798,12 +1792,6 @@ def test_bin_along_existing_dim_with_outer_point_coord_and_erase() -> None:
     assert_allclose(out.bins.sum(), reference.bins.sum())
 
 
-@pytest.mark.xfail(
-    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
-    "C++ implementation rejects. Here it drops the coord when flattening, so this "
-    "fails with a confusing KeyError instead.",
-    strict=True,
-)
 def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(x=2, y=3)
     del da.bins.coords['y']
@@ -1811,12 +1799,6 @@ def test_bin_by_outer_bin_edge_coord_raises_BinEdgeError() -> None:
         da.bin(y=2, dim=da.dims)
 
 
-@pytest.mark.xfail(
-    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
-    "C++ implementation rejects. Flattening a single dim is a mere rename, so the "
-    "coord survives and its first values are used, one per input bin.",
-    strict=True,
-)
 def test_bin_by_outer_bin_edge_coord_on_single_erased_dim_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(x=5)
     da.coords['s'] = sc.linspace('x', 0.0, 1.0, 6, unit='m')
@@ -1825,12 +1807,6 @@ def test_bin_by_outer_bin_edge_coord_on_single_erased_dim_raises_BinEdgeError() 
         da.bin(s=sc.linspace('s', 0.0, 1.0, 3, unit='m'))
 
 
-@pytest.mark.xfail(
-    reason="scipp/scipp#3955: combine_bins accepts bin-edge outer coords, which the "
-    "C++ implementation rejects. Flattening a single dim is a mere rename, so the "
-    "coord survives and its first values are used, one per input bin.",
-    strict=True,
-)
 def test_bin_by_own_bin_edge_coord_on_single_erased_dim_raises_BinEdgeError() -> None:
     da = sc.data.table_xyz(100).bin(y=3)
     del da.bins.coords['y']


### PR DESCRIPTION
`bin` and `group` have accepted a bin-edge outer coord ever since the `combine_bins` fast path was introduced, while the C++ implementation rejects such input with `BinEdgeError`. Which semantics applied therefore depended on whether the fast path happened to be taken, and the fast path itself was inconsistent: flattening a single dim silently used the coord's first values, one per input bin, whereas flattening more than one dim dropped the coord and failed later with a confusing `KeyError: "Expected 'y' in <scipp.Dict.keys {}>."`.

Reject such coords in `_can_operate_on_bins` so that binning falls through to the C++ implementation, which explains the problem and how to fix it.

**Breaking change.** Code that binned or grouped by a bin-edge outer coord and relied on the fast path now raises `BinEdgeError`. The fix is to pass a non-edge coord, choosing explicitly which value represents each bin. Our own filtering docs relied on this, and are updated accordingly; the numbers in that notebook are unchanged.

Stacked on #3949, which marks these cases as `xfail`. Review/merge that one first.

Fixes #3955

## Test plan

- The four `xfail` markers added in #3949 are removed; the tests now pass.
- `docs/user-guide/binned-data/filtering.ipynb` was executed against this branch and produces results identical to `main`.
