### PR TITLE
Honor the dim argument when histogramming by a dense coord

### DIFF
--- a/src/scipp/core/binning.py
+++ b/src/scipp/core/binning.py
@@ -85,7 +85,12 @@ def make_histogrammed(
                     "Cannot histogram data with existing bin edges "
                     "unless event data coordinate for histogramming is available."
                 )
-            return make_histogrammed(x.bins.sum(), edges=edges, erase=erase)
+            if set(x.coords[dim].dims) <= set(erase):
+                return make_histogrammed(x.bins.sum(), edges=edges, erase=erase)
+            # Summing bins first would let the C++ implementation replace all dims of
+            # the coord by the new dim. Dims outside `erase` must be preserved, which
+            # binning does, at the cost of moving event data.
+            return make_binned(x, edges=[edges], erase=list(erase)).bins.sum()
     _check_erase_dimension_clash(erase, edges)
     # The C++ implementation uses an older heuristic histogramming a single dimension.
     # We therefore transpose and flatten the input to match this.
@@ -599,6 +604,11 @@ def hist(
 
       >>> xyz.hist(t=4, dim='y').sizes
       {'x': 4, 'z': 6, 't': 4}
+
+    Setting `dim=()` preserves all input dimensions and adds the new one:
+
+      >>> xyz.hist(t=3, dim=()).sizes
+      {'x': 4, 'y': 5, 'z': 6, 't': 3}
     """  # noqa: E501
     if isinstance(x, DataGroup):
         # Only to make mypy happy because we have `DataGroup` in annotation of `x`
@@ -676,12 +686,7 @@ def _order_edges_for_hist(
         (dims & set(x.coords[name].dims)) - {name} for name in edges if name in x.coords
     ):
         return values
-    ordered = sorted(values, key=lambda edge: not _replaces_existing_dim(x, edge))
-    # Histogramming by a non-event coord erases the dims of that coord, so which edges
-    # come last affects more than just the dim order of the result.
-    if ordered[-1].dims[-1] not in x.bins.coords:
-        return values
-    return ordered
+    return sorted(values, key=lambda edge: not _replaces_existing_dim(x, edge))
 
 
 def _replaces_existing_dim(x: DataArray, edge: Variable) -> bool:

--- a/tests/binning_test.py
+++ b/tests/binning_test.py
@@ -1285,6 +1285,32 @@ def test_op_on_binned_with_explicit_dim_arg_yields_expected_output_dims(z) -> No
     assert xy.nanhist(z=4, dim=()).dims == ('x', 'y', 'z')
 
 
+@pytest.mark.parametrize(
+    'z',
+    [
+        sc.linspace('x', 0, 1, 4, unit='m'),
+        sc.linspace('y', 0, 1, 6, unit='m'),
+        sc.linspace('x', 0, 1, 4, unit='m') + sc.linspace('y', 0, 1, 6, unit='m'),
+    ],
+)
+def test_op_on_binned_without_event_coord_yields_expected_output_dims(z) -> None:
+    xy = sc.data.table_xyz(1000).bin(x=4, y=6)
+    xy.coords['z'] = z
+    del xy.bins.coords['z']
+    assert xy.bin(z=4, dim=xy.dims).dims == ('z',)
+    assert xy.bin(z=4, dim='y').dims == ('x', 'z')
+    assert xy.bin(z=4, dim=()).dims == ('x', 'y', 'z')
+    assert xy.group('z', dim=xy.dims).dims == ('z',)
+    assert xy.group('z', dim='y').dims == ('x', 'z')
+    assert xy.group('z', dim=()).dims == ('x', 'y', 'z')
+    assert xy.hist(z=4, dim=xy.dims).dims == ('z',)
+    assert xy.hist(z=4, dim='y').dims == ('x', 'z')
+    assert xy.hist(z=4, dim=()).dims == ('x', 'y', 'z')
+    assert xy.nanhist(z=4, dim=xy.dims).dims == ('z',)
+    assert xy.nanhist(z=4, dim='y').dims == ('x', 'z')
+    assert xy.nanhist(z=4, dim=()).dims == ('x', 'y', 'z')
+
+
 @pytest.mark.parametrize('op', [sc.bin, sc.hist, sc.nanhist])
 def test_op_with_explicit_dim_arg_keeps_aux_coord(op) -> None:
     data = sc.ones(dims=['xyz'], shape=(60,))
@@ -1738,10 +1764,11 @@ def test_hist_rebinning_existing_dim_last_does_not_create_huge_intermediate() ->
     assert da.hist(y=100, x=100, dim=da.dims).sizes == {'y': 100, 'x': 100}
 
 
-def _with_event_coord(da: sc.DataArray, name: str) -> sc.DataArray:
-    """Broadcast an outer coord onto the events, for an independent reference."""
+def _with_event_coords(da: sc.DataArray, *names: str) -> sc.DataArray:
+    """Broadcast outer coords onto the events, for an independent reference."""
     out = da.copy()
-    out.bins.coords[name] = sc.bins_like(out, out.coords[name])
+    for name in names:
+        out.bins.coords[name] = sc.bins_like(out, out.coords[name])
     return out
 
 
@@ -1761,7 +1788,7 @@ def test_hist_2d_with_outer_point_coord_and_erased_dim() -> None:
     zx = da.hist(z=2, x=2, dim=da.dims)
     assert zx.dims == ('z', 'x')
     assert_allclose(da.hist(x=2, z=2, dim=da.dims), zx.transpose(('x', 'z')))
-    reference = _with_event_coord(da, 'x').hist(z=2, x=2, dim=da.dims)
+    reference = _with_event_coords(da, 'x').hist(z=2, x=2, dim=da.dims)
     assert_allclose(zx, reference)
 
 
@@ -1773,9 +1800,7 @@ def test_hist_with_outer_bin_edge_coord_raises_BinEdgeError() -> None:
             da.hist(edges, dim=da.dims)
 
 
-def test_hist_does_not_reorder_when_final_edges_would_use_outer_coord() -> None:
-    # Histogramming by an outer coord erases that coord's dims, so reordering would
-    # change which dims the result has, not just their order.
+def test_hist_by_outer_and_event_coord_adds_dims_without_erasing() -> None:
     da = sc.data.table_xyz(1000).bin(x=5, y=4)
     da.coords['p'] = sc.arange('x', 5, unit='s')
     assert da.hist(p=3, y=3, dim=()).sizes == {'x': 5, 'p': 3, 'y': 3}
@@ -1788,7 +1813,7 @@ def test_bin_along_existing_dim_with_outer_point_coord_and_erase() -> None:
     out = da.bin(x=2, dim=da.dims)
     assert out.dims == ('x',)
     assert out.bins.size().sum().value == da.bins.size().sum().value
-    reference = _with_event_coord(da, 'x').bin(x=2, dim=da.dims)
+    reference = _with_event_coords(da, 'x').bin(x=2, dim=da.dims)
     assert_allclose(out.bins.sum(), reference.bins.sum())
 
 
@@ -1827,14 +1852,11 @@ def test_hist_by_existing_dim_and_by_coord_on_that_dim_is_order_independent() ->
     assert_allclose(da.hist(x=4, p=3).transpose(expected.dims), expected)
 
 
-@pytest.mark.xfail(
-    reason="scipp/scipp#3952: hist by a 1-D and a 2-D outer coord depends on the "
-    "argument order",
-    strict=True,
-)
 def test_hist_by_1d_and_2d_outer_coords_is_order_independent() -> None:
     da = sc.data.table_xyz(1000).bin(x=5, y=4)
     da.coords['p'] = sc.arange('x', 5, unit='s')
     da.coords['r'] = sc.arange('x', 5, unit='K') + 5 * sc.arange('y', 4, unit='K')
-    expected = da.hist(r=2, p=3, dim=())
-    assert_allclose(da.hist(p=3, r=2, dim=()).transpose(expected.dims), expected)
+    expected = _with_event_coords(da, 'p', 'r').hist(r=2, p=3, dim=())
+    assert expected.sizes == {'x': 5, 'y': 4, 'r': 2, 'p': 3}
+    for edges in ({'r': 2, 'p': 3}, {'p': 3, 'r': 2}):
+        assert_allclose(da.hist(edges, dim=()).transpose(expected.dims), expected)


### PR DESCRIPTION
Fixes #3958.

ADR 0018 defines `dim` as the dimensions to be *replaced*, so `dim=()` must preserve all input dims and add a new one. `bin`, `group` and `nanhist` do this; `hist` did not, whenever the coord used for histogramming is a dense (outer) coord of binned data rather than an event coord. The tabulated ADR row `(x,) | (x,) | (x,y) | .hist(y=y, dim=())` was violated, and the same call with a multi-dimensional coord raised `DimensionError` instead — including the exact example the `hist` docstring uses to advertise `dim=()`.

In that situation `make_histogrammed` summed the bins and handed the result to the C++ dense `histogram`, which always replaces all dims of the coord by the new dim. `erase` only drove a `flatten` beforehand, so dims outside it could not survive. Bin instead when `erase` does not already cover the coord's dims, which is what `nanhist` (`bin` followed by `nansum`) has always done. The dense fast path is kept when `erase` does cover them, so the common `dim=None` case is unaffected — `hist(t=10)` over 5M events stays at 2 ms rather than moving event data.

This is not a regression from a recent optimization: the fallback dates from #3020 (2023) and predates the ADR. It went unnoticed because `test_op_on_binned_with_explicit_dim_arg_yields_expected_output_dims` leaves the event coord in place, so the fallback branch was never exercised. This PR adds the same table without the event coord.

Two consequences beyond the bug itself:

- One of the `xfail` cases from #3949 now passes and is strengthened to check the values against a reference that broadcasts the outer coords onto the events, as requested in review. The remaining `xfail` there (re-binning a dim drops coords defined over it) is unaffected, so #3952 stays open.
- The reordering guard added in #3949 is dropped. It existed because histogramming by an outer coord erased that coord's dims, so which edges came last changed which dims the result had. That is no longer true.

## Not in scope: dense input

Dense (non-binned) data has the same gap on a separate code path, which this PR does not touch. There `bin`, `group` and `nanhist` are non-conforming too, so routing through `bin` is not an option and a different mechanism is needed. Tracked in #3960, reproduced here so the boundary of this PR is clear.

`bin`, `group` and `nanhist` agree in every cell, so they share a column. `!` marks a result that violates ADR 0018. **Kind** is the dividing line: *degenerate* means the coord is constant across everything being summed (`coord.dims ∩ dim = ∅`), so each preserved position feeds exactly one `z` bin and the output is the input scattered one-hot. *Meaningful* means the coord varies over a summed dim, so the histogram does real work.

| data | coord `z` | `dim` | ADR expected | bin/group/nanhist | hist | kind | proposed |
|---|---|---|---|---|---|---|---|
| `(x,)` | `(x,)` | `()` | `(x,z)` | `(z,)` ! | `(z,)` ! | degenerate | raise |
| `(x,)` | `(x,)` | `'x'` | `(z,)` | `(z,)` | `(z,)` | meaningful | unchanged |
| `(x,y)` | `(x,)` | `()` | `(x,y,z)` | `(y,z)` ! | `(y,z)` ! | degenerate | raise |
| `(x,y)` | `(x,)` | `'x'` | `(y,z)` | `(y,z)` | `(y,z)` | meaningful | unchanged |
| `(x,y)` | `(x,)` | `'y'` | `(x,z)` | `(z,)` ! | `DTypeError` ! | degenerate | raise |
| `(x,y)` | `(x,)` | `('x','y')` | `(z,)` | `(z,)` | `(z,)` | meaningful | unchanged |
| `(x,y)` | `(y,)` | `()` | `(x,y,z)` | `(x,z)` ! | `(x,z)` ! | degenerate | raise |
| `(x,y)` | `(y,)` | `'x'` | `(y,z)` | `(z,)` ! | `DTypeError` ! | degenerate | raise |
| `(x,y)` | `(y,)` | `'y'` | `(x,z)` | `(x,z)` | `(x,z)` | meaningful | unchanged |
| `(x,y)` | `(y,)` | `('x','y')` | `(z,)` | `(z,)` | `(z,)` | meaningful | unchanged |
| `(x,y)` | `(x,y)` | `()` | `(x,y,z)` | `(x,z)` ! | `DimensionError` ! | degenerate | raise |
| `(x,y)` | `(x,y)` | `'x'` | `(y,z)` | **`(z,)` !** | `(y,z)` | **meaningful** | **fix bin/group/nanhist** |
| `(x,y)` | `(x,y)` | `'y'` | `(x,z)` | `(x,z)` | `(x,z)` | meaningful | unchanged |
| `(x,y)` | `(x,y)` | `('x','y')` | `(z,)` | `(z,)` | `(z,)` | meaningful | unchanged |

Binned input conforms in all twelve equivalent cells after this PR, degenerate ones included. The asymmetry is intended: binned data composes the degenerate case with useful edges, which is exactly what #3958 was, whereas dense data cannot.

Stacked on #3956, which is stacked on #3949. Review/merge those first.

## Test plan

- New parametrized test covering the full `dim` table for `bin`, `group`, `hist` and `nanhist` on binned data whose histogramming coord exists only as an outer coord, over 1-D and 2-D coords. All three parametrizations fail on the base branch.
- The `hist` docstring gains a `dim=()` example, so the documented behaviour is now checked by the doctests.
