### PR TITLE
Fix IPO detection for C++ builds

### DIFF
--- a/lib/cmake/IPO.cmake
+++ b/lib/cmake/IPO.cmake
@@ -1,20 +1,29 @@
-include(CheckIPOSupported)
-check_ipo_supported(RESULT result OUTPUT output)
-if(result)
-  if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION
+   OR CMAKE_INTERPROCEDURAL_OPTIMIZATION
+)
+  include(CheckIPOSupported)
+  # Dependencies may enable other languages; Scipp only requires C++ IPO.
+  check_ipo_supported(
+    RESULT result
+    OUTPUT output
+    LANGUAGES CXX
+  )
+  if(result)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
         TRUE
-        CACHE BOOL "Link-time optimization: ON/OFF" FORCE
+        CACHE BOOL "Link-time optimization: ON/OFF"
     )
+  elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    message(FATAL_ERROR "IPO was requested but is not supported: ${output}")
+  else()
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
+        FALSE
+        CACHE BOOL "Link-time optimization: ON/OFF"
+    )
+    message(WARNING "IPO is not supported: ${output}")
   endif()
-  message(STATUS "IPO set to ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}")
-else()
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
-      FALSE
-      CACHE BOOL "Link-time optimization: ON/OFF" FORCE
-  )
-  message(WARNING "IPO is not supported: ${output}")
 endif()
+message(STATUS "IPO set to ${CMAKE_INTERPROCEDURAL_OPTIMIZATION}")
 
 if(MSVC)
   # CMake IPO does not include LTCG flag, causing the linker to restart

--- a/pixi.toml
+++ b/pixi.toml
@@ -49,9 +49,7 @@ backend = { name = "pixi-build-cmake", version = "0.*" }
 
 [package.build.config]
 # `compilers = ["cxx"]` is the pixi-build-cmake default, so it is omitted here.
-# No IPO flag: check_ipo_supported() fails with the conda compilers (as on
-# main), and lib/cmake/IPO.cmake FORCE-overrides the cache variable to FALSE,
-# so requesting it here would be silently ignored.
+# Leave IPO at its default: enabled when the C++ toolchain supports it.
 extra-args = ["-DBENCHMARK=OFF", "-DSANITIZERS=OFF"]
 
 # Note on ccache: the package build invokes ccache when it is on PATH (see


### PR DESCRIPTION
Check only CXX so dependencies enabling C cannot disable LTO. Preserve explicit OFF, reject unsupported ON requests, and remove forced cache overrides. Update the Pixi comment to reflect automatic detection.

Fixes #3942